### PR TITLE
Updated the grsec package name to current. a meta package will need to b...

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,7 +49,7 @@ Vagrant.configure("2") do |config|
     app_staging.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/site.yml"
       # options 'tor' 'grsec' 'iptables' 'ssh' 'tests' 'ossec' also takes an array
-      ansible.skip_tags = [ 'grsec' ]
+      #ansible.skip_tags = [ 'grsec' ]
       ansible.verbose = 'v'
     end
     app_staging.vm.provider "virtualbox" do |v|
@@ -72,7 +72,7 @@ Vagrant.configure("2") do |config|
     mon_staging.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/site.yml"
       # tags: 'tor' 'grsec' 'ssh' 'iptables' 'apparmor-complain' 'apparmor-enforce' 'tests' also takes an array
-      ansible.skip_tags = [ 'grsec' ]
+      #ansible.skip_tags = [ 'grsec' ]
       ansible.verbose = 'v'
     end
     mon_staging.vm.provider "virtualbox" do |v|

--- a/install_files/ansible-base/group_vars/securedrop.yml
+++ b/install_files/ansible-base/group_vars/securedrop.yml
@@ -9,7 +9,7 @@ tor_DataDirectory: /var/lib/tor
 securedrop_tor_user: "debian-tor"
 
 dns_server: "8.8.8.8"
-grsec_package: linux-image-3.2.62-grsec
+
 
 # this should be changed to use ansible facts
 distribution_release: "trusty"
@@ -61,9 +61,8 @@ sysctl_flags:
 grub_pax:
   - /usr/sbin/grub-probe
   - /usr/sbin/grub-mkdevicemap
-  - /usr/sbin/grub-setup
-  - /usr/bin/grub-script-check
-  - /usr/bin/grub-mount
+
+grsec_package: linux-image-3.14.21-grsec
 
 ### Used by the build-ossec-deb-pkg roles ###
 build_ossec_deb_pkg_dependencies:

--- a/install_files/ansible-base/roles/common/tasks/sysctl.yml
+++ b/install_files/ansible-base/roles/common/tasks/sysctl.yml
@@ -2,6 +2,10 @@
 - sysctl: name="{{ item.name }}" value="{{ item.value }}" sysctl_set=yes state=present reload=yes
   with_items: sysctl_flags
 
+- stat: path="/proc/sys/kernel/grsecurity/grsec_lock"
+  register: grsec_lock
+
 - sysctl: name=kernel.grsecurity.grsec_lock value=1 sysctl_set=yes state=present reload=yes
   tags:
     - grsec
+  when: grsec_lock.stat.exists


### PR DESCRIPTION
Updated the grsec package name to current. A meta package will need to be put created and hosted by fpf so we don't need to hard code a specific version

The grsec lock will not exist until the system is rebooted in the kernel.

Removed extra pax changes that were required for 12.04

Removed the grsec skip from vagrantfile
