### PR TITLE
remove option to use codenames with less than 7 words - closes #162

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -97,7 +97,7 @@ def generate():
     number_words = 8
     if request.method == 'POST':
         number_words = int(request.form['number-words'])
-        if number_words not in range(4, 11):
+        if number_words not in range(7, 11):
             abort(403)
     session['codename'] = crypto_util.genrandomid(number_words)
     return render_template('generate.html', codename=session['codename'])

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -11,9 +11,6 @@
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
       Desired code name length:
       <select name="number-words" id="number-words">
-        <option value="4">4</option>
-        <option value="5">5</option>
-        <option value="6">6</option>
         <option value="7">7</option>
         <option value="8" selected>8</option>
         <option value="9">9</option>
@@ -21,7 +18,6 @@
       </select>
       words.
       <input type="submit" id="regenerate-submit" value="Generate">
-      <div class='regenerate-warning'><span class='regenerate-warning'>Warning:</span> Choosing a code below 7 words is not recommended.</div>
     </form>
   </div>
   <p>

--- a/securedrop/test.py
+++ b/securedrop/test.py
@@ -109,7 +109,7 @@ class TestSource(TestCase):
 
     def test_regenerate_valid_lengths(self):
         """Make sure we can regenerate all valid length codenames"""
-        for codename_len in xrange(4, 11):
+        for codename_len in xrange(7, 11):
             response = self.client.post('/generate', data={
                 'number-words': str(codename_len),
             })


### PR DESCRIPTION
Want feedback on this before merging - from @Hainish, @taipo, @trevortimm, @micahflee, and anybody else who is interested. This is a quick fix - we can later consider, as @taipo suggested, adding to the wordlist so it is safe to use shorter codenames.
