### PR TITLE
Filters for journalist interface

### DIFF
--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -77,9 +77,10 @@ class Source(Base):
         except AttributeError:
             self.docs_msgs_count = {'messages': 0, 'documents': 0}
             for submission in self.submissions:
-                if submission.filename.endswith('msg.gpg'):
+                doc_or_msg = submission.document_or_message()
+                if doc_or_msg == "message":
                     self.docs_msgs_count['messages'] += 1
-                elif submission.filename.endswith('doc.zip.gpg'):
+                elif doc_or_msg == "document":
                     self.docs_msgs_count['documents'] += 1
             return self.docs_msgs_count
 
@@ -101,6 +102,13 @@ class Submission(Base):
 
     def __repr__(self):
         return '<Submission %r>' % (self.filename)
+
+    def document_or_message(self):
+        if self.filename.endswith('msg.gpg') or self.filename.endswith('reply.gpg'):
+            return "message"
+        elif self.filename.endswith('doc.zip.gpg'):
+            return "document"
+        return "unknown"
 
 class SourceStar(Base):
     __tablename__ = 'source_stars'

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -92,6 +92,7 @@ class Submission(Base):
     filename = Column(String(255), nullable=False)
     size = Column(Integer, nullable=False)
     downloaded = Column(Boolean, default=False)
+    starred = Column(Boolean, default=False)
 
     def __init__(self, source, filename):
         self.source_id = source.id

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -84,6 +84,11 @@ class Source(Base):
                     self.docs_msgs_count['documents'] += 1
             return self.docs_msgs_count
 
+    def starred(self):
+        if self.star and self.star.starred:
+            return True
+        return False
+
 
 class Submission(Base):
     __tablename__ = 'submissions'

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -131,18 +131,12 @@ def submission_add_star(fn):
 
 @app.route('/')
 def index():
-    unstarred = []
-    starred = []
-    for source in Source.query.filter_by(pending=False).order_by(Source.last_updated.desc()).all():
-        star = SourceStar.query.filter(SourceStar.source_id == source.id).first()
-        if star and star.starred:
-            starred.append(source)
-        else:
-            unstarred.append(source)
+    sources = Source.query.filter_by(pending=False).order_by(Source.last_updated.desc()).all()
+    for source in sources:
         source.num_unread = len(
             Submission.query.filter(Submission.source_id == source.id, Submission.downloaded == False).all())
 
-    return render_template('index.html', unstarred=unstarred, starred=starred)
+    return render_template('index.html', sources=sources)
 
 
 @app.route('/col/<sid>')

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -144,10 +144,10 @@ def index():
 @app.route('/col/<sid>')
 def col(sid):
     source = get_source(sid)
-    docs = get_docs(sid)
+    submissions = get_docs(sid)
     haskey = crypto_util.getkey(sid)
     return render_template("col.html", sid=sid,
-                           codename=source.journalist_designation, docs=docs, haskey=haskey,
+                           codename=source.journalist_designation, submissions=submissions, haskey=haskey,
                            flagged=source.flagged)
 
 

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -117,16 +117,16 @@ def remove_star(sid):
     db_session.commit()
     return redirect(url_for('index'))
 
-@app.route('/col/submission_remove_star/<fn>', methods=('POST',))
-def submission_remove_star(fn):
-    submission = Submission.query.filter(Submission.filename==fn).one()
+@app.route('/col/submission_remove_star/<filename>', methods=('POST',))
+def submission_remove_star(filename):
+    submission = Submission.query.filter(Submission.filename==filename).one()
     submission.starred = False
     db_session.commit()
     return redirect('/col/' + submission.source.filesystem_id)
 
-@app.route('/col/submission_add_star/<fn>', methods=('POST',))
-def submission_add_star(fn):
-    submission = Submission.query.filter(Submission.filename==fn).one()
+@app.route('/col/submission_add_star/<filename>', methods=('POST',))
+def submission_add_star(filename):
+    submission = Submission.query.filter(Submission.filename==filename).one()
     submission.starred = True
     db_session.commit()
     return redirect('/col/' + submission.source.filesystem_id)

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -81,7 +81,9 @@ def get_docs(sid):
             name=filename,
             date=datetime.fromtimestamp(os_stat.st_mtime),
             size=os_stat.st_size,
-            starred=submissions_dict[filename].starred
+            starred=submissions_dict[filename].starred,
+            downloaded=submissions_dict[filename].downloaded,
+            type=submissions_dict[filename].document_or_message()
         ))
     # sort in chronological order
     docs.sort(key=lambda x: int(x['name'].split('-')[0]))
