### PR TITLE
Iptables invalid and acks

### DIFF
--- a/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
@@ -4,13 +4,8 @@
 :OUTPUT ACCEPT [0:0]
 :LOGNDROP - [0:0]
 
-# Drop and log all packets with invalid state.
--A OUTPUT -m state --state INVALID -j LOGNDROP
--A INPUT -m state --state INVALID -j LOGNDROP
-
 # Allow the tor instances used for ssh, source and document interface outbound access
 # Load before tor user drop rules
--A OUTPUT -p tcp -m owner --uid-owner messagebus -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "tor instance that provides ssh access"
 -A OUTPUT -p tcp -m owner --uid-owner debian-tor -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "tor instance that provides ssh access"
 -A INPUT -p tcp -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow traffic back for tor"
 
@@ -67,15 +62,16 @@
 -A INPUT -i lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"
 -A OUTPUT -o lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"
 
-# Drop and log all other traffic
--A INPUT -j LOGNDROP -m comment --comment "Drop all other incomming traffic"
--A OUTPUT -j LOGNDROP -m comment --comment "Drop all other outgoing traffic"
+# Don't log inbound invalid state packets related to issue #830
+-A INPUT -p tcp -m state --state INVALID -j DROP -m comment --comment "drop but don't log inbound invalid state packets"
+
+# Catch all drop rule
+-A INPUT -j LOGNDROP -m comment --comment "Drop and log all other incomming traffic"
+-A OUTPUT -j DROP -m comment --comment "Drop all other outgoing traffic"
 
 # LOGNDROP everything else
--A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-prefix "Denied_INVALID " --log-ip-options --log-tcp-options --log-uid --log-level 4
--A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-prefix "Denied_TCP " --log-ip-options --log-tcp-options --log-uid --log-level 4
--A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-prefix "Denied_UDP " --log-ip-options --log-uid --log-level 4
--A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-prefix "Denied_ICMP " --log-ip-options --log-uid --log-level 4
+-A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-ip-options --log-tcp-options --log-uid --log-level 4
+-A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-ip-options --log-uid --log-level 4
+-A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-ip-options --log-uid --log-level 4
 -A LOGNDROP -j DROP
-
 COMMIT

--- a/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
@@ -62,7 +62,7 @@
 -A INPUT -i lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"
 -A OUTPUT -o lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"
 
-# Don't log inbound invalid state packets related to issue #830
+# Don't log inbound invalid state packets related to issue #845
 -A INPUT -p tcp -m state --state INVALID -j DROP -m comment --comment "drop but don't log inbound invalid state packets"
 
 # Catch all drop rule

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
@@ -4,15 +4,6 @@
 :OUTPUT ACCEPT [0:0]
 :LOGNDROP - [0:0]
 
-# Drop but do not log all packets with invalid state for SMTP traffic.
-# This was added due to issue #836
--A OUTPUT -p tcp --dport {{ smtp_relay_port }} -m state --state INVALID -j DROP
--A INPUT -p tcp --sport {{ smtp_relay_port }} -m state --state INVALID -j DROP
-
-# LOGNDROP all other invalid state packets
--A OUTPUT -m state --state INVALID -j LOGNDROP
--A INPUT -m state --state INVALID -j LOGNDROP
-
 # Allow the tor instance used for ssh access
 -A OUTPUT -p tcp -m owner --uid-owner debian-tor -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow Tor out"
 -A INPUT -p tcp -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow traffic back for tor"
@@ -65,12 +56,24 @@
 -A INPUT -i lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"
 -A OUTPUT -o lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"
 
