### PR TITLE
Load the JS warning bubble in the initial HTML

### DIFF
--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -50,5 +50,19 @@
         Like all software, SecureDrop may contain security bugs. Use at your own risk. Powered by SecureDrop {{ version }}.
       </footer>
     </div>
+
+    <!-- Warning bubble to help TB users disable Javascript with NoScript.
+    Included here so the images can preload while the user is first
+    reading the page. Hidden by default. -->
+    <div class="bubble">
+      <p>You appear to be using the Tor Browser. You can disable Javascript in 3 easy steps!</p> 
+      <ol>
+        <li>Click the <img src="static/i/no16.png"> NoScript icon in the toolbar above</li> 
+        <li>Click <strong><img src="static/i/no16-global.png"/> Forbid Scripts Globally (advised)</strong></li> 
+        <li>If the page does not refresh automatically, <a href="/">click here</a> to refresh the page</li> 
+      </ol>
+      <p><a href="/howto-disable-js">Not using the Tor Browser Bundle?</a></p>
+    </div>
+
   </body>
 </html>

--- a/securedrop/static/css/styles.css
+++ b/securedrop/static/css/styles.css
@@ -509,19 +509,19 @@ a#already-have-codename:hover {
   color:#666;
 }
 
-p.bubble {
+div.bubble {
     width:415px;
     position:absolute;
     background-color:#ffffff;
     left:115px;
-    top:38px;
+    top:58px;
     border-radius:10px;
     border: 3px solid #666;
     padding: 10px 25px;
-    display:none;
+    display: none;
 }
 
-p.bubble:before {
+div.bubble:before {
     content:'';
     position:absolute;
     border-color: transparent transparent #666 #666;
@@ -533,7 +533,7 @@ p.bubble:before {
     height:0px;
 }
 
-p.bubble:after {
+div.bubble:after {
     content:'';
     position:absolute;
     border-color: transparent transparent #fff #fff;
@@ -545,7 +545,7 @@ p.bubble:after {
     height:0px;
 }
 
-p.bubble.tbb31plus {
+div.bubble.tbb31plus {
   /* The NoScript logo was moved to the left of the back/forward buttons in TBB
    * 4.0 (based on Firefox 31) */
   left: 5px;

--- a/securedrop/static/js/source.js
+++ b/securedrop/static/js/source.js
@@ -31,29 +31,14 @@ $(function() {
   if (is_likely_tor_browser()) {
     $("a#disable-js").click(function() {
       // Toggle the bubble if it already exists
-      var infoBubble = $("p.bubble");
-      if (infoBubble.length > 0) {
-        infoBubble.toggle();
-      } else {
-        var infoBubble = $('<p class="bubble">').html(
-          '<p>You appear to be using the Tor Browser. ' +
-          'You can disable Javascript in 3 easy steps!</p>' +
-          '<ol>' +
-          '<li>Click the <img src="static/i/no16.png"> NoScript icon in the toolbar above</li>' +
-          '<li>Click <strong><img src="static/i/no16-global.png"/> Forbid Scripts Globally (advised)</strong></li>' +
-          '<li>If the page does not refresh automatically, <a href="">click here</a> to refresh the page</li>' +
-          '</ol>' +
-          '<p><a href="/howto-disable-js">Not using the Tor Browser Bundle?</a>'
-        );
-        if (tbb_version() >= 31) {
-          infoBubble.addClass("tbb31plus");
-        }
-        $(document.body).append(infoBubble);
-        infoBubble.fadeIn(500);
-        infoBubble.click(function() {
-          infoBubble.toggle();
-        });
+      var infoBubble = $("div.bubble");
+      if (tbb_version() >= 31) {
+        infoBubble.addClass("tbb31plus");
       }
+      infoBubble.fadeIn(500);
+      infoBubble.click(function() {
+        infoBubble.toggle();
+      });
       return false; // don't follow link
     });
   }


### PR DESCRIPTION
Loading the JS warning bubble in the initial HTML (it is hidden at first
by the CSS) triggers the loads for the icons right away. Previously, we
were generating the bubble's HTML in JS and then appending it to body,
which triggered the image loads once the element added (and thus,
visible). This caused the bubble to load without the icons at first due
to Tor's general sluggishness.

Doing it this way means the icons will probably already be loaded by the
time the user has read the JS warning and decided to click the link,
which provides a better experience overall.
