### PR TITLE
Upgrade docs for 0.3.5 and 0.3.6

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,6 +63,8 @@ anonymous sources.
    :maxdepth: 2
 
    upgrade/upgrade-0.3.x.rst
+   upgrade/0.3.x-to-0.3.5.rst
+   upgrade/0.3.5-to-0.3.6.rst
 
 .. toctree::
    :caption: Developer Documentation

--- a/docs/upgrade/0.3.5-to-0.3.6.rst
+++ b/docs/upgrade/0.3.5-to-0.3.6.rst
@@ -4,7 +4,7 @@ Upgrade from 0.3.5 to 0.3.6
 SecureDrop 0.3.6 was a maintenance release to update the expiration
 date on the GPG signing key used for the Freedom of the Press
 apt repository. The signing key expired on October 26, 2015, preventing
-automatically updates from Freedom of the Press until the issue is
+automatic updates from Freedom of the Press until the issue is
 manually resolved.
 
 
@@ -15,7 +15,8 @@ manually resolved.
 
 
 The upgrade steps in this document will upgrade a 0.3.5 SecureDrop to
-0.3.6. If you have not yet upgraded to 0.3.5, :doc:`do that first <0.3.x-to-0.3.5>`.
+0.3.6. If you have not yet upgraded to 0.3.5, :doc:`do that first 
+<0.3.x-to-0.3.5>`.
 
 Important Changes
 -----------------
@@ -51,7 +52,8 @@ Upgrade Procedure
 
 The upgrade procedure can be performed entirely from the Admin
 Workstation. Start by booting the Admin Tails USB on the Admin 
-Workstation. Make sure you set an *Adminstrator Password* in the *Tails Greeter*.
+Workstation. Make sure you set an *Adminstrator Password* in the *Tails 
+Greeter*.
 
 #. Open a terminal (it is an icon on the top of the screen that looks
    like a little black TV).
@@ -70,6 +72,13 @@ Workstation. Make sure you set an *Adminstrator Password* in the *Tails Greeter*
     gpg --keyserver pool.sks-keyservers.net --recv-key B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
     gpg --fingerprint B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
 
+   .. tip:: The GPG Master Signing Key is also available from the
+             `Freedom of the Press website 
+<https://freedom.press/sites/default/files/fpf.asc>`_,
+             and the key is signed by the Lead Developer's personal GPG keys, 
+so you can verify
+             that you have the correct key through the GPG Web of Trust (WoT).
+
 #. Pull the latest code ::
 
      git pull
@@ -86,15 +95,18 @@ Workstation. Make sure you set an *Adminstrator Password* in the *Tails Greeter*
 
      git stash pop
 
-#. Make sure you have Ansible installed. If running ``which ansible`` returns ``ansible not found``, you should ::
+#. Make sure you have Ansible installed. If running ``which ansible`` returns 
+``ansible not found``, you should ::
 
     sudo apt-get update
     sudo apt-get install ansible
 
-#. Run the Ansible playbooks (substitute the admin account on the servers for ``<user>``) ::
+#. Run the Ansible playbooks (substitute the admin account on the servers for 
+``<user>``) ::
 
     ansible-playbook -i inventory -s -u <user> securedrop-prod.yml
 
 During the playbook run, the GPG signing key will be updated, and all packages
-will be upgraded on both servers. The new signing key is valid until October 2016,
+will be upgraded on both servers. The new signing key is valid until October 
+2016,
 at which point another manual update may be necessary.

