### PR TITLE
Remove Flask-Testing dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - pip install --upgrade distribute
   - pip install -r securedrop/source-requirements.txt
   - pip install -r securedrop/document-requirements.txt
-  - pip install --allow-external twill --allow-unverified twill -r securedrop/test-requirements.txt
+  - pip install -r securedrop/test-requirements.txt
 before_script:
   - sudo apt-get install gnupg2 secure-delete python-dev haveged
   - cp securedrop/config/base.py.example securedrop/config/base.py

--- a/securedrop/test-requirements.txt
+++ b/securedrop/test-requirements.txt
@@ -1,3 +1,2 @@
 selenium==2.39.0
-Flask-Testing==0.4
 mock==1.0.1


### PR DESCRIPTION
In the unit tests, creates the self.app and self.client variables that were
being automatically created by Flask-Testing's TestCase.

Removes unnecessary (and inconsistently used) special status code asserts,
replaces them with standard lookups on the response.

Closes #317
