### PR TITLE
Various changes to verification processes

### DIFF
--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -113,11 +113,14 @@ installation:
 
     cp ossec.pub install_files/ansible-base/
 
-The fingerprint is a unique identifier for an encryption key that is
-longer than, but contains both the shortid and longid. The value for
-``ossec_gpg_fpr`` must be the full 40-character GPG fingerprint for this
-same key, with all capital letters and no spaces. Here's a series of
-commands that will retrieve and format the fingerprint per our
+The fingerprint is a unique identifier for an encryption (public) key. It is the
+output of running a cryptographic hash function (in this case SHA1) over the
+key, represented in hexadecimal. The short and long key IDs correspond to the
+last 8 and 16 hexadecimal digits (or 32 and 64 bits) of the fingerprint,
+respectively, and are thus a subset of the fingerprint. The value for
+``ossec_gpg_fpr`` must be the full 40 hexadecimal digit (160 bit) GPG
+fingerprint for this same key, with all capital letters and no spaces. Here's a
+series of commands that will retrieve and format the fingerprint per our
 requirements:
 
 ::

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -55,17 +55,14 @@ Start by running the following commands to download the git repository.
 Verify the Release Tag
 ~~~~~~~~~~~~~~~~~~~~~~
 
-First, download the *Freedom of the Press Foundation Master Signing Key*
-and verify the fingerprint.
+First, download and verify the *Freedom of the Press Foundation Master
+Signing Key*. When passing the full public key fingerprint to the
+:code:`--recv-key` command, GPG will implicitly verify that the
+fingerprint of the key received matches the argument passed.
 
 .. code:: sh
 
-    gpg --keyserver pool.sks-keyservers.net --recv-key B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
-    gpg --fingerprint B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
-
-The Freedom of the Press Foundation Master Signing Key should have a
-fingerprint of ``B89A 29DB 2128 160B 8E4B 1B4C BADD E0C7 FC9F
-6818``.
+    gpg --keyserver hkp://qdigse2yzvuglcix.onion --recv-key B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
 
 .. caution:: If the fingerprint does not match, fingerprint
 	     verification has failed and you **should not** proceed

--- a/docs/ubuntu_install.rst
+++ b/docs/ubuntu_install.rst
@@ -1,30 +1,31 @@
 Ubuntu Install Guide
 ====================
 
-The *Application Server* and the *Monitor Server* specifically require
-the 64-bit version of `Ubuntu Server 14.04.2 LTS (Trusty
-Tahr) <http://old-releases.ubuntu.com/releases/14.04.2/>`__. The image
-you want to get is named ``ubuntu-14.04.2-server-amd64.iso``. In order
-to verify the installation media, you should also download the files
-named ``SHA256SUMS`` and ``SHA256SUMS.gpg``.
+The *Admin Workstation*, running Tails, should be used to download and verify
+Ubuntu Server.  The *Application Server* and the *Monitor Server* specifically
+require the 64-bit version of `Ubuntu Server 14.04.2 LTS (Trusty Tahr)
+<http://old-releases.ubuntu.com/releases/14.04.2/>`__. The image you want to get
+is named ``ubuntu-14.04.2-server-amd64.iso``. In order to verify the
+installation media, you should also download the files named ``SHA256SUMS`` and
+``SHA256SUMS.gpg``.
 
 Verify the Ubuntu installation media
 ------------------------------------
 
-First you should make sure that the Ubuntu image you downloaded hasn't
-been modified by a malicious attacker by checking its integrity with
-cryptographic signatures and hashes — which might sound complex but it's
-relatively easy to do. Before you can verify the Ubuntu installation
-media, you will need to download the associated public key.
+First, you should verify the Ubuntu image you downloaded hasn't been modified by
+a malicious attacker or otherwise corrupted. We can do so by checking its
+integrity with cryptographic signatures and hashes. First, we will download
+*Ubuntu Image Signing Key* and verify its fingerprint. Fortunately, we can do
+this in one step; GPG will implicity verify that the fingerprint of the key
+received matches the one requested when the full fingerprint is passed to the
+:code:`--recv-key` command.
 
 ::
 
