### PR TITLE
Fix logo display breaking onto a newline

### DIFF
--- a/securedrop/static/css/styles.css
+++ b/securedrop/static/css/styles.css
@@ -47,9 +47,8 @@ a {
   float: right;
 }
 
-#header, .panel {
-  display: inline-block;
-  vertical-align: top;
+#header {
+  float: left;
 }
 #header .powered {
   margin-top: 10px;


### PR DESCRIPTION
Hopefully fixes #569 which @micahflee noted was introduced in #542. I was starting to get worried. I've only looked at SecureDrop when it was displaying this bug, I was starting to think you all had no design sense at all :)

I've tested this briefly in Iceweasel and Chromium.  
