### PR TITLE
doc update with better suggestion for build-deps

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -38,14 +38,21 @@ We recommend using the latest stable version of Vagrant (`1.7.4` at the time of
 this writing), which might be newer than what is in the Ubuntu repositories.
 
 If `apt-cache policy vagrant` says your candidate version is not at least
-1.4, you should download the current version from
-https://www.vagrantup.com/downloads.html. We *do not* recommend using an older
-version of Vagrant from Ubuntu's package repositories. E.g, version 1.5.4
+1.7, you should download the current version from
+https://www.vagrantup.com/downloads.html and then install it.
+
+```sh
+sudo dpkg -i vagrant.deb    # if you downloaded vagrant.deb from vagrantup.com
+
+sudo apt-get install vagrant    # OR this, if your OS vagrant is recent enough
+```
+
+We *do not* recommend using an older version of Vagrant older than 1.7 from
+Ubuntu's package repositories. For instance, version 1.5.4 in Ubuntu
 is significantly out of date and does not work with SecureDrop
 ([context](https://github.com/freedomofpress/securedrop/pull/932)).
 
 ```sh
-sudo dpkg -i vagrant.deb
 sudo dpkg-reconfigure virtualbox-dkms
 ```
 

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -34,11 +34,13 @@ To get started, you will need to install Vagrant, Virtualbox, and Ansible.
 sudo apt-get install -y dpkg-dev virtualbox-dkms linux-headers-$(uname -r) build-essential git
 ```
 
-We recommend using the latest stable version of Vagrant (`1.7.2` at the time of
-this writing), which is newer than what is in the Ubuntu repositories at the
-time of this writing.  Download the current version from
-https://www.vagrantup.com/downloads.html. We *do not* recommend using the
-version of Vagrant available from Ubuntu's package repositories (1.5.4), which
+We recommend using the latest stable version of Vagrant (`1.7.4` at the time of
+this writing), which might be newer than what is in the Ubuntu repositories.
+
+If `apt-cache policy vagrant` says your candidate version is not at least
+1.4, you should download the current version from
+https://www.vagrantup.com/downloads.html. We *do not* recommend using an older
+version of Vagrant from Ubuntu's package repositories. E.g, version 1.5.4
 is significantly out of date and does not work with SecureDrop
 ([context](https://github.com/freedomofpress/securedrop/pull/932)).
 


### PR DESCRIPTION
Single .deb downloads don't get security updates, so if the OS has a recent
vagrant version, we should prefer it and suggest developers use it. Tell them
how to find out from APT what would be installed, so they can compare.