### PR TITLE
reduce ossec spam

### DIFF
--- a/install_files/ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/ossec-agent/var/ossec/etc/ossec.conf
@@ -40,6 +40,9 @@
     <ignore>/var/ossec/var</ignore>
     <ignore>/etc/motd</ignore>
 
+    <ignore>/etc/apparmor.d/cache/.features</ignore>
+    <ignore>/etc/blkid.tab</ignore>
+
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
     <ignore>/etc/mnttab</ignore>

--- a/install_files/ossec-server/var/ossec/etc/ossec.conf
+++ b/install_files/ossec-server/var/ossec/etc/ossec.conf
@@ -8,7 +8,7 @@
 
   <syscheck>
     <alert_new_files>yes</alert_new_files>
-   
+
     <!-- Directories to check  (perform all possible verifications) -->
     <directories realtime="yes" check_all="yes" report_changes="yes">/etc,/usr/bin,/usr/sbin</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/bin,/sbin</directories>
@@ -23,6 +23,8 @@
     <ignore>/var/ossec/etc/shared/merged.mg</ignore>
     <ignore>/var/ossec/.gnupg/random_seed</ignore>
     <ignore>/etc/grsec/learning.logs</ignore>
+    <ignore>/etc/apparmor.d/cache/.features</ignore>
+    <ignore>/etc/blkid.tab</ignore>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>


### PR DESCRIPTION
add ignore `/etc/blkid.tab` and `/etc/apparmor.d/cache/.features` to ossec server and agent configs. To reduce spam messages of known events when first installing OSSEC.

Packages will need to be updated in the repo.
