### PR TITLE
removes validation for ATHS users

### DIFF
--- a/install_files/validate_CONFIG_OPTIONS
+++ b/install_files/validate_CONFIG_OPTIONS
@@ -79,7 +79,6 @@ validate_CONFIG_OPTIONS() {
         validate_email $EMAIL_FROM
     fi
     if [ "$ROLE" = 'app' ]; then
-        validate_user_exists $JOURNALIST_USERS
         validate_KEY
         validate_file_exists $SOURCE_SCRIPTS
         validate_file_exists $DOCUMENT_SCTIPTS


### PR DESCRIPTION
The authenticated tor hidden service user names for the document interface do not need to be valid OS system users. Removes validate_user_exists check for the journalist usernames. Fixes #265
