### PR TITLE
Add ansible tags

### DIFF
--- a/install_files/ansible-base/roles/allow_direct_access/tasks/main.yml
+++ b/install_files/ansible-base/roles/allow_direct_access/tasks/main.yml
@@ -6,9 +6,13 @@
     line: "ListenAddress 0.0.0.0:22"
   notify:
     - restart direct access ssh
+  tags:
+    - ssh
 
 - stat: path=/etc/network/iptables/rules_v4
   register: iptables_rules
+  tags:
+    - iptables
 
 - name: allow direct SSH acccess in iptables rules
   lineinfile:
@@ -26,3 +30,6 @@
     - reload direct access iptables
   with_items: direct_access_rules
   when: iptables_rules.stat.exists
+  tags:
+    - ssh
+    - iptables

--- a/install_files/ansible-base/roles/app-test/tasks/apparmor_complain.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/apparmor_complain.yml
@@ -2,3 +2,6 @@
 - name: ensure custom appamror profiles are in complain mode
   command: "aa-complain /etc/apparmor.d/{{ item }}"
   with_items: apparmor_profiles 
+  tags:
+    - aa-complain
+    - non-development

--- a/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
@@ -1,17 +1,30 @@
 ---
 - name: install pip dependencies for running the unit and functional tests
   pip: requirements="{{ test_pip_requirements }}"
+  tags:
+    - pip
 
 - name: install testing deb pkg dependencies
   apt: name="{{ item }}" state=latest
   with_items: test_apt_dependencies
+  tags:
+    - apt
 
 - name: copy xvfb init script to /etc/init.d
   copy: src=xvfb dest=/etc/init.d/xvfb owner=root mode=700
+  tags:
+    - xvfb
+    - permissions
 
 - name: update rc.d to run xvfb at boot
   command: "update-rc.d xvfb defaults"
   notify: start xvfb
+  tags:
+    - xvfb
 
 - name: set DISPLAY environment variable for xvfb on reboot
   copy: src=xvfb_display.sh dest=/etc/profile.d/xvfb_display.sh owner=root mode=444
+  tags:
+    - xvfb
+    - environment
+    - permissions

--- a/install_files/ansible-base/roles/app-test/tasks/main.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - include: staging_wsgi_files.yml
-  tags: non-development
+  tags:
+    - apache
+    - non-development
 
 - include: apparmor_complain.yml
   tags: non-development,aa-complain

--- a/install_files/ansible-base/roles/app-test/tasks/main.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/main.yml
@@ -5,6 +5,8 @@
     - non-development
 
 - include: apparmor_complain.yml
-  tags: non-development,aa-complain
+  tags:
+    - aa-complain
+    - non-development
 
 - include: dev_setup_xvfb_for_functional_tests.yml

--- a/install_files/ansible-base/roles/app-test/tasks/staging_wsgi_files.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/staging_wsgi_files.yml
@@ -5,3 +5,6 @@
 # by this task.
 - name: ensure logging enabled source wsgi app files exists
   copy: src=source.wsgi.logging dest=/var/www/source.wsgi owner={{ apache_user }} mode=0640
+  tags:
+    - apache
+    - non-development

--- a/install_files/ansible-base/roles/app/tasks/app_install_fpf_deb_pkgs.yml
+++ b/install_files/ansible-base/roles/app/tasks/app_install_fpf_deb_pkgs.yml
@@ -1,3 +1,5 @@
 ---
 - name: ensure securedrop-app-code packages are installed from repo
   apt: pkg=securedrop-app-code state=present
+  tags:
+    - apt

--- a/install_files/ansible-base/roles/app/tasks/configure_haveged.yml
+++ b/install_files/ansible-base/roles/app/tasks/configure_haveged.yml
@@ -6,3 +6,6 @@
     line: 'DAEMON_ARGS="-w 2400"'
   notify:
     - restart haveged
+  tags:
+    - haveged
+    - hardening

--- a/install_files/ansible-base/roles/app/tasks/configure_securedrop_worker.yml
+++ b/install_files/ansible-base/roles/app/tasks/configure_securedrop_worker.yml
@@ -7,6 +7,8 @@
     mode: 0644
   notify:
     - reload supervisor
+  tags:
+    - supervisor
 
   # Supervisor will not write logs if the parent directory does not exist, so
   # we create it here.
@@ -18,3 +20,7 @@
     owner: root
     group: root
     mode: 0644
+  tags:
+    - supervisor
+    - permissions
+    - logging

--- a/install_files/ansible-base/roles/app/tasks/create_app_dirs.yml
+++ b/install_files/ansible-base/roles/app/tasks/create_app_dirs.yml
@@ -3,6 +3,9 @@
   file:
     state: absent
     dest: "/var/www/html"
+  tags:
+    - apache
+    - permissions
 
 - name: ensure securedrop root directory exists
   file:
@@ -11,6 +14,8 @@
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
     dest: "{{ securedrop_code }}"
+  tags:
+    - permissions
 
 - name: ensure securedrop data directory exists
   file:
@@ -19,6 +24,8 @@
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
     dest: "{{ securedrop_data }}"
+  tags:
+    - permissions
 
 - name: ensure securedrop data store directory exists
   file:
@@ -27,6 +34,8 @@
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
     dest: "{{ securedrop_data }}/store"
+  tags:
+    - permissions
 
 - name: ensure securedrop keyring directory exists
   file:
@@ -35,6 +44,8 @@
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
     dest: "{{ securedrop_data }}/keys"
+  tags:
+    - permissions
 
 - name: ensure securedrop temp directory exists
   file:
@@ -43,3 +54,5 @@
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
     dest: "{{ securedrop_data }}/tmp"
+  tags:
+    - permissions

--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -2,14 +2,21 @@
 - name: ensure secureDrop web application apt packages are installed
   apt: pkg="{{ item }}" state=latest
   with_items: app_deps
+  tags:
+    - apt
 
 - name: copy the app gpg key from the admin host machine to the app server
   copy:
     src: "{{ securedrop_app_gpg_public_key }}"
     dest: "{{ securedrop_data }}/"
+  tags:
+    - securedrop_config
 
 - name: import app gpg public key
   command: "su -s /bin/bash -c \"gpg --homedir {{ securedrop_data }}/keys --import {{ securedrop_data }}/{{ securedrop_app_gpg_public_key }}\" {{ securedrop_user }}"
+  tags:
+    - gpg
+    - securedrop_config
 
   # only a config.py.example is included in the securedrop-app-code package. If
   # a config.py file is not already present copy the one installed by the
@@ -17,10 +24,14 @@
   # package would not overwrite the config.py on upgrades.
 - stat: path="{{ securedrop_code }}/config.py"
   register: config
+  tags:
+    - securedrop_config
 
 - name: if config.py does not exist copy example from the securedrop code root
   command: "cp {{ securedrop_code }}/config.py.example {{ securedrop_code }}/config.py"
   when: not config.stat.exists
+  tags:
+    - securedrop_config
 
 - name: ensure config.py is owned by www-data
   file:
@@ -28,6 +39,9 @@
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
     mode: 0600
+  tags:
+    - permissions
+    - securedrop_config
 
 # TODO: config.py.example is already written using Jinja2 format, and should be
 # easy to template-ize. However, we cannot do this because when Ansible writes
@@ -45,6 +59,8 @@
   shell: "head -c 32 /dev/urandom | base64"
   register: source_secret_key
   when: not config.stat.exists
+  tags:
+    - securedrop_config
 
 - name: if source secret key is blank insert 32 byte random value
   lineinfile:
