### PR TITLE
Apache config headers and error page fixes

### DIFF
--- a/install_files/document.site
+++ b/install_files/document.site
@@ -1,7 +1,9 @@
 NameVirtualHost 127.0.0.1:8080
 <VirtualHost 127.0.0.1:8080>
 ServerName 127.0.0.1:8080
+
 #ServerAlias for each hidden service address in the tor hostname file
+#ServerAlias ONION_ADDRESS
 #INSERT_SERVER_ALIASES_HERE
 
 DocumentRoot /var/www/securedrop/static

--- a/install_files/source.site
+++ b/install_files/source.site
@@ -12,6 +12,7 @@ WSGIDaemonProcess source  processes=2 threads=30 display-name=%{GROUP} python-pa
 WSGIProcessGroup source
 WSGIScriptAlias / /var/www/securedrop/source.wsgi/
 AddType text/html .py
+
 #Allow-Origin for each hidden service address in the tor hostname file
 #Header set Access-Control-Allow-Origin "http://ONION_URL"
 #INSERT_ORIGIN_HERE
@@ -20,7 +21,6 @@ Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
 Header edit Set-Cookie ^(.*)$ $;HttpOnly
 Header set Pragma "no-cache"
 Header set Expires "-1"
-Header edit Set-Cookie ^(.*)$ $;HttpOnly
 Header always append X-Frame-Options: DENY
 Header set X-XSS-Protection: 1; mode-block
 Header set X-Content-Type-Options: nosniff
@@ -29,6 +29,7 @@ Header set X-Download-Options: noopen
 Header set Content-Security-Policy: "default-src 'self'"
 Header unset Etag
 
+# Limit the max submitted size of requests.
 LimitRequestBody MAX_REQUEST_SIZE
 
 #Redirect error pages to ensure headers are sent


### PR DESCRIPTION
Fixes issue #107
Adds custom error pages all pointing to the /notfound page so the defined headers are sent for error pages

Adds Pragma, Expires, X-Content-Type, X-download, X-Content-Security policy, Content-Security-Policy headers to the source and document interface apache configs

Removes X-XSS-Protection header from apache configs