@@ -144,18 +146,8 @@ def col(sid):
     source = get_source(sid)
     docs = get_docs(sid)
     haskey = crypto_util.getkey(sid)
-
-    # separate out starred and unstarred docs
-    unstarred = []
-    starred = []
-    for doc in docs:
-        if doc['starred']:
-            starred.append(doc)
-        else:
-            unstarred.append(doc)
-
     return render_template("col.html", sid=sid,
-                           codename=source.journalist_designation, unstarred=unstarred, starred=starred, haskey=haskey,
+                           codename=source.journalist_designation, docs=docs, haskey=haskey,
                            flagged=source.flagged)
 
 

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -4,15 +4,39 @@
   <p class="breadcrumbs"><a href="/">All Sources</a> <i class="fa fa-chevron-right"></i> <strong>{{ codename }}</strong></p>
   <hr class="no-line" />
 
-  {% if docs %}
+  {% if starred or unstarred %}
     <p>The documents are stored encrypted for security. To read them, you will need to decrypt them using PGP.</p>
     <div class="document-actions">
       <div id='select-container'></div>
     </div>
     <form action="/bulk" method="post">
+      <p class="fa starred_title">Starred</p>
       <ul id="submissions" class="plain submissions">
-        {% for doc in docs %}
-          <li class="submission"><input type="checkbox" name="doc_names_selected" value="{{ doc.name }}" class="doc-check"/>
+        {% for doc in starred %}
+          <li class="submission">
+            <button class="button-star starred" type="submit" formaction="/col/submission_remove_star/{{ doc.name }}"><i class="fa fa-star"></i></button>
+            <input type="checkbox" name="doc_names_selected" value="{{ doc.name }}" class="doc-check"/>
+            {% if doc.name.endswith('reply.gpg') %}
+              <span class="file reply"><span class="filename">{{ doc.name }}</span></span>
+              <span class="info" title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }} sent {{ doc.date|datetimeformat }}</span>
+            {% else %}
+              <span class="file"><a class="btn small" href="/col/{{ sid }}/{{ doc.name }}"><i class="fa fa-download"></i> <span class="filename">{{ doc.name }}</span></a></span>
+              <span class="info" title="{{ doc.size }} bytes" >{{ doc.size|filesizeformat }} uploaded {{ doc.date|datetimeformat }}</span>
+            {% endif %}
+            {% if doc.name.endswith('-doc.zip.gpg') %}
+              <i class="fa fa-file-archive-o pull-right"></i>
+            {% else %}
+              <i class="fa fa-file-text-o pull-right"></i>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+      <p class="fa starred_title">Un-Starred</p>
+      <ul id="unstarred_submissions" class="plain submissions">
+        {% for doc in unstarred %}
+          <li class="submission">
+            <button class="button-star un-starred" type="submit" formaction="/col/submission_add_star/{{ doc.name }}"><i class="fa fa-star"></i></button>
+            <input type="checkbox" name="doc_names_selected" value="{{ doc.name }}" class="doc-check"/>
             {% if doc.name.endswith('reply.gpg') %}
               <span class="file reply"><span class="filename">{{ doc.name }}</span></span>
               <span class="info" title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }} sent {{ doc.date|datetimeformat }}</span>

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -1,50 +1,54 @@
 {% extends "base.html" %}
 {% block body %}
+<script type='text/x-underscore-template' id='filter_block'>
+  Show me this sources
+  <select id='type'>
+    <option value='both'>both documents and messages</option>
+    <option value='documents'>documents</option>
+    <option value='messages'>messages</option>
+  </select>
+  which are
+  <select id='read_status'>
+    <option value='both'>both read and unread</option>
+    <option value='read'>read</option>
+    <option value='unread'>unread</option>
+  </select>,
+  and
+  <select id='starred_status'>
+    <option value='both'>both starred and unstarred</option>
+    <option value='starred'>starred</option>
+    <option value='unstarred'>unstarred</option>
+  </select>
+</script>
+
 <div id="content" class="journalist-view-single">
   <p class="breadcrumbs"><a href="/">All Sources</a> <i class="fa fa-chevron-right"></i> <strong>{{ codename }}</strong></p>
   <hr class="no-line" />
 
-  {% if starred or unstarred %}
+  {% if docs %}
     <p>The documents are stored encrypted for security. To read them, you will need to decrypt them using PGP.</p>
     <div class="document-actions">
       <div id='select-container'></div>
     </div>
     <form action="/bulk" method="post">
