### PR TITLE
Rspec tests for apparmor iptables grsecurity

### DIFF
--- a/install_files/ansible-base/host_vars/app.yml
+++ b/install_files/ansible-base/host_vars/app.yml
@@ -131,19 +131,19 @@ ossec_apt_dependencies:
   - adduser
 
 agent_auth_rules:
-  - "-A OUTPUT -d {{ monitor_ip  }} -p tcp --dport 1515 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A INPUT -s {{ monitor_ip }} -p tcp --sport 1515 -m state --state ESTABLISHED,RELATED -j ACCEPT"
+  - '-A OUTPUT -d {{ monitor_ip  }} -p tcp --dport 1515 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "ossec authd rule only required for initial agent registration"'
+  - '-A INPUT -s {{ monitor_ip }} -p tcp --sport 1515 -m state --state ESTABLISHED,RELATED -v ACCEPT -m comment --comment "ossec authd rule only required for initial agent registration"'
 
 ### Used by the restrict access role ###
 direct_access_rules:
-  - "-A INPUT -p tcp --dport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A OUTPUT -p tcp --sport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A OUTPUT -p udp --dport 53 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A INPUT -p udp --sport 53 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A INPUT -p tcp --dport 80 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A OUTPUT -p tcp --sport 80 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A INPUT -p tcp --dport 8080 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A OUTPUT -p tcp --sport 8080 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
+  - '-A INPUT -p tcp --dport 22 -m state --state NEW,ESTABLISHED,RELATED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  - '-A OUTPUT -p tcp --sport 22 -m state --state NEW,ESTABLISHED,RELATED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  - '-A OUTPUT -p udp --dport 53 -m state --state NEW,ESTABLISHED,RELATED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  - '-A INPUT -p udp --sport 53 -m state --state NEW,ESTABLISHED,RELATED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  - '-A INPUT -p tcp --dport 80 -m state --state NEW,ESTABLISHED,RELATED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  - '-A OUTPUT -p tcp --sport 80 -m state --state NEW,ESTABLISHED,RELATED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  - '-A INPUT -p tcp --dport 8080 -m state --state NEW,ESTABLISHED,RELATED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  - '-A OUTPUT -p tcp --sport 8080 -m state --state NEW,ESTABLISHED,RELATED -m comment --comment "Staging only allow direct access" -j ACCEPT'
 
 test_apt_dependencies:
   - firefox

--- a/install_files/ansible-base/roles/app-test/tasks/main.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/main.yml
@@ -8,3 +8,4 @@
 - include: dev_setup_xvfb_for_functional_tests.yml
 
 - include: security_hardening_tests.yml
+  tags: non-development

--- a/install_files/ansible-base/roles/app-test/tasks/main.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/main.yml
@@ -6,3 +6,5 @@
   tags: non-development,aa-complain
 
 - include: dev_setup_xvfb_for_functional_tests.yml
+
+- include: security_hardening_tests.yml

--- a/install_files/ansible-base/roles/app-test/tasks/security_hardening_tests.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/security_hardening_tests.yml
@@ -1,6 +1,7 @@
 ---
 - name: install paxtest for running buffer overflow protection auditing
   apt: name=paxtest state=latest
+  tags: paxtest
 
 #- name: install lynix for system security hardening auditing
 #  apt: name=lynis state=latest

--- a/install_files/ansible-base/roles/app-test/tasks/security_hardening_tests.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/security_hardening_tests.yml
@@ -1,0 +1,6 @@
+---
+- name: install paxtest for running buffer overflow protection auditing
+  apt: name=paxtest state=latest
+
+#- name: install lynix for system security hardening auditing
+#  apt: name=lynis state=latest

--- a/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
@@ -63,7 +63,7 @@
 -A OUTPUT -o lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"
 
 # Don't log inbound invalid state packets related to issue #845
