### PR TITLE
fix custom header image

### DIFF
--- a/install_files/ansible-base/development-specific.yml
+++ b/install_files/ansible-base/development-specific.yml
@@ -16,6 +16,7 @@ app_ip: "10.0.1.2"
 securedrop_code: "/vagrant/securedrop"
 # The securedrop_header_image has to be in the install_files/ansible-base/ or
 # the install_files/ansible-base/roles/app/files/ directory
+# Leave set to None to use the SecureDrop logo.
 securedrop_header_image: "None"
 # The app gpg public key has to be in the install_files/ansible-base/ or
 # install_files/ansible-base/roles/app/files/ directory

--- a/install_files/ansible-base/prod-specific.yml
+++ b/install_files/ansible-base/prod-specific.yml
@@ -13,7 +13,8 @@ securedrop_user: "www-data"
 securedrop_code: "/var/www/securedrop"
 # The securedrop_header_image has to be in the install_files/ansible-base/ or
 # the install_files/ansible-base/roles/app/files/ directory
-securedrop_header_image: ""
+# Leave set to None to use the SecureDrop logo.
+securedrop_header_image: "None"
 # The app gpg public key has to be in the install_files/ansible-base/ or
 # install_files/ansible-base/roles/app/files/ directory
 securedrop_app_gpg_public_key: ""

--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -101,16 +101,12 @@
   # If using a custom header overwrite the existing one
   # dpkg will not override it on upgrades
   # otherwise will need to templatizing the apparmor profile
-- name: check to see if header file is present
-  stat: path="{{ securedrop_header_image }}"
-  register: header
-
-- name: if header file is present copy interface header to web app path
+- name: if header file variable is defined copy interface header to web app path
   copy:
     src: "{{ securedrop_header_image }}"
-    dest: "{{ securedrop_code }}/static/i/securedrop.png"
+    dest: "{{ securedrop_code }}/static/i/logo.png"
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
     mode: 400
     backup: yes
-  when: header.stat.exists
+  when: securedrop_header_image != "None"

--- a/install_files/ansible-base/staging-specific.yml
+++ b/install_files/ansible-base/staging-specific.yml
@@ -16,6 +16,7 @@ app_ip: "10.0.1.2"
 securedrop_code: "/var/www/securedrop"
 # The securedrop_header_image has to be in the install_files/ansible-base/ or
 # the install_files/ansible-base/roles/app/files/ directory
+# Leave set to None to use the SecureDrop logo.
 securedrop_header_image: "None"
 # The app gpg public key has to be in the install_files/ansible-base/ or
 # install_files/ansible-base/roles/app/files/ directory

--- a/install_files/ansible-base/travis-specific.yml
+++ b/install_files/ansible-base/travis-specific.yml
@@ -7,6 +7,7 @@ securedrop_repo: "{{ lookup('env', 'TRAVIS_BUILD_DIR') }}"
 securedrop_code: "{{ securedrop_repo }}/securedrop"
 # The securedrop_header_image has to be in the install_files/ansible-base/ or
 # the install_files/ansible-base/roles/app/files/ directory
+# Leave set to None to use the SecureDrop logo.
 securedrop_header_image: "None"
 # The app gpg public key has to be in the install_files/ansible-base/ or
 # install_files/ansible-base/roles/app/files/ directory


### PR DESCRIPTION
If a custom header image was defined ansible was overwriting the wrong image.

also changed the way the header image tasks worked to just check if the variable was defined.
