### PR TITLE
Re-add signal rule to Apache AppArmor profile

### DIFF
--- a/install_files/ansible-base/usr.sbin.apache2
+++ b/install_files/ansible-base/usr.sbin.apache2
@@ -5,6 +5,8 @@
   #include <abstractions/base>
   #include <abstractions/tor>
 
+  signal (send) set=("term") peer=unconfined,
+
   capability kill,
   capability net_bind_service,
   capability sys_ptrace,


### PR DESCRIPTION
When Apache shuts down, it needs to be able to send a SIGTERM to its
worker child processes, which are currently unconfined by
AppArmor. Re-adding this rule allows Apache to work with AppArmor on
systems using an Ubuntu kernel, which has kernel support for the signal
rules. On other kernels (generic, grsecurty, etc.) this rule is ignored.

Fixes #1078.