### PR TITLE
Fixed PEP8 Errors

### DIFF
--- a/install_files/ansible-base/roles/backup/files/0.3_collect.py
+++ b/install_files/ansible-base/roles/backup/files/0.3_collect.py
@@ -8,7 +8,6 @@ to backup the 0.3 system and stores it in /tmp/sd-backup-0.3-TIME_STAMP.zip.gpg
 """
 
 import sys
-sys.path.append("/var/www/securedrop")
 import os
 import re
 import zipfile
@@ -19,12 +18,16 @@ import config
 import gnupg
 import subprocess
 
-TOR_SERVICES    = "/var/lib/tor/services"
-TOR_CONFIG      = "/etc/tor/torrc"
+sys.path.append("/var/www/securedrop")
+
+TOR_SERVICES = "/var/lib/tor/services"
+TOR_CONFIG = "/etc/tor/torrc"
+
 
 def collect_config_file(zf):
     config_file_path = os.path.join(config.SECUREDROP_ROOT, "config.py")
     zf.write(config_file_path)
+
 
 def collect_securedrop_data_root(zf):
     # The store and key dirs are shared between both interfaces
@@ -32,9 +35,11 @@ def collect_securedrop_data_root(zf):
         for name in files:
             zf.write(os.path.join(root, name))
 
+
 def collect_custom_header_image(zf):
     # The custom header image is copied over the deafult `static/i/logo.png`.
     zf.write(os.path.join(config.SECUREDROP_ROOT, "static/i/logo.png"))
+
 
 def collect_tor_files(zf):
     # All of the tor hidden service private keys are stored in the THS specific
@@ -51,6 +56,7 @@ def collect_tor_files(zf):
     # restore.
     zf.write(TOR_CONFIG)
 
+
 def encrypt_zip_file(zf_fn):
     # Encrypt the backup zip file with the application's gpg public key
     gpg = gnupg.GPG(binary='gpg2', homedir=config.GPG_KEY_DIR)
@@ -58,6 +64,7 @@ def encrypt_zip_file(zf_fn):
 
     stream = open(zf_fn, "rb")
     gpg.encrypt_file(stream, config.JOURNALIST_KEY, always_trust='True', output=e_fn)
+
 
 def main():
     # name append a timestamp to the sd-backup zip filename

--- a/install_files/ansible-base/roles/backup/files/0.3_restore.py
+++ b/install_files/ansible-base/roles/backup/files/0.3_restore.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python2.7
 """
 
-This script and decrypted backup zip should be copied to the App server 
+This script and decrypted backup zip should be copied to the App server
 and run by the anisble plabook. When run (as root), it restores the 0.3
 backup file.
 
@@ -19,6 +19,7 @@ from datetime import datetime
 from operator import itemgetter
 import calendar
 import traceback
