### PR TITLE
 Up app-staging and app vm to 1GB

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,7 +54,13 @@ Vagrant.configure("2") do |config|
     end
     app_staging.vm.provider "virtualbox" do |v|
       v.name = "app-staging"
-    end
+      # Running the functional tests with Selenium/Firefox has started causing out-of-memory errors.
+      #
+      # This started around October 14th and was first observed on the task-queue branch. There are two likely causes:
+      # 1. The new job queue backend (redis) is taking up a signiicant amount of memory. According to top, it is not (a couple MB on average).
+      # 2. Firefox 33 was released on October 13th: https://www.mozilla.org/en-US/firefox/33.0/releasenotes/ It may require more memory than the previous version did.
+      v.memory = 1024
+     end
   end
 
   config.vm.define 'mon-staging', autostart: false do |mon_staging|
@@ -86,7 +92,13 @@ Vagrant.configure("2") do |config|
     end
     app.vm.provider "virtualbox" do |v|
       v.name = "app"
-    end
+      # Running the functional tests with Selenium/Firefox has started causing out-of-memory errors.
+      #
+      # This started around October 14th and was first observed on the task-queue branch. There are two likely causes:
+      # 1. The new job queue backend (redis) is taking up a signiicant amount of memory. According to top, it is not (a couple MB on average).
+      # 2. Firefox 33 was released on October 13th: https://www.mozilla.org/en-US/firefox/33.0/releasenotes/ It may require more memory than the previous version did.
+      v.memory = 1024
+     end
   end
 
   config.vm.define 'mon', autostart: false do |mon|


### PR DESCRIPTION
Upped the app-staging and app vm Vagrant config to 1GB for memory to avoid issues of running out of memory while running the tests.
