### PR TITLE
added docs for upgrading 0.2.1 and 0.3-pre versions

### DIFF
--- a/docs/0.2.1-upgrade-to-0.3.3.md
+++ b/docs/0.2.1-upgrade-to-0.3.3.md
@@ -8,7 +8,7 @@
 
 ## Upgrade 0.2.1 steps
 
-There is a `0.2.1_collect.py` python script that will backup a SecureDrop version 0.2.1 app server. This script will need to be ran on the app server prior to performing a clean install of SecureDrop 0.3.x. The direction below assume that the admin has physical access to the app server.
+There is a `0.2.1_collect.py` python script that will backup a SecureDrop version 0.2.1 app server. This script will need to be run on the app server prior to performing a clean install of SecureDrop 0.3.x. The directions below assume that the admin has physical access to the app server.
 
 ### On the App server
 
@@ -26,7 +26,7 @@ There is a `0.2.1_collect.py` python script that will backup a SecureDrop versio
 
 * Checkout and verify the current release
 
-`git checkout tags/0.3.3`
+`git checkout 0.3.3`
 
 `git tags -v 0.3.3`
 

--- a/docs/0.2.1-upgrade-to-0.3.3.md
+++ b/docs/0.2.1-upgrade-to-0.3.3.md
@@ -1,0 +1,48 @@
+# Upgrading 0.2.1 version
+
+## Prerequisites
+
+* A networked Admin tails workstation configured with the SecureDrop repo cloned to the `Persistent` directory.
+
+* Physical/remote access to the app and monitor servers
+
+## Upgrade 0.2.1 steps
+
+There is a `0.2.1_collect.py` python script that will backup a SecureDrop version 0.2.1 app server. This script will need to be ran on the app server prior to performing a clean install of SecureDrop 0.3.x. The direction below assume that the admin has physical access to the app server.
+
+### On the App server
+
+* Install git
+
+`sudo apt-get install git`
+
+* Clone the SecureDrop repo
+
+`git clone https://github.com/freedomofpress/securedrop`
+
+* Change directory into the securedrop folder
+
+`cd securedrop`
+
+* Checkout and verify the current release
+
+`git checkout tags/0.3.3`
+
+`git tags -v 0.3.3`
+
+* On the app server run this script as root and provide a file name for the backup.
+
+`sudo ./migration_scripts/0.3/0.2.1_collect.py sdbackup`
+
+* Copy `sdbackup.tar.gz` to removable media and transfer it to the  new instance's app server. If you are re-using the same hardware for  your 0.3 installation as you did for 0.2.1, make sure you copy this file  to a external media before beginning the 0.3 installation - otherwise  you will lose your data!
+
+* Perform a fresh install of the app and monitor servers. https://github.com/freedomofpress/securedrop/blob/develop/docs/install.md
+
+* Once you've successfully installed 0.3, copy `sdbackup.tar.gz` to any location on the 0.3 app server. You will also need 0.3_migrate.py, along with the rest of the files in migration-scripts/0.3. You can copy the 0.3 directory to the running instance with a flash drive, or `git clone` the repo on the new app server and `cd` into `securedrop/migration_scripts/0.2.1`.
+
+* Once that's done, run 0.3_migrate.py as root, passing the path to the backup from the 0.2.1 machine.
+
+`sudo 0.3/0.3_migrate.py sdbackup.tar.gz`
+
+The script will say "Done!" when it completes successfully.  Otherwise, it will print an error and a Python traceback. If you  encounter such an error, please encrypt the traceback and email it to us at securedrop@freedom.press
+Finally, test your new installation and make sure that everything was successfully migrated.

