### PR TITLE
Reboot every 24 hours to periodically wipe memory

### DIFF
--- a/install_files/ansible-base/roles/common/files/cron-apt
+++ b/install_files/ansible-base/roles/common/files/cron-apt
@@ -1,7 +1,12 @@
 #
 # Regular cron jobs for the cron-apt package
 #
+
 # Every night at 4 o'clock run cron-apt
 0 4 * * * root    /usr/bin/test -x /usr/sbin/cron-apt && /usr/sbin/cron-apt
-# Every night at 5 o'clock if reboot is required reboot
-0 5 * * * root    /usr/bin/test -e /var/run/reboot-required && /sbin/reboot
+
+# Every night at 5 o'clock reboot (regardless of whether reboot is
+# required by the most recent package upgrade). This guarantees that
+# submission plaintext will be retained in memory for at most 24
+# hours.
+0 5 * * * root    /sbin/reboot


### PR DESCRIPTION
This is a kludge, but a reasonably effective one. This change reboots
the servers every day at 5am. Previously this reboot would only happen
if required by the daily package upgrade (e.g. for a kernel upgrade),
but now it happens every day regardless of whether it is needed.

This ensures that the plaintext of submissions can reside in memory for
at most 24 hours after submission. Resolves #99, although we can and
should do better in a future release.
