### PR TITLE
Making all markdown links relative

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -3,4 +3,4 @@
 Mailing List: securedrop-dev@lists.riseup.net
 IRC: #securedrop-dev on OFTC
 
-If you want to hack on the web application, check out `deaddrop/HACKING.md`.
+If you want to hack on the web application, check out [deaddrop/HACKING.md](/modules/deaddrop/files/deaddrop/HACKING.md).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![SecureDrop](https://raw.github.com/freedomofpress/securedrop/master/docs/images/logo.png)
+![SecureDrop](/docs/images/logo.png)
 
 SecureDrop is an open-source whistleblower submission system managed by Freedom of the Press Foundation that media organizations use to securely accept documents from anonymous sources. It was originally coded by the late Aaron Swartz.
 
@@ -19,7 +19,7 @@ These computers should all physically be in your organization's office.
 
 ## Before You Begin
 
-Before beginning installation, you should have three servers running Ubuntu Server 12.04.3 LTS, each with the grsec kernel patches installed. If you don't yet have those computers configured, see additional documentation for [Preparing Ubuntu servers for installation](https://github.com/freedomofpress/securedrop/blob/master/docs/ubuntu_config.md).
+Before beginning installation, you should have three servers running Ubuntu Server 12.04.3 LTS, each with the grsec kernel patches installed. If you don't yet have those computers configured, see additional documentation for [Preparing Ubuntu servers for installation](/docs/ubuntu_config.md).
 
 You will need a DVD with the latest version of the [Tails](https://tails.boum.org/download/index.en.html) operating system burned to it. You will only have to use this DVD once: After the first run from a Live DVD you can create a Live USB to boot from instead. If you already have a Tails Live USB, you may skip this requirement.
 
@@ -39,11 +39,11 @@ Each journalist will also need to come up with a password for login to the `Docu
 
 ## How to Install SecureDrop
 
-After installing and configuring Ubuntu Server on `Source Server`, `Document Server`, and `Monitor Server`, and download, verifying, and burning Tails to a Live DVD, follow the [SecureDrop Installation Guide](https://github.com/freedomofpress/securedrop/blob/master/docs/install.md).
+After installing and configuring Ubuntu Server on `Source Server`, `Document Server`, and `Monitor Server`, and download, verifying, and burning Tails to a Live DVD, follow the [SecureDrop Installation Guide](/docs/install.md).
 
 ## How to Use SecureDrop
 
-See [How to Use SecureDrop](https://github.com/freedomofpress/securedrop/blob/master/docs/user_manual.md).
+See [How to Use SecureDrop](/docs/user_manual.md).
 
 ## Demo
 
@@ -56,6 +56,6 @@ In an actual SecureDrop setup, these websites are Tor hidden services running on
 
 ## License
 
-SecureDrop is open source and released under the [GNU General Public License v2](https://github.com/freedomofpress/securedrop/blob/master/LICENSE). 
+SecureDrop is open source and released under the [GNU General Public License v2](/LICENSE). 
 
-The [wordlist](https://github.com/freedomofpress/securedrop/blob/master/modules/deaddrop/files/deaddrop/wordlist) we use to generate source passphrases comes from [Diceware](http://world.std.com/~reinhold/diceware.html), and is licensed under Creative Commons Attribution 3.0 Unported thanks to A G Reinhold. 
+The [wordlist](/modules/deaddrop/files/deaddrop/wordlist) we use to generate source passphrases comes from [Diceware](http://world.std.com/~reinhold/diceware.html), and is licensed under Creative Commons Attribution 3.0 Unported thanks to A G Reinhold. 

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,7 +3,7 @@ SecureDrop Installation Guide
 
 Before installing SecureDrop, you should make sure you've got the environment properly set up. 
 
-* You must have three servers — called the `Source Server`, the `Document Server`, and the `Monitor Server` with [Ubuntu Server installed](https://github.com/freedomofpress/securedrop/blob/master/docs/ubuntu_config.md).
+* You must have three servers — called the `Source Server`, the `Document Server`, and the `Monitor Server` with [Ubuntu Server installed](/ubuntu_config.md).
 
 * You must have a DVD configured as a Live DVD for the Tails operating system. You will only have to use this DVD once: After the first run from a Live DVD you can create a Live USB to boot from instead. If you already have a Tails Live USB, you may skip this requirement.
 
@@ -36,15 +36,15 @@ Reboot the `Viewing Station` laptop and boot into the Tails Live USB again to co
 
 In order to avoid transfering plaintext files between the `Viewing Station` and `Journalist Workstations`, each journalist should have their own personal PGP key. Start by copying all of the journalists' public keys to a USB stick. Plug this into the `Viewing Station` running Tails and open the file manager. Double-click on each public key to import it. If the public key isn't importing, try renaming it to end in ".asc".
 
-![Importing Journalist PGP Keys](https://raw.github.com/freedomofpress/securedrop/master/docs/images/install/viewing1.jpg)
+![Importing Journalist PGP Keys](/images/install/viewing1.jpg)
 
 To generate the application PGP key, click in the clipboard icon in the top right and choose `Manage Keys`. A program called `Passwords and Encryption Keys` will open. You can click on the `Other Keys` tab to manage the keys that you just imported.
 
-![Tails PGP Clipboard](https://raw.github.com/freedomofpress/securedrop/master/docs/images/install/viewing2.jpg)
+![Tails PGP Clipboard](/images/install/viewing2.jpg)
 
 Click `File`, `New`. Choose `PGP Key`, and click Continue.
 
-![New...](https://raw.github.com/freedomofpress/securedrop/master/docs/images/install/viewing3.jpg)
+![New...](/images/install/viewing3.jpg)
 
 Put these values in:
 
@@ -54,24 +54,24 @@ Put these values in:
 
 Click the arrow to expland `Advanced key options`. Change the `Key Strength` from 2048 to 4096. Then click Create.
 
-![New PGP Key](https://raw.github.com/freedomofpress/securedrop/master/docs/images/install/viewing4.jpg)
+![New PGP Key](/images/install/viewing4.jpg)
 
 Type in the PGP passphrase that you came up with earlier twice and click OK. Then wait while your key is being generated. 
 
-![Set Passphrase](https://raw.github.com/freedomofpress/securedrop/master/docs/images/install/viewing5.jpg)
-![Key Generation](https://raw.github.com/freedomofpress/securedrop/master/docs/images/install/viewing6.jpg)
+![Set Passphrase](/images/install/viewing5.jpg)
+![Key Generation](/images/install/viewing6.jpg)
 
 When it's done, you should see your key in the `My Personal Keys` tab.
 
-![My Keys](https://raw.github.com/freedomofpress/securedrop/master/docs/images/install/viewing7.jpg)
+![My Keys](/images/install/viewing7.jpg)
 
 Right-click on the key you just generated and click `Export`. Save it to your USB stick as `SecureDrop.asc`.
 
-![My Keys](https://raw.github.com/freedomofpress/securedrop/master/docs/images/install/viewing8.jpg)
+![My Keys](/images/install/viewing8.jpg)
 
 You'll also need to write down the 40 character hex fingerprint for this new key for the next step. Double-click on the new key you just generated and change to the `Details` tab. Write down the 40 digits under `Fingerprint`. (Your PGP key fingerprint will be different than what's in this photo.)
 
-![Fingerprint](https://raw.github.com/freedomofpress/securedrop/master/docs/images/install/viewing9.jpg)
+![Fingerprint](/images/install/viewing9.jpg)
 
 ## Server Installation
 
@@ -170,8 +170,8 @@ And the `torrc` file for the second journalist should look like something this:
 
 * Open run the Tor Browser Bundle and enter the journalist's unique Tor hidden service URL without the Auth value  
 
-![Journalist_workstation1](https://raw.github.com/freedomofpress/securedrop/master/docs/images/install/journalist_workstation1.png)
+![Journalist_workstation1](/images/install/journalist_workstation1.png)
 
 ## Test It
 
-Once it's installed, test it out. See [How to Use SecureDrop](https://github.com/freedomofpress/securedrop/blob/master/docs/user_manual.md).
+Once it's installed, test it out. See [How to Use SecureDrop](/user_manual.md).

--- a/docs/ubuntu_config.md
+++ b/docs/ubuntu_config.md
@@ -4,7 +4,7 @@
 
 After booting the the Ubuntu Server CD, select "Install Ubuntu Server".
 
-![Ubuntu Server](https://raw.github.com/freedomofpress/securedrop/master/docs/images/install/ubuntu_server.png)
+![Ubuntu Server](/images/install/ubuntu_server.png)
 
 Follow the steps to choose your language and keyboard, and let the setup continue. When it asks for your hostname choose a name that makes sense. Each server should have its own hostname.  You can choose whatever username and password you would like. There's no need to encrypt home directories. Configure your time zone. When you get to the partition step, choose "Guided - use entire disk and set up LVM". Then wait for base system to finish installing. 
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -10,29 +10,29 @@ Once you have the Tor Browser installed you can access Tor hidden service URLs t
 
 Open the Tor Browser and visit the hidden service for the SecureDrop website you're visiting.
 
-![Source website](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/source1.png)
+![Source website](/images/manual/source1.png)
 
 If this is the first time you're using SecureDrop with this organization, click the "Submit Documents" button.
 
-![Generating code name](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/source2.png)
+![Generating code name](/images/manual/source2.png)
 
 SecureDrop will create a code name for you to use. In the preview screenshot the codename that was generated was `naiad edit carrie bahama brew hardy cannot gosh`. You must either memorize this or write it down in a safe place. After you submit documents, you must know this code name in order to login and check for responses.
 
 You can choose the length of your code name. Longer code names are more secure but harder to memorize, and shorter code names are less secure but easier to memorize, so use your discretion. Once you have generated a code name, click Continue.
 
-![Generating code name](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/source3.png)
+![Generating code name](/images/manual/source3.png)
 
 You can then choose to upload a document and/or enter a message to send to the journalists. When you are done, click Submit.
 
-![Document upload success](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/source4.png)
+![Document upload success](/images/manual/source4.png)
 
 If you have already submitted a document and you would like to check for a response, from the source homepage click the "Check for a Response" button instead.
 
-![Check for response](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/source5.png)
+![Check for response](/images/manual/source5.png)
 
 Enter the code name that you already know and click Continue.
 
-![Check for response](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/source6.png)
+![Check for response](/images/manual/source6.png)
 
 If a journalist has responded there will be a message waiting for you to read and delete. You can also upload another document or send another message to the journalists.
 
@@ -44,23 +44,23 @@ Each journalist has their own authenticated Tor hidden service URL. The journali
 
 Start by opening Tor Browser and loading the .onion URL to access the `Document Server`. If any sources have uploaded documents or sent you message, they will be listed on the homepage by a code name. **Note: The code name the journalists see is different than the code name that sources see.**
 
-![Document server](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/document1.png)
+![Document server](/images/manual/document1.png)
 
 ### Interacting With Sources
 
 Click on the code name to see the page specifically for that source. You will see all of the messages that they have written and documents that they have uploads.
 
-![Read documents](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/document2.png)
+![Read documents](/images/manual/document2.png)
 
 Documents and messages are encrypted to the application's PGP public key. In order to read the messages or look at the documents you will need to transfer them to the `Viewing Station`. But first, if you'd like to reply to the source you can fill out the text area and click Submit.
 
-![Sent reply](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/document3.png)
+![Sent reply](/images/manual/document3.png)
 
 ### Moving Documents to Viewing Station
 
 The first step is downloading the documents. Click on a document or message name to save it. In order to protect you from malware, Tor Browser pops up a notice that looks like this every time you try to download a file that can't be opened in Tor Browser itself:
 
-![Load external content](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/document4.png)
+![Load external content](/images/manual/document4.png)
 
 Go ahead and click `Launch application` anyway, and save the document to a USB stick.
 
@@ -68,21 +68,21 @@ Boot up the `Viewing Station` to Tails and mount the persistent volume. Once you
 
 **Copy these documents to the Persistent folder before decrypting them. This an important step. Otherwise you might accidentally decrypt the documents on the USB stick, and they could be recoverable in the future.**
 
-![Copy files to Persistent](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/viewing1.jpg)
+![Copy files to Persistent](/images/manual/viewing1.jpg)
 
 ### Decrypting and Working on the Secure Viewing Station
 
 To decrypt documents, double-click on them. It will prompt you for the application PGP key passphrase to decrypt the document.
 
-![Decrypting](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/viewing2.jpg)
+![Decrypting](/images/manual/viewing2.jpg)
 
 When you decrypt the file it will have the same filename, but without the .gpg at the end.
 
-![Decrypted documents](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/viewing3.jpg)
+![Decrypted documents](/images/manual/viewing3.jpg)
 
 You can double-click on the decrypted document to open it in it's default application.
 
-![Opened document](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/viewing4.jpg)
+![Opened document](/images/manual/viewing4.jpg)
 
 If you the default application doesn't work, you can right-click on the document and choose "Open with Other Application..." to try opening the document with OpenOffice Writer, or Document Viewer. You can right-click on a file and choose "Rename..." to rename a document and give it a file extension.
 
@@ -98,7 +98,7 @@ We recommend that you do as much work as you can inside of Tails before copying 
 
 When you no longer need documents you can right-click on them and choose Wipe to delete them.
 
-![Wiping documents](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/viewing5.jpg)
+![Wiping documents](/images/manual/viewing5.jpg)
 
 ### Encrypting and Moving Documents to Journalist Workstation
 
@@ -106,15 +106,15 @@ Before you move documents back to the USB stick to copy them to your workstation
 
 Right-click on the document you want to encrypt and choose "Encrypt..."
 
-![Encrypting 1](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/viewing6.jpg)
+![Encrypting 1](/images/manual/viewing6.jpg)
 
 Then choose the public keys of the journalist you want to encrypt the documents to and click OK.
 
-![Encrypting 2](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/viewing7.jpg)
+![Encrypting 2](/images/manual/viewing7.jpg)
 
 When you are done you will have another document with the same filename but ending in .pgp that is encrypted to the PGP keys you selected. You can copy the encrypted documents to the USB stick to transfer them to your workstation.
 
-![Encrypted document](https://raw.github.com/freedomofpress/securedrop/master/docs/images/manual/viewing8.jpg)
+![Encrypted document](/images/manual/viewing8.jpg)
 
 ### Decrypting and Preparing to Publish
 


### PR DESCRIPTION
It turns out it's easy to make relative links using GitHub's markdown. I've updated all of the absolute links that link directly into freedomofpress/securedrop to be relative.
