### PR TITLE
Improvements for iptables

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,6 +6,9 @@ display_skipped_hosts=False
 timeout=60
 
 [ssh_connection]
+# These options are required to be able to run the playbook over tor and
+# with the ssh iptables rules rate-limiting. Removing this file or changing these
+# options could break being able to run the playbook over tor
 scp_if_ssh=True
 ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ConnectTimeout=60
 pipelining=True

--- a/install_files/ansible-base/host_vars/app.yml
+++ b/install_files/ansible-base/host_vars/app.yml
@@ -135,14 +135,14 @@ agent_auth_rules:
 
 ### Used by the restrict access role ###
 direct_access_rules:
-  - "-A INPUT -p tcp --dport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A OUTPUT -p tcp --sport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
+  - "-A INPUT -i {{ansible_default_ipv4.interface}}  -p tcp --dport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
+  - "-A OUTPUT -o {{ansible_default_ipv4.interface}}  -p tcp -m owner --uid-owner root --sport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
   - "-A OUTPUT -p udp --dport 53 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
   - "-A INPUT -p udp --sport 53 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A INPUT -p tcp --dport 80 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A OUTPUT -p tcp --sport 80 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A INPUT -p tcp --dport 8080 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A OUTPUT -p tcp --sport 8080 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
+  - "-A INPUT -i {{ansible_default_ipv4.interface}} -p tcp --dport 80 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
+  - "-A OUTPUT -o {{ansible_default_ipv4.interface}} -p tcp --sport 80 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
+  - "-A INPUT -i {{ansible_default_ipv4.interface}} -p tcp --dport 8080 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
+  - "-A OUTPUT -o {{ansible_default_ipv4.interface}} -p tcp --sport 8080 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
 
 test_apt_dependencies:
   - firefox

--- a/install_files/ansible-base/host_vars/mon.yml
+++ b/install_files/ansible-base/host_vars/mon.yml
@@ -58,7 +58,7 @@ authd_rules:
 
 # To allow direct access
 direct_access_rules:
-  - "-A INPUT -p tcp --dport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
-  - "-A OUTPUT -p tcp --sport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
+  - "-A INPUT -i {{ansible_default_ipv4.interface}} -p tcp --dport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
+  - "-A OUTPUT -o {{ansible_default_ipv4.interface}} -p tcp --sport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
   - "-A OUTPUT -p udp --dport 53 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
   - "-A INPUT -p udp --sport 53 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"

--- a/install_files/ansible-base/roles/restrict_direct_access_app/files/app_rules_v6
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/files/app_rules_v6
@@ -1,0 +1,5 @@
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT DROP [0:0]
+COMMIT

--- a/install_files/ansible-base/roles/restrict_direct_access_app/files/load_iptables
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/files/load_iptables
@@ -6,4 +6,12 @@ else
   echo "Iptables rules file does not exist"
   exit 1
 fi
+
+if [ -f /etc/network/iptables/rules_v6 ]; then
+  ip6tables-restore < /etc/network/iptables/rules_v6
+else
+  echo "Ip6tables rules file does not exist"
+  exit 1
+fi
+
 exit 0

--- a/install_files/ansible-base/roles/restrict_direct_access_app/tasks/app_iptables.yml
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/tasks/app_iptables.yml
@@ -28,3 +28,6 @@
 
 - name: ensure iptables rules_v4 file is present
   template: src=app_rules_v4 dest=/etc/network/iptables/rules_v4 owner=root mode=0644
+
+- name: ensure ip6tables rules_v6 file is present
+  copy: src=app_rules_v6 dest=/etc/network/iptables/rules_v6 owner=root mode=0644

--- a/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
@@ -1,7 +1,7 @@
 *filter
-:INPUT ACCEPT [0:0]
-:FORWARD ACCEPT [0:0]
-:OUTPUT ACCEPT [0:0]
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT DROP [0:0]
 :LOGNDROP - [0:0]
 
 # Allow the tor instances used for ssh, source and document interface outbound access

--- a/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_app/templates/app_rules_v4
@@ -4,15 +4,24 @@
 :OUTPUT DROP [0:0]
 :LOGNDROP - [0:0]
 
-# Allow the tor instances used for ssh, source and document interface outbound access
+# Prod ssh connections happen through an authenticated tor hidden service
+# The ssh connection is proxied on the server by the tor client to
+# the ssh dameon listening on the local loopback.
+# Limit the number of new tcp connections allowed by the tor user to the ssh dameon
+# listening on the local loopback. Drop new connection attempts after the limit
+# by the tor user.
+# limit-burst is set to '3' which means the limit of 3/min only starts after the
+# first three connection are made. To test will need to try to create 7 connections.
+# The 7th (and any additional attempts during that minute) will be dropped.
+-A OUTPUT -o lo -p tcp --dport 22 -m owner --uid-owner debian-tor -m state --state NEW -m limit --limit 3/min --limit-burst 3 -j ACCEPT -m comment --comment "Rate limit traffic from tor to the ssh dameon"
+-A OUTPUT -o lo -p tcp --dport 22 -m owner --uid-owner debian-tor -m state --state NEW -j LOGNDROP -m comment --comment "Drop all other new connections from tor to the ssh dameon"
+-A OUTPUT -o lo -p tcp --dport 22 -m owner --uid-owner debian-tor -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow the established traffic from tor to the ssh dameon"
+
 # Load before tor user drop rules
