### PR TITLE
Don't set "no cache" headers in Flask

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -77,20 +77,6 @@ def get_docs(sid):
     return docs
 
 
-@app.after_request
-def no_cache(response):
-    """Minimize potential traces of site access by telling the browser not to
-    cache anything"""
-    no_cache_headers = {
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-        'Pragma': 'no-cache',
-        'Expires': '-1',
-    }
-    for header, header_value in no_cache_headers.iteritems():
-        response.headers.add(header, header_value)
-    return response
-
-
 @app.route('/')
 def index():
     sources = Source.query.order_by(Source.last_updated.desc()).all()

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -102,20 +102,6 @@ def check_tor2web():
               "header-warning")
 
 
-@app.after_request
-def no_cache(response):
-    """Minimize potential traces of site access by telling the browser not to
-    cache anything"""
-    no_cache_headers = {
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-        'Pragma': 'no-cache',
-        'Expires': '-1',
-    }
-    for header, header_value in no_cache_headers.iteritems():
-        response.headers.add(header, header_value)
-    return response
-
-
 @app.route('/')
 def index():
     return render_template('index.html')


### PR DESCRIPTION
These headers are set by Apache, according to the {source,document}.site
configuration files, in production. They are unnecessary in development.
Therefore, setting these headers in Flask is redundant (and could potentially
cause conflicts with the Apache configuration, especially if they diverge in
the future).
