### PR TITLE
Rounded timestamps qf 822

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -30,7 +30,7 @@
               <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }}</span> sent <time title="{{ doc.date|datetimeformat }}" datetime="{{ doc.date }}">{{ doc.date|datetimeformat(relative=True) }}</time></span>
             {% else %}
               <span class="file"><a class="btn small" href="/col/{{ sid }}/{{ doc.name }}"><i class="fa fa-download"></i> <span class="filename">{{ doc.name }}</span></a></span>
-              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }}</span> uploaded <time title="{{ doc.date|datetimeformat }}" datetime="{{ doc.date }}">{{ doc.date|datetimeformat(relative=True) }}</time></span>
+              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }}</span> uploaded <time>{{ doc.date|datetimeformat(relative=True) }}</time></span>
             {% endif %}
             {% if doc.name.endswith('-doc.zip.gpg') %}
               <i title="Uploaded Document" class="fa fa-file-archive-o pull-right"></i>

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -30,7 +30,7 @@
               <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }}</span> sent <time title="{{ doc.date|datetimeformat }}" datetime="{{ doc.date }}">{{ doc.date|datetimeformat(relative=True) }}</time></span>
             {% else %}
               <span class="file"><a class="btn small" href="/col/{{ sid }}/{{ doc.name }}"><i class="fa fa-download"></i> <span class="filename">{{ doc.name }}</span></a></span>
-              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }}</span> uploaded <time>{{ doc.date|datetimeformat(relative=True) }}</time></span>
+              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat }}</span> uploaded <time>{{ doc.date|datetimeformat(relative=True,imprecise=True) }}</time></span>
             {% endif %}
             {% if doc.name.endswith('-doc.zip.gpg') %}
               <i title="Uploaded Document" class="fa fa-file-archive-o pull-right"></i>

--- a/securedrop/journalist_templates/delete.html
+++ b/securedrop/journalist_templates/delete.html
@@ -22,7 +22,7 @@
     {% if doc.name.startswith('reply-') %}
       (sent {{ doc.date }})
     {% else %}
-      (uploaded {{ doc.date }})
+      (uploaded {{ doc.date|datetimeformat(relative=True,imprecise=True) }})
     {% endif %}
   </li>
   {% endfor %}

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -19,7 +19,7 @@
             {% set docs = source.documents_messages_count()['documents'] %}
             {% set msgs = source.documents_messages_count()['messages'] %}
             <li class="source" data-source-designation="{{ source.journalist_designation|lower }}">
-              <time class="date" title="{{ source.last_updated|datetimeformat }}" datetime="{{ source.last_updated }}">{{ source.last_updated|datetimeformat(relative=True) }}</time>
+              <time class="date">{{ source.last_updated|datetimeformat(relative=True) }}</time>
               <div class="designation">
                 <button class="button-star starred" type="submit" formaction="/col/remove_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
                 <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
@@ -45,7 +45,7 @@
             {% set docs = source.documents_messages_count()['documents'] %}
             {% set msgs = source.documents_messages_count()['messages'] %}
             <li class="source" data-source-designation="{{ source.journalist_designation|lower }}">
-              <time class="date" title="{{ source.last_updated|datetimeformat }}" datetime="{{ source.last_updated }}">{{ source.last_updated|datetimeformat(relative=True) }}</time>
+              <time class="date">{{ source.last_updated|datetimeformat(relative=True) }}</time>
               <div class="designation">
                 <button class="button-star un-starred" type="submit" formaction="/col/add_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
                 <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -19,7 +19,7 @@
             {% set docs = source.documents_messages_count()['documents'] %}
             {% set msgs = source.documents_messages_count()['messages'] %}
             <li class="source" data-source-designation="{{ source.journalist_designation|lower }}">
-              <time class="date">{{ source.last_updated|datetimeformat(relative=True) }}</time>
+              <time class="date">{{ source.last_updated|datetimeformat(relative=True,imprecise=True) }}</time>
               <div class="designation">
                 <button class="button-star starred" type="submit" formaction="/col/remove_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
                 <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
@@ -45,7 +45,7 @@
             {% set docs = source.documents_messages_count()['documents'] %}
             {% set msgs = source.documents_messages_count()['messages'] %}
             <li class="source" data-source-designation="{{ source.journalist_designation|lower }}">
