### PR TITLE
Remove weak DH groups of <= 2000 bits

### DIFF
--- a/install_files/ansible-base/roles/common/tasks/dh_moduli.yml
+++ b/install_files/ansible-base/roles/common/tasks/dh_moduli.yml
@@ -1,0 +1,19 @@
+---                                                                             
+- name: Check whether Diffie-Hellman groups have been updated                   
+  stat:                                                                         
+    path: /etc/ssh/moduli                                                       
+  register: dh_moduli                                                           
+                                                                                
+- name: Remove weak DH moduli                                                   
+  command: awk '$5 > 2000' /etc/ssh/moduli                                      
+  register: new_dh_moduli                                                       
+  when: dh_moduli.stat.checksum == '2dc7b3b18a2d3884ca4604466b75cf7903e96a97'   
+                                                                                
+- name: Install updated DH moduli                                               
+  copy:                                                                         
+    dest: /etc/ssh/moduli                                                       
+    content: "{{ new_dh_moduli.stdout }}"                                       
+    owner: root                                                                 
+    group: root                                                                 
+    mode: "0644"                                                                
+  when: dh_moduli.stat.checksum == '2dc7b3b18a2d3884ca4604466b75cf7903e96a97' 

--- a/install_files/ansible-base/roles/common/tasks/main.yml
+++ b/install_files/ansible-base/roles/common/tasks/main.yml
@@ -17,3 +17,4 @@
 
 - include: remove_kernel_modules.yml
 
+- include: dh_moduli.yml

--- a/install_files/ansible-base/roles/common/tasks/main.yml
+++ b/install_files/ansible-base/roles/common/tasks/main.yml
@@ -16,5 +16,3 @@
 - include: disable_swap.yml
 
 - include: remove_kernel_modules.yml
-
-- include: dh_moduli.yml

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/dh_moduli.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/dh_moduli.yml
@@ -3,6 +3,8 @@
   stat:                                                                         
     path: /etc/ssh/moduli                                                       
   register: dh_moduli                                                           
+
+# SHA1 checksum represents the latest default primes/moduli shipped with OpenSSH
                                                                                 
 - name: Remove weak DH moduli                                                   
   command: awk '$5 > 2000' /etc/ssh/moduli                                      

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/main.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - include: fetch_tor_config.yml
 
+- include: dh_moduli.yml
+
 - include: ssh.yml
 
 - include: iptables.yml


### PR DESCRIPTION
This is a first approach to the problem in #1161.

Generating new prime numbers and testing them with `ssh-keygen` takes a lot of time, so various guides across the internet have recommended keeping the default primes, but just deleting the weak ones from `/etc/ssh/moduli`.

So we're doing that using a common awk command based on whether we have a SHA1 checksum of the moduli file shipped with `openssh-client`.

My only misgiving about this method concerns registering the moduli into a variable (it's ~200 kilobytes). Maybe it should be using a temporary file instead?