### PR TITLE
removed ansible.skip_tags config line for app and mon vm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,8 +86,6 @@ Vagrant.configure("2") do |config|
     app.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
     app.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/site.yml"
-      # options 'ssh' 'iptables' 'tests' also takes an array
-      ansible.skip_tags = [ 'grsec' ] # options 'tor' 'grsec' 'ssh-hardening' 'iptables' 'tests' 'ossec' also takes an array
       ansible.verbose = 'v'
     end
     app.vm.provider "virtualbox" do |v|
@@ -107,8 +105,6 @@ Vagrant.configure("2") do |config|
     mon.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
     mon.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/site.yml"
-      # tags: 'tor' 'grsec' 'ssh' 'iptables' 'apparmor-compalin' 'apparmor-enforce' 'tests' also takes an array
-      ansible.skip_tags = [ 'grsec' ]
       ansible.verbose = 'v'
     end
     mon.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
removed ansible.skip_tags config line for app and mon vm that was skipping the grsec steps. This shouldn't affect testing since prod deployments do not use vagrant.