+# TODO: use ansible facts to populate the in use interface to further restrict
+# the rules.
 -A OUTPUT -p tcp -m owner --uid-owner debian-tor -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "tor instance that provides ssh access"
 -A INPUT -p tcp -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow traffic back for tor"
-
-# Rate limit ssh connections coming from the tor network
-# Load before generic loopback rules
--A OUTPUT -o lo -p tcp --dport 22 -m owner --uid-owner debian-tor -m state --state NEW -m limit --limit 3/min --limit-burst 3 -j ACCEPT -m comment --comment "SSH with rate limiting only thru tor"
--A OUTPUT -o lo -p tcp --dport 22 -m owner --uid-owner debian-tor -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "SSH with rate limiting only thru tor"
 
 # Drop all other outbound traffic by the tor user.
 # Load before generic loopback rules

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/files/load_iptables
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/files/load_iptables
@@ -6,4 +6,12 @@ else
   echo "Iptables rules file does not exist"
   exit 1
 fi
+
+if [ -f /etc/network/iptables/rules_v6 ]; then
+  ip6tables-restore < /etc/network/iptables/rules_v6
+else
+  echo "Ip6tables rules file does not exist"
+  exit 1
+fi
+
 exit 0

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/files/mon_rules_v6
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/files/mon_rules_v6
@@ -1,0 +1,5 @@
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT DROP [0:0]
+COMMIT

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/tasks/mon_iptables.yml
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/tasks/mon_iptables.yml
@@ -34,3 +34,6 @@
   # manually rebooted for production installs.
 - name: ensure iptables rules_v4 file is present
   template: src=mon_rules_v4 dest=/etc/network/iptables/rules_v4 owner=root mode=0644
+
+- name: ensure ip6tables rules_v6 file is present
+  copy: src=mon_rules_v6 dest=/etc/network/iptables/rules_v6 owner=root mode=0644

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
@@ -1,7 +1,7 @@
 *filter
-:INPUT ACCEPT [0:0]
-:FORWARD ACCEPT [0:0]
-:OUTPUT ACCEPT [0:0]
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT DROP [0:0]
 :LOGNDROP - [0:0]
 
 # Allow the tor instance used for ssh access

--- a/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
+++ b/install_files/ansible-base/roles/restrict_direct_access_mon/templates/mon_rules_v4
@@ -4,17 +4,26 @@
 :OUTPUT DROP [0:0]
 :LOGNDROP - [0:0]
 
-# Allow the tor instance used for ssh access
--A OUTPUT -p tcp -m owner --uid-owner debian-tor -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow Tor out"
+# Prod ssh connections happen through an authenticated tor hidden service
+# The ssh connection is proxied on the server by the tor client to
+# the ssh dameon listening on the local loopback.
+# Limit the number of new tcp connections allowed by the tor user to the ssh dameon
+# listening on the local loopback. Drop new connection attempts after the limit
+# by the tor user.
+# limit-burst is set to '3' which means the limit of 3/min only starts after the
+# first three connection are made. To test will need to try to create 7 connections.
+# The 7th (and any additional attempts during that minute) will be dropped.
+-A OUTPUT -o lo -p tcp --dport 22 -m owner --uid-owner debian-tor -m state --state NEW -m limit --limit 3/min --limit-burst 3 -j ACCEPT -m comment --comment "Rate limit traffic from tor to the ssh dameon"
+-A OUTPUT -o lo -p tcp --dport 22 -m owner --uid-owner debian-tor -m state --state NEW -j LOGNDROP -m comment --comment "Drop all other new connections from tor to the ssh dameon"
+-A OUTPUT -o lo -p tcp --dport 22 -m owner --uid-owner debian-tor -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow the established traffic from tor to the ssh dameon"
+
+# Load before tor user drop rules
+# TODO: use ansible facts to populate the in use interface to further restrict
+# the rules.
+-A OUTPUT -p tcp -m owner --uid-owner debian-tor -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "tor instance that provides ssh access"
 -A INPUT -p tcp -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "Allow traffic back for tor"
 
-# Rate limit ssh connections coming from the tor network
-# Restrict to users in the ssh group
-# Load before generic loopback rules
--A OUTPUT -o lo -p tcp --dport 22 -m owner --uid-owner debian-tor -m state --state NEW -m limit --limit 3/min --limit-burst 3 -j ACCEPT -m comment --comment "SSH with rate limiting only thur tor"
--A OUTPUT -o lo -p tcp --dport 22 -m owner --uid-owner debian-tor -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "SSH with rate limiting only thur tor"
-
-# Drop all other outbound traffic by the tor users.
+# Drop all other outbound traffic by the tor user.
 # Load before generic loopback rules
 -A OUTPUT -m owner --uid-owner debian-tor -j LOGNDROP -m comment --comment "Drop all other traffic for the tor instance used for ssh"
 


