### PR TITLE
added defaultcharset to apache global config

### DIFF
--- a/install_files/document.apache2.conf
+++ b/install_files/document.apache2.conf
@@ -15,7 +15,7 @@ MaxRequestsPerChild   500
 </IfModule>
 User document
 Group document
-
+AddDefaultCharset utf-8
 AccessFileName .htaccess
 <Files ~ \"^\.ht\">
 Order allow,deny

--- a/install_files/source.apache2.conf
+++ b/install_files/source.apache2.conf
@@ -15,7 +15,7 @@ MaxRequestsPerChild   500
 </IfModule>
 User source
 Group source
-
+AddDefaultCharset utf-8
 AccessFileName .htaccess
 <Files ~ \"^\.ht\">
 Order allow,deny


### PR DESCRIPTION
Added `AddDefaultCharset utf-8` to both the source and document interface apache2.conf files
related to issue #311