@@ -52,11 +68,15 @@
     regexp: "source_secret_key"
     line: "    SECRET_KEY = '{{ source_secret_key.stdout}}'"
   when: not config.stat.exists
+  tags:
+    - securedrop_config
 
 - name: generating 32 byte value for "journalist secret key"
   shell: "head -c 32 /dev/urandom | base64"
   register: journalist_secret_key
   when: not config.stat.exists
+  tags:
+    - securedrop_config
 
 - name: if journalist secret key is blank insert 32 byte random value
   lineinfile:
@@ -64,11 +84,15 @@
     regexp: "journalist_secret_key"
     line: "    SECRET_KEY = '{{ journalist_secret_key.stdout }}'"
   when: not config.stat.exists
+  tags:
+    - securedrop_config
 
 - name: generating 32 byte value for "scrypt id pepper"
   shell: "head -c 32 /dev/urandom | base64"
   register: scrypt_id_pepper
   when: not config.stat.exists
+  tags:
+    - securedrop_config
 
 - name: if scrypt id pepper is blank insert 32 byte random value
   lineinfile:
@@ -76,11 +100,15 @@
     regexp: "scrypt_id_pepper"
     line: "SCRYPT_ID_PEPPER = '{{ scrypt_id_pepper.stdout }}'"
   when: not config.stat.exists
+  tags:
+    - securedrop_config
 
 - name: generating 32 byte value for "scrypt gpg pepper"
   shell: "head -c 32 /dev/urandom | base64"
   register: scrypt_gpg_pepper
   when: not config.stat.exists
+  tags:
+    - securedrop_config
 
 - name: if scrypt gpg pepper is blank insert 32 byte random value
   lineinfile:
@@ -88,19 +116,30 @@
     regexp: "scrypt_gpg_pepper"
     line: "SCRYPT_GPG_PEPPER = '{{ scrypt_gpg_pepper.stdout }}'"
   when: not config.stat.exists
+  tags:
+    - securedrop_config
 
 - name: verify application gpg fingerprint is defined in config.py
   lineinfile:
     dest: "{{ securedrop_code }}/config.py"
     regexp: "^JOURNALIST_KEY = "
     line: "JOURNALIST_KEY = '{{ securedrop_app_gpg_fingerprint }}'"
+  tags:
+    - gpg
+    - securedrop_config
 
 - stat: path="{{ securedrop_data }}/db.sqlite"
   register: db
+  tags:
+    - database
+    - securedrop_config
 
 - name: initialize sqlite db
   shell: "su -s /bin/bash -c \"PYTHONPATH={{ securedrop_code }} python -c 'import db; db.init_db()'\" {{ securedrop_user }}"
   when: not db.stat.exists
+  tags:
+    - database
+    - securedrop_config
 
   # If using a custom header overwrite the existing one
   # dpkg will not override it on upgrades
@@ -114,3 +153,7 @@
     mode: 400
     backup: yes
   when: securedrop_header_image != ""
+  tags:
+    - logo
+    - securedrop_config
+

--- a/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
+++ b/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
@@ -2,37 +2,58 @@
 - name: install apache packages
   apt: pkg="{{ item }}" state=latest
   with_items: apache_packages
+  tags:
+    - apt
+    - apache
 
 - name: ensure apache configuration files are present
   copy: src={{ item }} dest=/etc/apache2/{{ item }} owner=root mode=0644
   with_items: apache_files
+  tags:
+    - apache
 
 - name: ensure templatized apache configs are present
   template: src={{ item }} dest=/etc/apache2/{{ item }} owner=root mode=0644
   with_items: apache_templates
+  tags:
+    - apache
 
 - name: ensure required apache modules are present
   apache2_module: state=present name={{ item }}
   with_items: apache_modules
+  tags:
+    - apache
 
 - name: ensure non-required apache modules are disabled
   apache2_module: state=absent name={{ item }}
   with_items: apache_disabled_modules
+  tags:
+    - apache
+    - hardening
 
 - name: ensure 000-default site is disabled
   file:
     state: absent
     dest: /etc/apache2/sites-enabled/000-default.conf
+  tags:
+    - apache
+    - hardening
 
 - name: ensure default-ssl site is disabled
   file:
     state: absent
     dest: /etc/apache2/sites-enabled/default-ssl.conf
+  tags:
+    - apache
+    - hardening
 
 - name: ensure default site is disabled
   file:
     state: absent
     dest: /etc/apache2/sites-enabled/default.conf
+  tags:
+    - apache
+    - hardening
 
 - name: ensure securedrop sites are enabled
   file:
@@ -42,3 +63,5 @@
   with_items: apache_sites
   notify:
     - restart apache2
+  tags:
+    - apache

--- a/install_files/ansible-base/roles/app/tasks/setup_cron.yml
+++ b/install_files/ansible-base/roles/app/tasks/setup_cron.yml
@@ -4,3 +4,5 @@
     name: cleanup SecureDrop temp dir
     job: "/var/www/securedrop/manage.py clean_tmp"
     special_time: daily
+  tags:
+    - cron

--- a/install_files/ansible-base/roles/backup/tasks/main.yml
+++ b/install_files/ansible-base/roles/backup/tasks/main.yml
@@ -4,6 +4,10 @@
   # version or to read it from the securedrop_code version.py
 - name: copy the versions collect.py script to the target server /tmp directory
   copy: src=0.3_collect.py dest=/tmp/ owner=root mode=770
+  tags:
+    - collect
+    - script
+    - permissions
 
   # This runs the backup script to collect the tor config, tor services
   # directory, securedrop_data directory, securedrop_code config.py and the
@@ -17,34 +21,54 @@
   async: 300
   poll: 10
   register: backup_filename
+  tags:
+    - collect
+    - script
 
 - name: fetch the created backup file back to the host machine's ansible_base directory
   fetch: src=/tmp/{{ backup_filename.stdout }}.gpg dest=./{{ backup_filename.stdout }}.gpg flat=yes fail_on_missing=yes
+  tags:
+    - fetch
 
 - name: secure delete backup zip requires secure-delete package
   command: srm /tmp/{{ backup_filename.stdout }}
   async: 300
   poll: 10
+  tags:
+    - srm
 
 - name: secure delete the encrypted backup requires secure-delete package
   command: srm /tmp/{{ backup_filename.stdout }}.gpg
   async: 300
   poll: 10
+  tags:
+    - srm
 
 - name: if a restore file is declared copy migrate script to the app server tmp dir
   copy: src=0.3_restore.py dest=/tmp/ owner=root mode=770
   when: backup_zip is defined
+  tags:
+    - script
+    - restore
+    - permissions
 
 - name: if a restore file is defined copy it to the app server tmp dir
   copy: src={{ backup_zip }} dest=/tmp/{{ backup_zip }}
   when: backup_zip is defined
+  tags:
+    - restore
 
 - name: if a restore file is defined run the restore.py script
   shell: /tmp/0.3_restore.py /tmp/{{ backup_zip }}
   when: backup_zip is defined
+  tags:
+    - restore
 
 - name: if a restore file is defined secure delete it
   command: srm /tmp/{{ backup_zip }}
   async: 300
   poll: 10
   when: backup_zip is defined
+  tags:
+    - restore
+    - srm

--- a/install_files/ansible-base/roles/build-generic-pkg/tasks/main.yml
+++ b/install_files/ansible-base/roles/build-generic-pkg/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: run bash script to build generic packages
   command: "{{ securedrop_repo }}/build/build_generic_package.sh {{ package_name }}"
+  tags:
+    - build
+    - script

