### PR TITLE
Mask codename

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -274,7 +274,7 @@ def valid_codename(codename):
     return os.path.exists(store.path(crypto_util.hash_codename(codename)))
 
 @app.route('/login', methods=('GET', 'POST'))
-def login():
+def login(masked=False):
     if request.method == 'POST':
         codename = request.form['codename']
         if valid_codename(codename):
@@ -282,8 +282,14 @@ def login():
             return redirect(url_for('lookup', from_login='1'))
         else:
             flash("Sorry, that is not a recognized codename.", "error")
-    return render_template('login.html')
+    if masked:
+        return render_template('login_masked.html')
+    else:
+        return render_template('login.html')
 
+@app.route('/login_masked', methods=('GET', 'POST'))
+def login_masked():
+    return login(masked=True)
 
 @app.route('/howto-disable-js')
 def howto_disable_js():

--- a/securedrop/source_templates/login_masked.html
+++ b/securedrop/source_templates/login_masked.html
@@ -7,8 +7,8 @@
 
 <form method="post" action="/login" autocomplete="off">
 <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-<p class="center"><input type="text" name="codename" class="codename" autocomplete="off" placeholder="Enter your codename" autofocus /></p>
-<p class="center"><a href='/login_masked'>or click here to login without revealing your codename...</a></p>
+<p class="center"><input type="password" name="codename" class="codename" autocomplete="off" placeholder="Enter your codename" autofocus /></p>
+<p class="center"><a href='/login'>or click here for a login which displays your codename...</a></p>
 <p class="center"><button type="submit" class="btn block"><i class="fa fa-arrow-circle-o-right"></i> Continue</button></p>
 </form>
 {% endblock %}

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -54,7 +54,7 @@
 <hr class="no-line"/>
 
 <div class="code-reminder">
-  <i class="fa fa-lock pull-left"></i> Remember, your codename is (hover over to reveal): <strong id='codename'>{{ codename }}</strong>
+  <i class="fa fa-lock pull-left"></i> Remember, your codename is (select to reveal): <strong id='codename'>{{ codename }}</strong>
 </div>
 
 </div>

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -54,7 +54,7 @@
 <hr class="no-line"/>
 
 <div class="code-reminder">
-  <i class="fa fa-lock pull-left"></i> Remember, your codename is: <strong>{{ codename }}</strong>
+  <i class="fa fa-lock pull-left"></i> Remember, your codename is (hover over to reveal): <strong id='codename'>{{ codename }}</strong>
 </div>
 
 </div>

--- a/securedrop/static/css/styles.css
+++ b/securedrop/static/css/styles.css
@@ -333,6 +333,13 @@ p#codename {
   margin:0;
 }
 
+strong#codename{
+  background-color: black;
+}
+strong#codename:hover{
+  background-color: inherit;
+}
+
 #filter {
   font-family: monospace;
   padding: 5px;

--- a/securedrop/static/css/styles.css
+++ b/securedrop/static/css/styles.css
@@ -336,9 +336,6 @@ p#codename {
 strong#codename{
   background-color: black;
 }
-strong#codename:hover{
-  background-color: inherit;
-}
 
 #filter {
   font-family: monospace;


### PR DESCRIPTION
Fixes #525

Allow sources the option to log in with a new route, login_masked, which does not reveal their codename as they are typing it in.

Masks the codename on the submission page, revealing it with text select.