### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![SecureDrop](/docs/images/logo.png)
+<img src="/docs/images/logo.png" width="350" height="350">
 
 [![Build Status](https://travis-ci.org/freedomofpress/securedrop.png)](http://travis-ci.org/freedomofpress/securedrop)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img src="/docs/images/logo.png" width="350" height="350">
+<p align="center">
+  <img src="/docs/images/logo.png" width="350" height="350">
+</p>
 
 [![Build Status](https://travis-ci.org/freedomofpress/securedrop.png)](http://travis-ci.org/freedomofpress/securedrop)
 

--- a/README.md
+++ b/README.md
@@ -13,22 +13,6 @@ If you're here because you want to report an issue in SecureDrop, please observe
 * If you want to report a **_security issue_**, please use our [bug bounty hosted by Bugcrowd](https://bugcrowd.com/freedomofpress).
 * If the issue does not have a security impact, just create a [Github Issue](https://github.com/freedomofpress/securedrop/issues/new).
 
-## Technical Summary
-
-SecureDrop is a tool for sources to communicate securely with journalists. The SecureDrop application environment consists of three dedicated computers:
-
-* `Secure Viewing Station`: An air-gapped laptop running the [Tails operating system](https://tails.boum.org/) from a USB stick that journalists use to decrypt and view submitted documents.
-* `Application Server`: Ubuntu server running two segmented Tor hidden services. The source connects to the *Source Interface*, a public-facing Tor hidden service, to send messages and documents to the journalist. The journalist connects to the *Document Interface*, an [authenticated Tor hidden service](https://gitweb.torproject.org/torspec.git/tree/rend-spec.txt#n851), to download encrypted documents and respond to sources.
-* `Monitor server`: Ubuntu server that monitors the `Application Server` with [OSSEC](http://www.ossec.net/) and sends email alerts.
-
-In addition to these dedicated computers, the journalist will also use his or her normal workstation computer:
-
-* `Journalist Workstation`: The every-day laptop that the journalist uses for his or her work. The journalist will use this computer to connect to the `Application Server` to download encrypted documents that he or she will transfer to the `Secure Viewing Station`. The `Journalist Workstation` is also used to respond to sources via the *Document Interface*.
-
-Depending on the news organizations's threat model, it is recommended that journalists always use the [Tails operating system](https://tails.boum.org/) on their `Journalist Workstation` when connecting to the `Application Server`. Alternatively, this can also be its own dedicated computer.
-
-These computers should all physically be in your organization's office.
-
 ## How to Install SecureDrop
 
 See the [Installation Guide](https://docs.securedrop.org/en/latest/#installtoc).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 SecureDrop is an open-source whistleblower submission system that media organizations can use to securely accept documents from and communicate with anonymous sources. It was originally created by the late Aaron Swartz and is currently managed by [Freedom of the Press Foundation](https://freedom.press).
 
+SecureDrop's documentation is now built and hosted by [Read the Docs](https://readthedocs.org): https://docs.securedrop.org. If you are still trying to use links to Markdown files on our Github to read documentation, please update your bookmarks.
+
 ## Found an issue?
 
 If you're here because you want to report an issue in SecureDrop, please observe the following protocol to report an issue responsibly:
@@ -29,16 +31,16 @@ These computers should all physically be in your organization's office.
 
 ## How to Install SecureDrop
 
-See the [Installation Guide](/docs/install.md).
+See the [Installation Guide](https://docs.securedrop.org/en/latest/#installtoc).
 
 ## How to Use SecureDrop
 
-* [How to use SecureDrop as a source](/docs/source_user_manual.md)
-* [How to use SecureDrop as a journalist](/docs/journalist_user_manual.md)
+* [How to use SecureDrop as a source](https://docs.securedrop.org/en/latest/source.html)
+* [How to use SecureDrop as a journalist](https://docs.securedrop.org/en/latest/journalist.html)
 
 ## How to Contribute to SecureDrop
 
-See the [Development Guide](/docs/develop.md).
+See the [Development Guide](https://docs.securedrop.org/en/latest/development/getting_started.html).
 
 ## License
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -7,6 +7,41 @@ with anonymous sources. It was originally created by the late Aaron
 Swartz and is currently managed by `Freedom of the Press
 Foundation <https://freedom.press>`__.
 
+Technical Summary
+-----------------
+
+SecureDrop is a tool for sources to communicate securely with journalists. The
+SecureDrop application environment consists of three dedicated computers:
+
+- ``Secure Viewing Station``: An air-gapped laptop running the `Tails operating
+   system <https://tails.boum.org/>`__ from a USB stick that journalists use to
+   decrypt and view submitted documents.
+- ``Application Server``: Ubuntu server running two segmented Tor hidden
+   services. The source connects to the *Source Interface*, a public-facing Tor
+   hidden service, to send messages and documents to the journalist. The
+   journalist connects to the *Document Interface*, an `authenticated Tor
+   hidden service
+   <https://gitweb.torproject.org/torspec.git/tree/rend-spec.txt#n851>`__, to
+   download encrypted documents and respond to sources.
+- ``Monitor server``: Ubuntu server that monitors the ``Application Server``
+   with `OSSEC <http://www.ossec.net/>`__ and sends email alerts.
+
+In addition to these dedicated computers, the journalist will also use his or
+her normal workstation computer:
+
+- ``Journalist Workstation``: The every-day laptop that the journalist uses for
+   his or her work. The journalist will use this computer to connect to the
+   ``Application Server`` to download encrypted documents that he or she will
+   transfer to the ``Secure Viewing Station``. The ``Journalist Workstation``
+   is also used to respond to sources via the *Document Interface*.
+
+Depending on the news organizations's threat model, it is recommended that
+journalists always use the `Tails operating system <https://tails.boum.org/>`__
+on their ``Journalist Workstation`` when connecting to the ``Application
+Server``. Alternatively, this can also be its own dedicated computer.
+
+These computers should all physically be in your organization's office.
+
 Infrastructure
 --------------
 


### PR DESCRIPTION
Various updates to the README, should be clear from the commit messages.

Addresses the README as a source of broken links to the old documentation from #1166.