--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/build_securedrop_app_code_deb.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/build_securedrop_app_code_deb.yml
@@ -2,65 +2,103 @@
 - name: install deb packages required to build securedrop-app-code.deb
   apt: pkg="{{ item }}" state=latest
   with_items: dev_deps
+  tags:
+    - apt
 
 - name: install pip install wheel
   pip: name=wheel
+  tags:
+    - pip
 
 - name: copy install_files/securedrop-app-code dir to build path
   command: creates=/tmp/{{ securedrop_app_code_deb }}/ cp -R {{ securedrop_app_code_deb_config }} /tmp/{{ securedrop_app_code_deb }}/
+  tags:
+    - build
 
 - name: ensure build path var structure exists
   file:
     state: directory
     dest: "/tmp/{{ securedrop_app_code_deb }}/var/"
+  tags:
+    - build
 
 - name: ensure build path www structure exists
   file:
     state: directory
     dest: "/tmp/{{ securedrop_app_code_deb }}/var/www"
+  tags:
+    - build
 
 - name: ensure build path directory for wheelhouse exists
   file:
     state: directory
     dest: "/tmp/{{ securedrop_app_code_deb }}/var/securedrop"
+  tags:
+    - build
 
 - name: copy securedrop to build path
   command: creates=/tmp/{{ securedrop_app_code_deb }}/var/www/{{ build_app_code_dir }} cp -R {{ build_app_code_dir }} /tmp/{{ securedrop_app_code_deb }}/var/www/
+  tags:
+    - build
 
 - name: ensure config.py does not exist in the build path
   file:
     state: absent
     dest: "/tmp/{{ securedrop_app_code_deb }}/var/www/securedrop/config.py"
+  tags:
+    - build
+    - cleanup
 
 - name: make pip wheel archive for our debian package requirements
   command: pip wheel -r {{ securedrop_pip_requirements }} -w /tmp/{{ securedrop_app_code_deb }}/var/securedrop/wheelhouse
+  tags:
+    - pip
+    - build
 
 - name: ensure build dir /etc exists
   file:
     state: directory
     dest: "/tmp/{{ securedrop_app_code_deb }}/etc/"
+  tags:
+    - build
 
 - name: ensure apparmor build dir exists
   file:
     state: directory
     dest: "/tmp/{{ securedrop_app_code_deb }}/etc/apparmor.d"
+  tags:
+    - build
+    - apparmor
 
 - name: copy apparmor profiles to build path
   copy: src={{ item }} dest=/tmp/{{ securedrop_app_code_deb }}/etc/apparmor.d/{{ item }}
   with_items: apparmor_profiles
+  tags:
+    - build
+    - apparmor
 
 - name: create the deb package
   command: creates=/tmp/{{ securedrop_app_code_deb }}.deb dpkg-deb --build /tmp/{{ securedrop_app_code_deb }}
+  tags:
+    - build
 
 - name: move the deb to the Vagrant shared folder
   command: cp /tmp/{{ securedrop_app_code_deb }}.deb {{ securedrop_repo }}/build
+  tags:
+    - build
 
 - name: remove the build temp dir
   file:
     state: absent
     dest: "/tmp/{{ securedrop_app_code_deb }}"
+  tags:
+    - build
+    - cleanup
 
 - name: remove temp package
   file:
     state: absent
     dest: "/tmp/{{ securedrop_app_code_deb }}.deb"
+  tags:
+    - build
+    - cleanup

--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/main.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 - name: apt-get update
   apt: update_cache=yes
+  tags:
+    - apt
+    - build
 
 - include: build_securedrop_app_code_deb.yml

--- a/install_files/ansible-base/roles/common-app/tasks/app_configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/common-app/tasks/app_configure_tor_hidden_services.yml
@@ -4,6 +4,8 @@
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}"
     owner: "{{ tor_user }}"
+  tags:
+    - tor
 
 - name: ensure each hidden service's directory exists
   file:
@@ -11,13 +13,21 @@
     dest: "{{ tor_hidden_services_parent_dir }}/{{ item }}"
     owner: "{{ tor_user }}"
   with_items: app_tor_instances
+  tags:
+    - tor
 
 - name: ensure securedrop app servers torrc is present
   copy: src=torrc-app dest=/etc/tor/torrc owner="{{ tor_user }}" mode=0644
   notify:
     - restart tor
+  tags:
+    - tor
 
 - meta: flush_handlers
+  tags:
+    - tor
 
 - name: ensure tor is running
   service: name=tor state=running
+  tags:
+    - tor

--- a/install_files/ansible-base/roles/common-app/tasks/install_tor.yml
+++ b/install_files/ansible-base/roles/common-app/tasks/install_tor.yml
@@ -3,12 +3,18 @@
   apt_key: >
     state=present
     data="{{ lookup('file', 'tor-signing-key.pub') }}"
+  tags:
+    - apt
+    - tor
 
 - name: setup tor apt repo
   apt_repository: >
     repo='deb http://deb.torproject.org/torproject.org {{ ansible_lsb.codename }} main'
     state=present 
     update_cache=yes
+  tags:
+    - apt
+    - tor
 
 - name: install tor and tor keyring packages
   apt:
@@ -16,3 +22,6 @@
     state: latest
     force: yes
   with_items: ["deb.torproject.org-keyring", "tor"]
+  tags:
+    - apt
+    - tor

--- a/install_files/ansible-base/roles/common-app/tasks/set_etc_hosts_for_prod_env.yml
+++ b/install_files/ansible-base/roles/common-app/tasks/set_etc_hosts_for_prod_env.yml
@@ -7,3 +7,6 @@
     line: "{{ item.ip }}  {{ item.hostname }}"
     regexp: "^{{ item.ip }}    {{ item.hostname }}"
   with_items: ip_info
+  tags:
+    - host_aliases
+    - static-hosts

--- a/install_files/ansible-base/roles/common-mon/tasks/install_tor.yml
+++ b/install_files/ansible-base/roles/common-mon/tasks/install_tor.yml
@@ -3,12 +3,18 @@
   apt_key: >
     state=present
     data="{{ lookup('file', 'tor-signing-key.pub') }}"
+  tags:
+    - apt
+    - tor
 
 - name: setup tor apt repo
   apt_repository: >
     repo='deb http://deb.torproject.org/torproject.org {{ ansible_lsb.codename }} main'
     state=present 
     update_cache=yes
+  tags:
+    - apt
+    - tor
 
 - name: install tor and tor keyring packages
   apt:
@@ -16,3 +22,6 @@
     state: latest
     force: yes
   with_items: ["deb.torproject.org-keyring", "tor"]
+  tags:
+    - apt
+    - tor

--- a/install_files/ansible-base/roles/common-mon/tasks/mon_configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/common-mon/tasks/mon_configure_tor_hidden_services.yml
@@ -4,6 +4,8 @@
     state: directory
     path: "{{ tor_hidden_services_parent_dir }}"
     owner: "{{ tor_user }}"
+  tags:
+    - tor
 
 - name: ensure each hidden service's directory exists
   file:
@@ -11,13 +13,21 @@
     dest: "{{ tor_hidden_services_parent_dir }}/{{ item }}"
     owner: "{{ tor_user }}"
   with_items: mon_tor_instances
+  tags:
+    - tor
 
 - name: ensure securedrop mon servers torrc is present
   copy: src=torrc-mon dest=/etc/tor/torrc owner="{{ tor_user }}" mode=0644
   notify:
     - restart tor
+  tags:
+    - tor
 
 - meta: flush_handlers
+  tags:
+    - tor
 
 - name: ensure tor is running
   service: name=tor state=running
+  tags:
+    - tor

