### PR TITLE
added a validate role that would only be run when running non-staging or...

### DIFF
--- a/install_files/ansible-base/roles/validate/tasks/main.yml
+++ b/install_files/ansible-base/roles/validate/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+#This role is to check that development and staging defaults gpg info and
+#credentials are not used when running the app and mon playbooks for
+#production.
+
+- debug: msg="verifying ssh_users is not set to vagrant"
+  #always_run: true
+  failed_when: ssh_users.stdout == "vagrant"
+
+- debug: msg="verifying securedrop_app_gpg_fingerprint is not the journalist test key"
+  failed_when: securedrop_app_gpg_fingerprint == "65A1B5FF195B56353CC63DFFCC40EF1228271441"
+
+- debug: msg="verifying securedrop_app_gpg_fingerprint is not the admin test key"
+  failed_when: securedrop_app_gpg_fingerprint == "600BC6D5142C68F35DDBCEA87B597104EDDDC102"
+
+- debug: msg="verifying ossec_gpg_fpr is not the journalist test key"
+  failed_when: securedrop_app_gpg_fingerprint == "65A1B5FF195B56353CC63DFFCC40EF1228271441"
+
+- debug: msg="verifying ossec_gpg_fpr is not the admin test key"
+  failed_when: ossec_gpg_fpr == "600BC6D5142C68F35DDBCEA87B597104EDDDC102"
+
+- debug: msg="verifying ossec_alert_email is not the test value"
+  failed_when: ossec_alert_email == "ossec@ossec.test"
+
+- debug: msg="verifying sasl_username is not test value"
+  failed_when: sasl_username == "test"
+
+- debug: msg="verifying sasl_password is not the insane test value"
+  failed_when: sasl_password == "password123"

--- a/install_files/ansible-base/securedrop-app.yml
+++ b/install_files/ansible-base/securedrop-app.yml
@@ -9,6 +9,7 @@
   vars:
 
   roles:
+    - validate
     - common
     - app
 

--- a/install_files/ansible-base/securedrop-mon.yml
+++ b/install_files/ansible-base/securedrop-mon.yml
@@ -7,6 +7,7 @@
     - prod-specific.yml
 
   roles:
+    - validate
     - common
     - mon
 


### PR DESCRIPTION
... development playbooks.

This role verifies that the development/testing gpg keys, ossec alert email address, and sasl credentials are not used for production
