### PR TITLE
fix for #494: make codename length dropdown text ("7 words", "8 words"...) more consistent.

### DIFF
--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -14,8 +14,8 @@
       <select name="number-words" id="number-words">
         <option value="7">7 words</option>
         <option value="8" selected>8 words</option>
-        <option value="9">9</option>
-        <option value="10">10</option>
+        <option value="9">9 words</option>
+        <option value="10">10 words</option>
       </select>
       <button type="submit" id="regenerate-submit" class="small">
         <i class="fa fa-refresh"></i>


### PR DESCRIPTION
commit: f15c97fed5a8d76a941579869540cc4a51bc2caf
issue #494