--- a/install_files/ansible-base/roles/common-mon/tasks/set_etc_hosts_for_prod_env.yml
+++ b/install_files/ansible-base/roles/common-mon/tasks/set_etc_hosts_for_prod_env.yml
@@ -7,3 +7,7 @@
     line: "{{ item.ip }}  {{ item.hostname }}"
     regexp: "^{{ item.ip }}    {{ item.hostname }}"
   with_items: ip_info
+  tags:
+    - host_aliases
+    - static-hosts
+

--- a/install_files/ansible-base/roles/common/tasks/apply_grsec_lock.yml
+++ b/install_files/ansible-base/roles/common/tasks/apply_grsec_lock.yml
@@ -5,6 +5,8 @@
   # Check to ensure a restart is needed to apply sysctl grsec lock command
 - stat: path="/proc/sys/kernel/grsecurity/grsec_lock"
   register: grsec_lock
+  tags:
+    - grsec
 
   # If the grsec package is installed (via common role) and the grsec_lock is
   # not present reboot the system, to boot into the grsec kernel.
@@ -15,6 +17,8 @@
   ignore_errors: true
   when: not grsec_lock.stat.exists
   sudo: yes
+  tags:
+    - reboot
 
   # Give the server time to cycle before checking to see if it up
   # The var ansible_ssh_host for what host to check will work in production,
@@ -29,7 +33,13 @@
       state=started
   when: not grsec_lock.stat.exists
   sudo: false
+  tags:
+    - reboot
 
 - sysctl: name="{{ item.name }}" value="{{ item.value }}" sysctl_set=yes state=present reload=yes
   with_items: grsec_sysctl_flags
   sudo: yes
+  tags:
+    - hardening
+    - grsec
+    - sysctl

--- a/install_files/ansible-base/roles/common/tasks/create_users.yml
+++ b/install_files/ansible-base/roles/common/tasks/create_users.yml
@@ -7,10 +7,16 @@
     group=root
     mode=0440
   register: sudoers_st
+  tags:
+    - users
+    - sudoers
 
 - name: ensure sudoers file is installed if syntax check passes
   shell: visudo -q -c -f /etc/sudoers.tmp && cp -f /etc/sudoers.tmp /etc/sudoers
   when: sudoers_st.changed
+  tags:
+    - users
+    - sudoers
 
 - name: ensure secureDrop admin user accounts exist
   user:
@@ -18,6 +24,9 @@
     shell=/bin/bash
     groups=sudo,ssh
   with_items: ssh_users
+  tags:
+    - users
+    - sudoers
 
 - name: copy SecureDrop bashrc additions
   copy:
@@ -26,6 +35,9 @@
     owner: root
     group: root
     mode: 0644
+  tags:
+    - users
+    - environment
 
 - name: add line to each users bashrc to source the SecureDrop additions
   lineinfile:
@@ -33,3 +45,6 @@
     line: ". /etc/bashrc.securedrop_additions"
     insertbefore: BOF
   with_items: ssh_users
+  tags:
+    - users
+    - environment

--- a/install_files/ansible-base/roles/common/tasks/cron_apt.yml
+++ b/install_files/ansible-base/roles/common/tasks/cron_apt.yml
@@ -1,39 +1,66 @@
 ---
 - name: install cron-apt to handle unattended security upgrades
   apt: name=cron-apt state=latest
+  tags:
+    - apt
+    - cron-apt
 
 - name: ensure custom cron-apt config file is present
   copy: src=cron-apt-config dest=/etc/cron-apt/config
+  tags:
+    - apt
+    - cron-apt
 
 - name: ensure security.list file exists
   template:
     src: security.list
     dest: /etc/apt/security.list
+  tags:
+    - apt
 
 - name: ensure cron-apt updates the security.list packages
   copy: src=0-update dest=/etc/cron-apt/action.d/0-update
+  tags:
+    - apt
+    - cron-apt
 
 - name: ensure cron-apt upgrades the secruity.list packages
   copy: src=5-security dest=/etc/cron-apt/action.d/5-security
+  tags:
+    - apt
+    - cron-apt
 
   # The default config file would download all security update every night
   # regardless if they were a security update. we only need it download and
   # install the security updates.
 - name: ensure default cron-apt file to download all updates does not exist
   file: dest=/etc/cron-apt/action.d/3-download state=absent
+  tags:
+    - apt
+    - cron-apt
 
 - name: ensure the cron.d config for cron-apt exists
   copy: src=cron-apt dest=/etc/cron.d/cron-apt mode=644 owner=root
+  tags:
+    - apt
+    - cron-apt
 
 - name: perform safe upgrade to ensure all the packages are updated
   apt: upgrade=safe
+  tags:
+    - apt
+    - apt-upgrade
 
 - stat: path=/var/run/reboot-required
   register: reboot_required
+  tags:
+    - reboot
 
 - name: reboot if required due to security updates
   command: reboot
   when: reboot_required.stat.exists
+  tags:
+    - reboot
 
 - name: waiting for server to come back
   local_action:
@@ -44,3 +71,5 @@
       state=started
   when: reboot_required.stat.exists
   sudo: false
+  tags:
+    - reboot

--- a/install_files/ansible-base/roles/common/tasks/from_fpf_repo_install_grsec.yml
+++ b/install_files/ansible-base/roles/common/tasks/from_fpf_repo_install_grsec.yml
@@ -8,28 +8,57 @@
   # Disabling calling that script during login.
 - name: remove motd pam module from ssh logins
   lineinfile: dest=/etc/pam.d/sshd regexp=pam.motd state=absent backup=yes
+  tags:
+    - motd
+    - grsecurity
 
 - name: install grsec predepends paxctl package
   apt: pkg=paxctl state=present
+  tags:
+    - apt
+    - paxctl
+    - kernel
+    - hardening
 
 - name: make the required grub paxctl changes
   command: paxctl -Cpm {{ item }}
   with_items: grub_pax
+  tags:
+    - paxctl
+    - kernel
+    - hardening
 
 - name: install grsec package from fpf repo
   apt: pkg={{ grsec_package }} state=latest
   async: 300
   poll: 10
+  tags:
+    - apt
+    - grsec
+    - kernel
+    - hardening
 
 - name: get grsec kernel string
   shell: grep menuentry /boot/grub/grub.cfg | grep grsec | grep -v recovery | head -1 | cut -d "'" -f2
   register: grsec_str
+  tags:
+    - grsec
+    - kernel
+    - hardening
 
 - name: set grsec kernel as default for next boot
   command: grub-reboot "Advanced options for Ubuntu>{{ grsec_str.stdout }}"
+  tags:
+    - grsec
+    - kernel
+    - hardening
 
 - stat: path="/proc/sys/kernel/grsecurity/grsec_lock"
   register: running_grsec
+  tags:
+    - grsec
+    - kernel
+    - hardening
 
 - name: reboot into the grsec kernel
   command: shutdown -r now "Rebooting into the grsec kernel..."
@@ -39,6 +68,9 @@
   when: not running_grsec.stat.exists
   tags:
     - reboot
+    - grsec
+    - kernel
+    - hardening
 
 - name: waiting for server to come back
   local_action:
@@ -51,21 +83,36 @@
   when: not running_grsec.stat.exists
   tags:
     - reboot
+    - grsec
+    - kernel
+    - hardening
 
 - name: remove generic kernel metapackages
   apt: name=linux-signed-image-generic-lts-utopic state=absent
   apt: name=linux-signed-image-generic state=absent
   apt: name=linux-signed-generic-lts-utopic state=absent
   apt: name=linux-signed-generic state=absent
+  tags: 
+    - apt
 
 - name: remove remaining generic kernels
   command: apt-get -y remove '^linux-image-.*generic$'
