### PR TITLE
Fixed hanging functional tests when starting vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.provision :shell,
-    inline: "sudo -u vagrant /vagrant/setup_dev.sh -r '/home/vagrant/.securedrop' -u"
+    inline: "sudo -H -u vagrant /vagrant/setup_dev.sh -r '/home/vagrant/.securedrop' -u"
   config.vm.network "forwarded_port", guest: 8080, host: 8080
   config.vm.network "forwarded_port", guest: 8081, host: 8081
   config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
When setup_dev.sh was ran by vagrant, it used "sudo -u vagrant" to run as the correct user.

sudo was not setting the home directory, so when firefox started it tried to create a profile in "/root/.mozilla" while running as the "vagrant" user. It didn't have permission to do so and hung, not responding to webdriver.

Adding the -H option forces sudo to set the correct home directory, and fixes the problem.

Follow up tasks:
- always keep firefox logs to aid debugging
- have functional tests fail gracefully when firefox stops responding

closes #368
