### PR TITLE
Catch when a users codename contains invalid characters

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -278,15 +278,14 @@ def login():
     if request.method == 'POST':
         codename = request.form['codename']
         try:
-            valid_codename(codename)
+            valid = valid_codename(codename)
         except crypto_util.CryptoException:
-            flash("Sorry, that codename contains invalid characters.", "error")
+            pass
         else:
-            if valid_codename(codename):
+            if valid:
                 session.update(codename=codename, logged_in=True)
                 return redirect(url_for('lookup', from_login='1'))
-            else:
-                flash("Sorry, that is not a recognized codename.", "error")
+        flash("Sorry, that is not a recognized codename.", "error")
     return render_template('login.html')
 
 


### PR DESCRIPTION
fixes #548. Catch the error produced when a user specifies a codename containing potentially dangerous characters, and flash that user an informative message.