--- a/docs/0.3-pre-upgrade-to-0.3.3.md
+++ b/docs/0.3-pre-upgrade-to-0.3.3.md
@@ -1,0 +1,93 @@
+# Upgrading 0.3 version
+
+## Prerequisites
+
+* An Admin networked Tails workstation with persistence enabled and an Admin password set during boot.
+
+* Double click the "SecureDrop Init" icon to load the Tor authenticated hidden service values into your system's torrc file.
+
+* A filled out prod-specific.yml file `/home/amnesia/Persistent/install_files/ansible-base/prod-specific.yml`
+
+## From the admin Tails workstation:
+
+Open a terminal (it is an icon on the top of the screen that looks like a little black TV)
+
+* Change into the SecureDrop repo directory:
+
+`cd /home/amnesia/Persistent/securedrop`
+
+* Stash your local changes to the inventory and prod-specific.yml
+
+`git stash save "site specific configs"`
+
+* Pull the latest code
+
+`git pull`
+
+* Checkout the latest tagged release
+
+`git checkout 0.3.3`
+
+* Verify the github tag
+
+`git tag -v 0.3.3`
+
+* Pop the site specific configs back in place
+
+`git stash pop "site specific configs"`
+
+## 0.3 upgrade steps
+
+Run the 0.3 upgrade helper script. This script will do some basic sanity checks for your ansible inventory, prod-specific.yml and the system's torrc file are properly configured and then run the correct ansible playbooks.
+
+* Run the upgrade helper script
+
+`sudo ./migration_scripts/0.3/upgrade.sh`
+
+## Notes about the 0.3 upgrade helper script
+
+`Error: This script must be run as root.`
+
+* Use the 'sudo' command and provide the administrative password you created at the beginning of the Tails session. i.e. `sudo ./upgrade.sh`
+
+`Error: This script must be run on Tails with a persistent volume.`
+
+* In order for this to work, you must be running Tails on the admin workstation and have access to a persistent volume. Did you unlock your persistent storage at the beginning of the Tails session?
+
+`Error: There is no SSH key file present.`
+
+* When you installed SecureDrop, you generated an SSH key (and probably saved to the default location: `~/.ssh/id_rsa`) for the user 'amnesia' and copied it to both the App and Mon server. You should still have access to that key through the OpenSSH persistence in Tails. If you got this error, check if you lost the key or saved it to a different location. You won't be able to login to the servers remotely without it.
+
+`Error: This script must be run with SecureDrop's git repository cloned to 'securedrop' in your Persistent folder.`
+
+* When you first installed SecureDrop, we assume that you cloned our GitHub repository to a specific location: `/home/amnesia/Persistent/securedrop`. If it's not there, you either need to move it there or start anew.
+
+`Error: There are no HidServAuth values in your torrc file.`
+
+* Did you run the 'SecureDrop Init' script located in the Persistent folder? The init script and the additions it makes to Tor's configuration file are needed in order to access the App and Mon servers using SSH over Tor.
+
+`Error: monitor_ip or app_ip in prod-specific.yml is not an IP address.`
+
+* The production playbook in `/install_files/ansible-base/prod-specific.yml` needs to be fully filled out, with the local IP address for each server specified.
+
+`Error: ssh_users is not defined in prod-specific.yml.`
+
+* Inside the production playbook you must have ssh_users defined as the user which you use to log in to the App and Mon servers, which was created when you installed Ubuntu Server.
+
+`Error: the app or mon ansible_ssh_host in Ansible's inventory file is not an .onion address.`
+
+* Our new provisioner, Ansible, must be run over Tor in order to reach the servers. Replace the IP addresses in `/install_files/ansible-base/inventory` with the .onion hostnames for the App and Mon server's Tor hidden services for SSH.
+
+`Error: can't connect to the Application or Monitor Server via SSH.`
+
+* Something's wrong and we can't connect. You can re-run the script to try again.
+
+** Is the Vidalia connection indicator green?
+
+** Did you enter the .onion addresses correctly?
+
+** Are both servers powered on?
+
+** Try to SSH to the servers manually - did your client accept the server's host key?
+
+** Did the server accept your client's key?

--- a/docs/0.3-pre-upgrade-to-0.3.3.md
+++ b/docs/0.3-pre-upgrade-to-0.3.3.md
@@ -82,12 +82,12 @@ Run the 0.3 upgrade helper script. This script will do some basic sanity checks 
 
 * Something's wrong and we can't connect. You can re-run the script to try again.
 
-** Is the Vidalia connection indicator green?
+  * Is the Vidalia connection indicator green?
 
-** Did you enter the .onion addresses correctly?
+  * Did you enter the .onion addresses correctly?
 
-** Are both servers powered on?
+  * Are both servers powered on?
 
-** Try to SSH to the servers manually - did your client accept the server's host key?
+  * Try to SSH to the servers manually - did your client accept the server's host key?
 
-** Did the server accept your client's key?
+  * Did the server accept your client's key?


### PR DESCRIPTION
Added two docs to cover upgrading from a 0.2.1 version to 0.3.3 and different document for upgrading 0.3-pre to 0.3.3 version.

In the hackpad these were 1 document. @conorsch thought it would be easier for the organizations if the documents were split up.