### PR DESCRIPTION
### Summary:
 1) Adding IPv6 rules to change the behavior for the default chains to `DROP` Fixes #1046 iSEC-15FTC-3 reported by @isecpartners
 2) Changing the IP v4 rules default action for chains to `DROP` Fixes #1046 iSEC-15FTC-3 reported by @isecpartners
 3) Restricting the staging env specific allow direct access rule exemptions to make testing the ssh over tor rule easier.
 4) Moving the ssh over tor IP v4 rules before the more generic tor rule. Fixes iSEC-15FTC-7 reported by @isecpartners
 5) Adding a corresponding drop rule immediately after the ssh rate limiting rule, to ensure that all traffic over the rate-limit will be dropped.

Each change is contained in its own commit.

## Changing the default actions for IPv6 chains:

* Added `rules_v6` file for ansible to copy to the servers.
* Modified the load_iptables script to load the rules_v6 at same time as the rules_v4

The default Ubuntu chains/actions are:
```
root@mon-staging:/home/vagrant# ip6tables -L
Chain INPUT (policy ACCEPT)
target prot opt source destination

Chain FORWARD (policy ACCEPT)
target prot opt source destination

Chain OUTPUT (policy ACCEPT)
target prot opt source destination
```

With the changes from this PR

```
root@app-staging:/home/vagrant# ip6tables -L
Chain INPUT (policy DROP)
target     prot opt source               destination

Chain FORWARD (policy DROP)
target     prot opt source               destination

Chain OUTPUT (policy DROP)
target     prot opt source               destination
```

Even though IPv6 is disabled via sysctl the default ip6table rules should also be changed for defense in depth reasons.

This adds the defualt: Input, Forward, Output chains default action to `drop`

* A respective ansible task was created to place the `rules_v6` config file.

* The load_iptables script was modified to also load the `rules_v6` config.

## Changing the default action for IP v4 chains

* modified rules_v4  for both servers

```
root@app-staging:/home/vagrant# iptables -S
-P INPUT DROP
-P FORWARD DROP
-P OUTPUT DROP
-N LOGNDROP
```
## Restricting the allow direct access exemption rules

* Added restrictions for the interface to the port 80,8080,22 rule that allow direct access. This removed the overlap with the prod ssh over tor iptables rule.

## Changes to the iptable order.

* Moved the ssh over tor rules above the more generic tor rule.
* limit-burst is set to 3 which mean that iptables will allow the first 3 new tcp packets and then the rate limit of 3/min kicks in.
* To test the rate limiting you will need to generate over 6 connections in a minute.

## Add corresponding drop rule after the ssh over tor rate limiting rule

* Since the more generic OUTPUT tor accept iptables rules would match all traffic over the rate limit, added a specific drop rule immediately after the rate limiting rule that match the interface `lo` destination port `22` that it is from the tor user `debian-tor` and its state is `NEW`.

### Steps used to generate the required traffic to test iptable rules
Steps used in testing:

* put updated rules in place
* perform the following function test to generate the needed traffic:
  * ssh using allow direct access exemption
  * ssh over tor using ATHS
  * run apt-get update
  * remove ntp exemption and modify the prod ntp rule for virtual environment to test ntp rule
  * restart servers to register the OSSEC agent to test the traffic.
  * hit the source and doc interface over the allowed direct access exemption
  * hit the source and doc interface over the respective THS
  * generate reddis traffic
  * attempt to create over 6 ssh connections that are proxied over the tor authenticated hidden service in a minute. Verify by looking at the counters for the iptables. `iptables-save -c`

Verified by looking at the iptables rules counters that this change worked.

```
[6:360] -A OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 109 -m state --state NEW -m limit --limit 3/min --limit-burst 3 -m comment --comment "Rate limit traffic from tor to the ssh server" -j ACCEPT
[28:1680] -A OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 109 -m state --state NEW -m comment --comment "Drop all other new connections from tor to ssh server" -j LOGNDROP
[1138:91786] -A OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 109 -m state --state RELATED,ESTABLISHED -m comment --comment "Allow the established traffic from tor to ssh server" -j ACCEPT
[777:674290] -A OUTPUT -p tcp -m owner --uid-owner 109 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tor instance that provides ssh access" -j ACCEPT
[0:0] -A OUTPUT -m owner --uid-owner 109 -m comment --comment "Drop all other traffic for the tor instance used for ssh" -j LOGNDROP
```

Directly ssh'ing into the servers only matches the allow direct access exemption rule's user ID and interface
SSH'ing over tor only triggers the ssh throttling rule's based on the protocol, port, user id, state
All other tor traffic matches the generic tor outbound rule based on user ID.

To further restrict the generic tor rule we could add the interface using an ansible fact `{{ansible_default_ipv4.interface}}` in the iptable's rule_v4 templates. This is a bigger change that would require more testing and should be a different issue/pr.