### PR TITLE
Update version fixes

### DIFF
--- a/update_version.sh
+++ b/update_version.sh
@@ -31,8 +31,8 @@ sed -i "s/$OLD_VERSION/$NEW_VERSION/g" securedrop/version.py
 
 # Update the version in the Debian packages
 sed -i "s/^\(Version: \).*/\1$NEW_VERSION/" install_files/securedrop-app-code/DEBIAN/control
-sed -i "s/^\(Version: 2.8.1+\).*/\1$NEW_VERSION/" install_files/securedrop-ossec-agent/DEBIAN/control
-sed -i "s/^\(Version: 2.8.1+\).*/\1$NEW_VERSION/" install_files/securedrop-ossec-server/DEBIAN/control
+sed -i "s/^\(Version: [0-9.]\++\).*/\1$NEW_VERSION/" install_files/securedrop-ossec-agent/DEBIAN/control
+sed -i "s/^\(Version: [0-9.]\++\).*/\1$NEW_VERSION/" install_files/securedrop-ossec-server/DEBIAN/control
 
 # Update the version used by Ansible for the filename of the output of the deb building role
 sed -i "s/^\(securedrop_app_code_version: \"\)[0-9a-z.]*/\1$NEW_VERSION/" install_files/ansible-base/group_vars/securedrop.yml

--- a/update_version.sh
+++ b/update_version.sh
@@ -55,9 +55,10 @@ git commit -a
 
 # Initiate the process of creating a signed tag, using the workflow for signing with the airgapped signing key.
 git tag -a $NEW_VERSION
-git cat-file tag $NEW_VERSION > "$NEW_VERSION.tag"
+TAGFILE="$NEW_VERSION.tag"
+git cat-file tag $NEW_VERSION > $TAGFILE
 
 echo
 echo "[ok] Version update complete and committed."
-echo "     Please continue the airgapped signing process with $TAGFILE".
+echo "     Please continue the airgapped signing process with the tag file: $TAGFILE"
 echo


### PR DESCRIPTION
Fix some minor issues in the `update_version.sh` script that were discovered while testing the 0.3.5 release.

* The OSSEC version number for the `securedrop-ossec-*` packages was hardcoded, which broke because we've upgrades OSSEC since I last ran `update_version.sh`. I changed the sed regex to be more generic so it should update all version-y looking strings correctly (the format is `$OSSEC_VERSION+$SECUREDROP_VERSION`).
* A previous refactor broke the final "success" echo statements because it got rid of `$TAGFILE`. I added it back in and cleaned up the message a bit.