--- a/docs/upgrade/0.3.5-to-0.3.6.rst
+++ b/docs/upgrade/0.3.5-to-0.3.6.rst
@@ -1,0 +1,100 @@
+Upgrade from 0.3.5 to 0.3.6
+============================
+
+SecureDrop 0.3.6 was a maintenance release to update the expiration
+date on the GPG signing key used for the Freedom of the Press
+apt repository. The signing key expired on October 26, 2015, preventing
+automatically updates from Freedom of the Press until the issue is
+manually resolved.
+
+
+.. note:: We're considering creating a separate ``securedrop-keyring`` 
+      Debian package to package to manage the signing keys into the future. 
+      If you have strong feelings about how the signing key is managed,
+      `open an issue <https://github.com/freedomofpress/securedrop/issues/>`_.
+
+
+The upgrade steps in this document will upgrade a 0.3.5 SecureDrop to
+0.3.6. If you have not yet upgraded to 0.3.5, :doc:`do that first <0.3.x-to-0.3.5>`.
+
+Important Changes
+-----------------
+
+Update Expired GPG Signing Key (Admin Workstation)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The Admin Workstation is used to verify the signed git tag on new
+SecureDrop releases. Prior to running the 0.3.6 upgrade, the Admin
+Workstation should update the signing key.
+
+Update Expired GPG Signing Key (SecureDrop Servers)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The Application Server and Monitor Server will need to have their apt
+keyrings updated, which can be accomplished by running the Ansible playbooks.
+
+
+Prerequisites
+-------------
+
+-  An Admin networked Tails workstation with persistence enabled and an
+   Admin password set during boot.
+   
+-  A running SecureDrop instance of 0.3.5.
+
+.. note:: If your SecureDrop instance is not already running 0.3.5,
+          :doc:`run that upgrade first <0.3.x-to-0.3.5>`. Failure to do 
+          so will result in a merge conflict for your site-specific
+          settings, which can be tedious to resolve if you're not
+          experienced with git.
+
+Upgrade Procedure
+-----------------
+
+The upgrade procedure can be performed entirely from the Admin
+Workstation. Start by booting the Admin Tails USB on the Admin 
+Workstation. Make sure you set an *Adminstrator Password* in the *Tails Greeter*.
+
+#. Open a terminal (it is an icon on the top of the screen that looks
+   like a little black TV).
+
+#. Change into the SecureDrop repo directory ::
+
+     cd /home/amnesia/Persistent/securedrop
+
+#. Stash your local changes to the inventory and prod-specific.yml ::
+
+     git stash save "site specific configs"
+
+#. Update the Freedom of the Press signing key
+   (these commands are from the :doc:`../set_up_admin_tails` guide) ::
+
+    gpg --keyserver pool.sks-keyservers.net --recv-key B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
+    gpg --fingerprint B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
+
+#. Pull the latest code ::
+
+     git pull
+
+#. Verify the signed git tag for the latest stable release ::
+
+     git tag -v 0.3.6
+
+#. Checkout the latest release ::
+
+     git checkout 0.3.6
+
+#. Pop the site specific configs back in place ::
+
+     git stash pop
+
+#. Make sure you have Ansible installed. If running ``which ansible`` returns ``ansible not found``, you should ::
+
+    sudo apt-get update
+    sudo apt-get install ansible
+
+#. Run the Ansible playbooks (substitute the admin account on the servers for ``<user>``) ::
+
+    ansible-playbook -i inventory -s -u <user> securedrop-prod.yml
+
+During the playbook run, the GPG signing key will be updated, and all packages
+will be upgraded on both servers. The new signing key is valid until October 2016,
+at which point another manual update may be necessary.

--- a/docs/upgrade/0.3.5-to-0.3.6.rst
+++ b/docs/upgrade/0.3.5-to-0.3.6.rst
@@ -1,18 +1,15 @@
 Upgrade from 0.3.5 to 0.3.6
 ============================
 
-SecureDrop 0.3.6 was a maintenance release to update the expiration
-date on the GPG signing key used for the Freedom of the Press
-apt repository. The signing key expired on October 26, 2015, preventing
-automatic updates from Freedom of the Press until the issue is
-manually resolved.
+SecureDrop 0.3.6 was a maintenance release to update the expiration date on 
+the GPG signing key used for the Freedom of the Press apt repository. The 
+signing key expired on October 26, 2015, preventing automatic updates from 
+Freedom of the Press until the issue is manually resolved.
 
-
-.. note:: We're considering creating a separate ``securedrop-keyring`` 
-      Debian package to package to manage the signing keys into the future. 
-      If you have strong feelings about how the signing key is managed,
-      `open an issue <https://github.com/freedomofpress/securedrop/issues/>`_.
-
+.. note:: We're considering creating a separate Debian package to
+          manage the signing keys into the future. If you have strong 
+          feelings about how the signing key is managed, `open an issue 
+          <https://github.com/freedomofpress/securedrop/issues/>`_.
 
 The upgrade steps in this document will upgrade a 0.3.5 SecureDrop to
 0.3.6. If you have not yet upgraded to 0.3.5, :doc:`do that first 
@@ -31,7 +28,6 @@ Update Expired GPG Signing Key (SecureDrop Servers)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Application Server and Monitor Server will need to have their apt
 keyrings updated, which can be accomplished by running the Ansible playbooks.
-
 
 Prerequisites
 -------------
@@ -73,11 +69,11 @@ Greeter*.
     gpg --fingerprint B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
 
    .. tip:: The GPG Master Signing Key is also available from the
-             `Freedom of the Press website 
-<https://freedom.press/sites/default/files/fpf.asc>`_,
-             and the key is signed by the Lead Developer's personal GPG keys, 
-so you can verify
-             that you have the correct key through the GPG Web of Trust (WoT).
+            `Freedom of the Press website 
+            <https://freedom.press/sites/default/files/fpf.asc>`_,
+            and the key is signed by the Lead Developer's personal GPG keys, 
+            so you can verify that you have the correct key 
+            through the GPG Web of Trust (WoT).
 
 #. Pull the latest code ::
 
