### PR TITLE
add ssl support to apache apparmor profile

### DIFF
--- a/install_files/ansible-base/usr.sbin.apache2
+++ b/install_files/ansible-base/usr.sbin.apache2
@@ -203,6 +203,11 @@
   /var/www/.gnupg/ rw,
   /var/www/.gnupg/** rw,
   /var/log/apache2/other_vhosts_access.log rw,
+  /etc/apache2/mods-available/ssl.conf r,
+  /etc/apache2/mods-available/ssl.load r,
+  /etc/apache2/mods-available/socache_shmcb.load r,
+  /run/lock/apache2/ssl-cache.* rwk,
+  /var/lib/ssl/* r,
 
   ^DEFAULT_URI {
   }


### PR DESCRIPTION
Some orgs are already using HTTPS for the source interface. This adds the required modules and default cert locations to the apparmor profile for apache to use ssl.

This pr does not add ssl support to the ansible playbook. Just the apparmor support is being included now so that when unattended security updates for securedrop-app-code.deb package are applied it does not break the existing installs using ssl.

Fixes #949