### PR TITLE
changed task for authd fw exemptions to a handler

### DIFF
--- a/install_files/ansible-base/roles/ossec_agent/handlers/main.yml
+++ b/install_files/ansible-base/roles/ossec_agent/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: reload iptables rules
-  shell: iptables-restore < /etc/network/iptables/rules_v4 
+  shell: iptables-restore < /etc/network/iptables/rules_v4
 
 - name: restart ossec
   service: name=ossec state=restarted

--- a/install_files/ansible-base/roles/ossec_server/handlers/main.yml
+++ b/install_files/ansible-base/roles/ossec_server/handlers/main.yml
@@ -1,6 +1,15 @@
 ---
-## Tor section
-- name: reload iptables rules
+- name: add firewall rule exemption for authd
+  lineinfile:
+    dest: /etc/network/iptables/rules_v4
+    # last line in the initial *filter stanza (which must come before any rules)
+    # rules will be applied before the default rules defined in rules_v4 file
+    insertafter: "^:LOGNDROP"
+    regexp: "{{ item }}"
+    line: "{{ item }}"
+  with_items: authd_rules
+
+- name: reload authd iptables
   shell: iptables-restore < /etc/network/iptables/rules_v4
 
 - name: update aliases

--- a/install_files/ansible-base/roles/ossec_server/tasks/authd.yml
+++ b/install_files/ansible-base/roles/ossec_server/tasks/authd.yml
@@ -17,20 +17,9 @@
 
 - stat: path=/etc/network/iptables/rules_v4
   register: iptables_rules
+  notify: add firewall rule exemption for authd
+  notify: reload authd iptables
   when: list_agents.stdout != "{{ app_hostname }}-{{ app_ip }} is available."
-
-- name: add firewall rule exmeption for authd
-  lineinfile:
-    dest: /etc/network/iptables/rules_v4
-    # last line in the initial *filter stanza (which must come before any rules)
-    # rules will be applied before the default rules defined in rules_v4 file
-    insertafter: "^:LOGNDROP"
-    regexp: "{{ item }}"
-    line: "{{ item }}"
-  notify:
-    - reload iptables rules
-  with_items: authd_rules
-  when: iptables_rules.stat.exists and list_agents.stdout != "{{ app_hostname }}-{{ app_ip }} is available."
 
 - name: start authd
   shell: "/var/ossec/bin/ossec-authd -i {{ app_ip }} -p 1515 >/dev/null 2>&1 &"


### PR DESCRIPTION
moved the authd firewall exemptions task to a handler to avoid matching multiple conditions.
ensured that the handler name was unique to avoid confusion later.