@@ -96,17 +92,16 @@ so you can verify
      git stash pop
 
 #. Make sure you have Ansible installed. If running ``which ansible`` returns 
-``ansible not found``, you should ::
+   ``ansible not found``, you should ::
 
     sudo apt-get update
     sudo apt-get install ansible
 
 #. Run the Ansible playbooks (substitute the admin account on the servers for 
-``<user>``) ::
+   ``<user>``) ::
 
     ansible-playbook -i inventory -s -u <user> securedrop-prod.yml
 
 During the playbook run, the GPG signing key will be updated, and all packages
 will be upgraded on both servers. The new signing key is valid until October 
-2016,
-at which point another manual update may be necessary.
+2016, at which point another manual update may be necessary.

--- a/docs/upgrade/0.3.x-to-0.3.5.rst
+++ b/docs/upgrade/0.3.x-to-0.3.5.rst
@@ -15,10 +15,11 @@ Important Changes
 OSSEC Postfix configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Postfix configuration on the Monitor Server previously used a hard-coded
-fingerprint value, specified as ``smtp_relay_fingerprint`` in the ``prod-specific.yml`` file,
-to verify the TLS certificate prior to sending mail. Some mail providers use load balancing
-on the SMTP relay, which causes the fingerprint to change periodicially during normal use.
-With a hard-coded fingerprint, this caused OSSEC alerts to be delayed, so the default
+fingerprint value, specified as ``smtp_relay_fingerprint`` in the 
+``prod-specific.yml`` file, to verify the TLS certificate prior to sending 
+mail.Some mail providers use load balancing on the SMTP relay, which causes
+the fingerprint to change periodicially during normal use. With a hard-coded
+fingerprint, this caused OSSEC alerts to be delayed, so the default
 functionality is now to trust the system CAs on the Monitor Server.
 
 In order to upgrade to the new verification functionality, admins update the 
@@ -64,7 +65,8 @@ Upgrade Procedure
 
 The upgrade procedure can be performed entirely from the Admin
 Workstation. Start by booting the Admin Tails USB on the Admin 
-Workstation. Make sure you set an *Adminstrator Password* in the *Tails Greeter*.
+Workstation. Make sure you set an *Adminstrator Password* in the *Tails 
+Greeter*.
 
 #. Open a terminal (it is an icon on the top of the screen that looks
    like a little black TV).
@@ -74,7 +76,8 @@ Workstation. Make sure you set an *Adminstrator Password* in the *Tails Greeter*
      cd /home/amnesia/Persistent/securedrop/install_files/ansible-base
 
 #. Open ``prod-specific.yml`` in your preferred text editor.
-   Delete the line that starts with ``smtp_relay_fingerprint`` and save the file.
+   Delete the line that starts with ``smtp_relay_fingerprint`` and save the 
+file.
    If you are using your own or your organization's SMTP relay (not Google's),
    you may want want to continue using fingerprint verification.
    If you are unsure, contact us and we will help you make a determination.
@@ -105,15 +108,17 @@ Workstation. Make sure you set an *Adminstrator Password* in the *Tails Greeter*
              Since 0.3.5 makes changes to the ``prod-specific.yml`` file,
              more verbose git commands are necessary to avoid a merge conflict.
 
-#. Make sure you have Ansible installed. If running ``which ansible`` returns ``ansible not found``, you should ::
+#. Make sure you have Ansible installed. If running ``which ansible`` returns 
+``ansible not found``, you should ::
 
     sudo apt-get update
     sudo apt-get install ansible
 
-#. Run the Ansible playbooks (substitute the admin account on the servers for ``<user>``) ::
+#. Run the Ansible playbooks (substitute the admin account on the servers for 
+``<user>``) ::
 
     ansible-playbook -i inventory -s -u <user> securedrop-prod.yml
 
 During the playbook run, the Postfix TLS verification settings will be updated
-on the Monitor Server, the AppArmor profiles will be updated on the Application Server,
-and both servers will receive new logic for rebooting after unattended-upgrades.
+on the Monitor Server, and both servers will receive new logic for rebooting
+after unattended-upgrades.

