### PR TITLE
Forbid sudo in 0.3 upgrade script

### DIFF
--- a/docs/0.3-pre-upgrade-to-0.3.3.md
+++ b/docs/0.3-pre-upgrade-to-0.3.3.md
@@ -42,7 +42,7 @@ Run the 0.3 upgrade helper script. This script will do some basic sanity checks 
 
 * Run the upgrade helper script
 
-  `sudo ./migration_scripts/0.3pre/upgrade.sh`
+  `./migration_scripts/0.3pre/upgrade.sh`
 
 ## Notes about the 0.3 upgrade helper script
 

--- a/migration_scripts/0.3pre/upgrade.sh
+++ b/migration_scripts/0.3pre/upgrade.sh
@@ -26,6 +26,19 @@ function parse_yaml {
 HOMEDIR=/home/amnesia
 ANSIBLE_BASE=$HOMEDIR/Persistent/securedrop/install_files/ansible-base
 
+# check for elevated privileges. running with `sudo` will
+# cause script to fail on SSH connections, since only the normal
+# user has access to the ssh-agent keychain for the ATHS connections.
+if [[ $UID == 0 ]]; then
+  cat <<-EOS
+  This script should not be run as root.
+  If elevated privileges are required to install
+  additional packages, you will be prompted to enter
+  your sudo password.
+EOS
+  exit 1
+fi
+
 # check for persistence
 if [[ ! -d /live/persistence/TailsData_unlocked ]]; then
   echo "Error: This script must be run on Tails with a persistent volume." 1>&2


### PR DESCRIPTION
Modified upgrade docs for 0.3pre versions. Previously the docs recommended invoking `migration_scripts/0.3pre/upgrade.sh` with `sudo`, but this caused silent failure during connection to the ATHS via SSH. This particular failure may only affect admins with a passphrase-protected SSH key on the admin workstation. Currently our installation docs recommend using a passphrase, so we should expect that circumstance and plan accordingly.

The script at `migration_scripts/0.3pre/upgrade.sh` now checks for `UID == 0` and bails out if detected, with a helpful message:

```
  This script should not be run as root.
  If elevated privileges are required to install
  additional packages, you will be prompted to enter
  your sudo password.
```