### PR TITLE
Bugfix: Page Content shifts downward after refreshing in Chrome

### DIFF
--- a/securedrop/static/css/styles.css
+++ b/securedrop/static/css/styles.css
@@ -39,7 +39,6 @@ a {
 }
 
 .panel {
-  float: right;
   max-width: 800px;
   width: 100%;
   margin: 0 auto;
@@ -47,8 +46,9 @@ a {
   border: 1px solid #c3c3c3;
 }
 
-#header {
+#header, .panel {
   display: inline-block;
+  vertical-align: top;
 }
 #header .powered {
   margin-top: 10px;


### PR DESCRIPTION
## Issue

When refreshing the page from /generate, /login, and /lookup on the source service, the content gets shifted down. This does not happen on a hard refresh or navigating to the page.
Probably not a high priority as it's only in Chrome (bug not present in Firefox).

**Normal:**
![screen shot 2014-09-06 at 3 50 41 pm](https://cloud.githubusercontent.com/assets/3454429/4176572/25254b84-360b-11e4-9843-3912ba189db2.png)
**After Refresh:**
![screen shot 2014-09-06 at 3 51 09 pm](https://cloud.githubusercontent.com/assets/3454429/4176562/f1012922-360a-11e4-8faa-3d06f1031e5f.png)
## Fix

Removed the float right from `.panel`, then added `display: inline-block;` and `vertical-align: top;` to `#header` and `.panel`. Not a responsive solution, but it works for now.