+# Drop but don't log all other state invalid packets
+-A OUTPUT -m state --state INVALID -j DROP
+-A INPUT -m state --state INVALID -j DROP
+
+# Drop but don't log all state untracked packets
+-A OUTPUT -m state --state UNTRACKED -j DROP
+-A INPUT -m state --state UNTRACKED -j DROP
+
+# Add Mike Perry's rules to block but not log rest of possible leaked traffic
+-A OUTPUT ! -o lo ! -d 127.0.0.1 ! -s 127.0.0.1 -p tcp --dport 587 -m tcp --tcp-flags ACK ACK -j DROP
+-A OUTPUT ! -o lo ! -d 127.0.0.1 ! -s 127.0.0.1 -p tcp -m tcp --tcp-flags ACK,FIN ACK,FIN -j DROP
+-A OUTPUT ! -o lo ! -d 127.0.0.1 ! -s 127.0.0.1 -p tcp -m tcp --tcp-flags ACK,RST ACK,RST -j DROP
+
 # Drop and log all other traffic
 -A INPUT -j LOGNDROP -m comment --comment "Drop all other incomming traffic"
 -A OUTPUT -j LOGNDROP -m comment --comment "Drop all other outgoing traffic"
 
 # LOGNDROP everything else
--A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-prefix "Denied_INVALID " --log-ip-options --log-tcp-options --log-uid --log-level 4
 -A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-prefix "Denied_TCP " --log-ip-options --log-tcp-options --log-uid --log-level 4
 -A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-prefix "Denied_UDP " --log-ip-options --log-uid --log-level 4
 -A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-prefix "Denied_ICMP " --log-ip-options --log-uid --log-level 4

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
@@ -56,26 +56,16 @@
 -A INPUT -i lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"
 -A OUTPUT -o lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"
 
-# Drop but don't log all other state invalid packets
--A OUTPUT -m state --state INVALID -j DROP
--A INPUT -m state --state INVALID -j DROP
+# Don't log inbound invalid state packets related to issue #830
+-A INPUT -p tcp -m state --state INVALID -j DROP -m comment --comment "drop but don't log inbound invalid state packets"
 
-# Drop but don't log all state untracked packets
--A OUTPUT -m state --state UNTRACKED -j DROP
--A INPUT -m state --state UNTRACKED -j DROP
+# Catch all drop rule
+-A INPUT -j LOGNDROP -m comment --comment "Log and drop all other incomming traffic"
+-A OUTPUT -j DROP -m comment --comment "Drop all other outgoing traffic"
 
-# Add Mike Perry's rules to block but not log rest of possible leaked traffic
--A OUTPUT ! -o lo ! -d 127.0.0.1 ! -s 127.0.0.1 -p tcp --dport 587 -m tcp --tcp-flags ACK ACK -j DROP
--A OUTPUT ! -o lo ! -d 127.0.0.1 ! -s 127.0.0.1 -p tcp -m tcp --tcp-flags ACK,FIN ACK,FIN -j DROP
--A OUTPUT ! -o lo ! -d 127.0.0.1 ! -s 127.0.0.1 -p tcp -m tcp --tcp-flags ACK,RST ACK,RST -j DROP
-
-# Drop and log all other traffic
--A INPUT -j LOGNDROP -m comment --comment "Drop all other incomming traffic"
--A OUTPUT -j LOGNDROP -m comment --comment "Drop all other outgoing traffic"
-
-# LOGNDROP everything else
--A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-prefix "Denied_TCP " --log-ip-options --log-tcp-options --log-uid --log-level 4
--A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-prefix "Denied_UDP " --log-ip-options --log-uid --log-level 4
--A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-prefix "Denied_ICMP " --log-ip-options --log-uid --log-level 4
+# LOGNDROP inbound non whitelisted traffic
+-A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-ip-options --log-tcp-options --log-uid --log-level 4
+-A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-ip-options --log-uid --log-level 4
+-A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-ip-options --log-uid --log-level 4
 -A LOGNDROP -j DROP
 COMMIT

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
@@ -56,7 +56,7 @@
 -A INPUT -i lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"
 -A OUTPUT -o lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"
 
-# Don't log inbound invalid state packets related to issue #830
+# Don't log inbound invalid state packets related to issue #845
 -A INPUT -p tcp -m state --state INVALID -j DROP -m comment --comment "drop but don't log inbound invalid state packets"
 
 # Catch all drop rule


### PR DESCRIPTION
Modified the iptable rules to not log outbound host fw drops to reduce the OSSEC spam

Also not logging inbound invalid state packets since this was generating excessive OSSEC alerts

All other inbound fw drops are logged.

Related issue #845 

