### PR TITLE
Don't show partially uploaded files on the /col view.

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -123,6 +123,11 @@ def index():
 def col(sid):
     source = get_source(sid)
     docs = get_docs(sid)
+    submissions = [submission.filename for submission in Submission.query.filter(Submission.source_id == source.id).all()]
+    # Only include documents loaded from the filesystem which are replies or which are also listed in the
+    # submissions table to avoid displaying partially uploaded files (#561).
+    docs = [doc for doc in docs if doc['name'] in submissions or doc['name'].endswith('reply.gpg')]
+
     haskey = crypto_util.getkey(sid)
     return render_template("col.html", sid=sid,
                            codename=source.journalist_designation, docs=docs, haskey=haskey,


### PR DESCRIPTION
Resolves #561. The local list of files is compared with the submissions list in
the database to remove files which are currently being uploaded
but which have not yet completed and added to the databases.

It will probably be necessary to implement some kind of clean
up mechanism for file uploads don't complete as they will no longer
show up for deletion on the journalist interface. 
