### PR TITLE
Format displayed timestamps in a more readable way.

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -177,7 +177,7 @@ def lookup():
             except UnicodeDecodeError:
                 app.logger.error("Could not decode reply %s" % fn)
             else:
-                date = datetime.fromtimestamp(os.stat(store.path(g.sid, fn)).st_mtime)
+                date = datetime.fromtimestamp(os.stat(store.path(g.sid, fn)).st_mtime).strftime("%b %d, %Y %I:%M %p")
                 replies.append(dict(id=fn, date=date, msg=msg))
 
     def async_genkey(sid, codename):


### PR DESCRIPTION
Aims to resolve #559 by formating the timestamps according to @garrettr's example. It might be better to display a relative time to the user and make the full timestamp visible on hover. It would save the user the trouble of parsing the time in their head.

e.g "about 4 hours ago"
