### PR TITLE
Set RNG to /dev/urandom

### DIFF
--- a/install_files/base_install.sh
+++ b/install_files/base_install.sh
@@ -144,6 +144,15 @@ catch_error $? "configuring sysctl.conf"
 echo "Sysctl.conf configured"
 
 
+#rng-tools tweaks
+echo ""
+echo "Configuring /etc/default/rng-tools..."
+echo "HRNGDEVICE=/dev/urandom" >> /etc/default/rng-tools
+service rng-tools restart | tee -a build.log
+catch_error $? "configuring rng-tools"
+echo "rng-tools configured"
+
+
 #Install tor repo, keyring and tor
 echo ""
 echo "Installing Tor..."


### PR DESCRIPTION
This commit allows rng-tools to work in virtual machines, and precludes the error 'Cannot find a hardware RNG device to use' or the following in build.log:

Starting Hardware RNG entropy gatherer daemon: (failed).
invoke-rc.d: initscript rng-tools, action "start" failed.

Some more info here: https://bugs.launchpad.net/ubuntu/+source/gnupg/+bug/706011
Might want to run this by the security/audit people.
