### PR TITLE
whitelisted grsec Denied RWX mmap

### DIFF
--- a/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
+++ b/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
@@ -71,6 +71,26 @@
     <description>time was set on the system</description>
     <options>no_email_alert</options>
   </rule>
+
+  <!--
+    Drop the denied RWX mmap events. Choose to keep logging the events and just
+    not alert on them. This will help identify when this behavior is causing an
+    issue somewhere on the system, while not flooding the admin with extra
+    alerts.
+    https://en.wikibooks.org/wiki/Grsecurity/Appendix/Grsecurity_and_PaX_Configuration_Options#Denied_RWX_mmap.2Fmprotect_logging
+    Sample:
+      Received From: (app-prod) 10.0.1.4->/var/log/syslog
+      Rule: 100101 fired (level 7) -> "grsec error was detected"
+      Portion of the log(s):
+
+      Feb 10 23:32:53 app-prod kernel: [   17.657822] grsec: denied RWX mmap of <anonymous mapping> by /usr/bin/cloud-init[cloud-init:1541] uid/euid:0/0 gid/egid:0/0, parent /sbin/init[init:1] uid/euid:0/0 gid/egid:0/0
+  -->
+  <rule id="100103" level="0">
+    <if_sid>100101</if_sid>
+    <match>denied RWX mmap of</match>
+    <description>Denied RWX mmap mprotect logging</description>
+    <option>no_email_alert</option>
+  </rule>
 </group>
 
 <!--


### PR DESCRIPTION
Whitelisted the following grsec so it does not send an OSSEC email alert.

```
Rule: 100101 fired (level 7) -> "grsec error was detected"
Portion of the log(s):

Feb 10 23:34:40 app-prod kernel: [  124.188641] grsec: denied RWX mmap of <anonymous mapping> by /usr/sbin/apache2[apache2:1328] uid/euid:33/33 gid/egid:33/33, parent /usr/sbin/apache2[apache2:1309] uid/euid:0/0 gid/egid:0/0
```

It is generated by [ this ](https://en.wikibooks.org/wiki/Grsecurity/Appendix/Grsecurity_and_PaX_Configuration_Options#Denied_RWX_mmap.2Fmprotect_logging) grsec option.

Talked about this with @garrett and figured it was better to know when it occured for reactive troubleshooting and just not alert on it rather than just disable the action from being logged in the grsec kernel.