### PR TITLE
Fixes for build env VMs and playbook

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -134,7 +134,7 @@ Vagrant.configure("2") do |config|
       ansible.verbose = 'v'
     end
     build.vm.provider "virtualbox" do |v|
-      v.name = "mon"
+      v.name = "app-build"
     end
   end
 
@@ -147,7 +147,7 @@ Vagrant.configure("2") do |config|
       ansible.verbose = 'v'
     end
     build.vm.provider "virtualbox" do |v|
-      v.name = "mon"
+      v.name = "mon-build"
     end
   end
 

--- a/install_files/ansible-base/build-deb-pkgs.yml
+++ b/install_files/ansible-base/build-deb-pkgs.yml
@@ -4,7 +4,7 @@
   vars_files:
     - group_vars/securedrop.yml
     - host_vars/mon.yml
-    - staging-specific.yml
+    - development-specific.yml
 
   roles:
     - build-ossec-deb-pkg
@@ -16,11 +16,10 @@
   vars_files:
     - group_vars/securedrop.yml
     - host_vars/app.yml
-    - staging-specific.yml
+    - development-specific.yml
 
   roles:
     - build-securedrop-app-code-deb-pkg
     - build-ossec-deb-pkg
 
   sudo: yes
-


### PR DESCRIPTION
changed the build deb pkgs playbook to use the development-specific.yml var file instead of staging.

updated the virtualbox names of the /build$/ VMs.

**\* Changes to Vagrantfile warning ***
You will want to run `vagrant destroy /build$/ -f` prior to merging this change or will get vagrant errors later.
