### PR TITLE
SecureDrop i18n

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,9 @@
+[main]
+host = https://www.transifex.com
+
+[securedrop-app-code.messagespot-develop]
+file_filter = securedrop/translations/<lang>/LC_MESSAGES/messages.po
+source_file = securedrop/translations/messages.pot
+source_lang = en
+type = PO
+lang_map = zh-Hant:zh_Hant,zh-Hans:zh_Hans

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,4 @@
+[python: **.py]
+[jinja2: source_templates/**.html]
+[jinja2: journalist_templates/**.html]
+extensions=jinja2.ext.autoescape,jinja2.ext.with_

--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -114,3 +114,6 @@
     mode: 400
     backup: yes
   when: securedrop_header_image != "None"
+
+- name: compile language files
+  shell: "{{ securedrop_repo }}/loc_tools.py compile"

--- a/loc_tools.py
+++ b/loc_tools.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import sys
+import subprocess
+import os
+
+SECUREDROP_DIR = "securedrop"
+BABEL_FILE = "babel.cfg"
+TRANSLATIONS_DIR = SECUREDROP_DIR + "/translations"
+POT_FILE = TRANSLATIONS_DIR + "/messages.pot"
+
+def init():
+    """Initializes a new language"""
+    if len(sys.argv) != 3:
+        print "./lang_tools.py init LANG"
+        sys.exit(1)
+    lang = sys.argv[2]
+    rc = int(subprocess.call(
+        ['pybabel', 'init', '-i', POT_FILE, '-d', TRANSLATIONS_DIR, '-l', lang]))
+    sys.exit(rc)
+
+def update():
+    """Extracts messages and updates PO files"""
+    print "Extracting messages..."
+    rc = int(subprocess.call(
+        ['pybabel', 'extract', '--project=SecureDrop', '-F', BABEL_FILE, '-o', POT_FILE, SECUREDROP_DIR]))
+    if rc != 0:
+        sys.exit(rc)
+    print "Updating PO files..."
+    rc = int(subprocess.call(
+        ['pybabel', 'update', '-i', POT_FILE, '-d', TRANSLATIONS_DIR]))
+    sys.exit(rc)
+
+def compile():
+    """Compiles the PO files into MO files"""
+    rc = int(subprocess.call(
+        ['pybabel', 'compile', '-d', TRANSLATIONS_DIR]))
+    sys.exit(rc)
+
+def main():
+    valid_cmds = ["init", "update", "compile"]
+    help_str = "./lang_tools.py {{{0}}}".format(','.join(valid_cmds))
+
+    if len(sys.argv) < 2 or len(sys.argv) > 3 or sys.argv[1] not in valid_cmds:
+        print help_str
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+
+    wd = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(wd)
+
+    try:
+        getattr(sys.modules[__name__], cmd)()
+    except KeyboardInterrupt:
+        print # So our prompt appears on a nice new line
+
+if __name__ == "__main__":
+    main()

--- a/securedrop/config.py.example
+++ b/securedrop/config.py.example
@@ -1,3 +1,4 @@
+# coding=UTF-8
 import os
 
 # Default values for production, may be overridden later based on environment
@@ -83,3 +84,8 @@ TEMP_DIR = os.path.join(SECUREDROP_DATA_ROOT, "tmp")
 DATABASE_ENGINE = 'sqlite'
 DATABASE_FILE = os.path.join(SECUREDROP_DATA_ROOT, 'db.sqlite')
 
+LOCALES = {
+    'en': u'English',
+    'zh_Hant': u'繁體中文',
+    'it': u'Italian'
+}

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -7,6 +7,7 @@ import functools
 from flask import (Flask, request, render_template, send_file, redirect, flash,
                    url_for, g, abort, session)
 from flask_wtf.csrf import CsrfProtect
+from flask.ext.babel import Babel, _, ngettext
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.exc import IntegrityError
 
@@ -24,6 +25,8 @@ app = Flask(__name__, template_folder=config.JOURNALIST_TEMPLATES_DIR)
 app.config.from_object(config.JournalistInterfaceFlaskConfig)
 CsrfProtect(app)
 
+babel = Babel(app)
+
 app.jinja_env.globals['version'] = version.__version__
 if getattr(config, 'CUSTOM_HEADER_IMAGE', None):
     app.jinja_env.globals['header_image'] = config.CUSTOM_HEADER_IMAGE
@@ -33,6 +36,18 @@ else:
     app.jinja_env.globals['use_custom_header_image'] = False
 
 app.jinja_env.filters['datetimeformat'] = template_filters.datetimeformat
+
+
+@babel.localeselector
+def get_locale():
+    locale = session.get("locale")
+    try:
+        if locale and locale in config.LOCALES.keys():
+            return locale
+        return request.accept_languages.best_match(config.LOCALES.keys())
+    except AttributeError:
+        app.logger.warning("LOCALES is not defined in config")
+        return None
 
 
 @app.teardown_appcontext
@@ -66,6 +81,22 @@ def setup_g():
             g.source = get_source(sid)
 
 
+@app.before_request
+def apply_locale():
+    try:
+        if 'l' in request.args:
+            locale = request.args['l']
+            if locale in config.LOCALES.keys():
+                session['locale'] = locale
+            elif len(locale) == 0 and 'locale' in session:
+                del session['locale']
+    except AttributeError:
+        pass
+    # Save the resolved locale in g for templates
+    g.resolved_locale = get_locale()
+    g.locales = getattr(config, 'LOCALES', None)
+
+
 def logged_in():
     # When a user is logged in, we push their user id (database primary key)
     # into the session. setup_g checks for this value, and if it finds it,
@@ -92,7 +123,7 @@ def admin_required(func):
         if logged_in() and g.user.is_admin:
             return func(*args, **kwargs)
         # TODO: sometimes this gets flashed 2x (Chrome only?)
-        flash("You must be an administrator to access that page",
+        flash(_("You must be an administrator to access that page"),
               "notification")
         return redirect(url_for('index'))
     return wrapper
@@ -108,15 +139,15 @@ def login():
         except Exception as e:
             app.logger.error("Login for '{}' failed: {}".format(
                 request.form['username'], e))
-            login_flashed_msg = "Login failed."
+            login_flashed_msg = _("Login failed.")
 
             if isinstance(e, LoginThrottledException):
-                login_flashed_msg += " Please wait at least 60 seconds before logging in again."
+                login_flashed_msg = _("Login failed. Please wait at least 60 seconds before logging in again.")
             else:
                 try:
                     user = Journalist.query.filter_by(username=request.form['username']).one()
                     if user.is_totp:
-                        login_flashed_msg += " Please wait for a new two-factor token before logging in again."
+                        login_flashed_msg = _("Login failed. Please wait for a new two-factor token before logging in again.")
                 except:
                     pass
 
@@ -157,13 +188,13 @@ def admin_add_user():
         username = request.form['username']
         if len(username) == 0:
             form_valid = False
-            flash("Missing username", "username_validation")
+            flash(_("Missing username"), "username_validation")
 
         password = request.form['password']
         password_again = request.form['password_again']
         if password != password_again:
             form_valid = False
-            flash("Passwords didn't match", "password_validation")
+            flash(_("Passwords didn't match"), "password_validation")
 
         is_admin = bool(request.form.get('is_admin'))
 
@@ -181,10 +212,10 @@ def admin_add_user():
             except IntegrityError as e:
                 form_valid = False
                 if "username is not unique" in str(e):
-                    flash("That username is already in use",
+                    flash(_("That username is already in use"),
                           "username_validation")
                 else:
-                    flash("An error occurred saving this user to the database",
+                    flash(_("An error occurred saving this user to the database"),
                           "general_validation")
 
         if form_valid:
@@ -202,10 +233,10 @@ def admin_new_user_two_factor():
     if request.method == 'POST':
         token = request.form['token']
         if user.verify_token(token):
-            flash("Two factor token successfully verified for user {}!".format(user.username), "notification")
+            flash(_("Two factor token successfully verified for user %(username)s!", username=user.username), "notification")
             return redirect(url_for("admin_index"))
         else:
-            flash("Two factor token failed to verify", "error")
+            flash(_("Two factor token failed to verify"), "error")
 
     return render_template("admin_new_user_two_factor.html", user=user)
 
@@ -246,7 +277,7 @@ def admin_edit_user(user_id):
 
         if request.form['password'] != "":
             if request.form['password'] != request.form['password_again']:
-                flash("Passwords didn't match", "password_validation")
+                flash(_("Passwords didn't match"), "password_validation")
                 return redirect(url_for("admin_edit_user"))
             user.set_password(request.form['password'])
 
@@ -258,9 +289,9 @@ def admin_edit_user(user_id):
         except Exception, e:
             db_session.rollback()
             if "username is not unique" in str(e):
-                flash("That username is already in use", "notification")
+                flash(_("That username is already in use"), "notification")
             else:
-                flash("An unknown error occurred, please inform your administrator", "notification")
+                flash(_("An unknown error occurred, please inform your administrator"), "notification")
 
     return render_template("admin_edit_user.html", user=user)
 
@@ -408,21 +439,20 @@ def col_delete_single(sid):
     """deleting a single collection from its /col page"""
     source = get_source(sid)
     delete_collection(sid)
-    flash("%s's collection deleted" % (source.journalist_designation,), "notification")
+    flash(_("%(journalist_designation)s's collection deleted", journalist_designation=source.journalist_designation), "notification")
     return redirect(url_for('index'))
 
 
 def col_delete(cols_selected):
     """deleting multiple collections from the index"""
     if len(cols_selected) < 1:
-        flash("No collections selected to delete!", "error")
+        flash(_("No collections selected to delete!"), "error")
     else:
         for source_id in cols_selected:
             delete_collection(source_id)
-        flash("%s %s deleted" % (
+        flash(ngettext("%(cols_selected)d collection deleted", "%(cols_selected)d collections deleted",
             len(cols_selected),
-            "collection" if len(cols_selected) == 1 else "collections"
-        ), "notification")
+            cols_selected=len(cols_selected)), "notification")
 
     return redirect(url_for('index'))
 
@@ -466,7 +496,7 @@ def generate_code():
         doc.filename = store.rename_submission(g.sid, doc.filename, g.source.journalist_filename())
     db_session.commit()
 
-    flash("The source '%s' has been renamed to '%s'" % (original_journalist_designation, g.source.journalist_designation), "notification")
+    flash(_("The source '%(original_journalist_designation)s' has been renamed to '%(new_journalist_designation)s'", original_journalist_designation=original_journalist_designation, new_journalist_designation=g.source.journalist_designation), "notification")
     return redirect('/col/' + g.sid)
 
 
@@ -492,9 +522,9 @@ def bulk():
 
     if not docs_selected:
         if action == 'download':
-            flash("No collections selected to download!", "error")
+            flash(_("No collections selected to download!"), "error")
         elif action == 'delete':
-            flash("No collections selected to delete!", "error")
+            flash(_("No collections selected to delete!"), "error")
         return redirect(url_for('col', sid=g.sid))
 
     if action == 'download':

--- a/securedrop/journalist_templates/admin.html
+++ b/securedrop/journalist_templates/admin.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% block body %}
-<h2>Admin Interface</h2>
+<h2>{{_("Admin Interface")}}</h2>
 
 <form action="{{ url_for('admin_add_user') }}">
-  <button type="submit" class="btn" id="add-user"><i class="fa fa-plus"></i> Add user</button>
+  <button type="submit" class="btn" id="add-user"><i class="fa fa-plus"></i> {{_("Add user")}}</button>
 </form>
 
 <hr class="no-line" />
@@ -13,11 +13,11 @@
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
   <table id="users">
     <tr>
-      <th>Username</th>
-      <th>Edit</th>
-      <th>Delete</th>
-      <th>Created</th>
-      <th>Last login</th>
+      <th>{{_("Username")}}</th>
+      <th>{{_("Edit")}}</th>
+      <th>{{_("Delete")}}</th>
+      <th>{{_("Created")}}</th>
+      <th>{{_("Last login")}}</th>
     </tr>
     {% for user in users %}
       <tr class="user">
@@ -28,14 +28,14 @@
         {% if user.last_access %}
           <td><time class="date" title="{{ user.last_access }}">{{ user.last_access|datetimeformat(relative=True) }}</time></td>
         {% else %}
-          <td><time class="date">Never</time></td>
+          <td><time class="date">{{_("Never")}}</time></td>
         {% endif %}
       </tr>
     {% endfor %}
   </table>
 </form>
 {% else %}
-<p>No users to display</p>
+<p>{{_("No users to display")}}</p>
 {% endif %}
 
 {% endblock %}

--- a/securedrop/journalist_templates/admin_add_user.html
+++ b/securedrop/journalist_templates/admin_add_user.html
@@ -1,23 +1,23 @@
 {% extends "base.html" %}
 {% block body %}
 <p>
-  <a href="/admin">&laquo; Back to admin interface</a>
+  <a href="/admin">&laquo; {{_("Back to admin interface")}}</a>
 </p>
 
 <form method="post">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
-  <p><input name="username" type="text" placeholder="Username" /></p>
-  <p><input name="password" type="password" placeholder="Password" /></p>
-  <p><input name="password_again" type="password" placeholder="Password (again)" /></p>
+  <p><input name="username" type="text" placeholder="{{ _("Username") }}" /></p>
+  <p><input name="password" type="password" placeholder="{{ _("Password") }}" /></p>
+  <p><input name="password_again" type="password" placeholder="{{ _("Password (again)") }}" /></p>
   <p>
     <input name="is_admin" id="is_admin" type="checkbox" />
-    <label for="is_admin">Is Administrator</label>
+    <label for="is_admin">{{_("Is Administrator")}}</label>
   </p>
   <p>
     <input name="is_hotp" id="is_totp" type="checkbox" />
-    <label for="is_hotp">I'm using a Yubikey </label>
-    <input name="otp_secret" type="text" placeholder="HOTP Secret" size="60"><br />
+    <label for="is_hotp">{{_("I'm using a Yubikey ")}}</label>
+    <input name="otp_secret" type="text" placeholder="{{_("HOTP Secret")}}" size="60"><br />
   </p>
-  <button type="submit">Add user</button>
+  <button type="submit">{{_("Add user")}}</button>
 </form>
 {% endblock %}

--- a/securedrop/journalist_templates/admin_edit_hotp_secret.html
+++ b/securedrop/journalist_templates/admin_edit_hotp_secret.html
@@ -4,9 +4,9 @@
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
   <input type="hidden" name="uid" value="{{ uid }}" />
   <p>
-    <label for="otp_secret">Change Secret</label>
+    <label for="otp_secret">{{_("Change Secret")}}</label>
     <input name="otp_secret" type="text" placeholder="HOTP Secret"><br />
   </p>
-  <button type="submit">Continue</button>
+  <button type="submit">{{_("Continue")}}</button>
 </form>
 {% endblock %}

--- a/securedrop/journalist_templates/admin_edit_user.html
+++ b/securedrop/journalist_templates/admin_edit_user.html
@@ -1,43 +1,43 @@
 {% extends "base.html" %}
 {% block body %}
-<h2>Edit user "{{ user.username }}"</h2>
-<p><a href="/admin">&laquo; Back to admin interface</a></p>
+<h2>{{_("Edit user")}} "{{ user.username }}"</h2>
+<p><a href="/admin">&laquo; {{_("Back to admin interface")}}</a></p>
 
 <form method="post">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
   <p>
-    <label for="username">Change username</label>
+    <label for="username">{{_("Change username")}}</label>
     <input name="username" id="username" type="text" placeholder="{{ user.username }}" />
   </p>
   <p>
-    <label for="password">Change password</label>
+    <label for="password">{{_("Change password")}}</label>
     <input name="password" id="password" type="text" />
-    <em class="light">Leave blank for no change</em>
+    <em class="light">{{_("Leave blank for no change")}}</em>
   </p>
   <p>
-    <label for="password_again">Change password (confirm)</label>
+    <label for="password_again">{{_("Change password (confirm)")}}</label>
     <input name="password_again" id="password_again" type="password" />
   </p>
   <p>
     <input name="is_admin" id="is_admin" type="checkbox" {% if user.is_admin %}checked{% endif %} />
-    <label for="is_admin">Is Administrator</label>
+    <label for="is_admin">{{_("Is Administrator")}}</label>
   </p>
-  <button type="submit" id="update-user">Update user</button>
+  <button type="submit" id="update-user">{{_("Update user")}}</button>
 </form>
 
 <hr class="no-line">
 
-<h2>Reset Two Factor Authentication</h2>
-<p>If a user's two factor authentication credentials have been lost or compromised, you can reset them here. <em>If you do this, make sure the user is present and ready to set up their device with the new two factor credentials. Otherwise, they will be locked out of their account.</em></p>
+<h2>{{_("Reset Two Factor Authentication")}}</h2>
+<p>{{_("If a user's two factor authentication credentials have been lost or compromised, you can reset them here. ")}}<em>{{_("If you do this, make sure the user is present and ready to set up their device with the new two factor credentials. Otherwise, they will be locked out of their account.")}}</em></p>
 <form method="post" action="{{ url_for('admin_reset_two_factor_totp') }}" id="reset-two-factor-totp">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
   <input name="uid" type="hidden" value="{{ user.id }}"/>
-  <button type="submit" class="center"><i class="fa fa-refresh"></i> Reset two factor authentication (Google Authenticator)</button>
+  <button type="submit" class="center"><i class="fa fa-refresh"></i> {{_("Reset two factor authentication (Google Authenticator)")}}</button>
 </form>
 </br />
 <form method="post" action="{{ url_for('admin_reset_two_factor_hotp') }}" id="reset-two-factor-hotp">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
   <input name="uid" type="hidden" value="{{ user.id }}"/>
-  <button type="submit" class="center"><i class="fa fa-refresh"></i> Reset two factor authentication (HOTP Yubikey)</button>
+  <button type="submit" class="center"><i class="fa fa-refresh"></i> {{_("Reset two factor authentication (HOTP Yubikey)")}}</button>
 </form>
 {% endblock %}

--- a/securedrop/journalist_templates/admin_new_user_two_factor.html
+++ b/securedrop/journalist_templates/admin_new_user_two_factor.html
@@ -1,25 +1,25 @@
 {% extends "base.html" %}
 {% block body %}
 {% if user.is_totp %}
-<h1>Enable Google Authenticator</h1>
-<p>You're almost done! To finish adding this new user, have them follow the instructions below to set up two factor authentication with Google Authenticator. Once they've added an entry for this account in the app, have them enter one of the 6-digit codes from the app to confirm that two factor authentication is set up correctly.</p>
+<h1>{{_("Enable Google Authenticator")}}</h1>
+<p>{{_("You're almost done! To finish adding this new user, have them follow the instructions below to set up two factor authentication with Google Authenticator. Once they've added an entry for this account in the app, have them enter one of the 6-digit codes from the app to confirm that two factor authentication is set up correctly.")}}</p>
 <ol>
-  <li>Install Google Authenticator on your phone</li>
-  <li>Open the Google Authenticator app</li>
-  <li>Tap menu, then tap "Set up account", then tap "Scan a barcode"</li>
-  <li>Your phone will now be in "scanning" mode. When you are in this mode, scan the barcode below:</li>
+  <li>{{_("Install Google Authenticator on your phone")}}</li>
+  <li>{{_("Open the Google Authenticator app")}}</li>
+  <li>{{_("Tap menu, then tap \"Set up account\", then tap \"Scan a barcode\"")}}</li>
+  <li>{{_("Your phone will now be in \"scanning\" mode. When you are in this mode, scan the barcode below:")}}</li>
 </ol>
 <div id="qrcode_container">{{ user.shared_secret_qrcode|safe }}</div>
-<p>Can't scan the barcode? Enter the following code manually: <span id="shared_secret">{{ user.formatted_otp_secret }}</span></p>
-<p>Once you have scanned the barcode, enter the 6-digit code below:</p>
+<p>{{_("Can't scan the barcode? Enter the following code manually:")}} <span id="shared_secret">{{ user.formatted_otp_secret }}</span></p>
+<p>{{_("Once you have scanned the barcode, enter the 6-digit code below:")}}</p>
 {% else %}
-<h1>Enable Yubikey (OATH-HOTP)</h1>
-<p>Once you have configured your Yubikey, enter the 6-digit code below:</p>
+<h1>{{_("Enable Yubikey (OATH-HOTP)")}}</h1>
+<p>{{_("Once you have configured your Yubikey, enter the 6-digit code below:")}}</p>
 {% endif %}
 <form id="check_token" method="post">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
-  <label for="token">Verification code</label>
+  <label for="token">{{_("Verification code")}}</label>
   <input name="token" id="token" type="text" placeholder="123456" />
-  <button type="submit">Submit</button>
+  <button type="submit">{{_("Submit")}}</button>
 </form>
 {% endblock %}

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>SecureDrop</title>
+    <title>{{_("SecureDrop")}}</title>
     <link rel="stylesheet" href="/static/css/normalize.css" type="text/css" media="all" />
     <link rel="stylesheet" href="/static/css/styles.css" type="text/css" media="all" />
     <link rel="stylesheet" href="/static/css/font-awesome.css" type="text/css" media="all" />
@@ -15,9 +15,9 @@
     {% if g.user %}
     <div id="logout">
       {% if g.user and g.user.is_admin %}
-      <a href="{{ url_for('admin_index') }}">Admin</a> | 
+      <a href="{{ url_for('admin_index') }}">{{_("Admin")}}</a> |
       {% endif %}
-      <a href="{{ url_for('logout') }}">Logout</a>
+      <a href="{{ url_for('logout') }}">{{_("Logout")}}</a>
     </div>
     <div class="clearfix"></div>
     {% endif %}
@@ -43,8 +43,9 @@
 
       {% block footer %}
       <footer>
-        Powered by <em>SecureDrop {{ version }}</em>.
+        {{_("Powered by <em>SecureDrop %(version)s</em>.", version=version)}}
       </footer>
+      {% include 'locale_selection.html' %}
       {% endblock %}
     </div>
   </body>

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -7,35 +7,35 @@
     <input type="hidden" name="sid" value="{{ sid }}">
 
     <p class="breadcrumbs">
-      <a href="/">All Sources</a>
+      <a href="/">{{ _("All Sources") }}</a>
       <i class="fa fa-chevron-right"></i>
       <strong>{{ codename }}</strong>
-      <button type="submit" title="Generate a new random codename for this source. We recommend doing this if the first random codename is difficult to say or remember. You can generate new random codenames as many times as you like." class="plain" id="regenerate-codename-btn"><i class="fa fa-refresh"></i> <span id="regenerate-codename-btn-label">Change codename</span></button>
+      <button type="submit" title="{{_("Generate a new random codename for this source. We recommend doing this if the first random codename is difficult to say or remember. You can generate new random codenames as many times as you like.")}}" class="plain" id="regenerate-codename-btn"><i class="fa fa-refresh"></i> <span id="regenerate-codename-btn-label">{{_("Change codename")}}</span></button>
     </p>
   </form>
 
   {% if docs %}
-    <p>The documents are stored encrypted for security. To read them, you will need to decrypt them using GPG.</p>
+    <p>{{_("The documents are stored encrypted for security. To read them, you will need to decrypt them using GPG.")}}</p>
     <form action="/bulk" method="post">
     <div class="document-actions">
       <div id='select-container'></div>
-      <button type="submit" name="action" value="download"><i class="fa fa-download"></i> Download selected</button>
-      <button type="submit" name="action" value="delete" class="danger"><i class="fa fa-times"></i> Delete selected</button>
+      <button type="submit" name="action" value="download"><i class="fa fa-download"></i> {{_("Download selected")}}</button>
+      <button type="submit" name="action" value="delete" class="danger"><i class="fa fa-times"></i> {{_("Delete selected")}}</button>
     </div>
       <ul id="submissions" class="plain submissions">
         {% for doc in docs %}
           <li class="submission"><input type="checkbox" name="doc_names_selected" value="{{ doc.name }}" class="doc-check"/>
             {% if doc.name.endswith('reply.gpg') %}
               <span class="file reply"><span class="filename">{{ doc.name }}</span></span>
-              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }}</span> sent <time title="{{ doc.date|datetimeformat }}" datetime="{{ doc.date }}">{{ doc.date|datetimeformat(relative=True) }}</time></span>
+              <span class="info">{{_("%(file_size)s sent %(date)s", file_size="<span title=\"%d bytes\">%s</span>"|safe|format(doc.size, doc.size|filesizeformat), date="<time title=\"%s\" datetime=\"%s\">%s</time>"|safe|format(doc.date|datetimeformat, doc.date, doc.date|datetimeformat(relative=True)))}}</span>
             {% else %}
               <span class="file"><a class="btn small" href="/col/{{ sid }}/{{ doc.name }}"><i class="fa fa-download"></i> <span class="filename">{{ doc.name }}</span></a></span>
-              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }}</span> uploaded <time title="{{ doc.date|datetimeformat }}" datetime="{{ doc.date }}">{{ doc.date|datetimeformat(relative=True) }}</time></span>
+              <span class="info">{{_("%(file_size)s uploaded %(date)s", file_size="<span title=\"%d bytes\">%s</span>"|safe|format(doc.size, doc.size|filesizeformat), date="<time title=\"%s\" datetime=\"%s\">%s</time>"|safe|format(doc.date|datetimeformat, doc.date, doc.date|datetimeformat(relative=True)))}}</span>
             {% endif %}
             {% if doc.name.endswith('-doc.zip.gpg') %}
-              <i title="Uploaded Document" class="fa fa-file-archive-o pull-right"></i>
+              <i title="{{ _("Uploaded Document") }}" class="fa fa-file-archive-o pull-right"></i>
             {% else %}
-              <i title="Message" class="fa fa-file-text-o pull-right"></i>
+              <i title="{{ _("Message") }}" class="fa fa-file-text-o pull-right"></i>
             {% endif %}
           </li>
         {% endfor %}
@@ -45,41 +45,41 @@
       <input type="hidden" name="sid" value="{{ sid }}" autocomplete="off"/>
     </form>
   {% else %}
-    <p><br />No documents to display.</p>
+    <p><br />{{_("No documents to display.")}}</p>
   {% endif %}
 
   <hr class="cut-out" />
   <hr class="no-line" />
-  <h3><i class="fa fa-reply"></i> Reply</h3>
+  <h3><i class="fa fa-reply"></i> {{_("Reply")}}</h3>
   {% if haskey %}
-    <p>You can write a secure reply to the person who submitted these documents:</p>
+    <p>{{_("You can write a secure reply to the person who submitted these documents:")}}</p>
     <form action="/reply" method="post" autocomplete="off">
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
       <input type="hidden" name="sid" value="{{ sid }}" autocomplete="off"/>
       <textarea name="msg" cols="72" rows="10" autocomplete="off"></textarea>
       <hr class="no-line" />
-      <button id="reply-button" class="button-custom" type="submit">Submit</button>
+      <button id="reply-button" class="button-custom" type="submit">{{_("Submit")}}</button>
     </form>
   {% elif flagged %}
-    <p class="notification">You've flagged this source for reply.</p>
-    <p>An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here.</p>
+    <p class="notification">{{_("You've flagged this source for reply.")}}</p>
+    <p>{{_("An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here.")}}</p>
   {% else %}
-    <p>Click below if you would like to write a reply to this source.</p>
+    <p>{{_("Click below if you would like to write a reply to this source.")}}</p>
     <form action="/flag" method="post">
       <input type="hidden" name="sid" value="{{ sid }}" autocomplete="off" />
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      <button id="flag-button" class="button-custom" type="submit"><i class="fa fa-flag"></i> Flag this source for reply</button>
+      <button id="flag-button" class="button-custom" type="submit"><i class="fa fa-flag"></i> {{_("Flag this source for reply")}}</button>
     </form>
   {% endif %}
   <hr class="no-line" />
   <hr class="cut-out" />
-  <p>Click below to delete this source's collection. <em>Warning: If you do this, the files seen here will be unrecoverable and the source will no longer be able to login using their previous codename.</em></p>
+  <p>{{_("Click below to delete this source's collection. ")}}<em>{{_("Warning: If you do this, the files seen here will be unrecoverable and the source will no longer be able to login using their previous codename.")}}</em></p>
 
   <form id="delete_collection" action="/col/delete/{{sid}}" method="post">
     <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
     <input type="hidden" name="sid" value="{{ sid }}"/>
     <input type="hidden" name="col_name" value="{{ codename }}"/>
-    <button type="submit" class="danger"><i class="fa fa-times"></i> Delete collection</button>
+    <button type="submit" class="danger"><i class="fa fa-times"></i> {{_("Delete collection")}}</button>
   </form>
 
 </div>

--- a/securedrop/journalist_templates/delete.html
+++ b/securedrop/journalist_templates/delete.html
@@ -4,13 +4,13 @@
 {% if confirm_delete %}
 
   {% with count=docs_selected|length %}
-  <p class="notification">File{% if count > 1 %}s{% endif %} permanently deleted.</p>
+  <p class="notification">{{ ngettext("File permanently deleted.", "Files permanently deleted.", count) }}</p>
   {% endwith %}
 
 {% else %}
 
   {% with count=docs_selected|length %}
-  <p>The following {% if count == 1 %}file has{% else %}{{ count }} files have{% endif %} been selected for <strong>permanent deletion</strong>:</p>
+  <p>{{ ngettext('The following file has been selected for <strong>permanent deletion</strong>', 'The following %(value)d files have been selected for <strong>permanent deletion</strong>', count, value=count) }}</p>
   {% endwith %}
 
   <form action="/bulk" method="post">
@@ -20,20 +20,20 @@
     {{ doc.name }}
     <input type="hidden" name="doc_names_selected" value="{{ doc.name }}" />
     {% if doc.name.startswith('reply-') %}
-      (sent {{ doc.date }})
+      {{_("(sent %(date)s)", date=doc.date)}}
     {% else %}
-      (uploaded {{ doc.date }})
+      {{_("(uploaded %(date)s)", date=doc.date)}}
     {% endif %}
   </li>
   {% endfor %}
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
   <input type="hidden" name="sid" value="{{ sid }}" autocomplete="off"/>
   <input type="hidden" name="confirm_delete" value="1" />
-  <p><button type="submit" name="action" value="delete">Permanently delete files</button></p>
+  <p><button type="submit" name="action" value="delete">{{_("Permanently delete files")}}</button></p>
   </ul>
   </form>
 
 {% endif %}
 
-<p><a href="/col/{{ sid }}">Return to the list of documents for {{ codename }}...</a></p>
+<p><a href="/col/{{ sid }}">{{_("Return to the list of documents for %(codename)s...", codename=codename)}}</a></p>
 {% endblock %}

--- a/securedrop/journalist_templates/flag.html
+++ b/securedrop/journalist_templates/flag.html
@@ -2,10 +2,10 @@
 {% block body %}
 <p class="flash notification">
   <i class="fa fa-info-circle pull-left"></i>
-Thanks!
+{{_("Thanks!")}}
 </p>
 
-<p>SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them.</p>
+<p>{{_("SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them.")}}</p>
 
-<p><a href="/col/{{ sid }}">Continue to the list of documents for {{ codename }}...</a></p>
+<p><a href="/col/{{ sid }}">{{_("Continue to the list of documents for %(codename)s...", codename=codename)}}</a></p>
 {% endblock %}

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -1,16 +1,16 @@
 {% extends "base.html" %}
 {% block body %}
 <div id="content" class="journalist-view-all">
-<h2><span class="headline">Sources</span></h2>
+<h2><span class="headline">{{_("Sources")}}</span></h2>
 {% if unstarred or starred %}
   <div id='filter-container'></div>
     <form id="process_collections" action="/col/process" method="post">
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
       <p>
-        <span id="select_all" class="select"><i class="fa fa-check-square-o"></i> select all</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> select none</span>
-        <button type="submit" id="delete_collections" name="action" value="delete" class="small"><i class="fa fa-minus-circle"></i> Delete selected</button>
-        <button type="submit" name="action" value="star" class="small"><i class="fa fa-minus-circle"></i> Star Selected</button>
-        <button type="submit" name="action" value="un-star" class="small"><i class="fa fa-minus-circle"></i> Un-star Selected</button>
+        <span id="select_all" class="select"><i class="fa fa-check-square-o"></i> {{_("select all")}}</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> {{_("select none")}}</span>
+        <button type="submit" id="delete_collections" name="action" value="delete" class="small"><i class="fa fa-minus-circle"></i> {{_("Delete selected")}}</button>
+        <button type="submit" name="action" value="star" class="small"><i class="fa fa-minus-circle"></i> {{_("Star Selected")}}</button>
+        <button type="submit" name="action" value="un-star" class="small"><i class="fa fa-minus-circle"></i> {{_("Un-star Selected")}}</button>
       </p>
 
       {% if starred %}
@@ -26,11 +26,11 @@
                 <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="starred-source-link-{{loop.index}}">{{ source.journalist_designation }}</a></span>
               </div>
               <div class="submission-count">
-                <span><i class="fa fa-file-archive-o"></i> {{ docs }} docs</span>
-                <span><i class="fa fa-file-text-o"></i> {{ msgs }} messages</span>
+                <span><i class="fa fa-file-archive-o"></i> {{ docs }} {{_("docs")}}</span>
+                <span><i class="fa fa-file-text-o"></i> {{ msgs }} {{_("messages")}}</span>
                 {% if source.num_unread > 0 %}
                   <span class="unread">
-                    <a class="btn small" href='/download_unread/{{ source.filesystem_id }}'><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
+                    <a class="btn small" href='/download_unread/{{ source.filesystem_id }}'><i class="fa fa-download"></i> {{ source.num_unread }}{{_(" unread")}}</a>
                   </span>
                 {% endif %}
               </div>
@@ -52,11 +52,11 @@
                 <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="un-starred-source-link-{{loop.index}}">{{ source.journalist_designation }}</a></span>
               </div>
               <div class="submission-count">
-                <span><i class="fa fa-file-archive-o"></i> {{ docs }} docs</span>
-                <span><i class="fa fa-file-text-o"></i> {{ msgs }} messages</span>
+                <span><i class="fa fa-file-archive-o"></i> {{ docs }} {{_("docs")}}</span>
+                <span><i class="fa fa-file-text-o"></i> {{ msgs }} {{_("messages")}}</span>
                 {% if source.num_unread > 0 %}
                   <span class="unread">
-                    <a class="btn small" href='/download_unread/{{ source.filesystem_id }}' ><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
+                    <a class="btn small" href='/download_unread/{{ source.filesystem_id }}' ><i class="fa fa-download"></i> {{ source.num_unread }} {{_("unread")}}</a>
                   </span>
                 {% endif %}
               </div>
@@ -68,6 +68,6 @@
     </form>
   </div>
 {% else %}
-  <p>No documents have been submitted!</p>
+  <p>{{_("No documents have been submitted!")}}</p>
 {% endif %}
 {% endblock %}

--- a/securedrop/journalist_templates/locale_selection.html
+++ b/securedrop/journalist_templates/locale_selection.html
@@ -1,0 +1,15 @@
+{% if g.locales and g.locales.keys()|length > 1 %}
+<div class="locales">
+  <ul class="plain">
+    {% for locale in g.locales %}
+      <li>
+      {% if locale == g.resolved_locale %}
+        {{ g.locales[locale] }}
+      {% else %}
+        <a href="?l={{ locale }}" rel="nofollow">{{ g.locales[locale] }}</a>
+      {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}

--- a/securedrop/journalist_templates/login.html
+++ b/securedrop/journalist_templates/login.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 {% block body %}
 
-<h2>Login to access the journalist interface</h2>
+<h2>{{_("Login to access the journalist interface")}}</h2>
 
 <form method="post" action="/login" autocomplete="off">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-  <p class="center"><input type="text" name="username" autocomplete="off" placeholder="Username" autofocus></p>
-  <p class="center"><input type="password" name="password" placeholder="Password"></p>
-  <p class="center"><input name="token" id="token" type="text" placeholder="Two-factor Code"></p>
-  <p class="center"><button type="submit">Log in <i class="fa fa-arrow-circle-o-right"></i></button></p>
+  <p class="center"><input type="text" name="username" autocomplete="off" placeholder="{{_("Username")}}" autofocus></p>
+  <p class="center"><input type="password" name="password" placeholder="{{_("Password")}}"></p>
+  <p class="center"><input name="token" id="token" type="text" placeholder="{{_("Two-factor Code")}}"></p>
+  <p class="center"><button type="submit">{{_("Log in")}} <i class="fa fa-arrow-circle-o-right"></i></button></p>
 </form>
 
 {% endblock %}

--- a/securedrop/journalist_templates/reply.html
+++ b/securedrop/journalist_templates/reply.html
@@ -2,10 +2,10 @@
 {% block body %}
 <p class="flash notification">
   <i class="fa fa-info-circle pull-left"></i>
-  Thanks! Your reply has been stored.
+  {{_("Thanks! Your reply has been stored.")}}
 </p>
 
-<p>You will now see it in the list of documents in that collection. Once the source has read it, they will be asked to delete it. If it disappears from the list, then you know it has been read and deleted by the source.</p>
+<p>{{_("You will now see it in the list of documents in that collection. Once the source has read it, they will be asked to delete it. If it disappears from the list, then you know it has been read and deleted by the source.")}}</p>
 
-<p><a href="/col/{{ sid }}">Return to the list of documents for <strong>{{ codename }}</strong>...</a></p>
+<p><a href="/col/{{ sid }}">{{_("Return to the list of documents for <strong>%(codename)s</strong>...", codename=codename)}}</a></p>
 {% endblock %}

--- a/securedrop/requirements/securedrop-requirements.txt
+++ b/securedrop/requirements/securedrop-requirements.txt
@@ -18,3 +18,5 @@ SQLAlchemy==0.9.7
 Werkzeug==0.9.6
 wsgiref==0.1.2
 WTForms==2.0.1
+Flask-Babel==0.9
+python-gettext==2.1

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -16,6 +16,7 @@ log = logging.getLogger('source')
 from flask import (Flask, request, render_template, session, redirect, url_for,
                    flash, abort, g, send_file)
 from flask_wtf.csrf import CsrfProtect
+from flask.ext.babel import Babel, _
 
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.exc import IntegrityError
@@ -32,6 +33,8 @@ app = Flask(__name__, template_folder=config.SOURCE_TEMPLATES_DIR)
 app.config.from_object(config.SourceInterfaceFlaskConfig)
 CsrfProtect(app)
 
+babel = Babel(app)
+
 app.jinja_env.globals['version'] = version.__version__
 if getattr(config, 'CUSTOM_HEADER_IMAGE', None):
     app.jinja_env.globals['header_image'] = config.CUSTOM_HEADER_IMAGE
@@ -42,6 +45,19 @@ else:
 
 app.jinja_env.filters['datetimeformat'] = template_filters.datetimeformat
 app.jinja_env.filters['nl2br'] = evalcontextfilter(template_filters.nl2br)
+
+
+@babel.localeselector
+def get_locale():
+    locale = session.get("locale")
+    try:
+        if locale and locale in config.LOCALES.keys():
+            return locale
+        return request.accept_languages.best_match(config.LOCALES.keys())
+    except AttributeError:
+        app.logger.warning("LOCALES is not defined in config")
+        return None
+
 
 @app.teardown_appcontext
 def shutdown_session(exception=None):
@@ -102,10 +118,28 @@ def check_tor2web():
         # ignore_static here so we only flash a single message warning about Tor2Web,
         # corresponding to the intial page load.
     if 'X-tor2web' in request.headers:
-        flash('<strong>WARNING:</strong> You appear to be using Tor2Web. '
+        flash(_('<strong>WARNING:</strong> You appear to be using Tor2Web. '
               'This <strong>does not</strong> provide anonymity. '
-              '<a href="/tor2web-warning">Why is this dangerous?</a>',
+              '%(tor2web_warning)s',
+              tor2web_warning='<a href="/tor2web-warning">{}</a>'.format(_('Why is this dangerous?'))),
               "banner-warning")
+
+
+@app.before_request
+@ignore_static
+def apply_locale():
+    try:
+        if 'l' in request.args:
+            locale = request.args['l']
+            if locale in config.LOCALES.keys():
+                session['locale'] = locale
+            elif len(locale) == 0 and 'locale' in session:
+                del session['locale']
+    except AttributeError:
+        pass
+    # Save the resolved locale in g for templates
+    g.resolved_locale = get_locale()
+    g.locales = getattr(config, 'LOCALES', None)
 
 
 @app.route('/')
@@ -239,16 +273,16 @@ def submit():
         g.source.interaction_count += 1
         fnames.append(store.save_message_submission(g.sid, g.source.interaction_count,
             journalist_filename, msg))
-        flash("Thanks! We received your message.", "notification")
+        flash(_("Thanks! We received your message."), "notification")
     if fh:
         g.source.interaction_count += 1
         fnames.append(store.save_file_submission(g.sid, g.source.interaction_count,
             journalist_filename, fh.filename, fh.stream))
-        flash('{} "{}".'.format("Thanks! We received your document",
-                                fh.filename or '[unnamed]'), "notification")
+        flash(_("Thanks! We received your document \"%(filename)s\".",
+                filename=fh.filename or '[unnamed]'), "notification")
 
     if first_submission:
-        flash("Thanks for submitting something to SecureDrop! Please check back later for replies.",
+        flash(_("Thanks for submitting something to SecureDrop! Please check back later for replies."),
               "notification")
 
     for fname in fnames:
@@ -279,7 +313,7 @@ def delete():
     if msgid not in potential_files:
         abort(404)  # TODO are the checks necessary?
     store.secure_unlink(store.path(g.sid, msgid))
-    flash("Reply deleted", "notification")
+    flash(_("Reply deleted"), "notification")
 
     return redirect(url_for('lookup'))
 
@@ -299,7 +333,7 @@ def login():
             if valid:
                 session.update(codename=codename, logged_in=True)
                 return redirect(url_for('lookup', from_login='1'))
-        flash("Sorry, that is not a recognized codename.", "error")
+        flash(_("Sorry, that is not a recognized codename."), "error")
     return render_template('login.html')
 
 
@@ -344,4 +378,3 @@ if __name__ == "__main__":
     write_pidfile()
     # TODO make sure debug is not on in production
     app.run(debug=True, host='0.0.0.0', port=8080)
-

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>SecureDrop | Protecting Journalists and Sources</title>
+    <title>{{_("SecureDrop | Protecting Journalists and Sources")}}</title>
     <link rel="stylesheet" href="/static/css/normalize.css" type="text/css" media="all" />
     <link rel="stylesheet" href="/static/css/styles.css" type="text/css" media="all" />
     <link rel="stylesheet" href="/static/css/font-awesome.css" type="text/css" media="all" />
@@ -33,10 +33,10 @@
 
       {% block footer %}
       <footer>
-        Like all software, SecureDrop may contain security bugs. Use at your own risk. Powered by SecureDrop {{ version }}.
+        {{_("Like all software, SecureDrop may contain security bugs. Use at your own risk. Powered by SecureDrop %(version)s.", version=version)}}
       </footer>
+      {% include 'locale_selection.html' %}
       {% endblock %}
     </div>
   </body>
 </html>
-

--- a/securedrop/source_templates/error.html
+++ b/securedrop/source_templates/error.html
@@ -2,10 +2,10 @@
 {% block body %}
 <div id="content">
 
-<h2>Server error</h2>
+<h2>{{_("Server error")}}</h2>
 
-<p>Sorry, the website encountered an error and was unable to complete your request.</p>
+<p>{{_("Sorry, the website encountered an error and was unable to complete your request.")}}</p>
 
-<p><a href="/login">Look up a codename...</a></p>
+<p><a href="/login">{{_("Look up a codename...")}}</a></p>
 </div>
 {% endblock %}

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
 {% block body %}
-<h2>Remember this codename and keep it secret</h2>
-<p class="center">To protect your identity, we're assigning you a unique codename.</p>
+<h2>{{_("Remember this codename and keep it secret")}}</h2>
+<p class="center">{{_("To protect your identity, we're assigning you a unique codename.")}}</p>
 
 <hr class="no-line" />
 
@@ -26,15 +26,15 @@
 <div class="clearfix"></div>
 <hr class="no-line">
 
-<p>After you submit documents and messages, you can return to this SecureDrop site later to read replies from journalists and submit more information. <strong>You will need this codename to log in.</strong> This is the only way we can communicate back to you.</p>
+<p>{{_("After you submit documents and messages, you can return to this SecureDrop site later to read replies from journalists and submit more information. <strong>You will need this codename to log in.</strong> This is the only way we can communicate back to you.")}}</p>
 
-<p class="serious">The best way to protect your codename is to memorize it. If you cannot memorize it right away, we recommend writing it down and keeping it in a safe place at first, and gradually working to memorize it over time. Once you have memorized it, you should destroy the written copy.</p>
+<p class="serious">{{_("The best way to protect your codename is to memorize it. If you cannot memorize it right away, we recommend writing it down and keeping it in a safe place at first, and gradually working to memorize it over time. Once you have memorized it, you should destroy the written copy.")}}</p>
 
 <hr class="no-line" />
 
 <form id="create-form" method="post" action="/create" autocomplete="off">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-  <button type="submit" class="btn block pull-right" id="continue-button"><i class="fa fa-arrow-circle-o-right"></i> Continue</button>
-  <a id="already-have-codename" href="/login">Already have a codename?</a>
+  <button type="submit" class="btn block pull-right" id="continue-button"><i class="fa fa-arrow-circle-o-right"></i> {{_("Continue")}}</button>
+  <a id="already-have-codename" href="/login">{{_("Already have a codename?")}}</a>
 </form>
 {% endblock %}

--- a/securedrop/source_templates/howto-disable-js.html
+++ b/securedrop/source_templates/howto-disable-js.html
@@ -1,14 +1,15 @@
 {% extends "base.html" %}
 {% block body %}
 
-<h1>Disable JavaScript to Protect Your Anonymity</h1>
+<h1>{{_("Disable JavaScript to Protect Your Anonymity")}}</h1>
 
-<p>JavaScript is a widely used programming language for creating interactive web pages. Unfortunately, JavaScript is also the most common source of security vulnerabilities in browsers. In August 2013, the FBI wrote malware that used a JavaScript exploit to de-anonymize Tor users (http://www.wired.com/threatlevel/2013/09/freedom-hosting-fbi). JavaScript exploits are also mentioned in documents describing the NSA's Egotistical Giraffe (http://www.theguardian.com/world/interactive/2013/oct/04/egotistical-giraffe-nsa-tor-document) program, which also has the goal of targeting and de-anonymizing Tor users.</p>
+<p>{{_("JavaScript is a widely used programming language for creating interactive web pages. Unfortunately, JavaScript is also the most common source of security vulnerabilities in browsers. In August 2013, the FBI wrote malware that used a JavaScript exploit to de-anonymize Tor users (http://www.wired.com/threatlevel/2013/09/freedom-hosting-fbi). JavaScript exploits are also mentioned in documents describing the NSA's Egotistical Giraffe (http://www.theguardian.com/world/interactive/2013/oct/04/egotistical-giraffe-nsa-tor-document) program, which also has the goal of targeting and de-anonymizing Tor users.")}}</p>
 
-<p>We encourage SecureDrop users to disable JavaScript to protect themselves from malware that would use it to attack their browser and potentially de-anonymize them. There are other ways to get hacked, but given the use of JavaScript-based attacks recently, we believe it is prudent to disable it at this time.</p>
+<p>{{_("We encourage SecureDrop users to disable JavaScript to protect themselves from malware that would use it to attack their browser and potentially de-anonymize them. There are other ways to get hacked, but given the use of JavaScript-based attacks recently, we believe it is prudent to disable it at this time.")}}</p>
 
-<p>The Tor Browser comes with an add-on called NoScript that can be used to completely disable JavaScript by default, and to only enable it for sites that you trust.</p>
+<p>{{_("The Tor Browser comes with an add-on called NoScript that can be used to completely disable JavaScript by default, and to only enable it for sites that you trust.")}}</p>
 
-<p><strong>To disable JavaScript in Tor Browser, click the NoScript icon <img src="/static/i/no16.png"/> to the left of the address bar above and choose "Forbid Scripts Globally (advised)".</strong></p>
+<p><strong>{{_("To disable JavaScript in Tor Browser, click the NoScript icon %(icon)s to the left of the address bar above and choose \"Forbid Scripts Globally (advised)\"", icon="<img src=\"/static/i/no16.png\"/>"|safe)}}.</strong></p>
+
 
 {% endblock %}

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -10,7 +10,7 @@
     <script type="text/javascript" src="/static/js/source.js"></script>
   </head>
   <body>
-    <div class="warning"><strong>We recommend disabling JavaScript to protect your anonymity:</strong> <a id="disable-js" href="/howto-disable-js">Learn how to disable it</a>, or ignore this warning to continue. <i id="warning-close" class="fa fa-times"></i></div>
+    <div class="warning"><strong>{{_("We recommend disabling JavaScript to protect your anonymity:")}}</strong>{{_(" %(howto_disable_js)s, or ignore this warning to continue.", howto_disable_js="<a id=\"disable-js\" href=\"/howto-disable-js\">%s</a>"|safe|format(_("Learn how to disable it")))}} <i id="warning-close" class="fa fa-times"></i></div>
 
     {% include 'banner_warning_flashed.html' %}
 
@@ -28,40 +28,41 @@
 
         <div class="grid-item option alt">
           <h2>
-            Submit documents for the first time
+            {{_("Submit documents for the first time")}}
           </h2>
           <hr class="cut-out" />
-          <p>If this is your first time submitting documents to journalists, start here.</p>
+          <p>{{_("If this is your first time submitting documents to journalists, start here.")}}</p>
           <hr class="no-line" />
-          <a href="/generate" class="btn alt block pull-bottom" id="submit-documents-button"><i class="fa fa-cloud-upload"></i> Submit Documents</a>
+          <a href="/generate" class="btn alt block pull-bottom" id="submit-documents-button"><i class="fa fa-cloud-upload"></i> {{_("Submit Documents")}}</a>
         </div>
         <div class="grid-item option">
           <h2>
-            Already submitted something?
+            {{_("Already submitted something?")}}
           </h2>
           <hr class="cut-out" />
-          <p>If you have already submitted documents in the past, log in here to check for responses.</p>
+          <p>{{_("If you have already submitted documents in the past, log in here to check for responses.")}}</p>
           <hr class="no-line" />
-          <a href="/login" class="btn block pull-bottom"><i class="fa fa-comments"></i> Check for a response</a>
+          <a href="/login" class="btn block pull-bottom"><i class="fa fa-comments"></i> {{_("Check for a response")}}</a>
         </div>
       </div>
 
       <footer>
-        Like all software, SecureDrop may contain security bugs. Use at your own risk. Powered by SecureDrop {{ version }}.
+        {{_("Like all software, SecureDrop may contain security bugs. Use at your own risk. Powered by SecureDrop %(version)s.", version=version)}}
       </footer>
+      {% include 'locale_selection.html' %}
     </div>
 
     <!-- Warning bubble to help TB users disable Javascript with NoScript.
     Included here so the images can preload while the user is first
     reading the page. Hidden by default. -->
     <div class="bubble">
-      <p>You appear to be using the Tor Browser. You can disable Javascript in 3 easy steps!</p> 
+      <p>{{_("You appear to be using the Tor Browser. You can disable Javascript in 3 easy steps!")}}</p>
       <ol>
-        <li>Click the <img src="static/i/no16.png"> NoScript icon in the toolbar above</li> 
-        <li>Click <strong><img src="static/i/no16-global.png"/> Forbid Scripts Globally (advised)</strong></li> 
-        <li>If the page does not refresh automatically, <a href="/">click here</a> to refresh the page</li> 
+        <li>{{_("Click %(img)s NoScript icon in the toolbar above", img="<img src=\"static/i/no16.png\">"|safe)}}</li>
+        <li>{{_("Click <strong>%(img)s Forbid Scripts Globally (advised)</strong>", img="<img src=\"static/i/no16-global.png\"/>"|safe)}}</li>
+        <li>{{_("If the page does not refresh automatically, %(click_here)s to refresh the page", click_here="<a href=\"/\">%s</a>"|safe|format(_("click here")))}}</li>
       </ol>
-      <p><a href="/howto-disable-js">Not using the Tor Browser Bundle?</a></p>
+      <p><a href="/howto-disable-js">{{_("Not using the Tor Browser Bundle?")}}</a></p>
     </div>
 
   </body>

--- a/securedrop/source_templates/locale_selection.html
+++ b/securedrop/source_templates/locale_selection.html
@@ -1,0 +1,15 @@
+{% if g.locales and g.locales.keys()|length > 1 %}
+<div class="locales">
+  <ul class="plain">
+    {% for locale in g.locales %}
+      <li>
+      {% if locale == g.resolved_locale %}
+        {{ g.locales[locale] }}
+      {% else %}
+        <a href="?l={{ locale }}" rel="nofollow">{{ g.locales[locale] }}</a>
+      {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 {% block body %}
 
-<h2>Login to check for responses</h2>
+<h2>{{_("Login to check for responses")}}</h2>
 
 {% include 'flashed.html' %}
 
 <form method="post" action="/login" autocomplete="off">
 <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-<p class="center"><input type="text" name="codename" class="codename" autocomplete="off" placeholder="Enter your codename" autofocus /></p>
-<p class="center"><button type="submit" class="btn block"><i class="fa fa-arrow-circle-o-right"></i> Continue</button></p>
+<p class="center"><input type="text" name="codename" class="codename" autocomplete="off" placeholder="{{_("Enter your codename")}}" autofocus /></p>
+<p class="center"><button type="submit" class="btn block"><i class="fa fa-arrow-circle-o-right"></i> {{_("Continue")}}</button></p>
 </form>
 {% endblock %}

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -5,11 +5,11 @@
   {% include 'flashed.html' %}
 
   {% if flagged and not haskey %}
-  <p class="notification"> <i class="fa fa-info-circle pull-left"></i> A journalist has been waiting for you to log in again so SecureDrop can generate a crypto key for you. Now that you have logged in, they are able to write you a reply. Check back later for replies.</p>
+  <p class="notification"> <i class="fa fa-info-circle pull-left"></i> {{_("A journalist has been waiting for you to log in again so SecureDrop can generate a crypto key for you. Now that you have logged in, they are able to write you a reply. Check back later for replies.")}}</p>
   {% endif %}
 
-  <h2 class="headline">Submit documents and messages</h2>
-  <p>You can send a file, a message, or both.</p>
+  <h2 class="headline">{{_("Submit documents and messages")}}</h2>
+  <p>{{_("You can send a file, a message, or both.")}}</p>
 
   <hr class="no-line">
 </center>
@@ -19,27 +19,29 @@
   <div class="snippet grid">
     <div class="attachment grid-item">
       <i class="fa fa-cloud-upload upload-icon"></i> <input type="file" name="fh" autocomplete="off">
-      <p class="center" id="max-file-size">Maximum upload size: 500 MB</p>
+      <p class="center" id="max-file-size">{{_("Maximum upload size:")}} 500 MB</p>
     </div>
     <div class="message grid-item">
-      <textarea name="msg" class="fill-parent" placeholder="Add message"></textarea>
+      <textarea name="msg" class="fill-parent" placeholder="{{ _("Add message") }}"></textarea>
     </div>
   </div>
 
   <hr class="no-line">
 
-  <button type="submit" class="btn primary" href="upload.html"><i class="fa fa-cloud-upload"></i> Submit</button>
+  <button type="submit" class="btn primary" href="upload.html"><i class="fa fa-cloud-upload"></i> {{_("Submit")}}</button>
 </form>
 
-<p><strong>Tip:</strong> If you are already familiar with GPG, you can optionally encrypt your files and messages with our <a href="/journalist-key" class="text-link">public key</a> before submission. Files are encrypted as they are received by SecureDrop; encrypting before submission provides an extra layer of security before your data reaches SecureDrop. <a href="/why-journalist-key" class="text-link">Learn more</a>.</p>
+<p><strong>{{_("Tip:")}}</strong>{{_(" If you are already familiar with GPG, you can optionally encrypt your files and messages with our %(journalist_key)s before submission. Files are encrypted as they are received by SecureDrop; encrypting before submission provides an extra layer of security before your data reaches SecureDrop. %(why_journalist_key)s.",
+  journalist_key="<a href=\"/journalist-key\" class=\"text-link\">%s</a>"|safe|format(_("public key")),
+  why_journalist_key="<a href=\"/why-journalist-key\" class=\"text-link\">%s</a>"|safe|format(_("Learn more")))}}</p>
 
 <hr class="no-line"/>
 
-<h2 class="headline">Replies</h2>
+<h2 class="headline">{{_("Replies")}}</h2>
 
 <div id="replies">
   {% if replies %}
-    <p>You have received a reply. For your security, please delete all replies when you're done with them. This also lets us know that you have received our reply. You can respond by submitting a new message above.</p>
+    <p>{{_("You have received a reply. For your security, please delete all replies when you're done with them. This also lets us know that you have received our reply. You can respond by submitting a new message above.")}}</p>
     <hr class="no-line">
     {% for reply in replies %}
       <div class="reply">
@@ -47,21 +49,21 @@
         <form class="message" method="post" action="/delete" autocomplete="off">
           <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
           <input type="hidden" name="msgid" value="{{ reply.id }}" autocomplete="off"/>
-          <button type="submit"><i class="fa fa-trash-o"></i> Delete</button>
+          <button type="submit"><i class="fa fa-trash-o"></i> {{_("Delete")}}</button>
         </form>
         <blockquote>{{ reply.msg | nl2br }}</blockquote>
         <div class="clearfix"></div>
       </div>
     {% endfor %}
   {% else %}
-    <p id="no-replies">There are no replies at this time.</p>
+    <p id="no-replies">{{_("There are no replies at this time.")}}</p>
   {% endif %}
 </div>
 
 <hr class="no-line">
 
 <div class="code-reminder">
-  <i class="fa fa-lock pull-left"></i> Remember, your codename is: <strong>{{ codename }}</strong>
+  <i class="fa fa-lock pull-left"></i> {{_("Remember, your codename is:")}} <strong>{{ codename }}</strong>
 </div>
 
 </div>

--- a/securedrop/source_templates/notfound.html
+++ b/securedrop/source_templates/notfound.html
@@ -2,10 +2,10 @@
 {% block body %}
 <div id="content">
 
-<h2>Page not found</h2>
+<h2>{{_("Page not found")}}</h2>
 
-<p>Sorry, we couldn't locate what you requested.</p>
+<p>{{_("Sorry, we couldn't locate what you requested.")}}</p>
 
-<p><a href="/login">Look up a codename...</a></p>
+<p><a href="/login">{{_("Look up a codename...")}}</a></p>
 </div>
 {% endblock %}

--- a/securedrop/source_templates/tor2web-warning.html
+++ b/securedrop/source_templates/tor2web-warning.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block body %}
-<h2>Why is there a warning about Tor2Web?</h2>
-<p>Tor2Web (http://tor2web.org) is a proxy service that lets you browse Tor Hidden Services (.onion sites) without installing Tor. It was designed to facilitate anonymous publishing.</p>
-<p>Tor2Web only protects publishers, not readers. If you upload documents to us using Tor2Web, you are <strong>not anonymous</strong> and could be identified by your ISP or the Tor2Web proxy operators. Additionally, since Tor2Web sites typically use HTTPS, it is possible that your connection could be MITM'ed by a capable adversary.</p>
-<p>If you want to submit information, we <strong>strongly advise you</strong> to install Tor (https://www.torproject.org/download.html.en) and use it to access our site safely and anonymously.</p>
+<h2>{{_("Why is there a warning about Tor2Web?")}}</h2>
+<p>{{_("Tor2Web (http://tor2web.org) is a proxy service that lets you browse Tor Hidden Services (.onion sites) without installing Tor. It was designed to facilitate anonymous publishing."}}</p>
+<p>{{_("Tor2Web only protects publishers, not readers. If you upload documents to us using Tor2Web, you are <strong>not anonymous</strong> and could be identified by your ISP or the Tor2Web proxy operators. Additionally, since Tor2Web sites typically use HTTPS, it is possible that your connection could be MITM'ed by a capable adversary.")}}</p>
+<p>{{_("If you want to submit information, we <strong>strongly advise you</strong> to install Tor (https://www.torproject.org/download.html.en) and use it to access our site safely and anonymously.")}}</p>
 {% endblock %}

--- a/securedrop/source_templates/why-journalist-key.html
+++ b/securedrop/source_templates/why-journalist-key.html
@@ -1,26 +1,26 @@
 {% extends "base.html" %}
 {% block body %}
-<h2>Why download the journalist's public key?</h2>
-<p>SecureDrop encrypts files and messages after they are submitted. Encrypting messages and files before submission can provide an extra layer of security before your data reaches the SecureDrop server.</p>
-<p>If you are already familiar with the GPG encryption software, you may wish to encrypt your submissions yourself. To do so:
+<h2>{{_("Why download the journalist's public key?")}}</h2>
+<p>{{_("SecureDrop encrypts files and messages after they are submitted. Encrypting messages and files before submission can provide an extra layer of security before your data reaches the SecureDrop server.")}}</p>
+<p>{{_("If you are already familiar with the GPG encryption software, you may wish to encrypt your submissions yourself. To do so:")}}
 <ol>
-<li><a href="/journalist-key">Download</a> the public key. The public key is a text file with the extension <code>.asc</code></li>
-<li>Import it into your GPG keyring.
+<li>{{_("%(download)s the public key. The public key is a text file with the extension <code>.asc</code>", download="<a href=\"/journalist-key\">%s</a>"|safe|format(_("Download")))}}</li>
+<li>{{_("Import it into your GPG keyring.")}}
 <ul>
-<li>If you are using Tails (https://tails.boum.org/), you can double-click the <code>.asc</code> file you just downloaded and it will be automatically imported to your keyring.</li>
-<li>If you are using Mac/Linux, open the Terminal. You can import the key with <code>gpg --import /path/to/key.asc</code>.</li>
+<li>{{_("If you are using Tails (https://tails.boum.org/), you can double-click the <code>.asc</code> file you just downloaded and it will be automatically imported to your keyring.")}}</li>
+<li>{{_("If you are using Mac/Linux, open the Terminal. You can import the key with <code>gpg --import /path/to/key.asc</code>.")}}</li>
 </ul>
 </li>
-<li>Encrypt your submission.
+<li>{{_("Encrypt your submission.")}}
 <ol>
-<li>You will need to be able to identify the key (this is called the "user ID" or uid). Since the public key's filename is the key's fingerprint (with .asc at the end), you can just copy and paste that. (don't include the <code>.asc</code>!)</li>
-<li>On all systems, open the Terminal and use this gpg command: <code>gpg --recipient &lt;user ID&gt; --encrypt roswell_photos.pdf</code></li>
+<li>{{_("You will need to be able to identify the key (this is called the \"user ID\" or uid). Since the public key's filename is the key's fingerprint (with .asc at the end), you can just copy and paste that. (don't include the <code>.asc</code>!)")}}</li>
+<li>{{_("On all systems, open the Terminal and use this gpg command: <code>gpg --recipient &lt;user ID&gt; --encrypt roswell_photos.pdf</code>")}}</li>
 </ol>
 </li>
-<li>Upload your encrypted submission. It will have the same filename as the unencrypted file, with .gpg at the end (e.g. <code>roswell_photos.pdf.gpg</code>)</li>
+<li>{{_("Upload your encrypted submission. It will have the same filename as the unencrypted file, with .gpg at the end (e.g. <code>roswell_photos.pdf.gpg</code>)")}}</li>
 </ol>
 
-<p><strong>Tip:</strong> If you wish to remain anonymous, <strong>do not</strong> use GPG to sign the encrypted file (with the <code>--sign</code> or <code>-s</code> flag) as this will reveal your GPG identity to us.</p>
+<p>{{_("<strong>Tip:</strong> If you wish to remain anonymous, <strong>do not</strong> use GPG to sign the encrypted file (with the <code>--sign</code> or <code>-s</code> flag) as this will reveal your GPG identity to us.")}}</p>
 
-<p><a href="/lookup">&laquo; Back to submission page</a></p>
+<p><a href="/lookup">&laquo; {{_("Back to submission page")}}</a></p>
 {% endblock %}

--- a/securedrop/static/css/styles.css
+++ b/securedrop/static/css/styles.css
@@ -78,6 +78,15 @@ footer {
   padding-top: 20px;
   color: #9e9e9e;
 }
+.locales {
+  text-align: center;
+  margin-top: 10px;
+  font-size: small;
+}
+.locales li {
+  display: inline-block;
+  margin: 0 5px;
+}
 a.text-link {
   color: #7985aa;
 }

--- a/securedrop/tests/test_unit_integration.py
+++ b/securedrop/tests/test_unit_integration.py
@@ -427,7 +427,7 @@ class TestIntegration(unittest.TestCase):
                                       follow_redirects=True)
         self.assertEquals(rv.status_code, 200)
 
-        self.assertIn(escape("%s's collection deleted" % (col_name,)), rv.data)
+        self.assertIn(escape("%s's collection deleted" % (col_name,)), rv.data.decode('utf-8'))
         self.assertIn("No documents have been submitted!", rv.data)
 
         # Make sure the collection is deleted from the filesystem

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -7,7 +7,7 @@ import zipfile
 
 import mock
 
-from flask import url_for
+from flask import url_for, session, g
 from flask.ext.testing import TestCase
 
 # Set environment variable so config.py uses a test environment
@@ -136,6 +136,20 @@ class TestJournalist(TestCase):
         self.assertTrue(zipfile.ZipFile(StringIO(rv.data)).getinfo(
             os.path.join(source.journalist_filename(), files[0])
         ))
+
+    def test_apply_locale(self):
+        journalist.config.LOCALES = {'en': 'English', 'zh': 'Chinese'}
+        with self.client as c:
+            c.get('/?l=zh')
+            self.assertEqual(g.resolved_locale, 'zh')
+            self.assertEqual(session['locale'], 'zh')
+
+    def test_apply_locale_accept_language(self):
+        journalist.config.LOCALES = {'en': 'English', 'zh': 'Chinese'}
+        with self.client as c:
+            c.get('/', headers=[('Accept-Language', 'zh-Hant, zh;q=0.8')])
+            self.assertEqual(g.resolved_locale, 'zh')
+            self.assertEqual(session.get('locale'), None)
 
 
 if __name__ == "__main__":

--- a/securedrop/translations/it/LC_MESSAGES/messages.po
+++ b/securedrop/translations/it/LC_MESSAGES/messages.po
@@ -1,0 +1,856 @@
+# Translations template for SecureDrop.
+# Copyright (C) 2014 ORGANIZATION
+# This file is distributed under the same license as the SecureDrop project.
+# 
+# Translators:
+# edwincheese <edwincheese@gmail.com>, 2014
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
+# gio <gdamiola@gmail.com>, 2014
+# gio <gdamiola@gmail.com>, 2014
+msgid ""
+msgstr ""
+"Project-Id-Version: SecureDrop\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2014-11-19 06:57+0000\n"
+"PO-Revision-Date: 2014-11-19 07:07+0000\n"
+"Last-Translator: edwincheese <edwincheese@gmail.com>\n"
+"Language-Team: Italian (http://www.transifex.com/projects/p/securedrop-app-code/language/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: securedrop/journalist.py:126
+msgid "You must be an administrator to access that page"
+msgstr "Devi essere un amministratore per poter accedere a questa pagina"
+
+#: securedrop/journalist.py:143
+msgid "Login failed"
+msgstr "Login fallito"
+
+#: securedrop/journalist.py:177
+msgid "Missing username"
+msgstr "Manca il nome utente"
+
+#: securedrop/journalist.py:183 securedrop/journalist.py:266
+msgid "Passwords didn't match"
+msgstr "Le password non corrispondono"
+
+#: securedrop/journalist.py:201 securedrop/journalist.py:278
+msgid "That username is already in use"
+msgstr "Nome utente non disponibile"
+
+#: securedrop/journalist.py:204
+msgid "An error occurred saving this user to the database"
+msgstr "Si è presentato un errore salvando l'utente nel database"
+
+#: securedrop/journalist.py:222
+#, python-format
+msgid "Two factor token successfully verified for user %(username)s!"
+msgstr "Token per l'autenticazione a due fattori verificato per l'utente %(username)s!"
+
+#: securedrop/journalist.py:225
+msgid "Two factor token failed to verify"
+msgstr "Token per l'autenticazione a due fattori non valido"
+
+#: securedrop/journalist.py:280
+msgid "An unknown error occurred, please inform your administrator"
+msgstr "Si è verificato un errore, contatta l'amministratore"
+
+#: securedrop/journalist.py:428
+#, python-format
+msgid "%(journalist_designation)s's collection deleted"
+msgstr "L'archivio del giornalista %(journalist_designation)s è stato cancellato"
+
+#: securedrop/journalist.py:435 securedrop/journalist.py:513
+msgid "No collections selected to delete!"
+msgstr "Non è stato selezionato nessun archivio!"
+
+#: securedrop/journalist.py:441
+#, python-format
+msgid "%(cols_selected)d collection deleted"
+msgid_plural "%(cols_selected)d collections deleted"
+msgstr[0] "%(cols_selected)d archivio cancellato"
+msgstr[1] "%(cols_selected)d archivi cancellati"
+
+#: securedrop/journalist.py:485
+#, python-format
+msgid ""
+"The source '%(original_journalist_designation)s' has been renamed to "
+"'%(new_journalist_designation)s'"
+msgstr "La fonte '%(original_journalist_designation)s' è stata rinominata con '%(new_journalist_designation)s'"
+
+#: securedrop/journalist.py:511
+msgid "No collections selected to download!"
+msgstr "Nessun archivio selezionato per il download!"
+
+#: securedrop/source.py:124
+#, python-format
+msgid ""
+"<strong>WARNING:</strong> You appear to be using Tor2Web. This <strong>does "
+"not</strong> provide anonymity. %(tor2web_warning)s"
+msgstr "<strong>ATTENZIONE:</strong> Sembra che tu stia usando Tor2Web. Si tratta di un servizio che <strong>non serve</strong> a garantire l'anonimato. %(tor2web_warning)s"
+
+#: securedrop/source.py:258
+msgid "Thanks! We received your message."
+msgstr "Grazie! Abbiamo ricevuto il tuo messaggio"
+
+#: securedrop/source.py:263
+#, python-format
+msgid "Thanks! We received your document \"%(filename)s\"."
+msgstr "Grazie! Abbiamo ricevuto il tuo documento \"%(filename)s\"."
+
+#: securedrop/source.py:293
+msgid "Reply deleted"
+msgstr "Risposta cancellata"
+
+#: securedrop/source.py:313
+msgid "Sorry, that is not a recognized codename."
+msgstr "Spiacente, il codename non è valido"
+
+#: securedrop/journalist_templates/admin.html:3
+msgid "Admin Interface"
+msgstr "Interfaccia Amministrazione"
+
+#: securedrop/journalist_templates/admin.html:6
+#: securedrop/journalist_templates/admin_add_user.html:21
+msgid "Add user"
+msgstr "Aggiungi utente"
+
+#: securedrop/journalist_templates/admin.html:16
+#: securedrop/journalist_templates/admin_add_user.html:9
+#: securedrop/journalist_templates/login.html:8
+msgid "Username"
+msgstr "Username"
+
+#: securedrop/journalist_templates/admin.html:17
+msgid "Edit"
+msgstr "Modifica"
+
+#: securedrop/journalist_templates/admin.html:18
+#: securedrop/source_templates/lookup.html:52
+msgid "Delete"
+msgstr "Cancella"
+
+#: securedrop/journalist_templates/admin.html:19
+msgid "Created"
+msgstr "Creato"
+
+#: securedrop/journalist_templates/admin.html:20
+msgid "Last login"
+msgstr "Ultimo login"
+
+#: securedrop/journalist_templates/admin.html:31
+msgid "Never"
+msgstr "Mai"
+
+#: securedrop/journalist_templates/admin.html:38
+msgid "No users to display"
+msgstr "Non ci sono utenti"
+
+#: securedrop/journalist_templates/admin_add_user.html:4
+#: securedrop/journalist_templates/admin_edit_user.html:4
+msgid "Back to admin interface"
+msgstr "Torna all'interfaccia di amministrazione"
+
+#: securedrop/journalist_templates/admin_add_user.html:10
+#: securedrop/journalist_templates/login.html:9
+msgid "Password"
+msgstr "Password"
+
+#: securedrop/journalist_templates/admin_add_user.html:11
+msgid "Password (again)"
+msgstr "Ripeti la password"
+
+#: securedrop/journalist_templates/admin_add_user.html:14
+#: securedrop/journalist_templates/admin_edit_user.html:23
+msgid "Is Administrator"
+msgstr "Admin"
+
+#: securedrop/journalist_templates/admin_add_user.html:18
+msgid "I'm using a Yubikey "
+msgstr "Uso un chiave Yubikey"
+
+#: securedrop/journalist_templates/admin_add_user.html:19
+msgid "HOTP Secret"
+msgstr "HOTP Secret"
+
+#: securedrop/journalist_templates/admin_edit_hotp_secret.html:7
+msgid "Change Secret"
+msgstr "Cambia Secret"
+
+#: securedrop/journalist_templates/admin_edit_hotp_secret.html:10
+#: securedrop/source_templates/generate.html:39
+#: securedrop/source_templates/login.html:11
+msgid "Continue"
+msgstr "Continua"
+
+#: securedrop/journalist_templates/admin_edit_user.html:3
+msgid "Edit user"
+msgstr "Modifica utente"
+
+#: securedrop/journalist_templates/admin_edit_user.html:9
+msgid "Change username"
+msgstr "Cambia username"
+
+#: securedrop/journalist_templates/admin_edit_user.html:13
+msgid "Change password"
+msgstr "Cambia password"
+
+#: securedrop/journalist_templates/admin_edit_user.html:15
+msgid "Leave blank for no change"
+msgstr "Lascia vuoto per non cambiare"
+
+#: securedrop/journalist_templates/admin_edit_user.html:18
+msgid "Change password (confirm)"
+msgstr "Cambia password (conferma)"
+
+#: securedrop/journalist_templates/admin_edit_user.html:25
+msgid "Update user"
+msgstr "Modifica utente"
+
+#: securedrop/journalist_templates/admin_edit_user.html:30
+msgid "Reset Two Factor Authentication"
+msgstr "Resetta l'autenticazione a due fattori"
+
+#: securedrop/journalist_templates/admin_edit_user.html:31
+msgid ""
+"If a user's two factor authentication credentials have been lost or "
+"compromised, you can reset them here. "
+msgstr "Se le credenziali di autenticazione a due fattori di un utente sono perse o compromesse, puoi resettarle qui."
+
+#: securedrop/journalist_templates/admin_edit_user.html:31
+msgid ""
+"If you do this, make sure the user is present and ready to set up their "
+"device with the new two factor credentials. Otherwise, they will be locked "
+"out of their account."
+msgstr "Se lo vuoi fare, assicurati che gli utenti siano presenti e pronti per fare il setup con le nuove credenziali. Altrimenti resteranno chiusi fuori dai loro account."
+
+#: securedrop/journalist_templates/admin_edit_user.html:35
+msgid "Reset two factor authentication (Google Authenticator)"
+msgstr "Resetta l'autenticazione a due fattori (Google Authenticator)"
+
+#: securedrop/journalist_templates/admin_edit_user.html:41
+msgid "Reset two factor authentication (HOTP Yubikey)"
+msgstr "Resetta l'autenticazione a due fattori (HOTP Yubikey)"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:4
+msgid "Enable Google Authenticator"
+msgstr "Abilita Google Authenticator"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:5
+msgid ""
+"You're almost done! To finish adding this new user, have them follow the "
+"instructions below to set up two factor authentication with Google "
+"Authenticator. Once they've added an entry for this account in the app, have"
+" them enter one of the 6-digit codes from the app to confirm that two factor"
+" authentication is set up correctly."
+msgstr "Hai quasi terminato! Per completare il setup per questo nuovo utente, segui le istruzioni riportate qui sotto configurando l'autenticazione a due fattori con Google Authenticator. Una volta aggiunta l'entry per questo account nell'app, per confermare la corretta configurazione dell'autenticazione a due fattori si inserisca uno dei codici a 6 cifre generati dall'app."
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:7
+msgid "Install Google Authenticator on your phone"
+msgstr "Installa Google Authenticator sul tuo telefono"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:8
+msgid "Open the Google Authenticator app"
+msgstr "Apri Google Authenticator"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:9
+msgid "Tap menu, then tap \"Set up account\", then tap \"Scan a barcode\""
+msgstr "Clicca menu, poi \"Set up account\" e infine \"Scan Barcode\""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:10
+msgid ""
+"Your phone will now be in \"scanning\" mode. When you are in this mode, scan"
+" the barcode below:"
+msgstr "Il tuo telefono ora ora pronto per la scansione del QR code qua sotto."
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:13
+msgid "Can't scan the barcode? Enter the following code manually:"
+msgstr "Non riesci a fare la scansione del QR code? Inserisci il seguente codice manualmente:"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:14
+msgid "Once you have scanned the barcode, enter the 6-digit code below:"
+msgstr "Una volta fatta la scansione del QR code, inserisci il codice a 6 cifre qua sotto:"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:16
+msgid "Enable Yubikey (OATH-HOTP)"
+msgstr "Abilita Yubikey (OATH-HOTP)"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:17
+msgid "Once you have configured your Yubikey, enter the 6-digit code below:"
+msgstr "Una volta configurata la Yubikey, inserisci il codice a 6 cifre qui sotto:"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:21
+msgid "Verification code"
+msgstr "Codice di verifica"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:23
+#: securedrop/journalist_templates/col.html:61
+#: securedrop/source_templates/lookup.html:31
+msgid "Submit"
+msgstr "Invia"
+
+#: securedrop/journalist_templates/base.html:4
+msgid "SecureDrop"
+msgstr "SecureDrop"
+
+#: securedrop/journalist_templates/base.html:18
+msgid "Admin"
+msgstr "Admin"
+
+#: securedrop/journalist_templates/base.html:20
+msgid "Logout"
+msgstr "Logout"
+
+#: securedrop/journalist_templates/base.html:46
+#, python-format
+msgid "Powered by <em>SecureDrop %(version)s</em>."
+msgstr "Powered by <em>SecureDrop %(version)s</em>."
+
+#: securedrop/journalist_templates/col.html:10
+msgid "All Sources"
+msgstr "Tutte le fonti"
+
+#: securedrop/journalist_templates/col.html:13
+msgid ""
+"Generate a new random codename for this source. We recommend doing this if "
+"the first random codename is difficult to say or remember. You can generate "
+"new random codenames as many times as you like."
+msgstr "Genera un nuovo codename casuale per questa fonte. Si raccomanda di farlo nel caso il codename generato sia troppo difficile da memorizzare. Puoi generare un nuovo codename casuale quante volte vuoi."
+
+#: securedrop/journalist_templates/col.html:13
+msgid "Change codename"
+msgstr "Cambia codename"
+
+#: securedrop/journalist_templates/col.html:18
+msgid ""
+"The documents are stored encrypted for security. To read them, you will need"
+" to decrypt them using GPG."
+msgstr "I documenti sono salvati in forma criptata per ragioni di sicurezza. Per leggerli dovrai decrittarli usando GPG."
+
+#: securedrop/journalist_templates/col.html:22
+msgid "Download selected"
+msgstr "Scarica i files selezionati"
+
+#: securedrop/journalist_templates/col.html:23
+#: securedrop/journalist_templates/index.html:11
+msgid "Delete selected"
+msgstr "Cancella i files selezionati"
+
+#: securedrop/journalist_templates/col.html:30
+#, python-format
+msgid "%(file_size)s sent %(date)s"
+msgstr "%(file_size)s inviato %(date)s"
+
+#: securedrop/journalist_templates/col.html:33
+#, python-format
+msgid "%(file_size)s uploaded %(date)s"
+msgstr "%(file_size)s caricato %(date)s"
+
+#: securedrop/journalist_templates/col.html:36
+msgid "Uploaded Document"
+msgstr "Documento caricato"
+
+#: securedrop/journalist_templates/col.html:38
+msgid "Message"
+msgstr "Messaggio"
+
+#: securedrop/journalist_templates/col.html:48
+msgid "No documents to display."
+msgstr "Non ci sono documenti da mostrare."
+
+#: securedrop/journalist_templates/col.html:53
+msgid "Reply"
+msgstr "Rispondi"
+
+#: securedrop/journalist_templates/col.html:55
+msgid ""
+"You can write a secure reply to the person who submitted these documents:"
+msgstr "Puoi scrivere una risposta sicura alla persona che ha inviato questi documenti:"
+
+#: securedrop/journalist_templates/col.html:64
+msgid "You've flagged this source for reply."
+msgstr "Hai selezionato questa fonte per una risposta."
+
+#: securedrop/journalist_templates/col.html:65
+msgid ""
+"An encryption key will be generated for the source the next time they log "
+"in, after which you will be able to reply to the source here."
+msgstr "Una chiave crittografica sarà generata per la fonte la prossima volta che si connetterà, dopodiché potrai risponderle qui."
+
+#: securedrop/journalist_templates/col.html:67
+msgid "Click below if you would like to write a reply to this source."
+msgstr "Clicca qui sotto se voui scrivere una risposta a questa fonte."
+
+#: securedrop/journalist_templates/col.html:71
+msgid "Flag this source for reply"
+msgstr "Marca questa fonte per una risposta"
+
+#: securedrop/journalist_templates/col.html:76
+msgid "Click below to delete this source's collection. "
+msgstr "Clicca qui sotto per cancellare l'archivio di questa fonte."
+
+#: securedrop/journalist_templates/col.html:76
+msgid ""
+"Warning: If you do this, the files seen here will be unrecoverable and the "
+"source will no longer be able to login using their previous codename."
+msgstr "Attenzione: i seguenti files andranno perduti e la fonte non sarà più in grado di connettersi con il proprio codename."
+
+#: securedrop/journalist_templates/col.html:82
+msgid "Delete collection"
+msgstr "Cancella archivio"
+
+#: securedrop/journalist_templates/delete.html:7
+msgid "File permanently deleted."
+msgid_plural "Files permanently deleted."
+msgstr[0] "File cancellato definitivamente"
+msgstr[1] "File cancellati definitivamente."
+
+#: securedrop/journalist_templates/delete.html:13
+#, python-format
+msgid ""
+"The following file has been selected for <strong>permanent deletion</strong>"
+msgid_plural ""
+"The following %(value)d files have been selected for <strong>permanent "
+"deletion</strong>"
+msgstr[0] "Il file seguente è stato selezionato per essere <strong>cancellato definitivamente</strong>"
+msgstr[1] "I file %(value)d sono stati selezionati per essere <strong>cancellati definitivamente</strong>"
+
+#: securedrop/journalist_templates/delete.html:23
+#, python-format
+msgid "(sent %(date)s)"
+msgstr "(inviato %(date)s)"
+
+#: securedrop/journalist_templates/delete.html:25
+#, python-format
+msgid "(uploaded %(date)s)"
+msgstr "(caricato %(date)s)"
+
+#: securedrop/journalist_templates/delete.html:32
+msgid "Permanently delete files"
+msgstr "File cancellati definitivamente"
+
+#: securedrop/journalist_templates/delete.html:38
+#, python-format
+msgid "Return to the list of documents for %(codename)s..."
+msgstr "Ritorna alla lista dei documenti per %(codename)s..."
+
+#: securedrop/journalist_templates/flag.html:5
+msgid "Thanks!"
+msgstr "Grazie!"
+
+#: securedrop/journalist_templates/flag.html:8
+msgid ""
+"SecureDrop will generate a secure encryption key for this source the next "
+"time that they log in. Once the key has been generated, a reply box will "
+"appear under their collection of documents. You can use this box to write "
+"encrypted replies to them."
+msgstr "SecureDrop genererà una chiave crittografica per la fonte la prossima volta che si connetterà. Una volta che la chiave è stata generate, un box di risposta apparirà sotto la collezione dei documenti. Puoi usare questo box per scrivere una risposta crittografata."
+
+#: securedrop/journalist_templates/flag.html:10
+#, python-format
+msgid "Continue to the list of documents for %(codename)s..."
+msgstr "Vai alla lista documenti per %(codename)s..."
+
+#: securedrop/journalist_templates/index.html:4
+msgid "Sources"
+msgstr "Fonti"
+
+#: securedrop/journalist_templates/index.html:10
+msgid "select all"
+msgstr "seleziona tutto"
+
+#: securedrop/journalist_templates/index.html:10
+msgid "select none"
+msgstr "deseleziona tutto"
+
+#: securedrop/journalist_templates/index.html:12
+msgid "Star Selected"
+msgstr "seleziona stella"
+
+#: securedrop/journalist_templates/index.html:13
+msgid "Un-star Selected"
+msgstr "seleziona senza-stella"
+
+#: securedrop/journalist_templates/index.html:29
+#: securedrop/journalist_templates/index.html:55
+msgid "docs"
+msgstr "docs"
+
+#: securedrop/journalist_templates/index.html:30
+#: securedrop/journalist_templates/index.html:56
+msgid "messages"
+msgstr "messaggi"
+
+#: securedrop/journalist_templates/index.html:33
+msgid " unread"
+msgstr "non letto"
+
+#: securedrop/journalist_templates/index.html:59
+msgid "unread"
+msgstr "non letto"
+
+#: securedrop/journalist_templates/index.html:71
+msgid "No documents have been submitted!"
+msgstr "Non è stato ricevuto nessun documento."
+
+#: securedrop/journalist_templates/login.html:4
+msgid "Login to access the journalist interface"
+msgstr "Login per accedere all'interfaccia giornalista"
+
+#: securedrop/journalist_templates/login.html:10
+msgid "Two-factor Code"
+msgstr "Codice a due fattori"
+
+#: securedrop/journalist_templates/login.html:11
+msgid "Log in"
+msgstr "Login"
+
+#: securedrop/journalist_templates/reply.html:5
+msgid "Thanks! Your reply has been stored."
+msgstr "Grazie! La tua risposta è stata salvata."
+
+#: securedrop/journalist_templates/reply.html:8
+msgid ""
+"You will now see it in the list of documents in that collection. Once the "
+"source has read it, they will be asked to delete it. If it disappears from "
+"the list, then you know it has been read."
+msgstr "A questo punto lo vedrai nella lista dei documenti in questo archivio. Una volta che la fonte l'avrà letto gli verrà chiesto di cancellarlo. Una volta scomparso dalla lista saprai che è stato letto."
+
+#: securedrop/journalist_templates/reply.html:10
+#, python-format
+msgid "Return to the list of documents for <strong>%(codename)s</strong>..."
+msgstr "Ritorna alla lista dei documenti per <strong>%(codename)s</strong>..."
+
+#: securedrop/source_templates/base.html:4
+msgid "SecureDrop | Protecting Journalists and Sources"
+msgstr "SecureDrop | Protecting Journalists and Sources"
+
+#: securedrop/source_templates/base.html:36
+#: securedrop/source_templates/index.html:50
+#, python-format
+msgid ""
+"Like all software, SecureDrop may contain security bugs. Use at your own "
+"risk. Powered by SecureDrop %(version)s."
+msgstr "Come ogni software, SecureDrop può contentere bug di sicurezza. Usalo a tuo rischio e pericolo. Powered by SecureDrop %(version)s."
+
+#: securedrop/source_templates/error.html:5
+msgid "Server error"
+msgstr "Server error"
+
+#: securedrop/source_templates/error.html:7
+msgid ""
+"Sorry, the website encountered an error and was unable to complete your "
+"request."
+msgstr "Spiacenti, si è verificato un errore ed è impossible completare la tua richiesta"
+
+#: securedrop/source_templates/error.html:9
+#: securedrop/source_templates/notfound.html:9
+msgid "Look up a codename..."
+msgstr "Ricerca codename in corso.... "
+
+#: securedrop/source_templates/generate.html:4
+msgid "Remember this code and keep it secret"
+msgstr "Ricordati questo codice e mantienilo segreto"
+
+#: securedrop/source_templates/generate.html:5
+msgid "To protect your identity, we're assigning you a unique codename."
+msgstr "Per proteggere la tua identità, ti verrà assegnato un codename unico."
+
+#: securedrop/source_templates/generate.html:29
+msgid ""
+"Store this code somewhere safe, or memorize it. It can be used to compromise"
+" your anonymity."
+msgstr "Questo codename può essere utilizzato per compromettere il tuo anonimato, conservalo in un luogo sicuro o imparalo a memoria."
+
+#: securedrop/source_templates/generate.html:33
+msgid "Important:"
+msgstr "Importante: "
+
+#: securedrop/source_templates/generate.html:33
+msgid ""
+" After you submit documents and messages, you will need this code to log in "
+"and read replies. This is the only way we can communicate back to you. You "
+"can also use your code to log in to submit more files and messages."
+msgstr "Dopo aver inviato i documenti e i messaggi, avrai bisogno di questo codice per fare login e leggere le risposte. Questo è il solo modo per poter rimanere in contatto. Potrai usare questo codice anche per inviare altri files o messaggi."
+
+#: securedrop/source_templates/generate.html:40
+msgid "Already have a codename?"
+msgstr "Hai già un codename?"
+
+#: securedrop/source_templates/howto-disable-js.html:4
+msgid "Disable JavaScript to Protect Your Anonymity"
+msgstr "Disabilita JavaScript per proteggere il tuo anonimato:"
+
+#: securedrop/source_templates/howto-disable-js.html:6
+msgid ""
+"JavaScript is a widely used programming language for creating interactive "
+"web pages. Unfortunately, JavaScript is also the most common source of "
+"security vulnerabilities in browsers. In August 2013, the FBI wrote malware "
+"that used a JavaScript exploit to de-anonymize Tor users "
+"(http://www.wired.com/threatlevel/2013/09/freedom-hosting-fbi). JavaScript "
+"exploits are also mentioned in documents describing the NSA's Egotistical "
+"Giraffe (http://www.theguardian.com/world/interactive/2013/oct/04"
+"/egotistical-giraffe-nsa-tor-document) program, which also has the goal of "
+"targeting and de-anonymizing Tor users."
+msgstr "JavaScript è un linguaggio utilizzato per creare pagine web interattive. Sfortunatamente, JavaScript è anche la principale fonte di vulnerabilità del tuo browser. Nell'agosto 2013, l'FBI ha utilizzato JavaScript per uno malware exploit in grado di de anonimizzare gli utenti Tor (http://www.wired.com/threatlevel/2013/09/freedom-hosting-fbi). Alcuni exploit JavaScript sono menzionati anche nel programma Egotistical Giraffe dell'NSA (http://www.theguardian.com/world/interactive/2013/oct/04/egotistical-giraffe-nsa-tor-document), il cui obiettivo è de anonimizzare gli utenti Tor."
+
+#: securedrop/source_templates/howto-disable-js.html:8
+msgid ""
+"We encourage SecureDrop users to disable JavaScript to protect themselves "
+"from malware that would use it to attack their browser and potentially de-"
+"anonymize them. There are other ways to get hacked, but given the use of "
+"JavaScript-based attacks recently, we believe it is prudent to disable it at"
+" this time."
+msgstr "Incoraggiamo gli utenti di SecureDrop a disabilitare JavaScript per proteggersi da malware che potrebbero de-anonimizzarne l'attività. Esistono anche altre tecniche, ma visti i recenti attacchi basati su JavaScript riteniamo prudente disabilitarne il supporto."
+
+#: securedrop/source_templates/howto-disable-js.html:10
+msgid ""
+"The Tor Browser comes with an add-on called NoScript that can be used to "
+"completely disable JavaScript by default, and to only enable it for sites "
+"that you trust."
+msgstr "Il Browser Tor è configurato con un add-on chiamato NoScript che può essere utilizzato per disabilitare JavaScript di default e attivarlo solo per i siti di cui ci fidiamo. "
+
+#: securedrop/source_templates/howto-disable-js.html:12
+#, python-format
+msgid ""
+"To disable JavaScript in Tor Browser, click the NoScript icon %(icon)s to "
+"the left of the address bar above and choose \"Forbid Scripts Globally "
+"(advised)\""
+msgstr "Per disabilitare JavaScript nel Browser Tor, clicca sull'icona NoScript %(icon)s nella barra di navigazione e seleziona \"Forbid Scripts Globally (advised)\""
+
+#: securedrop/source_templates/index.html:13
+msgid "We recommend disabling JavaScript to protect your anonymity:"
+msgstr "Disabilita JavaScript per proteggere il tuo anonimato: "
+
+#: securedrop/source_templates/index.html:13
+#, python-format
+msgid " %(howto_disable_js)s, or ignore this warning to continue."
+msgstr "%(howto_disable_js)s, o ignora questo avviso per continuare."
+
+#: securedrop/source_templates/index.html:13
+msgid "Learn how to disable it"
+msgstr "Scopri come disabilitarlo "
+
+#: securedrop/source_templates/index.html:31
+msgid "Submit documents for the first time"
+msgstr "Invia i documenti per la prima volta"
+
+#: securedrop/source_templates/index.html:34
+msgid ""
+"If this is your first time submitting documents to journalists, start here."
+msgstr "Se questa è la prima volta che invii documenti ai giornalisti, comincia qui."
+
+#: securedrop/source_templates/index.html:36
+msgid "Submit Documents"
+msgstr "Invia Documenti"
+
+#: securedrop/source_templates/index.html:40
+msgid "Already submitted something?"
+msgstr "Hai già inviato qualcosa?"
+
+#: securedrop/source_templates/index.html:43
+msgid ""
+"If you have already submitted documents in the past, log in here to check "
+"for responses."
+msgstr "Se hai già inviato dei documenti in passato, fai login qui per controllare le risposte."
+
+#: securedrop/source_templates/index.html:45
+msgid "Check for a response"
+msgstr "Controlla le risposte"
+
+#: securedrop/source_templates/index.html:59
+msgid ""
+"You appear to be using the Tor Browser. You can disable Javascript in 3 easy"
+" steps!"
+msgstr "Sembra che tu stia usando Tor Browser. Puoi disabilitare Javascript in 3 semplici passi!"
+
+#: securedrop/source_templates/index.html:61
+#, python-format
+msgid "Click %(img)s NoScript icon in the toolbar above"
+msgstr "Fai click sull'icona %(img)s NoScript nella toolbar"
+
+#: securedrop/source_templates/index.html:62
+#, python-format
+msgid "Click <strong>%(img)s Forbid Scripts Globally (advised)</strong>"
+msgstr "Fai click <strong>%(img)s Disabilita gli scripts globalmente (consigliato)</strong>"
+
+#: securedrop/source_templates/index.html:63
+#, python-format
+msgid ""
+"If the page does not refresh automatically, %(click_here)s to refresh the "
+"page"
+msgstr "Se la pagina non si ricarica automaticamente, %(click_here)s "
+
+#: securedrop/source_templates/index.html:63
+msgid "click here"
+msgstr "clicca qui"
+
+#: securedrop/source_templates/index.html:65
+msgid "Not using the Tor Browser Bundle?"
+msgstr "Non stai usando Tor Browser Bundle?"
+
+#: securedrop/source_templates/login.html:4
+msgid "Login to check for responses"
+msgstr "Fai login per controllare le risposte"
+
+#: securedrop/source_templates/login.html:10
+msgid "Enter your codename"
+msgstr "Inserisci il tuo codename"
+
+#: securedrop/source_templates/lookup.html:8
+msgid ""
+"A journalist has been waiting for you to log in again so SecureDrop can "
+"generate a crypto key for you. Now that you have logged in, they are able to"
+" write you a reply. Check back later for replies."
+msgstr "Un giornalista è in attesa che tu ti connetta nuovamente in modo che SecureDrop possa generare per te una chiave crittografica. Una volta loggato il giornalista sarà in grado di risponderti. Torna più tardi per controllare se ci sono nuove risposte."
+
+#: securedrop/source_templates/lookup.html:11
+msgid "Submit documents and messages"
+msgstr "Invio documenti e messaggi"
+
+#: securedrop/source_templates/lookup.html:12
+msgid "You can send a file, a message, or both."
+msgstr "Puoi inviare un file, un messaggio o entrambi"
+
+#: securedrop/source_templates/lookup.html:22
+msgid "Maximum upload size:"
+msgstr "Dimensione di massimo upload"
+
+#: securedrop/source_templates/lookup.html:25
+msgid "Add message"
+msgstr "Aggiungi un messaggio"
+
+#: securedrop/source_templates/lookup.html:34
+msgid "Tip:"
+msgstr "Consiglio: "
+
+#: securedrop/source_templates/lookup.html:34
+#, python-format
+msgid ""
+" If you are already familiar with GPG, you can optionally encrypt your files"
+" and messages with our %(journalist_key)s before submission. Files are "
+"encrypted as they are received by SecureDrop; encrypting before submission "
+"provides an extra layer of security before your data reaches SecureDrop. "
+"%(why_journalist_key)s."
+msgstr "Se hai famigliarità con GPG, puoi crittare i tuoi file e messaggi prima dell'invio usando la nostra %(journalist_key)s. Normalmente i file vengono crittati una volta ricevuto da SecureDrop; crittandoli prima dell'invio aggiungerai un livello extra di sicurezza prima che i dati arrivino a SecureDrop. %(why_journalist_key)s."
+
+#: securedrop/source_templates/lookup.html:35
+msgid "public key"
+msgstr "chiave pubblica"
+
+#: securedrop/source_templates/lookup.html:36
+msgid "Learn more"
+msgstr "Scopri maggiori dettagli"
+
+#: securedrop/source_templates/lookup.html:40
+msgid "Replies"
+msgstr "Risposte"
+
+#: securedrop/source_templates/lookup.html:44
+msgid ""
+"You have received a reply. For your security, please delete all replies when"
+" you're done with them. This also lets us know that you have received our "
+"reply. You can respond by submitting a new message above."
+msgstr "Hai ricevuto una risposta. Per la tua sicurezza, cancella tutte le risposte non appena le avrai lette. Questo, inoltre, ci permetterà di sapere che hai letto la nostra risposta. Puoi rispondere inviando un messaggio qui sotto. "
+
+#: securedrop/source_templates/lookup.html:59
+msgid "There are no replies at this time."
+msgstr "In questo momento non ci sono risposte."
+
+#: securedrop/source_templates/lookup.html:66
+msgid "Remember, your codename is:"
+msgstr "Ricorda, il tuo codename è:"
+
+#: securedrop/source_templates/notfound.html:5
+msgid "Page not found"
+msgstr "Pagina non trovata"
+
+#: securedrop/source_templates/notfound.html:7
+msgid "Sorry, we couldn't locate what you requested."
+msgstr "Spiacenti, non troviamo quanto hai richiesto."
+
+#: securedrop/source_templates/why-journalist-key.html:3
+msgid "Why download the journalist's public key?"
+msgstr "Perché scaricare la chiave pubblica del giornalista?"
+
+#: securedrop/source_templates/why-journalist-key.html:4
+msgid ""
+"SecureDrop encrypts files and messages after they are submitted. Encrypting "
+"messages and files before submission can provide an extra layer of security "
+"before your data reaches the SecureDrop server."
+msgstr "SecureDrop critta i file e i messaggi solo dopo averli ricevuti. Crittarli prima dell'invio garantisce un ulteriore livello di sicurezza prima che i tuoi dati raggiungano i server di SecureDrop."
+
+#: securedrop/source_templates/why-journalist-key.html:5
+msgid ""
+"If you are already familiar with the GPG encryption software, you may wish "
+"to encrypt your submissions yourself. To do so:"
+msgstr "Se conosci già GPG potresti voler crittare i file e il messaggio autonomamente. Per fare questo: "
+
+#: securedrop/source_templates/why-journalist-key.html:7
+#, python-format
+msgid ""
+"%(download)s the public key. The public key is a text file with the "
+"extension <code>.asc</code>"
+msgstr "%(download)s la chiave pubblica, si tratta di un file testo con estensione <code>.asc</code>"
+
+#: securedrop/source_templates/why-journalist-key.html:7
+msgid "Download"
+msgstr "Download"
+
+#: securedrop/source_templates/why-journalist-key.html:8
+msgid "Import it into your GPG keyring."
+msgstr "Importala nel tuo keyring GPG"
+
+#: securedrop/source_templates/why-journalist-key.html:10
+msgid ""
+"If you are using Tails (https://tails.boum.org/), you can double-click the "
+"<code>.asc</code> file you just downloaded and it will be automatically "
+"imported to your keyring."
+msgstr "Se stai usando Tails (https://tails.boum.org/), clicca due volte il file <code>.asc</code> che hai appena scaricato e sarà automaticamente importato nel tuo key ring."
+
+#: securedrop/source_templates/why-journalist-key.html:11
+msgid ""
+"If you are using Mac/Linux, open the Terminal. You can import the key with "
+"<code>gpg --import /path/to/key.asc</code>."
+msgstr "Se stai usando Mac o Linux, apri un terminale. Puoi importare la chiave con il comando <code>gpg --import /path/to/key.asc</code>."
+
+#: securedrop/source_templates/why-journalist-key.html:14
+msgid "Encrypt your submission."
+msgstr "Critta il materiale da inviare. "
+
+#: securedrop/source_templates/why-journalist-key.html:16
+msgid ""
+"You will need to be able to identify the key (this is called the \"user ID\""
+" or uid). Since the public key's filename is the key's fingerprint (with "
+".asc at the end), you can just copy and paste that. (don't include the "
+"<code>.asc</code>!)"
+msgstr "Dovrai essere in grado di identificare la chiave tramite l'user ID o uid. Poichè il nome del file della chiave pubblica è anche il nome del fingerprint della stessa (con estensione .asc), puoi semplicemente fare cut&paste (non includere <code>.asc</code>!)"
+
+#: securedrop/source_templates/why-journalist-key.html:17
+msgid ""
+"On all systems, open the Terminal and use this gpg command: <code>gpg "
+"--recipient &lt;user ID&gt; --encrypt roswell_photos.pdf</code>"
+msgstr "Su ogni altro sistema, apri un terminale e usa il seguente comando gpg:  <code>gpg --recipient &lt;user ID&gt; --encrypt roswell_photos.pdf</code>"
+
+#: securedrop/source_templates/why-journalist-key.html:20
+msgid ""
+"Upload your encrypted submission. It will have the same filename as the "
+"unencrypted file, with .gpg at the end (e.g. "
+"<code>roswell_photos.pdf.gpg</code>)"
+msgstr "Fai l'upload del materiale crittato. Il file avrà lo stesso nome del file originale con l'aggiunta dell'estensione .gpg alla fine (ad esempio <code>roswell_photos.pdf.gpg</code>)"
+
+#: securedrop/source_templates/why-journalist-key.html:23
+msgid ""
+"<strong>Tip:</strong> If you wish to remain anonymous, <strong>do "
+"not</strong> use GPG to sign the encrypted file (with the "
+"<code>--sign</code> or <code>-s</code> flag) as this will reveal your GPG "
+"identity to us."
+msgstr "<strong>Consiglio:</strong> Se vuoi rimanere anonimo <strong>non usare</strong> GPG per firmare il file crittato (con il flag <code>--sign</code> o <code>-s</code>) perché questo ci rivelerebbe la tua identità GPG."
+
+#: securedrop/source_templates/why-journalist-key.html:25
+msgid "Back to submission page"
+msgstr "Torna alla pagina di invio documenti e messaggi"

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -1,0 +1,869 @@
+# Translations template for SecureDrop.
+# Copyright (C) 2014 ORGANIZATION
+# This file is distributed under the same license as the SecureDrop project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2014.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: SecureDrop VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2014-12-26 03:49+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+#: securedrop/journalist.py:126
+msgid "You must be an administrator to access that page"
+msgstr ""
+
+#: securedrop/journalist.py:142
+msgid "Login failed."
+msgstr ""
+
+#: securedrop/journalist.py:145
+msgid "Login failed. Please wait at least 60 seconds before logging in again."
+msgstr ""
+
+#: securedrop/journalist.py:150
+msgid ""
+"Login failed. Please wait for a new two-factor token before logging in "
+"again."
+msgstr ""
+
+#: securedrop/journalist.py:191
+msgid "Missing username"
+msgstr ""
+
+#: securedrop/journalist.py:197 securedrop/journalist.py:280
+msgid "Passwords didn't match"
+msgstr ""
+
+#: securedrop/journalist.py:215 securedrop/journalist.py:292
+msgid "That username is already in use"
+msgstr ""
+
+#: securedrop/journalist.py:218
+msgid "An error occurred saving this user to the database"
+msgstr ""
+
+#: securedrop/journalist.py:236
+#, python-format
+msgid "Two factor token successfully verified for user %(username)s!"
+msgstr ""
+
+#: securedrop/journalist.py:239
+msgid "Two factor token failed to verify"
+msgstr ""
+
+#: securedrop/journalist.py:294
+msgid "An unknown error occurred, please inform your administrator"
+msgstr ""
+
+#: securedrop/journalist.py:442
+#, python-format
+msgid "%(journalist_designation)s's collection deleted"
+msgstr ""
+
+#: securedrop/journalist.py:449 securedrop/journalist.py:527
+msgid "No collections selected to delete!"
+msgstr ""
+
+#: securedrop/journalist.py:455
+#, python-format
+msgid "%(cols_selected)d collection deleted"
+msgid_plural "%(cols_selected)d collections deleted"
+msgstr[0] ""
+msgstr[1] ""
+
+#: securedrop/journalist.py:499
+#, python-format
+msgid ""
+"The source '%(original_journalist_designation)s' has been renamed to "
+"'%(new_journalist_designation)s'"
+msgstr ""
+
+#: securedrop/journalist.py:525
+msgid "No collections selected to download!"
+msgstr ""
+
+#: securedrop/source.py:124
+#, python-format
+msgid ""
+"<strong>WARNING:</strong> You appear to be using Tor2Web. This "
+"<strong>does not</strong> provide anonymity. %(tor2web_warning)s"
+msgstr ""
+
+#: securedrop/source.py:276
+msgid "Thanks! We received your message."
+msgstr ""
+
+#: securedrop/source.py:281
+#, python-format
+msgid "Thanks! We received your document \"%(filename)s\"."
+msgstr ""
+
+#: securedrop/source.py:285
+msgid ""
+"Thanks for submitting something to SecureDrop! Please check back later "
+"for replies."
+msgstr ""
+
+#: securedrop/source.py:316
+msgid "Reply deleted"
+msgstr ""
+
+#: securedrop/source.py:336
+msgid "Sorry, that is not a recognized codename."
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:3
+msgid "Admin Interface"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:6
+#: securedrop/journalist_templates/admin_add_user.html:21
+msgid "Add user"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:16
+#: securedrop/journalist_templates/admin_add_user.html:9
+#: securedrop/journalist_templates/login.html:8
+msgid "Username"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:17
+msgid "Edit"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:18
+#: securedrop/source_templates/lookup.html:52
+msgid "Delete"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:19
+msgid "Created"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:20
+msgid "Last login"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:31
+msgid "Never"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:38
+msgid "No users to display"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_add_user.html:4
+#: securedrop/journalist_templates/admin_edit_user.html:4
+msgid "Back to admin interface"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_add_user.html:10
+#: securedrop/journalist_templates/login.html:9
+msgid "Password"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_add_user.html:11
+msgid "Password (again)"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_add_user.html:14
+#: securedrop/journalist_templates/admin_edit_user.html:23
+msgid "Is Administrator"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_add_user.html:18
+msgid "I'm using a Yubikey "
+msgstr ""
+
+#: securedrop/journalist_templates/admin_add_user.html:19
+msgid "HOTP Secret"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_hotp_secret.html:7
+msgid "Change Secret"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_hotp_secret.html:10
+#: securedrop/source_templates/generate.html:37
+#: securedrop/source_templates/login.html:11
+msgid "Continue"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:3
+msgid "Edit user"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:9
+msgid "Change username"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:13
+msgid "Change password"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:15
+msgid "Leave blank for no change"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:18
+msgid "Change password (confirm)"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:25
+msgid "Update user"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:30
+msgid "Reset Two Factor Authentication"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:31
+msgid ""
+"If a user's two factor authentication credentials have been lost or "
+"compromised, you can reset them here. "
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:31
+msgid ""
+"If you do this, make sure the user is present and ready to set up their "
+"device with the new two factor credentials. Otherwise, they will be "
+"locked out of their account."
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:35
+msgid "Reset two factor authentication (Google Authenticator)"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:41
+msgid "Reset two factor authentication (HOTP Yubikey)"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:4
+msgid "Enable Google Authenticator"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:5
+msgid ""
+"You're almost done! To finish adding this new user, have them follow the "
+"instructions below to set up two factor authentication with Google "
+"Authenticator. Once they've added an entry for this account in the app, "
+"have them enter one of the 6-digit codes from the app to confirm that two"
+" factor authentication is set up correctly."
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:7
+msgid "Install Google Authenticator on your phone"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:8
+msgid "Open the Google Authenticator app"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:9
+msgid "Tap menu, then tap \"Set up account\", then tap \"Scan a barcode\""
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:10
+msgid ""
+"Your phone will now be in \"scanning\" mode. When you are in this mode, "
+"scan the barcode below:"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:13
+msgid "Can't scan the barcode? Enter the following code manually:"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:14
+msgid "Once you have scanned the barcode, enter the 6-digit code below:"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:16
+msgid "Enable Yubikey (OATH-HOTP)"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:17
+msgid "Once you have configured your Yubikey, enter the 6-digit code below:"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:21
+msgid "Verification code"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:23
+#: securedrop/journalist_templates/col.html:61
+#: securedrop/source_templates/lookup.html:31
+msgid "Submit"
+msgstr ""
+
+#: securedrop/journalist_templates/base.html:4
+msgid "SecureDrop"
+msgstr ""
+
+#: securedrop/journalist_templates/base.html:18
+msgid "Admin"
+msgstr ""
+
+#: securedrop/journalist_templates/base.html:20
+msgid "Logout"
+msgstr ""
+
+#: securedrop/journalist_templates/base.html:46
+#, python-format
+msgid "Powered by <em>SecureDrop %(version)s</em>."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:10
+msgid "All Sources"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:13
+msgid ""
+"Generate a new random codename for this source. We recommend doing this "
+"if the first random codename is difficult to say or remember. You can "
+"generate new random codenames as many times as you like."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:13
+msgid "Change codename"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:18
+msgid ""
+"The documents are stored encrypted for security. To read them, you will "
+"need to decrypt them using GPG."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:22
+msgid "Download selected"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:23
+#: securedrop/journalist_templates/index.html:11
+msgid "Delete selected"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:30
+#, python-format
+msgid "%(file_size)s sent %(date)s"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:33
+#, python-format
+msgid "%(file_size)s uploaded %(date)s"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:36
+msgid "Uploaded Document"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:38
+msgid "Message"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:48
+msgid "No documents to display."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:53
+msgid "Reply"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:55
+msgid "You can write a secure reply to the person who submitted these documents:"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:64
+msgid "You've flagged this source for reply."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:65
+msgid ""
+"An encryption key will be generated for the source the next time they log"
+" in, after which you will be able to reply to the source here."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:67
+msgid "Click below if you would like to write a reply to this source."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:71
+msgid "Flag this source for reply"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:76
+msgid "Click below to delete this source's collection. "
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:76
+msgid ""
+"Warning: If you do this, the files seen here will be unrecoverable and "
+"the source will no longer be able to login using their previous codename."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:82
+msgid "Delete collection"
+msgstr ""
+
+#: securedrop/journalist_templates/delete.html:7
+msgid "File permanently deleted."
+msgid_plural "Files permanently deleted."
+msgstr[0] ""
+msgstr[1] ""
+
+#: securedrop/journalist_templates/delete.html:13
+#, python-format
+msgid ""
+"The following file has been selected for <strong>permanent "
+"deletion</strong>"
+msgid_plural ""
+"The following %(value)d files have been selected for <strong>permanent "
+"deletion</strong>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: securedrop/journalist_templates/delete.html:23
+#, python-format
+msgid "(sent %(date)s)"
+msgstr ""
+
+#: securedrop/journalist_templates/delete.html:25
+#, python-format
+msgid "(uploaded %(date)s)"
+msgstr ""
+
+#: securedrop/journalist_templates/delete.html:32
+msgid "Permanently delete files"
+msgstr ""
+
+#: securedrop/journalist_templates/delete.html:38
+#, python-format
+msgid "Return to the list of documents for %(codename)s..."
+msgstr ""
+
+#: securedrop/journalist_templates/flag.html:5
+msgid "Thanks!"
+msgstr ""
+
+#: securedrop/journalist_templates/flag.html:8
+msgid ""
+"SecureDrop will generate a secure encryption key for this source the next"
+" time that they log in. Once the key has been generated, a reply box will"
+" appear under their collection of documents. You can use this box to "
+"write encrypted replies to them."
+msgstr ""
+
+#: securedrop/journalist_templates/flag.html:10
+#, python-format
+msgid "Continue to the list of documents for %(codename)s..."
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:4
+msgid "Sources"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:10
+msgid "select all"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:10
+msgid "select none"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:12
+msgid "Star Selected"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:13
+msgid "Un-star Selected"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:29
+#: securedrop/journalist_templates/index.html:55
+msgid "docs"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:30
+#: securedrop/journalist_templates/index.html:56
+msgid "messages"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:33
+msgid " unread"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:59
+msgid "unread"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:71
+msgid "No documents have been submitted!"
+msgstr ""
+
+#: securedrop/journalist_templates/login.html:4
+msgid "Login to access the journalist interface"
+msgstr ""
+
+#: securedrop/journalist_templates/login.html:10
+msgid "Two-factor Code"
+msgstr ""
+
+#: securedrop/journalist_templates/login.html:11
+msgid "Log in"
+msgstr ""
+
+#: securedrop/journalist_templates/reply.html:5
+msgid "Thanks! Your reply has been stored."
+msgstr ""
+
+#: securedrop/journalist_templates/reply.html:8
+msgid ""
+"You will now see it in the list of documents in that collection. Once the"
+" source has read it, they will be asked to delete it. If it disappears "
+"from the list, then you know it has been read and deleted by the source."
+msgstr ""
+
+#: securedrop/journalist_templates/reply.html:10
+#, python-format
+msgid "Return to the list of documents for <strong>%(codename)s</strong>..."
+msgstr ""
+
+#: securedrop/source_templates/base.html:4
+msgid "SecureDrop | Protecting Journalists and Sources"
+msgstr ""
+
+#: securedrop/source_templates/base.html:36
+#: securedrop/source_templates/index.html:50
+#, python-format
+msgid ""
+"Like all software, SecureDrop may contain security bugs. Use at your own "
+"risk. Powered by SecureDrop %(version)s."
+msgstr ""
+
+#: securedrop/source_templates/error.html:5
+msgid "Server error"
+msgstr ""
+
+#: securedrop/source_templates/error.html:7
+msgid ""
+"Sorry, the website encountered an error and was unable to complete your "
+"request."
+msgstr ""
+
+#: securedrop/source_templates/error.html:9
+#: securedrop/source_templates/notfound.html:9
+msgid "Look up a codename..."
+msgstr ""
+
+#: securedrop/source_templates/generate.html:4
+msgid "Remember this codename and keep it secret"
+msgstr ""
+
+#: securedrop/source_templates/generate.html:5
+msgid "To protect your identity, we're assigning you a unique codename."
+msgstr ""
+
+#: securedrop/source_templates/generate.html:29
+msgid ""
+"After you submit documents and messages, you can return to this "
+"SecureDrop site later to read replies from journalists and submit more "
+"information. <strong>You will need this codename to log in.</strong> This"
+" is the only way we can communicate back to you."
+msgstr ""
+
+#: securedrop/source_templates/generate.html:31
+msgid ""
+"The best way to protect your codename is to memorize it. If you cannot "
+"memorize it right away, we recommend writing it down and keeping it in a "
+"safe place at first, and gradually working to memorize it over time. Once"
+" you have memorized it, you should destroy the written copy."
+msgstr ""
+
+#: securedrop/source_templates/generate.html:38
+msgid "Already have a codename?"
+msgstr ""
+
+#: securedrop/source_templates/howto-disable-js.html:4
+msgid "Disable JavaScript to Protect Your Anonymity"
+msgstr ""
+
+#: securedrop/source_templates/howto-disable-js.html:6
+msgid ""
+"JavaScript is a widely used programming language for creating interactive"
+" web pages. Unfortunately, JavaScript is also the most common source of "
+"security vulnerabilities in browsers. In August 2013, the FBI wrote "
+"malware that used a JavaScript exploit to de-anonymize Tor users "
+"(http://www.wired.com/threatlevel/2013/09/freedom-hosting-fbi). "
+"JavaScript exploits are also mentioned in documents describing the NSA's "
+"Egotistical Giraffe "
+"(http://www.theguardian.com/world/interactive/2013/oct/04/egotistical-"
+"giraffe-nsa-tor-document) program, which also has the goal of targeting "
+"and de-anonymizing Tor users."
+msgstr ""
+
+#: securedrop/source_templates/howto-disable-js.html:8
+msgid ""
+"We encourage SecureDrop users to disable JavaScript to protect themselves"
+" from malware that would use it to attack their browser and potentially "
+"de-anonymize them. There are other ways to get hacked, but given the use "
+"of JavaScript-based attacks recently, we believe it is prudent to disable"
+" it at this time."
+msgstr ""
+
+#: securedrop/source_templates/howto-disable-js.html:10
+msgid ""
+"The Tor Browser comes with an add-on called NoScript that can be used to "
+"completely disable JavaScript by default, and to only enable it for sites"
+" that you trust."
+msgstr ""
+
+#: securedrop/source_templates/howto-disable-js.html:12
+#, python-format
+msgid ""
+"To disable JavaScript in Tor Browser, click the NoScript icon %(icon)s to"
+" the left of the address bar above and choose \"Forbid Scripts Globally "
+"(advised)\""
+msgstr ""
+
+#: securedrop/source_templates/index.html:13
+msgid "We recommend disabling JavaScript to protect your anonymity:"
+msgstr ""
+
+#: securedrop/source_templates/index.html:13
+#, python-format
+msgid " %(howto_disable_js)s, or ignore this warning to continue."
+msgstr ""
+
+#: securedrop/source_templates/index.html:13
+msgid "Learn how to disable it"
+msgstr ""
+
+#: securedrop/source_templates/index.html:31
+msgid "Submit documents for the first time"
+msgstr ""
+
+#: securedrop/source_templates/index.html:34
+msgid ""
+"If this is your first time submitting documents to journalists, start "
+"here."
+msgstr ""
+
+#: securedrop/source_templates/index.html:36
+msgid "Submit Documents"
+msgstr ""
+
+#: securedrop/source_templates/index.html:40
+msgid "Already submitted something?"
+msgstr ""
+
+#: securedrop/source_templates/index.html:43
+msgid ""
+"If you have already submitted documents in the past, log in here to check"
+" for responses."
+msgstr ""
+
+#: securedrop/source_templates/index.html:45
+msgid "Check for a response"
+msgstr ""
+
+#: securedrop/source_templates/index.html:59
+msgid ""
+"You appear to be using the Tor Browser. You can disable Javascript in 3 "
+"easy steps!"
+msgstr ""
+
+#: securedrop/source_templates/index.html:61
+#, python-format
+msgid "Click %(img)s NoScript icon in the toolbar above"
+msgstr ""
+
+#: securedrop/source_templates/index.html:62
+#, python-format
+msgid "Click <strong>%(img)s Forbid Scripts Globally (advised)</strong>"
+msgstr ""
+
+#: securedrop/source_templates/index.html:63
+#, python-format
+msgid ""
+"If the page does not refresh automatically, %(click_here)s to refresh the"
+" page"
+msgstr ""
+
+#: securedrop/source_templates/index.html:63
+msgid "click here"
+msgstr ""
+
+#: securedrop/source_templates/index.html:65
+msgid "Not using the Tor Browser Bundle?"
+msgstr ""
+
+#: securedrop/source_templates/login.html:4
+msgid "Login to check for responses"
+msgstr ""
+
+#: securedrop/source_templates/login.html:10
+msgid "Enter your codename"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:8
+msgid ""
+"A journalist has been waiting for you to log in again so SecureDrop can "
+"generate a crypto key for you. Now that you have logged in, they are able"
+" to write you a reply. Check back later for replies."
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:11
+msgid "Submit documents and messages"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:12
+msgid "You can send a file, a message, or both."
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:22
+msgid "Maximum upload size:"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:25
+msgid "Add message"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:34
+msgid "Tip:"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:34
+#, python-format
+msgid ""
+" If you are already familiar with GPG, you can optionally encrypt your "
+"files and messages with our %(journalist_key)s before submission. Files "
+"are encrypted as they are received by SecureDrop; encrypting before "
+"submission provides an extra layer of security before your data reaches "
+"SecureDrop. %(why_journalist_key)s."
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:35
+msgid "public key"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:36
+msgid "Learn more"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:40
+msgid "Replies"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:44
+msgid ""
+"You have received a reply. For your security, please delete all replies "
+"when you're done with them. This also lets us know that you have received"
+" our reply. You can respond by submitting a new message above."
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:59
+msgid "There are no replies at this time."
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:66
+msgid "Remember, your codename is:"
+msgstr ""
+
+#: securedrop/source_templates/notfound.html:5
+msgid "Page not found"
+msgstr ""
+
+#: securedrop/source_templates/notfound.html:7
+msgid "Sorry, we couldn't locate what you requested."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:3
+msgid "Why download the journalist's public key?"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:4
+msgid ""
+"SecureDrop encrypts files and messages after they are submitted. "
+"Encrypting messages and files before submission can provide an extra "
+"layer of security before your data reaches the SecureDrop server."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:5
+msgid ""
+"If you are already familiar with the GPG encryption software, you may "
+"wish to encrypt your submissions yourself. To do so:"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:7
+#, python-format
+msgid ""
+"%(download)s the public key. The public key is a text file with the "
+"extension <code>.asc</code>"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:7
+msgid "Download"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:8
+msgid "Import it into your GPG keyring."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:10
+msgid ""
+"If you are using Tails (https://tails.boum.org/), you can double-click "
+"the <code>.asc</code> file you just downloaded and it will be "
+"automatically imported to your keyring."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:11
+msgid ""
+"If you are using Mac/Linux, open the Terminal. You can import the key "
+"with <code>gpg --import /path/to/key.asc</code>."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:14
+msgid "Encrypt your submission."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:16
+msgid ""
+"You will need to be able to identify the key (this is called the \"user "
+"ID\" or uid). Since the public key's filename is the key's fingerprint "
+"(with .asc at the end), you can just copy and paste that. (don't include "
+"the <code>.asc</code>!)"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:17
+msgid ""
+"On all systems, open the Terminal and use this gpg command: <code>gpg "
+"--recipient &lt;user ID&gt; --encrypt roswell_photos.pdf</code>"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:20
+msgid ""
+"Upload your encrypted submission. It will have the same filename as the "
+"unencrypted file, with .gpg at the end (e.g. "
+"<code>roswell_photos.pdf.gpg</code>)"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:23
+msgid ""
+"<strong>Tip:</strong> If you wish to remain anonymous, <strong>do "
+"not</strong> use GPG to sign the encrypted file (with the "
+"<code>--sign</code> or <code>-s</code> flag) as this will reveal your GPG"
+" identity to us."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:25
+msgid "Back to submission page"
+msgstr ""
+

--- a/securedrop/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/securedrop/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -1,0 +1,848 @@
+# Translations template for SecureDrop.
+# Copyright (C) 2014 ORGANIZATION
+# This file is distributed under the same license as the SecureDrop project.
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: SecureDrop\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2014-11-17 03:00+0000\n"
+"PO-Revision-Date: 2014-11-17 03:00+0000\n"
+"Last-Translator: edwincheese <edwincheese@gmail.com>\n"
+"Language-Team: Chinese Simplified (http://www.transifex.com/projects/p/securedrop-app-code/language/zh-Hans/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+"Language: zh-Hans\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: securedrop/journalist.py:127
+msgid "You must be an administrator to access that page"
+msgstr ""
+
+#: securedrop/journalist.py:144
+msgid "Login failed"
+msgstr ""
+
+#: securedrop/journalist.py:178
+msgid "Missing username"
+msgstr ""
+
+#: securedrop/journalist.py:184 securedrop/journalist.py:267
+msgid "Passwords didn't match"
+msgstr ""
+
+#: securedrop/journalist.py:202 securedrop/journalist.py:279
+msgid "That username is already in use"
+msgstr ""
+
+#: securedrop/journalist.py:205
+msgid "An error occurred saving this user to the database"
+msgstr ""
+
+#: securedrop/journalist.py:223
+#, python-format
+msgid "Two factor token successfully verified for user %(username)s!"
+msgstr ""
+
+#: securedrop/journalist.py:226
+msgid "Two factor token failed to verify"
+msgstr ""
+
+#: securedrop/journalist.py:281
+msgid "An unknown error occurred, please inform your administrator"
+msgstr ""
+
+#: securedrop/journalist.py:429
+#, python-format
+msgid "%(journalist_designation)s's collection deleted"
+msgstr ""
+
+#: securedrop/journalist.py:436 securedrop/journalist.py:514
+msgid "No collections selected to delete!"
+msgstr ""
+
+#: securedrop/journalist.py:442
+#, python-format
+msgid "%(cols_selected)d collection deleted"
+msgid_plural "%(cols_selected)d collections deleted"
+msgstr[0] ""
+
+#: securedrop/journalist.py:486
+#, python-format
+msgid ""
+"The source '%(original_journalist_designation)s' has been renamed to "
+"'%(new_journalist_designation)s'"
+msgstr ""
+
+#: securedrop/journalist.py:512
+msgid "No collections selected to download!"
+msgstr ""
+
+#: securedrop/source.py:124
+#, python-format
+msgid ""
+"<strong>WARNING:</strong> You appear to be using Tor2Web. This <strong>does "
+"not</strong> provide anonymity. %(tor2web_warning)s"
+msgstr ""
+
+#: securedrop/source.py:259
+msgid "Thanks! We received your message."
+msgstr ""
+
+#: securedrop/source.py:264
+#, python-format
+msgid "Thanks! We received your document \"%(filename)s\"."
+msgstr ""
+
+#: securedrop/source.py:294
+msgid "Reply deleted"
+msgstr ""
+
+#: securedrop/source.py:314
+msgid "Sorry, that is not a recognized codename."
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:3
+msgid "Admin Interface"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:6
+#: securedrop/journalist_templates/admin_add_user.html:21
+msgid "Add user"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:16
+#: securedrop/journalist_templates/admin_add_user.html:9
+#: securedrop/journalist_templates/login.html:8
+msgid "Username"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:17
+msgid "Edit"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:18
+#: securedrop/source_templates/lookup.html:50
+msgid "Delete"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:19
+msgid "Created"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:20
+msgid "Last login"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:31
+msgid "Never"
+msgstr ""
+
+#: securedrop/journalist_templates/admin.html:38
+msgid "No users to display"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_add_user.html:4
+#: securedrop/journalist_templates/admin_edit_user.html:4
+msgid "Back to admin interface"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_add_user.html:10
+#: securedrop/journalist_templates/login.html:9
+msgid "Password"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_add_user.html:11
+msgid "Password (again)"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_add_user.html:14
+#: securedrop/journalist_templates/admin_edit_user.html:23
+msgid "Is Administrator"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_add_user.html:18
+msgid "I'm using a Yubikey "
+msgstr ""
+
+#: securedrop/journalist_templates/admin_add_user.html:19
+msgid "HOTP Secret"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_hotp_secret.html:7
+msgid "Change Secret"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_hotp_secret.html:10
+#: securedrop/source_templates/generate.html:39
+#: securedrop/source_templates/login.html:11
+msgid "Continue"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:3
+msgid "Edit user"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:9
+msgid "Change username"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:13
+msgid "Change password"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:15
+msgid "Leave blank for no change"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:18
+msgid "Change password (confirm)"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:25
+msgid "Update user"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:30
+msgid "Reset Two Factor Authentication"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:31
+msgid ""
+"If a user's two factor authentication credentials have been lost or "
+"compromised, you can reset them here. "
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:31
+msgid ""
+"If you do this, make sure the user is present and ready to set up their "
+"device with the new two factor credentials. Otherwise, they will be locked "
+"out of their account."
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:35
+msgid "Reset two factor authentication (Google Authenticator)"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_edit_user.html:41
+msgid "Reset two factor authentication (HOTP Yubikey)"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:4
+msgid "Enable Google Authenticator"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:5
+msgid ""
+"You're almost done! To finish adding this new user, have them follow the "
+"instructions below to set up two factor authentication with Google "
+"Authenticator. Once they've added an entry for this account in the app, have"
+" them enter one of the 6-digit codes from the app to confirm that two factor"
+" authentication is set up correctly."
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:7
+msgid "Install Google Authenticator on your phone"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:8
+msgid "Open the Google Authenticator app"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:9
+msgid "Tap menu, then tap \"Set up account\", then tap \"Scan a barcode\""
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:10
+msgid ""
+"Your phone will now be in \"scanning\" mode. When you are in this mode, scan"
+" the barcode below:"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:13
+msgid "Can't scan the barcode? Enter the following code manually:"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:14
+msgid "Once you have scanned the barcode, enter the 6-digit code below:"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:16
+msgid "Enable Yubikey (OATH-HOTP)"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:17
+msgid "Once you have configured your Yubikey, enter the 6-digit code below:"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:21
+msgid "Verification code"
+msgstr ""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:23
+#: securedrop/journalist_templates/col.html:61
+#: securedrop/source_templates/lookup.html:31
+msgid "Submit"
+msgstr ""
+
+#: securedrop/journalist_templates/base.html:4
+msgid "SecureDrop"
+msgstr ""
+
+#: securedrop/journalist_templates/base.html:18
+msgid "Admin"
+msgstr ""
+
+#: securedrop/journalist_templates/base.html:20
+msgid "Logout"
+msgstr ""
+
+#: securedrop/journalist_templates/base.html:46
+#, python-format
+msgid "Powered by <em>SecureDrop %(version)s</em>."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:10
+msgid "All Sources"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:13
+msgid ""
+"Generate a new random codename for this source. We recommend doing this if "
+"the first random codename is difficult to say or remember. You can generate "
+"new random codenames as many times as you like."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:13
+msgid "Change codename"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:18
+msgid ""
+"The documents are stored encrypted for security. To read them, you will need"
+" to decrypt them using GPG."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:22
+msgid "Download selected"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:23
+#: securedrop/journalist_templates/index.html:11
+msgid "Delete selected"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:30
+#, python-format
+msgid "%(file_size)s sent %(date)s"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:33
+#, python-format
+msgid "%(file_size)s uploaded %(date)s"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:36
+msgid "Uploaded Document"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:38
+msgid "Message"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:48
+msgid "No documents to display."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:53
+msgid "Reply"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:55
+msgid ""
+"You can write a secure reply to the person who submitted these documents:"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:64
+msgid "You've flagged this source for reply."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:65
+msgid ""
+"An encryption key will be generated for the source the next time they log "
+"in, after which you will be able to reply to the source here."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:67
+msgid "Click below if you would like to write a reply to this source."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:71
+msgid "Flag this source for reply"
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:76
+msgid "Click below to delete this source's collection. "
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:76
+msgid ""
+"Warning: If you do this, the files seen here will be unrecoverable and the "
+"source will no longer be able to login using their previous codename."
+msgstr ""
+
+#: securedrop/journalist_templates/col.html:82
+msgid "Delete collection"
+msgstr ""
+
+#: securedrop/journalist_templates/delete.html:7
+msgid "File permanently deleted."
+msgid_plural "Files permanently deleted."
+msgstr[0] ""
+
+#: securedrop/journalist_templates/delete.html:13
+#, python-format
+msgid ""
+"The following file has been selected for <strong>permanent deletion</strong>"
+msgid_plural ""
+"The following %(value)d files have been selected for <strong>permanent "
+"deletion</strong>"
+msgstr[0] ""
+
+#: securedrop/journalist_templates/delete.html:23
+#, python-format
+msgid "(sent %(date)s)"
+msgstr ""
+
+#: securedrop/journalist_templates/delete.html:25
+#, python-format
+msgid "(uploaded %(date)s)"
+msgstr ""
+
+#: securedrop/journalist_templates/delete.html:32
+msgid "Permanently delete files"
+msgstr ""
+
+#: securedrop/journalist_templates/delete.html:38
+#, python-format
+msgid "Return to the list of documents for %(codename)s..."
+msgstr ""
+
+#: securedrop/journalist_templates/flag.html:5
+msgid "Thanks!"
+msgstr ""
+
+#: securedrop/journalist_templates/flag.html:8
+msgid ""
+"SecureDrop will generate a secure encryption key for this source the next "
+"time that they log in. Once the key has been generated, a reply box will "
+"appear under their collection of documents. You can use this box to write "
+"encrypted replies to them."
+msgstr ""
+
+#: securedrop/journalist_templates/flag.html:10
+msgid "Continue to the list of documents for"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:4
+msgid "Sources"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:10
+msgid "select all"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:10
+msgid "select none"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:12
+msgid "Star Selected"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:13
+msgid "Un-star Selected"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:29
+#: securedrop/journalist_templates/index.html:55
+msgid "docs"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:30
+#: securedrop/journalist_templates/index.html:56
+msgid "messages"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:33
+msgid " unread"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:59
+msgid "unread"
+msgstr ""
+
+#: securedrop/journalist_templates/index.html:71
+msgid "No documents have been submitted!"
+msgstr ""
+
+#: securedrop/journalist_templates/login.html:4
+msgid "Login to access the journalist interface"
+msgstr ""
+
+#: securedrop/journalist_templates/login.html:10
+msgid "Two-factor Code"
+msgstr ""
+
+#: securedrop/journalist_templates/login.html:11
+msgid "Log in"
+msgstr ""
+
+#: securedrop/journalist_templates/reply.html:5
+msgid "Thanks! Your reply has been stored."
+msgstr ""
+
+#: securedrop/journalist_templates/reply.html:8
+msgid ""
+"You will now see it in the list of documents in that collection. Once the "
+"source has read it, they will be asked to delete it. If it disappears from "
+"the list, then you know it has been read."
+msgstr ""
+
+#: securedrop/journalist_templates/reply.html:10
+#, python-format
+msgid "Return to the list of documents for <strong>%(codename)s</strong>..."
+msgstr ""
+
+#: securedrop/source_templates/base.html:4
+msgid "SecureDrop | Protecting Journalists and Sources"
+msgstr ""
+
+#: securedrop/source_templates/base.html:36
+#: securedrop/source_templates/index.html:50
+#, python-format
+msgid ""
+"Like all software, SecureDrop may contain security bugs. Use at your own "
+"risk. Powered by SecureDrop %(version)s."
+msgstr ""
+
+#: securedrop/source_templates/error.html:5
+msgid "Server error"
+msgstr ""
+
+#: securedrop/source_templates/error.html:7
+msgid ""
+"Sorry, the website encountered an error and was unable to complete your "
+"request."
+msgstr ""
+
+#: securedrop/source_templates/error.html:9
+#: securedrop/source_templates/notfound.html:9
+msgid "Look up a codename..."
+msgstr ""
+
+#: securedrop/source_templates/generate.html:4
+msgid "Remember this code and keep it secret"
+msgstr ""
+
+#: securedrop/source_templates/generate.html:5
+msgid "To protect your identity, we're assigning you a unique codename."
+msgstr ""
+
+#: securedrop/source_templates/generate.html:29
+msgid ""
+"Store this code somewhere safe, or memorize it. It can be used to compromise"
+" your anonymity."
+msgstr ""
+
+#: securedrop/source_templates/generate.html:33
+msgid "Important:"
+msgstr ""
+
+#: securedrop/source_templates/generate.html:33
+msgid ""
+" After you submit documents and messages, you will need this code to log in "
+"and read replies. This is the only way we can communicate back to you. You "
+"can also use your code to log in to submit more files and messages."
+msgstr ""
+
+#: securedrop/source_templates/generate.html:40
+msgid "Already have a codename?"
+msgstr ""
+
+#: securedrop/source_templates/howto-disable-js.html:4
+msgid "Disable JavaScript to Protect Your Anonymity"
+msgstr ""
+
+#: securedrop/source_templates/howto-disable-js.html:6
+msgid ""
+"JavaScript is a widely used programming language for creating interactive "
+"web pages. Unfortunately, JavaScript is also the most common source of "
+"security vulnerabilities in browsers. In August 2013, the FBI wrote malware "
+"that used a JavaScript exploit to de-anonymize Tor users "
+"(http://www.wired.com/threatlevel/2013/09/freedom-hosting-fbi). JavaScript "
+"exploits are also mentioned in documents describing the NSA's Egotistical "
+"Giraffe (http://www.theguardian.com/world/interactive/2013/oct/04"
+"/egotistical-giraffe-nsa-tor-document) program, which also has the goal of "
+"targeting and de-anonymizing Tor users."
+msgstr ""
+
+#: securedrop/source_templates/howto-disable-js.html:8
+msgid ""
+"We encourage SecureDrop users to disable JavaScript to protect themselves "
+"from malware that would use it to attack their browser and potentially de-"
+"anonymize them. There are other ways to get hacked, but given the use of "
+"JavaScript-based attacks recently, we believe it is prudent to disable it at"
+" this time."
+msgstr ""
+
+#: securedrop/source_templates/howto-disable-js.html:10
+msgid ""
+"The Tor Browser comes with an add-on called NoScript that can be used to "
+"completely disable JavaScript by default, and to only enable it for sites "
+"that you trust."
+msgstr ""
+
+#: securedrop/source_templates/howto-disable-js.html:12
+#, python-format
+msgid ""
+"To disable JavaScript in Tor Browser, click the NoScript icon %(icon)s to "
+"the left of the address bar above and choose \"Forbid Scripts Globally "
+"(advised)\""
+msgstr ""
+
+#: securedrop/source_templates/index.html:13
+msgid "We recommend disabling JavaScript to protect your anonymity:"
+msgstr ""
+
+#: securedrop/source_templates/index.html:13
+#, python-format
+msgid " %(howto_disable_js)s, or ignore this warning to continue."
+msgstr ""
+
+#: securedrop/source_templates/index.html:13
+msgid "Learn how to disable it"
+msgstr ""
+
+#: securedrop/source_templates/index.html:31
+msgid "Submit documents for the first time"
+msgstr ""
+
+#: securedrop/source_templates/index.html:34
+msgid ""
+"If this is your first time submitting documents to journalists, start here."
+msgstr ""
+
+#: securedrop/source_templates/index.html:36
+msgid "Submit Documents"
+msgstr ""
+
+#: securedrop/source_templates/index.html:40
+msgid "Already submitted something?"
+msgstr ""
+
+#: securedrop/source_templates/index.html:43
+msgid ""
+"If you have already submitted documents in the past, log in here to check "
+"for responses."
+msgstr ""
+
+#: securedrop/source_templates/index.html:45
+msgid "Check for a response"
+msgstr ""
+
+#: securedrop/source_templates/index.html:59
+msgid ""
+"You appear to be using the Tor Browser. You can disable Javascript in 3 easy"
+" steps!"
+msgstr ""
+
+#: securedrop/source_templates/index.html:61
+#, python-format
+msgid "Click %(img)s NoScript icon in the toolbar above"
+msgstr ""
+
+#: securedrop/source_templates/index.html:62
+#, python-format
+msgid "Click <strong>%(img)s Forbid Scripts Globally (advised)</strong>"
+msgstr ""
+
+#: securedrop/source_templates/index.html:63
+#, python-format
+msgid ""
+"If the page does not refresh automatically, %(click_here)s to refresh the "
+"page"
+msgstr ""
+
+#: securedrop/source_templates/index.html:63
+msgid "click here"
+msgstr ""
+
+#: securedrop/source_templates/index.html:65
+msgid "Not using the Tor Browser Bundle?"
+msgstr ""
+
+#: securedrop/source_templates/login.html:4
+msgid "Login to check for responses"
+msgstr ""
+
+#: securedrop/source_templates/login.html:10
+msgid "Enter your codename"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:8
+msgid ""
+"A journalist has been waiting for you to log in again so SecureDrop can "
+"generate a crypto key for you. Now that you have logged in, they are able to"
+" write you a reply. Check back later for replies."
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:11
+msgid "Submit documents and messages"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:12
+msgid "You can send a file, a message, or both."
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:22
+msgid "Maximum upload size:"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:25
+msgid "Add message"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:34
+msgid "Tip:"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:34
+#, python-format
+msgid ""
+" If you are already familiar with GPG, you can optionally encrypt your files"
+" and messages with our %(journalist_key)s before submission. Files are "
+"encrypted as they are received by SecureDrop; encrypting before submission "
+"provides an extra layer of security before your data reaches SecureDrop. "
+"%(why_journalist_key)s."
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:34
+msgid "public key"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:34
+msgid "Learn more"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:38
+msgid "Replies"
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:42
+msgid ""
+"You have received a reply. For your security, please delete all replies when"
+" you're done with them. This also lets us know that you have received our "
+"reply. You can respond by submitting a new message above."
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:57
+msgid "There are no replies at this time."
+msgstr ""
+
+#: securedrop/source_templates/lookup.html:64
+msgid "Remember, your codename is:"
+msgstr ""
+
+#: securedrop/source_templates/notfound.html:5
+msgid "Page not found"
+msgstr ""
+
+#: securedrop/source_templates/notfound.html:7
+msgid "Sorry, we couldn't locate what you requested."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:3
+msgid "Why download the journalist's public key?"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:4
+msgid ""
+"SecureDrop encrypts files and messages after they are submitted. Encrypting "
+"messages and files before submission can provide an extra layer of security "
+"before your data reaches the SecureDrop server."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:5
+msgid ""
+"If you are already familiar with the GPG encryption software, you may wish "
+"to encrypt your submissions yourself. To do so:"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:7
+#, python-format
+msgid ""
+"%(download)s the public key. The public key is a text file with the "
+"extension <code>.asc</code>"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:7
+msgid "Download"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:8
+msgid "Import it into your GPG keyring."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:10
+msgid ""
+"If you are using Tails (https://tails.boum.org/), you can double-click the "
+"<code>.asc</code> file you just downloaded and it will be automatically "
+"imported to your keyring."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:11
+msgid ""
+"If you are using Mac/Linux, open the Terminal. You can import the key with "
+"<code>gpg --import /path/to/key.asc</code>."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:14
+msgid "Encrypt your submission."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:16
+msgid ""
+"You will need to be able to identify the key (this is called the \"user ID\""
+" or uid). Since the public key's filename is the key's fingerprint (with "
+".asc at the end), you can just copy and paste that. (don't include the "
+"<code>.asc</code>!)"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:17
+msgid ""
+"On all systems, open the Terminal and use this gpg command: <code>gpg "
+"--recipient &lt;user ID&gt; --encrypt roswell_photos.pdf</code>"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:20
+msgid ""
+"Upload your encrypted submission. It will have the same filename as the "
+"unencrypted file, with .gpg at the end (e.g. "
+"<code>roswell_photos.pdf.gpg</code>)"
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:23
+msgid ""
+"<strong>Tip:</strong> If you wish to remain anonymous, <strong>do "
+"not</strong> use GPG to sign the encrypted file (with the "
+"<code>--sign</code> or <code>-s</code> flag) as this will reveal your GPG "
+"identity to us."
+msgstr ""
+
+#: securedrop/source_templates/why-journalist-key.html:25
+msgid "Back to submission page"
+msgstr ""

--- a/securedrop/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/securedrop/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -1,0 +1,853 @@
+# Translations template for SecureDrop.
+# Copyright (C) 2014 ORGANIZATION
+# This file is distributed under the same license as the SecureDrop project.
+# 
+# Translators:
+# Cheng Ka Yue <chengkayue@gmail.com>, 2014
+# edwincheese <edwincheese@gmail.com>, 2014
+# edwincheese <edwincheese@gmail.com>, 2014
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
+msgid ""
+msgstr ""
+"Project-Id-Version: SecureDrop\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2014-11-19 06:57+0000\n"
+"PO-Revision-Date: 2014-11-19 07:06+0000\n"
+"Last-Translator: edwincheese <edwincheese@gmail.com>\n"
+"Language-Team: Chinese Traditional (http://www.transifex.com/projects/p/securedrop-app-code/language/zh-Hant/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+"Language: zh-Hant\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: securedrop/journalist.py:126
+msgid "You must be an administrator to access that page"
+msgstr "您必須是管理員才能訪問這頁面"
+
+#: securedrop/journalist.py:143
+msgid "Login failed"
+msgstr "登入失敗"
+
+#: securedrop/journalist.py:177
+msgid "Missing username"
+msgstr "欠缺使用者名稱"
+
+#: securedrop/journalist.py:183 securedrop/journalist.py:266
+msgid "Passwords didn't match"
+msgstr "密碼不符"
+
+#: securedrop/journalist.py:201 securedrop/journalist.py:278
+msgid "That username is already in use"
+msgstr "使用者名稱已被使用"
+
+#: securedrop/journalist.py:204
+msgid "An error occurred saving this user to the database"
+msgstr "寫入資料庫時發生錯誤"
+
+#: securedrop/journalist.py:222
+#, python-format
+msgid "Two factor token successfully verified for user %(username)s!"
+msgstr "使用者 %(username)s 成功通過雙重驗證"
+
+#: securedrop/journalist.py:225
+msgid "Two factor token failed to verify"
+msgstr "雙重驗證失敗"
+
+#: securedrop/journalist.py:280
+msgid "An unknown error occurred, please inform your administrator"
+msgstr "發生未知錯誤，請通知管理員"
+
+#: securedrop/journalist.py:428
+#, python-format
+msgid "%(journalist_designation)s's collection deleted"
+msgstr "已刪除 %(journalist_designation)s 的資料夾"
+
+#: securedrop/journalist.py:435 securedrop/journalist.py:513
+msgid "No collections selected to delete!"
+msgstr "未選擇要刪除的資料夾！"
+
+#: securedrop/journalist.py:441
+#, python-format
+msgid "%(cols_selected)d collection deleted"
+msgid_plural "%(cols_selected)d collections deleted"
+msgstr[0] "已刪除 %(cols_selected)d 個資料夾"
+
+#: securedrop/journalist.py:485
+#, python-format
+msgid ""
+"The source '%(original_journalist_designation)s' has been renamed to "
+"'%(new_journalist_designation)s'"
+msgstr "線人 '%(original_journalist_designation)s' 已經重新命名為 '%(new_journalist_designation)s'"
+
+#: securedrop/journalist.py:511
+msgid "No collections selected to download!"
+msgstr "未選擇要下載的資料夾！"
+
+#: securedrop/source.py:124
+#, python-format
+msgid ""
+"<strong>WARNING:</strong> You appear to be using Tor2Web. This <strong>does "
+"not</strong> provide anonymity. %(tor2web_warning)s"
+msgstr "<strong>警告：</strong>您正在使用 Tor2Web 。這並<strong>不能</strong>保護您的身份。%(tor2web_warning)s"
+
+#: securedrop/source.py:258
+msgid "Thanks! We received your message."
+msgstr "感謝您！我們已收到您的訊息。"
+
+#: securedrop/source.py:263
+#, python-format
+msgid "Thanks! We received your document \"%(filename)s\"."
+msgstr "感謝您！我們已收到您的文件 \"%(filename)s\"。"
+
+#: securedrop/source.py:293
+msgid "Reply deleted"
+msgstr "回覆已刪除"
+
+#: securedrop/source.py:313
+msgid "Sorry, that is not a recognized codename."
+msgstr "對不起，無法識別這個代號"
+
+#: securedrop/journalist_templates/admin.html:3
+msgid "Admin Interface"
+msgstr "管理員介面"
+
+#: securedrop/journalist_templates/admin.html:6
+#: securedrop/journalist_templates/admin_add_user.html:21
+msgid "Add user"
+msgstr "新增使用者"
+
+#: securedrop/journalist_templates/admin.html:16
+#: securedrop/journalist_templates/admin_add_user.html:9
+#: securedrop/journalist_templates/login.html:8
+msgid "Username"
+msgstr "使用者名稱"
+
+#: securedrop/journalist_templates/admin.html:17
+msgid "Edit"
+msgstr "更改"
+
+#: securedrop/journalist_templates/admin.html:18
+#: securedrop/source_templates/lookup.html:52
+msgid "Delete"
+msgstr "刪除"
+
+#: securedrop/journalist_templates/admin.html:19
+msgid "Created"
+msgstr "已建立"
+
+#: securedrop/journalist_templates/admin.html:20
+msgid "Last login"
+msgstr "最後登入"
+
+#: securedrop/journalist_templates/admin.html:31
+msgid "Never"
+msgstr "從未"
+
+#: securedrop/journalist_templates/admin.html:38
+msgid "No users to display"
+msgstr "沒有使用者"
+
+#: securedrop/journalist_templates/admin_add_user.html:4
+#: securedrop/journalist_templates/admin_edit_user.html:4
+msgid "Back to admin interface"
+msgstr "返回管理員介面"
+
+#: securedrop/journalist_templates/admin_add_user.html:10
+#: securedrop/journalist_templates/login.html:9
+msgid "Password"
+msgstr "密碼"
+
+#: securedrop/journalist_templates/admin_add_user.html:11
+msgid "Password (again)"
+msgstr "密碼（再一次）"
+
+#: securedrop/journalist_templates/admin_add_user.html:14
+#: securedrop/journalist_templates/admin_edit_user.html:23
+msgid "Is Administrator"
+msgstr "這是管理員"
+
+#: securedrop/journalist_templates/admin_add_user.html:18
+msgid "I'm using a Yubikey "
+msgstr "使用 Yubikey"
+
+#: securedrop/journalist_templates/admin_add_user.html:19
+msgid "HOTP Secret"
+msgstr "HOTP 密碼"
+
+#: securedrop/journalist_templates/admin_edit_hotp_secret.html:7
+msgid "Change Secret"
+msgstr "更改密碼"
+
+#: securedrop/journalist_templates/admin_edit_hotp_secret.html:10
+#: securedrop/source_templates/generate.html:39
+#: securedrop/source_templates/login.html:11
+msgid "Continue"
+msgstr "繼續"
+
+#: securedrop/journalist_templates/admin_edit_user.html:3
+msgid "Edit user"
+msgstr "編輯使用者"
+
+#: securedrop/journalist_templates/admin_edit_user.html:9
+msgid "Change username"
+msgstr "更改使用者名稱"
+
+#: securedrop/journalist_templates/admin_edit_user.html:13
+msgid "Change password"
+msgstr "更改密碼"
+
+#: securedrop/journalist_templates/admin_edit_user.html:15
+msgid "Leave blank for no change"
+msgstr "留空代表不作更改"
+
+#: securedrop/journalist_templates/admin_edit_user.html:18
+msgid "Change password (confirm)"
+msgstr "更改密碼（確認）"
+
+#: securedrop/journalist_templates/admin_edit_user.html:25
+msgid "Update user"
+msgstr "更改使用者"
+
+#: securedrop/journalist_templates/admin_edit_user.html:30
+msgid "Reset Two Factor Authentication"
+msgstr "重設雙重驗證"
+
+#: securedrop/journalist_templates/admin_edit_user.html:31
+msgid ""
+"If a user's two factor authentication credentials have been lost or "
+"compromised, you can reset them here. "
+msgstr "如果使用者的雙重驗證裝置丟失或外洩，您可以在這裡重設它們。"
+
+#: securedrop/journalist_templates/admin_edit_user.html:31
+msgid ""
+"If you do this, make sure the user is present and ready to set up their "
+"device with the new two factor credentials. Otherwise, they will be locked "
+"out of their account."
+msgstr "如果您要這樣做，請確保使用者在場並且能夠即時設定新的雙重驗證裝置。否則他們將無法登入帳戶。"
+
+#: securedrop/journalist_templates/admin_edit_user.html:35
+msgid "Reset two factor authentication (Google Authenticator)"
+msgstr "重設雙重驗證（Google Authenticator）"
+
+#: securedrop/journalist_templates/admin_edit_user.html:41
+msgid "Reset two factor authentication (HOTP Yubikey)"
+msgstr "重設雙重驗證（HOTP Yubikey）"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:4
+msgid "Enable Google Authenticator"
+msgstr "啟用 Google Authenticator"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:5
+msgid ""
+"You're almost done! To finish adding this new user, have them follow the "
+"instructions below to set up two factor authentication with Google "
+"Authenticator. Once they've added an entry for this account in the app, have"
+" them enter one of the 6-digit codes from the app to confirm that two factor"
+" authentication is set up correctly."
+msgstr "快將完成！請按以下指示為新使用者設定 Google Authenticator 雙重驗證。當設定完成後，請讓他們輸入6位數字驗證碼以確保設定無誤。"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:7
+msgid "Install Google Authenticator on your phone"
+msgstr "安裝 Google Authenticator 到您的電話"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:8
+msgid "Open the Google Authenticator app"
+msgstr "開啟 Google Authenticator"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:9
+msgid "Tap menu, then tap \"Set up account\", then tap \"Scan a barcode\""
+msgstr "先按目錄，再按 \"Set up account\"，最後按 \"Scan a barcode\""
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:10
+msgid ""
+"Your phone will now be in \"scanning\" mode. When you are in this mode, scan"
+" the barcode below:"
+msgstr "您的電話會開始掃描。請掃描以下的條碼："
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:13
+msgid "Can't scan the barcode? Enter the following code manually:"
+msgstr "如無法掃描條碼，請人手輸入以下文字："
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:14
+msgid "Once you have scanned the barcode, enter the 6-digit code below:"
+msgstr "掃描條碼後，請在下面輸入6個位的編碼："
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:16
+msgid "Enable Yubikey (OATH-HOTP)"
+msgstr "啟用 Yubikey (OATH-HOTP)"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:17
+msgid "Once you have configured your Yubikey, enter the 6-digit code below:"
+msgstr "設定 Yubikey 後，請在下面輸入6個位的編碼："
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:21
+msgid "Verification code"
+msgstr "驗證碼"
+
+#: securedrop/journalist_templates/admin_new_user_two_factor.html:23
+#: securedrop/journalist_templates/col.html:61
+#: securedrop/source_templates/lookup.html:31
+msgid "Submit"
+msgstr "提交"
+
+#: securedrop/journalist_templates/base.html:4
+msgid "SecureDrop"
+msgstr "SecureDrop"
+
+#: securedrop/journalist_templates/base.html:18
+msgid "Admin"
+msgstr "管理員"
+
+#: securedrop/journalist_templates/base.html:20
+msgid "Logout"
+msgstr "登出"
+
+#: securedrop/journalist_templates/base.html:46
+#, python-format
+msgid "Powered by <em>SecureDrop %(version)s</em>."
+msgstr "由 <em>SecureDrop %(version)s</em> 提供"
+
+#: securedrop/journalist_templates/col.html:10
+msgid "All Sources"
+msgstr "所有線人"
+
+#: securedrop/journalist_templates/col.html:13
+msgid ""
+"Generate a new random codename for this source. We recommend doing this if "
+"the first random codename is difficult to say or remember. You can generate "
+"new random codenames as many times as you like."
+msgstr "為線人產生新的隨機代號。我們建議您只在最初的隨機代號難以口述或記憶時這樣做。您可以多次產生新代號。"
+
+#: securedrop/journalist_templates/col.html:13
+msgid "Change codename"
+msgstr "更改代號"
+
+#: securedrop/journalist_templates/col.html:18
+msgid ""
+"The documents are stored encrypted for security. To read them, you will need"
+" to decrypt them using GPG."
+msgstr "為安全起見，所有文件都已經在儲存前加密。請使用 GPG 解密以查閱文件。"
+
+#: securedrop/journalist_templates/col.html:22
+msgid "Download selected"
+msgstr "下載已選"
+
+#: securedrop/journalist_templates/col.html:23
+#: securedrop/journalist_templates/index.html:11
+msgid "Delete selected"
+msgstr "刪除已選"
+
+#: securedrop/journalist_templates/col.html:30
+#, python-format
+msgid "%(file_size)s sent %(date)s"
+msgstr "%(file_size)s 寄出 %(date)s"
+
+#: securedrop/journalist_templates/col.html:33
+#, python-format
+msgid "%(file_size)s uploaded %(date)s"
+msgstr "%(file_size)s 上載 %(date)s"
+
+#: securedrop/journalist_templates/col.html:36
+msgid "Uploaded Document"
+msgstr "文件"
+
+#: securedrop/journalist_templates/col.html:38
+msgid "Message"
+msgstr "訊息"
+
+#: securedrop/journalist_templates/col.html:48
+msgid "No documents to display."
+msgstr "沒有文件"
+
+#: securedrop/journalist_templates/col.html:53
+msgid "Reply"
+msgstr "回覆"
+
+#: securedrop/journalist_templates/col.html:55
+msgid ""
+"You can write a secure reply to the person who submitted these documents:"
+msgstr "您可以撰寫訊息給文件提交者："
+
+#: securedrop/journalist_templates/col.html:64
+msgid "You've flagged this source for reply."
+msgstr "您已把線人標記為待回覆。"
+
+#: securedrop/journalist_templates/col.html:65
+msgid ""
+"An encryption key will be generated for the source the next time they log "
+"in, after which you will be able to reply to the source here."
+msgstr "系統會在線人下次登入時產生新的加密密鑰，之後您可以在這裡回覆線人。"
+
+#: securedrop/journalist_templates/col.html:67
+msgid "Click below if you would like to write a reply to this source."
+msgstr "請按下面以回覆這個線人。"
+
+#: securedrop/journalist_templates/col.html:71
+msgid "Flag this source for reply"
+msgstr "標記為待回覆的線人"
+
+#: securedrop/journalist_templates/col.html:76
+msgid "Click below to delete this source's collection. "
+msgstr "請按下面以刪除這個線人的檔案。"
+
+#: securedrop/journalist_templates/col.html:76
+msgid ""
+"Warning: If you do this, the files seen here will be unrecoverable and the "
+"source will no longer be able to login using their previous codename."
+msgstr "注意：這樣做會刪除這裡顯示的檔案而且無法還原，而線人亦不能再以舊代號登入。"
+
+#: securedrop/journalist_templates/col.html:82
+msgid "Delete collection"
+msgstr "刪除檔案"
+
+#: securedrop/journalist_templates/delete.html:7
+msgid "File permanently deleted."
+msgid_plural "Files permanently deleted."
+msgstr[0] "檔案已被永久刪除"
+
+#: securedrop/journalist_templates/delete.html:13
+#, python-format
+msgid ""
+"The following file has been selected for <strong>permanent deletion</strong>"
+msgid_plural ""
+"The following %(value)d files have been selected for <strong>permanent "
+"deletion</strong>"
+msgstr[0] "選定<strong>永久刪除</strong>以下%(value)d個檔案"
+
+#: securedrop/journalist_templates/delete.html:23
+#, python-format
+msgid "(sent %(date)s)"
+msgstr "(寄出 %(date)s)"
+
+#: securedrop/journalist_templates/delete.html:25
+#, python-format
+msgid "(uploaded %(date)s)"
+msgstr "(上載於 %(date)s)"
+
+#: securedrop/journalist_templates/delete.html:32
+msgid "Permanently delete files"
+msgstr "永久刪除檔案"
+
+#: securedrop/journalist_templates/delete.html:38
+#, python-format
+msgid "Return to the list of documents for %(codename)s..."
+msgstr "返回 %(codename)s 的文件列表⋯⋯"
+
+#: securedrop/journalist_templates/flag.html:5
+msgid "Thanks!"
+msgstr "感謝您！"
+
+#: securedrop/journalist_templates/flag.html:8
+msgid ""
+"SecureDrop will generate a secure encryption key for this source the next "
+"time that they log in. Once the key has been generated, a reply box will "
+"appear under their collection of documents. You can use this box to write "
+"encrypted replies to them."
+msgstr "SecureDrop 會在這個線人下次登入時產生新的加密金鑰。加密金鑰產生後，文件列表下會出現回覆欄。您可以在回覆欄撰寫訊息給線人。"
+
+#: securedrop/journalist_templates/flag.html:10
+#, python-format
+msgid "Continue to the list of documents for %(codename)s..."
+msgstr "返回 %(codename)s 的文件列表⋯⋯"
+
+#: securedrop/journalist_templates/index.html:4
+msgid "Sources"
+msgstr "線人"
+
+#: securedrop/journalist_templates/index.html:10
+msgid "select all"
+msgstr "全部選取"
+
+#: securedrop/journalist_templates/index.html:10
+msgid "select none"
+msgstr "取消選取"
+
+#: securedrop/journalist_templates/index.html:12
+msgid "Star Selected"
+msgstr "加星號"
+
+#: securedrop/journalist_templates/index.html:13
+msgid "Un-star Selected"
+msgstr "取消星號"
+
+#: securedrop/journalist_templates/index.html:29
+#: securedrop/journalist_templates/index.html:55
+msgid "docs"
+msgstr "文件"
+
+#: securedrop/journalist_templates/index.html:30
+#: securedrop/journalist_templates/index.html:56
+msgid "messages"
+msgstr "訊息"
+
+#: securedrop/journalist_templates/index.html:33
+msgid " unread"
+msgstr "未讀"
+
+#: securedrop/journalist_templates/index.html:59
+msgid "unread"
+msgstr "未讀"
+
+#: securedrop/journalist_templates/index.html:71
+msgid "No documents have been submitted!"
+msgstr "未有提交文件！"
+
+#: securedrop/journalist_templates/login.html:4
+msgid "Login to access the journalist interface"
+msgstr "登入記者介面"
+
+#: securedrop/journalist_templates/login.html:10
+msgid "Two-factor Code"
+msgstr "驗證碼"
+
+#: securedrop/journalist_templates/login.html:11
+msgid "Log in"
+msgstr "登入"
+
+#: securedrop/journalist_templates/reply.html:5
+msgid "Thanks! Your reply has been stored."
+msgstr "感謝您！我們已儲存您的回覆。"
+
+#: securedrop/journalist_templates/reply.html:8
+msgid ""
+"You will now see it in the list of documents in that collection. Once the "
+"source has read it, they will be asked to delete it. If it disappears from "
+"the list, then you know it has been read."
+msgstr "您現在會在文件列表看到該訊息。當線人查閱後，系統會提示他們刪除該訊息。如果訊息在文件列表消失，這就代表它已被查閱。"
+
+#: securedrop/journalist_templates/reply.html:10
+#, python-format
+msgid "Return to the list of documents for <strong>%(codename)s</strong>..."
+msgstr "返回  <strong>%(codename)s</strong> 的文件列表⋯⋯"
+
+#: securedrop/source_templates/base.html:4
+msgid "SecureDrop | Protecting Journalists and Sources"
+msgstr "SecureDrop | 安全告密文件提交平台"
+
+#: securedrop/source_templates/base.html:36
+#: securedrop/source_templates/index.html:50
+#, python-format
+msgid ""
+"Like all software, SecureDrop may contain security bugs. Use at your own "
+"risk. Powered by SecureDrop %(version)s."
+msgstr "正如所有軟件一樣，SecureDrop 可能存在安全漏洞。敬請注意使用風險。由 SecureDrop %(version)s 提供。"
+
+#: securedrop/source_templates/error.html:5
+msgid "Server error"
+msgstr "伺服器錯誤"
+
+#: securedrop/source_templates/error.html:7
+msgid ""
+"Sorry, the website encountered an error and was unable to complete your "
+"request."
+msgstr "對不起，網頁發生錯誤，我們未能完成您的請求。"
+
+#: securedrop/source_templates/error.html:9
+#: securedrop/source_templates/notfound.html:9
+msgid "Look up a codename..."
+msgstr "查詢代號⋯⋯"
+
+#: securedrop/source_templates/generate.html:4
+msgid "Remember this code and keep it secret"
+msgstr "請記住這個代號組合，或把它收藏在安全的地方"
+
+#: securedrop/source_templates/generate.html:5
+msgid "To protect your identity, we're assigning you a unique codename."
+msgstr "為保護您的身份，系統會為每個戶口隨機編配一組代號。"
+
+#: securedrop/source_templates/generate.html:29
+msgid ""
+"Store this code somewhere safe, or memorize it. It can be used to compromise"
+" your anonymity."
+msgstr "把代號組合收藏在安全的地方或牢記。洩漏這組代號可能會令您的身份暴光。"
+
+#: securedrop/source_templates/generate.html:33
+msgid "Important:"
+msgstr "請注意："
+
+#: securedrop/source_templates/generate.html:33
+msgid ""
+" After you submit documents and messages, you will need this code to log in "
+"and read replies. This is the only way we can communicate back to you. You "
+"can also use your code to log in to submit more files and messages."
+msgstr "提交文件或訊息之後，您可以利用這組代號再登入並查閱回覆。這是我們唯一與您聯絡的方法。您也可以在登入之後提交其他文件或訊息。"
+
+#: securedrop/source_templates/generate.html:40
+msgid "Already have a codename?"
+msgstr "已經有另一組代號？"
+
+#: securedrop/source_templates/howto-disable-js.html:4
+msgid "Disable JavaScript to Protect Your Anonymity"
+msgstr "關閉瀏覽器的 JavaScript 功能以保護您的身份安全"
+
+#: securedrop/source_templates/howto-disable-js.html:6
+msgid ""
+"JavaScript is a widely used programming language for creating interactive "
+"web pages. Unfortunately, JavaScript is also the most common source of "
+"security vulnerabilities in browsers. In August 2013, the FBI wrote malware "
+"that used a JavaScript exploit to de-anonymize Tor users "
+"(http://www.wired.com/threatlevel/2013/09/freedom-hosting-fbi). JavaScript "
+"exploits are also mentioned in documents describing the NSA's Egotistical "
+"Giraffe (http://www.theguardian.com/world/interactive/2013/oct/04"
+"/egotistical-giraffe-nsa-tor-document) program, which also has the goal of "
+"targeting and de-anonymizing Tor users."
+msgstr "JavaScript 是一個常用於動態網頁的編程語言。不幸地，JavaScript 亦是最常見的瀏覽器安全漏洞源頭。2013年8月，聯邦調查局曾用 JavaScript 安全漏洞取得 Tor 使用者的身份（ http://www.wired.com/threatlevel/2013/09/freedom-hosting-fbi ）。JavaScript 安全漏洞亦在美國國家安全局的 Egotistical Giraffe 計劃的簡介文件中提及過（ http://www.theguardian.com/world/interactive/2013/oct/04/egotistical-giraffe-nsa-tor-document ），這個計劃的目的也是追查 Tor 使用者的身份。"
+
+#: securedrop/source_templates/howto-disable-js.html:8
+msgid ""
+"We encourage SecureDrop users to disable JavaScript to protect themselves "
+"from malware that would use it to attack their browser and potentially de-"
+"anonymize them. There are other ways to get hacked, but given the use of "
+"JavaScript-based attacks recently, we believe it is prudent to disable it at"
+" this time."
+msgstr "我們建議 SecureDrop 使用者停用 JavaScript 以避免受惡意軟體攻擊或洩露身份。JavaScript 並非唯一的入侵的途徑，不過因應最近出現基於 JavaScript 的攻擊，為謹慎起見，我們建議停用 JavaScript。"
+
+#: securedrop/source_templates/howto-disable-js.html:10
+msgid ""
+"The Tor Browser comes with an add-on called NoScript that can be used to "
+"completely disable JavaScript by default, and to only enable it for sites "
+"that you trust."
+msgstr "Tor Browser 內置 NoScript 附加組件，您可以用它來完全停用 JavaScript，或者只在信任的網站啟用。"
+
+#: securedrop/source_templates/howto-disable-js.html:12
+#, python-format
+msgid ""
+"To disable JavaScript in Tor Browser, click the NoScript icon %(icon)s to "
+"the left of the address bar above and choose \"Forbid Scripts Globally "
+"(advised)\""
+msgstr "要在 TorBorwser 停用 JavaScript，請按地址列左邊的 NoScript 圖示 %(icon)s，並選取「全局禁止腳本 (推薦)」"
+
+#: securedrop/source_templates/index.html:13
+msgid "We recommend disabling JavaScript to protect your anonymity:"
+msgstr "為保護您的身份安全，我們強烈建議您關閉瀏覽器的 JavaScript 功能："
+
+#: securedrop/source_templates/index.html:13
+#, python-format
+msgid " %(howto_disable_js)s, or ignore this warning to continue."
+msgstr "%(howto_disable_js)s，或略過這個提示繼續。"
+
+#: securedrop/source_templates/index.html:13
+msgid "Learn how to disable it"
+msgstr "關閉 JavaScript"
+
+#: securedrop/source_templates/index.html:31
+msgid "Submit documents for the first time"
+msgstr "第一次提交文件"
+
+#: securedrop/source_templates/index.html:34
+msgid ""
+"If this is your first time submitting documents to journalists, start here."
+msgstr "第一次提交文件給記者，從這裡開始。"
+
+#: securedrop/source_templates/index.html:36
+msgid "Submit Documents"
+msgstr "提交文件"
+
+#: securedrop/source_templates/index.html:40
+msgid "Already submitted something?"
+msgstr "跟進已提交的文件？"
+
+#: securedrop/source_templates/index.html:43
+msgid ""
+"If you have already submitted documents in the past, log in here to check "
+"for responses."
+msgstr "如果您已提交過文件，您可以登入查閱回覆。"
+
+#: securedrop/source_templates/index.html:45
+msgid "Check for a response"
+msgstr "查閱回覆"
+
+#: securedrop/source_templates/index.html:59
+msgid ""
+"You appear to be using the Tor Browser. You can disable Javascript in 3 easy"
+" steps!"
+msgstr "您看來正在使用 Tor Browser。只需要3個簡單步驟即可關閉 JavaScript！"
+
+#: securedrop/source_templates/index.html:61
+#, python-format
+msgid "Click %(img)s NoScript icon in the toolbar above"
+msgstr "按瀏覽器工具欄的 %(img)s NoScript 標誌"
+
+#: securedrop/source_templates/index.html:62
+#, python-format
+msgid "Click <strong>%(img)s Forbid Scripts Globally (advised)</strong>"
+msgstr "按 <strong>%(img)s 全局禁止腳本 (推薦)</strong>"
+
+#: securedrop/source_templates/index.html:63
+#, python-format
+msgid ""
+"If the page does not refresh automatically, %(click_here)s to refresh the "
+"page"
+msgstr "如果網頁沒有重新載入，%(click_here)s重新載入。"
+
+#: securedrop/source_templates/index.html:63
+msgid "click here"
+msgstr "按這裡"
+
+#: securedrop/source_templates/index.html:65
+msgid "Not using the Tor Browser Bundle?"
+msgstr "並非使用 Tor Browser？"
+
+#: securedrop/source_templates/login.html:4
+msgid "Login to check for responses"
+msgstr "登入以查閱回覆"
+
+#: securedrop/source_templates/login.html:10
+msgid "Enter your codename"
+msgstr "請輸入您的代號組合："
+
+#: securedrop/source_templates/lookup.html:8
+msgid ""
+"A journalist has been waiting for you to log in again so SecureDrop can "
+"generate a crypto key for you. Now that you have logged in, they are able to"
+" write you a reply. Check back later for replies."
+msgstr "記者正在等候您再次登入 SecureDrop 以產生新的加密金鑰。您現在已經登入，他們將能夠發送訊息給您。請稍後再登入查閱訊息。"
+
+#: securedrop/source_templates/lookup.html:11
+msgid "Submit documents and messages"
+msgstr "提交文件或訊息"
+
+#: securedrop/source_templates/lookup.html:12
+msgid "You can send a file, a message, or both."
+msgstr "您可以上載文件或撰寫訊息。"
+
+#: securedrop/source_templates/lookup.html:22
+msgid "Maximum upload size:"
+msgstr "檔案大小上限："
+
+#: securedrop/source_templates/lookup.html:25
+msgid "Add message"
+msgstr "撰寫訊息"
+
+#: securedrop/source_templates/lookup.html:34
+msgid "Tip:"
+msgstr "提示："
+
+#: securedrop/source_templates/lookup.html:34
+#, python-format
+msgid ""
+" If you are already familiar with GPG, you can optionally encrypt your files"
+" and messages with our %(journalist_key)s before submission. Files are "
+"encrypted as they are received by SecureDrop; encrypting before submission "
+"provides an extra layer of security before your data reaches SecureDrop. "
+"%(why_journalist_key)s."
+msgstr "如果您能夠使用 GPG，您可以選擇在上載文件和訊息之前用我們的%(journalist_key)s加密。SecureDrop 會自動加密所有上載的資料，但上載前把文件和留言加密可以額外保障您的資料在在傳送到 SecureDrop 前的安全。%(why_journalist_key)s。"
+
+#: securedrop/source_templates/lookup.html:35
+msgid "public key"
+msgstr "公開金鑰"
+
+#: securedrop/source_templates/lookup.html:36
+msgid "Learn more"
+msgstr "了解更多"
+
+#: securedrop/source_templates/lookup.html:40
+msgid "Replies"
+msgstr "回覆"
+
+#: securedrop/source_templates/lookup.html:44
+msgid ""
+"You have received a reply. For your security, please delete all replies when"
+" you're done with them. This also lets us know that you have received our "
+"reply. You can respond by submitting a new message above."
+msgstr "您有新訊息。為安全起見，請在閱覽完畢後刪除訊息。這樣也可以令我們知道您已經收到該訊息。另外您也可以在上面撰寫新訊息回覆。"
+
+#: securedrop/source_templates/lookup.html:59
+msgid "There are no replies at this time."
+msgstr "暫時未有回覆。"
+
+#: securedrop/source_templates/lookup.html:66
+msgid "Remember, your codename is:"
+msgstr "請記住，您的代號組合是："
+
+#: securedrop/source_templates/notfound.html:5
+msgid "Page not found"
+msgstr "找不到網頁"
+
+#: securedrop/source_templates/notfound.html:7
+msgid "Sorry, we couldn't locate what you requested."
+msgstr "對不起，我們未能找到您所請求的網頁。"
+
+#: securedrop/source_templates/why-journalist-key.html:3
+msgid "Why download the journalist's public key?"
+msgstr "為什麼要下載記者的公開金鑰？"
+
+#: securedrop/source_templates/why-journalist-key.html:4
+msgid ""
+"SecureDrop encrypts files and messages after they are submitted. Encrypting "
+"messages and files before submission can provide an extra layer of security "
+"before your data reaches the SecureDrop server."
+msgstr "SecureDrop 會自動加密所有收到的資料。上載前把文件和留言加密可以額外保障資料在傳送到 SecureDrop 伺服器前的安全。"
+
+#: securedrop/source_templates/why-journalist-key.html:5
+msgid ""
+"If you are already familiar with the GPG encryption software, you may wish "
+"to encrypt your submissions yourself. To do so:"
+msgstr "如果您熟悉 GPG 加密軟件，您可以在上載文件前先自行加密。您可以："
+
+#: securedrop/source_templates/why-journalist-key.html:7
+#, python-format
+msgid ""
+"%(download)s the public key. The public key is a text file with the "
+"extension <code>.asc</code>"
+msgstr "%(download)s我們的公開金鑰。公開金鑰是一個副檔名為 <code>.asc</code> 的文字檔案"
+
+#: securedrop/source_templates/why-journalist-key.html:7
+msgid "Download"
+msgstr "下載"
+
+#: securedrop/source_templates/why-journalist-key.html:8
+msgid "Import it into your GPG keyring."
+msgstr "匯入至您的 GPG 鑰匙圈"
+
+#: securedrop/source_templates/why-journalist-key.html:10
+msgid ""
+"If you are using Tails (https://tails.boum.org/), you can double-click the "
+"<code>.asc</code> file you just downloaded and it will be automatically "
+"imported to your keyring."
+msgstr "如果您正在使用 Tails （https://tails.boum.org/）作業系統，您可以雙擊已下載的 <code>.asc</code> 檔案，這樣做會自動把金鑰匯入的您的鑰匙圈。"
+
+#: securedrop/source_templates/why-journalist-key.html:11
+msgid ""
+"If you are using Mac/Linux, open the Terminal. You can import the key with "
+"<code>gpg --import /path/to/key.asc</code>."
+msgstr "如果您使用 Mac/Linux 系統，請打開終端機。您可以用這個指令匯入金鑰：<code>gpg --import /path/to/key.asc</code>。"
+
+#: securedrop/source_templates/why-journalist-key.html:14
+msgid "Encrypt your submission."
+msgstr "把您要提交的文件或訊息加密"
+
+#: securedrop/source_templates/why-journalist-key.html:16
+msgid ""
+"You will need to be able to identify the key (this is called the \"user ID\""
+" or uid). Since the public key's filename is the key's fingerprint (with "
+".asc at the end), you can just copy and paste that. (don't include the "
+"<code>.asc</code>!)"
+msgstr "您需要辨認出我們的金鑰（稱為 \"user ID\" 或 uid）。因為公開金鑰的檔案名稱是金鑰的指紋（加上 .asc 結尾），你可以直接複製和貼上檔案名稱（不包括 <code>.asc</code>！）"
+
+#: securedrop/source_templates/why-journalist-key.html:17
+msgid ""
+"On all systems, open the Terminal and use this gpg command: <code>gpg "
+"--recipient &lt;user ID&gt; --encrypt roswell_photos.pdf</code>"
+msgstr "在所有系統，請打開「終端機」並執行以下 GPG 指令：<code>gpg --recipient &lt;user ID&gt; --encrypt 羅斯維爾報告.pdf</code>"
+
+#: securedrop/source_templates/why-journalist-key.html:20
+msgid ""
+"Upload your encrypted submission. It will have the same filename as the "
+"unencrypted file, with .gpg at the end (e.g. "
+"<code>roswell_photos.pdf.gpg</code>)"
+msgstr "上載經過加密的文件。除了添加了 .gpg 副檔名外，文件名稱應該和未加密前的文件一樣（例如  <code>羅斯維爾報告.pdf.gpg</code>）"
+
+#: securedrop/source_templates/why-journalist-key.html:23
+msgid ""
+"<strong>Tip:</strong> If you wish to remain anonymous, <strong>do "
+"not</strong> use GPG to sign the encrypted file (with the "
+"<code>--sign</code> or <code>-s</code> flag) as this will reveal your GPG "
+"identity to us."
+msgstr "<strong>提示：</strong>如果您希望保持匿名，<strong>請勿</strong>在 GPG 加密文件的同時進行數碼簽署（使用 <code>--sign</code> 或 <code>-s</code> 指令參數），這樣做會向我們揭示您的 GPG 身份。"
+
+#: securedrop/source_templates/why-journalist-key.html:25
+msgid "Back to submission page"
+msgstr "返回提交文件頁面"


### PR DESCRIPTION
![screen shot 2014-11-16 at 1 53 23 pm](https://cloud.githubusercontent.com/assets/800071/5063346/026a783e-6d98-11e4-9ebb-18e240008a15.png)
- Integrates with Flask-Babel to add i18n and l10n support
- Languages are selected by Accept-Languages header or manual override
  by query parameter
- Adds a language selection menu in page footer
- Tags strings in source and journalist interface for translation
- Integrates with Transifex to collaborate on translation (https://www.transifex.com/projects/p/securedrop-app-code/)
- Fully translates into Italian and Traditional Chinese
- Setup vagrant to compiles translation files while running provision
- Unit tests
- resolve #127

Todo:
- build_deb_packages.sh does not compile translation files
- Relative time format is not localized
