### PR TITLE
Merge app mon build vm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -123,8 +123,8 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  config.vm.define 'app-build', autostart: false do |build|
-    build.vm.box = "app-build"
+  config.vm.define 'build', autostart: false do |build|
+    build.vm.box = "build"
     build.vm.box = "trusty64"
     build.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
     build.vm.provision "ansible" do |ansible|
@@ -133,23 +133,9 @@ Vagrant.configure("2") do |config|
       #ansible.skip_tags = [ "ossec" ]
     end
     build.vm.provider "virtualbox" do |v|
-      v.name = "app-build"
+      v.name = "build"
     end
   end
-
-  config.vm.define 'mon-build', autostart: false do |build|
-    build.vm.box = "mon-build"
-    build.vm.box = "trusty64"
-    build.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
-    build.vm.provision "ansible" do |ansible|
-      ansible.playbook = "install_files/ansible-base/build-deb-pkgs.yml"
-      ansible.verbose = 'v'
-    end
-    build.vm.provider "virtualbox" do |v|
-      v.name = "mon-build"
-    end
-  end
-
 
   # "Quick Start" config from https://github.com/fgrehm/vagrant-cachier#quick-start
   #if Vagrant.has_plugin?("vagrant-cachier")

--- a/install_files/ansible-base/build-deb-pkgs.yml
+++ b/install_files/ansible-base/build-deb-pkgs.yml
@@ -1,17 +1,5 @@
 ---
-- hosts: [ 'mon-build' ]
-
-  vars_files:
-    - group_vars/securedrop.yml
-    - host_vars/mon.yml
-    - development-specific.yml
-
-  roles:
-    - { role: build-ossec-deb-pkg, tags: [ "ossec" ] }
-
-  sudo: yes
-
-- hosts: [ 'app-build' ]
+- hosts: [ 'build' ]
 
   vars_files:
     - group_vars/securedrop.yml
@@ -19,8 +7,9 @@
     - development-specific.yml
 
   roles:
-    - build-securedrop-app-code-deb-pkg
-    - { role: build-ossec-deb-pkg, tags: [ "ossec" ] }
+    - { role: build-securedrop-app-code-deb-pkg, tags: [ "app-deb" ] }
+    - { role: build-ossec-deb-pkg, tags: [ "ossec-server" ], ossec_build_dir: "securedrop-ossec-server-2.8.1-amd64", ossec_preloaded_vars: "mon-preloaded-vars.conf", ossec_package_name: "ossec-server" }
+    - { role: build-ossec-deb-pkg, tags: [ "ossec-agent" ], ossec_build_dir: "securedrop-ossec-agent-2.8.1-amd64", ossec_preloaded_vars: "app-preloaded-vars.conf", ossec_package_name: "ossec-agent" }
     - { role: build-grsec-metapackage-deb-pkg, tags: ["grsec-metapackage"] }
 
   sudo: yes

--- a/install_files/ansible-base/host_vars/app.yml
+++ b/install_files/ansible-base/host_vars/app.yml
@@ -37,7 +37,7 @@ securedrop_ossec_agent_deb: "{{ securedrop_repo }}/securedrop-ossec-agent-2.8.1-
 ### Used by the install_local_deb_pkgs role ###
 local_deb_packages:
   - securedrop-app-code-0.3-amd64.deb
-  #- securedrop-ossec-agent-2.8.1-amd64.deb
+  - securedrop-ossec-agent-2.8.1-amd64.deb
 
 ### Used by the app role ###
 

--- a/install_files/ansible-base/host_vars/app.yml
+++ b/install_files/ansible-base/host_vars/app.yml
@@ -37,7 +37,7 @@ securedrop_ossec_agent_deb: "{{ securedrop_repo }}/securedrop-ossec-agent-2.8.1-
 ### Used by the install_local_deb_pkgs role ###
 local_deb_packages:
   - securedrop-app-code-0.3-amd64.deb
