### PR TITLE
Fix TypeError in journalist.js

### DIFF
--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -60,6 +60,10 @@ $(function () {
 
   $('#filter').keyup(function(){ filter_codenames(this.value) })
 
-  filter_codenames($('#filter').val())
+  // Check if #filter exists by checking the .length of the jQuery selector
+  // http://stackoverflow.com/questions/299802/how-do-you-check-if-a-selector-matches-something-in-jquery
+  if ($('#filter').length) {
+    filter_codenames($('#filter').val())
+  }
 
 });


### PR DESCRIPTION
The quick filter dialog box was being checked on document load, even if
we were on pages (e.g. source collection pages) that don't have that
dialog box. This caused a TypeError, when we tried to match against an
undefined value from the non-existent dialog box.

Fixed by checking that the dialog box exists before calling
filter_codenames.

Fixes #598.
