### PR TITLE
Remove RC4 from deployment best practices

### DIFF
--- a/docs/deployment_practices.md
+++ b/docs/deployment_practices.md
@@ -74,7 +74,7 @@ In your SSL (port 443) virtual host, set up HSTS and use these settings to give 
     SSLProtocol all -SSLv2 -SSLv3
     SSLHonorCipherOrder on
     SSLCompression off
-    SSLCipherSuite EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:EECDH+RC4:RSA+RC4:!MD5
+    SSLCipherSuite EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5
 
 You'll need to run `a2enmod headers ssl rewrite` for all these to work. You should also set `ServerSignature Off` and `ServerTokens Prod`, typically in /etc/apache2/conf.d/security. The supported cipher suites are copied from [CloudFlare's SSL configuration](https://github.com/cloudflare/sslconfig/blob/master/conf).
 


### PR DESCRIPTION
Although RC4 is still safe in some combinations, the attacks are steadily becoming more realistic. Even though CloudFlare is still using it in their [sslconfig](https://github.com/cloudflare/sslconfig/blob/master/conf) I believe it's time to just drop it. Use of this config will result in a Qualys SSL Labs grade of A+.