### PR TITLE
Stop apache2 service before enforcing AppArmor profile

### DIFF
--- a/install_files/securedrop-app-code/DEBIAN/postinst
+++ b/install_files/securedrop-app-code/DEBIAN/postinst
@@ -29,7 +29,11 @@ case "$1" in
     # mode.
     a2dissite 000-default
     a2dissite default-ssl
-    service apache2 reload
+    # Stop Apache service before making changes to its AppArmor profile.
+    # If the Apache service is running unconfined, and the profile is
+    # set to "enforce", then apache2 will fail to restart, since it lacks
+    # the ability to send signals to unconfined peers.
+    service apache2 stop
 
     # If the profile was disabled enabled it.
     if [ -e "/etc/apparmor.d/disable/usr.sbin.apache2" ]; then


### PR DESCRIPTION
By ensuring that any running apache2 processes are stopped prior to enforcing the AppArmor profile, we can ensure that the service properly starts in a confined state. Tested this change up and down according to the following procedure:

1. Build deb with patch, then provision fresh staging hosts and ensure the custom-built `securedrop-app-code` deb installs without problems.
2. Perform point-and-click testing of the Source Interface, including submissions, to ensure server is actually working.
3. Reinstall `securedrop-app-code` as 0.3.4 by pulling down from the apt repo and make sure the apache service starts with the `postinst` script currently used in production (to get a sense for future regressions down the line).
4. Perform point-and-click testing of the document interface, to ensure server is actually working.
5. Repeat steps 1-4, but this time first install `securedrop-app-code=0.3.3` from the apt repo, then upgrade to `securedrop-app-code=0.3.4`, then upgrade to the custom-built `securedrop-app-code` deb, testing in between each.

The testing procedure outlined above was performed on:

 * DigitalOcean hosts
 * VirtualBox hosts *with* grsecurity enabled
 * VirtualBox hosts *without* grsecurity enabled

The apache2 service started every time. (While testing, some additional tags were skipped during provision: `aa-complain`, to ensure the profile was always set to enforce, and `apt-upgrade`, to ensure that the local deb package wasn't replaced by an apt repo package.)

It was tempting to implement stronger profile handling via `apparmor_parser` in the `postinst` script, but that's better handled as a separate issue.

Closes #1078.