### PR TITLE
Explain "optionally GPG encrypt w/public key" better

### DIFF
--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -51,7 +51,7 @@
   <button type="submit" class="btn primary" href="upload.html"><i class="fa fa-cloud-upload"></i> Submit</button>
 </form>
 
-<p><strong>Tip:</strong> If you are already familiar with GPG, you can optionally encrypt your files and messages with <a href="/journalist-key" class="text-link">our public key</a> before submission. Files are encrypted as they are received by SecureDrop, but encrypting before submission can provide an extra layer of security. (<a href="/why-journalist-key" class="text-link">More information</a>.)</p>
+<p><strong>Tip:</strong> If you are already familiar with GPG, you can optionally encrypt your files and messages with <a href="/journalist-key" class="text-link">our public key</a> before submission. Files are encrypted as they are received by SecureDrop; encrypting before submission can provide an extra layer of security before your data reaches SecureDrop. (<a href="/why-journalist-key" class="text-link">More information</a>.)</p>
 
 <hr class="no-line"/>
 

--- a/securedrop/source_templates/why-journalist-key.html
+++ b/securedrop/source_templates/why-journalist-key.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block body %}
 <h2>Why download the journalist's public key?</h2>
-<p>SecureDrop already encrypts files and messages as they are submitted, but encrypting before submission can provide an extra layer of security before your file reaches the SecureDrop server.</p>
+<p>SecureDrop encrypts files and messages after they are submitted. Encrypting messages and files before submission can provide an extra layer of security before your data reaches the SecureDrop server.</p>
 <p>If you are already familiar with the GPG encryption software, you may wish to encrypt your submissions yourself. To do so:
 <ol>
 <li><a href="/journalist-key">Download</a> the public key. The public key is a text file with the extension <code>.asc</code></li>


### PR DESCRIPTION
I’ve found the existing footer text a bit confusing — "of course I want all the security!" would be most users’ reaction — since most people directed to SecureDrop at most media organizations won’t be GPG-savvy.

And since SD encrypts-on-receipt, we should let users know that since otherwise they might be scared that the files are unencrypted unless they take this optional GPG step.

I’ve also added a warning to the "why encrypt with public key" page about signing the encrypted file & how that reveals your keyid. (This has happened once or twice.)
