### PR TITLE
Update dev install script

### DIFF
--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -26,7 +26,7 @@ blue=$(tput setaf 4)
 red=$(tput setaf 1)
 normalcolor=$(tput sgr 0)
 
-DEPENDENCIES='gnupg2 secure-delete haveged python-dev python-pip python-virtualenv mysql-server-5.5 libmysqlclient-dev bcrypt'
+DEPENDENCIES='gnupg2 secure-delete haveged python-dev python-pip python-virtualenv mysql-server-5.5 libmysqlclient-dev bcrypt bcrypt-python'
 
 # no password prompt to install mysql-server
 mysql_root=$(head -c 20 /dev/urandom | python -c 'import sys, base64; print base64.b32encode(sys.stdin.read())')


### PR DESCRIPTION
I'm getting this set up to bring the SecureDropDemo.org site up-to-date with recent changes.

Changes are:
- installing bcrypt and bcrypt-python
- installing from both requirements.txt files
- /tmp folder used in example_config.py
- moved bcrypt key generation before database table creation, because otherwise BCRYPT_ID_SALT == BCRYPT_GPG_SALT and `import db` fails
