### PR TITLE
text changes to clear things up for newbies

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -2,41 +2,44 @@
 
 ## SecureDrop Depends on the Tor Browser
 
-Sources who submit documents and journalists who download these documents must connect to the SecureDrop website using the Tor network. The easiest and most secure way to use Tor is to download the Tor Browser Bundle from https://www.torproject.org/.
+Sources submitting documents or messages to SecureDrop, and the journalists viewing this correspondence, must connect to the secure server using the Tor network, free software that makes users' internet activity much more difficult to trace. The easiest and most secure way to use Tor is to download the Tor Browser Bundle from https://www.torproject.org/. This bundle installs the Tor browser, as well as an application that is used to connect to the Tor network.
 
-Once you have the Tor Browser installed you can access Tor hidden service URLs that have domain names that end in .onion. Media organizations must link to the .onion URL for their instance of SecureDrop from their website. Each journalist that uses SecureDrop has their own personal .onion URL that they use to connect.
+The Tor Browser can be used to access Tor _hidden service URLs_, which have domain names that end in ".onion". Media organizations will provide links to the .onion URLs of their SecureDrop pages, and each journalist that uses SecureDrop connects to the service with his or her own personal .onion URL.
 
-## As a Source
+## Using SecureDrop As a Source
 
-Open the Tor Browser and visit the hidden service for the SecureDrop website you're visiting.
+Open the Tor Browser and navigate to the .onion hidden service URL provided by the media organization whose SecureDrop page you would like to visit. The page should look similar to the screenshot below. If this is the first time you are using SecureDrop with this organization, click the "Submit Documents" button.
 
 ![Source website](/images/manual/source1.png)
 
-If this is the first time you're using SecureDrop with this organization, click the "Submit Documents" button.
+You should now see a screen that shows the unique code name that SecureDrop has generated for you. In the example screenshot below the codename is `naiad edit carrie bahama brew hardy cannot gosh`, but yours will be different. It is extremely important that you both remember this code and keep it secret. Memorize the code or write it down and keep it in a safe place, but do not save it on your computer. After submitting documents, you will need to provide this code to log back in and check for responses.
+
+SecureDrop allows you to choose the length of your code name, but keep in mind that longer code names are much more secure than shorter ones. Once you have generated a code name and put it somewhere safe, click Continue.
 
 ![Generating code name](/images/manual/source2.png)
 
-SecureDrop will create a code name for you to use. In the preview screenshot the codename that was generated was `naiad edit carrie bahama brew hardy cannot gosh`. You must either memorize this or write it down in a safe place. After you submit documents, you must know this code name in order to login and check for responses.
+You will next be brought to the submission interface, where you may upload a document, enter a message to send to journalists, or both. You can only submit one document at a time, so you may want to combine several files into a zip archive if necessary. When your submission is ready, click Submit.
 
-You can choose the length of your code name. Longer code names are more secure but harder to memorize, and shorter code names are less secure but easier to memorize, so use your discretion. Once you have generated a code name, click Continue.
+![Making a submission](/images/manual/source3.png)
 
-![Generating code name](/images/manual/source3.png)
-
-You can then choose to upload a document and/or enter a message to send to the journalists. When you are done, click Submit.
+After clicking Submit, a confirmation page should appear, showing that your message and/or documents have been sent successfully. On this page you can make another submission or view responses to your previous messages.
 
 ![Document upload success](/images/manual/source4.png)
 
-If you have already submitted a document and you would like to check for a response, from the source homepage click the "Check for a Response" button instead.
+If you have already submitted a document and would like to check for responses, click the "Check for a Response" button on the media organizations' SecureDrop homepage.
+
+![Source website](/images/manual/source1.png)
+
+The next page will ask for your secret code name; enter it and click Continue.
 
 ![Check for response](/images/manual/source5.png)
 
-Enter the code name that you already know and click Continue.
+If a journalist has responded, his or her message will appear on the next page. This page also allows you to upload another document or send another message to the journalist. Be sure to delete any messages here before navigating away.
 
 ![Check for response](/images/manual/source6.png)
 
-If a journalist has responded there will be a message waiting for you to read and delete. You can also upload another document or send another message to the journalists.
 
-## As a Journalist
+## Using SecureDrop As a Journalist
 
 ### Connecting to the Document Server
 

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 {% block body %}
 <div id="content" class="submit-2">
-  <h2>Submit documents for the first time</h2>
-  <p>To protect your identity, we're assigning you a code name.</p>
+  <h2>Submitting for the first time</h2>
+  <p>To protect your identity, we're assigning you a unique code name.</p>
   <p><b>Your code name is:</b></p>
   <p id="code-name" class="code-name">{{ codename }}</p>
   <div id='regenerate-box'>
-    If you would like to pick a differnt code name, please regenerate.
+    Click Generate if you would like to create a different code name.
     <form id="regenerate-form" method="post">
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
       Desired code name length:
@@ -25,7 +25,7 @@
     </form>
   </div>
   <p>
-    You will need this code name to access any responses to your submission. Please memorize it or save it in a secure place if you want to be able to get responses. (However, this code name of course will help identify you as the submitter &mdash; so don't keep it anywhere it might get discovered.)
+    It is extremely important that you both remember this code and keep it secret. Memorize the code or write it down, but do not save it on your computer. After submitting documents, you will need to provide this code to log back in and check for responses. Also, this code is the only authentication needed to log in with your account: if you write it down, be sure to keep it hidden.
   </p>
   <form id="create-form" method="post" action="/create" autocomplete="off">
     <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -6,7 +6,7 @@
 
 <form method="post" action="/login" autocomplete="off">
 <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-<p>First you need to enter your code name:</p>
+<p>Enter your code name below:</p>
 <p><input type="text" name="codename" autocomplete="off"/> <button class="button-custom" type="submit">Continue...</button></p>
 </form>
 {% endblock %}

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -1,16 +1,16 @@
 {% extends "base.html" %}
 {% block body %}
 <div id="content" class="user-view">
-<h2><span class="headline">Upload documents</span></h2>
+<h2><span class="headline">Submit a document, message, or both</span></h2>
 
 {% include 'flashed.html' %}
 
 {% if flagged and not haskey %}
-  <p class="notification">A journalist would like to reply to you! Please check back shortly for their reply.</p>
+  <p class="notification">A journalist would like to reply to you! Please check back shortly to view the reply.</p>
 {% endif %}
 {% if msgs %}
 <div id="replies">
-  <p class="notification">You have received a reply. For your security, please delete all replies when you're done with them.</p>
+  <p class="notification">You have received a reply. For your security, please delete all replies when you're finished here.</p>
   {% for msg in msgs %}
   <div class="reply">
     <form class="message" method="post" action="/delete" autocomplete="off">


### PR DESCRIPTION
I have gone through the text aimed at sources who might be submitting through a SecureDrop instance for the first time and tried to make the instructions a bit clearer. The major themes throughout these changes:
- Assume the reader is unfamiliar with the technologies used
- Emphasize the importance of a source remembering their code name and keeping it secret
- Make sure sources are aware that they can send documents, messages, or both through SecureDrop
- Make the step-by-step in `docs/user_manual.md` easier to follow
- Generally clean up syntax and fix some typos, etc.

Happy to field any feedback on these changes, thanks!
