### PR TITLE
Persistent automatic SecureDrop Tails setup (redo)

### DIFF
--- a/docs/configure_admin_workstation_post_install.rst
+++ b/docs/configure_admin_workstation_post_install.rst
@@ -42,41 +42,11 @@ directory with these scripts, and run the install script:
 
 Type the Administration Password that you selected when starting Tails
 and hit enter. The install script will download some additional
-software, which may take a few minutes. It will then pop open a text
-editor with a file named ``torrc_additions``.
+software, which may take a few minutes.
 
-Edit this file, adding the ``HidServAuth`` information for each of the
-three authenticated hidden services that were created during the
-install process:
-
-#. ``app-document-aths``
-#. ``app-ssh-aths``
-#. ``mon-ssh-aths``
-
-You can double-click or use the 'cat' command to read the values from
-the corresponding files in ``install_files/ansible-base``. When you're
-done, ``torrc_additions`` will look something like this:
-
-::
-
-    # add HidServAuth lines here
-    HidServAuth gu6yn2ml6ns5qupv.onion Us3xMTN85VIj5NOnkNWzW # client: user
-    HidServAuth fsrrszf5qw7z2kjh.onion xW538OvHlDUo5n4LGpQTNh # client: admin
-    HidServAuth yt4j52ajfvbmvtc7.onion vNN33wepGtGCFd5HHPiY1h # client: admin
-
-.. tip:: An easy way to do this is to run ``cat *-aths`` from the
-	 ``install_files/ansible-base`` folder in a terminal window,
-	 and copy/paste the output into the opened text editor.
-
-When you are done, click **Save** and close the text editor. Once the
-editor is closed, the install script will automatically continue.
-
-.. todo:: This process is confusing and error prone. Since the
-          necessary information (the ``*-aths`` files) is in a
-          predictable location, can't we just skip the "manually
-          copy/paste into a text editor" step?
-
-The install scripts installs a Network Manager hook that runs on boot. It automatically adds the HidServAuth values from ``torrc_additions`` to the ``torrc`` and restarts Tor.
+This script installs a Network Manager hook that runs every time you connect to Tor. It automatically adds the HidServAuth values from ``torrc_additions`` to the ``torrc`` and restarts Tor.
+In addition, it creates desktop and main menu shortcuts for both interfaces, updates your Ansible inventory file to install playbooks over Tor in the future, directs Tails
+to install Ansible at the beginning of every session, and sets up SSH host aliases for the servers.
 
 .. note:: The only thing you need to remember to do is enable
           persistence when you boot the Admin Workstation. If you are
@@ -91,25 +61,11 @@ The install scripts installs a Network Manager hook that runs on boot. It automa
 SSH Host Aliases
 ----------------
 
-.. note:: This step is optional, but it makes it much easier to
-	  connect to the servers in order to administrate them in the future.
+The installation script in ``tails_files`` also sets up SSH host aliases for the admin.
 
-Create the file ``/home/amnesia/.ssh/config`` and add a configuration
-following the scheme below, replacing ``Hostname`` and ``User`` with
-the values specific to your setup:
-
-::
-
-    Host app
-      Hostname <app hostname>.onion
-      User <ssh username>
-    Host mon
-      Hostname <mon hostname>.onion
-      User <ssh username>
-
-Now you can simply use ``ssh app`` and ``ssh mon`` to connect to each
+You can simply use ``ssh app`` and ``ssh mon`` to connect to each
 server. This configuration will be persisted across reboots thanks to
-Tails' SSH Client persistence.
+Tails' SSH client persistence.
 
 Set up two-factor authentication for the Admin
 ----------------------------------------------

--- a/docs/configure_admin_workstation_post_install.rst
+++ b/docs/configure_admin_workstation_post_install.rst
@@ -6,43 +6,41 @@ Configure the Admin Workstation Post-Install
 Auto-connect to the Authenticated Tor Hidden Services
 -----------------------------------------------------
 
-The SecureDrop installation process adds multiple layers of
-authentication to protect access to the most sensitive assets in the
-SecureDrop system:
+The SecureDrop installation process adds multiple layers of authentication to 
+protect access to the most sensitive assets in the SecureDrop system:
 
-#. The Document Interface, because it provides access to submissions
-   (although they are encrypted to an offline key), and some metadata
-   about sources and submissions.
+#. The Document Interface, because it provides access to submissions (although 
+   they are encrypted to an offline key), and some metadata about sources and 
+   submissions.
 #. SSH on the Application Server
 #. SSH on the Monitor Server
 
-The installation process blocks direct access to each of these assets,
-and sets up `Authenticated Tor Hidden Services`_ (ATHS) to provide
-authenticated access instead. Authenticated Tor Hidden Services share
-the benefits of Tor Hidden Services, but are only accessible to users
-who possess a shared secret (``auth-cookie`` in the Tor documentation)
-that is generated during the hidden service setup process.
+The installation process blocks direct access to each of these assets, and sets 
+up `Authenticated Tor Hidden Services`_ (ATHS) to provide authenticated access 
+instead. Authenticated Tor Hidden Services share the benefits of Tor Hidden 
+Services, but are only accessible to users who possess a shared secret 
+(``auth-cookie`` in the Tor documentation) that is generated during the hidden 
+service setup process.
 
