### PR TITLE
Removed capabilities from apache apparmor

### DIFF
--- a/install_files/ansible-base/usr.sbin.apache2
+++ b/install_files/ansible-base/usr.sbin.apache2
@@ -5,10 +5,6 @@
   #include <abstractions/base>
   #include <abstractions/tor>
 
-  signal (send) set=("term") peer=unconfined,
-  ptrace (trace) peer=unconfined,
-
-  capability dac_override,
   capability kill,
   capability net_bind_service,
   capability sys_ptrace,


### PR DESCRIPTION
### Changes

Removed capabilities from apache apparmor

* The additional ptrace options aren't needed after granting the `sys_ptrace` capability.

* The `dac_override` is not needed. Need to sure up our apparmor profile creation process.

### To Test

Until @conor's pr is merged into all the current branches will need to jump through some hoops to get local packages installed in the staging environment.

* `vagrant up build`
* comment out the ossec packages for the `install_local_pkgs` var in `host_vars/app.yml`
* Comment out the `ansible.skip_tags =  [ "install_local_pkgs" ]` in the `Vagrantfile`
* Uncomment `ansible.skip_tags = [ "grsec",  "ossec", "app-test" ]`
* `vagrant destroy /staging/ -f`
* `vagrant up app-staging`

### Apparmor profile creation process

When creating the apparmor profile from scratch.

* Before putting the profile in enforce mode ensure that the apparmor profile grants enough permissions to allow apache to restart. If not you will get a false positive running aa-logprof at a later point prompting to provide dac_override capability
* Will look into providing a base template that just provides the permission/capabilities required for apache to restart without the additional permissions for the applications functionality.