-      <p class="fa starred_title">Starred</p>
+      <div id='filter-container'></div>
       <ul id="submissions" class="plain submissions">
-        {% for doc in starred %}
-          <li class="submission">
-            <button class="button-star starred" type="submit" formaction="/col/submission_remove_star/{{ doc.name }}"><i class="fa fa-star"></i></button>
+        {% for doc in docs %}
+          <li class="submission" data-starred="{% if doc['starred'] %}starred{% else %}unstarred{% endif %}" data-read="{% if doc['downloaded'] %}read{% else %}unread{% endif %}" data-type="{% if doc['type'] == "document" %}document{% else %}message{% endif %}">
+            {% if doc['starred'] %}
+              <button class="button-star starred" type="submit" formaction="/col/submission_remove_star/{{ doc.name }}"><i class="fa fa-star"></i></button>
+            {% else %}
+              <button class="button-star un-starred" type="submit" formaction="/col/submission_add_star/{{ doc.name }}"><i class="fa fa-star"></i></button>
+            {% endif %}
             <input type="checkbox" name="doc_names_selected" value="{{ doc.name }}" class="doc-check"/>
             {% if doc.name.endswith('reply.gpg') %}
-              <span class="file reply"><span class="filename">{{ doc.name }}</span></span>
+              <span class="file reply"><span class="filename {% if not doc['downloaded'] %}unread{% endif %}">{{ doc.name }}</span></span>
               <span class="info" title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }} sent {{ doc.date|datetimeformat }}</span>
             {% else %}
-              <span class="file"><a class="btn small" href="/col/{{ sid }}/{{ doc.name }}"><i class="fa fa-download"></i> <span class="filename">{{ doc.name }}</span></a></span>
+              <span class="file"><a class="btn small" href="/col/{{ sid }}/{{ doc.name }}"><i class="fa fa-download"></i> <span class="filename {% if not doc['downloaded'] %}unread{% endif %}">{{ doc.name }}</span></a></span>
               <span class="info" title="{{ doc.size }} bytes" >{{ doc.size|filesizeformat }} uploaded {{ doc.date|datetimeformat }}</span>
             {% endif %}
-            {% if doc.name.endswith('-doc.zip.gpg') %}
-              <i class="fa fa-file-archive-o pull-right"></i>
-            {% else %}
-              <i class="fa fa-file-text-o pull-right"></i>
-            {% endif %}
-          </li>
-        {% endfor %}
-      </ul>
-      <p class="fa starred_title">Un-Starred</p>
-      <ul id="unstarred_submissions" class="plain submissions">
-        {% for doc in unstarred %}
-          <li class="submission">
-            <button class="button-star un-starred" type="submit" formaction="/col/submission_add_star/{{ doc.name }}"><i class="fa fa-star"></i></button>
-            <input type="checkbox" name="doc_names_selected" value="{{ doc.name }}" class="doc-check"/>
-            {% if doc.name.endswith('reply.gpg') %}
-              <span class="file reply"><span class="filename">{{ doc.name }}</span></span>
-              <span class="info" title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }} sent {{ doc.date|datetimeformat }}</span>
-            {% else %}
-              <span class="file"><a class="btn small" href="/col/{{ sid }}/{{ doc.name }}"><i class="fa fa-download"></i> <span class="filename">{{ doc.name }}</span></a></span>
-              <span class="info" title="{{ doc.size }} bytes" >{{ doc.size|filesizeformat }} uploaded {{ doc.date|datetimeformat }}</span>
-            {% endif %}
-            {% if doc.name.endswith('-doc.zip.gpg') %}
+            {% if doc.type == "document" %}
               <i class="fa fa-file-archive-o pull-right"></i>
             {% else %}
               <i class="fa fa-file-text-o pull-right"></i>
@@ -56,8 +60,8 @@
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
       <input type="hidden" name="sid" value="{{ sid }}" autocomplete="off"/>
       <div class="document-actions">
-        <button type="submit" name="action" value="download"><i class="fa fa-download"></i> Download selected</button>
-        <button type="submit" name="action" value="delete" class="danger"><i class="fa fa-times"></i> Delete selected</button>
+        <button type="submit" id="download_submissions" name="action" value="download"><i class="fa fa-download"></i> Download selected</button>
+        <button type="submit" id="delete_submissions" name="action" value="delete" class="danger"><i class="fa fa-times"></i> Delete selected</button>
       </div>
     </form>
   {% else %}

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -25,7 +25,7 @@
   <p class="breadcrumbs"><a href="/">All Sources</a> <i class="fa fa-chevron-right"></i> <strong>{{ codename }}</strong></p>
   <hr class="no-line" />
 