-In order to access an ATHS, you need to add one or more "auth-cookie"
-values to your Tor configuration file (``torrc``) and restart
-Tor. Doing this manually is annoying and error-prone, so SecureDrop
-includes a set of scripts in ``securedrop/tails_files`` that can set
-up a Tails instance to automatically configure Tor to access a set of
-ATHS. In order to persist these changes across reboots, the Tails
-instance must have persistence enabled (specifically, the "dotfiles
-persistence").
+In order to access an ATHS, you need to add one or more "auth-cookie" values 
+to your Tor configuration file (``torrc``) and restart Tor. Doing this manually 
+is annoying and error-prone, so SecureDrop includes a set of scripts in 
+``securedrop/tails_files`` that can set up a Tails instance to automatically 
+configure Tor to access a set of ATHS. In order to persist these changes across 
+reboots, the Tails instance must have persistence enabled (specifically, the 
+"dotfiles persistence").
 
-To install the auto-connect configuration, start by navigating to the
-directory with these scripts, and run the install script:
+To install the auto-connect configuration, start by navigating to the directory 
+with these scripts, and run the install script:
 
 .. code:: sh
 
     cd ~/Persistent/securedrop/tails_files/
     sudo ./install.sh
 
-Type the Administration Password that you selected when starting Tails
-and hit enter. The install script will download some additional
-software, which may take a few minutes.
+Type the Administration Password that you selected when starting Tails and hit 
+enter. The install script will download some additional software, which may 
+take a few minutes.
 
 This script installs a Network Manager hook that runs every time you connect to 
 Tor. It automatically adds the HidServAuth values from ``torrc_additions`` to 
@@ -59,20 +57,19 @@ sets up SSH host aliases for the servers.
           of the authenticated hidden services, restart Tails and make
           sure to enable persistence.
 
-.. _Authenticated Tor Hidden Services: 
-https://www.torproject.org/docs/tor-manual.html.en#HiddenServiceAuthorizeClient
+.. _Authenticated Tor Hidden Services: https://www.torproject.org/docs/tor-manual.html.en#HiddenServiceAuthorizeClient
 
 .. _SSH Host Aliases:
 
 SSH Host Aliases
 ----------------
 
-The installation script in ``tails_files`` also sets up SSH host aliases for 
-the admin. These can be found in ``~/.ssh/config``.
+The installation script in ``tails_files`` also sets up SSH host aliases for the 
+admin. These can be found in ``~/.ssh/config``.
 
-You can simply use ``ssh app`` and ``ssh mon`` to connect to each
-server. This configuration will be persisted across reboots thanks to
-Tails' SSH client persistence.
+You can simply use ``ssh app`` and ``ssh mon`` to connect to each server. This 
+configuration will be persisted across reboots thanks to Tails' SSH client 
+persistence.
 
 Set up two-factor authentication for the Admin
 ----------------------------------------------
@@ -80,16 +77,15 @@ Set up two-factor authentication for the Admin
 .. todo:: Do we still want to recommend/require this? Should it be
           optional?
 
-As part of the SecureDrop installation process, you will need to set up
-two-factor authentication on the App Server and Monitor Server using the
-Google Authenticator mobile app.
+As part of the SecureDrop installation process, you will need to set up 
+two-factor authentication on the App Server and Monitor Server using the Google 
+Authenticator mobile app.
 
-After your torrc has been updated with the HidServAuth values, connect
-to the App Server using ``ssh`` and run ``google-authenticator``. Follow
-the instructions in :doc:`our Google Authenticator guide <google_authenticator>`
-to set up the app on your Android or iOS device.
+After your torrc has been updated with the HidServAuth values, connect to the 
+App Server using ``ssh`` and run ``google-authenticator``. Follow the 
+instructions in :doc:`our Google Authenticator guide <google_authenticator>` to 
+set up the app on your Android or iOS device.
 
-To disconnect enter the command ``exit``. Now do the same thing on the
-Monitor Server. You'll end up with an account for each server in the
-Google Authenticator app that generates two-factor codes needed for
-logging in.
+To disconnect enter the command ``exit``. Now do the same thing on the Monitor 
+Server. You'll end up with an account for each server in the Google 
+Authenticator app that generates two-factor codes needed for logging in.

--- a/docs/configure_admin_workstation_post_install.rst
+++ b/docs/configure_admin_workstation_post_install.rst
@@ -44,9 +44,14 @@ Type the Administration Password that you selected when starting Tails
 and hit enter. The install script will download some additional
 software, which may take a few minutes.
 
-This script installs a Network Manager hook that runs every time you connect to Tor. It automatically adds the HidServAuth values from ``torrc_additions`` to the ``torrc`` and restarts Tor.
-In addition, it creates desktop and main menu shortcuts for both interfaces, updates your Ansible inventory file to install playbooks over Tor in the future, directs Tails
-to install Ansible at the beginning of every session, and sets up SSH host aliases for the servers.
+This script installs a Network Manager hook that runs every time you connect to 
+Tor. It automatically adds the HidServAuth values from ``torrc_additions`` to 
+the ``torrc`` and restarts Tor.
+
+In addition, it creates desktop and main menu shortcuts for both interfaces, 
+updates your Ansible inventory file to install playbooks over Tor in the 
+future, directs Tails to install Ansible at the beginning of every session, and
+sets up SSH host aliases for the servers.
 
 .. note:: The only thing you need to remember to do is enable
           persistence when you boot the Admin Workstation. If you are
@@ -54,14 +59,16 @@ to install Ansible at the beginning of every session, and sets up SSH host alias
           of the authenticated hidden services, restart Tails and make
           sure to enable persistence.
 
-.. _Authenticated Tor Hidden Services: https://www.torproject.org/docs/tor-manual.html.en#HiddenServiceAuthorizeClient
+.. _Authenticated Tor Hidden Services: 
+https://www.torproject.org/docs/tor-manual.html.en#HiddenServiceAuthorizeClient
 
 .. _SSH Host Aliases:
 
 SSH Host Aliases
 ----------------
 
-The installation script in ``tails_files`` also sets up SSH host aliases for the admin.
+The installation script in ``tails_files`` also sets up SSH host aliases for 
+the admin. These can be found in ``~/.ssh/config``.
 
 You can simply use ``ssh app`` and ``ssh mon`` to connect to each
 server. This configuration will be persisted across reboots thanks to

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -72,7 +72,8 @@ Administrators need to access the servers over SSH.
 To get started, you should copy the ``HidServAuth`` value for the
 Document Interface ATHS from the Admin Workstation to the Journalist
 Workstation. The easiest way to do this is to copy the
-``app-document-aths`` and ``app-source-ths`` files from the Admin Workstation to the
+``app-document-aths`` and ``app-source-ths`` files from the Admin Workstation 
+to the
 Journalist Workstation with the Data Transfer Device.
 
 Now you need the Tails setup scripts (``securedrop/tails_files``) that
@@ -84,12 +85,14 @@ Workstation. Refer to the docs for :ref:`cloning the SecureDrop
 repository <Download the SecureDrop repository>`, then return here to
 continue setting up the Journalist Workstation.
 
-Once you've done this, you should set up auto-connect and shortcuts for the Document
+Once you've done this, you should set up auto-connect and shortcuts for the 
+Document
 Interface ATHS the same way you did on the Admin Workstation. Follow
 :ref:`the same docs <auto-connect ATHS>`, except on the Journalist
 Workstation, you should enter the lines from ``app-document-aths``
 and ``app-source-ths`` when prompted to by the ``install.sh`` script. Only the 
-Admin Workstation should have the ``HidServAuth`` lines from ``app-ssh-aths`` and ``mon-ssh-aths``.
+Admin Workstation should have the ``HidServAuth`` lines from ``app-ssh-aths`` 
+and ``mon-ssh-aths``.
 
 Once the ``install.sh`` script is finished, you should be able to access the
 Document Interface. Open the Tor Browser and navigate to the .onion address for

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -72,7 +72,7 @@ Administrators need to access the servers over SSH.
 To get started, you should copy the ``HidServAuth`` value for the
 Document Interface ATHS from the Admin Workstation to the Journalist
 Workstation. The easiest way to do this is to copy the
-``app-document-aths`` file from the Admin Workstation to the
+``app-document-aths`` and ``app-source-ths`` files from the Admin Workstation to the
 Journalist Workstation with the Data Transfer Device.
 
 Now you need the Tails setup scripts (``securedrop/tails_files``) that
@@ -84,12 +84,12 @@ Workstation. Refer to the docs for :ref:`cloning the SecureDrop
 repository <Download the SecureDrop repository>`, then return here to
 continue setting up the Journalist Workstation.
 
-Once you've done this, you should set up auto-connect for the Document
+Once you've done this, you should set up auto-connect and shortcuts for the Document
 Interface ATHS the same way you did on the Admin Workstation. Follow
 :ref:`the same docs <auto-connect ATHS>`, except on the Journalist
-Workstation, you should only add the line from ``app-document-aths``
-to ``torrc_additions``; only the Admin Workstation should *also* have
-the ``HidServAuth`` lines from ``app-ssh-aths`` and ``mon-ssh-aths``.
+Workstation, you should enter the lines from ``app-document-aths``
+and ``app-source-ths`` when prompted to by the ``install.sh`` script. Only the 
+Admin Workstation should have the ``HidServAuth`` lines from ``app-ssh-aths`` and ``mon-ssh-aths``.
 
 Once the ``install.sh`` script is finished, you should be able to access the
 Document Interface. Open the Tor Browser and navigate to the .onion address for

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -13,8 +13,6 @@ Technical Summary
 SecureDrop is a tool for sources to communicate securely with journalists. The
 SecureDrop application environment consists of three dedicated computers:
 
-.. _`Tails operating system`: https://tails.boum.org
-
 - ``Secure Viewing Station``: An air-gapped laptop running the 
    `Tails operating system`_ from a USB stick that journalists use to decrypt 
    and view submitted documents.
@@ -43,6 +41,8 @@ journalists always use the `Tails operating system`_ on their
 Alternatively, this can also be its own dedicated computer.
 
 These computers should all physically be in your organization's office.
+
+.. _`Tails operating system`: https://tails.boum.org
 
 Infrastructure
 --------------

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -2,10 +2,10 @@ Overview
 ========
 
 SecureDrop is an open-source whistleblower submission system that media
-organizations can use to securely accept documents from and communicate
-with anonymous sources. It was originally created by the late Aaron
-Swartz and is currently managed by `Freedom of the Press
-Foundation <https://freedom.press>`__.
+organizations can use to securely accept documents from and communicate with 
+anonymous sources. It was originally created by the late Aaron Swartz and is 
+currently managed by `Freedom of the Press Foundation 
+<https://freedom.press>`__.
 
 Technical Summary
 -----------------
@@ -13,9 +13,11 @@ Technical Summary
 SecureDrop is a tool for sources to communicate securely with journalists. The
 SecureDrop application environment consists of three dedicated computers:
 
-- ``Secure Viewing Station``: An air-gapped laptop running the `Tails operating
-   system <https://tails.boum.org/>`__ from a USB stick that journalists use to
-   decrypt and view submitted documents.
+.. _`Tails operating system`: https://tails.boum.org
+
+- ``Secure Viewing Station``: An air-gapped laptop running the 
+   `Tails operating system`_ from a USB stick that journalists use to decrypt 
+   and view submitted documents.
 - ``Application Server``: Ubuntu server running two segmented Tor hidden
    services. The source connects to the *Source Interface*, a public-facing Tor
    hidden service, to send messages and documents to the journalist. The
@@ -36,17 +38,17 @@ her normal workstation computer:
    is also used to respond to sources via the *Document Interface*.
 
 Depending on the news organizations's threat model, it is recommended that
-journalists always use the `Tails operating system <https://tails.boum.org/>`__
-on their ``Journalist Workstation`` when connecting to the ``Application
-Server``. Alternatively, this can also be its own dedicated computer.
+journalists always use the `Tails operating system`_ on their 
+``Journalist Workstation`` when connecting to the ``Application Server``. 
+Alternatively, this can also be its own dedicated computer.
 
 These computers should all physically be in your organization's office.
 
 Infrastructure
 --------------
 
-There are four main components of SecureDrop: the servers, the
-administrators, the sources, and the journalists.
+There are four main components of SecureDrop: the servers, the administrators, 
+the sources, and the journalists.
 
 |SecureDrop architecture overview diagram|
 
@@ -56,52 +58,50 @@ administrators, the sources, and the journalists.
 Servers
 ~~~~~~~
 
-At SecureDrop's heart is a pair of severs: the *Application (“App”)
-Server*, which runs the core SecureDrop software, and the *Monitor
-(“Mon”) Server*, which keeps track of the *Application Server* and sends
-out alerts if there's a problem. These two servers run on dedicated
-hardware connected to a dedicated firewall appliance. They are typically
-located physically inside the newsroom.
+At SecureDrop's heart is a pair of severs: the *Application (“App”) Server*, 
+which runs the core SecureDrop software, and the *Monitor (“Mon”) Server*, 
+which keeps track of the *Application Server* and sends out alerts if there's a 
+problem. These two servers run on dedicated hardware connected to a dedicated 
+firewall appliance. They are typically located physically inside the newsroom.
 
 Administrators
 ~~~~~~~~~~~~~~
 
-The SecureDrop servers are managed by a systems administrator; for
-larger newsrooms, there may be a team of systems administrators. The
-administrator uses a dedicated *Admin Workstation* running
-`Tails <https://tails.boum.org>`__ and connects to the App and Mon
-servers over authenticated `Tor Hidden
-Services <https://www.torproject.org/docs/hidden-services.html>`__ and
-manages them using `Ansible <http://www.ansible.com/>`__.
+The SecureDrop servers are managed by a systems administrator; for larger 
+newsrooms, there may be a team of systems administrators. The administrator 
+uses a dedicated *Admin Workstation* running `Tails <https://tails.boum.org>`__ 
+and connects to the App and Mon servers over authenticated `Tor Hidden Services 
+<https://www.torproject.org/docs/hidden-services.html>`__ and manages them 
+using `Ansible <http://www.ansible.com/>`__.
 
 Sources
 ~~~~~~~
 
-A source submits documents and messages by using `Tor
-Browser <https://www.torproject.org/projects/torbrowser.html>`__ (or
-Tails) to access the *Source Interface*: a public Tor Hidden Service.
-Submissions are encrypted in place on the App server as they are
-uploaded.
+A source submits documents and messages by using `Tor Browser 
+<https://www.torproject.org/projects/torbrowser.html>`__ (or Tails) to access 
+the *Source Interface*: a public Tor Hidden Service. Submissions are encrypted 
+in place on the App server as they are uploaded.
 
 Journalists
 ~~~~~~~~~~~
 
-Journalists working in the newsroom use two machines to interact with
-SecureDrop. First, they use a *Journalist Workstation* running Tails to
-connect to the *Document Interface*, an authenticated Tor Hidden
-Service. Journalists download `GPG <https://www.gnupg.org/>`__-encrypted
-submissions and copy them to a *Transfer Device* (a thumb drive or DVD).
-Those submissions are then connected to the airgapped *Secure Viewing
-Station* (SVS) which holds the key to decrypt them. Journalists can then
-use the SVS to read, print, and otherwise prepare documents for
-publication. Apart from those deliberately published, decrypted
-documents are never accessed on an Internet-connected computer.
+Journalists working in the newsroom use two machines to interact with 
+SecureDrop. First, they use a *Journalist Workstation* running Tails to connect 
+to the *Document Interface*, an authenticated Tor Hidden Service. Journalists 
+download `GPG <https://www.gnupg.org/>`__-encrypted submissions and copy them 
+to a *Transfer Device* (a thumb drive or DVD). Those submissions are then 
+connected to the airgapped *Secure Viewing Station* (SVS) which holds the key 
+to decrypt them. Journalists can then use the SVS to read, print, and 
+otherwise prepare documents for publication. Apart from those deliberately 
+published, decrypted documents are never accessed on an Internet-connected 
+computer.
 
 .. note:: The terms in italics are terms of art specific to SecureDrop. The
-	  :doc:`Terminology Guide <terminology>` provides more-precise definitions of
-	  these and other terms. SecureDrop is designed against a comprehensive
-	  :doc:`development/threat_model`, and has a specific notion of the :doc:`roles
-	  <passphrases>` that are involved in its operation.
+	  :doc:`Terminology Guide <terminology>` provides more-precise 
+          definitions of these and other terms. SecureDrop is designed against 
+          a comprehensive :doc:`development/threat_model`, and has a specific 
+          notion of the :doc:`roles <passphrases>` that are involved in its 
+          operation.
 
 Operation
 ---------
@@ -109,61 +109,57 @@ Operation
 Planning & Preparation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Setting up SecureDrop is a multi-step process. Before getting started,
-you should make sure that you're prepared to operate and maintain it.
-You'll need a systems administrator who's familiar with Linux, the GNU
-utilities, and the Bash shell. You'll need the
-:doc:`hardware <hardware>` on which SecureDrop runs — this will
-normally cost $2000-$3000 dollars. The journalists in your organization
-will need to be trained in the operation of SecureDrop, and you'll need
-to publish and promote your new SecureDrop instance afterwards — using
-your existing websites, mailing lists, and social media.
+Setting up SecureDrop is a multi-step process. Before getting started, you 
+should make sure that you're prepared to operate and maintain it. You'll need 
+a systems administrator who's familiar with Linux, the GNU utilities, and the 
+Bash shell. You'll need the :doc:`hardware <hardware>` on which SecureDrop 
+runs — this will normally cost $2000-$3000 dollars. The journalists in your 
+organization will need to be trained in the operation of SecureDrop, and 
+you'll need to publish and promote your new SecureDrop instance afterwards — 
+using your existing websites, mailing lists, and social media.
 
-It is recommended that you have all of this planned out before you get
-started. If you need help, contact the `Freedom of the Press
-Foundation <https://securedrop.org/help>`__ who will be glad to help
-walk you through the process and make sure that you're ready to
-proceeed.
+It is recommended that you have all of this planned out before you get started. 
+If you need help, contact the `Freedom of the Press Foundation 
+<https://securedrop.org/help>`__ who will be glad to help walk you through 
+the process and make sure that you're ready to proceeed.
 
 Technical Setup
 ~~~~~~~~~~~~~~~
 
-Once you are familiar with the architecture and have all the hardware,
-:doc:`setting up SecureDrop <install>` will take at least a day's work
-for your admin. We recommend that you set aside at least a week to
+Once you are familiar with the architecture and have all the hardware, 
+:doc:`setting up SecureDrop <install>` will take at least a day's work for your 
+admin. We recommend that you set aside at least a week to 
 :doc:`complete and test <deployment_practices>` your setup.
 
 Provisioning & Training
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Once SecureDrop is installed, journalists will need to be provided with
+Once SecureDrop is installed, journalists will need to be provided with 
 accounts, two-factor tokens, workstations, and so on — and then
-:doc:`trained <training_schedule>` to use these tools safely and
-reliably. You will probably also need to train additional backup
-administrators so that you can be sure that your SecureDrop setup keeps
-running even when your main administrator is on holiday.
+:doc:`trained <training_schedule>` to use these tools safely and reliably. You 
+will probably also need to train additional backup administrators so that you 
+can be sure that your SecureDrop setup keeps running even when your main 
+administrator is on holiday.
 
-Introducing staff to SecureDrop takes half a day. Training a group to
-use SecureDrop proficiently takes at least a day — and a single trainer
-can only work with so many people at once. You will probably need to run
-several training sessions to instruct an entire newsroom. Depending on
-staff availability, training and provisioning may take a week or more.
-If you have multiple offices, training will need to happen at each
-location. Again, the `Freedom of the Press
-Foundation <https://securedrop.org/help>`__ are happy to help you plan
-and train your team.
+Introducing staff to SecureDrop takes half a day. Training a group to use 
+SecureDrop proficiently takes at least a day — and a single trainer can only 
+work with so many people at once. You will probably need to run several 
+training sessions to instruct an entire newsroom. Depending on staff 
+availability, training and provisioning may take a week or more. If you have 
+multiple offices, training will need to happen at each location. Again, the 
+`Freedom of the Press Foundation <https://securedrop.org/help>`__ are happy to 
+help you plan and train your team.
 
 Going Public
 ~~~~~~~~~~~~
 
-Once you have a SecureDrop instance and your team knows how to use it,
-you should test it thoroughly and then tell the world. The `Freedom of
-the Press Foundation <https://securedrop.org/help>`__ are happy to help
-you check that your SecureDrop setup is up-to-code and properly
-grounded. After that, you'll need to use your existing tools to announce
-and promote your SecureDrop. There are some :doc:`best
-practices <deployment_practices>` for ways to show off and
-communicate your SecureDrop address, but more is better. Create a
+Once you have a SecureDrop instance and your team knows how to use it, you 
+should test it thoroughly and then tell the world. The `Freedom of the Press 
+Foundation <https://securedrop.org/help>`__ are happy to help you check that 
+your SecureDrop setup is up-to-code and properly grounded. After that, you'll 
+need to use your existing tools to announce and promote your SecureDrop. There 
+are some :doc:`best practices <deployment_practices>` for ways to show off and
+communicate your SecureDrop address, but more is better. Create a 
 promotion/advocacy plan and go wild.
 
 .. |SecureDrop architecture overview diagram| image:: ./diagrams/SecureDrop.png

--- a/docs/tails_guide.rst
+++ b/docs/tails_guide.rst
@@ -1,75 +1,70 @@
 Tails Guide
 ===========
 
-To log-in SecureDrop and retreived messages sent by sources, the
-journalist must be using the Tails operating system. The admin must also
-use Tails to access the *Document Interface* and create new users.
+To log-in SecureDrop and retreived messages sent by sources, the journalist 
+must be using the Tails operating system. The admin must also use Tails to 
+access the *Document Interface* and create new users.
 
-If you followed the :doc:`SecureDrop Installation
-instructions <install>` correctly, you should have already
-created a *journalist Tails USB* and an *admin Tails USB* and enabled
-the persistence volume on each. If you have not, or need to create
-another *journalist Tails USB* for a second journalist, follow the steps
-below.
+If you followed the :doc:`SecureDrop Installation instructions <install>` 
+correctly, you should have already created a *journalist Tails USB* and an 
+*admin Tails USB* and enabled the persistence volume on each. If you have not, 
+or need to create another *journalist Tails USB* for a second journalist, 
+follow the steps below.
 
-If you already know how to boot the *admin Tails USB* or the *journalist
-Tails USB* with persistence, you can skip down to the step 'download the
-repository'.
+If you already know how to boot the *admin Tails USB* or the *journalist Tails 
+USB* with persistence, you can skip down to the step 'download the repository'.
 
-Note that for all of these instructions to work, you should have already
+Note that for all of these instructions to work, you should have already 
 installed the main SecureDrop application.
 
 Installing Tails on USB sticks
 ------------------------------
 
-Tails is a live operating system that is run from removable media, such
-as a DVD or a USB stick. For SecureDrop, you'll need to install Tails
-onto USB sticks and enable persistent storage.
+Tails is a live operating system that is run from removable media, such as a 
+DVD or a USB stick. For SecureDrop, you'll need to install Tails onto USB 
+sticks and enable persistent storage.
 
-We recommend creating an initial Tails Live USB or DVD, and then using
-that to create additional Tails Live USBs with the *Tails Installer*, a
-special program that is only available from inside Tails. *You will only
-be able to create persistent volumes on USB sticks that had Tails
-installed via the Tails Installer*.
+We recommend creating an initial Tails Live USB or DVD, and then using that to 
+create additional Tails Live USBs with the *Tails Installer*, a special program 
+that is only available from inside Tails. *You will only be able to create 
+persistent volumes on USB sticks that had Tails installed via the Tails 
+Installer*.
 
-The `Tails website <https://tails.boum.org/>`__ has detailed and
-up-to-date instructions on how to download and verify Tails, and how to
-create a Tails USB stick. Here are some links to help you out:
+The `Tails website <https://tails.boum.org/>`__ has detailed and up-to-date 
+instructions on how to download and verify Tails, and how to create a Tails USB 
+stick. Here are some links to help you out:
 
--  `Download and verify the Tails
-   .iso <https://tails.boum.org/download/index.en.html>`__
--  `Install onto a USB stick or SD
-   card <https://tails.boum.org/doc/first_steps/installation/index.en.html>`__
--  `Create & configure the persistent
-   volume 
-<https://tails.boum.org/doc/first_steps/persistence/configure/index.en.html>`__
+.. _`Download and verify the Tails .iso`: https://tails.boum.org/download/index.en.html
+.. _`Install onto a USB stick or SD card`: https://tails.boum.org/doc/first_steps/installation/index.en.html
+.. _`Create & configure the persistent volume`: https://tails.boum.org/doc/first_steps/persistence/configure/index.en.html
+.. _`manually installing Tails onto a USB device on Mac OS X`: https://tails.boum.org/doc/first_steps/installation/manual/mac/index.en.html
+
+-  `Download and verify the Tails .iso`_
+-  `Install onto a USB stick or SD card`_
+-  `Create & configure the persistent volume`_
 
 Note for Mac OS X users manually installing Tails
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Tails documentation for `manually installing Tails onto a USB device
-on Mac OS
-X 
-<https://tails.boum.org/doc/first_steps/installation/manual/mac/index.en.html>`_
-_
-describes how to copy the downloaded .iso image to a USB stick in
-Section 4, "Do the copy". This section includes the following ``dd``
-invocation to copy the .iso to the USB:
+on Mac OS X`_ describes how to copy the downloaded .iso image to a USB stick in 
+Section 4, "Do the copy". This section includes the following ``dd`` invocation 
+to copy the .iso to the USB:
 
 ::
 
     dd if=[tails.iso] of=/dev/diskX
 
-This command is *very slow*. In our testing, it took about 18 minutes to
-copy the .iso to a USB 2.0 drive. You can speed it up by changing the
-arguments to ``dd`` like so:
+This command is *very slow*. In our testing, it took about 18 minutes to copy 
+the .iso to a USB 2.0 drive. You can speed it up by changing the arguments to 
+``dd`` like so:
 
 ::
 
     dd if=[tails.iso] of=/dev/rdiskX bs=1m
 
-Note the change from ``diskX`` to ``rdiskX``. This reduced the copy time
-to 3 minutes for us.
+Note the change from ``diskX`` to ``rdiskX``. This reduced the copy time to 3 
+minutes for us.
 
 Configure Tails for use with SecureDrop
 ---------------------------------------
@@ -77,32 +72,29 @@ Configure Tails for use with SecureDrop
 Persistence
 ~~~~~~~~~~~
 
-Creating an encrypted persistent volume will allow you to securely save
-information in the free space that is left on the Transfer Device. This
-information will remain available to you even if you reboot Tails.
-Instructions on how to create and use this volume can be found on the
-`Tails
+Creating an encrypted persistent volume will allow you to securely save 
+information in the free space that is left on the Transfer Device. This 
+information will remain available to you even if you reboot Tails. Instructions 
+on how to create and use this volume can be found on the `Tails 
 website <https://tails.boum.org/doc/first_steps/persistence/index.en.html>`__.
-You will be asked to select from a list of persistence features, such as
+You will be asked to select from a list of persistence features, such as 
 personal data. We require that you enable **all** features.
 
 Start Tails and enable the persistent volume
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When starting Tails, you should see a "Welcome to Tails" screen with two
-options. Select *Yes* to enable the persistent volume and enter your
-password. Select *Yes* to show more options and click *Forward*. Enter
-an *Administration password* for use with this specific Tails session
-and click *Login*.
+When starting Tails, you should see a "Welcome to Tails" screen with two 
+options. Select *Yes* to enable the persistent volume and enter your password. 
+Select *Yes* to show more options and click *Forward*. Enter an *Administration 
+password* for use with this specific Tails session and click *Login*.
 
 Download the repository
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The rest of the SecureDrop-specific configuration is assisted by files
-stored in the SecureDrop git repository. To get started, open a terminal
-and run the following commands to download the git repository. Note that
-since the repository is fairly large and Tor can be slow, this may take
-a few minutes.
+The rest of the SecureDrop-specific configuration is assisted by files stored 
+in the SecureDrop git repository. To get started, open a terminal and run the 
+following commands to download the git repository. Note that since the 
+repository is fairly large and Tor can be slow, this may take a few minutes.
 
 .. code:: sh
 
@@ -112,16 +104,16 @@ a few minutes.
 Passphrase Database
 ~~~~~~~~~~~~~~~~~~~
 
-As mentioned in the installation documentation, we provide a KeePassX
-password database template to make it easier for admins and journalists
-to generate strong, unique passphrases and store the securely. Once you
-have set up Tails with persistence and have cloned the repo, you can set
-up your personal password database using this template.
+As mentioned in the installation documentation, we provide a KeePassX password 
+database template to make it easier for admins and journalists to generate 
+strong, unique passphrases and store the securely. Once you have set up Tails 
+with persistence and have cloned the repo, you can set up your personal 
+password database using this template.
 
-You can find the template in ``tails_files/securedrop-keepassx.xml``
-inside the securedrop repository. Note that you will not be able to
-access your passwords if you forget the master password or the location
-of the key file used to protect the database.
+You can find the template in ``tails_files/securedrop-keepassx.xml`` inside 
+the securedrop repository. Note that you will not be able to access your 
+passwords if you forget the master password or the location of the key file 
+used to protect the database.
 
 To use the template:
 
@@ -137,31 +129,30 @@ To use the template:
 Set up easy access to the Document Interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To complete setup of the Admin Workstation or Journalist Workstation, we
-recommend using the scripts in ``tails_files`` to easily configure Tor
-to access the *Document Interface*.
+To complete setup of the Admin Workstation or Journalist Workstation, we 
+recommend using the scripts in ``tails_files`` to easily configure Tor to 
+access the *Document Interface*.
 
-Navigate to the directory with the setup scripts and begin the
-installation by typing these commands into the terminal:
+Navigate to the directory with the setup scripts and begin the installation 
+by typing these commands into the terminal:
 
 ::
 
     cd securedrop/tails_files/
     sudo ./install.sh
 
-Type the administration password that you selected when starting Tails
-and hit enter. This installation script does the following: 
+Type the administration password that you selected when starting Tails and hit 
+enter. This installation script does the following: 
 
 * Downloads additional software
 * Installs a program that automatically and persistently configures Tor to 
-access the
-SecureDrop servers and interfaces, by adding ``HidServAuth`` values to 
-``/etc/tor/torrc``.
+  access the SecureDrop servers and interfaces, by adding ``HidServAuth`` values 
+  to ``/etc/tor/torrc``.
 * Sets up desktop and main menu shortcuts for the *Document Interface* and 
-*Source Interface*
+  *Source Interface*
 * Sets up SSH host aliases for ``mon`` and ``app``
 * Updates your Ansible inventory file to run the playbooks over Tor in the 
-future
+  future
 * Makes it so that Tails installs Ansible at the beginning of every session
 
 If you are missing any files, the script will exit with an error. If you're 
@@ -170,21 +161,21 @@ running this script as an admin, the entire setup should be automatic.
 If you're running the script as a journalist, you will need the .onion addresses
 for each interface, provided to you by the admin.
 
-We use an authenticated Tor Hidden Service so that adversaries cannot access the
-Document Interface, which provides a layer of defense-in-depth and protects the
-Document Interface even if there is a security vulnerability in the 
-authentication implemented by the web application, or if the journalist's 
-username, password, and two-factor token are stolen.
+We use an "authenticated" Tor Hidden Service so that adversaries cannot access 
+the Document Interface, providing a layer of defense-in-depth which protects the
+Document Interface even if there is a security vulnerability in the web 
+application, or if the journalist's username, password, and two-factor token 
+are stolen. The extra configuration that is required is handled by this script.
 
 Our ``install.sh`` sets up Tails to work with SecureDrop every time you login. 
-As long as Tails is booted with the persistent volume enabled then you can open
- the Tor Browser and connect to the Document Interface as normal.
+As long as Tails is booted with the persistent volume enabled then you can open 
+the Tor Browser and connect to the Document Interface as normal.
 
 Create bookmarks for Source and Document Interfaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want, you can open the browser and create bookmarks for the
-Source and Document Interfaces. Navigate to the site you wish to
-bookmark, select *Bookmarks* and *Bookmark This Page*, give the site a
-useful name (e.g. *Source Interface*), and click *Done*. Tails will
-remember the bookmarks even if you reboot.
+If you want, you can open the browser and create bookmarks for the Source and 
+Document Interfaces. Navigate to the site you wish to bookmark, select 
+*Bookmarks* and *Bookmark This Page*, give the site a useful name (e.g. *Source 
+Interface*), and click *Done*. Tails will remember the bookmarks even if you 
+reboot.

--- a/docs/tails_guide.rst
+++ b/docs/tails_guide.rst
@@ -41,14 +41,17 @@ create a Tails USB stick. Here are some links to help you out:
 -  `Install onto a USB stick or SD
    card <https://tails.boum.org/doc/first_steps/installation/index.en.html>`__
 -  `Create & configure the persistent
-   volume <https://tails.boum.org/doc/first_steps/persistence/configure/index.en.html>`__
+   volume 
+<https://tails.boum.org/doc/first_steps/persistence/configure/index.en.html>`__
 
 Note for Mac OS X users manually installing Tails
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Tails documentation for `manually installing Tails onto a USB device
 on Mac OS
-X <https://tails.boum.org/doc/first_steps/installation/manual/mac/index.en.html>`__
+X 
+<https://tails.boum.org/doc/first_steps/installation/manual/mac/index.en.html>`_
+_
 describes how to copy the downloaded .iso image to a USB stick in
 Section 4, "Do the copy". This section includes the following ``dd``
 invocation to copy the .iso to the USB:
@@ -150,11 +153,15 @@ Type the administration password that you selected when starting Tails
 and hit enter. This installation script does the following: 
 
 * Downloads additional software
-* Installs a program that automatically and persistently configures Tor to access the
-SecureDrop servers and interfaces, by adding ``HidServAuth`` values to ``/etc/tor/torrc``.
-* Sets up desktop and main menu shortcuts for the *Document Interface* and *Source Interface*
+* Installs a program that automatically and persistently configures Tor to 
+access the
+SecureDrop servers and interfaces, by adding ``HidServAuth`` values to 
+``/etc/tor/torrc``.
+* Sets up desktop and main menu shortcuts for the *Document Interface* and 
+*Source Interface*
 * Sets up SSH host aliases for ``mon`` and ``app``
-* Updates your Ansible inventory file to run the playbooks over Tor in the future
+* Updates your Ansible inventory file to run the playbooks over Tor in the 
+future
 * Makes it so that Tails installs Ansible at the beginning of every session
 
 If you are missing any files, the script will exit with an error. If you're 
@@ -163,9 +170,11 @@ running this script as an admin, the entire setup should be automatic.
 If you're running the script as a journalist, you will need the .onion addresses
 for each interface, provided to you by the admin.
 
-We employ hidden service authentication so that no one but the journalist will be
-able to access to the *Document Interface*, even if they manage to steal
-the journalist's username, password, and two-factor authentication token.
+We use an authenticated Tor Hidden Service so that adversaries cannot access the
+Document Interface, which provides a layer of defense-in-depth and protects the
+Document Interface even if there is a security vulnerability in the 
+authentication implemented by the web application, or if the journalist's 
+username, password, and two-factor token are stolen.
 
 Our ``install.sh`` sets up Tails to work with SecureDrop every time you login. 
 As long as Tails is booted with the persistent volume enabled then you can open

--- a/docs/tails_guide.rst
+++ b/docs/tails_guide.rst
@@ -147,37 +147,29 @@ installation by typing these commands into the terminal:
     sudo ./install.sh
 
 Type the administration password that you selected when starting Tails
-and hit enter. The installation process will download additional
-software and then open a text editor with a file called
-*torrc\_additions*.
+and hit enter. This installation script does the following: 
 
-Edit the file, inserting the *HidServAuth* information for your
-SecureDrop instance that you received during the installation process.
-The values can be found in
-``install_files/ansible-base/app-document-aths``. This information
-includes the address to the Document Interface and your personal
-authentication string, as seen in the example below:
+* Downloads additional software
+* Installs a program that automatically and persistently configures Tor to access the
+SecureDrop servers and interfaces, by adding ``HidServAuth`` values to ``/etc/tor/torrc``.
+* Sets up desktop and main menu shortcuts for the *Document Interface* and *Source Interface*
+* Sets up SSH host aliases for ``mon`` and ``app``
+* Updates your Ansible inventory file to run the playbooks over Tor in the future
+* Makes it so that Tails installs Ansible at the beginning of every session
 
-::
+If you are missing any files, the script will exit with an error. If you're 
+running this script as an admin, the entire setup should be automatic.
 
-    # add HidServAuth lines here
-    HidServAuth gu6yn2ml6ns5qupv.onion Us3xMTN85VIj5NOnkNWzW # client: bob
+If you're running the script as a journalist, you will need the .onion addresses
+for each interface, provided to you by the admin.
 
-If you're working on the Admin Workstation, you should also insert the
-lines found in ``app-ssh-aths`` and ``mon-ssh-aths``, which will allow
-you to connect using a secure shell over Tor to the App and Monitor
-Servers. When you are done, click *Save* and close the text editor.
-
-The preceding steps are taken so that no one but the journalist will be
+We employ hidden service authentication so that no one but the journalist will be
 able to access to the *Document Interface*, even if they manage to steal
-the journalist's username, password, and two-factor authentication
-token.
+the journalist's username, password, and two-factor authentication token.
 
-Our ``install.sh`` sets up an initialization script that automatically
-updates Tor's configuration to work with SecureDrop every time you login
-to Tails. As long as Tails is booted with the persistent volume enabled
-then you can open the Tor Browser and connect to the Document Interface
-as normal.
+Our ``install.sh`` sets up Tails to work with SecureDrop every time you login. 
+As long as Tails is booted with the persistent volume enabled then you can open
+ the Tor Browser and connect to the Document Interface as normal.
 
 Create bookmarks for Source and Document Interfaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tails_guide.rst
+++ b/docs/tails_guide.rst
@@ -34,14 +34,13 @@ The `Tails website <https://tails.boum.org/>`__ has detailed and up-to-date
 instructions on how to download and verify Tails, and how to create a Tails USB 
 stick. Here are some links to help you out:
 
-.. _`Download and verify the Tails .iso`: https://tails.boum.org/download/index.en.html
-.. _`Install onto a USB stick or SD card`: https://tails.boum.org/doc/first_steps/installation/index.en.html
-.. _`Create & configure the persistent volume`: https://tails.boum.org/doc/first_steps/persistence/configure/index.en.html
-.. _`manually installing Tails onto a USB device on Mac OS X`: https://tails.boum.org/doc/first_steps/installation/manual/mac/index.en.html
-
 -  `Download and verify the Tails .iso`_
 -  `Install onto a USB stick or SD card`_
 -  `Create & configure the persistent volume`_
+
+.. _`Download and verify the Tails .iso`: https://tails.boum.org/download/index.en.html
+.. _`Install onto a USB stick or SD card`: https://tails.boum.org/doc/first_steps/installation/index.en.html
+.. _`Create & configure the persistent volume`: https://tails.boum.org/doc/first_steps/persistence/configure/index.en.html
 
 Note for Mac OS X users manually installing Tails
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -65,6 +64,8 @@ the .iso to a USB 2.0 drive. You can speed it up by changing the arguments to
 
 Note the change from ``diskX`` to ``rdiskX``. This reduced the copy time to 3 
 minutes for us.
+
+.. _`manually installing Tails onto a USB device on Mac OS X`: https://tails.boum.org/doc/first_steps/installation/manual/mac/index.en.html
 
 Configure Tails for use with SecureDrop
 ---------------------------------------

--- a/install_files/ansible-base/inventory
+++ b/install_files/ansible-base/inventory
@@ -5,7 +5,7 @@
 #
 # NOTE: after the install is complete, you can re-provision with Ansible but you will need to:
 # 1. Set up HidServAuth in your torrc with the values from app-ssh-aths and mon-ssh-aths
-# 2. Replace the IP addresses here with the corresponding .onion addresses
+# 2. Replace the IP addresses here with the corresponding addresses
 #
 app ansible_ssh_host=10.20.1.2 ansible_ssh_port=22
 mon ansible_ssh_host=10.20.2.2 ansible_ssh_port=22

--- a/install_files/ansible-base/inventory
+++ b/install_files/ansible-base/inventory
@@ -5,7 +5,7 @@
 #
 # NOTE: after the install is complete, you can re-provision with Ansible but you will need to:
 # 1. Set up HidServAuth in your torrc with the values from app-ssh-aths and mon-ssh-aths
-# 2. Replace the IP addresses here with the corresponding addresses
+# 2. Replace the IP addresses here with the corresponding .onion addresses
 #
 app ansible_ssh_host=10.20.1.2 ansible_ssh_port=22
 mon ansible_ssh_host=10.20.2.2 ansible_ssh_port=22

--- a/tails_files/document.desktop
+++ b/tails_files/document.desktop
@@ -1,0 +1,11 @@
+#!/usr/bin/env xdg-open
+
+[Desktop Entry]
+Version=1.0
+Type=Application
+Terminal=false
+Categories=Network;
+Name[en_US]=SecureDrop Document Interface
+Icon[en_US]=/home/amnesia/Persistent/.securedrop/securedrop_icon.png
+Name=SecureDrop Document Interface
+Icon=/home/amnesia/Persistent/.securedrop/securedrop_icon.png

--- a/tails_files/install.sh
+++ b/tails_files/install.sh
@@ -80,7 +80,7 @@ EOL
     echo "ansible" >> $TAILSCFG/live-additional-software.conf
   fi
   # update ansible inventory with .onion hostnames
-  if ! grep -q onion "$ANSIBLE/inventory"; then
+  if ! grep -v "^#.*onion" "$ANSIBLE/inventory" | grep -q onion; then
     sed -i "s/app ansible_ssh_host=.* /app ansible_ssh_host=$APPSSH /" $ANSIBLE/inventory
     sed -i "s/mon ansible_ssh_host=.* /mon ansible_ssh_host=$MONSSH /" $ANSIBLE/inventory
   fi

--- a/tails_files/install.sh
+++ b/tails_files/install.sh
@@ -1,22 +1,42 @@
 #!/bin/bash
+# SecureDrop persistent setup script for Tails 
 
 # check for root
 if [[ $EUID -ne 0 ]]; then
-    echo "This script must be run as root" 1>&2
-    exit 1
+  echo "This script must be run as root" 1>&2
+  exit 1
 fi
 
-PERSISTENT=/home/amnesia/Persistent
+# set paths and variables
+HOMEDIR=/home/amnesia
+PERSISTENT=$HOMEDIR/Persistent
 INSTALL_DIR=$PERSISTENT/.securedrop
 ADDITIONS=$INSTALL_DIR/torrc_additions
 SCRIPT_PY=$INSTALL_DIR/securedrop_init.py
 SCRIPT_BIN=$INSTALL_DIR/securedrop_init
 TAILSCFG=/live/persistence/TailsData_unlocked
+DOTFILES=$TAILSCFG/dotfiles
+DESKTOP=$HOMEDIR/Desktop
+ANSIBLE=$PERSISTENT/securedrop/install_files/ansible-base
+SSH_ALIASES=false
 
 # check for persistence
 if [ ! -d "$TAILSCFG" ]; then
   echo "This script must be run on Tails with a persistent volume." 1>&2
   exit 1
+fi
+
+# check for SecureDrop git repo
+if [ ! -d "$ANSIBLE" ]; then
+  echo "This script must be run with SecureDrop's git repository cloned to 'securedrop' in your Persistent folder." 1>&2
+  exit 1
+fi
+
+# detect whether admin or journalist
+if [ -f $ANSIBLE/app-document-aths ]; then
+  ADMIN=true
+else
+  ADMIN=false
 fi
 
 mkdir -p $INSTALL_DIR
@@ -26,15 +46,48 @@ apt-get update
 apt-get install -y build-essential
 gcc -o $SCRIPT_BIN securedrop_init.c
 
-# copy init scripts
+# copy icon, launchers and scripts
+cp securedrop_icon.png $INSTALL_DIR
+cp document.desktop $INSTALL_DIR
+cp source.desktop $INSTALL_DIR
 cp securedrop_init.py $SCRIPT_PY
 cp 99-tor-reload.sh $INSTALL_DIR
 
-cp securedrop_icon.png $INSTALL_DIR
-
-# prepare torrc_additions
-cp torrc_additions $ADDITIONS
-gedit $ADDITIONS > /dev/null 2>&1
+if $ADMIN; then
+  DOCUMENT=`cat $ANSIBLE/app-document-aths | cut -d ' ' -f 2`
+  SOURCE=`cat $ANSIBLE/app-source-ths`
+  APPSSH=`cat $ANSIBLE/app-ssh-aths | cut -d ' ' -f 2`
+  MONSSH=`cat $ANSIBLE/mon-ssh-aths | cut -d ' ' -f 2`
+  echo "# HidServAuth lines for SecureDrop's authenticated hidden services" | cat - $ANSIBLE/app-ssh-aths $ANSIBLE/mon-ssh-aths $ANSIBLE/app-document-aths > $ADDITIONS
+  if [[ -d "$HOMEDIR/.ssh" && ! -f "$HOMEDIR/.ssh/config" ]]; then
+    # create SSH host aliases and install them
+    SSHUSER=$(zenity --entry --title="Admin SSH user" --window-icon=$INSTALL_DIR/securedrop_icon.png --text="Enter your username on the App and Monitor server:")
+    cat > $INSTALL_DIR/ssh_config <<EOL
+Host app
+  Hostname $APPSSH
+  User $SSHUSER
+Host mon
+  Hostname $MONSSH
+  User $SSHUSER
+EOL
+    chown amnesia:amnesia $INSTALL_DIR/ssh_config
+    chmod 600 $INSTALL_DIR/ssh_config
+    cp -p $INSTALL_DIR/ssh_config $HOMEDIR/.ssh/config
+    SSH_ALIASES=true
+  fi
+  # set ansible to auto-install
+  if ! grep -q 'ansible' "$TAILSCFG/live-additional-software.conf"; then
+    echo "ansible" >> $TAILSCFG/live-additional-software.conf
+  fi
+  # update ansible inventory with .onion hostnames
+  if ! grep -q onion "$ANSIBLE/inventory"; then
+    sed -i "s/app ansible_ssh_host=.* /app ansible_ssh_host=$APPSSH /" $ANSIBLE/inventory
+    sed -i "s/mon ansible_ssh_host=.* /mon ansible_ssh_host=$MONSSH /" $ANSIBLE/inventory
+  fi
+else
+  # prepare torrc_additions (journalist)
+  cp torrc_additions $ADDITIONS
+fi
 
 # set permissions
 chmod 755 $INSTALL_DIR
@@ -45,10 +98,62 @@ chown root:root $SCRIPT_PY
 chmod 700 $SCRIPT_PY
 chown root:root $ADDITIONS
 chmod 400 $ADDITIONS
+
 chown amnesia:amnesia $INSTALL_DIR/securedrop_icon.png
-chmod 600 $INSTALL_DIR/securedrop_icon.png
+chmod 600 $INSTALL_DIR/securedrop_icon.png 
+chown amnesia:amnesia $INSTALL_DIR/document.desktop $INSTALL_DIR/source.desktop
+chmod 700 $INSTALL_DIR/document.desktop $INSTALL_DIR/source.desktop
 chown root:root $INSTALL_DIR/99-tor-reload.sh
 chmod 755 $INSTALL_DIR/99-tor-reload.sh
+
+# remove xsessionrc from 0.3.2 if present
+XSESSION_RC=$TAILSCFG/dotfiles/.xsessionrc
+if [ -f $XSESSION_RC ]; then
+  rm -f $XSESSION_RC > /dev/null 2>&1
+  # Repair the torrc backup, which was probably busted due to the
+  # race condition between .xsessionrc and
+  # /etc/NetworkManager/dispatch.d/10-tor.sh This avoids breaking
+  # Tor after this script is run.
+  #
+  # If the Sandbox directive is on in the torrc (now that the dust
+  # has settled from any race condition shenanigans), *and* there is
+  # no Sandbox directive already present in the backup of the
+  # original, "unmodified-by-SecureDrop" copy of the torrc used by
+  # securedrop_init, then port that Sandbox directive over to avoid
+  # breaking Tor by changing the Sandbox directive while it's
+  # running.
+  if grep -q 'Sandbox 1' /etc/tor/torrc && ! grep -q 'Sandbox 1' /etc/tor/torrc.bak; then
+    echo "Sandbox 1" >> /etc/tor/torrc.bak
+  fi
+fi
+
+# journalist workstation does not have the *-aths files created by the Ansible playbook, so we must prompt
+# to get the interface .onion addresses to setup launchers, and for the HidServAuth info used by Tor
+if ! $ADMIN; then
+  HIDSERVAUTH=$(zenity --entry --title="Hidden service authentication setup" --width=600 --window-icon=$INSTALL_DIR/securedrop_icon.png --text="Enter the HidServAuth value to be added to /etc/tor/torrc:")
+  echo $HIDSERVAUTH >> $ADDITIONS
+  SRC=$(zenity --entry --title="Desktop shortcut setup" --window-icon=$INSTALL_DIR/securedrop_icon.png --text="Enter the Source Interface's .onion address:")
+  SOURCE="${SRC#http://}"
+  DOCUMENT=`echo $HIDSERVAUTH | cut -d ' ' -f 2`
+fi
+
+# make the shortcuts
+echo "Exec=/usr/local/bin/tor-browser $DOCUMENT" >> $INSTALL_DIR/document.desktop
+echo "Exec=/usr/local/bin/tor-browser $SOURCE" >> $INSTALL_DIR/source.desktop
+
+# copy launchers to desktop and Applications menu
+cp -p $INSTALL_DIR/document.desktop $DESKTOP
+cp -p $INSTALL_DIR/source.desktop $DESKTOP
+cp -p $INSTALL_DIR/document.desktop $HOMEDIR/.local/share/applications
+cp -p $INSTALL_DIR/source.desktop $HOMEDIR/.local/share/applications
+
+# make it all persistent
+sudo -u amnesia mkdir -p $DOTFILES/Desktop
+sudo -u amnesia mkdir -p $DOTFILES/.local/share/applications
+cp -p $DESKTOP/document.desktop $DOTFILES/Desktop
+cp -p $DESKTOP/source.desktop $DOTFILES/Desktop
+cp -p $DESKTOP/document.desktop $DOTFILES/.local/share/applications
+cp -p $DESKTOP/source.desktop $DOTFILES/.local/share/applications
 
 # remove xsessionrc from 0.3.2 if present
 XSESSION_RC=$TAILSCFG/dotfiles/.xsessionrc
@@ -80,11 +185,26 @@ mkdir -p $TAILSCFG/custom-nm-hooks
 cp -p $INSTALL_DIR/99-tor-reload.sh $TAILSCFG/custom-nm-hooks
 cp -p $INSTALL_DIR/99-tor-reload.sh /etc/NetworkManager/dispatcher.d/
 
-# run the torrc update
+# set torrc and reload Tor
 $INSTALL_DIR/securedrop_init
 
+# finished
 echo ""
-echo "Successfully configured the persistent initialization script for SecureDrop's Tor configuration!"
-echo "You will see a notification appear in the top-right corner of your screen when it runs."
+echo "Successfully configured Tor and set up desktop bookmarks for SecureDrop!"
+echo "You will see a notification appear in the top-right corner of your screen."
+echo ""
+echo "The Document Interface's Tor onion URL is: http://$DOCUMENT"
+echo "The Source Interfaces's Tor onion URL is: http://$SOURCE"
+if $ADMIN; then
+  echo ""
+  echo "The App Server's SSH hidden service address is:"
+  echo $APPSSH
+  echo "The Monitor Server's SSH hidden service address is:"
+  echo $MONSSH
+  if $SSH_ALIASES; then
+    echo ""
+    echo "SSH aliases are set up. You can use them with 'ssh app' and 'ssh mon'"
+  fi
+fi
 echo ""
 exit 0

--- a/tails_files/source.desktop
+++ b/tails_files/source.desktop
@@ -1,0 +1,11 @@
+#!/usr/bin/env xdg-open
+
+[Desktop Entry]
+Version=1.0
+Type=Application
+Terminal=false
+Categories=Network;
+Name[en_US]=SecureDrop Source Interface
+Icon[en_US]=/home/amnesia/Persistent/.securedrop/securedrop_icon.png
+Name=SecureDrop Source Interface
+Icon=/home/amnesia/Persistent/.securedrop/securedrop_icon.png

--- a/tails_files/torrc_additions
+++ b/tails_files/torrc_additions
@@ -1,3 +1,1 @@
-# Add the HidServAuth lines for your authenticated hidden services here.
-# When you're done, save the file and quit the editor.
-
+# HidServAuth lines for SecureDrop's authenticated hidden services


### PR DESCRIPTION
This is PR #955 redone. Aspects of these modifications to `install.sh` have been extensively reviewed and tested in the past, but not on the latest version of Tails. We're doing the following things:
 
    * Detects whether user is an admin or journalist
    * Configures HidServAuth values and eliminates need to manually edit torrc_additions
    * Adds desktop and main menu launchers for both interfaces
    * Sets up SSH host aliases for mon and app server (if admin)
    * Updates inventory file to run playbooks over Tor (if admin) 
    * Use 'live-additional-software' to always install Ansible (if admin)
    * Updates the documentation to reflect

The shortcut setup will have to be updated to deal with TLS/HTTPS when that feature comes in. Those links are currently HTTP only.