-    gpg --keyserver pool.sks-keyservers.net --recv-key C5986B4F1257FFA86632CBA746181433FBB75451
-    gpg --fingerprint C5986B4F1257FFA86632CBA746181433FBB75451
+    gpg --keyserver hkp://qdigse2yzvuglcix.onion --recv-key C5986B4F1257FFA86632CBA746181433FBB75451
 
-The Ubuntu CD Image Automatic Signing Key should have a fingerprint of
-"C598 6B4F 1257 FFA8 6632 CBA7 4618 1433 FBB7 5451". If the fingerprint
-does not match what you see here, please get in touch at
+
+If the fingerprint does not match, please get in touch at
 securedrop@freedom.press.
 
 Verify the ``SHA256SUMS`` file and move on to the next step if you see
@@ -34,18 +35,12 @@ Verify the ``SHA256SUMS`` file and move on to the next step if you see
 
     gpg --verify SHA256SUMS.gpg SHA256SUMS
 
-The next and final step is to verify the Ubuntu image. If you are using
-Linux, use the following command.
+The next and final step is to verify the Ubuntu image.
 
 ::
 
     sha256sum -c <(grep ubuntu-14.04.2-server-amd64.iso SHA256SUMS)
 
-If you are using OS X, use the command below.
-
-::
-
-    shasum -a 256 -c <(grep ubuntu-14.04.2-server-amd64.iso SHA256SUMS)
 
 If the final verification step is successful, you should see the
 following output in your terminal.
@@ -57,18 +52,16 @@ following output in your terminal.
 Create the Ubuntu installation media
 ------------------------------------
 
-To create the Ubuntu installation media, you can either burn the ISO
-image to a CD-R or create a bootable USB stick (see instructions for
-doing this on `OS
-X <http://www.ubuntu.com/download/desktop/create-a-usb-stick-on-mac-osx>`__,
-`Ubuntu <http://www.ubuntu.com/download/desktop/create-a-usb-stick-on-ubuntu>`__
-and
-`Windows <http://www.ubuntu.com/download/desktop/create-a-usb-stick-on-windows>`__).
-As a reliable method we recommend using the ``dd`` command to copy the
-hybrid ISO directly to a USB drive rather than a utility like UNetbootin
-which can result in errors. Once you have a CD or USB with an ISO image
-of Ubuntu on it, you may begin the Ubuntu installation on both
-SecureDrop servers.
+To create the Ubuntu installation media, you can either burn the ISO image to a
+CD-R or create a bootable USB stick.  As a reliable method we recommend using
+the ``dd`` command to copy the hybrid ISO directly to a USB drive rather than a
+utility like UNetbootin which can result in errors. Once you have a CD or USB
+with an ISO image of Ubuntu on it, you may begin the Ubuntu installation on both
+SecureDrop servers. If your USB is mapped to /dev/sdb, you would use dd like so:
+
+::
+
+    sudo dd conv=fdatasync if=ubuntu-14.04.2-server-amd64.iso of=/dev/sdb
 
 Install Ubuntu
 --------------


### PR DESCRIPTION
This commit changes parts of various files relating to the verification process
of keys and software use in and by SecureDrop. It is a follow up to pull request
1157 and issue #520. Changes include:

* Removal of redundant verification of key fingerprint (since GPG now does it
  implicitly).
* Admin is now explicitly instructed to download and verify Ubuntu Server over
  Tor, for greater privacy and security (see comments on #1157 for details).
* SKS hidden keyserver is now used instead of non-HKPS SKS pool for greater
  privacy and security (see comments on #1157 for details).
* Improved exposition on key fingerprints in admin-oriented documentation, w/o
  being over-technical or introducing concepts not elsewhere mentioned.
* Lastly, since a modification to the documentation on creating an Ubuntu
  installation medium was already in place, I went ahead and gave a recommended
  usage of the dd command.

Signed-off-by: Noah Vesely <fowlslegs@riseup.net>