### PR TITLE
Fix tor service permissions

### DIFF
--- a/install_files/ansible-base/roles/common-app/tasks/app_configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/common-app/tasks/app_configure_tor_hidden_services.yml
@@ -4,6 +4,7 @@
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}"
     owner: "{{ tor_user }}"
+    group: "{{ tor_user }}"
     mode: '0700'
   tags:
     - tor
@@ -13,6 +14,7 @@
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}/{{ item }}"
     owner: "{{ tor_user }}"
+    group: "{{ tor_user }}"
     mode: '0700'
   with_items: app_tor_instances
   tags:
@@ -23,6 +25,7 @@
     src: torrc-app
     dest: /etc/tor/torrc
     owner: "{{ tor_user }}"
+    group: "{{ tor_user }}"
     mode: '0644'
   notify:
     - restart tor

--- a/install_files/ansible-base/roles/common-app/tasks/app_configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/common-app/tasks/app_configure_tor_hidden_services.yml
@@ -4,6 +4,7 @@
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}"
     owner: "{{ tor_user }}"
+    mode: '0700'
   tags:
     - tor
 
@@ -12,6 +13,7 @@
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}/{{ item }}"
     owner: "{{ tor_user }}"
+    mode: '0700'
   with_items: app_tor_instances
   tags:
     - tor

--- a/install_files/ansible-base/roles/common-mon/tasks/mon_configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/common-mon/tasks/mon_configure_tor_hidden_services.yml
@@ -4,6 +4,7 @@
     state: directory
     path: "{{ tor_hidden_services_parent_dir }}"
     owner: "{{ tor_user }}"
+    mode: '0700'
   tags:
     - tor
 
@@ -12,6 +13,7 @@
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}/{{ item }}"
     owner: "{{ tor_user }}"
+    mode: '0700'
   with_items: mon_tor_instances
   tags:
     - tor

--- a/install_files/ansible-base/roles/common-mon/tasks/mon_configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/common-mon/tasks/mon_configure_tor_hidden_services.yml
@@ -4,6 +4,7 @@
     state: directory
     path: "{{ tor_hidden_services_parent_dir }}"
     owner: "{{ tor_user }}"
+    group: "{{ tor_user }}"
     mode: '0700'
   tags:
     - tor
@@ -13,6 +14,7 @@
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}/{{ item }}"
     owner: "{{ tor_user }}"
+    group: "{{ tor_user }}"
     mode: '0700'
   with_items: mon_tor_instances
   tags:
@@ -23,6 +25,7 @@
     src: torrc-mon
     dest: /etc/tor/torrc
     owner: "{{ tor_user }}"
+    group: "{{ tor_user }}"
     mode: '0644'
   notify:
     - restart tor

--- a/spec_tests/spec/app-staging/tor_spec.rb
+++ b/spec_tests/spec/app-staging/tor_spec.rb
@@ -17,3 +17,20 @@ describe file('/etc/tor/torrc') do
   end
 end
 
+# declare app-specific tor service directories,
+# for mode and ownership checks. the parent dir
+# and the "ssh" service are validated in the
+# common-staging spectests.
+tor_service_directories = %w(
+  /var/lib/tor/services/document
+  /var/lib/tor/services/source
+)
+# ensure tor service dirs are owned by tor user and mode 0700
+tor_service_directories.each do |tor_service_directory|
+  describe file(tor_service_directory) do
+    it { should be_directory  }
+    it { should be_mode('700')  }
+    it { should be_owned_by 'debian-tor' }
+    it { should be_grouped_into 'debian-tor' }
+  end
+end

--- a/spec_tests/spec/common-staging/tor_spec.rb
+++ b/spec_tests/spec/common-staging/tor_spec.rb
@@ -32,12 +32,19 @@ describe file('/etc/tor/torrc') do
   end
 end
 
-# ensure parent directory for tor hidden services exists
-describe file('/var/lib/tor/services') do
-  it { should be_directory  }
-  it { should be_mode('2755')  }
-  it { should be_owned_by 'debian-tor' }
-  it { should be_grouped_into 'debian-tor' }
+# declare tor service directories, for mode and ownership checks
+tor_service_directories = %w(
+  /var/lib/tor/services
+  /var/lib/tor/services/ssh
+)
+# ensure tor service dirs are owned by tor user and mode 0700
+tor_service_directories.each do |tor_service_directory|
+  describe file(tor_service_directory) do
+    it { should be_directory  }
+    it { should be_mode('700')  }
+    it { should be_owned_by 'debian-tor' }
+    it { should be_grouped_into 'debian-tor' }
+  end
 end
 
 # ensure tor service is running


### PR DESCRIPTION
Ensures correct mode for tor hidden service directories. Updates spectests to validate new file modes, and to test each service directory individually.

Confirmed that these playbook changes resolve the tor failure described in #1044. Playbooks finished without error on a fresh provision of staging VMs based on trusty64-14.04.2. Also spun up snapshots of a working VMs running the previous version of tor and ran the modified playbooks against them, again without errors.

File mode tasks use quotes to force stringification, which is relevant to #1006.

Resolves #1044.