### PR TITLE
Limit notifications for initial submission

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -239,17 +239,20 @@ def submit():
         g.source.interaction_count += 1
         fnames.append(store.save_message_submission(g.sid, g.source.interaction_count,
             journalist_filename, msg))
-        flash("Thanks! We received your message.", "notification")
     if fh:
         g.source.interaction_count += 1
         fnames.append(store.save_file_submission(g.sid, g.source.interaction_count,
             journalist_filename, fh.filename, fh.stream))
-        flash('{} "{}".'.format("Thanks! We received your document",
-                                fh.filename or '[unnamed]'), "notification")
 
     if first_submission:
         flash("Thanks for submitting something to SecureDrop! Please check back later for replies.",
               "notification")
+    else:
+        if msg:
+            flash("Thanks! We received your message.", "notification")
+        if fh:
+            flash('{} "{}".'.format("Thanks! We received your document",
+                                    fh.filename or '[unnamed]'), "notification")
 
     for fname in fnames:
         submission = Submission(g.source, fname)

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -38,7 +38,7 @@ class SourceNavigationSteps():
             submit_button.click()
 
             notification = self.driver.find_element_by_css_selector( 'p.notification')
-            expected_notification = 'Thanks! We received your document "%s".' % filebasename
+            expected_notification = 'Thanks for submitting something to SecureDrop! Please check back later for replies.'
             self.assertIn(expected_notification, notification.text)
 
     def _source_submits_a_message(self):
@@ -50,4 +50,4 @@ class SourceNavigationSteps():
         submit_button.click()
 
         notification = self.driver.find_element_by_css_selector( 'p.notification')
-        self.assertIn('Thanks! We received your message.', notification.text)
+        self.assertIn('Thanks for submitting something to SecureDrop! Please check back later for replies.', notification.text)

--- a/securedrop/tests/test_unit_source.py
+++ b/securedrop/tests/test_unit_source.py
@@ -128,8 +128,31 @@ class TestSource(TestCase):
             self.assertIn('Sorry, that is not a recognized codename.', rv.data)
             self.assertNotIn('logged_in', session)
 
+    def _dummy_submission(self):
+        """
+        Helper to make a submission (content unimportant), mostly useful in
+        testing notification behavior for a source's first vs. their
+        subsequent submissions
+        """
+        return self.client.post('/submit', data=dict(
+                msg="Pay no attention to the man behind the curtain.",
+                fh=(StringIO(''), ''),
+            ), follow_redirects=True)
+
+    def test_initial_submission_notification(self):
+        """
+        Regardless of the type of submission (message, file, or both), the
+        first submission is always greeted with a notification
+        reminding sources to check back later for replies.
+        """
+        self._new_codename()
+        rv = self._dummy_submission()
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn("Thanks for submitting something to SecureDrop! Please check back later for replies.", rv.data)
+
     def test_submit_message(self):
         self._new_codename()
+        self._dummy_submission()
         rv = self.client.post('/submit', data=dict(
             msg="This is a test.",
             fh=(StringIO(''), ''),
@@ -139,6 +162,7 @@ class TestSource(TestCase):
 
     def test_submit_file(self):
         self._new_codename()
+        self._dummy_submission()
         rv = self.client.post('/submit', data=dict(
             msg="",
             fh=(StringIO('This is a test'), 'test.txt'),
@@ -148,6 +172,7 @@ class TestSource(TestCase):
 
     def test_submit_both(self):
         self._new_codename()
+        self._dummy_submission()
         rv = self.client.post('/submit', data=dict(
             msg="This is a test",
             fh=(StringIO('This is a test'), 'test.txt'),


### PR DESCRIPTION
We added a "first submission" reminder a while back as a friendly way to remind sources that they should remember to return to their account and check back for replies after making a submission. At the time, this notification was shown in addition to the standard message and/or file submission notifications. However, this resulted in a cluttered UI after the first submission. After some experimentation, I decided it feels natural to thank them for submitting something after the first submission, and to use the standard message and/or file submission notifications after that.

This commit changes the initial notification behavior on the Source Interface and updates the tests accordingly.