+  tags: 
+    - apt
 
 - name: remove remaining kernel headers
   command: apt-get -y remove '^linux-headers-.*'
+  tags: 
+    - apt
 
 - name: mark GRUB2 as manually installed so its not removed
   command: apt-mark manual grub-pc
+  tags:
+    - apt
+    - kernel
+    - grub
 
 - name: cleanup any dependencies left
   command: apt-get -y autoremove
+  tags:
+    - apt

--- a/install_files/ansible-base/roles/common/tasks/harden_dns.yml
+++ b/install_files/ansible-base/roles/common/tasks/harden_dns.yml
@@ -3,3 +3,6 @@
   template:
     src: dns_base
     dest: /etc/resolvconf/resolv.conf.d/base
+  tags:
+    - dns
+    - hardening

--- a/install_files/ansible-base/roles/common/tasks/install_ntp.yml
+++ b/install_files/ansible-base/roles/common/tasks/install_ntp.yml
@@ -3,3 +3,6 @@
     pkg: ntp
     state: latest
     force: yes
+  tags:
+    - apt
+    - ntp

--- a/install_files/ansible-base/roles/common/tasks/main.yml
+++ b/install_files/ansible-base/roles/common/tasks/main.yml
@@ -26,3 +26,5 @@
 
 - name: disable swap space
   command: swapoff -a
+  tags:
+    - swapspace

--- a/install_files/ansible-base/roles/common/tasks/remove_kernel_modules.yml
+++ b/install_files/ansible-base/roles/common/tasks/remove_kernel_modules.yml
@@ -2,7 +2,13 @@
 - name: remove kernel modules
   modprobe: name="{{ item }}" state=absent
   with_items: disabled_kernel_modules
+  tags:
+    - kernel
+    - hardening
 
 - name: add disabled kernels modules to modprobe.d blacklist
   lineinfile: dest=/etc/modprobe.d/blacklist.conf line="blacklist {{ item }}" insertafter=EOF
   with_items: disabled_kernel_modules
+  tags:
+    - kernel
+    - hardening

--- a/install_files/ansible-base/roles/common/tasks/sysctl.yml
+++ b/install_files/ansible-base/roles/common/tasks/sysctl.yml
@@ -1,3 +1,6 @@
 ---
 - sysctl: name="{{ item.name }}" value="{{ item.value }}" sysctl_set=yes state=present reload=yes
   with_items: sysctl_flags
+  tags:
+    - sysctl
+    - hardening

--- a/install_files/ansible-base/roles/development/tasks/main.yml
+++ b/install_files/ansible-base/roles/development/tasks/main.yml
@@ -1,13 +1,22 @@
 ---
 - name: update apt package lists
   apt: update_cache=yes
+  tags:
+    - apt
+    - development
 
 - name: install apt package deps for dev environment
   apt: pkg="{{ item }}" state=latest
   with_items: dev_deps
+  tags:
+    - apt
+    - development
 
 - name: install pip dependencies for securedrop
   pip: requirements="{{ securedrop_pip_requirements }}"
+  tags:
+    - pip
+    - development
 
 - name: set SECUREDROP_ENV in bashrc
   lineinfile:
@@ -15,3 +24,6 @@
     state: present
     insertafter: EOF
     line: "export SECUREDROP_ENV=dev"
+  tags:
+    - environment
+    - development

--- a/install_files/ansible-base/roles/install_fpf_repo/tasks/main.yml
+++ b/install_files/ansible-base/roles/install_fpf_repo/tasks/main.yml
@@ -3,9 +3,15 @@
   apt_key: >
     state=present
     data="{{ lookup('file', 'fpf-signing-key.pub') }}"
+  tags:
+    - apt
+    - fpf_repo
 
 - name: setup fpf apt repo
   apt_repository: >
     repo='deb [arch=amd64] {{ apt_repo_url }} {{ ansible_lsb.codename }} main'
     state=present
     update_cache=yes
+  tags:
+    - apt
+    - fpf_repo

--- a/install_files/ansible-base/roles/install_local_pkgs/tasks/main.yml
+++ b/install_files/ansible-base/roles/install_local_pkgs/tasks/main.yml
@@ -3,6 +3,8 @@
 - name: if defined copy local deb packages to target system
   copy: src=../../build/{{ item }} dest=/root/
   with_items: local_deb_packages
+  tags:
+    - install_local_pkgs
 
 # This should use the ansible apt module
 # apt: deb=/root/{{ item }}
@@ -11,3 +13,5 @@
 - name: if defined install local deb packages
   shell: "dpkg -i /root/{{ item }} || true && apt-get -f install -y"
   with_items: local_deb_packages
+  tags:
+    - install_local_pkgs

--- a/install_files/ansible-base/roles/ossec_agent/tasks/main.yml
+++ b/install_files/ansible-base/roles/ossec_agent/tasks/main.yml
@@ -1,12 +1,18 @@
 ---
 - name: ensure securedrop-ossec-agent package is installed
   apt: name=securedrop-ossec-agent state=present
+  tags:
+    - apt
 
 - stat: path=/var/ossec/etc/client.keys
   register: ossec_client_keys
+  tags:
+    - ossec_auth
 
 - stat: path=/etc/network/iptables/rules_v4
   register: iptables_rules
+  tags:
+    - iptables
 
 - name: if agent is not already added add agent_auth firewall exmeptions rules
   lineinfile:
@@ -20,10 +26,15 @@
     - reload iptables rules
   with_items: agent_auth_rules
   when: iptables_rules.stat.exists and not ossec_client_keys.stat.exists
+  tags:
+    - iptables
+    - ossec_auth
 
 - name: run agent auth
   shell: /var/ossec/bin/agent-auth -m {{ monitor_ip }} -p 1515 -A {{ app_hostname }}
   when: not ossec_client_keys.stat.exists
+  tags:
+    - ossec_auth
 
   # If the OSSEC agent auth iptable rule exemptions are in place remove them and
   # restart OSSEC. This order does matter. The app server's
@@ -41,3 +52,6 @@
     - restart ossec
   with_items: agent_auth_rules
   when: iptables_rules.stat.exists
+  tags:
+    - iptables
+    - ossec_auth

--- a/install_files/ansible-base/roles/ossec_server/tasks/authd.yml
+++ b/install_files/ansible-base/roles/ossec_server/tasks/authd.yml
@@ -6,23 +6,34 @@
 - name: check to see if app agent already exists
   shell: /var/ossec/bin/list_agents -a
   register: list_agents
+  tags:
+    - ossec_auth
 
 - name: create authd SSL keys
   shell: creates=/var/ossec/etc/sslmanager.key openssl genrsa -out /var/ossec/etc/sslmanager.key 4096
   when: list_agents != "{{ app_hostname }}-{{ app_ip }} is available."
+  tags:
+    - ossec_auth
 
 - name: create ssl cert
   shell: creates=/var/ossec/etc/sslmanager.cert openssl req -new -x509 -batch -subj "/CA=AU/ST=Some-State/locality=city/O=Internet Widgits Pty Ltd/commonName=mon/organizationUnitName=section/emailAddress=admin@localhost" -key /var/ossec/etc/sslmanager.key -out /var/ossec/etc/sslmanager.cert -days 365
   when: list_agents != "{{ app_hostname }}-{{ app_ip }} is available."
+  tags:
+    - ossec_auth
 
 - stat: path=/etc/network/iptables/rules_v4
   register: iptables_rules
   notify: add firewall rule exemption for authd
   notify: reload authd iptables
   when: list_agents.stdout != "{{ app_hostname }}-{{ app_ip }} is available."
