### PR TITLE
Better names for dirs in config

### DIFF
--- a/securedrop/config.py.example
+++ b/securedrop/config.py.example
@@ -18,13 +18,13 @@ class JournalistInterfaceFlaskConfig(FlaskConfig):
 # These files are in the same directory as config.py. Use absolute paths to
 # avoid potential problems with the test runner - otherwise, you have to be in
 # this directory when you run the code.
-CODE_ROOT = os.path.dirname(os.path.realpath(__file__))
+SECUREDROP_ROOT = os.path.dirname(os.path.realpath(__file__))
 
-SOURCE_TEMPLATES_DIR = os.path.join(CODE_ROOT, 'source_templates')
-JOURNALIST_TEMPLATES_DIR = os.path.join(CODE_ROOT, 'journalist_templates')
-WORD_LIST = os.path.join(CODE_ROOT, 'wordlist')
-NOUNS = os.path.join(CODE_ROOT, 'dictionaries/nouns.txt')
-ADJECTIVES = os.path.join(CODE_ROOT, './dictionaries/adjectives.txt')
+SOURCE_TEMPLATES_DIR = os.path.join(SECUREDROP_ROOT, 'source_templates')
+JOURNALIST_TEMPLATES_DIR = os.path.join(SECUREDROP_ROOT, 'journalist_templates')
+WORD_LIST = os.path.join(SECUREDROP_ROOT, 'wordlist')
+NOUNS = os.path.join(SECUREDROP_ROOT, 'dictionaries/nouns.txt')
+ADJECTIVES = os.path.join(SECUREDROP_ROOT, './dictionaries/adjectives.txt')
 
 JOURNALIST_PIDFILE = "/tmp/journalist.pid"
 SOURCE_PIDFILE = "/tmp/source.pid"
@@ -41,7 +41,7 @@ JOURNALIST_KEY = '{{ journalist_key }}'
 
 # Directory where SecureDrop stores the database file, GPG keyring, and
 # encrypted submissions.
-SECUREDROP_ROOT = '{{ securedrop_root }}'
+SECUREDROP_DATA_ROOT = '{{ securedrop_data_root }}'
 
 # Modify configuration for alternative environments
 env = os.environ.get('SECUREDROP_ENV') or 'prod'
@@ -59,20 +59,20 @@ elif env == 'test':
     # Disable CSRF checks for tests to make writing tests easier
     FlaskConfig.WTF_CSRF_ENABLED = False
     # TODO use a unique temporary directory for each test so we can parallelize them
-    SECUREDROP_ROOT = '/tmp/securedrop'
+    SECUREDROP_DATA_ROOT = '/tmp/securedrop'
 
-# The following configuration is dependent on SECUREDROP_ROOT
+# The following configuration is dependent on SECUREDROP_DATA_ROOT
 
 # Directory where encrypted submissions are stored
-STORE_DIR=os.path.join(SECUREDROP_ROOT, 'store')
+STORE_DIR=os.path.join(SECUREDROP_DATA_ROOT, 'store')
 
 # Directory where GPG keyring is stored
-GPG_KEY_DIR=os.path.join(SECUREDROP_ROOT, 'keys')
+GPG_KEY_DIR=os.path.join(SECUREDROP_DATA_ROOT, 'keys')
 
 # Database configuration
 # TODO we currently use sqlite in production since it is sufficient and simple,
 # but in the future may want to be able to choose a different database
 # depending on the environment
 DATABASE_ENGINE = 'sqlite'
-DATABASE_FILE = os.path.join(SECUREDROP_ROOT, 'db.sqlite')
+DATABASE_FILE = os.path.join(SECUREDROP_DATA_ROOT, 'db.sqlite')
 

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -67,9 +67,9 @@ def reset():
     """
     Clears the Securedrop development application's state, restoring it to the
     way it was immediately after running `setup_dev.sh`. This command:
-    1. Erases the development sqlite database file ($SECUREDROP_ROOT/db.sqlite)
+    1. Erases the development sqlite database file
     2. Regenerates the database
-    3. Erases stored submissions and replies from $SECUREDROP_ROOT/store
+    3. Erases stored submissions and replies from the store dir
     """
     import config
     import db

--- a/securedrop/tests/common.py
+++ b/securedrop/tests/common.py
@@ -8,12 +8,12 @@ import crypto_util
 
 
 def clean_root():
-    shutil.rmtree(config.SECUREDROP_ROOT)
+    shutil.rmtree(config.SECUREDROP_DATA_ROOT)
 
 
 def create_directories():
     # Create directories for the file store and the GPG keyring
-    for d in (config.SECUREDROP_ROOT, config.STORE_DIR, config.GPG_KEY_DIR):
+    for d in (config.SECUREDROP_DATA_ROOT, config.STORE_DIR, config.GPG_KEY_DIR):
         if not os.path.isdir(d):
             os.mkdir(d)
 

--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -7,9 +7,9 @@ set -e
 
 usage() {
   cat <<EOS
-Usage: setup_dev.sh [-uh] [-r SECUREDROP_ROOT]
+Usage: setup_dev.sh [-uh] [-r securedrop_data_root]
 
-   -r SECUREDROP_ROOT  # specify a root driectory for docs, keys etc.
+   -r securedrop_data_root  # specify a root driectory for docs, keys etc.
    -u                  # unaided execution of this script (useful for Vagrant)
    -h                  # This help message.
 
@@ -18,13 +18,13 @@ EOS
 
 SOURCE_ROOT=$(dirname $0)
 
-securedrop_root=/var/securedrop
+securedrop_data_root=/var/securedrop
 DEPENDENCIES="gnupg2 secure-delete haveged python-dev python-pip sqlite python-distutils-extra xvfb firefox gdb"
 
 while getopts "r:uh" OPTION; do
     case $OPTION in
         r)
-            securedrop_root=$OPTARG
+            securedrop_data_root=$OPTARG
             ;;
         u)
             UNAIDED_INSTALL=true
@@ -83,10 +83,10 @@ sudo pip install -r requirements/test-requirements.txt
 
 echo "Setting up configurations..."
 
-sudo mkdir -p $securedrop_root/{store,keys}
+sudo mkdir -p $securedrop_data_root/{store,keys}
 me=$(whoami)
-sudo chown -R $me:$me $securedrop_root
-keypath=$securedrop_root/keys
+sudo chown -R $me:$me $securedrop_data_root
+keypath=$securedrop_data_root/keys
 
 # avoid the "unsafe permissions on GPG homedir" warning
 chmod 700 $keypath
@@ -103,7 +103,7 @@ cp config.py.example config.py
 # fill in the instance-specific configuration
 # Use | instead of / for sed's delimiters, since some of the environment
 # variables are paths and contain /'s, which confuses sed.
-sed -i "s|{{ securedrop_root }}|$securedrop_root|" config.py
+sed -i "s|{{ securedrop_data_root }}|$securedrop_data_root|" config.py
 sed -i "s|{{ source_secret_key }}|$source_secret_key|" config.py
 sed -i "s|{{ journalist_secret_key }}|$journalist_secret_key|" config.py
 sed -i "s|{{ scrypt_id_pepper }}|$scrypt_id_pepper|" config.py


### PR DESCRIPTION
Previously, we used `SECUREDROP_ROOT` for the directory where all of the
data (db, submissions, keyring) was stored. This caused confusion, as it
sounds like it refers to the root of the web application
(`/vagrant/securedrop` or `/var/www/securedrop`, depending on dev or
prod).

Changed `CODE_ROOT` => `SECUREDROP_ROOT`
Changed `SECUREDROP_ROOT` => `SECUREDROP_DATA_ROOT`