--A INPUT -p tcp -m state --state INVALID -j DROP -m comment --comment "drop but don't log inbound invalid state packets"
+-A INPUT -p tcp -m state --state INVALID -j DROP -m comment --comment "drop but do not log inbound invalid state packets"
 
 # Catch all drop rule
 -A INPUT -j LOGNDROP -m comment --comment "Drop and log all other incomming traffic"

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
@@ -57,7 +57,7 @@
 -A OUTPUT -o lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"
 
 # Don't log inbound invalid state packets related to issue #845
--A INPUT -p tcp -m state --state INVALID -j DROP -m comment --comment "drop but don't log inbound invalid state packets"
+-A INPUT -p tcp -m state --state INVALID -j DROP -m comment --comment "drop but do not log inbound invalid state packets"
 
 # Catch all drop rule
 -A INPUT -j LOGNDROP -m comment --comment "Log and drop all other incomming traffic"

--- a/spec_tests/spec/localhost/apparmor_spec.rb
+++ b/spec_tests/spec/localhost/apparmor_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+# Apparmor package dependencies
+['apparmor', 'apparmor-utils' ].each do |pkg|
+  describe package(pkg) do
+    it { should be_installed }
+  end
+end
+
+# Required apparmor profiles configs
+#
+# SecureDrop apache apparmor profile
+describe file('/etc/apparmor.d/usr.sbin.apache2') do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  it { should be_mode '644' }
+  # The following line should not contain `complain`
+  # And should have the correct path for apache2
+  its(:content) { should match "/usr/sbin/apache2 {" }
+end
+
+# Check that apparmor is enabled.
+# The command returns error code if AppArmor not enabled
+describe command("aa-status --enabled") do
+  it { should_not return_stderr }
+end
+
+# Check that the expected profiles are present in the aa-status command.
+[ 'apache', 'tor', 'ntp'].each do |enforcedProfiles|
+  describe command("aa-status") do
+    it { should return_stdout /#{enforcedProfiles}/ }
+  end
+end
+
+# Ensure that there are no processes in complain mode
+describe command("aa-status --complaining") do
+  it { should return_stdout "0" }
+end
+
+# Ensure that there are no processes that are unconfined but have a profile
+describe command("aa-status") do
+  it { should return_stdout /0 processes are unconfined but have a profile defined/ }
+end

--- a/spec_tests/spec/localhost/grsec_spec.rb
+++ b/spec_tests/spec/localhost/grsec_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+['securedrop-grsec'].each do |pkg|
+  describe package(pkg) do
+    it { should be_installed }
+  end
+end
+
+# Check that the system is booted in grsec
+describe command("uname -r") do
+  it { should return_stdout /grsec/ }
+end
+
+# Check that the grsec sysctl settings are correct
+describe 'Grsecurity kernel parameters' do
+  context linux_kernel_parameter('kernel.grsecurity.grsec_lock') do
+    its(:value) { should eq 1 }
+  end
+
+  context linux_kernel_parameter('kernel.grsecurity.rwxmap_logging') do
+    its(:value) { should eq 0 }
+  end
+end
+
+# Check that paxtest does not report anything vulnerable
+# Requires the package paxtest to be installed
+# The paxtest package is currently being installed in the app-test role
+describe command("paxtest blackhat") do
+  it { should_not return_stdout /vulnerable/ }
+end
+
+# Check pax flags for apache tor
+# paxctl -v /usr/sbin/apache2
+# paxctl -v /usr/sbin/tor
+# paxctl -v /usr/sbin/ntp
+# paxctl -v /usr/sbin/apt

--- a/spec_tests/spec/localhost/iptables_spec.rb
+++ b/spec_tests/spec/localhost/iptables_spec.rb
@@ -2,22 +2,28 @@ require 'spec_helper'
 
 describe iptables do
   # These are the staging specific rules that should not be present in prod
-  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
-  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
-  it { should_not have_rule(' INPUT -p udp -m udp --sport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
-  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 22 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
-  it { should_not have_rule(' OUTPUT -p tcp -m tcp --sport 8080 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
-  it { should_not have_rule(' OUTPUT -p tcp -m tcp --sport 80 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
-  it { should_not have_rule(' OUTPUT -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
-  it { should_not have_rule(' OUTPUT -p tcp -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT') }
+  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT') }
+  it { should_not have_rule(' INPUT -p udp -m udp --sport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT') }
+  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 22 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT') }
+  it { should_not have_rule(' OUTPUT -p tcp -m tcp --sport 8080 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT') }
+  it { should_not have_rule(' OUTPUT -p tcp -m tcp --sport 80 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT') }
+  it { should_not have_rule(' OUTPUT -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT') }
+  it { should_not have_rule(' OUTPUT -p tcp -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT') }
 
   # These rules should only exist when the while the ossec agent is registering
   # with the OSSEC server and then should be removed prior to the playbook
   # finishing
-  it { should_not have_rule(' OUTPUT -d {{ monitor_ip  }} -p tcp --dport 1515 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "ossec authd rule only required for initial agent registration"'
-  it { should_not have_rule(' INPUT -s {{ monitor_ip }} -p tcp --sport 1515 -m state --state ESTABLISHED,RELATED -v ACCEPT -m comment --comment "ossec authd rule only required for initial agent registration"'
+  # TODO: The Vagrantfile virtualbox static IP was hardcoded into the two rules
+  # below. This will need to be fixed. Possibly with using something like
+  # https://github.com/volanja/ansible_spec Using the values for IP addresses
+  # from the ansible inventory should cover most use cases. (except inventories
+  # with just the *.onion address.
+  it { should_not have_rule(' OUTPUT -d 10.0.1.3 -p tcp --dport 1515 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "ossec authd rule only required for initial agent registration"') }
+  it { should_not have_rule(' INPUT -s 10.0.1.3 -p tcp --sport 1515 -m state --state ESTABLISHED,RELATED -v ACCEPT -m comment --comment "ossec authd rule only required for initial agent registration"') }
 
   # These rules should be present in prod and staging
+  # TODO: There are also hardcoded IP addresses in this section.
   it { should have_rule(' INPUT -p tcp -m state --state RELATED,ESTABLISHED -m comment --comment "Allow traffic back for tor" -j ACCEPT') }
   it { should have_rule(' INPUT -i lo -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor connection from local loopback to connect to source int" -j ACCEPT') }
   it { should have_rule(' INPUT -i lo -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor connection from local loopback to connect to document int" -j ACCEPT') }

--- a/spec_tests/spec/localhost/iptables_spec.rb
+++ b/spec_tests/spec/localhost/iptables_spec.rb
@@ -2,15 +2,22 @@ require 'spec_helper'
 
 describe iptables do
   # These are the staging specific rules that should not be present in prod
-  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should_not have_rule(' INPUT -p udp -m udp --sport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should have_rule(' OUTPUT -p tcp -m tcp --sport 8080 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should have_rule(' OUTPUT -p tcp -m tcp --sport 80 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should have_rule(' OUTPUT -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should have_rule(' OUTPUT -p tcp -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-   # These rules should be present in prod and staging
+  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  it { should_not have_rule(' INPUT -p udp -m udp --sport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 22 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  it { should_not have_rule(' OUTPUT -p tcp -m tcp --sport 8080 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  it { should_not have_rule(' OUTPUT -p tcp -m tcp --sport 80 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  it { should_not have_rule(' OUTPUT -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+  it { should_not have_rule(' OUTPUT -p tcp -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Staging only allow direct access" -j ACCEPT'
+
+  # These rules should only exist when the while the ossec agent is registering
+  # with the OSSEC server and then should be removed prior to the playbook
+  # finishing
+  it { should_not have_rule(' OUTPUT -d {{ monitor_ip  }} -p tcp --dport 1515 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "ossec authd rule only required for initial agent registration"'
+  it { should_not have_rule(' INPUT -s {{ monitor_ip }} -p tcp --sport 1515 -m state --state ESTABLISHED,RELATED -v ACCEPT -m comment --comment "ossec authd rule only required for initial agent registration"'
+
+  # These rules should be present in prod and staging
   it { should have_rule(' INPUT -p tcp -m state --state RELATED,ESTABLISHED -m comment --comment "Allow traffic back for tor" -j ACCEPT') }
   it { should have_rule(' INPUT -i lo -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor connection from local loopback to connect to source int" -j ACCEPT') }
   it { should have_rule(' INPUT -i lo -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor connection from local loopback to connect to document int" -j ACCEPT') }

--- a/spec_tests/spec/localhost/iptables_spec.rb
+++ b/spec_tests/spec/localhost/iptables_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe iptables do
+  it { should have_rule(' INPUT -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should have_rule(' INPUT -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should have_rule(' INPUT -p udp -m udp --sport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should have_rule(' INPUT -p tcp -m tcp --dport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should have_rule(' INPUT -p tcp -m state --state RELATED,ESTABLISHED -m comment --comment "Allow traffic back for tor" -j ACCEPT') }
+  it { should have_rule(' INPUT -i lo -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor connection from local loopback to connect to source int" -j ACCEPT') }
+  it { should have_rule(' INPUT -i lo -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor connection from local loopback to connect to document int" -j ACCEPT') }
+  it { should have_rule(' INPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -i lo -p tcp -m state --state RELATED,ESTABLISHED -m comment --comment "for redis worker all application user local loopback user" -j ACCEPT') }
+  it { should have_rule(' INPUT -s 8.8.8.8/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT') }
+  it { should have_rule(' INPUT -s 8.8.8.8/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT') }
+  it { should have_rule(' INPUT -p udp -m udp --sport 123 --dport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT') }
+  it { should have_rule(' INPUT -p tcp -m multiport --sports 80,8080,443 -m state --state RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT') }
+  it { should have_rule(' INPUT -s 10.0.1.3/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT') }
+  it { should have_rule(' INPUT -i lo -m comment --comment "Allow lo to lo traffic all protocols" -j ACCEPT') }
+  it { should have_rule(' INPUT -p tcp -m state --state INVALID -m comment --comment "drop but do not log inbound invalid state packets" -j DROP') }
+  it { should have_rule(' INPUT -m comment --comment "Drop and log all other incomming traffic" -j LOGNDROP') }
+  it { should have_rule(' OUTPUT -p tcp -m tcp --sport 8080 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should have_rule(' OUTPUT -p tcp -m tcp --sport 80 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should have_rule(' OUTPUT -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should have_rule(' OUTPUT -p tcp -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should have_rule(' OUTPUT -p tcp -m owner --uid-owner 109 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tor instance that provides ssh access" -j ACCEPT') }
+  it { should have_rule(' OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 109 -m state --state NEW -m limit --limit 3/min --limit-burst 3 -m comment --comment "SSH with rate limiting only thru tor" -j ACCEPT') }
+  it { should have_rule(' OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 109 -m state --state RELATED,ESTABLISHED -m comment --comment "SSH with rate limiting only thru tor" -j ACCEPT') }
+  it { should have_rule(' OUTPUT -m owner --uid-owner 109 -m comment --comment "Drop all other traffic for the tor instance used for ssh" -j LOGNDROP') }
+  it { should have_rule(' OUTPUT -o lo -p tcp -m tcp --sport 80 -m owner --uid-owner 33 -m state --state RELATED,ESTABLISHED -m comment --comment "Restrict the apache user outbound connections" -j ACCEPT') }
+  it { should have_rule(' OUTPUT -o lo -p tcp -m tcp --sport 8080 -m owner --uid-owner 33 -m state --state RELATED,ESTABLISHED -m comment --comment "Restrict the apache user outbound connections" -j ACCEPT') }
+  it { should have_rule(' OUTPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -o lo -p tcp -m owner --uid-owner 33 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "for redis worker all application user local loopback user" -j ACCEPT') }
+  it { should have_rule(' OUTPUT -m owner --uid-owner 33 -m comment --comment "Drop all other traffic by the securedrop user" -j LOGNDROP') }
+  it { should have_rule(' OUTPUT -m owner --gid-owner 108 -m comment --comment "Drop all other outbound traffic for ssh user" -j LOGNDROP') }
+  it { should have_rule(' OUTPUT -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT') }
+  it { should have_rule(' OUTPUT -d 8.8.8.8/32 -p udp -m udp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT') }
+  it { should have_rule(' OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT') }
+  it { should have_rule(' OUTPUT -p tcp -m multiport --dports 80,8080,443 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT') }
+  it { should have_rule(' OUTPUT -d 10.0.1.3/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT') }
+  it { should have_rule(' OUTPUT -o lo -m comment --comment "Allow lo to lo traffic all protocols" -j ACCEPT') }
+  it { should have_rule(' OUTPUT -m comment --comment "Drop all other outgoing traffic" -j DROP') }
+  it { should have_rule(' LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-tcp-options --log-ip-options --log-uid') }
+  it { should have_rule(' LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-ip-options --log-uid') }
+  it { should have_rule(' LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-ip-options --log-uid') }
+  it { should have_rule(' LOGNDROP -j DROP') }
+end

--- a/spec_tests/spec/localhost/iptables_spec.rb
+++ b/spec_tests/spec/localhost/iptables_spec.rb
@@ -1,10 +1,16 @@
 require 'spec_helper'
 
 describe iptables do
-  it { should have_rule(' INPUT -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should have_rule(' INPUT -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should have_rule(' INPUT -p udp -m udp --sport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should have_rule(' INPUT -p tcp -m tcp --dport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  # These are the staging specific rules that should not be present in prod
+  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should_not have_rule(' INPUT -p udp -m udp --sport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should_not have_rule(' INPUT -p tcp -m tcp --dport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should have_rule(' OUTPUT -p tcp -m tcp --sport 8080 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should have_rule(' OUTPUT -p tcp -m tcp --sport 80 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should have_rule(' OUTPUT -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+  it { should have_rule(' OUTPUT -p tcp -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
+   # These rules should be present in prod and staging
   it { should have_rule(' INPUT -p tcp -m state --state RELATED,ESTABLISHED -m comment --comment "Allow traffic back for tor" -j ACCEPT') }
   it { should have_rule(' INPUT -i lo -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor connection from local loopback to connect to source int" -j ACCEPT') }
   it { should have_rule(' INPUT -i lo -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor connection from local loopback to connect to document int" -j ACCEPT') }
@@ -17,10 +23,6 @@ describe iptables do
   it { should have_rule(' INPUT -i lo -m comment --comment "Allow lo to lo traffic all protocols" -j ACCEPT') }
   it { should have_rule(' INPUT -p tcp -m state --state INVALID -m comment --comment "drop but do not log inbound invalid state packets" -j DROP') }
   it { should have_rule(' INPUT -m comment --comment "Drop and log all other incomming traffic" -j LOGNDROP') }
-  it { should have_rule(' OUTPUT -p tcp -m tcp --sport 8080 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should have_rule(' OUTPUT -p tcp -m tcp --sport 80 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should have_rule(' OUTPUT -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
-  it { should have_rule(' OUTPUT -p tcp -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT') }
   it { should have_rule(' OUTPUT -p tcp -m owner --uid-owner 109 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tor instance that provides ssh access" -j ACCEPT') }
   it { should have_rule(' OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 109 -m state --state NEW -m limit --limit 3/min --limit-burst 3 -m comment --comment "SSH with rate limiting only thru tor" -j ACCEPT') }
   it { should have_rule(' OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 109 -m state --state RELATED,ESTABLISHED -m comment --comment "SSH with rate limiting only thru tor" -j ACCEPT') }


### PR DESCRIPTION
This adds rspec tests for the following

* Tests for each iptables rule
** Modified an iptable rule comment to work with the iptables test.

* Tests for grsec packages
* Tests that system is booted into grsec
* Tests for grsec sysctl flags
* Tests for output of paxtest out
** Added an ansible task to the app-test role to install paxtest

* Test for apparmor packages
* Tests for presence of SD profile
* Tests expected profiles are being tracked
* Tests that no profiles are in complain mode
* Tests that no processes are in unconfined mode that have profiles defined.
