### PR TITLE
Strip leading + trailing whitespaces from codename

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -340,7 +340,7 @@ def valid_codename(codename):
 @app.route('/login', methods=('GET', 'POST'))
 def login():
     if request.method == 'POST':
-        codename = request.form['codename']
+        codename = request.form['codename'].strip()
         try:
             valid = valid_codename(codename)
         except crypto_util.CryptoException:

--- a/securedrop/tests/test_unit_source.py
+++ b/securedrop/tests/test_unit_source.py
@@ -129,6 +129,28 @@ class TestSource(TestCase):
             self.assertIn('Sorry, that is not a recognized codename.', rv.data)
             self.assertNotIn('logged_in', session)
 
+    def test_login_with_whitespace(self):
+        rv = self.client.get('/login')
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn("Login to check for responses", rv.data)
+
+        codename = self._new_codename()
+	codename = ' ' + codename + ' '
+        with self.client as c:
+            rv = c.post('/login', data=dict(codename),
+                        follow_redirects=True)
+            self.assertEqual(rv.status_code, 200)
+            self.assertIn("Submit documents and messages", rv.data)
+            self.assertTrue(session['logged_in'])
+            common.logout(c)
+
+        with self.client as c:
+            rv = self.client.post('/login', data=dict(codename='invalid'),
+                                  follow_redirects=True)
+            self.assertEqual(rv.status_code, 200)
+            self.assertIn('Sorry, that is not a recognized codename.', rv.data)
+            self.assertNotIn('logged_in', session)
+
     def _dummy_submission(self):
         """
         Helper to make a submission (content unimportant), mostly useful in


### PR DESCRIPTION
I think it's a smart idea to strip leading and trailing white spaces from a codename entered by the source in order to work around the inclusion of unintentional spaces and resulting issues with logging in.