+  tags:
+    - ossec_auth
+    - iptables
 
 - name: start authd
   shell: "/var/ossec/bin/ossec-authd -i {{ app_ip }} -p 1515 >/dev/null 2>&1 &"
   async: 0
   poll: 0
   when: list_agents.stdout != "{{ app_hostname }}-{{ app_ip }} is available."
+  tags:
+    - ossec_auth

--- a/install_files/ansible-base/roles/ossec_server/tasks/mon_configure_ossec_gpg_alerts.yml
+++ b/install_files/ansible-base/roles/ossec_server/tasks/mon_configure_ossec_gpg_alerts.yml
@@ -1,17 +1,26 @@
 ---
 - name: ensure ossec server package is installed
   apt: name=securedrop-ossec-server state=present
+  tags:
+    - apt
 
 - name: ensure procmail is installed
   apt: name=procmail state=latest
+  tags:
+    - apt
+    - procmail
 
 - name: copy the ossec alert gpg public key to the monitor server
   copy:
     src: "{{ ossec_alert_gpg_public_key }}"
     dest: "/var/ossec"
+  tags:
+    - gpg
 
 - name: ensure ossec alert gpg public key is in the ossec keyring
   command: "su -s /bin/bash -c \"gpg --homedir /var/ossec/.gnupg --import /var/ossec/{{ ossec_alert_gpg_public_key }}\" {{ ossec_group }}"
+  tags:
+    - gpg
 
 - name: ensure send_encrypted_alarm script is present
   template:
@@ -20,6 +29,9 @@
     mode: 775
     owner: ossec
     group: root
+  tags:
+    - procmail
+    - permissions
 
   # TODO This might not be necessary
 - name: create procmail log file
@@ -29,6 +41,10 @@
     mode: 660
     owner: ossec
     group: root
+  tags:
+    - procmail
+    - permissions
+    - logging
 
 - name: ensure procmail config is present
   copy:
@@ -36,3 +52,5 @@
     dest: /var/ossec/.procmailrc
     owner: ossec
     group: root
+  tags:
+    - procmail

--- a/install_files/ansible-base/roles/ossec_server/tasks/mon_install_postfix.yml
+++ b/install_files/ansible-base/roles/ossec_server/tasks/mon_install_postfix.yml
@@ -2,12 +2,17 @@
 - name: install postfix
   apt: pkg={{ item }} state=latest
   with_items: ossec_postfix_dependencies
+  tags:
+    - apt
+    - postfix
 
 - name: ensure postfix /etc/aliases is present and configured for ossec
   copy:
     src: aliases
     dest: /etc/aliases
   notify: update aliases
+  tags:
+    - postfix
 
 - name: configure sasl password for smtp relay
   template:
@@ -15,17 +20,25 @@
     dest: /etc/postfix/sasl_passwd
     mode: 0400
   notify: update sasl_passwd db
+  tags:
+    - postfix
+    - permissions
 
 - name: ensure header_checks regex to strip smtp headers is present
   copy:
     src: header_checks
     dest: /etc/postfix/header_checks
   notify: postmap_header_checks
+  tags:
+    - postfix
+    - hardening
 
 - name: configure postfix main.cf
   template:
     src: main.cf
     dest: /etc/postfix/main.cf
   notify: restart postfix
+  tags:
+    - postfix
 
 # TODO - name: configure postfix proxy

--- a/install_files/ansible-base/roles/reboot/tasks/main.yml
+++ b/install_files/ansible-base/roles/reboot/tasks/main.yml
@@ -5,3 +5,5 @@
   poll: 0
   ignore_errors: true
   sudo: yes
+  tags:
+    - reboot

--- a/install_files/ansible-base/roles/remove_authd_exemptions/tasks/main.yml
+++ b/install_files/ansible-base/roles/remove_authd_exemptions/tasks/main.yml
@@ -16,6 +16,9 @@
     - reload iptables rules
     - restart ossec
   with_items: authd_rules
+  tags:
+    - iptables
+    - ossec_auth
 
 - name: kill authd if it is running
   # This should work using the pattern to grep for in the output of ps per
@@ -25,3 +28,7 @@
   #  msg: service not found: ossec-authd
   #service: name=ossec-authd pattern=/var/ossec/bin/ossec-authd state=started
   shell: "pkill ossec-authd || true"
+  tags:
+    - iptables
+    - ossec_auth
+    - authd

--- a/install_files/ansible-base/roles/restrict_direct_access_app/tasks/app_display_onions.yml
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/tasks/app_display_onions.yml
@@ -2,15 +2,29 @@
 - name: wait for all tor hidden services hostname files
   wait_for: state=present path="{{ tor_hidden_services_parent_dir }}/{{ item }}/hostname" delay=5
   with_items: app_tor_instances
+  tags:
+    - tor
 
 - name: fetch securedrop source ths
   fetch: src=/var/lib/tor/services/source/hostname dest=./app-source-ths flat=yes fail_on_missing=yes
+  tags:
+    - tor
+    - fetch
+    - admin
 
 - name: fetch securedrop document aths
   fetch: src=/var/lib/tor/services/document/hostname dest=./app-document-aths flat=yes fail_on_missing=yes
+  tags:
+    - tor
+    - fetch
+    - admin
 
 - name: fetch securedrop ssh aths
   fetch: src=/var/lib/tor/services/ssh/hostname dest=./app-ssh-aths flat=yes fail_on_missing=yes
+  tags:
+    - tor
+    - fetch
+    - admin
 
   # These tasks modifies the fetched copy of the server's aths info to
   # format it for a torrc file on the admins workstation.
@@ -19,7 +33,13 @@
 - name: format securedrop document aths
   local_action: lineinfile dest=./app-document-aths regexp='(.*)' backrefs=yes line='HidServAuth \1'
   sudo: no
+  tags:
+    - tor
+    - admin
 
 - name: format app ssh aths
   local_action: lineinfile dest=./app-ssh-aths regexp='(.*)' backrefs=yes line='HidServAuth \1'
   sudo: no
+  tags:
+    - tor
+    - admin

--- a/install_files/ansible-base/roles/restrict_direct_access_app/tasks/app_iptables.yml
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/tasks/app_iptables.yml
@@ -17,6 +17,9 @@
 
 - name: ensure load_iptables script is present
   copy: src=load_iptables dest=/etc/network/if-up.d/load_iptables owner=root mode=0744
+  tags:
+    - iptables
+    - permissions
 
 - name: ensure iptables directory exists
   file:
@@ -25,6 +28,12 @@
     owner: root
     group: root
     dest: /etc/network/iptables
+  tags:
+    - iptables
+    - permissions
 
 - name: ensure iptables rules_v4 file is present
   template: src=app_rules_v4 dest=/etc/network/iptables/rules_v4 owner=root mode=0644
+  tags:
+    - iptables
+    - permissions

--- a/install_files/ansible-base/roles/restrict_direct_access_app/tasks/ssh.yml
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/tasks/ssh.yml
@@ -2,15 +2,30 @@
 - name: install 2fa pam module for ssh access
   apt: name="{{ item }}" state=latest
   with_items: ssh_2fa_dependencies
+  tags:
+    - apt
+    - 2fa
+    - ssh
+    - pam
 
 - name: ensure ssh configuration files are present
   copy: src={{ item }} dest=/etc/ssh/{{ item }} owner=root mode=0644
   with_items:
    - sshd_config
    - ssh_config
+  tags:
+    - ssh
+    - 2fa
+    - permissions
 
 - name: ensure pam config is installed
   copy: src="common-auth" dest="/etc/pam.d/" owner=root mode=0644