+
 
 def replace_prefix(path, p1, p2):
     """
@@ -46,8 +47,7 @@ def extract_to_path(archive, member, path, user):
     if upperdirs and not os.path.exists(upperdirs):
         os.makedirs(upperdirs)
 
-    with archive.open(member) as source, \
-         file(path, "wb") as target:
+    with archive.open(member) as source, file(path, "wb") as target:
         shutil.copyfileobj(source, target)
 
     # Update the timestamps as well (as best we can, thanks, conversion to
@@ -60,7 +60,8 @@ def extract_to_path(archive, member, path, user):
         os.utime(path, (timestamp, timestamp))
 
     ug = "{}:{}".format(user, user)
-    subprocess.call(['chown', '-R', ug , path])
+    subprocess.call(['chown', '-R', ug, path])
+
 
 def restore_config_file(zf):
     print "* Migrating SecureDrop config file from backup..."
@@ -69,6 +70,7 @@ def restore_config_file(zf):
     for zi in zf.infolist():
         if "var/www/securedrop/config.py" in zi.filename:
             extract_to_path(zf, "var/www/securedrop/config.py", "/var/www/securedrop/config.py", "www-data")
+
 
 def restore_securedrop_root(zf):
     print "* Migrating directories from SECUREDROP_ROOT..."
@@ -84,16 +86,19 @@ def restore_securedrop_root(zf):
             extract_to_path(zf, zi, replace_prefix(zi.filename,
                 "var/lib/securedrop/keys", "/var/lib/securedrop/keys"), "www-data")
 
+
 def restore_database(zf):
     print "* Migrating database..."
 
     extract_to_path(zf, "var/lib/securedrop/db.sqlite", "/var/lib/securedrop/db.sqlite", "www-data")
+
 
 def restore_custom_header_image(zf):
     print "* Migrating custom header image..."
     extract_to_path(zf,
         "var/www/securedrop/static/i/logo.png",
         "/var/www/securedrop/static/i/logo.png", "www-data")
+
 
 def restore_tor_files(zf):
     tor_root_dir = "/var/lib/tor"

--- a/migration_scripts/0.3/0.2.1_collect.py
+++ b/migration_scripts/0.3/0.2.1_collect.py
@@ -15,9 +15,11 @@ import zipfile
 # Arbitrarily pick the source chroot jail (doesn't matter)
 securedrop_root = "/var/chroot/source/var/www/securedrop"
 
+
 def collect_config_file(zf):
     config_file_path = os.path.join(securedrop_root, "config.py")
     zf.write(config_file_path)
+
 
 def collect_securedrop_root(zf):
     # The store and key dirs are shared between the chroot jails in 0.2.1, and
@@ -26,15 +28,18 @@ def collect_securedrop_root(zf):
         for name in files:
             zf.write(os.path.join(root, name))
 
+
 def collect_database(zf):
     # Copy the db file, which is only present in the document interface's
     # chroot jail in 0.2.1
     zf.write("/var/chroot/document/var/www/securedrop/db.sqlite")
 
+
 def collect_custom_header_image(zf):
     # 0.2.1's deployment didn't actually use config.CUSTOM_HEADER_IMAGE - it
     # just overwrote the default header image, `static/i/securedrop.png`.
     zf.write(os.path.join(securedrop_root, "static/i/securedrop.png"))
+
 
 def collect_tor_files(zf):
     tor_files = [
@@ -46,6 +51,7 @@ def collect_tor_files(zf):
 
     for tor_file in tor_files:
         zf.write(tor_file)
+
 
 def main():
     if len(sys.argv) <= 1:

--- a/migration_scripts/0.3/0.3_migrate.py
+++ b/migration_scripts/0.3/0.3_migrate.py
@@ -17,6 +17,7 @@ from operator import itemgetter
 import calendar
 import traceback
 
+
 def migrate_config_file(zf):
     print "* Migrating values from old config file..."
 
@@ -70,8 +71,7 @@ def extract_to_path(archive, member, path):
     if upperdirs and not os.path.exists(upperdirs):
         os.makedirs(upperdirs)
 
-    with archive.open(member) as source, \
-         file(path, "wb") as target:
+    with archive.open(member) as source, file(path, "wb") as target:
         shutil.copyfileobj(source, target)
 
     # Update the timestamps as well (as best we can, thanks, conversion to
@@ -120,7 +120,7 @@ def migrate_database(zf):
     # Generate a list of the filesystem ids that have journalist designations
     # store din the database, since they are already known and should not be
     # generated from the filesystem id
-    already_processed = set([ source[0] for source in sources ])
+    already_processed = set([source[0] for source in sources])
     for fs_id in os.listdir("/var/lib/securedrop/store"):
         if fs_id in already_processed:
             continue
@@ -230,6 +230,7 @@ def migrate_database(zf):
 
     # chown the databse file to the securedrop user
     subprocess.call(['chown', 'www-data:www-data', "/var/lib/securedrop/db.sqlite"])
+
 
 def migrate_custom_header_image(zf):
     print "* Migrating custom header image..."

--- a/migration_scripts/0.3/crypto_util.py
+++ b/migration_scripts/0.3/crypto_util.py
@@ -10,8 +10,8 @@ SRC_DIR = os.path.dirname(os.path.realpath(__file__))
 nouns = file(os.path.join(SRC_DIR, "nouns.txt")).read().split('\n')
 adjectives = file(os.path.join(SRC_DIR, "adjectives.txt")).read().split('\n')
 
+
 def displayid(n):
     badrandom_value = badrandom.WichmannHill()
     badrandom_value.seed(n)
     return badrandom_value.choice(adjectives) + " " + badrandom_value.choice(nouns)
-

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -8,12 +8,6 @@ from cStringIO import StringIO
 import subprocess
 from threading import Thread
 import operator
-
-import logging
-# This module's logger is explicitly labeled so the correct logger is used,
-# even when this is run from the command line (e.g. during development)
-log = logging.getLogger('source')
-
 from flask import (Flask, request, render_template, session, redirect, url_for,
                    flash, abort, g, send_file)
 from flask_wtf.csrf import CsrfProtect
@@ -29,6 +23,11 @@ import template_filters
 from db import db_session, Source, Submission, Reply, get_one_or_else
 from request_that_secures_file_uploads import RequestThatSecuresFileUploads
 from jinja2 import evalcontextfilter
+
+import logging
+# This module's logger is explicitly labeled so the correct logger is used,
+# even when this is run from the command line (e.g. during development)
+log = logging.getLogger('source')
 
 app = Flask(__name__, template_folder=config.SOURCE_TEMPLATES_DIR)
 app.request_class = RequestThatSecuresFileUploads

--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -9,13 +9,12 @@ import tempfile
 import subprocess
 from cStringIO import StringIO
 import gzip
-
-import logging
-log = logging.getLogger(__name__)
-
 from werkzeug import secure_filename
 
 from secure_tempfile import SecureTemporaryFile
+
+import logging
+log = logging.getLogger(__name__)
 
 VALIDATE_FILENAME = re.compile("^(?P<index>\d+)\-[a-z0-9-_]*(?P<file_type>msg|doc\.(gz|zip)|reply)\.gpg$").match
 

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -10,7 +10,7 @@ import gnupg
 import urllib2
 import sys
 
-os.environ['SECUREDROP_ENV'] = 'test'
+
 import config
 
 import source
@@ -23,6 +23,8 @@ import traceback
 from datetime import datetime
 import time
 import mock
+
+os.environ['SECUREDROP_ENV'] = 'test'
 
 
 class FunctionalTest():

--- a/securedrop/tests/test_unit_integration.py
+++ b/securedrop/tests/test_unit_integration.py
@@ -17,8 +17,6 @@ import gnupg
 from flask import session, g, escape
 from bs4 import BeautifulSoup
 
-# Set environment variable so config.py uses a test environment
-os.environ['SECUREDROP_ENV'] = 'test'
 import config
 import crypto_util
 import source
@@ -26,6 +24,9 @@ import journalist
 import common
 from db import db_session, Journalist
 import store
+
+# Set environment variable so config.py uses a test environment
+os.environ['SECUREDROP_ENV'] = 'test'
 
 
 def _block_on_reply_keypair_gen(codename):

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -10,12 +10,13 @@ import mock
 from flask import url_for
 from flask.ext.testing import TestCase
 
-# Set environment variable so config.py uses a test environment
-os.environ['SECUREDROP_ENV'] = 'test'
 import crypto_util
 import journalist
 import common
 from db import db_session, Source, Journalist
+
+# Set environment variable so config.py uses a test environment
+os.environ['SECUREDROP_ENV'] = 'test'
 
 
 class TestJournalist(TestCase):

--- a/securedrop/tests/test_unit_source.py
+++ b/securedrop/tests/test_unit_source.py
@@ -10,9 +10,8 @@ from bs4 import BeautifulSoup
 from flask.ext.testing import TestCase
 from flask import session, escape
 from mock import patch, ANY
-
-os.environ['SECUREDROP_ENV'] = 'test'
 import source
+os.environ['SECUREDROP_ENV'] = 'test'
 
 
 class TestSource(TestCase):

--- a/securedrop/tests/test_unit_store.py
+++ b/securedrop/tests/test_unit_store.py
@@ -3,15 +3,14 @@
 import os
 import unittest
 import zipfile
-
-
-# Set environment variable so config.py uses a test environment
-os.environ['SECUREDROP_ENV'] = 'test'
 import config
 import store
 import common
 from db import db_session, Source
 import crypto_util
+
+# Set environment variable so config.py uses a test environment
+os.environ['SECUREDROP_ENV'] = 'test'
 
 
 class TestStore(unittest.TestCase):

--- a/tails_files/securedrop_init.py
+++ b/tails_files/securedrop_init.py
@@ -40,5 +40,5 @@ if __name__ == '__main__':
     subprocess.call(['/usr/sbin/service', 'tor', 'reload'])
 
     # success
-    subprocess.call(['/usr/bin/sudo', '-u', 'amnesia', '/usr/bin/notify-send', '-i', '/home/amnesia/Persistent/.securedrop/securedrop_icon.png', 
-	'Updated torrc!', 'You can now connect to your SecureDrop\ndocument interface.'])
+    subprocess.call(['/usr/bin/sudo', '-u', 'amnesia', '/usr/bin/notify-send', '-i', '/home/amnesia/Persistent/.securedrop/securedrop_icon.png',
+        'Updated torrc!', 'You can now connect to your SecureDrop\ndocument interface.'])


### PR DESCRIPTION
Fixed a bunch of PEP8 Errors

Errors before:

```
./tails_files/securedrop_init.py:14:80: E501 line too long (81 > 79 characters)
./tails_files/securedrop_init.py:43:145: W291 trailing whitespace
./tails_files/securedrop_init.py:44:1: E101 indentation contains mixed spaces and tabs
./tails_files/securedrop_init.py:44:1: W191 indentation contains tabs
./tails_files/securedrop_init.py:44:2: E128 continuation line under-indented for visual indent
./migration_scripts/0.3/0.2.1_collect.py:18:1: E302 expected 2 blank lines, found 1
./migration_scripts/0.3/0.3_migrate.py:74:10: E127 continuation line over-indented for visual indent
./migration_scripts/0.3/0.3_migrate.py:123:30: E201 whitespace after '['
./migration_scripts/0.3/0.3_migrate.py:123:62: E202 whitespace before ']'
./migration_scripts/0.3/crypto_util.py:17:1: W391 blank line at end of file
./install_files/ansible-base/roles/backup/files/0.3_collect.py:12:1: E402 module level import not at top of file
./install_files/ansible-base/roles/backup/files/0.3_collect.py:22:13: E221 multiple spaces before operator
./install_files/ansible-base/roles/backup/files/0.3_restore.py:63:39: E203 whitespace before ','
```

Errors after:

```
./tails_files/securedrop_init.py:14:80: E501 line too long (81 > 79 characters)
./tails_files/securedrop_init.py:44:9: E128 continuation line under-indented for visual indent
```
Continuation of #886 