### PR TITLE
fix test_lookup (tests.test_unit.TestSource) failure due to wording change

### DIFF
--- a/securedrop/tests/test_unit.py
+++ b/securedrop/tests/test_unit.py
@@ -139,7 +139,7 @@ class TestSource(unittest.TestCase):
         rv = self.client.post('login', data=dict(codename=codename),
                               follow_redirects=True)
         # redirects to /lookup
-        self.assertIn("journalist's public key", rv.data)
+        self.assertIn("our public key", rv.data)
         # download the public key
         rv = self.client.get('journalist-key')
         self.assertIn("BEGIN PGP PUBLIC KEY BLOCK", rv.data)


### PR DESCRIPTION
fixes this:

```
======================================================================
FAIL: test_lookup (tests.test_unit.TestSource)
Test various elements on the /lookup page
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/vagrant/securedrop/tests/test_unit.py", line 142, in test_lookup
    self.assertIn("journalist's public key", rv.data)
AssertionError: "journalist's public key" not found in '<!DOCTYPE html>\n<html>\n  <head>\n    <title>SecureDrop | Protecting Journalists and Sources</title>\n    <link rel="stylesheet" href="/static/css/normalize.css" type="text/css" media="all" />\n    <link rel="stylesheet" href="/static/css/styles.css" type="text/css" media="all" />\n    <link rel="stylesheet" href="/static/css/font-awesome.css" type="text/css" media="all" />\n    <link rel="icon" type="image/png" href="/static/i/favicon.png" >\n    \n  </head>\n  <body>\n    \n\n  \n\n\n    <div class="content">\n      \n      <div id="header">\n        <a href="/"><img src="/static/i/logo.png" class="logo small" alt="SecureDrop"></a>\n        \n      </div>\n      \n\n      <div class="panel selected">\n        <hr class="no-line" />\n\n        \n\n<center>\n  <h2 class="headline">Submit documents and messages</h2>\n  <p>You can send a file, a message, or both.</p>\n\n  \n\n  \n    \n      <p class="flash notification">\n        \n        <i class="fa fa-info-circle pull-left"></i>\n        \n        There are no replies at this time. You can submit more documents from this code name below.\n      </p>\n    \n  \n\n\n\n\n  \n  \n\n  <hr class="no-line">\n</center>\n\n<form id="upload" method="post" action="/submit" enctype="multipart/form-data" autocomplete="off">\n  <input name="csrf_token" type="hidden" value="1406922782.35##60a499f60e6ee384320d727c2912169f1b0b4250"/>\n  <div class="snippet grid">\n    <div class="attachment grid-item">\n      <i class="fa fa-cloud-upload upload-icon"></i> <input type="file" name="fh" autocomplete="off">\n      <div class="file-options">\n        <input type="checkbox" id="notclean" name="notclean" value="True" />\n        <label for="notclean">Attempt to remove file metadata</label>\n      </div>\n    </div>\n    <div class="message grid-item">\n      <textarea name="msg" class="fill-parent" placeholder="Add message"></textarea>\n    </div>\n  </div>\n\n  <hr class="no-line">\n\n  <button type="submit" class="btn primary" href="upload.html"><i class="fa fa-cloud-upload"></i> Submit</button>\n</form>\n\n<p><strong>Tip:</strong> If you are already familiar with GPG, you can optionally encrypt your files and messages with <a href="/journalist-key" class="text-link">our public key</a> before submission. Files are encrypted as they are received by SecureDrop; encrypting before submission can provide an extra layer of security before your data reaches SecureDrop. (<a href="/why-journalist-key" class="text-link">More information</a>.)</p>\n\n<hr class="no-line"/>\n\n<div class="code-reminder">\n  <i class="fa fa-lock pull-left"></i> Remember, your codename is: <strong>sims ankle asset cabal rifle infix aida acts</strong>\n</div>\n\n</div>\n\n\n      </div>\n\n      \n      <footer>\n        Like all software, SecureDrop may contain security bugs. Use at your own risk. Powered by SecureDrop 0.2.1.\n      </footer>\n      \n    </div>\n  </body>\n</html>\n'
```

since wording was changed to "our public key" in #488
