### PR TITLE
Don't create empty submissions

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -239,6 +239,11 @@ def submit():
     msg = request.form['msg']
     fh = request.files['fh']
 
+    # Don't bother submitting anything if it was an "empty" submission. #878.
+    if not (msg or fh):
+        flash("You must enter a message or choose a file to submit.", "error")
+        return redirect(url_for('lookup'))
+
     fnames = []
     journalist_filename = g.source.journalist_filename
     first_submission = g.source.interaction_count == 0


### PR DESCRIPTION
Prevents creating "empty" submissions (which are confusing and annoying
to open due to the airgapped procedure), and instead flashes an error
when the user attempts to click "Submit" without entering a message or
choosing a file.

Fixes #878.