### PR TITLE
update %s notation to new .format syntax

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -78,7 +78,7 @@ def clean(s, also=''):
     ok = ' !#%$&)(+*-1032547698;:=?@acbedgfihkjmlonqpsrutwvyxzABCDEFGHIJKLMNOPQRSTUVWXYZ'
     for c in s:
         if c not in ok and c not in also:
-            raise CryptoException("invalid input: %s" % s)
+            raise CryptoException("invalid input: {0}".format(s))
     # scrypt.hash requires input of type str. Since the wordlist is all ASCII
     # characters, this conversion is not problematic
     return str(s)


### PR DESCRIPTION
So here's a small update to test my workflow in submitting to SecureDrop.

Looking at this code and wondering, how could this be refactored for utf-8 and, ultimately, unicode support?

```python
def clean(s, also=''):
    """
    >>> clean("Hello, world!")
    Traceback (most recent call last):
    ...
    CryptoException: invalid input
    >>> clean("Helloworld")
    'Helloworld'
    """
    # safe characters for every possible word in the wordlist includes capital
    # letters because codename hashes are base32-encoded with capital letters
    ok = ' !#%$&)(+*-1032547698;:=?@acbedgfihkjmlonqpsrutwvyxzABCDEFGHIJKLMNOPQRSTUVWXYZ'
    for c in s:
        if c not in ok and c not in also:
             raise CryptoException("invalid input: %s" % s)
    # scrypt.hash requires input of type str. Since the wordlist is all ASCII
    # characters, this conversion is not problematic
    return str(s)
```
 Diceware lists in a [dozen languages](http://world.std.com/~reinhold/diceware.html) are now available. i18n is a big task, if you could point me in the right direction, I'd be happy to look into refactoring this code for future i18n support.