### PR TITLE
sanitized gen_ajax words

### DIFF
--- a/modules/deaddrop/files/deaddrop/source.py
+++ b/modules/deaddrop/files/deaddrop/source.py
@@ -42,6 +42,8 @@ class gen_ajax:
     request_params = web.input()
     if 'words' in request_params:
       word_num = int(request_params['words'])
+      if (word_num not in range(4, 11)):
+        raise web.notfound()
       uid = crypto.genrandomid(word_num)
       return json.dumps({'result': 'success', 'id': uid})
     else:


### PR DESCRIPTION
You fixed the /generate/ page, but not the similar /gen_ajax/ request.

Also, since integers can hold values up to 2-billion, a single request can potentially consume all the RAM in the system.
