### PR TITLE
Install securedrop-keyring package

### DIFF
--- a/install_files/ansible-base/roles/install-fpf-repo/tasks/main.yml
+++ b/install_files/ansible-base/roles/install-fpf-repo/tasks/main.yml
@@ -15,3 +15,11 @@
   tags:
     - apt
     - fpf_repo
+
+- name: ensure the fpf apt repo keyring package is installed
+  apt:
+    pkg: securedrop-keyring
+    state: present
+  tags:
+    - apt
+    - fpf_repo

--- a/install_files/securedrop-app-code/DEBIAN/control
+++ b/install_files/securedrop-app-code/DEBIAN/control
@@ -6,5 +6,5 @@ Homepage: https://securedrop.org
 Package: securedrop-app-code
 Version: 0.3.6
 Architecture: amd64
-Depends: python-pip,apparmor-utils,gnupg2,haveged,python,python-pip,secure-delete,sqlite,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor
+Depends: python-pip,apparmor-utils,gnupg2,haveged,python,python-pip,secure-delete,sqlite,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor,securedrop-keyring
 Description: Packages the SecureDrop application code pip dependencies and apparmor profiles. This package will put the apparmor profiles in enforce mode. This package does use pip to install the pip wheelhouse


### PR DESCRIPTION
This is the change to the playbook required to install the [SecureDrop keyring package](https://github.com/freedomofpress/securedrop-keyring) as part of the FPF apt repo, which will allow us to update the public key which is used to sign the [apt.freedom.press](https://apt.freedom.press) Release file and its expiry in the future without requiring manual action by SecureDrop instance admins. For context, our master signing key expired without us being aware on October 26, 2015, necessitating the 0.3.6 hotfix.

Per #1196 , the `install_fpf_repo` role is mostly the same, it just has slashes instead of underscores.

The actual package and its build process is simple and described in the linked GitHub repository. Merging this PR should occur concurrent with adding the package to our repository, which is a whole process.