### PR TITLE
Fixes #353: When the session identifier is changed, logout the user

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -115,6 +115,7 @@ def generate():
         if number_words not in range(7, 11):
             abort(403)
     session['codename'] = crypto_util.genrandomid(number_words)
+    session.pop('logged_in', None)
     # TODO: make sure this codename isn't a repeat
     return render_template('generate.html', codename=session['codename'])
 


### PR DESCRIPTION
When on the source generate page, the codename is regenerated on each
request. If the user had a previous session codename is it overwritten,
but they are still considered logged in. If they attempt to hit that
page again the session will be looked up because they are logged in.

This approach ensures that the user is logged out when regenerating the
codename by destroying the logged_in flag in the session.
