### PR TITLE
moved grsec specific sysctl flags

### DIFF
--- a/install_files/ansible-base/group_vars/securedrop.yml
+++ b/install_files/ansible-base/group_vars/securedrop.yml
@@ -50,8 +50,14 @@ sysctl_flags:
     value: "1"
   - name: "net.ipv6.conf.lo.disable_ipv6"
     value: "1"
+
+grsec_sysctl_flags:
   - name: "kernel.grsecurity.rwxmap_logging"
     value: "0"
+    # The grsec lock value needs to be the last sysctl flag set or else the
+    # rest will not be applied
+  - name: "kernel.grsecurity.grsec_lock"
+    value: "1"
 
 # grsec vars
 grub_pax:

--- a/install_files/ansible-base/roles/common/tasks/apply_grsec_lock.yml
+++ b/install_files/ansible-base/roles/common/tasks/apply_grsec_lock.yml
@@ -30,5 +30,6 @@
   when: not grsec_lock.stat.exists
   sudo: false
 
-- sysctl: name=kernel.grsecurity.grsec_lock value=1 sysctl_set=yes state=present reload=yes
+- sysctl: name="{{ item.name }}" value="{{ item.value }}" sysctl_set=yes state=present reload=yes
+  with_items: grsec_sysctl_flags
   sudo: yes


### PR DESCRIPTION
fixes issue #905.

This moves the grsec specific sysctl flags to one role. This avoids an error if the grsec role is skipped. It also ensures that the grsec lock flag is the last flag set.

*having an issue downloading the grsec package from the fpf repo to test this pr right now. will update in comment when it is tested.*