+  tags:
+    - ssh
+    - pam
+    - permissions
 
 - name: ensure sshd is running
   service: name=ssh state=running
+  tags:
+    - ssh

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/tasks/mon_display_onions.yml
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/tasks/mon_display_onions.yml
@@ -2,9 +2,15 @@
 - name: wait for all tor hidden services hostname files
   wait_for: state=present path="{{ tor_hidden_services_parent_dir }}/{{ item }}/hostname" delay=5
   with_items: mon_tor_instances
+  tags:
+    - tor
 
 - name: fetch securedrop ssh aths
   fetch: src=/var/lib/tor/services/ssh/hostname dest=./mon-ssh-aths flat=yes fail_on_missing=yes
+  tags:
+    - tor
+    - fetch
+    - admin
 
   # These tasks modifies the fetched copy of the server's aths info to
   # format it for a torrc file on the admins workstation.
@@ -13,3 +19,6 @@
 - name: format mon ssh aths
   local_action: lineinfile dest=./mon-ssh-aths regexp='(.*)' backrefs=yes line='HidServAuth \1'
   sudo: no
+  tags:
+    - tor
+    - admin

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/tasks/mon_iptables.yml
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/tasks/mon_iptables.yml
@@ -17,6 +17,9 @@
 
 - name: ensure load_iptables script is present
   copy: src=load_iptables dest=/etc/network/if-up.d/load_iptables owner=root mode=0744
+  tags:
+    - iptables
+    - permissions
 
 - name: ensure iptables directory exists
   file:
@@ -25,6 +28,9 @@
     owner: root
     group: root
     dest: /etc/network/iptables
+  tags:
+    - iptables
+    - permissions
 
   # This task needs to be in the same host group as allow-direct-access
   # playbook. and be the last set of roles ran in the playbook. For the initial
@@ -34,3 +40,6 @@
   # manually rebooted for production installs.
 - name: ensure iptables rules_v4 file is present
   template: src=mon_rules_v4 dest=/etc/network/iptables/rules_v4 owner=root mode=0644
+  tags:
+    - iptables
+    - permissions

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/tasks/ssh.yml
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/tasks/ssh.yml
@@ -2,15 +2,30 @@
 - name: install 2fa pam module for ssh access
   apt: name="{{ item }}" state=latest
   with_items: ssh_2fa_dependencies
+  tags:
+    - apt
+    - 2fa
+    - ssh
+    - pam
 
 - name: ensure ssh configuration files are present
   copy: src={{ item }} dest=/etc/ssh/{{ item }} owner=root mode=0644
   with_items:
    - sshd_config
    - ssh_config
+  tags:
+    - ssh
+    - 2fa
+    - permissions
 
 - name: ensure pam config is installed
   copy: src="common-auth" dest="/etc/pam.d/" owner=root mode=0644
+  tags:
+    - ssh
+    - pam
+    - permissions
 
 - name: ensure sshd is running
   service: name=ssh state=running
+  tags:
+    - ssh

--- a/install_files/ansible-base/roles/validate/tasks/main.yml
+++ b/install_files/ansible-base/roles/validate/tasks/main.yml
@@ -5,24 +5,48 @@
 
 - debug: msg="verifying ssh_users is not set to vagrant"
   failed_when: ssh_users == "vagrant"
+  tags:
+    - validate
+    - debug
 
 - debug: msg="verifying securedrop_app_gpg_fingerprint is not the journalist test key"
   failed_when: securedrop_app_gpg_fingerprint == "65A1B5FF195B56353CC63DFFCC40EF1228271441"
+  tags:
+    - validate
+    - debug
 
 - debug: msg="verifying securedrop_app_gpg_fingerprint is not the admin test key"
   failed_when: securedrop_app_gpg_fingerprint == "600BC6D5142C68F35DDBCEA87B597104EDDDC102"
+  tags:
+    - validate
+    - debug
 
 - debug: msg="verifying ossec_gpg_fpr is not the journalist test key"
   failed_when: securedrop_app_gpg_fingerprint == "65A1B5FF195B56353CC63DFFCC40EF1228271441"
+  tags:
+    - validate
+    - debug
 
 - debug: msg="verifying ossec_gpg_fpr is not the admin test key"
   failed_when: ossec_gpg_fpr == "600BC6D5142C68F35DDBCEA87B597104EDDDC102"
+  tags:
+    - validate
+    - debug
 
 - debug: msg="verifying ossec_alert_email is not the test value"
   failed_when: ossec_alert_email == "ossec@ossec.test"
+  tags:
+    - validate
+    - debug
 
 - debug: msg="verifying sasl_username is not test value"
   failed_when: sasl_username == "test"
+  tags:
+    - validate
+    - debug
 
 - debug: msg="verifying sasl_password is not the insane test value"
   failed_when: sasl_password == "password123"
+  tags:
+    - validate
+    - debug

--- a/install_files/ansible-base/securedrop-development.yml
+++ b/install_files/ansible-base/securedrop-development.yml
@@ -7,8 +7,8 @@
     - development-specific.yml
 
   roles:
-    - development
-    - app
-    - app-test
+    - { role: development, tags: development }
+    - { role: app, tags: app }
+    - { role: app-test, tags: app-test }
 
   sudo: yes

--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -6,8 +6,8 @@
     - prod-specific.yml
 
   roles:
-    - install_fpf_repo
-    - common
+    - { role: install_fpf_repo, tags: fpf_repo }
+    - { role: common, tags: common }
 
   sudo: yes
 
@@ -20,9 +20,9 @@
     - prod-specific.yml
 
   roles:
-    - { role: validate, tags: [ 'validate' ] }
-    - common-mon
-    - ossec_server
+    - { role: validate, tags: validate }
+    - { role: common-mon, tags: 'tor' }
+    - { role: ossec_server, tags: ['ossec', 'ossec_server'] }
 
   sudo: yes
 
@@ -36,10 +36,10 @@
   vars:
 
   roles:
-    - { role: validate, tags: [ 'validate' ] }
-    - common-app
-    - ossec_agent
-    - app
+    - { role: validate, tags: validate }
+    - { role: common-app, tags: ['common-app', 'tor'] }
+    - { role: ossec_agent, tags: [ 'ossec', 'ossec_agent' ] }
+    - { role: app, tags: app }
 
   sudo: yes
 
@@ -60,7 +60,7 @@
     - prod-specific.yml
 
   roles:
-    - remove_authd_exemptions
+    - { role: remove_authd_exemptions, tags: ['ossec', 'ossec_server', 'remove_authd_exemptions' ] }
 
   sudo: yes
 
@@ -78,8 +78,8 @@
     - prod-specific.yml
 
   roles:
-    - restrict_direct_access_app
-    - { role: backup, tags: [ 'backup' ] }
+    - { role: restrict_direct_access_app, tags: [ 'common', 'restrict_direct_access', 'restrict_direct_access_app' ] }
+    - { role: backup, tags: backup }
 
   sudo: yes
 
@@ -91,13 +91,13 @@
     - prod-specific.yml
 
   roles:
-    - restrict_direct_access_mon
+    - { role: restrict_direct_access_mon, tags: [ 'common', 'restrict_direct_access', 'restrict_direct_access_mon' ] }
 
   sudo: yes
 
 - hosts: [ 'app', 'mon', 'app-prod', 'mon-prod' ]
 
   roles:
-    - reboot
+    - { role: reboot, tags: reboot }
 
   sudo: yes

--- a/install_files/ansible-base/securedrop-staging.yml
+++ b/install_files/ansible-base/securedrop-staging.yml
@@ -6,8 +6,8 @@
     - staging-specific.yml
 
   roles:
