### PR TITLE
temp removing building ossec deb from staging roles

### DIFF
--- a/install_files/ansible-base/securedrop-app-staging.yml
+++ b/install_files/ansible-base/securedrop-app-staging.yml
@@ -9,7 +9,7 @@
   roles:
     - common
     - build-securedrop-app-code-deb-pkg
-    - build-ossec-deb-pkg
+    #- build-ossec-deb-pkg
     - app
     - allow-direct-access
     - app-test

--- a/install_files/ansible-base/securedrop-mon-staging.yml
+++ b/install_files/ansible-base/securedrop-mon-staging.yml
@@ -8,7 +8,7 @@
 
   roles:
     - common
-    - build-ossec-deb-pkg
+    #- build-ossec-deb-pkg
     - mon
     - allow-direct-access
 


### PR DESCRIPTION
Building the ossec deb packages takes awhile and the ssh connection to the vm's are timing out during that process. 

Since the ossec deb packge does not change often and we are working on migrating to building with pbuilder commenting out that role in both staging playbooks.

The app/mon roles already are configured to install ossec from the fpf repo if it wasn't already installed so this will not break anything.