-  - securedrop-ossec-agent-2.8.1-amd64.deb
+  #- securedrop-ossec-agent-2.8.1-amd64.deb
 
 ### Used by the app role ###
 

--- a/install_files/ansible-base/host_vars/app.yml
+++ b/install_files/ansible-base/host_vars/app.yml
@@ -27,11 +27,6 @@ dev_deps:
   - python-dev
   - python-pip
 
-# Building the securedrop-ossec-agent.deb and securedrop-ossec-server.deb package
-ossec_build_dir: "securedrop-ossec-agent-2.8.1-amd64"
-ossec_preloaded_vars: "app-preloaded-vars.conf"
-ossec_package_name: "ossec-agent"
-
 # Installing the securedrop-app-code.deb package
 securedrop_deb_path: "{{ securedrop_repo }}"
 securedrop_app_code_deb: "securedrop-app-code-0.3-amd64" # do not enter .deb extension
@@ -42,9 +37,7 @@ securedrop_ossec_agent_deb: "{{ securedrop_repo }}/securedrop-ossec-agent-2.8.1-
 ### Used by the install_local_deb_pkgs role ###
 local_deb_packages:
   - securedrop-app-code-0.3-amd64.deb
-  # Commenting out the ossec package until we have the published pbuilder
-  # process
-  #- securedrop-ossec-agent_2.8.1_amd64.deb
+  - securedrop-ossec-agent-2.8.1-amd64.deb
 
 ### Used by the app role ###
 

--- a/install_files/ansible-base/host_vars/mon.yml
+++ b/install_files/ansible-base/host_vars/mon.yml
@@ -11,14 +11,6 @@ ip_info:
   - ip: "{{ app_ip }}"
     hostname: "{{ app_hostname }}"
 
-
-### Used by the debs role ###
-
-# Building the securedrop-ossec-agent.deb and securedrop-ossec-server.deb package
-ossec_build_dir: "securedrop-ossec-server-2.8.1-amd64"
-ossec_preloaded_vars: "mon-preloaded-vars.conf"
-ossec_package_name: "ossec-server"
-
 # Installing securedrop-ossec-server.deb package
 #
 # This is the path to the directory where we build the deb. The deb package

--- a/install_files/ansible-base/roles/build-ossec-deb-pkg/tasks/build_securedrop_ossec_deb.yml
+++ b/install_files/ansible-base/roles/build-ossec-deb-pkg/tasks/build_securedrop_ossec_deb.yml
@@ -73,3 +73,18 @@
   file:
     state: absent
     dest: /tmp/{{ ossec_version }}
+
+- name: delete ossec install directory
+  file:
+    state: absent
+    dest: /var/ossec
+
+- name: delete ossec init conf file
+  file:
+    state: absent
+    dest: /etc/ossec-init.conf
+
+- name: delete init script
+  file:
+    state: absent
+    dest: /etc/init.d/ossec

--- a/install_files/ansible-base/roles/install_local_pkgs/tasks/main.yml
+++ b/install_files/ansible-base/roles/install_local_pkgs/tasks/main.yml
@@ -4,6 +4,10 @@
   copy: src=../../build/{{ item }} dest=/root/
   with_items: local_deb_packages
 
-- name: if defined install local deb packages.
-  apt: deb=/root/{{ item }}
+# This should use the ansible apt module
+# apt: deb=/root/{{ item }}
+# but keep getting an error when using a list with that module. Using the shell
+# command as a temp work around until that is resolved.
+- name: if defined install local deb packages
+  shell: "dpkg -i /root/{{ item }} || true && apt-get -f install"
   with_items: local_deb_packages


### PR DESCRIPTION
Per @garrettr request to re-merge the app-build and mon-build vm. Merging the two vm into the single `build` vm is done. `vagrant up build` will create the securedrop-app-code, ossec-server, ossec-agent and grsec meta package in the build directory. 

I'm still having an issue in the install_local_packages role for the app server to install the securedrop-app-code and ossec-agent deb packages. I put more details in commit 79d369bd18d8c7c77fd74aee666bb948c7574035