### PR TITLE
Added the hmac-sha1 to the allowed server ssh configs. 

### DIFF
--- a/install_files/app-hardening/etc/ssh/sshd_config
+++ b/install_files/app-hardening/etc/ssh/sshd_config
@@ -33,7 +33,7 @@ UseDNS no
 ClientAliveInterval 300
 ClientAliveCountMax 0
 Ciphers blowfish-cbc,aes256-cbc,aes256-ctr
-MACs hmac-sha2-256,hmac-sha2-512
+MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1
 GatewayPorts no
 AllowGroups ssh
 AllowTcpForwarding no

--- a/install_files/monitor-hardening/etc/ssh/sshd_config
+++ b/install_files/monitor-hardening/etc/ssh/sshd_config
@@ -33,7 +33,7 @@ UseDNS no
 ClientAliveInterval 300
 ClientAliveCountMax 0
 Ciphers blowfish-cbc,aes256-cbc,aes256-ctr
-MACs hmac-sha2-256,hmac-sha2-512
+MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1
 GatewayPorts no
 AllowGroups ssh
 AllowTcpForwarding no


### PR DESCRIPTION
Tails ssh client doesn't support hmac-sha2-256 or hmac-sha2-512 yet so added hmac-sha1 to the app and monitor servers ssh configs so that the admin can ssh from a tails host. Fixes #284 
