### PR TITLE
Ubuntu/Debian dev setup script

### DIFF
--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -48,12 +48,12 @@ echo "Setting up configurations..."
 cp example_config.py config.py
 mkdir -p ./tmp/deaddrop/{store,keys}
 mkdir ./tmp/deaddrop_test
-storepath=$(pwd)/tmp/store
-keypath=$(pwd)/tmp/keys
+storepath=$(pwd)/tmp/deaddrop/store
+keypath=$(pwd)/tmp/deaddrop/keys
 testpath=$(pwd)/tmp/deaddrop_test
 sed -i "s@^STORE_DIR.*@STORE_DIR=\'$storepath\'@" config.py
 sed -i "s@^GPG_KEY_DIR.*@GPG_KEY_DIR=\'$keypath\'@" config.py
-# TODO: replace below line so that indents are not hard-coded
+# TODO: replace below line so that indents are not hard-coded :/
 sed -i "s@    TEST_DIR.*@    TEST_DIR=\'$testpath\'@" config.py
 
 echo "" >> .gitignore


### PR DESCRIPTION
This is a dev environment setup script for Ubuntu/Debian. It does most everything automatically except for modifying JOURNALIST_CONFIG in config.py with the journalist key that the user decides to use, but at least reminds the user to do that. It also runs the unit tests after setup to ensure everything went smoothly.
