### PR TITLE
iptables rule fixes for prod mon server

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,7 +83,9 @@ Vagrant.configure("2") do |config|
   config.vm.define 'app', autostart: false do |app|
     app.vm.hostname = "app"
     app.vm.box = "trusty64"
+    app.vm.network "private_network", ip: "10.0.1.4", virtualbox__intnet: true
     app.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+    app.vm.synced_folder './', '/vagrant', disabled: true
     app.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/site.yml"
       ansible.verbose = 'v'
@@ -102,7 +104,9 @@ Vagrant.configure("2") do |config|
   config.vm.define 'mon', autostart: false do |mon|
     mon.vm.box = "mon"
     mon.vm.box = "trusty64"
+    mon.vm.network "private_network", ip: "10.0.1.5", virtualbox__intnet: true
     mon.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+    mon.vm.synced_folder './', '/vagrant', disabled: true
     mon.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/site.yml"
       ansible.verbose = 'v'

--- a/install_files/ansible-base/group_vars/securedrop.yml
+++ b/install_files/ansible-base/group_vars/securedrop.yml
@@ -8,9 +8,6 @@ tor_user: debian-tor
 tor_DataDirectory: /var/lib/tor
 securedrop_tor_user: "debian-tor"
 
-dns_server: "8.8.8.8"
-
-
 # this should be changed to use ansible facts
 distribution_release: "trusty"
 

--- a/install_files/ansible-base/prod-specific.yml
+++ b/install_files/ansible-base/prod-specific.yml
@@ -1,6 +1,7 @@
 ---
 ### Used by the common role ###
 ssh_users: ""
+dns_server: "8.8.8.8"
 
 # TODO Should use ansible to gather this info
 monitor_ip: ""

--- a/install_files/ansible-base/roles/mon/templates/mon_rules_v4
+++ b/install_files/ansible-base/roles/mon/templates/mon_rules_v4
@@ -43,9 +43,15 @@
 -A OUTPUT -d {{ app_hostname }} -p udp --sport 1514 -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow OSSEC agent to monitor"
 
 # OSSEC smtp out rules
-#TODO restrict outbound by process owner
--A OUTPUT -p tcp --match multiport --dports 25,587,465 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow ossec email alerts out"
--A INPUT -p tcp --match multiport --sports 25,587,465 -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow ossec email alerts out"
+# dns rule for postfix to lookup smtp relay
+-A OUTPUT -d {{ dns_server }} -p tcp --dport 53 -m owner --uid-owner postfix -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "postfix dns rule"
+-A INPUT -s {{ dns_server }} -p tcp --sport 53 -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "tcp/udp dns"
+-A OUTPUT -d {{ dns_server }} -p udp --dport 53 -m owner --uid-owner postfix -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "postfix dns rule"
+-A INPUT -s {{ dns_server }} -p udp --sport 53 -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "tcp/udp dns"
+
+# postfix rule for outbound smtp
+-A OUTPUT -p tcp --dport {{ smtp_relay_port }} -m owner --uid-owner postfix -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow ossec email alerts out"
+-A INPUT -p tcp --sport {{ smtp_relay_port }}  -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow ossec email alerts out"
 
 # Allow generic loopback connections
 -A INPUT -i lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"

--- a/install_files/ansible-base/staging-specific.yml
+++ b/install_files/ansible-base/staging-specific.yml
@@ -2,6 +2,7 @@
 ### General (used by more than one role) ###
 securedrop_repo: "/vagrant"
 securedrop_user: "www-data"
+dns_server: "8.8.8.8"
 
 ### Used by the common role ###
 ssh_users: "vagrant"


### PR DESCRIPTION
added the uid to output rules for sending smtp
changed the hard coded port in the mon iptables rules to use the smtp_relay_port variable instead
added IP addresses for the app and mon vm in the vagrant file
moved defining the dns IP to the environment specific yml files and removed it from the global variable yml file