-  {% if docs %}
+  {% if submissions %}
     <p>The submissions are stored encrypted for security. To read them, you will need to decrypt them using PGP.</p>
     <div class="document-actions">
       <div id='select-container'></div>

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block body %}
-<script type='text/x-underscore-template' id='filter_block'>
-  Show me this sources
+<script type='text/x-jquery-template' id='filter_block'>
+  Show me this source's
   <select id='type'>
     <option value='both'>both documents and messages</option>
     <option value='documents'>documents</option>
@@ -26,29 +26,29 @@
   <hr class="no-line" />
 
   {% if docs %}
-    <p>The documents are stored encrypted for security. To read them, you will need to decrypt them using PGP.</p>
+    <p>The submissions are stored encrypted for security. To read them, you will need to decrypt them using PGP.</p>
     <div class="document-actions">
       <div id='select-container'></div>
     </div>
     <form action="/bulk" method="post">
       <div id='filter-container'></div>
       <ul id="submissions" class="plain submissions">
-        {% for doc in docs %}
-          <li class="submission" data-starred="{% if doc['starred'] %}starred{% else %}unstarred{% endif %}" data-read="{% if doc['downloaded'] %}read{% else %}unread{% endif %}" data-type="{% if doc['type'] == "document" %}document{% else %}message{% endif %}">
-            {% if doc['starred'] %}
-              <button class="button-star starred" type="submit" formaction="/col/submission_remove_star/{{ doc.name }}"><i class="fa fa-star"></i></button>
+        {% for submission in submissions %}
+          <li class="submission" data-starred="{% if submission['starred'] %}starred{% else %}unstarred{% endif %}" data-read="{% if submission['downloaded'] %}read{% else %}unread{% endif %}" data-type="{% if submission['type'] == "document" %}document{% else %}message{% endif %}">
+            {% if submission['starred'] %}
+              <button class="button-star starred" type="submit" formaction="/col/submission_remove_star/{{ submission.name }}"><i class="fa fa-star"></i></button>
             {% else %}
-              <button class="button-star un-starred" type="submit" formaction="/col/submission_add_star/{{ doc.name }}"><i class="fa fa-star"></i></button>
+              <button class="button-star un-starred" type="submit" formaction="/col/submission_add_star/{{ submission.name }}"><i class="fa fa-star"></i></button>
             {% endif %}
-            <input type="checkbox" name="doc_names_selected" value="{{ doc.name }}" class="doc-check"/>
-            {% if doc.name.endswith('reply.gpg') %}
-              <span class="file reply"><span class="filename {% if not doc['downloaded'] %}unread{% endif %}">{{ doc.name }}</span></span>
-              <span class="info" title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }} sent {{ doc.date|datetimeformat }}</span>
+            <input type="checkbox" name="doc_names_selected" value="{{ submission.name }}" class="doc-check"/>
+            {% if submission.name.endswith('reply.gpg') %}
+              <span class="file reply"><span class="filename {% if not submission['downloaded'] %}unread{% endif %}">{{ submission.name }}</span></span>
+              <span class="info" title="{{ submission.size }} bytes">{{ submission.size|filesizeformat }} sent {{ submission.date|datetimeformat }}</span>
             {% else %}
-              <span class="file"><a class="btn small" href="/col/{{ sid }}/{{ doc.name }}"><i class="fa fa-download"></i> <span class="filename {% if not doc['downloaded'] %}unread{% endif %}">{{ doc.name }}</span></a></span>
-              <span class="info" title="{{ doc.size }} bytes" >{{ doc.size|filesizeformat }} uploaded {{ doc.date|datetimeformat }}</span>
+              <span class="file"><a class="btn small" href="/col/{{ sid }}/{{ submission.name }}"><i class="fa fa-download"></i> <span class="filename {% if not submission['downloaded'] %}unread{% endif %}">{{ submission.name }}</span></a></span>
+              <span class="info" title="{{ submission.size }} bytes" >{{ submission.size|filesizeformat }} uploaded {{ submission.date|datetimeformat }}</span>
             {% endif %}
-            {% if doc.type == "document" %}
+            {% if submission.type == "document" %}
               <i class="fa fa-file-archive-o pull-right"></i>
             {% else %}
               <i class="fa fa-file-text-o pull-right"></i>
@@ -65,7 +65,7 @@
       </div>
     </form>
   {% else %}