--- a/docs/upgrade/0.3.x-to-0.3.5.rst
+++ b/docs/upgrade/0.3.x-to-0.3.5.rst
@@ -87,7 +87,6 @@ Workstation. Make sure you set an *Adminstrator Password* in the *Tails Greeter*
 
      git pull
 
-
 #. Verify the signed git tag for the latest stable release ::
 
      git tag -v 0.3.5
@@ -114,7 +113,6 @@ Workstation. Make sure you set an *Adminstrator Password* in the *Tails Greeter*
 #. Run the Ansible playbooks (substitute the admin account on the servers for ``<user>``) ::
 
     ansible-playbook -i inventory -s -u <user> securedrop-prod.yml
-
 
 During the playbook run, the Postfix TLS verification settings will be updated
 on the Monitor Server, the AppArmor profiles will be updated on the Application Server,

--- a/docs/upgrade/0.3.x-to-0.3.5.rst
+++ b/docs/upgrade/0.3.x-to-0.3.5.rst
@@ -1,10 +1,9 @@
 Upgrade from 0.3.x to 0.3.5
 ============================
 
-SecureDrop 0.3.5 updates how TLS certificates for the SMTP relay
-used to send OSSEC notifications are handled. It also updates
-the AppArmor profile for Apache to ensure the service starts
-successfully.
+SecureDrop 0.3.5 updates how TLS certificates for the SMTP relay used to send 
+OSSEC notifications are handled. It also updates the AppArmor profile for 
+Apache to ensure the service starts successfully.
 
 The upgrade steps in this document will upgrade a 0.3.x (where x < 5)
 SecureDrop instance to 0.3.5.
@@ -26,7 +25,6 @@ In order to upgrade to the new verification functionality, admins update the
 ``prod-specific.yml`` file and run a special git command designed to merge
 site-specific changes in safely.
 
-
 Allow log rotation for Apache
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The AppArmor profile for Apache was aggressively preventing the service
@@ -46,7 +44,6 @@ Blacklist additional kernel modules
 Newer versions of the Intel NUCs come with wifi and bluetooth hardware,
 so the playbooks now disable the ``btusb`` and ``iwlmvm`` kernel modules,
 in addition to ``bluetooth`` and ``iwlwifi``, which are still blacklisted.
-
 
 Prerequisites
 -------------
@@ -75,9 +72,8 @@ Greeter*.
 
      cd /home/amnesia/Persistent/securedrop/install_files/ansible-base
 
-#. Open ``prod-specific.yml`` in your preferred text editor.
-   Delete the line that starts with ``smtp_relay_fingerprint`` and save the 
-file.
+#. Open ``prod-specific.yml`` in your preferred text editor. Delete the line 
+   that starts with ``smtp_relay_fingerprint`` and save the file.
    If you are using your own or your organization's SMTP relay (not Google's),
    you may want want to continue using fingerprint verification.
    If you are unsure, contact us and we will help you make a determination.

