### PR TITLE
remove the app IP from ossec alerts

### DIFF
--- a/install_files/ansible-base/roles/ossec_server/templates/send_encrypted_alarm.sh
+++ b/install_files/ansible-base/roles/ossec_server/templates/send_encrypted_alarm.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-/usr/bin/formail -I "" | /usr/bin/gpg --homedir /var/ossec/.gnupg --trust-model always -ear "{{ ossec_gpg_fpr }}" | /usr/bin/mail -s "$SUBJECT" {{ ossec_alert_email }}
-
+/usr/bin/formail -I "" | /usr/bin/gpg --homedir /var/ossec/.gnupg --trust-model always -ear "{{ ossec_gpg_fpr }}" | /usr/bin/mail -s "$(echo $SUBJECT | sed 's/{{ app_ip }}//g' )" {{ ossec_alert_email }}

--- a/install_files/ansible-base/roles/ossec_server/templates/send_encrypted_alarm.sh
+++ b/install_files/ansible-base/roles/ossec_server/templates/send_encrypted_alarm.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/formail -I "" | /usr/bin/gpg --homedir /var/ossec/.gnupg --trust-model always -ear "{{ ossec_gpg_fpr }}" | /usr/bin/mail -s "$(echo $SUBJECT | sed -r 's/([0-9]{1,3}\.){3}[0-9]{1,3}\s//g' )" {{ ossec_alert_email }}
+/usr/bin/formail -I "" | /usr/bin/gpg --homedir /var/ossec/.gnupg --trust-model always -ear "{{ ossec_gpg_fpr }}" | /usr/bin/mail -s "$(echo $SUBJECT | sed -r 's/([0-9]{1,3}\.){3}[0-9]{1,3}\s?//g' )" {{ ossec_alert_email }}

--- a/install_files/ansible-base/roles/ossec_server/templates/send_encrypted_alarm.sh
+++ b/install_files/ansible-base/roles/ossec_server/templates/send_encrypted_alarm.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/formail -I "" | /usr/bin/gpg --homedir /var/ossec/.gnupg --trust-model always -ear "{{ ossec_gpg_fpr }}" | /usr/bin/mail -s "$(echo $SUBJECT | sed -r 's/([0-9]{1,3}\.){3}[0-9]{1,3}//g' )" {{ ossec_alert_email }}
+/usr/bin/formail -I "" | /usr/bin/gpg --homedir /var/ossec/.gnupg --trust-model always -ear "{{ ossec_gpg_fpr }}" | /usr/bin/mail -s "$(echo $SUBJECT | sed -r 's/([0-9]{1,3}\.){3}[0-9]{1,3}\s//g' )" {{ ossec_alert_email }}

--- a/install_files/ansible-base/roles/ossec_server/templates/send_encrypted_alarm.sh
+++ b/install_files/ansible-base/roles/ossec_server/templates/send_encrypted_alarm.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/formail -I "" | /usr/bin/gpg --homedir /var/ossec/.gnupg --trust-model always -ear "{{ ossec_gpg_fpr }}" | /usr/bin/mail -s "$(echo $SUBJECT | sed 's/{{ app_ip }}//g' )" {{ ossec_alert_email }}
+/usr/bin/formail -I "" | /usr/bin/gpg --homedir /var/ossec/.gnupg --trust-model always -ear "{{ ossec_gpg_fpr }}" | /usr/bin/mail -s "$(echo $SUBJECT | sed -r 's/([0-9]{1,3}\.){3}[0-9]{1,3}//g' )" {{ ossec_alert_email }}


### PR DESCRIPTION
The OSSEC alerts for the app server include the internal IP address (which is also published in our public install guide). This will strip out the specific IP address from all subject.