### PR TITLE
Change Tor package repository to HTTPS transport

### DIFF
--- a/install_files/ansible-base/roles/common-app/tasks/install_tor.yml
+++ b/install_files/ansible-base/roles/common-app/tasks/install_tor.yml
@@ -9,7 +9,7 @@
 
 - name: setup tor apt repo
   apt_repository:
-    repo: deb http://deb.torproject.org/torproject.org {{ ansible_lsb.codename }} main
+    repo: deb https://deb.torproject.org/torproject.org {{ ansible_lsb.codename }} main
     state: present
     update_cache: yes
   tags:

--- a/install_files/ansible-base/roles/common-mon/tasks/install_tor.yml
+++ b/install_files/ansible-base/roles/common-mon/tasks/install_tor.yml
@@ -9,7 +9,7 @@
 
 - name: setup tor apt repo
   apt_repository:
-    repo: deb http://deb.torproject.org/torproject.org {{ ansible_lsb.codename }} main
+    repo: deb https://deb.torproject.org/torproject.org {{ ansible_lsb.codename }} main
     state: present
     update_cache: yes
   tags:

--- a/install_files/ansible-base/roles/common/templates/security.list
+++ b/install_files/ansible-base/roles/common/templates/security.list
@@ -3,4 +3,4 @@ deb-src http://security.ubuntu.com/ubuntu trusty-security main
 deb http://security.ubuntu.com/ubuntu trusty-security universe
 deb-src http://security.ubuntu.com/ubuntu trusty-security universe
 deb [arch=amd64] {{ apt_repo_url }} trusty main
-deb http://deb.torproject.org/torproject.org trusty main
+deb https://deb.torproject.org/torproject.org trusty main

--- a/spec_tests/spec/common/cron_apt_spec.rb
+++ b/spec_tests/spec/common/cron_apt_spec.rb
@@ -21,7 +21,7 @@ security_repositories = [
   'deb http://security.ubuntu.com/ubuntu trusty-security universe',
   'deb-src http://security.ubuntu.com/ubuntu trusty-security universe',
   'deb [arch=amd64] https://apt.freedom.press trusty main',
-  'deb http://deb.torproject.org/torproject.org trusty main',
+  'deb https://deb.torproject.org/torproject.org trusty main',
 ]
 # ensure custom security.list file is present
 describe file('/etc/apt/security.list') do

--- a/spec_tests/spec/common/tor_spec.rb
+++ b/spec_tests/spec/common/tor_spec.rb
@@ -1,6 +1,6 @@
 # ensure tor repo is present
 describe file('/etc/apt/sources.list.d/deb_torproject_org_torproject_org.list') do
-  repo_regex = Regexp.quote('deb http://deb.torproject.org/torproject.org trusty main')
+  repo_regex = Regexp.quote('deb https://deb.torproject.org/torproject.org trusty main')
   its(:content) { should match /^#{repo_regex}$/ }
 end
 


### PR DESCRIPTION
deb.torproject.org repos are reliably being served over HTTPS. We can update our stuff accordingly to fetch Tor with transport layer security. (the `snapci` role already uses https://deb.torproject.org, not sure why that is)