### PR TITLE
Add document describing SecureDrop apt repository

### DIFF
--- a/docs/development/apt_repo.rst
+++ b/docs/development/apt_repo.rst
@@ -1,0 +1,31 @@
+SecureDrop apt repository
+=========================
+
+This document contains a brief description of the Debian packages which are 
+hosted and maintained by Freedom of the Press Foundation in our apt repository 
+at `apt.freedom.press`_.
+
+linux-image-3.14.*-grsec
+    This package contains the Linux kernel image, patched with grsecurity.
+
+linux-headers-3.14.*-grsec
+    Header files related to the Linux kernel.
+
+securedrop-app-code
+    Packages the SecureDrop application code, Python pip dependencies and 
+    AppArmor profiles.
+
+`securedrop-keyring <https://github.com/freedomofpress/securedrop-keyring>`_
+    Packages the public signing key used in conjunction with this apt 
+    repository.
+
+securedrop-ossec-agent
+    Installs the pre-configured OSSEC agent for the SecureDrop App Server.
+
+securedrop-ossec-server
+    Installs the pre-configured OSSEC manager for the SecureDrop Mon Server.
+
+`securedrop-grsec <https://github.com/freedomofpress/grsec>`_
+    SecureDrop grsec kernel (metapackage depending on the latest version).
+
+.. _apt.freedom.press: https://apt.freedom.press

--- a/docs/development/apt_repo.rst
+++ b/docs/development/apt_repo.rst
@@ -15,10 +15,6 @@ securedrop-app-code
     Packages the SecureDrop application code, Python pip dependencies and 
     AppArmor profiles.
 
-`securedrop-keyring <https://github.com/freedomofpress/securedrop-keyring>`_
-    Packages the public signing key used in conjunction with this apt 
-    repository.
-
 securedrop-ossec-agent
     Installs the pre-configured OSSEC agent for the SecureDrop App Server.
 
@@ -27,5 +23,11 @@ securedrop-ossec-server
 
 `securedrop-grsec <https://github.com/freedomofpress/grsec>`_
     SecureDrop grsec kernel (metapackage depending on the latest version).
+
+.. note:: To be added in the future: 
+
+          `securedrop-keyring <https://github.com/freedomofpress/securedrop-keyring>`_    
+              Packages the public signing key used in conjunction with this apt           
+              repository.               
 
 .. _apt.freedom.press: https://apt.freedom.press

--- a/docs/development/apt_repo.rst
+++ b/docs/development/apt_repo.rst
@@ -22,10 +22,10 @@ securedrop-app-code
     AppArmor profiles.
 
 securedrop-ossec-agent
-    Installs the SecureDrop-specific configuration for the App Server.
+    Installs the SecureDrop-specific OSSEC configuration for the App Server.
 
 securedrop-ossec-server
-    Installs the SecureDrop-specific configuration for the Mon Server.
+    Installs the SecureDrop-specific OSSEC configuration for the Mon Server.
 
 `securedrop-grsec <https://github.com/freedomofpress/grsec>`_
     SecureDrop grsec kernel (metapackage depending on the latest version).

--- a/docs/development/apt_repo.rst
+++ b/docs/development/apt_repo.rst
@@ -11,15 +11,21 @@ linux-image-3.14.*-grsec
 linux-headers-3.14.*-grsec
     Header files related to the Linux kernel.
 
+`ossec-agent <https://github.com/freedomofpress/ossec>`_                        
+    Installs the OSSEC agent.
+                                                                                
+`ossec-server <https://github.com/freedomofpress/ossec>`_ 
+    Installs the OSSEC manager.
+
 securedrop-app-code
     Packages the SecureDrop application code, Python pip dependencies and 
     AppArmor profiles.
 
 securedrop-ossec-agent
-    Installs the pre-configured OSSEC agent for the SecureDrop App Server.
+    Installs the SecureDrop-specific configuration for the App Server.
 
 securedrop-ossec-server
-    Installs the pre-configured OSSEC manager for the SecureDrop Mon Server.
+    Installs the SecureDrop-specific configuration for the Mon Server.
 
 `securedrop-grsec <https://github.com/freedomofpress/grsec>`_
     SecureDrop grsec kernel (metapackage depending on the latest version).

--- a/docs/upgrade/0.3.5-to-0.3.6.rst
+++ b/docs/upgrade/0.3.5-to-0.3.6.rst
@@ -19,13 +19,13 @@ Important Changes
 -----------------
 
 Update Expired GPG Signing Key (Admin Workstation)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Admin Workstation is used to verify the signed git tag on new
 SecureDrop releases. Prior to running the 0.3.6 upgrade, the Admin
 Workstation should update the signing key.
 
 Update Expired GPG Signing Key (SecureDrop Servers)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Application Server and Monitor Server will need to have their apt
 keyrings updated, which can be accomplished by running the Ansible playbooks.
 


### PR DESCRIPTION
I figured we should have something describing the contents of our repo _somewhere_. I put it under /development.

I also fixed a small Sphinx error in the upgrade docs that were merged yesterday.