### PR TITLE
changed cron-apt log to syslog format

### DIFF
--- a/install_files/ansible-base/roles/common/files/cron-apt-config
+++ b/install_files/ansible-base/roles/common/files/cron-apt-config
@@ -1,12 +1,5 @@
 # Configuration for cron-apt. For further information about the possible
 # configuration settings see /usr/share/doc/cron-apt/README.gz.
 
-DEBUG=verbose
-
-LOG=/var/log/cron-apt/log
-
+SYSLOGON="always"
 EXITON=error
-
-MAIL=/var/log/cron-apt/mail
-MAILON=error
-MAILTTO=root

--- a/install_files/ossec-agent/var/ossec/etc/local_decoder.xml
+++ b/install_files/ossec-agent/var/ossec/etc/local_decoder.xml
@@ -1,0 +1,17 @@
+<decoder name="cron-apt">
+  <program_name>cron-apt</program_name>
+</decoder>
+
+<decoder name="cron-apt warning">
+  <parent>cron-apt</parent>
+  <prematch offset="after_parent">^W:\s</prematch>
+  <regex offset="after_parent">^(\S+) (\.*)</regex>
+  <order>status, extra_data</order>
+</decoder>
+
+<decoder name="cron-apt error">
+  <parent>cron-apt</parent>
+  <prematch offset="after_parent">^E:\s</prematch>
+  <regex offset="after_parent">^(\S+) (\.*)</regex>
+  <order>status, extra_data</order>
+</decoder>

--- a/install_files/ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/ossec-agent/var/ossec/etc/ossec.conf
@@ -116,7 +116,7 @@
 
   <localfile>
    <log_format>syslog</log_format>
-   <location>/var/chroot/document/var/log/apache2/document-error.log</location>
+   <location>/var/log/apache2/document-error.log</location>
   </localfile>
 
   <localfile>
@@ -132,10 +132,5 @@
   <localfile>
     <log_format>syslog</log_format>
     <location>/var/www/securedrop/securedrop.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/cron-apt/log</location>
   </localfile>
 </ossec_config>

--- a/install_files/ossec-server/var/ossec/etc/local_decoder.xml
+++ b/install_files/ossec-server/var/ossec/etc/local_decoder.xml
@@ -1,0 +1,17 @@
+<decoder name="cron-apt">
+  <program_name>cron-apt</program_name>
+</decoder>
+
+<decoder name="cron-apt warning">
+  <parent>cron-apt</parent>
+  <prematch offset="after_parent">^W:\s</prematch>
+  <regex offset="after_parent">^(\S+) (\.*)</regex>
+  <order>status, extra_data</order>
+</decoder>
+
+<decoder name="cron-apt error">
+  <parent>cron-apt</parent>
+  <prematch offset="after_parent">^E:\s</prematch>
+  <regex offset="after_parent">^(\S+) (\.*)</regex>
+  <order>status, extra_data</order>
+</decoder>

--- a/install_files/ossec-server/var/ossec/etc/ossec.conf
+++ b/install_files/ossec-server/var/ossec/etc/ossec.conf
@@ -83,14 +83,9 @@
     <command>df -h</command>
   </localfile>
 
- <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
-  </localfile>
-
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/cron-apt/log</location>
+    <location>/var/log/kern.log</location>
   </localfile>
 
   <localfile>

--- a/install_files/ossec-server/var/ossec/rules/local_rules.xml
+++ b/install_files/ossec-server/var/ossec/rules/local_rules.xml
@@ -1,0 +1,18 @@
+<group name="cron-apt">
+  <rule id="100002" level="0">
+    <decoded_as>cron-apt</decoded_as>
+    <description>Custom cron-apt alert</description>
+  </rule>
+
+  <rule id="100003" level="7">
+    <if_sid>100002</if_sid>
+    <status>W:</status>
+    <description>A cron-apt warning was detected</description>
+  </rule>
+
+  <rule id="100004" level="7">
+    <if_sid>100002</if_sid>
+    <status>E:</status>
+    <description>A cron-apt error was detected</description>
+  </rule>
+</group>


### PR DESCRIPTION
changed the cron-apt log to log to the syslog log file in syslog log format

```
Jan 30 20:54:42 mon-staging cron-apt: CRON-APT RUN [/etc/cron-apt/config]: Fri Jan 30 20:54:34 UTC 2015
Jan 30 20:54:42 mon-staging cron-apt: CRON-APT ACTION: 0-update
Jan 30 20:54:42 mon-staging cron-apt: CRON-APT LINE: /usr/bin/apt-get -o quiet=1 update -o quiet=2 -o Dir::Etc::SourceList=/etc/apt/security.list
```

Cron-apt warnings have the following format with a `W:` while errors have a `E:`

```
Jan 30 20:54:42 mon-staging cron-apt: W: Duplicate sources.list entry https://apt.freedom.press/ trusty/main amd64 Packages (/var/lib/apt/lists/apt.freedom.press_dists_trusty_main_binary-amd64_Packages)
Jan 30 20:54:42 mon-staging cron-apt: W: Duplicate sources.list entry http://deb.torproject.org/torproject.org/ trusty/main amd64 Packages (/var/lib/apt/lists/deb.torproject.org_torproject.org_dists_trusty_main_binary-amd64_Packages)
Jan 30 20:54:42 mon-staging cron-apt: W: You may want to run apt-get update to correct these problems
```

An OSSEC decoder to look for `cron-apt` and then either a `E:` or `W:` respectively in `var/ossec/etc/local_decoder.xml`

An OSSEC rule that sets the priority of the decoded warning or error events to a sevirity level 7, since that is the min for OSSEC to send an alert. The options to send these alerts without delay or not grouped in the ossec.conf was not choosen since one cron-apt run will generate multiple error or warning events per run.

Spacing, an old ref to a chroot'd log files and the old cron-apt log file were fixed in the ossec.conf files.