### PR TITLE
Get rid of useless gpg logging

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -40,18 +40,7 @@ def do_runtime_tests():
 
 do_runtime_tests()
 
-GPG_BINARY = 'gpg2'
-try:
-    p = subprocess.Popen([GPG_BINARY, '--version'], stdout=subprocess.PIPE)
-except OSError:
-    GPG_BINARY = 'gpg'
-    p = subprocess.Popen([GPG_BINARY, '--version'], stdout=subprocess.PIPE)
-
-assert p.stdout.readline().split()[
-    -1].split('.')[0] == '2', "upgrade GPG to 2.0"
-del p
-
-gpg = gnupg.GPG(binary=GPG_BINARY, homedir=config.GPG_KEY_DIR)
+gpg = gnupg.GPG(binary='gpg2', homedir=config.GPG_KEY_DIR)
 
 words = file(config.WORD_LIST).read().split('\n')
 nouns = file(config.NOUNS).read().split('\n')

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -40,7 +40,19 @@ def do_runtime_tests():
 
 do_runtime_tests()
 
-gpg = gnupg.GPG(binary='gpg2', homedir=config.GPG_KEY_DIR)
+# HACK: use_agent=True is used to avoid logging noise.
+#
+# --use-agent is a dummy option in gpg2, which is the only version of
+# gpg used by SecureDrop. If use_agent=False, gpg2 prints a warning
+# message every time it runs because the option is deprecated and has
+# no effect. This message cannot be silenced even if you change the
+# --debug-level (controlled via the verbose= keyword argument to the
+# gnupg.GPG constructor), and creates a lot of logging noise.
+#
+# The best solution here would be to avoid passing either --use-agent
+# or --no-use-agent to gpg2, and I have filed an issue upstream to
+# address this: https://github.com/isislovecruft/python-gnupg/issues/96
+gpg = gnupg.GPG(binary='gpg2', homedir=config.GPG_KEY_DIR, use_agent=True)
 
 words = file(config.WORD_LIST).read().split('\n')
 nouns = file(config.NOUNS).read().split('\n')


### PR DESCRIPTION
Fixes:

* Logging noise due to `--no-use-agent` being deprecated in gpg2
* Apparmor conflicts with the creation of `/var/www/.gnupg`, which was due to the initial (but actually unnecessary) gpg version check. See [this PR comment](https://github.com/freedomofpress/securedrop/pull/863#discussion-diff-24270287) for context.