### PR TITLE
fix recursive default variables

### DIFF
--- a/install_files/ansible-base/development-specific.yml
+++ b/install_files/ansible-base/development-specific.yml
@@ -1,7 +1,7 @@
 ---
 ### General (used by more than one role) ###
-securedrop_repo: "/vagrant"
-securedrop_user: "vagrant"
+non_default_securedrop_repo: "/vagrant"
+non_default_securedrop_user: "vagrant"
 
 ### Used by the common role ###
 ssh_users: "vagrant"

--- a/install_files/ansible-base/host_vars/app.yml
+++ b/install_files/ansible-base/host_vars/app.yml
@@ -4,8 +4,8 @@
 # securedrop_code and securedrop_user variables. Setting a default values
 # allows us not to define these two variables in the prod-specific and
 # staging-specific yml configs.
-securedrop_code: "{{ securedrop_code | default(/var/www/securedrop) }}"
-securedrop_user: "{{ securedrop_user | default(www-data) }}"
+securedrop_code: "{{ non_default_securedrop_code | default('/var/www/securedrop') }}"
+securedrop_user: "{{ non_default_securedrop_user | default('www-data') }}"
 
 ### Used by the common role ###
 # ssh_users is defined in the site-specific.yml config

--- a/install_files/ansible-base/travis-specific.yml
+++ b/install_files/ansible-base/travis-specific.yml
@@ -1,10 +1,10 @@
 ---
 ### General (used by more than one role) ###
-securedrop_user: "travis"
+non_default_securedrop_user: "travis"
 securedrop_repo: "{{ lookup('env', 'TRAVIS_BUILD_DIR') }}"
 
 ### Used by the app role ###
-securedrop_code: "{{ securedrop_repo }}/securedrop"
+non_default_securedrop_code: "{{ securedrop_repo }}/securedrop"
 # The securedrop_header_image has to be in the install_files/ansible-base/ or
 # the install_files/ansible-base/roles/app/files/ directory
 # Leave set to None to use the SecureDrop logo.


### PR DESCRIPTION
Only the travis and development version use non-default values for securedrop_code and securedrop_user.

Instead of defining a default value ever location that securedrop_code or securedrop_user added two variables non_default_securedrop_code and non_default_securedrop_user. If these variables are defined (in travis-specific.yml and development-specific.yml) then those values will be used for securedrop_code and securedrop_user respectively.
