### PR TITLE
Get and verify the latest tag, import the key for another Ubuntu dev

### DIFF
--- a/docs/ubuntu_grsec.md
+++ b/docs/ubuntu_grsec.md
@@ -102,10 +102,13 @@ gpg --keyserver pool.sks-keyservers.net --recv-key DD14FC2A1EA5E51369635AD73D76C
 gpg --keyserver pool.sks-keyservers.net --recv-key D4E1E31744709144B0F8101ADB74AEB8FDCE24FC
 ```
 
+Tim Gardner should have a fingerprint of "DD14 FC2A 1EA5 E513 6963  5AD7 3D76 C845 FA14 47CA" and Luis Henriques should have a fingerprint of "D4E1 E317 4470 9144 B0F8  101A DB74 AEB8 FDCE 24FC". If either of the fingerprints do not match what you see here, please get in touch at securedrop@freedom.press.
+
 Verify the archive and move on to the next step if you see "Good Signature" in the output.
 
 ```
 cd ubuntu-trusty/
+git checkout `git describe --abbrev=0 --tags`
 git tag -v `git describe --abbrev=0 --tags`
 ```
 


### PR DESCRIPTION
Updated the guide to import the key for yet another Ubuntu developer, get the latest tag in the Ubuntu Trusty repository and verify it.
