### PR TITLE
Delete submissions and replies when source deleted

### DIFF
--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -132,7 +132,8 @@ class Submission(Base):
         "Source",
         backref=backref(
             'submissions',
-            order_by=id))
+            order_by=id,
+        cascade="delete"))
     filename = Column(String(255), nullable=False)
     size = Column(Integer, nullable=False)
     downloaded = Column(Boolean, default=False)
@@ -158,7 +159,8 @@ class Reply(Base):
             order_by=id))
 
     source_id = Column(Integer, ForeignKey('sources.id'))
-    source = relationship("Source", backref=backref('replies', order_by=id))
+    source = relationship("Source", backref=backref('replies', order_by=id,
+                          cascade="delete"))
 
     filename = Column(String(255), nullable=False)
     size = Column(Integer, nullable=False)


### PR DESCRIPTION
This PR will delete submissions and replies linked to a source when a
source is deleted. This will fix https://github.com/freedomofpress/securedrop/issues/1188.
