### PR TITLE
Limit SSH key exchange algorithms

### DIFF
--- a/install_files/ansible-base/roles/restrict_direct_access_app/files/sshd_config
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/files/sshd_config
@@ -34,6 +34,7 @@ UseDNS no
 ClientAliveInterval 300
 ClientAliveCountMax 0
 Ciphers aes256-gcm@openssh.com,aes256-ctr,chacha20-poly1305@openssh.com
+KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
 MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1
 GatewayPorts no
 AllowGroups ssh

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/files/sshd_config
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/files/sshd_config
@@ -34,6 +34,7 @@ UseDNS no
 ClientAliveInterval 300
 ClientAliveCountMax 0
 Ciphers aes256-gcm@openssh.com,aes256-ctr,chacha20-poly1305@openssh.com
+KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
 MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1
 GatewayPorts no
 AllowGroups ssh


### PR DESCRIPTION
I am a loser with git so I had to redo this PR. Previous comment:

I tested this setting with Tails 1.2.3 and the staging VMs. Of course I had to make a new user, copy my SSH key to authorized_keys, and add that user to the ssh group. I also disabled pam_google_authenticator.so for ease, but at the end of the day, the SSH client was successfully able to connect and negotiate with the daemon.

There was a message saying "Agent admitted failure to sign using the key" (not sure as yet what that means) but that was present without the KexAlgorithms setting too.