### PR TITLE
Fade out inactive source interface, implements #447

### DIFF
--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="/static/css/normalize.css" type="text/css" media="all" />
     <link rel="stylesheet" href="/static/css/styles.css" type="text/css" media="all" />
     <link rel="stylesheet" href="/static/css/font-awesome.css" type="text/css" media="all" />
+    <link rel="stylesheet" href="/static/css/source.css" type="text/css" media="all" />
     <link rel="icon" type="image/png" href="/static/i/favicon.png" >
     {% block extrahead %}{% endblock %}
   </head>

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" href="/static/css/normalize.css" type="text/css" media="all" />
     <link rel="stylesheet" href="/static/css/styles.css" type="text/css" media="all" />
     <link rel="stylesheet" href="/static/css/font-awesome.css" type="text/css" media="all" />
+    <link rel="stylesheet" href="/static/css/source.css" type="text/css" media="all" />
     <link rel="icon" type="image/png" href="/static/i/favicon.png">
     <script type="text/javascript" src="/static/js/libs/jquery-2.1.1.min.js"></script>
     <script type="text/javascript" src="/static/js/source.js"></script>

--- a/securedrop/static/css/source.css
+++ b/securedrop/static/css/source.css
@@ -1,0 +1,22 @@
+@keyframes fadein { 
+  from { opacity: 0; } to { opacity: 1; } 
+}
+@-webkit-keyframes fadein { 
+  from { opacity: 0; } to { opacity: 1; }
+} 
+@keyframes fadeout { 
+  0% { opacity: 1; } 98% { opacity: 1; } 100% { opacity: 0; } 
+}
+@-webkit-keyframes fadeout {
+  0% { opacity: 1; } 98% { opacity: 1; } 100% { opacity: 0; }
+} 
+html {
+  animation: fadeout 120s;
+  -webkit-animation: fadeout 120s;
+  opacity: 0;
+}
+html:hover {
+  animation: none;
+  -webkit-animation: none;
+  opacity: 1;
+}


### PR DESCRIPTION
After two minutes of inactivity, this fades out the source interface (in the interest of some marginal shoulder-surfing protection). It's in the base template so it should affect everything except the initial main page.