### PR TITLE
re-added ansible handler to run postmap /etc/postfix/header_checks

### DIFF
--- a/install_files/ansible-base/roles/mon/handlers/main.yml
+++ b/install_files/ansible-base/roles/mon/handlers/main.yml
@@ -10,5 +10,8 @@
 - name: update sasl_passwd db
   command: postmap /etc/postfix/sasl_passwd
 
+- name: postmap_header_checks
+  command: postmap /etc/postfix/header_checks
+
 - name: restart postfix
   service: name=postfix state=restarted

--- a/install_files/ansible-base/roles/mon/tasks/mon_install_postfix.yml
+++ b/install_files/ansible-base/roles/mon/tasks/mon_install_postfix.yml
@@ -25,6 +25,7 @@
   copy:
     src: header_checks
     dest: /etc/postfix/header_checks
+  notify: postmap_header_checks
 
 - name: configure postfix main.cf
   template:


### PR DESCRIPTION
re-added handler for the ansible mon role to run postmap /etc/postfix/header_checks if the file changes.

This needs to run before restart postfix for it to take affect.
