### PR TITLE
Update layout for submission list

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -25,19 +25,29 @@
       <ul id="submissions" class="plain submissions">
         {% for doc in source.collection %}
           <li class="submission"><input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check"/>
+          <span class="info">
+            
+            <span title="count">{{ doc.filename[0] }}</span>
+
+            |<span title="type">
+              {% if doc.filename.endswith('-doc.gz.gpg') %}
+                Document
+                <i title="Uploaded Document" class="fa fa-file-archive-o"></i>
+              {% elif doc.filename.endswith('-reply.gpg') %}
+                Reply
+						    <i title="Reply" class="fa fa-reply"></i>
+              {% else %} 
+                Message
+                <i title="Messages" class="fa fa-file-text-o"></i>
+              {% endif %}
+            </span>
+            |<span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat(binary=True) }}</span>
+
+          </span>
             {% if doc.filename.endswith('reply.gpg') %}
-              <span class="file reply"><span class="filename">{{ doc.filename }}</span></span>
-              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat(binary=True) }}</span></span>
+              <span class="file reply pull-right"><span class="filename">{{ doc.filename }}</span></span>
             {% else %}
-              <span class="file"><a class="btn small" href="/col/{{ sid }}/{{ doc.filename }}"><i class="fa fa-download"></i> <span class="filename">{{ doc.filename }}</span></a></span>
-              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat(binary=True) }}</span></span>
-            {% endif %}
-            {% if doc.filename.endswith('-doc.gz.gpg') %}
-              <i title="Uploaded Document" class="fa fa-file-archive-o pull-right"></i>
-						{% elif doc.filename.endswith('-reply.gpg') %}
-						  <i title="Reply" class="fa fa-reply pull-right"></i>
-						{% else %}
-              <i title="Message" class="fa fa-file-text-o pull-right"></i>
+              <span class="file pull-right"><a class="btn small" href="/col/{{ sid }}/{{ doc.filename }}"><i class="fa fa-download"></i> <span class="filename">{{ doc.filename }}</span></a></span>
             {% endif %}
           </li>
         {% endfor %}

--- a/securedrop/static/css/journalist.css
+++ b/securedrop/static/css/journalist.css
@@ -480,15 +480,23 @@ p#no-replies {
   border-bottom: none;
 }
 .submission .file {
-  min-width: 300px;
   display: inline-block;
 }
 .submission .file.reply {
   font-size: small;
+  padding: 0 3px;
 }
 .submission .info {
   font-size: 12px;
   color: #666666;
+}
+
+.submission .info > span {
+  padding: 0 6px;
+}
+
+.submission .info > span:first-of-type {
+  padding: 0 6px 0 0;
 }
 
 ul.plain {


### PR DESCRIPTION
I made some minor enhancements to the submission list layout (related to #556) Here's what it looks like now:
<img width="753" alt="screen shot 2015-08-18 at 4 29 43 am" src="https://cloud.githubusercontent.com/assets/7584833/9326772/df8a407c-4561-11e5-8df8-6855d77304c0.png">

What do you think?
