### PR TITLE
normalize VM names

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,24 +86,24 @@ Vagrant.configure("2") do |config|
   # The prod hosts are just like production but are virtualized. All access to ssh and
   # the web interfaces is only over tor.
   config.vm.define 'mon-prod', autostart: false do |prod|
-    prod.vm.box = "mon"
+    prod.vm.box = "mon-prod"
     prod.vm.box = "trusty64"
     prod.vm.network "private_network", ip: "10.0.1.5", virtualbox__intnet: true
     prod.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
     prod.vm.synced_folder './', '/vagrant', disabled: true
     prod.vm.provider "virtualbox" do |v|
-      v.name = "mon"
+      v.name = "mon-prod"
     end
   end
 
   config.vm.define 'app-prod', autostart: false do |prod|
-    prod.vm.hostname = "app"
+    prod.vm.hostname = "app-prod"
     prod.vm.box = "trusty64"
     prod.vm.network "private_network", ip: "10.0.1.4", virtualbox__intnet: true
     prod.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
     prod.vm.synced_folder './', '/vagrant', disabled: true
     prod.vm.provider "virtualbox" do |v|
-      v.name = "app"
+      v.name = "app-prod"
       # Running the functional tests with Selenium/Firefox has started causing out-of-memory errors.
       #
       # This started around October 14th and was first observed on the task-queue branch. There are two likely causes:

--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: [ 'mon', 'app' ]
+- hosts: [ 'mon', 'app', 'mon-prod', 'app-prod' ]
 
   vars_files:
     - group_vars/securedrop.yml
@@ -12,7 +12,7 @@
   sudo: yes
 
 
-- hosts: [ 'mon' ]
+- hosts: [ 'mon', 'mon-prod' ]
 
   vars_files:
     - group_vars/securedrop.yml
@@ -26,7 +26,7 @@
 
   sudo: yes
 
-- hosts: [ 'app' ]
+- hosts: [ 'app', 'app-prod' ]
 
   vars_files:
    - group_vars/securedrop.yml
@@ -52,7 +52,7 @@
   # service needs to be listening and reachable, then agent needs to connect to
   # ossec server, agent needs to restart, then ossec server exemptions can be
   # removed and the ossec server process can restart.
-- hosts: [ 'mon' ]
+- hosts: [ 'mon', 'mon-prod' ]
 
   vars_files:
     - group_vars/securedrop.yml
@@ -70,7 +70,7 @@
   # So iptables will not be reloaded until the exemptions are applied
   # for production the last task is apply iptables. This will break their
   # connection. After that point the admin will to proxy traffic over tor.
-- hosts: [ 'app' ]
+- hosts: [ 'app', 'app-prod' ]
 
   vars_files:
     - group_vars/securedrop.yml
@@ -83,7 +83,7 @@
 
   sudo: yes
 
-- hosts: [ 'mon' ]
+- hosts: [ 'mon', 'mon-prod' ]
 
   vars_files:
     - group_vars/securedrop.yml
@@ -95,7 +95,7 @@
 
   sudo: yes
 
-- hosts: [ 'app', 'mon' ]
+- hosts: [ 'app', 'mon', 'app-prod', 'mon-prod' ]
 
   roles:
     - reboot


### PR DESCRIPTION
The prod VM names defined in the Vagrantfile did not match the format of the other environements and did not match the hosts entries in the prod playbook.

This will also allow `vagrant up /prod$/` to work in the vagrant testing environments.