### PR TITLE
Standardize on full spelling for MAT

### DIFF
--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -196,7 +196,7 @@ information, visit `Work on sensitive
 documents <https://tails.boum.org/doc/sensitive_documents/index.en.html>`__
 on the Tails website.
 
-Tails also comes with the `Metadata Anonymization
+Tails also comes with the `Metadata Anonymisation
 Toolkit <https://mat.boum.org/>`__ (MAT) that is used to help strip
 metadata from a variety of types of files, including png, jpg,
 OpenOffice/LibreOffice documents, Microsoft Office documents, pdf, tar,

--- a/docs/training_schedule.rst
+++ b/docs/training_schedule.rst
@@ -98,7 +98,7 @@ Participants: journalists and admins
    to a distant journalist's air-gapped SVS
 -  Do complete journalist process walk through twice, either on
    different days or between morning/afternoon sessions
--  Using MAT
+-  Using MAT (Metadata Anonymisation Toolkit)
 -  What to do for unsupported formats
 
 Admin training


### PR DESCRIPTION
We use the American spelling "anonymization" throughout most of the docs, but the MAT website (https://mat.boum.org) refers to it consistently as the "Metadata Anonymisation Toolkit" (UK spelling), so we should standardize on the UK spelling when using the word in the context of MAT.

Closes #1147 (same goal, but makes the change to the re-written documentation added in #1158).