### PR TITLE
Add placeholders to redirect people from old docs

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -1,0 +1,20 @@
+## Notice: Documentation Moved
+
+**New documentation:** https://docs.securedrop.org
+
+If you are viewing this file on GitHub in your web browser, you are using an
+outdated link to the SecureDrop documentation. The new and improved
+documentation is available at https://docs.securedrop.org.
+
+This document (the Developer Guide) has been moved to
+https://docs.securedrop.org/en/latest/development/getting_started.html.
+
+This document is a temporary placeholder to help redirect users who still have
+links to the old-style SecureDrop documentation hosted on GitHub. Please update
+your bookmarks. If you came here from another website, please [file an issue][]
+so we can follow up with the website maintainer.
+
+Finally, note that this placeholder will eventually be removed, and that
+removal may happen without warning and at any time.
+
+[file an issue]: https://github.com/freedomofpress/securedrop/issues/new

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -1,0 +1,20 @@
+## Notice: Documentation Moved
+
+**New documentation:** https://docs.securedrop.org
+
+If you are viewing this file on GitHub in your web browser, you are using an
+outdated link to the SecureDrop documentation. The new and improved
+documentation is available at https://docs.securedrop.org.
+
+This document (the Hardware Guide) has been moved to
+https://docs.securedrop.org/en/latest/hardware.html.
+
+This document is a temporary placeholder to help redirect users who still have
+links to the old-style SecureDrop documentation hosted on GitHub. Please update
+your bookmarks. If you came here from another website, please [file an issue][]
+so we can follow up with the website maintainer.
+
+Finally, note that this placeholder will eventually be removed, and that
+removal may happen without warning and at any time.
+
+[file an issue]: https://github.com/freedomofpress/securedrop/issues/new

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,21 @@
+## Notice: Documentation Moved
+
+**New documentation:** https://docs.securedrop.org
+
+If you are viewing this file on GitHub in your web browser, you are using an
+outdated link to the SecureDrop documentation. The new and improved
+documentation is available at https://docs.securedrop.org.
+
+This document (the Install Guide) has been split into a series of smaller, more
+manageable documents; you can see the Table of Contents for the installation
+documentation here: https://docs.securedrop.org/en/latest/#installtoc.
+
+This document is a temporary placeholder to help redirect users who still have
+links to the old-style SecureDrop documentation hosted on GitHub. Please update
+your bookmarks. If you came here from another website, please [file an issue][]
+so we can follow up with the website maintainer.
+
+Finally, note that this placeholder will eventually be removed, and that
+removal may happen without warning and at any time.
+
+[file an issue]: https://github.com/freedomofpress/securedrop/issues/new

--- a/docs/journalist_user_manual.md
+++ b/docs/journalist_user_manual.md
@@ -1,0 +1,20 @@
+## Notice: Documentation Moved
+
+**New documentation:** https://docs.securedrop.org
+
+If you are viewing this file on GitHub in your web browser, you are using an
+outdated link to the SecureDrop documentation. The new and improved
+documentation is available at https://docs.securedrop.org.
+
+This document (the Journalist User Manual) has been moved to
+https://docs.securedrop.org/en/latest/journalist.html.
+
+This document is a temporary placeholder to help redirect users who still have
+links to the old-style SecureDrop documentation hosted on GitHub. Please update
+your bookmarks. If you came here from another website, please [file an issue][]
+so we can follow up with the website maintainer.
+
+Finally, note that this placeholder will eventually be removed, and that
+removal may happen without warning and at any time.
+
+[file an issue]: https://github.com/freedomofpress/securedrop/issues/new

--- a/docs/source_user_manual.md
+++ b/docs/source_user_manual.md
@@ -1,0 +1,20 @@
+## Notice: Documentation Moved
+
+**New documentation:** https://docs.securedrop.org
+
+If you are viewing this file on GitHub in your web browser, you are using an
+outdated link to the SecureDrop documentation. The new and improved
+documentation is available at https://docs.securedrop.org.
+
+This document (the Source User Manual) has been moved to
+https://docs.securedrop.org/en/latest/source.html.
+
+This document is a temporary placeholder to help redirect users who still have
+links to the old-style SecureDrop documentation hosted on GitHub. Please update
+your bookmarks. If you came here from another website, please [file an issue][]
+so we can follow up with the website maintainer.
+
+Finally, note that this placeholder will eventually be removed, and that
+removal may happen without warning and at any time.
+
+[file an issue]: https://github.com/freedomofpress/securedrop/issues/new


### PR DESCRIPTION
Before we migrated to ReadTheDocs in #1158, we regularly shared links to
the documentation as links to the Markdown files on GitHub (because
GitHub would render the Markdown for us automatically). In order to
assist people who may still be using those old links, I've added
placeholders for some of our more popular documentation (based on a
quick skim of my Sent email and the broken links cited in #1166) that
explain the migration and redirect users to the correct pages in the new
docs.