### PR TITLE
Fixes fetching Source Interface THS URL

### DIFF
--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
@@ -29,8 +29,9 @@
     dest: ./{{ item.item.filename }}
     # The `content` parameter does not automatically append a newline, so
     # force adding one. Doing so ensures that the resulting files can be
-    # concatenated into the torrc.
-    content: "HidServAuth {{ item.stdout }}\\n"
+    # concatenated into the torrc. We also only want the "HidServAuth"
+    # string for ATHS URLs, but not for THS urls.
+    content: "{% if item.item.filename.endswith('-aths') %}HidServAuth {% endif %}{{ item.stdout }}\\n"
   # Local action, so we don't want elevated privileges
   sudo: no
   with_items: tor_hidden_service_hostname_lookup.results


### PR DESCRIPTION
Recent changes (#1196) to how the Tor hidden service files are collected from the servers and written to the Admin Workstation yielded a regression in formatting: the `HidServAuth` string was inappropriately prepended to _all_ hidden service files. Instead, it should be prepended only to the ATHS files:

* `app-document-aths`
* `app-ssh-aths`
* `mon-ssh-aths`

but _not_ to the THS file (the Source Interface) file:

* `app-source-ths`

Thanks for spotting, @ageis!