### PR TITLE
Confirm before changing a source's journalist designation

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -2,7 +2,7 @@
 {% block body %}
 <div id="content" class="journalist-view-single">
 
-  <form action='/regenerate-code' method='post' id="regnerate-code">
+  <form action='/regenerate-code' method='post' id="regenerate-code">
     <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
     <input type="hidden" name="sid" value="{{ sid }}">
 

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -75,4 +75,9 @@ $(function () {
       return confirm("Are you sure to want to reset this user's two factor authentication?");
   });
 
+  // Confirm before changing a user's codename
+  $("form#regenerate-code").submit(function(event) {
+    return confirm("Are you sure you want to generate a new random codename for this source? You will not be able to return to using the previous codename.");
+  });
+
 });


### PR DESCRIPTION
Fixes #550. However, it displays the confirmation every time, which makes it annoying to use multiple times in a row (for example, if you were repeatedly cycling through random codenames until you got one that you liked).

The obvious solution here would be to add a checkbox to the dialog, something like "Don't ask me again" or "Always confirm before changing source codename". However, that would require creating a custom dialog with JS (there is no way to add a checkbox with Javascript's built-in `confirm` function). You would also want to fully support it by providing a prefs page for the journalist to change their selection in the future.

Given all of this, I'm inclined to target this for 0.4 or 0.3.x, and not 0.3. I don't think it's a major problem that we don't ask for confirmation before changing a source's journalist designation since it doesn't contain any useful information.

@runasand, @micahflee I would appreciate your input on this!
