### PR TITLE
Set Cache-Control header time of 30 minutes.

### DIFF
--- a/install_files/ansible-base/roles/app/templates/sites-available/document.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/document.conf
@@ -12,10 +12,8 @@ XSendFile        On
 XSendFilePath    /var/lib/securedrop/store/
 XSendFilePath    /var/lib/securedrop/tmp/
 
-Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+Header set Cache-Control "max-age=1800"
 Header edit Set-Cookie ^(.*)$ $1;HttpOnly
-Header set Pragma "no-cache"
-Header set Expires "-1"
 Header always append X-Frame-Options: DENY
 Header set X-XSS-Protection: "1; mode=block"
 Header set X-Content-Type-Options: nosniff

--- a/install_files/ansible-base/roles/app/templates/sites-available/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/source.conf
@@ -10,10 +10,8 @@ AddType text/html .py
 
 XSendFile        Off
 
-Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+Header set Cache-Control "max-age=1800, must-revalidate"
 Header edit Set-Cookie ^(.*)$ $1;HttpOnly
-Header set Pragma "no-cache"
-Header set Expires "-1"
 Header always append X-Frame-Options: DENY
 Header set X-XSS-Protection: "1; mode=block"
 Header set X-Content-Type-Options: nosniff


### PR DESCRIPTION
Previously we used
 * cache-control
 * pragma
 * expires

headers to ensure that assets being served were not cached at all by the
client, the theory being that we don't want to leave any forensic
evidence on the source machine indicating that they've used securedrop.

TorBrowser patches Firefox such that it does not persist cached assets
to disk, and keeps them solely in RAM.

Neither TorBrowser, nor our use of cache-control headers can prevent the
OS from swapping to disk, in which case all cached assets are persisted
to disk leaking information.

The size of the assets being served in securedrop is in the order of
tens of kilobytes now that we're minimizing them. It is highly unlikely
that these assets will be the straw to break the camels back memory
wise causing a swap to disk.

Without the caching headers the experience of loading securedrop is
disjointed, as the stylesheets load well after the page has begun
rendering. The experience of loading securedrop is *greatly* improved by
allowing short-term caching of these assets.