### PR TITLE
Avoid cron-apt warning about multiple source lists

### DIFF
--- a/install_files/ansible-base/roles/common/files/0-update
+++ b/install_files/ansible-base/roles/common/files/0-update
@@ -1,1 +1,1 @@
-update -o quiet=2 -o Dir::Etc::sourcelist=/etc/apt/security.list
+update -o quiet=2 -o Dir::Etc::SourceList=/etc/apt/security.list -o Dir::Etc::SourceParts=""


### PR DESCRIPTION
Make sure the *only* list that is being checked for updates is
`security.list` by explictily telling cron-apt to ignore source lists in
`/etc/apt/sources.list.d`, which is defined by the configuration
variable `Dir::Etc::SourceParts`. See the man page for details.