### PR TITLE
Be consistent with naming the required Ubuntu release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ These computers should all physically be in your organization's office.
 
 ## Before You Begin
 
-Before beginning installation, you should have two servers running Ubuntu Server 12.04.3 LTS, each with the grsec kernel patches installed. If you don't yet have those computers configured, see additional documentation for [Preparing Ubuntu servers for installation](/docs/ubuntu_config.md).
+Before beginning installation, you should have two servers running Ubuntu Server 12.04.4 LTS (Precise Pangolin), each with the grsec kernel patches installed. If you don't yet have those computers configured, see additional documentation for [Preparing Ubuntu servers for installation](/docs/ubuntu_config.md).
 
 You will need a DVD with the latest version of the [Tails operating system](https://tails.boum.org/download/index.en.html) burned to it. Go [here for instructions](https://tails.boum.org/download/index.en.html) on how to download and burn Tails to a DVD.  You will only have to use this DVD once: After the first run from a Live DVD, you can create a Live USB to boot from instead. If you already have a Tails Live USB, you may skip this requirement. If you can't or don't want to burn a DVD, see the [Tails documentation](https://tails.boum.org/download/index.en.html) for alternative instructions.
 

--- a/docs/ubuntu_config.md
+++ b/docs/ubuntu_config.md
@@ -1,6 +1,6 @@
 # Preparing Ubuntu servers for installation
 
-The `App Server` and `Monitor Server` require [Ubuntu Server 12.04.4](http://releases.ubuntu.com/12.04/). Download the ISO, burn it to CDs, and begin installing it on each of these computers. The following setup process is the same for each server.
+The `App Server` and `Monitor Server` require [Ubuntu Server 12.04.4 LTS (Precise Pangolin)](http://releases.ubuntu.com/12.04/). Download the ISO, burn it to CDs, and begin installing it on each of these computers. The following setup process is the same for each server.
 
 After booting the the Ubuntu Server CD, select "Install Ubuntu Server".
 


### PR DESCRIPTION
Minor nitpick, but we should be consistent with naming the Ubuntu release required for SecureDrop.
