### PR TITLE
improve Mac OSX instructions

### DIFF
--- a/modules/deaddrop/files/deaddrop/HACKING.md
+++ b/modules/deaddrop/files/deaddrop/HACKING.md
@@ -2,13 +2,16 @@ development setup for deaddrop
 ==============================
 
 This document assumes your development environment is a Debian, Ubuntu
-or Fedora derivative.  If you're familiar with homebrew on OSX you
-should be able to follow along (documentation patches welcome).
+or Fedora derivative.
+
+If you're familiar with homebrew and pip on OSX you should be able to follow along. Secure RM
+may already installed as srm.
 
 install gnupg2:
 
     $ sudo yum install gnupg2
     $ sudo apt-get install gnupg2
+    $ brew install gnupg2
 
 install srm (secure remove utility):
 
@@ -19,6 +22,7 @@ install virtualenv:
 
     $ sudo yum install python-virtualenv
     $ sudo apt-get install python-virtualenv
+    $ pip install virtualenv
 
 create and activate a new virtualenv:
 


### PR DESCRIPTION
Minor additions to specify which packages need to be installed on Mac OSX, and how to install them.

I was looking everywhere for an srm or secure-remove package, when all I needed to do was type 'srm' in Terminal!

Everything else works great - thanks
