### PR TITLE
Updated wording

### DIFF
--- a/install_files/securedrop-app-code/DEBIAN/control
+++ b/install_files/securedrop-app-code/DEBIAN/control
@@ -7,4 +7,4 @@ Package: securedrop-app-code
 Version: 0.3
 Architecture: amd64
 Depends: python-pip,apparmor-utils,gnupg2,haveged,python,python-pip,secure-delete,sqlite,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor
-Description: Packages the SecureDrop application code pip dependencies and apparmor profiles as deb packag. This package will not put the apparmor profiles in enforce mode; that is done as needed by the ansible playbook. This package does use pip to install the pip wheelhouse
+Description: Packages the SecureDrop application code pip dependencies and apparmor profiles. This package will put the apparmor profiles in enforce mode. This package does use pip to install the pip wheelhouse


### PR DESCRIPTION
Updating the wording to reflect that the apparmor profiles are put in enforce mode by default when the deb package is installed. If the the ansible test role is ran, then ansible will put the profiles in complain mode.