### PR TITLE
Fix to handle multiple grsec kernels

### DIFF
--- a/install_files/ansible-base/roles/common/tasks/set_grsec_default.yml
+++ b/install_files/ansible-base/roles/common/tasks/set_grsec_default.yml
@@ -1,5 +1,5 @@
 - name: get grsec kernel string
-  shell: grep menuentry /boot/grub/grub.cfg | grep grsec | grep -v recovery | cut -d "'" -f2
+  shell: grep menuentry /boot/grub/grub.cfg | grep grsec | grep -v recovery | head -1 | cut -d "'" -f2
   register: grsec_str
 
 - name: set grsec kernel as default for next boot


### PR DESCRIPTION
There was an oversight in my line of shell code that would cause getting the grsec kernel string to fail if multiple grsec kernels are installed. Therefore you either need to include `head -1` to register only the first line or add `-m 1` to grep for the first match.