### PR TITLE
ansible over tor fixes

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,15 @@
+[defaults]
+# This was added so it doesn't confuse people running production why hosts were
+# skipped.
+display_skipped_hosts=False
+# After the initial installation ansible runs over tor required the ssh
+# modifications below to get it to not time out
+timeout=60
+
 [ssh_connection]
+# Ansible defaults to SFTP which is disabled in our sshd config.
 scp_if_ssh=True
+
+# More settings to improve ansible over tor
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ConnectTimeout=60
+pipelining=True

--- a/install_files/ansible-base/roles/common/files/sudoers
+++ b/install_files/ansible-base/roles/common/files/sudoers
@@ -24,6 +24,7 @@ root    ALL=(ALL:ALL) ALL
 
 # Allow members of group sudo to execute any command
 %sudo   ALL=(ALL) NOPASSWD: ALL
+Defaults:%sudo !requiretty
 
 # See sudoers(5) for more information on "#include" directives:
 


### PR DESCRIPTION
ansible.cfg
1. ansible defaults to using sftp which we have disabled in our config so had to change it to use scp
2. ssh connections kept timing out so we changed some of the timeouts. Will need to go back and test if these settings need to be adjusted any more
3. Enabled ssh pipelining [1]
- this required disabling requiretty for the sudo group.
  1. Disabled displaying the skipped hosts (build_securedrop_app_code, app-test...) so in production users would not be confused and think it was something was failing.
