### PR TITLE
Fix regexes for submissions and downloads

### DIFF
--- a/modules/deaddrop/files/deaddrop/journalist.py
+++ b/modules/deaddrop/files/deaddrop/journalist.py
@@ -6,8 +6,8 @@ import config, crypto, store
 urls = (
   '/', 'index',
   '/reply/', 'reply',
-  '/([a-f0-9]+)/', 'col',
-  '/([a-f0-9]+)/([0-9]+\.[0-9]+(?:_msg|_doc|)\.gpg)', 'doc'
+  '/([A-Z1-7]+)/', 'col',
+  '/([A-Z1-7]+)/([0-9]+\.[0-9]+(?:_msg|_doc|)\.gpg)', 'doc'
 )
 
 render = web.template.render(config.JOURNALIST_TEMPLATES_DIR, base='base')


### PR DESCRIPTION
Switching to b32 encoding (part of the bcrypt changes) broke these links, which
expected b16.

Fixes #52.