-    <p><br />No documents to display.</p>
+    <p><br />No submissions to display.</p>
   {% endif %}
 
   <hr class="cut-out" />

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -1,5 +1,21 @@
 {% extends "base.html" %}
 {% block body %}
+<script type='text/x-underscore-template' id='filter_block'>
+  Show me sources which have
+  <select id='read_status'>
+    <option value='both'>both read and unread</option>
+    <option value='read'>all read</option>
+    <option value='unread'>unread</option>
+  </select>
+  documents,
+  <select id='starred_status'>
+    <option value='both'>both starred and unstarred</option>
+    <option value='starred'>starred</option>
+    <option value='unstarred'>unstarred</option>
+  </select>,
+  with a codename containing
+  <input id="codename" type="text" placeholder="anything" autofocus >
+</script>
 <div id="content" class="journalist-view-all">
 <h2><span class="headline">Sources</span></h2>
 {% if unstarred or starred %}
@@ -11,7 +27,7 @@
         {% for source in starred %}
           {% set docs = source.documents_messages_count()['documents'] %}
           {% set msgs = source.documents_messages_count()['messages'] %}
-          <li class="source" data-source-designation="{{ source.journalist_designation|lower }}">
+          <li class="source" data-source-designation="{{ source.journalist_designation|lower }}" data-starred="starred" data-read="{% if source.num_unread > 0 %}unread{% else %}read{% endif %}">
             <div class="date">{{ source.last_updated|datetimeformat }}</div>
             <div class="designation">
               <button class="button-star starred" type="submit" formaction="/col/remove_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
@@ -22,8 +38,8 @@
               <span><i class="fa fa-file-archive-o"></i> {{ docs }} docs</span>
               <span><i class="fa fa-file-text-o"></i> {{ msgs }} messages</span>
               {% if source.num_unread > 0 %}
-                <span class="unread">
-                  <a class="btn small" href='/download_unread/{{ source.filesystem_id }}'><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
+                <span class="unread" data-sid="{{ source.filesystem_id }}">
+                  <a class="btn small" data-sid="{{ source.filesystem_id }}" href='/download_unread/{{ source.filesystem_id }}'><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
                 </span>
               {% endif %}
             </div>
@@ -36,7 +52,7 @@
         {% for source in unstarred %}
           {% set docs = source.documents_messages_count()['documents'] %}
           {% set msgs = source.documents_messages_count()['messages'] %}
-          <li class="source" data-source-designation="{{ source.journalist_designation|lower }}">
+          <li class="source" data-source-designation="{{ source.journalist_designation|lower }}" data-starred="unstarred" data-read="{% if source.num_unread > 0 %}unread{% else %}read{% endif %}">
             <div class="date">{{ source.last_updated|datetimeformat }}</div>
             <div class="designation">
               <button class="button-star un-starred" type="submit" formaction="/col/add_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
@@ -47,8 +63,8 @@
               <span><i class="fa fa-file-archive-o"></i> {{ docs }} docs</span>
               <span><i class="fa fa-file-text-o"></i> {{ msgs }} messages</span>
               {% if source.num_unread > 0 %}
-                <span class="unread">
-                  <a class="btn small" href='/download_unread/{{ source.filesystem_id }}' ><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
+                <span class="unread" data-sid="{{ source.filesystem_id }}">
+                  <a class="btn small" data-sid="{{ source.filesystem_id }}" href='/download_unread/{{ source.filesystem_id }}'><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
                 </span>
               {% endif %}
             </div>
@@ -58,8 +74,8 @@
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
       <p>
         <button type="submit" id="delete_collections" name="action" value="delete" class="small"><i class="fa fa-minus-circle"></i> Delete selected</button>
-        <button type="submit" name="action" value="star" class="small"><i class="fa fa-minus-circle"></i> Star Selected</button>
-        <button type="submit" name="action" value="un-star" class="small"><i class="fa fa-minus-circle"></i> Un-star Selected</button>
+        <button type="submit" id="star_collections" name="action" value="star" class="small"><i class="fa fa-minus-circle"></i> Star Selected</button>
+        <button type="submit" id="unstar_collections" name="action" value="un-star" class="small"><i class="fa fa-minus-circle"></i> Un-star Selected</button>
         <span id="select_all" class="select"><i class="fa fa-check-square-o"></i> select all</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> select none</span>
       </p>
     </form>

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body %}
-<script type='text/x-underscore-template' id='filter_block'>
+<script type='text/x-jquery-template' id='filter_block'>
   Show me sources which have
   <select id='read_status'>
     <option value='both'>both read and unread</option>

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -18,19 +18,22 @@
 </script>
 <div id="content" class="journalist-view-all">
 <h2><span class="headline">Sources</span></h2>
