### PR TITLE
remove temp travis fix for config.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ script:
   # on Travis. I believe Travis' service machinery may be interfering. See
   # http://docs.travis-ci.com/user/database-setup/#Redis
 - sudo service redis-server start
+  # travis needs the config.py file ran owned by root in other environments it is the
+  # securedrop_user default www-data
+- sudo chown root:root securedrop/config.py
 - sudo sh -c "export DISPLAY=:1; cd securedrop && ./manage.py test"
 notifications:
   slack:

--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -11,6 +11,10 @@
 - name: import app gpg public key
   command: "su -s /bin/bash -c \"gpg --homedir {{ securedrop_data }}/keys --import {{ securedrop_data }}/{{ securedrop_app_gpg_public_key }}\" {{ securedrop_user }}"
 
+  # only a config.py.example is included in the securedrop-app-code package. If
+  # a config.py file is not already present copy the one installed by the
+  # securedrop-app-code package. This was done so the securedrop-app-code
+  # package would not overwrite the config.py on upgrades.
 - stat: path="{{ securedrop_code }}/config.py"
   register: config
 
@@ -18,12 +22,12 @@
   command: "cp {{ securedrop_code }}/config.py.example {{ securedrop_code }}/config.py"
   when: not config.stat.exists
 
-#- name: ensure config.py is owned by www-data
-#  file:
-#    dest: "{{ securedrop_code }}/config.py"
-#    owner: "{{ securedrop_user }}"
-#    group: "{{ securedrop_user }}"
-#    mode: 666
+- name: ensure config.py is owned by www-data
+  file:
+    dest: "{{ securedrop_code }}/config.py"
+    owner: "{{ securedrop_user }}"
+    group: "{{ securedrop_user }}"
+    mode: 0600
 
 # TODO: config.py.example is already written using Jinja2 format, and should be
 # easy to template-ize. However, we cannot do this because when Ansible writes


### PR DESCRIPTION
We put in a temp fix for travis previously so the config.py file could be owned by root so travis would work. This pr removes the temp fix and moves it to the travis script where it will not affect production installs.
