### PR TITLE
Add first basic coverage for py.test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 - sudo /etc/init.d/rng-tools restart
 install:
 - pip install ansible
+- pip install coveralls
 script:
 - echo localhost > inventory
 - ansible-playbook -i inventory --syntax-check install_files/ansible-base/securedrop-travis.yml
@@ -24,6 +25,8 @@ script:
   # securedrop_user default www-data
 - sudo chown root:root securedrop/config.py
 - sudo sh -c "export DISPLAY=:1; cd securedrop && ./manage.py test"
+after_success:
+  cd securedrop && coveralls
 notifications:
   slack:
     secure: jmEgJkFg6IVLl78dbLPBUpWkVuHkQ+HtXHNoY4cdgx2Gq5kVDuLtBIuMK5ubbj3zsp99JIJZ9DFQlunCkoLYZ7PAKQ7fhfwLEWNFJiAajMTZF/nNKV2J4i0NyMBHeFQ5eagAe3wrGiY5sblTbnExY4zERcdGoC1S2UImWX0xMRw=

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 </p>
 
 [![Build Status](https://travis-ci.org/freedomofpress/securedrop.png)](http://travis-ci.org/freedomofpress/securedrop)
+[![Coverage Status](https://coveralls.io/repos/freedomofpress/securedrop/badge.svg?branch=develop&service=github)](https://coveralls.io/github/freedomofpress/securedrop?branch=develop)
+
 
 SecureDrop is an open-source whistleblower submission system that media organizations can use to securely accept documents from and communicate with anonymous sources. It was originally created by the late Aaron Swartz and is currently managed by [Freedom of the Press Foundation](https://freedom.press).
 

--- a/securedrop/.coveragerc
+++ b/securedrop/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source = .
+omit = tests/*

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -70,7 +70,7 @@ def test():
     os.environ['SECUREDROP_ENV'] = 'test'
     import config
     _start_test_rqworker(config)
-    test_cmds = ["py.test", "./test.sh"]
+    test_cmds = [("py.test", "--cov=securedrop"), "./test.sh"]
     test_rc = int(any([subprocess.call(cmd) for cmd in test_cmds]))
     _stop_test_rqworker()
     sys.exit(test_rc)
@@ -83,7 +83,7 @@ def test_unit():
     os.environ['SECUREDROP_ENV'] = 'test'
     import config
     _start_test_rqworker(config)
-    test_rc = int(subprocess.call("py.test"))
+    test_rc = int(subprocess.call(["py.test", "--cov=securedrop"]))
     _stop_test_rqworker()
     sys.exit(test_rc)
 

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -70,7 +70,7 @@ def test():
     os.environ['SECUREDROP_ENV'] = 'test'
     import config
     _start_test_rqworker(config)
-    test_cmds = [("py.test", "--cov=securedrop"), "./test.sh"]
+    test_cmds = [["py.test", "--cov"], "./test.sh"]
     test_rc = int(any([subprocess.call(cmd) for cmd in test_cmds]))
     _stop_test_rqworker()
     sys.exit(test_rc)
@@ -83,7 +83,7 @@ def test_unit():
     os.environ['SECUREDROP_ENV'] = 'test'
     import config
     _start_test_rqworker(config)
-    test_rc = int(subprocess.call(["py.test", "--cov=securedrop"]))
+    test_rc = int(subprocess.call(["py.test", "--cov"]))
     _stop_test_rqworker()
     sys.exit(test_rc)
 

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -2,3 +2,4 @@ Flask-Testing==0.4.2
 mock==1.0.1
 pytest==2.6.4
 selenium==2.45.0
+pytest-cov==2.2.0


### PR DESCRIPTION
When running, this will also output a `.coverage` that can be visualized via `coverage html` or `coverage report`.

Left to do:

* [x] integrate with travis and coveralls
* [ ] add coverage for the 3 functional tests too

Sample output of `coverage html`:

<img width="683" alt="screen shot 2015-11-07 at 5 52 02 pm" src="https://cloud.githubusercontent.com/assets/1469823/11018300/6b47ae14-8578-11e5-96d6-7b43ee304fb0.png">
