### PR TITLE
rng-tools hack for low entropy causing tests to time out on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,14 @@ python:
   - "2.7"
 virtualenv:
   system_site_packages: true
+# For more information about the nasty /dev/random hack, please see:
+# https://github.com/travis-ci/travis-ci/issues/1913#issuecomment-33891474
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install --yes dpkg-dev fakeroot lintian python-apt rng-tools
+  - sudo rm -f /dev/random
+  - sudo mknod -m 0666 /dev/random c 1 9
+  - echo HRNGDEVICE=/dev/urandom | sudo tee /etc/default/rng-tools
+  - sudo /etc/init.d/rng-tools restart
 script:
   - ./setup_dev.sh -u


### PR DESCRIPTION
Ugly but effective (Travis now runs in 3 minutes!) hack to fix the issues with Travis tests timing out due to low entropy on their VMs. Props to @xolox for sharing his .travis.yml!

Fixes #280
