### PR TITLE
Add explanation for renaming sources to hover text

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -10,7 +10,7 @@
       <a href="/">All Sources</a>
       <i class="fa fa-chevron-right"></i>
       <strong>{{ codename }}</strong>
-      <button type="submit" title="Generate a new random codename for this source" class="plain" id="regenerate-codename-btn"><i class="fa fa-refresh"></i> <span id="regenerate-codename-btn-label">Change codename</span></button>
+      <button type="submit" title="Generate a new random codename for this source. We recommend doing this if the first random codename is difficult to say or remember. You can generate new random codenames as many times as you like." class="plain" id="regenerate-codename-btn"><i class="fa fa-refresh"></i> <span id="regenerate-codename-btn-label">Change codename</span></button>
     </p>
   </form>
 


### PR DESCRIPTION
This is a (partial?) fix for #558. It adds an explanation of why, as a journalist, you might want to change a particular source's codename. Since I recently re-worked the UI for re-generating codenames (in the manner of the "additional improvements" mentioned in #558), I've only added this additional explanation to the hover text of the "Change codename" link.

We should also, at a minimum, mention the reasoning for changing the codename in the documentation for journalists (`docs/user_manual.md`).
