### PR TITLE
fix pre0.3 to 0.3.1 upgrade script

### DIFF
--- a/install_files/ansible-base/roles/upgrade/files/0.3pre_upgrade.py
+++ b/install_files/ansible-base/roles/upgrade/files/0.3pre_upgrade.py
@@ -49,7 +49,6 @@ def clean_large_deleted():
             print "Deleting source with no db entry..."
             secure_unlink(os.path.join(store_dir, source_dir))
             print
-            continue
 
 def migrate_app_db():
     # To get CREATE TABLE from SQLAlchemy:

--- a/install_files/ansible-base/roles/upgrade/tasks/0-3pre-upgrade.yml
+++ b/install_files/ansible-base/roles/upgrade/tasks/0-3pre-upgrade.yml
@@ -1,6 +1,17 @@
 ---
 # This role will upgrade 0.3pre instances to 0.3 instances.
 # It will copy and run the upgrade.py script on the app and monitor servers.
+- name: stop the apache service prior to upgrade tasks
+  service: name=apache2 status=stopped
+
+- name: copy upgrade script to servers
+  copy: src="0.3pre_upgrade.py" dest="/tmp" owner="root" mode="740"
+  sudo: yes
+
+- name: run the upgrade script
+  shell: "/tmp/0.3pre_upgrade.py {{ server_role }}"
+  sudo: yes
+
 - name: remove old 0.3 packages to avoid version error
   apt: name={{ item }} state=absent
   with_items:
@@ -11,11 +22,3 @@
 
 - name: remove the previous signing key
   apt_key: id=BD67D096 state=absent
-
-- name: copy upgrade script to servers
-  copy: src="0.3pre_upgrade.py" dest="/tmp" owner="root" mode="740"
-  sudo: yes
-
-- name: run the upgrade script
-  shell: "/tmp/0.3pre_upgrade.py {{ server_role }}"
-  sudo: yes


### PR DESCRIPTION
The pre0.3 SD version had an issue where deleting large submission would timeout, leaving the encrypted submission in place but removing it from the db. Added @garrett's fix for cleaning that up prior to running the db migration.

Re-ordered the sequence of events so the backup task and the migration happen prior to removing the old deb packages. This ensures that a custom logo.png will get backuped before dpkg deletes it.

Need to setup another pre0.3 instance to test these changes. Will update in comments when tested.