### PR TITLE
Use 0.3.x for all upgrade documentation

### DIFF
--- a/docs/0.3-pre-upgrade-to-0.3.x.md
+++ b/docs/0.3-pre-upgrade-to-0.3.x.md
@@ -1,4 +1,6 @@
-# Upgrading 0.3 version
+# Upgrading 0.3pre version
+
+The upgrade steps in this document will upgrade a 0.3pre SecureDrop to any `0.3.x` SecureDrop version. Throughout the rest of this document, substitute `0.3.x` with the current release's version number.
 
 ## Prerequisites
 
@@ -8,7 +10,7 @@
 
 * A filled out prod-specific.yml file `/home/amnesia/Persistent/install_files/ansible-base/prod-specific.yml`
 
-## From the admin Tails workstation:
+## From the admin Tails workstation
 
 Open a terminal (it is an icon on the top of the screen that looks like a little black TV)
 
@@ -24,13 +26,13 @@ Open a terminal (it is an icon on the top of the screen that looks like a little
 
   `git pull`
 
-* Checkout the latest tagged release
+* Checkout the latest tagged release (0.3.x)
 
-  `git checkout 0.3.3`
+  `git checkout 0.3.x`
 
 * Verify the github tag
 
-  `git tag -v 0.3.3`
+  `git tag -v 0.3.x`
 
 * Pop the site specific configs back in place
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -4,7 +4,7 @@ Look up the version you wish to upgrade *to* below.
 
 ## 0.3.x
 
-There are two upgrade paths to the SecureDrop 0.3.3 version. Upgrading a
+There are two upgrade paths to the SecureDrop 0.3.x version. Upgrading a
 running 0.2.1 version is a little different than upgrading a 0.3-pre version of
 SecureDrop. Upgrading a 0.2.1 version will require backing up the existing
 instance, performing a clean install (including re-installing Ubuntu) and then
@@ -17,6 +17,6 @@ If a networked Admin tails workstation is not provisioned please follow this
 Choose the correct guide below, depending on the version of SecureDrop you are
 currently running:
 
-* [Upgrade from 0.2.1](0.2.1-upgrade-to-0.3.3.md)
-* [Upgrade from 0.3pre](0.3-pre-upgrade-to-0.3.3.md)
+* [Upgrade from 0.2.1](0.2.1-upgrade-to-0.3.x.md)
+* [Upgrade from 0.3pre](0.3-pre-upgrade-to-0.3.x.md)
 


### PR DESCRIPTION
The documented upgrade paths from 0.2.1 and 0.3pre will work for any
0.3.x release. Therefore, we should explain this and direct an admin who
is upgrading to upgrade to the *latest* 0.3.x minor version.

This process was begun in #1063 and is completed for all relevant
documentation here.