### PR TITLE
Fix parameters to gnupg.GPG()

### DIFF
--- a/modules/deaddrop/files/deaddrop/crypto.py
+++ b/modules/deaddrop/files/deaddrop/crypto.py
@@ -52,7 +52,7 @@ except OSError:
     p = subprocess.Popen([GPG_BINARY, '--version'], stdout=subprocess.PIPE)
 
 assert p.stdout.readline().split()[-1].split('.')[0] == '2', "upgrade GPG to 2.0"
-gpg = gnupg.GPG(binary=GPG_BINARY, homedir=config.GPG_KEY_DIR)
+gpg = gnupg.GPG(gpgbinary=GPG_BINARY, gnupghome=config.GPG_KEY_DIR)
 
 def genkeypair(name, secret):
     """


### PR DESCRIPTION
This code originally used the gnupg Python library [1]. The installation
instructions were recently updated to recommned the use of the python-gnupg
library [2] instead. This code was forked from gnupg, but has a slightly
different interface, so the code was broken after the update.

[1] https://pypi.python.org/pypi/gnupg/1.2.3
[2] https://pypi.python.org/pypi/python-gnupg/0.3.5