-              <time class="date">{{ source.last_updated|datetimeformat(relative=True) }}</time>
+              <time class="date">{{ source.last_updated|datetimeformat(relative=True,imprecise=True) }}</time>
               <div class="designation">
                 <button class="button-star un-starred" type="submit" formaction="/col/add_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
                 <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -217,12 +217,11 @@ def normalize_timestamps(sid):
     """
     sub_paths = [ store.path(sid, submission.filename)
                   for submission in g.source.submissions ]
-    if len(sub_paths) > 1:
-        args = ["touch"]
-        args.extend(sub_paths[:-1])
-        rc = subprocess.call(args)
-        if rc != 0:
-            app.logger.warning("Couldn't normalize submission timestamps (touch exited with %d)" % rc)
+    args = ["touch", "-t", datetime.now().strftime("%Y%m%d") + "0000"]
+    args.extend(sub_paths)
+    rc = subprocess.call(args)
+    if rc != 0:
+        app.logger.warning("Couldn't normalize submission timestamps (touch exited with %d)" % rc)
 
 
 @app.route('/submit', methods=('POST',))

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -175,7 +175,7 @@ def async_genkey(sid, codename):
     # flagged source logs in and has a key generated for them. #789
     try:
         source = Source.query.filter(Source.filesystem_id == sid).one()
-        source.last_updated = datetime.utcnow()
+        source.last_updated = datetime.now.date()
         db_session.commit()
     except Exception as e:
         app.logger.error("async_genkey for source (sid={}): {}".format(sid, e))
@@ -262,7 +262,7 @@ def submit():
         if entropy_avail >= 2400:
             async_genkey(g.sid, g.codename)
 
-    g.source.last_updated = datetime.utcnow()
+    g.source.last_updated = datetime.now().date()
     db_session.commit()
     normalize_timestamps(g.sid)
 

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -217,6 +217,9 @@ def normalize_timestamps(sid):
     """
     sub_paths = [ store.path(sid, submission.filename)
                   for submission in g.source.submissions ]
+    # touch accepts date in local time (server's timezone), which
+    # causes truncation to nearest midnight local time. Python's now()
+    # is assumed to use the same local time. See #822.
     args = ["touch", "-t", datetime.now().strftime("%Y%m%d") + "0000"]
     args.extend(sub_paths)
     rc = subprocess.call(args)

--- a/securedrop/template_filters.py
+++ b/securedrop/template_filters.py
@@ -3,33 +3,41 @@ from datetime import datetime
 from jinja2 import Markup, escape
 
 
-def datetimeformat(dt, fmt=None, relative=False):
+def datetimeformat(dt, fmt=None, relative=False, imprecise=False):
     """Template filter for readable formatting of datetime.datetime"""
-    fmt = fmt or '%b %d, %Y %I:%M %p'
+    if fmt and imprecise:
+        raise ValueError("'imprecise' cannot be used with 'fmt'")
+    fmt = fmt or ('%b %d, %Y' if imprecise else '%b %d, %Y %I:%M %p')
     if relative:
-        time_difference = _relative_timestamp(dt)
+        time_difference = _relative_timestamp(dt, imprecise)
         if time_difference:
             return '{} ago'.format(time_difference)
     return dt.strftime(fmt)
 
 
-def _relative_timestamp(dt):
+def _relative_timestamp(dt, imprecise=False):
     """"
     Format a human readable relative time for timestamps up to 30 days old
     """
     delta = datetime.utcnow() - dt
     diff = (delta.microseconds + (delta.seconds + delta.days * 24 * 3600) * 1e6) / 1e6
-    if diff < 45:
-        return '{} second{}'.format(int(diff), '' if int(diff) == 1 else 's')
-    elif diff < 90:
-        return 'a minute'
-    elif diff < 2700:
-        return '{} minutes'.format(int(max(diff / 60, 2)))
-    elif diff < 5400:
-        return 'an hour'
-    elif diff < 79200:
-        return '{} hours'.format(int(max(diff / 3600, 2)))
-    elif diff < 129600:
+
+    if imprecise:
+        if diff < 86400:
+            return 'less than a day'
+    else:
+        if diff < 45:
+            return '{} second{}'.format(int(diff), '' if int(diff) == 1 else 's')
+        elif diff < 90:
+            return 'a minute'
+        elif diff < 2700:
+            return '{} minutes'.format(int(max(diff / 60, 2)))
+        elif diff < 5400:
+            return 'an hour'
+        elif diff < 79200:
+            return '{} hours'.format(int(max(diff / 3600, 2)))
+
+    if diff < 129600:
         return 'a day'
     elif diff < 2592000:
         return '{} days'.format(int(max(diff / 86400, 2)))


### PR DESCRIPTION
Fixes #822 by truncating source-related HH:MM times to 00:00, leaving only the date information according to the server's local time.

This would normally provide 1 day of granularity except:
- When "a day ago" is visible, the granularity is at 0.5 days
- If the journalist sees a new item on the page very early in the day, at say 1AM, then it must have been uploaded in the past hour.

The former issue could be solved by making 2 days mean 2.0-3.0 days, instead of the current 1.5-2.5 days, however half a day of granularity is about as good as could be achieved at the moment anyway.

The latter issue could be improved by replacing all date information with a "new" flag or solved by batching uploads, but subject to it being acceptable for users.
