### PR TITLE
Mask codename on login and submission pages

### DIFF
--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -7,7 +7,7 @@
 
 <form method="post" action="/login" autocomplete="off">
 <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-<p class="center"><input type="text" name="codename" class="codename" autocomplete="off" placeholder="Enter your codename" autofocus /></p>
+<p class="center"><input type="password" name="codename" class="codename" autocomplete="off" placeholder="Enter your codename" autofocus /></p>
 <p class="center"><button type="submit" class="btn block"><i class="fa fa-arrow-circle-o-right"></i> Continue</button></p>
 </form>
 {% endblock %}

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -66,8 +66,11 @@
 
 <hr class="no-line">
 
+
 <div class="code-reminder">
-  <i class="fa fa-lock pull-left"></i> Remember, your codename is: <strong>{{ codename }}</strong>
+  <i class="fa fa-lock pull-left"></i> Remember your codename is:
+  <div id="show" class="show pull-right"></div>
+  <span id="content"><p class="alert"><strong>{{ codename }}</strong></p></span>
 </div>
 
 {% endblock %}

--- a/securedrop/static/css/source.css
+++ b/securedrop/static/css/source.css
@@ -392,6 +392,31 @@ button.center {
   font-size: 18pt;
 }
 
+input#show {
+  display:none;
+}
+#content {
+    display: block;
+    transition: opacity 1s ease-out;
+    opacity: 0; 
+    height: 0;
+    font-size: 0;
+    overflow: hidden;
+}
+#show:before {
+    color:blue;
+    content: "Show"
+}
+#show:hover.show:before {
+    color:gray;
+    content: "Hide"
+}
+#show:hover ~ span#content {
+    opacity: 1;
+    font-size: 100%;
+    height: auto;
+}
+
 input.codename {
   width: 400px;
   padding: 10px;


### PR DESCRIPTION
This commit masks sources' codenames altogether as they enter them into the
login page. On the submission page, it hides the codename by default, but
allows the source to click a lock to reveal and hide the codename. The lock icon
also changes from closed to open (and back) as the source hides and reveals,
respectively, the codename.

Signed-off-by: Noah Vesely <fowlslegs@riseup.net>