### PR TITLE
Mark GRUB as manually installed (fixes #945)

### DIFF
--- a/install_files/ansible-base/roles/common/tasks/from_fpf_repo_install_grsec.yml
+++ b/install_files/ansible-base/roles/common/tasks/from_fpf_repo_install_grsec.yml
@@ -64,5 +64,8 @@
 - name: remove remaining kernel headers
   command: apt-get -y remove '^linux-headers-.*'
 
+- name: mark GRUB2 as manually installed so its not removed
+  command: apt-mark manual grub-pc
+
 - name: cleanup any dependencies left
   command: apt-get -y autoremove


### PR DESCRIPTION
This is intended to fix and address #945. Ultimately I came up with two equally viable solutions and decided to go with the simpler one, but I'll describe them here.

@dolanjs had suggested simply setting the `grub-pc` package to be installed. This makes sense at first, however if you put that before the autoremove task then it has no effect - grub-pc is already installed, and so it's still marked as automatically installed and Ansible doesn't set it as manually installed which is what we really need. It still gets removed - so then you would have to think about removing GRUB first and then re-installing it afterward, which doesn't really make sense.

So here's another idea. We could create a file named `99grub` in `/etc/apt/apt.conf.d` with the following contents:
```
APT
{
  NeverAutoRemove
  {
  "^grub.*";
  };

};
```
This has the expected effect that any GRUB packages are never auto-removed. You don't even have to `update_cache=true`, just install that config any time before you run autoremove and it just works. However, although we already have a number of custom config files in our playbooks, this is ultimately more complexity, and one extra file, than we really need.

So the simplest thing to do is to use `apt-mark` to mark grub-pc as manually installed, which will "prevent the package from being automatically removed if no other packages depend on it." This is what I did in the commit and it works very well.