### PR TITLE
Updated OSSEC versions

### DIFF
--- a/install_files/ansible-base/host_vars/app.yml
+++ b/install_files/ansible-base/host_vars/app.yml
@@ -32,13 +32,13 @@ securedrop_deb_path: "{{ securedrop_repo }}"
 securedrop_app_code_deb: "securedrop-app-code-{{ securedrop_app_code_version }}-amd64" # do not enter .deb extension
 
 # Installing the securedrop-ossec-agent.deb package
-securedrop_ossec_agent_deb: "{{ securedrop_repo }}/securedrop-ossec-agent-2.8.1-amd64" # do not include .deb extension
+securedrop_ossec_agent_deb: "{{ securedrop_repo }}/securedrop-ossec-agent-2.8.2-amd64" # do not include .deb extension
 
 ### Used by the install_local_deb_pkgs role ###
 local_deb_packages:
   - "{{ securedrop_app_code_deb }}.deb"
-  - ossec-agent-2.8.1-amd64.deb
-  - "securedrop-ossec-agent-2.8.1+{{ securedrop_app_code_version }}-amd64.deb"
+  - ossec-agent-2.8.2-amd64.deb
+  - "securedrop-ossec-agent-2.8.2+{{ securedrop_app_code_version }}-amd64.deb"
 
 ### Used by the app role ###
 

--- a/install_files/ansible-base/host_vars/mon.yml
+++ b/install_files/ansible-base/host_vars/mon.yml
@@ -15,13 +15,13 @@ ip_info:
 #
 # This is the path to the directory where we build the deb. The deb package
 # will be created alongside it and will have ".deb" automatically appended.
-securedrop_ossec_server_deb: "{{ securedrop_repo }}/securedrop-ossec-server-2.8.1-amd64"
+securedrop_ossec_server_deb: "{{ securedrop_repo }}/securedrop-ossec-server-2.8.2-amd64"
 
 
 ### Used by the install_local_deb_pkgs role ###
 local_deb_packages:
-  - ossec-server-2.8.1-amd64.deb
-  - "securedrop-ossec-server-2.8.1+{{ securedrop_app_code_version }}-amd64.deb"
+  - ossec-server-2.8.2-amd64.deb
+  - "securedrop-ossec-server-2.8.2+{{ securedrop_app_code_version }}-amd64.deb"
 
 ### Used by the mon role ###
 

--- a/install_files/securedrop-ossec-agent/DEBIAN/control
+++ b/install_files/securedrop-ossec-agent/DEBIAN/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
 Homepage: https://freedom.press/securedrop
 Package: securedrop-ossec-agent
-Version: 2.8.1+0.3.3
+Version: 2.8.2+0.3.4
 Architecture: amd64
 Depends: ossec-agent
 Replaces: ossec-agent

--- a/install_files/securedrop-ossec-server/DEBIAN/control
+++ b/install_files/securedrop-ossec-server/DEBIAN/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
 Homepage: https://freedom.press/securedrop
 Package: securedrop-ossec-server
-Version: 2.8.1+0.3.3
+Version: 2.8.2+0.3.4
 Architecture: amd64
 Depends: ossec-server
 Replaces: ossec-server


### PR DESCRIPTION
A new version of OSSEC came out (2.8.2). Updated the OSSEC package names in the securedrop specific deb package control files. And in the ansible host var config files.

* Will need to update the respective changelogs.

Tested to ensure that the deb package are created correctly and work in the staging environment.