### PR TITLE
add explanation for disabling javascript

### DIFF
--- a/securedrop/source_templates/howto-disable-js.html
+++ b/securedrop/source_templates/howto-disable-js.html
@@ -1,10 +1,16 @@
 {% extends "base.html" %}
 {% block body %}
-<p>Here are instructions for disabling Javascript depending on your browser.</p>
-<h1>Firefox</h1>
-<p>There are two ways to disable Javascript in Firefox.</p>
-  <h2>NoScript</h2>
-  <p>We recommend installing the NoScript add-on, which allows you to disable Javascript with various levels of granularity and also protects against other common web exploits. To use NoScript to disable Javascript globally:</p>
+<div class="info">
+<h1 id="why">Why disable Javascript?</h1>
+<p>Javascript is a widely used programming language for creating interactive web pages. In recent years, it has become nearly ubiquitous and most browsers enable it by default as a result.</p>
+<p>Unfortunately, Javascript is also a common source of security vulnerabilities in browsers. A Javascript exploit was used by the FBI-deployed August 2013 Tor Freedom Hosting malware to de-anonymize Tor users (http://www.wired.com/threatlevel/2013/09/freedom-hosting-fbi/). Javascript exploits are also mentioned in documents describing the NSA's "Egotistical Giraffe" program (http://www.theguardian.com/world/interactive/2013/oct/04/egotistical-giraffe-nsa-tor-document), which also has the goal of targeting and de-anonymizing Tor users.</p>
+<p>Given these trends, we encourage Securedrop users to disable Javascript to protect themselves from malware that would use it to attack their browser and potentially de-anonymize them. Javascript is not the only potential source of such exploits, but given its use in recent attacks, we believe it is prudent to disable it at this time. Current and future work, especially in the realm of browser sandboxing, presents another path to mitigating these attacks that would allow sites to use Javascript without concern. Securedrop may choose to use Javascript (and discontinue this recommendation) in future versions, but for now we do not believe the security tradeoff is worth it.</p>
+<h1 id="how">How?</h1>
+<h2>Firefox</h2>
+<p>There are two ways to disable Javascript in Firefox. We recommend installing the NoScript add-on, which allows you to disable Javascript with various levels of granularity and also protects against other common web exploits.</p>
+<p>If you are using the Tor Browser Bundle, NoScript is installed (but not set to block Javascript) by default. To set it block all Javascript, simply click the NoScript icon <img src="/static/i/no16.png"/> to the left of the address bar above and choose "Forbid Scripts Globally (advised)".</p>
+  <h3>NoScript</h3>
+  <p>To install NoScript, and use it to block Javascript by default:</p>
   <ol>
     <li>Visit the NoScript download page (https://addons.mozilla.org/en-US/firefox/addon/noscript).</li>
     <li>Click the green <strong>Add to Firefox</strong> button. Wait for the add-on to download.</li>
@@ -12,18 +18,19 @@
     <li>In the dialog that says <strong>This add-on will be installed after you restart Firefox</strong>, click <strong>Restart Now</strong>.</li>
     <li>Now all Javascript is blocked by default, except for scripts from a small set of "whitelisted" sites. To learn more about using NoScript, visit the website (http://noscript.net), which automatically pops up when you first restart Firefox after installation.</li>
   </ol>
-  <h2>about:config</h2>
+  <h3>about:config</h3>
   <p>If you don't want to install an add-on, it is also possible to disable Javascript in Firefox's settings. Unfortunately, starting with Firefox 23, Mozilla removed the "Enable Javascript" checkbox in Firefox's preferences. However, you can still disable Javascript by following these steps:</p>
   <ol>
-    <li>In a new tab, type or paste <strong>about:config</strong> in the address bar and press Enter. Click the button promising to be careful.</li> 
+    <li>In a new tab, type or paste <strong>about:config</strong> in the address bar and press Enter. Click the button promising to be careful.</li>
     <li>In the filter box, type or paste <strong>java</strong> and pause while the list is filtered.</li>
     <li>Double-click <strong>javascript.enabled</strong> to switch it from true to false.</li>
   </ol>
-<h1>Chromium/Google Chrome</h1>
+<h2>Chromium/Google Chrome</h2>
 <ol>
   <li>Type <strong>chrome://settings</strong> into the URL bar and press Enter.</li>
   <li>Scroll to the bottom of the settings page and click <strong>Show advanced settings...</strong></li>
   <li>Scroll to the <strong>Privacy</strong> section and click <strong>Content Settings...</strong></li>
   <li>In the section labeled <strong>JavaScript</strong>, choose <strong>Do not allow any site to run JavaScript</strong>, then click the <strong>Done</strong> button.</li>
 </ol>
+</div>
 {% endblock %}

--- a/securedrop/static/css/securedrop.css
+++ b/securedrop/static/css/securedrop.css
@@ -51,6 +51,31 @@ h2{
   margin-bottom:20px;
 }
 
+div.info h1 {
+  font-size:28px;
+  font-weight:bold;
+  line-height:1.4em;
+  margin-bottom:16px;
+}
+
+div.info h2 {
+  font-size:24px;
+  font-weight:bold;
+  line-height:1.4em;
+  margin-bottom:16px;
+}
+
+div.info h3 {
+  font-size:18px;
+  font-weight:bold;
+  line-height:1.4em;
+  margin-bottom:16px;
+}
+
+div.info ol {
+  margin-bottom:20px;
+}
+
 code {
   /* shamelessly stolen from Github */
   color:rgb(51, 51, 51);

--- a/securedrop/static/js/warn.js
+++ b/securedrop/static/js/warn.js
@@ -11,9 +11,10 @@ function is_likely_tor_browser() {
 function warn_user(messageDiv) {
   display_error(
     '<b>WARNING:</b> Your browser currently has Javascript enabled. ' +
-    '<a id="disable-js-anchor" href="/howto-disable-js">Click here</a> ' +
+    '<a id="disable-js-anchor" href="/howto-disable-js#how">Click here</a> ' +
     'to learn how to disable it, or ignore this warning to continue.<br>' +
-    '<strong>We recommend disabling Javascript to protect your anonymity.</strong>'
+    '<strong>We recommend disabling Javascript to protect your anonymity. </strong>' +
+    '<a href="/howto-disable-js#why">Learn more &raquo;</a>'
   );
 }
 


### PR DESCRIPTION
Improves the links in the warning popup so they go right to the intended
content. Cleans up the styles on the info page. Closes #190.
