### PR TITLE
drop invalid state packets

### DIFF
--- a/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
@@ -4,10 +4,9 @@
 :OUTPUT ACCEPT [0:0]
 :LOGNDROP - [0:0]
 
-# Drop but do not log all packets with invalid state.
-# This was added due to issue #836
--A OUTPUT -m state --state INVALID -j DROP
--A INPUT -m state --state INVALID -j DROP
+# Drop and log all packets with invalid state.
+-A OUTPUT -m state --state INVALID -j LOGNDROP
+-A INPUT -m state --state INVALID -j LOGNDROP
 
 # Allow the tor instances used for ssh, source and document interface outbound access to default tor destination ports.
 # Load before tor user drop rules
@@ -74,6 +73,7 @@
 -A OUTPUT -j LOGNDROP -m comment --comment "Drop all other outgoing traffic"
 
 # LOGNDROP everything else
+-A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-prefix "Denied_INVALID " --log-ip-options --log-tcp-options --log-uid --log-level 4
 -A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-prefix "Denied_TCP " --log-ip-options --log-tcp-options --log-uid --log-level 4
 -A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-prefix "Denied_UDP " --log-ip-options --log-uid --log-level 4
 -A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-prefix "Denied_ICMP " --log-ip-options --log-uid --log-level 4

--- a/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
@@ -4,6 +4,11 @@
 :OUTPUT ACCEPT [0:0]
 :LOGNDROP - [0:0]
 
+# Drop but do not log all packets with invalid state.
+# This was added due to issue #836
+-A OUTPUT -m state --state INVALID -j DROP
+-A INPUT -m state --state INVALID -j DROP
+
 # Allow the tor instances used for ssh, source and document interface outbound access to default tor destination ports.
 # Load before tor user drop rules
 # Ports are from https://www.torproject.org/docs/faq#OutboundPorts

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
@@ -4,10 +4,14 @@
 :OUTPUT ACCEPT [0:0]
 :LOGNDROP - [0:0]
 
-# Drop but do not log all packets with invalid state.
+# Drop but do not log all packets with invalid state for SMTP traffic.
 # This was added due to issue #836
--A OUTPUT -m state --state INVALID -j DROP
--A INPUT -m state --state INVALID -j DROP
+-A OUTPUT -p tcp --dport {{ smtp_relay_port }} -m state --state INVALID -j DROP
+-A INPUT -p tcp --sport {{ smtp_relay_port }} -m state --state INVALID -j DROP
+
+# LOGNDROP all other invalid state packets
+-A OUTPUT -m state --state INVALID -j LOGNDROP
+-A INPUT -m state --state INVALID -j LOGNDROP
 
 # Allow the tor instance used for ssh access to default tor destination ports.
 # Ports are from https://www.torproject.org/docs/faq#OutboundPorts
@@ -67,6 +71,7 @@
 -A OUTPUT -j LOGNDROP -m comment --comment "Drop all other outgoing traffic"
 
 # LOGNDROP everything else
+-A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-prefix "Denied_INVALID " --log-ip-options --log-tcp-options --log-uid --log-level 4
 -A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-prefix "Denied_TCP " --log-ip-options --log-tcp-options --log-uid --log-level 4
 -A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-prefix "Denied_UDP " --log-ip-options --log-uid --log-level 4
 -A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-prefix "Denied_ICMP " --log-ip-options --log-uid --log-level 4

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
@@ -4,6 +4,11 @@
 :OUTPUT ACCEPT [0:0]
 :LOGNDROP - [0:0]
 
+# Drop but do not log all packets with invalid state.
+# This was added due to issue #836
+-A OUTPUT -m state --state INVALID -j DROP
+-A INPUT -m state --state INVALID -j DROP
+
 # Allow the tor instance used for ssh access to default tor destination ports.
 # Ports are from https://www.torproject.org/docs/faq#OutboundPorts
 -A OUTPUT -p tcp --match multiport --dports 80,8080,443,8443,9001,9030 -m owner --uid-owner debian-tor -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "document chrooted tor instances"


### PR DESCRIPTION
Drop but do not log packets with invalid state. This situation was occuring around sending smtp alerts to google smtp servers. Where the connection would be removed from the iptables state table, but the mon server would then still try to send a FIN, RST packet but since it was no longer in the state table it lost the associated PID and UID. The distant end already closed the connection so this does not prevent the alerts from being sent but does cause an OSSEC spam loop. An OSSEC alert is sent causing a fw drop, that then generates another OSSEC alert.

These packets are dropped but not logged by jumping (-j DROP) directly to DROP chain instead of the LOGNDROP chain

This should close #836 