### PR TITLE
Extend mail queue lifetime to 14 days

### DIFF
--- a/install_files/ansible-base/roles/ossec_server/templates/main.cf
+++ b/install_files/ansible-base/roles/ossec_server/templates/main.cf
@@ -57,3 +57,4 @@ mydestination = $myhostname, localhost.localdomain , localhost
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +
+maximal_queue_lifetime = 14d


### PR DESCRIPTION
Default `maximal_queue_lifetime` is 5 days. The idea here is if SMTP breaks for any reason longer than 5 days and shorter than 2 weeks (ex. change of certificate or fingerprint or credentials, or mail server outage) OSSEC alerts that may contain important info can still get delivered to the admin instead of purged from the deferred queue. Such alerts will still be in OSSEC's alerts.log of course but since that hardly ever gets checked I think we should widen the window for admins to receive them via e-mail and allow for the possibility that SMTP functionality could break for a period longer than 5 days. Open for discussion. 