### PR TITLE
Logo links to lookup view if source is logged in

### DIFF
--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -14,7 +14,7 @@
     <div class="content">
       {% block header %}
       <div id="header">
-        <a href="/"><img src="/static/i/{{ header_image }}" class="logo small" alt="SecureDrop"></a>
+        <a href="{% if 'logged_in' in session %}{{ url_for('lookup') }}{% else %}{{ url_for('index') }}{% endif %}"><img src="/static/i/{{ header_image }}" class="logo small" alt="SecureDrop"></a>
         {% if use_custom_header_image %}
         <div class="powered">
           Powered by<br/>


### PR DESCRIPTION
Currently, the logo always links to the index. This is a little bit
different from the standard web UX, where such a "home" link takes a
logged in user to their user-specific home page. I'm concerned that the
current behavior may lead to users being locked out of the account they
just created if they accidentally click it without having memorized or
recorded their codename.

This change checks if the user is logged in, and if so, makes the logo
link back to their lookup page, where they can make submissions and
receive replies.
