### PR TITLE
Password + TOTP as a ssh authentication option

### DIFF
--- a/install_files/ansible-base/group_vars/securedrop.yml
+++ b/install_files/ansible-base/group_vars/securedrop.yml
@@ -18,6 +18,9 @@ disabled_kernel_modules:
   - bluetooth
   - iwlwifi
 
+ssh_2fa_dependencies:
+  - libpam-google-authenticator
+
 sysctl_flags:
   - name: "net.ipv4.tcp_max_syn_backlog"
     value: "4096"

--- a/install_files/ansible-base/roles/common/files/sshd_config
+++ b/install_files/ansible-base/roles/common/files/sshd_config
@@ -18,6 +18,7 @@ IgnoreRhosts yes
 RhostsRSAAuthentication no
 HostbasedAuthentication no
 PermitEmptyPasswords no
+# This is needed for libpam-google-authenticator package for 2fa SSH access.
 ChallengeResponseAuthentication yes
 KerberosAuthentication no
 KerberosGetAFSToken no

--- a/install_files/ansible-base/roles/common/tasks/ssh.yml
+++ b/install_files/ansible-base/roles/common/tasks/ssh.yml
@@ -1,4 +1,8 @@
 ---
+- name: install 2fa pam module for ssh access
+  apt: name="{{ item }}" state=latest
+  with_items: ssh_2fa_dependencies
+
 - name: ensure ssh configuration files are present
   copy: src={{ item }} dest=/etc/ssh/{{ item }} owner=root mode=0644
   with_items:
@@ -7,10 +11,8 @@
   notify:
    - restart ssh
 
+- name: ensure pam config is installed
+  copy: src="common-auth" dest="/etc/pam.d/" owner=root mode=0644
+
 - name: ensure sshd is running
   service: name=ssh state=running
-
-### Disabling this task until we settle if we are going to use 2fa (password
-#and OTP or a ssh keyfile and out of band option
-#- name: ensure pam config is installed
-#  copy: src="common-auth" dest="/etc/pam.d/" owner=root mode=0644


### PR DESCRIPTION
This adds back the libpam-google-authenticator module for 2fa for ssh access.

This does not configure the users 2fa code. The admin users will need to run `google-authenticator` on each server prior to trying to authenticate without the ssh-keyfile

If a admin users 2fa secret file is not created and the user does not have the ssh-private key, they will just see a password prompt and will not be able to authenticate.

There are different errors shown if the pasword failed or if it was the 2fa code.

This does not disable ssh-key files. When you are authenticating via ssh-keyfile the 2fa pam module will not be used.