-    - { role: install_fpf_repo, tags: [ 'fpf_repo' ] }
-    - { role: common, tags: [ 'common' ] }
+    - { role: install_fpf_repo, tags: fpf_repo }
+    - { role: common, tags: common }
 
   sudo: yes
 
@@ -19,10 +19,10 @@
     - staging-specific.yml
 
   roles:
-    - { role: common-mon, tags: [ 'tor' ] }
+    - { role: common-mon, tags: 'tor' }
     # this is a staging only role
-    - { role: install_local_pkgs, tags: [ 'install_local_pkgs' ] }
-    - ossec_server
+    - { role: install_local_pkgs, tags: install_local_pkgs }
+    - { role: ossec_server, tags: ['ossec', 'ossec_server'] }
 
   sudo: yes
 
@@ -38,12 +38,12 @@
     # It installs tor. Tor is required to be installed prior to the securedrop
     # app-code package which contains an apparmor profile that depends on tor
     # being present.
-    - { role: common-app, tags: [ 'tor' ] }
+    - { role: common-app, tags: ['common-app', 'tor'] }
     # this is a staging only role
-    - { role: install_local_pkgs, tags: [ 'install_local_pkgs' ] }
-    - { role: ossec_agent, tags: [ 'ossec' ] }
-    - app
-    - { role: app-test, tags: [ 'app-test' ] }
+    - { role: install_local_pkgs, tags: install_local_pkgs }
+    - { role: ossec_agent, tags: [ 'ossec', 'ossec_agent' ] }
+    - { role: app, tags: app }
+    - { role: app-test, tags: app-test }
 
   sudo: yes
 
@@ -63,7 +63,7 @@
     - staging-specific.yml
 
   roles:
-    - { role: remove_authd_exemptions, tags: [ 'ossec' ] }
+    - { role: remove_authd_exemptions, tags: ['ossec', 'ossec_server', 'remove_authd_exemptions' ] }
 
   sudo: yes
 
@@ -81,9 +81,9 @@
     - staging-specific.yml
 
   roles:
-    - { role: restrict_direct_access_app, tags: [ 'common' ] }
-    - { role: allow_direct_access, tags: [ 'common' ] }
-    - { role: backup, tags: [ 'backup' ] }
+    - { role: restrict_direct_access_app, tags: [ 'common', 'restrict_direct_access', 'restrict_direct_access_app' ] }
+    - { role: allow_direct_access, tags: [ 'common', 'allow_direct_access' ] }
+    - { role: backup, tags: backup }
 
   sudo: yes
 
@@ -95,7 +95,7 @@
     - staging-specific.yml
 
   roles:
-    - { role: restrict_direct_access_mon, tags: [ 'common' ] }
-    - { role: allow_direct_access, tags: [ 'common' ] }
+    - { role: restrict_direct_access_mon, tags: [ 'common', 'restrict_direct_access', 'restrict_direct_access_mon' ] }
+    - { role: allow_direct_access, tags: [ 'common', 'allow_direct_access' ] }
 
   sudo: yes

--- a/install_files/ansible-base/securedrop-travis.yml
+++ b/install_files/ansible-base/securedrop-travis.yml
@@ -7,8 +7,8 @@
     - travis-specific.yml
 
   roles:
-    - development
-    - app
-    - app-test
+    - { role: development, tags: development }
+    - { role: app, tags: app }
+    - { role: app-test, tags: app-test }
 
   sudo: yes


### PR DESCRIPTION
Added tags throughout all Ansible roles, as well as to the `securedrop-prod.yml` playbook. No functionality changes here, just lots more tags. An admin can now target much smaller sections of the provisioning process to rerun. For example, running against the `securedrop-prod.yml` playbook with `--list-tasks --tags postfix` displays these tasks:

```
playbook: install_files/ansible-base/securedrop-prod.yml

  play #1 (mon;app;mon-prod;app-prod):  TAGS: []

  play #2 (mon;mon-prod):       TAGS: []
    install postfix     TAGS: [apt, ossec, ossec_server, postfix]
    ensure postfix /etc/aliases is present and configured for ossec     TAGS: 
[ossec, ossec_server, postfix]
    configure sasl password for smtp relay      TAGS: [ossec, ossec_server, 
permissions, postfix]
    ensure header_checks regex to strip smtp headers is present TAGS: 
[hardening, ossec, ossec_server, postfix]
    configure postfix main.cf   TAGS: [ossec, ossec_server, postfix]

  play #3 (app;app-prod):       TAGS: []

  play #4 (mon;mon-prod):       TAGS: []

  play #5 (app;app-prod):       TAGS: []

  play #6 (mon;mon-prod):       TAGS: []

  play #7 (app;mon;app-prod;mon-prod):  TAGS: []
```
That's much more efficient than rerunning the whole playbook, or even using `--start-at-task` to jump in at a certain point in the playbook. 
### Before
```
playbook: install_files/ansible-base/securedrop-prod.yml

  play #1 (mon;app;mon-prod;app-prod):  TAGS: []
    TASK TAGS: [grsec, reboot]

  play #2 (mon;mon-prod):       TAGS: []
    TASK TAGS: [authd, static-hosts, validate]

  play #3 (app;app-prod):       TAGS: []
    TASK TAGS: [non-development, static-hosts, validate]

  play #4 (mon;mon-prod):       TAGS: []
    TASK TAGS: []

  play #5 (app;app-prod):       TAGS: []
    TASK TAGS: [backup]

  play #6 (mon;mon-prod):       TAGS: []
    TASK TAGS: []

  play #7 (app;mon;app-prod;mon-prod):  TAGS: []
    TASK TAGS: []
```

### After
```
playbook: install_files/ansible-base/securedrop-prod.yml

  play #1 (mon;app;mon-prod;app-prod):  TAGS: []
    TASK TAGS: [apt, apt-upgrade, common, cron-apt, dns, environment, fpf_repo, 
grsec, grsecurity, grub, hardening, kernel, motd, ntp, paxctl, reboot, sudoers, 
swapspace, sysctl, users]

  play #2 (mon;mon-prod):       TAGS: []
    TASK TAGS: [apt, authd, debug, gpg, hardening, host_aliases, iptables, 
logging, ossec, ossec_auth, ossec_server, permissions, postfix, procmail, 
static-hosts, tor, validate]

  play #3 (app;app-prod):       TAGS: []
    TASK TAGS: [apache, app, apt, common-app, cron, database, debug, gpg, 
hardening, haveged, host_aliases, iptables, logging, logo, non-development, 
ossec, ossec_agent, ossec_auth, permissions, securedrop_config, static-hosts, 
supervisor, tor, validate]

  play #4 (mon;mon-prod):       TAGS: []
    TASK TAGS: [authd, iptables, ossec, ossec_auth, ossec_server, 
remove_authd_exemptions]

  play #5 (app;app-prod):       TAGS: []
    TASK TAGS: [2fa, admin, apt, backup, collect, common, fetch, iptables, pam, 
permissions, restore, restrict_direct_access, restrict_direct_access_app, 
script, srm, ssh, tor]

  play #6 (mon;mon-prod):       TAGS: []
    TASK TAGS: [2fa, admin, apt, common, fetch, iptables, pam, permissions, 
restrict_direct_access, restrict_direct_access_mon, ssh, tor]

  play #7 (app;mon;app-prod;mon-prod):  TAGS: []
    TASK TAGS: [reboot]
```

Further changes to tags will come as part of the Ansible reorg, but this is a good enough start. This PR closes #958.