-{% if unstarred or starred %}
+{% if sources %}
   <p>Here are the various collections of documents that have been submitted, with the most recently updated first:</p>
   <div id='filter-container'></div>
     <form id="process_collections" action="/col/process" method="post">
       <ul id="cols" class="plain">
-        <p class="fa starred-title">Starred</p>
-        {% for source in starred %}
+        {% for source in sources %}
           {% set docs = source.documents_messages_count()['documents'] %}
           {% set msgs = source.documents_messages_count()['messages'] %}
-          <li class="source" data-source-designation="{{ source.journalist_designation|lower }}" data-starred="starred" data-read="{% if source.num_unread > 0 %}unread{% else %}read{% endif %}">
+          <li class="source" data-source-designation="{{ source.journalist_designation|lower }}" data-starred="{% if source.star and source.star.starred %}starred{% else %}unstarred{% endif %}" data-read="{% if source.num_unread > 0 %}unread{% else %}read{% endif %}">
             <div class="date">{{ source.last_updated|datetimeformat }}</div>
             <div class="designation">
-              <button class="button-star starred" type="submit" formaction="/col/remove_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
+              {% if source.star and source.star.starred %}
+                <button class="button-star starred" type="submit" formaction="/col/remove_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
+              {% else %}
+                <button class="button-star un-starred" type="submit" formaction="/col/add_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
+              {% endif %}
               <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
               <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="starred-source-link-{{loop.index}}">{{ source.journalist_designation }}</a></span>
             </div>
@@ -47,30 +50,6 @@
         {% endfor %}
       </ul>
 
-      <ul id="cols" class="plain">
-        <p class="fa">Un-Starred</p>
-        {% for source in unstarred %}
-          {% set docs = source.documents_messages_count()['documents'] %}
-          {% set msgs = source.documents_messages_count()['messages'] %}
-          <li class="source" data-source-designation="{{ source.journalist_designation|lower }}" data-starred="unstarred" data-read="{% if source.num_unread > 0 %}unread{% else %}read{% endif %}">
-            <div class="date">{{ source.last_updated|datetimeformat }}</div>
-            <div class="designation">
-              <button class="button-star un-starred" type="submit" formaction="/col/add_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
-              <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
-              <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="un-starred-source-link-{{loop.index}}">{{ source.journalist_designation }}</a></span>
-            </div>
-            <div class="submission-count">
-              <span><i class="fa fa-file-archive-o"></i> {{ docs }} docs</span>
-              <span><i class="fa fa-file-text-o"></i> {{ msgs }} messages</span>
-              {% if source.num_unread > 0 %}
-                <span class="unread" data-sid="{{ source.filesystem_id }}">
-                  <a class="btn small" data-sid="{{ source.filesystem_id }}" href='/download_unread/{{ source.filesystem_id }}'><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
-                </span>
-              {% endif %}
-            </div>
-          </li>
-        {% endfor %}
-      </ul>
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
       <p>
         <button type="submit" id="delete_collections" name="action" value="delete" class="small"><i class="fa fa-minus-circle"></i> Delete selected</button>

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -7,7 +7,7 @@
   <div id='filter-container'></div>
     <form id="process_collections" action="/col/process" method="post">
       <ul id="cols" class="plain">
-        <p class="fa">Starred</p>
+        <p class="fa starred-title">Starred</p>
         {% for source in starred %}
           {% set docs = source.documents_messages_count()['documents'] %}
           {% set msgs = source.documents_messages_count()['messages'] %}

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -26,7 +26,7 @@
         {% for source in sources %}
           {% set docs = source.documents_messages_count()['documents'] %}
           {% set msgs = source.documents_messages_count()['messages'] %}
-          <li class="source" data-source-designation="{{ source.journalist_designation|lower }}" data-starred="{% if source.star and source.star.starred %}starred{% else %}unstarred{% endif %}" data-read="{% if source.num_unread > 0 %}unread{% else %}read{% endif %}">
+          <li class="source" data-source-designation="{{ source.journalist_designation|lower }}" data-starred="{% if source.starred() %}starred{% else %}unstarred{% endif %}" data-read="{% if source.num_unread > 0 %}unread{% else %}read{% endif %}">
             <div class="date">{{ source.last_updated|datetimeformat }}</div>
             <div class="designation">
               {% if source.star and source.star.starred %}

