### PR TITLE
Ignore Whitespace in Auth Token

### DIFF
--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -198,7 +198,7 @@ class Journalist(Base):
         return hash
 
     def _format_token(self, token):
-        """Strips whitespace from authentication tokens, as many clients add these for readability"""
+        """Strips from authentication tokens the whitespace that many clients add for readability"""
         return ''.join(token.split())
 
     def set_password(self, password):

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -197,6 +197,10 @@ class Journalist(Base):
             print "Scrypt hashing failed for password='{}', salt='{}', params='{}', traceback: {}".format(password, salt, params, e)
         return hash
 
+    def _format_token(self, token):
+        """Strips whitespace from authentication tokens, as many clients add these for readability"""
+        return ''.join(token.split())
+
     def set_password(self, password):
         self.pw_salt = self._gen_salt()
         self.pw_hash = self._scrypt_hash(password, self.pw_salt)
@@ -246,6 +250,8 @@ class Journalist(Base):
         return ' '.join(chunks).lower()
 
     def verify_token(self, token):
+        token = self._format_token(token)
+
         # Only allow each authentication token to be used once. This
         # prevents some MITM attacks.
         if token == self.last_token and LOGIN_HARDENING:

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -197,10 +197,6 @@ class Journalist(Base):
             print "Scrypt hashing failed for password='{}', salt='{}', params='{}', traceback: {}".format(password, salt, params, e)
         return hash
 
-    def _format_token(self, token):
-        """Strips from authentication tokens the whitespace that many clients add for readability"""
-        return ''.join(token.split())
-
     def set_password(self, password):
         self.pw_salt = self._gen_salt()
         self.pw_hash = self._scrypt_hash(password, self.pw_salt)
@@ -248,6 +244,10 @@ class Journalist(Base):
         sec = self.otp_secret
         chunks = [ sec[i:i+4] for i in xrange(0, len(sec), 4) ]
         return ' '.join(chunks).lower()
+
+    def _format_token(self, token):
+        """Strips from authentication tokens the whitespace that many clients add for readability"""
+        return ''.join(token.split())
 
     def verify_token(self, token):
         token = self._format_token(token)


### PR DESCRIPTION
Removes any whitespace from the user's authentication token before attempting to verify it. Closes #820.