### PR TITLE
Fix typo in x-xss-protection header

### DIFF
--- a/install_files/document.site
+++ b/install_files/document.site
@@ -22,7 +22,7 @@ Header edit Set-Cookie ^(.*)$ $;HttpOnly
 Header set Pragma "no-cache"
 Header set Expires "-1"
 Header always append X-Frame-Options: DENY
-Header set X-XSS-Protection: "1; mode-block"
+Header set X-XSS-Protection: "1; mode=block"
 Header set X-Content-Type-Options: nosniff
 Header set X-download-Options: noopen
 Header set X-Content-Security-Policy: "default-src 'self'"

--- a/install_files/source.site
+++ b/install_files/source.site
@@ -22,7 +22,7 @@ Header edit Set-Cookie ^(.*)$ $;HttpOnly
 Header set Pragma "no-cache"
 Header set Expires "-1"
 Header always append X-Frame-Options: DENY
-Header set X-XSS-Protection: "1; mode-block"
+Header set X-XSS-Protection: "1; mode=block"
 Header set X-Content-Type-Options: nosniff
 Header set X-Content-Security-Policy: "default-src 'self'"
 Header set X-Download-Options: noopen


### PR DESCRIPTION
Noticed this one while checking out ProPublica's live SD instance. 
