### PR TITLE
Fix tor service directory permissions

### DIFF
--- a/install_files/ansible-base/roles/common-app/tasks/app_configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/common-app/tasks/app_configure_tor_hidden_services.yml
@@ -4,12 +4,14 @@
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}"
     owner: "{{ tor_user }}"
+    mode: '0700'
 
 - name: ensure each hidden service's directory exists
   file:
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}/{{ item }}"
     owner: "{{ tor_user }}"
+    mode: '0700'
   with_items: app_tor_instances
 
 - name: ensure securedrop app servers torrc is present

--- a/install_files/ansible-base/roles/common-app/tasks/app_configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/common-app/tasks/app_configure_tor_hidden_services.yml
@@ -4,6 +4,7 @@
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}"
     owner: "{{ tor_user }}"
+    group: "{{ tor_user }}"
     mode: '0700'
 
 - name: ensure each hidden service's directory exists
@@ -11,11 +12,12 @@
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}/{{ item }}"
     owner: "{{ tor_user }}"
+    group: "{{ tor_user }}"
     mode: '0700'
   with_items: app_tor_instances
 
 - name: ensure securedrop app servers torrc is present
-  copy: src=torrc-app dest=/etc/tor/torrc owner="{{ tor_user }}" mode=0644
+  copy: src=torrc-app dest=/etc/tor/torrc owner="{{ tor_user }}" group="{{ tor_user }}" mode=0644
   notify:
     - restart tor
 

--- a/install_files/ansible-base/roles/common-mon/tasks/mon_configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/common-mon/tasks/mon_configure_tor_hidden_services.yml
@@ -4,6 +4,7 @@
     state: directory
     path: "{{ tor_hidden_services_parent_dir }}"
     owner: "{{ tor_user }}"
+    group: "{{ tor_user }}"
     mode: '0700'
 
 - name: ensure each hidden service's directory exists
@@ -11,11 +12,12 @@
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}/{{ item }}"
     owner: "{{ tor_user }}"
+    group: "{{ tor_user }}"
     mode: '0700'
   with_items: mon_tor_instances
 
 - name: ensure securedrop mon servers torrc is present
-  copy: src=torrc-mon dest=/etc/tor/torrc owner="{{ tor_user }}" mode=0644
+  copy: src=torrc-mon dest=/etc/tor/torrc owner="{{ tor_user }}" group="{{ tor_user }}" mode=0644
   notify:
     - restart tor
 

--- a/install_files/ansible-base/roles/common-mon/tasks/mon_configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/common-mon/tasks/mon_configure_tor_hidden_services.yml
@@ -4,12 +4,14 @@
     state: directory
     path: "{{ tor_hidden_services_parent_dir }}"
     owner: "{{ tor_user }}"
+    mode: '0700'
 
 - name: ensure each hidden service's directory exists
   file:
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}/{{ item }}"
     owner: "{{ tor_user }}"
+    mode: '0700'
   with_items: mon_tor_instances
 
 - name: ensure securedrop mon servers torrc is present


### PR DESCRIPTION
Ensures correct mode for tor hidden service directories.

Confirmed that these playbook changes resolve the tor failure described in #1044. Playbooks finished without error on a fresh provision of staging VMs based on trusty64-14.04.2.

These changes were originally submitted as #1047, but that PR targeted the `develop` branch, which poses problems for preparing a minor release. Therefore this PR targets `master` 

Resolves #1044.