### PR TITLE
Minor CSS and layout fixes [Fixing #875 and #876]

### DIFF
--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% block body %}
 <div id="content" class="journalist-view-all">
-<h2><span class="headline">Sources</span></h2>
-{% if unstarred or starred %}
-  <div id='filter-container'></div>
+  <h2><span class="headline">Sources</span></h2>
+  {% if unstarred or starred %}
+    <div id='filter-container'></div>
     <form id="process_collections" action="/col/process" method="post">
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
       <p>
@@ -66,8 +66,8 @@
       {% endif %}
 
     </form>
-  </div>
-{% else %}
-  <p>No documents have been submitted!</p>
-{% endif %}
+  {% else %}
+    <p>No documents have been submitted!</p>
+  {% endif %}
+</div>
 {% endblock %}

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -21,6 +21,7 @@
       </button>
     </form>
   </div>
+  <div class="clearfix"></div>
 </div>
 
 <div class="clearfix"></div>


### PR DESCRIPTION
Fixes a mismatch of \<div\> and \</div\> tags on the journalist index, putting "Powered by SecureDrop" back in the footer

Adds a clearfix div to expand and contain the codename generate button