### PR TITLE
Manually set the system time on the SVS before creating a GPG key,

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -180,9 +180,12 @@ The *Secure Viewing Station (SVS)* is a machine that is kept offline and only ev
 
 ### Create a GPG key for the SecureDrop application
 
-When a document is submitted through the *Source Interface* on the *App Server*, the document is automatically encrypted with the SecureDrop Application GPG key. If you have not previously created a GPG key for SecureDrop, follow the steps below to do so now:
+When a document is submitted through the *Source Interface* on the *App Server*, the document is automatically encrypted with the SecureDrop Application GPG key. If you have not previously created a GPG key for SecureDrop, you will need to create one now before you continue with the installation. 
 
-* Boot the Secure Viewing Station from the *offline* USB stick
+Start by booting the Secure Viewing Station from the *offline* USB stick. When starting Tails, you should see a *Welcome to Tails*-screen with two options. Select *Yes* to enable the persistent volume and enter your password. Select *Yes* to show more options and click *Forward*. Enter an *Administration password* for use with this current Tails session and click *Login*.
+
+After logging in, you will need to manually set the systm time before you create the GPG key. To set the system time, right-click the time in the top menu bar and select *Adjust Date & Time.* Click *Unlock* in the top-right corner of the dialog window and enter your *Administration password.* Set the correct time and date for your region, click *Lock*, enter your password one more time and wait for the system time to update in the top menu bar. Once that's done, folow the steps below to create a GPG key.
+
 * Open a terminal and run `gpg --gen-key`
 * When it says, `Please select what kind of key you want`, choose `(1) RSA and RSA (default)`
 * When it asks, `What keysize do you want?` type `4096`


### PR DESCRIPTION
resolves #783.
