### PR TITLE
Add rng-tools and config to speed up keygen for dev/ci

### DIFF
--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -19,7 +19,7 @@ EOS
 SOURCE_ROOT=$(dirname $0)
 
 securedrop_root=$(pwd)/.securedrop
-DEPENDENCIES="gnupg2 secure-delete haveged python-dev python-pip sqlite python-distutils-extra python-poppler rng-tools"
+DEPENDENCIES="gnupg2 secure-delete haveged python-dev python-pip sqlite python-distutils-extra python-poppler"
 
 while getopts "r:uh" OPTION; do
     case $OPTION in


### PR DESCRIPTION
Trying @aegis's idea with rng-tools. Closes #280.
