### PR TITLE
Provide additional informations to keep the tests from hanging.

### DIFF
--- a/securedrop/HACKING.md
+++ b/securedrop/HACKING.md
@@ -19,6 +19,7 @@ ports from the VM) at [http://localhost:8080] and the journalist site at
 
 To run tests:
 
+    Make sure to shutdown source.py and journalist.py if they are running
     $ cd /vagrant/securedrop
     $ ./test.sh
 


### PR DESCRIPTION
```
If journalist.py and source.py are running it interferes with the test
test_submit_and_retrieve_happy_path. The docs suggest that this is
possible.
```