--- a/docs/upgrade/0.3.x-to-0.3.5.rst
+++ b/docs/upgrade/0.3.x-to-0.3.5.rst
@@ -1,0 +1,121 @@
+Upgrade from 0.3.x to 0.3.5
+============================
+
+SecureDrop 0.3.5 updates how TLS certificates for the SMTP relay
+used to send OSSEC notifications are handled. It also updates
+the AppArmor profile for Apache to ensure the service starts
+successfully.
+
+The upgrade steps in this document will upgrade a 0.3.x (where x < 5)
+SecureDrop instance to 0.3.5.
+
+Important Changes
+-----------------
+
+OSSEC Postfix configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The Postfix configuration on the Monitor Server previously used a hard-coded
+fingerprint value, specified as ``smtp_relay_fingerprint`` in the ``prod-specific.yml`` file,
+to verify the TLS certificate prior to sending mail. Some mail providers use load balancing
+on the SMTP relay, which causes the fingerprint to change periodicially during normal use.
+With a hard-coded fingerprint, this caused OSSEC alerts to be delayed, so the default
+functionality is now to trust the system CAs on the Monitor Server.
+
+In order to upgrade to the new verification functionality, admins update the 
+``prod-specific.yml`` file and run a special git command designed to merge
+site-specific changes in safely.
+
+
+Allow log rotation for Apache
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The AppArmor profile for Apache was aggressively preventing the service
+from creating new log files, which prevented normal log rotation functionality.
+The adjustments to the AppArmor profile not only restore the expected rotation,
+but will also reduce false positives reported by OSSEC.
+
+Prevent reboots during cron-apt upgrade
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The servers are set to reboot nightly, to ensure submissions are not retained
+in memory. The timing of the reboot task was fuzzy, and it was possible that
+a reboot would interrupt a running upgrade for cron-apt. The new logic
+ensures that the reboot only takes place after cron-apt exits.
+
+Blacklist additional kernel modules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Newer versions of the Intel NUCs come with wifi and bluetooth hardware,
+so the playbooks now disable the ``btusb`` and ``iwlmvm`` kernel modules,
+in addition to ``bluetooth`` and ``iwlwifi``, which are still blacklisted.
+
+
+Prerequisites
+-------------
+
+-  An Admin networked Tails workstation with persistence enabled and an
+   Admin password set during boot.
+   
+-  A running SecureDrop instance of 0.3.x, where x is less than 5.
+
+.. note:: If your organization uses an internal SMTP relay, you may
+          wish to continue using fingerprint-style verification of the
+          TLS certificate. You can therefore skip #3 below.
+
+Upgrade Procedure
+-----------------
+
+The upgrade procedure can be performed entirely from the Admin
+Workstation. Start by booting the Admin Tails USB on the Admin 
+Workstation. Make sure you set an *Adminstrator Password* in the *Tails Greeter*.
+
+#. Open a terminal (it is an icon on the top of the screen that looks
+   like a little black TV).
+
+#. Change into the SecureDrop repo directory ::
+
+     cd /home/amnesia/Persistent/securedrop/install_files/ansible-base
+
+#. Open ``prod-specific.yml`` in your preferred text editor.
+   Delete the line that starts with ``smtp_relay_fingerprint`` and save the file.
+   If you are using your own or your organization's SMTP relay (not Google's),
+   you may want want to continue using fingerprint verification.
+   If you are unsure, contact us and we will help you make a determination.
+
+#. Stash your updated local changes ::
+
+     git stash save "site specific configs"
+
+#. Pull the latest code ::
+
+     git pull
+
+
+#. Verify the signed git tag for the latest stable release ::
+
+     git tag -v 0.3.5
+
+#. Checkout the latest release ::
+
+     git checkout 0.3.5
+
+#. Restore your instance-specific settings ::
+
+     git checkout stash -- prod-specific.yml inventory
+     git reset
+
+   .. note:: SecureDrop upgrades typically recommend using the simpler
+             ``git stash pop`` command to restore instance-specific settings.
+             Since 0.3.5 makes changes to the ``prod-specific.yml`` file,
+             more verbose git commands are necessary to avoid a merge conflict.
+
+#. Make sure you have Ansible installed. If running ``which ansible`` returns ``ansible not found``, you should ::
+
+    sudo apt-get update
+    sudo apt-get install ansible
+
+#. Run the Ansible playbooks (substitute the admin account on the servers for ``<user>``) ::
+
+    ansible-playbook -i inventory -s -u <user> securedrop-prod.yml
+
+
+During the playbook run, the Postfix TLS verification settings will be updated
+on the Monitor Server, the AppArmor profiles will be updated on the Application Server,
+and both servers will receive new logic for rebooting after unattended-upgrades.

--- a/docs/upgrade/upgrade-0.3.x.rst
+++ b/docs/upgrade/upgrade-0.3.x.rst
@@ -13,6 +13,4 @@ you are currently running:
 
    0.2.1-to-0.3.x
    0.3pre-to-0.3.x
-   0.3.x-to-0.3.5
-   0.3.5-to-0.3.6
 

--- a/docs/upgrade/upgrade-0.3.x.rst
+++ b/docs/upgrade/upgrade-0.3.x.rst
@@ -13,4 +13,5 @@ you are currently running:
 
    0.2.1-to-0.3.x
    0.3pre-to-0.3.x
+   0.3.x-to-0.3.5
 

--- a/docs/upgrade/upgrade-0.3.x.rst
+++ b/docs/upgrade/upgrade-0.3.x.rst
@@ -14,4 +14,5 @@ you are currently running:
    0.2.1-to-0.3.x
    0.3pre-to-0.3.x
    0.3.x-to-0.3.5
+   0.3.5-to-0.3.6
 


### PR DESCRIPTION
Adds new documentation for the upgrade procedure for releases `0.3.5` and `0.3.6`. Both releases require admin intervention to update local files on the Admin Workstation, then run the Ansible playbooks. These changes are now documented publicly (see #1173), and will be available on docs.securedrop.org after merging.

To review the docs offline prior to merging, run:

```
cd docs/
make html
```

Then open `_build/html/index.html` in your favorite browser and review the additions to the **Upgrade SecureDrop** section in the navbar. If you have trouble, see the [Documentation Guidelines](https://docs.securedrop.org/en/latest/development/documentation.html) (thanks, @garrettr!).