### PR TITLE
Converts Travis CI tests to use trusty64 with sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
+# Use Ubuntu 14.04 LTS images, and explicitly require sudo.
+# Relevant docs: https://docs.travis-ci.com/user/trusty-ci-environment/
+sudo: required
+dist: trusty
+
 language: python
 python:
 - '2.7'
+
 virtualenv:
   system_site_packages: true
 before_install:


### PR DESCRIPTION
The Travis CI tests have been running on legacy infrastructure. Indeed, on each and every run Travis reminds us:

> This job ran on our legacy infrastructure. Please read our docs on how to upgrade. [0]

We've been dragging our feet on the upgrade, because the new Docker-based containers explicitly do not allow the use of sudo, which is a hard requirement for our tests. But sudo-less Docker containers are
not our only option (praise the old gods and the new)! We also have the option of using Ubuntu 14.04 LTS builds with sudo enabled [1], which is a much better option for our use case, given that we explicitly support 14.04 for production instances, and our development VMs also run 14.04.

[0] https://docs.travis-ci.com/user/migrating-from-legacy
[1] https://docs.travis-ci.com/user/trusty-ci-environment/

The new test suite ran fine over here: https://travis-ci.org/conorsch/securedrop/builds/95879540 So I say let's enable it project-wide on the `develop` branch. I accept full responsibility for debugging the new test suite—I've had my head buried in tests lately anyway, so now's a fine time to make this change.