### PR TITLE
Blacklist "btusb" and "iwlmvm" kernel modules.

### DIFF
--- a/install_files/ansible-base/group_vars/securedrop.yml
+++ b/install_files/ansible-base/group_vars/securedrop.yml
@@ -11,7 +11,9 @@ tor_DataDirectory: /var/lib/tor
 securedrop_tor_user: "debian-tor"
 
 disabled_kernel_modules:
+  - btusb
   - bluetooth
+  - iwlmvm
   - iwlwifi
 
 ssh_2fa_dependencies:


### PR DESCRIPTION
The configuration previously blacklisted only
"bluetooth" and "iwlwifi". On newer generation NUCs,
removing those modules fails due to dependencies,
which must be removed first. The dependecies are
"btusb" and "iwlmvm", respectively. See #1109
for details. Closes #1109.