### PR TITLE
added the additional MAT depends to the document-interface pip reqs

### DIFF
--- a/securedrop/document-requirements.txt
+++ b/securedrop/document-requirements.txt
@@ -14,3 +14,7 @@ gnupg-securedrop==1.2.5-9-g6f9d63a-dirty
 scrypt==0.6.1
 wsgiref==0.1.2
 https://mat.boum.org/files/mat-0.4.2.tar.gz
+hachoir-core==1.3.3
+hachoir-parser==1.3.4
+mutagen==1.22
+pdfrw==0.1


### PR DESCRIPTION
added the additional MAT depends to the document-interface pip requirments even though the documnet interface doesn't use the MAT.

journalist.py imports store.py which imports MAT, MAT required  the additional packages. hachoir-core hachoir-parser mutagen pdfrw
