### PR TITLE
Set SECUREDROP_ENV for development environment

### DIFF
--- a/install_files/ansible-base/roles/development/tasks/main.yml
+++ b/install_files/ansible-base/roles/development/tasks/main.yml
@@ -5,3 +5,10 @@
 
 - name: install pip deps for dev env
   pip: requirements="{{ dev_pip_requirements }}"
+
+- name: set SECUREDROP_ENV in bashrc
+  lineinfile:
+    dest: /home/{{ securedrop_user }}/.bashrc
+    state: present
+    insertafter: EOF
+    line: "export SECUREDROP_ENV=dev"


### PR DESCRIPTION
This makes running certain tasks manually, such as the individual
`source.py` or `journalist.py` applications, less error-prone. You need
to set `SECUREDROP_ENV=dev` in order to have `FlaskConfig.DEBUG = True`,
which is necessary for Flask to serve the static files.
