### PR TITLE
Redirect source to /lookup if visiting /generate and already logged in

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -154,12 +154,10 @@ def generate_unique_codename(num_words):
 
 @app.route('/generate', methods=('GET', 'POST'))
 def generate():
-    # Popping this key prevents errors when a logged in user returns to /generate.
-    # TODO: is this the best experience? A logged in user will be automatically
-    # logged out if they navigate to /generate by accident, which could be
-    # confusing. It might be better to instead redirect them to the lookup
-    # page, or inform them that they're logged in.
-    session.pop('logged_in', None)
+    if logged_in():
+        flash("You were redirected because you are already logged in. If you want"
+              "to create a new account, you should log out first.", "notification")
+        return redirect(url_for('lookup'))
 
     num_words = 7
     if request.method == 'POST':
@@ -381,6 +379,15 @@ def login():
                     "Login failed for invalid codename".format(codename))
             flash("Sorry, that is not a recognized codename.", "error")
     return render_template('login.html')
+
+@app.route('/logout')
+def logout():
+    if logged_in():
+        session.clear()
+        flash("Thank you for logging out.", "notification")
+
+    return redirect(url_for('index'))
+        
 
 
 @app.route('/howto-disable-js')

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -27,6 +27,9 @@
       {% endblock %}
 
       <div class="panel selected">
+	{% if 'logged_in' in session %}
+	<a href="{{ url_for('logout') }}" class="btn pull-right" id="logout">Log Out</a>
+	{% endif %}
         <hr class="no-line" />
 
         {% block body %}{% endblock %}

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -19,6 +19,7 @@
 
     <div class="content">
       <div class="grid">
+	{% include 'flashed.html' %}
         <div id="header">
           <img src="/static/i/{{ header_image }}" class="logo grid-item" alt="SecureDrop" width="250px">
           {% if use_custom_header_image %}

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -1,6 +1,5 @@
 import tempfile
 
-
 class SourceNavigationSteps():
 
     def _source_visits_source_homepage(self):
@@ -60,3 +59,8 @@ class SourceNavigationSteps():
         self.assertIn('Thanks for submitting something to SecureDrop!'
                       ' Please check back later for replies.',
                       notification.text)
+
+    def _source_logs_out(self):
+        logout_button = self.driver.find_element_by_id('logout').click()
+        notification = self.driver.find_element_by_css_selector('p.notification')
+        self.assertIn('Thank you for logging out.', notification.text)

--- a/securedrop/tests/functional/submit_and_retrieve_file.py
+++ b/securedrop/tests/functional/submit_and_retrieve_file.py
@@ -21,6 +21,7 @@ class SubmitAndRetrieveFile(
         self._source_chooses_to_submit_documents()
         self._source_continues_to_submit_page()
         self._source_submits_a_file()
+        self._source_logs_out()
         self._journalist_logs_in()
         self._journalist_checks_messages()
         self._journalist_downloads_message()

--- a/securedrop/tests/functional/submit_and_retrieve_message.py
+++ b/securedrop/tests/functional/submit_and_retrieve_message.py
@@ -22,6 +22,7 @@ class SubmitAndRetrieveMessage(
         self._source_chooses_to_submit_documents()
         self._source_continues_to_submit_page()
         self._source_submits_a_message()
+        self._source_logs_out()
         self._journalist_logs_in()
         self._journalist_checks_messages()
         self._journalist_downloads_message()


### PR DESCRIPTION
Add ability to log out at /logout.

Add test to ensure that /generate handles users who are already logged in appropriately

Improve test for generate when already logged in

Add log out button to source_templates/base.html

This is the exact same thing as this PR, but squashed and rebased to the current source since mine was 2 months outdated: https://github.com/freedomofpress/securedrop/pull/1080
I ended up getting the job at the company I interviewed for and had to get managerial approval before I could continue working on this project. Luckily, I got managerial approval!