### PR TITLE
Update spectests for 0.3.5

### DIFF
--- a/snap_ci/pinned.sh
+++ b/snap_ci/pinned.sh
@@ -23,7 +23,7 @@ vagrant_version="${vagrant_version:-1.7.2}"
 vagrant_rpm="vagrant_${vagrant_version}_x86_64.rpm"
 vagrant_url="https://dl.bintray.com/mitchellh/vagrant/${vagrant_rpm}"
 
-[[ -f "${tmp_dir}/${vagrant_rpm}" ]] || wget "$vagrant_url" -O "${tmp_dir}/${vagrant_rpm}"
+[[ -f "${tmp_dir}/${vagrant_rpm}" ]] || wget -q "$vagrant_url" -O "${tmp_dir}/${vagrant_rpm}"
 [[ -x /usr/bin/vagrant ]] || sudo -E rpm -ivh "${tmp_dir}/$vagrant_rpm"
 
 # Install Vagrant plugins

--- a/snap_ci/pinned.sh
+++ b/snap_ci/pinned.sh
@@ -19,7 +19,7 @@ tmp_dir="${SNAP_CACHE_DIR:-/tmp}"
 repo_root=$( dirname "$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd )" )
 
 # Cache and install Vagrant
-vagrant_version="${vagrant_version:-1.7.2}"
+vagrant_version="${vagrant_version:-1.7.3}"
 vagrant_rpm="vagrant_${vagrant_version}_x86_64.rpm"
 vagrant_url="https://dl.bintray.com/mitchellh/vagrant/${vagrant_rpm}"
 

--- a/snap_ci/pinned.sh
+++ b/snap_ci/pinned.sh
@@ -19,7 +19,7 @@ tmp_dir="${SNAP_CACHE_DIR:-/tmp}"
 repo_root=$( dirname "$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd )" )
 
 # Cache and install Vagrant
-vagrant_version="${vagrant_version:-1.7.3}"
+vagrant_version="${vagrant_version:-1.7.2}"
 vagrant_rpm="vagrant_${vagrant_version}_x86_64.rpm"
 vagrant_url="https://dl.bintray.com/mitchellh/vagrant/${vagrant_rpm}"
 

--- a/spec_tests/spec/common/cron_apt_spec.rb
+++ b/spec_tests/spec/common/cron_apt_spec.rb
@@ -60,6 +60,10 @@ describe file('/etc/cron-apt/action.d/3-download') do
 end
 
 desired_cronjobs = [
+  '0 4 * * * root    /usr/bin/test -x /usr/sbin/cron-apt && /usr/sbin/cron-apt && /sbin/reboot'
+]
+# Checking for old cronjobs to guard against regressions.
+unwanted_cronjobs = [
   '0 4 * * * root    /usr/bin/test -x /usr/sbin/cron-apt && /usr/sbin/cron-apt',
   '0 5 * * * root    /sbin/reboot',
 ]
@@ -71,6 +75,10 @@ describe file('/etc/cron.d/cron-apt') do
   desired_cronjobs.each do |cronjob|
     cronjob_regex = Regexp.quote(cronjob)
     its(:content) { should match /^#{cronjob_regex}$/ }
+  end
+  unwanted_cronjobs.each do |cronjob|
+    cronjob_regex = Regexp.quote(cronjob)
+    its(:content) { should_not match /^#{cronjob_regex}$/ }
   end
 end
 

--- a/spec_tests/spec/development/securedrop_app_dev_spec.rb
+++ b/spec_tests/spec/development/securedrop_app_dev_spec.rb
@@ -67,9 +67,14 @@ end
 # TODO: add check for custom logo header file
 describe file("#{property['securedrop_code']}/static/i/logo.png") do
   it { should be_file }
-  # TODO: ansible task declares mode 400 but the file ends up as 644 on host
-  # TODO: 644 on app-staging, 664 in development
-  it { should be_mode '664' }
+  # TODO: Ansible task declares mode 400 but not as string, needs to be fixed
+  # and tests updated. Also, not using "mode" in tests below because umask
+  # on snapci machines differs from the /vagrant folder in dev VM.
+  # Fixing Ansible task may fix differing perms.
+  it { should be_writable.by('owner') }
+  it { should be_readable.by('owner') }
+  it { should be_readable.by('group') }
+  it { should be_readable.by('others') }
   it { should be_owned_by property['securedrop_user'] }
   it { should be_grouped_into property['securedrop_user'] }
 end

--- a/spec_tests/spec/mon-general/ossec_server_spec.rb
+++ b/spec_tests/spec/mon-general/ossec_server_spec.rb
@@ -81,6 +81,10 @@ postfix_settings = [
   'mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128',
   'mailbox_size_limit = 0',
   'recipient_delimiter = +',
+
+  # This line was merged into develop via #1102,
+  # but hasn't made it into a release yet, so don't check for it.
+  # 'maximal_queue_lifetime = 14d',
 ]
 # ensure all desired postfix settings are declared
 describe file('/etc/postfix/main.cf') do

--- a/spec_tests/spec/mon-general/ossec_server_spec.rb
+++ b/spec_tests/spec/mon-general/ossec_server_spec.rb
@@ -51,11 +51,19 @@ postfix_settings = [
   'smtp_sasl_auth_enable = yes',
   'smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd',
   'smtp_sasl_security_options = noanonymous',
-  'smtp_use_tls=yes',
+  'smtp_use_tls = yes',
   'smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache',
-  'smtp_tls_security_level = fingerprint',
-  'smtp_tls_fingerprint_digest = sha1',
-  'smtp_tls_fingerprint_cert_match = 6D:87:EE:CB:D0:37:2F:88:B8:29:06:FB:35:F4:65:00:7F:FD:84:29',
+
+  # The security settings below are the default values
+  # set by the Ansible config as of #1100, but the playbooks
+  # still support TLS fingerprint verification. If you're testing
+  # the fingerprint verification functionality, you'll need to
+  # swap the strings below so the tests check for the appropriate config lines.
+  # 'smtp_tls_fingerprint_digest = sha1',
+  # 'smtp_tls_fingerprint_cert_match = 6D:87:EE:CB:D0:37:2F:88:B8:29:06:FB:35:F4:65:00:7F:FD:84:29',
+  'smtp_tls_security_level = secure',
+  'smtp_tls_CApath = /etc/ssl/certs',
+
   'smtp_tls_ciphers = high',
   'smtp_tls_protocols = TLSv1.2 TLSv1.1 TLSv1 !SSLv3 !SSLv2',
   'myhostname = ossec.server',


### PR DESCRIPTION
Brings the serverspec tests up to par with the current state of `develop`, now that `0.3.5` has shipped.

The changes are mostly cosmetic, but c5c468f points out a problem with upgrading to the newest version of Vagrant in Snap CI—there's a dependency conflict with versions of `bundler`. The long-term solution is to strictly enforce the version of `bundler` in Snap CI, but for now, sticking with Vagrant v1.7.2 in Snap.

Note that #1099 recommends updating the version recommendation for devs to Vagrant v1.7.4. The issue described in c5c468f is **not** a blocker to merging #1099, since the Serverspec docs recommend installing bundler via `apt-get`, which installs a matching version that Vagrant is happy with.

In a separate PR I'll work on resolving the bundler version mismatch in Snap.