### PR TITLE
This upgrades `distribute` to the latest of the 0.6 releases

### DIFF
--- a/securedrop/HACKING.md
+++ b/securedrop/HACKING.md
@@ -39,7 +39,7 @@ install dependencies:
 
     $ sudo yum install python-devel
     $ sudo apt-get install python-dev
-    $ pip install -r requirements.txt
+    $ pip install --upgrade -r requirements.txt
 
 cp the config template and fill in empty values:
 

--- a/securedrop/requirements.txt
+++ b/securedrop/requirements.txt
@@ -1,3 +1,4 @@
+distribute==0.6.34
 Flask==0.10.1
 Flask-Testing==0.4
 Flask-WTF==0.9.3
@@ -7,7 +8,6 @@ WTForms==1.0.5
 Werkzeug==0.9.4
 argparse==1.2.1
 beautifulsoup4==4.3.2
-distribute==0.6.34
 itsdangerous==0.23
 psutil==1.1.1
 pycrypto==2.6.1

--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -68,7 +68,7 @@ echo "Setting up the virtual environment..."
 virtualenv securedrop/venv
 source securedrop/venv/bin/activate
 cd securedrop/deaddrop
-pip install -r requirements.txt
+pip install --upgrade -r requirements.txt
 
 echo "Setting up configurations..."
 # create directories for keys and store


### PR DESCRIPTION
Which is currently 0.6.34.  This is useful because some packages need a newer
version of distribute, and others some do not yet support setuptools.
