### PR TITLE
Remove ReachableAddresses from app and mon torrc

### DIFF
--- a/install_files/ansible-base/roles/common-app/files/torrc-app
+++ b/install_files/ansible-base/roles/common-app/files/torrc-app
@@ -3,9 +3,6 @@ SocksPort 0
 SafeLogging 1
 RunAsDaemon 1
 
-# Ports are from https://www.torproject.org/docs/faq#OutboundPorts
-ReachableAddresses *:80,*:8080,*:443,*:8443,*:9001,*:9030
-
 HiddenServiceDir /var/lib/tor/services/source
 HiddenServicePort 80 127.0.0.1:80
 

--- a/install_files/ansible-base/roles/common-mon/files/torrc-mon
+++ b/install_files/ansible-base/roles/common-mon/files/torrc-mon
@@ -6,6 +6,3 @@ RunAsDaemon 1
 HiddenServiceDir /var/lib/tor/services/ssh
 HiddenServicePort 22 127.0.0.1:22
 HiddenServiceAuthorizeClient stealth admin
-
-# Ports are from https://www.torproject.org/docs/faq#OutboundPorts
-ReachableAddresses *:80,*:8080,*:443,*:8443,*:9001,*:9030


### PR DESCRIPTION
We ran into issues with a recent installation due to what appeared to be a conflict between some ISP settings (Verizon residential Internet connection) and the ReachableAddress in torrc. One of the machines continually failed to build Tor circuits, and viewing Tor's logs showed that attempting to build Tor circuits kept timing out. A new circuit would be tried, which would time out, and so on. Commenting out the ReachableAddresses and reloading Tor allowed Tor to connect immediately and without problems.

For context, `ReachableAddress` tells Tor which addresses and/or ports it can expect to be reachable. The idea is that Tor looks up relays from the directory servers, and each relay has an IP and advertises one or more ports that may be used to connect to it. If some part of your network has a firewall that blocks certain ports, Tor may try to connect to those ports if they are advertised for a relay that it's picked. In that situation, Tor will time out trying to connect and will try other ports, eventually trying different bridges, etc. This configuration option is intended to help avoid this problem by telling Tor to only bother trying the listed set of IPs/ports. However, in our recent installation experience, it caused problems that prevented connecting to the relays.