--- a/securedrop/static/css/styles.css
+++ b/securedrop/static/css/styles.css
@@ -339,6 +339,10 @@ p#codename {
   width: 250px;
 }
 
+#filter-container{
+  text-align: left;
+}
+
 #cols {
   padding: 0;
 }
@@ -534,4 +538,8 @@ p.breadcrumbs {
 
 .fa.starred_title:nth-child(1){
   margin-top: 40px;
+}
+
+.filename.unread{
+  font-weight: bold;
 }

--- a/securedrop/static/css/styles.css
+++ b/securedrop/static/css/styles.css
@@ -417,6 +417,7 @@ p#codename {
 
 .submissions {
   padding-left: 0px;
+  margin-bottom: 40px;
 }
 .submission {
   background: #f3f3f3;
@@ -524,4 +525,13 @@ p.breadcrumbs {
 
 .button-star:focus {
     outline:0;
+}
+
+.fa.starred_title{
+  text-align: left;
+  display: block;
+}
+
+.fa.starred_title:nth-child(1){
+  margin-top: 40px;
 }

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -3,8 +3,8 @@
  * confusing users, this function dyanamically adds elements that require JS.
  */
 function enhance_ui() {
-  // Add the "quick filter" box for sources
-  $('div#filter-container').html('<input id="filter" type="text" placeholder="filter by codename" autofocus >');
+  // Add the filter block for sources
+  $('div#filter-container').html($('#filter_block').html());
 
   // Add the "select {all,none}" buttons
   $('div#select-container').html('<span id="select_all" class="select"><i class="fa fa-check-square-o"></i> select all</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> select none</span>');
@@ -23,9 +23,6 @@ $(function () {
   all.click( function() { checkboxes.prop('checked', true); });
   none.click( function() { checkboxes.prop('checked', false); });
 
-  $("#delete_collection").submit(function () {
-    return confirm("Are you sure you want to delete this collection?");
-  });
   $("#delete_collections").click(function () {
     var num_checked = 0;
 
@@ -45,21 +42,49 @@ $(function () {
     return false;
   });
 
-  $("#unread a").click(function(){
-    $("#unread").html("unread: 0");
+  // don't star/unstar invisible collections
+  $("#star_collections, #unstar_collections").click(function(){
+    $('ul#cols li:not(:visible) :checkbox').attr('checked', false)
+    return true;
   });
 
-  var filter_codenames = function(value){
-    if(value == ""){
-      $('ul#cols li').show()
-    } else {
+  $("span.unread a").click(function(){
+    sid = $(this).data('sid');
+    $("span.unread[data-sid='" + sid + "']").remove();
+  });
+
+  var filter = function(){
+    var codename = $('#codename').val()
+    var starred_status = $('#starred_status').val()
+    var read_status = $('#read_status').val()
+
+    $('ul#cols li').show()
+
+    if(codename != ""){
       $('ul#cols li').hide()
-      $('ul#cols li[data-source-designation*="' + value.replace(/"/g, "").toLowerCase() + '"]').show()
+      $('ul#cols li[data-source-designation*="' + codename.replace(/"/g, "").toLowerCase() + '"]').show()
     }
+
+    if(starred_status == "starred"){
+      $('ul#cols li[data-starred="unstarred"]').hide()
+    }
+    if(starred_status == "unstarred"){
+      $('ul#cols li[data-starred="starred"]').hide()
+    }
+
+    if(read_status == "read"){
+      $('ul#cols li[data-read="unread"]').hide()
+    }
+    if(read_status == "unread"){
+      $('ul#cols li[data-read="read"]').hide()
+    }
+
   }
 
-  $('#filter').keyup(function(){ filter_codenames(this.value) })
+  $('#codename').keyup(filter)
+  $('#starred_status').change(filter)
+  $('#read_status').change(filter)
 
-  filter_codenames($('#filter').val())
+  filter()
 
 });

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -23,6 +23,10 @@ $(function () {
   all.click( function() { checkboxes.prop('checked', true); });
   none.click( function() { checkboxes.prop('checked', false); });
 
+  $("#delete_collection").submit(function(){
+    return confirm("Are you sure you want to delete this collection?");
+  });
+
   $("#delete_collections").click(function () {
     var num_checked = 0;
 

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -64,6 +64,7 @@ $(function () {
 
       if(codename != ""){
         $('ul#cols li').hide()
+        // we need the replace here: if the user enters a '"' in the filter box, it will escape the data-source-designation attribute of this selection
         $('ul#cols li[data-source-designation*="' + codename.replace(/"/g, "").toLowerCase() + '"]').show()
       }
 

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -43,8 +43,8 @@ $(function () {
   });
 
   // don't star/unstar invisible collections
-  $("#star_collections, #unstar_collections").click(function(){
-    $('ul#cols li:not(:visible) :checkbox').attr('checked', false)
+  $("#star_collections, #unstar_collections, #delete_submissions, #download_submissions").click(function(){
+    $('ul li:not(:visible) :checkbox').attr('checked', false)
     return true;
   });
 
@@ -53,38 +53,77 @@ $(function () {
     $("span.unread[data-sid='" + sid + "']").remove();
   });
 
-  var filter = function(){
-    var codename = $('#codename').val()
-    var starred_status = $('#starred_status').val()
-    var read_status = $('#read_status').val()
+  if($('#content.journalist-view-all').length){
+    var filter = function(){
+      var codename = $('#codename').val()
+      var starred_status = $('#starred_status').val()
+      var read_status = $('#read_status').val()
 
-    $('ul#cols li').show()
+      $('ul#cols li').show()
 
-    if(codename != ""){
-      $('ul#cols li').hide()
-      $('ul#cols li[data-source-designation*="' + codename.replace(/"/g, "").toLowerCase() + '"]').show()
+      if(codename != ""){
+        $('ul#cols li').hide()
+        $('ul#cols li[data-source-designation*="' + codename.replace(/"/g, "").toLowerCase() + '"]').show()
+      }
+
+      if(starred_status == "starred"){
+        $('ul#cols li[data-starred="unstarred"]').hide()
+      }
+      if(starred_status == "unstarred"){
+        $('ul#cols li[data-starred="starred"]').hide()
+      }
+
+      if(read_status == "read"){
+        $('ul#cols li[data-read="unread"]').hide()
+      }
+      if(read_status == "unread"){
+        $('ul#cols li[data-read="read"]').hide()
+      }
+
     }
 
-    if(starred_status == "starred"){
-      $('ul#cols li[data-starred="unstarred"]').hide()
-    }
-    if(starred_status == "unstarred"){
-      $('ul#cols li[data-starred="starred"]').hide()
-    }
+    $('#codename').keyup(filter)
+    $('#starred_status').change(filter)
+    $('#read_status').change(filter)
 
-    if(read_status == "read"){
-      $('ul#cols li[data-read="unread"]').hide()
-    }
-    if(read_status == "unread"){
-      $('ul#cols li[data-read="read"]').hide()
-    }
-
+    filter()
   }
+  if($('#content.journalist-view-single').length){
+    var filter = function(){
+      var starred_status = $('#starred_status').val()
+      var read_status = $('#read_status').val()
+      var type = $('#type').val()
 
-  $('#codename').keyup(filter)
-  $('#starred_status').change(filter)
-  $('#read_status').change(filter)
+      $('ul#submissions li').show()
 
-  filter()
+      if(starred_status == "starred"){
+        $('ul#submissions li[data-starred="unstarred"]').hide()
+      }
+      if(starred_status == "unstarred"){
+        $('ul#submissions li[data-starred="starred"]').hide()
+      }
+
+      if(read_status == "read"){
+        $('ul#submissions li[data-read="unread"]').hide()
+      }
+      if(read_status == "unread"){
+        $('ul#submissions li[data-read="read"]').hide()
+      }
+
+      if(type == "documents"){
+        $('ul#submissions li[data-type="message"]').hide()
+      }
+      if(type == "messages"){
+        $('ul#submissions li[data-type="document"]').hide()
+      }
+
+    }
+
+    $('#type').change(filter)
+    $('#starred_status').change(filter)
+    $('#read_status').change(filter)
+
+    filter()
+  }
 
 });

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -53,6 +53,7 @@ $(function () {
     $("span.unread[data-sid='" + sid + "']").remove();
   });
 
+  // if we are on the index route, use this filter function
   if($('#content.journalist-view-all').length){
     var filter = function(){
       var codename = $('#codename').val()
@@ -88,6 +89,7 @@ $(function () {
 
     filter()
   }
+  // if we are on the single source route, use this filter function
   if($('#content.journalist-view-single').length){
     var filter = function(){
       var starred_status = $('#starred_status').val()


### PR DESCRIPTION
This is branched from https://github.com/freedomofpress/securedrop/pull/463, and resolves #464.  This adds filters for the journalist interface, both the overview of sources and list of documents.  It also makes sure that any souces / submissions that are not visible will not be deleted/starred/unstarred.  Only visible items will be acted upon.  This preserves the graceful degradation of both `index` and `col`.