### PR TITLE
Autoremove unused packages after upgrading

### DIFF
--- a/install_files/ansible-base/roles/common/files/5-security
+++ b/install_files/ansible-base/roles/common/files/5-security
@@ -1,2 +1,3 @@
 autoclean -y
 dist-upgrade -y -o APT::Get::Show-Upgraded=true -o Dir::Etc::SourceList=/etc/apt/security.list
+autoremove -y


### PR DESCRIPTION
For SecureDrop, this is primarily useful because it avoids allowing too
many kernels to be installed in `/boot`, which can lead to issues
booting if the partition gets too full.

Closes #914.