### PR TITLE
Exit link at /lookup takes source back to the homepage

### DIFF
--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -12,17 +12,17 @@
   </head>
   <body>
 
-    {% if g.user %}
-    <div id="logout">
-      {% if g.user and g.user.is_admin %}
-      <a href="{{ url_for('admin_index') }}">Admin</a> | 
-      {% endif %}
-      <a href="{{ url_for('logout') }}">Logout</a>
-    </div>
-    <div class="clearfix"></div>
-    {% endif %}
-
     <div class="content">
+      {% if g.user %}
+      <div id="navigation">
+        {% if g.user and g.user.is_admin %}
+        <a href="{{ url_for('admin_index') }}">Admin</a> | 
+        {% endif %}
+        <a href="{{ url_for('logout') }}">Logout</a>
+      </div>
+      <div class="clearfix"></div>
+      {% endif %}
+
       {% block header %}
       <div id="header">
         <a href="{{ url_for('index') }}"><img src="/static/i/{{ header_image }}" class="logo small" alt="SecureDrop"></a>

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -11,14 +11,14 @@
   <body>
     {% include 'banner_warning_flashed.html' %}
 
-    {% if 'logged_in' in session %}
-    <div id="logout">
-      <a href="{{ url_for('index') }}">Exit</a>
-    </div>
-    <div class="clearfix"></div>
-    {% endif %}
-
     <div class="content">
+     {% if 'logged_in' in session %}
+       <div id="navigation">
+         <a href="{{ url_for('index') }}">Exit</a>
+       </div>
+       <div class="clearfix"></div>
+     {% endif %}
+
       {% block header %}
       <div id="header">
         <a href="{% if 'logged_in' in session %}{{ url_for('lookup') }}{% else %}{{ url_for('index') }}{% endif %}"><img src="/static/i/{{ header_image }}" class="logo small" alt="SecureDrop"></a>

--- a/securedrop/static/css/styles.css
+++ b/securedrop/static/css/styles.css
@@ -595,9 +595,9 @@ time:not([title='']):hover, i:not([title='']):hover {
   cursor: pointer;
 }
 
-div#logout {
+div#navigation {
   float:right;
-  margin: 1em 1em 0 1em;
+  margin: 1em 0;
 }
 
 label {


### PR DESCRIPTION
Create an Exit link for source's /lookup page to go back to homepage.  Closes #682.

Also includes UI improvement that locates Admin/Logout/Exit links closer to content.
