### PR TITLE
Set the max request body size in the CONFIG_OPTIONS file

### DIFF
--- a/CONFIG_OPTIONS
+++ b/CONFIG_OPTIONS
@@ -1,17 +1,18 @@
 # Global
-ROLE=""                     # Role of the server (monitor|app)
-APP_IP=""                   # IP address of the Source Server
-MONITOR_IP=""               # IP address of the Monitor Server
-SSH_USERS=""                # Space separated list of usernames that will SSH into this server
+ROLE=""                      # Role of the server (monitor|app)
+APP_IP=""                    # IP address of the Source Server
+MONITOR_IP=""                # IP address of the Monitor Server
+SSH_USERS=""                 # Space separated list of usernames that will SSH into this server
 
 # You only need to fill these out on the Monitor Server
 # If you leave these blank, SecureDrop won't send email notifications
-SMTP_SERVER=""              # FQDN of the destination SMTP server
-EMAIL_DISTRO=""             # The email distribution list to send ossec alerts to
-EMAIL_FROM="ossec@test.com" # The email address that the ossec alert will appear to come from
+SMTP_SERVER=""               # FQDN of the destination SMTP server
+EMAIL_DISTRO=""              # The email distribution list to send ossec alerts to
+EMAIL_FROM="ossec@test.com"  # The email address that the ossec alert will appear to come from
 
 # You only need to fill these out on the App Server
-JOURNALIST_USERS=""         # Space separated list of journalist usernames (make them up now, one per journalist)
-KEY="SecureDrop.asc"        # The application public GPG keypair
-SOURCE_SCRIPTS=""           # Space separated list of scripts to be run in the source interface
-DOCUMENT_SCRIPTS=""         # Space separated list scripts to be run in the document interface
+JOURNALIST_USERS=""          # Space separated list of journalist usernames (make them up now, one per journalist)
+KEY="SecureDrop.asc"         # The application public GPG keypair
+MAX_REQUEST_SIZE="524288000" # In bytes, the size limit on the allowed body of a HTTP request messages in Apache
+SOURCE_SCRIPTS=""            # Space separated list of scripts to be run in the source interface
+DOCUMENT_SCRIPTS=""          # Space separated list scripts to be run in the document interface

--- a/install_files/document.site
+++ b/install_files/document.site
@@ -21,7 +21,7 @@ Header edit Set-Cookie ^(.*)$ $;HttpOnly
 Header always append X-Frame-Options DENY
 Header set X-XSS-Protection "1; mode=block"
 
-LimitRequestBody 512000
+LimitRequestBody MAX_REQUEST_SIZE
 
 <Directory />
   Options None

--- a/install_files/install_chroot.sh
+++ b/install_files/install_chroot.sh
@@ -257,6 +257,9 @@ FOE
   ONION_ADDRESS="$(echo /var/chroot/$JAIL/var/lib/tor/hidden_service/hostname)"
   sed -i "s|ONION_ADDRESS|$ONION_ADDRESS|g" /var/chroot/$JAIL/etc/apache2/sites-enabled/$JAIL
 
+  #Set the max file size for requests in the apache config
+  sed -i "s|MAX_REQUEST_SIZE|$MAX_REQUEST_SIZE|g" /var/chroot/$JAIL/etc/apache2/sites-enabled/$JAIL
+
   if grep -q "APP_GPG_KEY_FINGERPRINT" /var/chroot/$JAIL/var/www/securedrop/config.py; then
     echo "Copying GPG Fingerprint to $JAIL/var/www/securedrop/config.py"
     sed -i -e "s|APP_GPG_KEY_FINGERPRINT|$APP_GPG_KEY_FINGERPRINT|g" /var/chroot/$JAIL/var/www/securedrop/config.py

--- a/install_files/source.site
+++ b/install_files/source.site
@@ -23,7 +23,7 @@ Header edit Set-Cookie ^(.*)$ $;HttpOnly
 Header always append X-Frame-Options DENY
 Header set X-XSS-Protection "1; mode=block"
 
-LimitRequestBody 512000
+LimitRequestBody MAX_REQUEST_SIZE
 
 <Directory />
   Options None


### PR DESCRIPTION
Rebased on top of master and resubmitting pull request.
This adds an option to CONFIG_OPTIONS to set the max HTTP request size. 
Fixes issue #223 
