### PR TITLE
Update Apache access control directives for version 2.4

### DIFF
--- a/install_files/ansible-base/roles/app/templates/sites-available/document.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/document.conf
@@ -42,7 +42,11 @@ ErrorDocument 500 /error
   Options {{ apache_dir_options | default('None') }}
   AllowOverride None
   <Limit GET POST HEAD>
+{% if apache_allow_from == "all" %}
+    Require all granted
+{% else %}
     Require ip {{ apache_allow_from | default('127.0.0.1') }}
+{% endif %}
   </Limit>
   <LimitExcept GET POST HEAD>
     Require all denied
@@ -53,7 +57,11 @@ ErrorDocument 500 /error
   Options {{ apache_dir_options | default('None') }}
   AllowOverride None
   <Limit GET POST HEAD>
+{% if apache_allow_from == "all" %}
+    Require all granted
+{% else %}
     Require ip {{ apache_allow_from | default('127.0.0.1') }}
+{% endif %}
   </Limit>
   <LimitExcept GET POST HEAD>
     Require all denied

--- a/install_files/ansible-base/roles/app/templates/sites-available/document.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/document.conf
@@ -35,20 +35,17 @@ ErrorDocument 500 /error
 <Directory />
   Options None
   AllowOverride None
-  Order deny,allow
-  Deny from all
+  Require all denied
 </Directory>
 
 <Directory /var/www/>
   Options {{ apache_dir_options | default('None') }}
   AllowOverride None
   <Limit GET POST HEAD>
-    Order allow,deny
-    allow from {{ apache_allow_from | default('127.0.0.1') }}
+    Require ip {{ apache_allow_from | default('127.0.0.1') }}
   </Limit>
   <LimitExcept GET POST HEAD>
-    Order deny,allow
-    Deny from all
+    Require all denied
   </LimitExcept>
 </Directory>
 
@@ -56,12 +53,10 @@ ErrorDocument 500 /error
   Options {{ apache_dir_options | default('None') }}
   AllowOverride None
   <Limit GET POST HEAD>
-    Order allow,deny
-    allow from {{ apache_allow_from | default('127.0.0.1') }}
+    Require ip {{ apache_allow_from | default('127.0.0.1') }}
   </Limit>
   <LimitExcept GET POST HEAD>
-    Order deny,allow
-    Deny from all
+    Require all denied
   </LimitExcept>
 </Directory>
 

--- a/install_files/ansible-base/roles/app/templates/sites-available/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/source.conf
@@ -40,7 +40,11 @@ ErrorDocument 500 /notfound
   Options {{ apache_dir_options | default('None') }}
   AllowOverride None
   <Limit GET POST HEAD>
+{% if apache_allow_from == "all" %}
+    Require all granted
+{% else %}
     Require ip {{ apache_allow_from | default('127.0.0.1') }}
+{% endif %}
   </Limit>
   <LimitExcept GET POST HEAD>
     Require all denied
@@ -51,7 +55,11 @@ ErrorDocument 500 /notfound
   Options {{ apache_dir_options | default('None') }}
   AllowOverride None
   <Limit GET POST HEAD>
+{% if apache_allow_from == "all" %}
+    Require all granted
+{% else %}
     Require ip {{ apache_allow_from | default('127.0.0.1') }}
+{% endif %}
   </Limit>
   <LimitExcept GET POST HEAD>
     Require all denied

--- a/install_files/ansible-base/roles/app/templates/sites-available/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/source.conf
@@ -33,20 +33,17 @@ ErrorDocument 500 /notfound
 <Directory />
   Options None
   AllowOverride None
-  Order deny,allow
-  Deny from all
+  Require all denied
 </Directory>
 
 <Directory /var/www/>
   Options {{ apache_dir_options | default('None') }}
   AllowOverride None
   <Limit GET POST HEAD>
-    Order allow,deny
-    allow from {{ apache_allow_from | default('127.0.0.1') }}
+    Require ip {{ apache_allow_from | default('127.0.0.1') }}
   </Limit>
   <LimitExcept GET POST HEAD>
-    Order deny,allow
-    Deny from all
+    Require all denied
   </LimitExcept>
 </Directory>
 
@@ -54,12 +51,10 @@ ErrorDocument 500 /notfound
   Options {{ apache_dir_options | default('None') }}
   AllowOverride None
   <Limit GET POST HEAD>
-    Order allow,deny
-    allow from {{ apache_allow_from | default('127.0.0.1') }}
+    Require ip {{ apache_allow_from | default('127.0.0.1') }}
   </Limit>
   <LimitExcept GET POST HEAD>
-    Order deny,allow
-    Deny from all
+    Require all denied
   </LimitExcept>
 </Directory>
 

--- a/spec_tests/spec/app-general/apache_spec.rb
+++ b/spec_tests/spec/app-general/apache_spec.rb
@@ -94,7 +94,7 @@ common_apache2_directory_declarations = <<eos
   Options None
   AllowOverride None
   <Limit GET POST HEAD>
-    Require ip #{property['apache_allow_from']}
+    #{property['apache_allow_line']}
   </Limit>
   <LimitExcept GET POST HEAD>
     Require all denied
@@ -105,7 +105,7 @@ common_apache2_directory_declarations = <<eos
   Options None
   AllowOverride None
   <Limit GET POST HEAD>
-    Require ip #{property['apache_allow_from']}
+    #{property['apache_allow_line']}
   </Limit>
   <LimitExcept GET POST HEAD>
     Require all denied

--- a/spec_tests/spec/app-general/apache_spec.rb
+++ b/spec_tests/spec/app-general/apache_spec.rb
@@ -87,20 +87,17 @@ common_apache2_directory_declarations = <<eos
 <Directory />
   Options None
   AllowOverride None
-  Order deny,allow
-  Deny from all
+  Require all denied
 </Directory>
 
 <Directory /var/www/>
   Options None
   AllowOverride None
   <Limit GET POST HEAD>
-    Order allow,deny
-    allow from #{property['apache_allow_from']}
+    Require ip #{property['apache_allow_from']}
   </Limit>
   <LimitExcept GET POST HEAD>
-    Order deny,allow
-    Deny from all
+    Require all denied
   </LimitExcept>
 </Directory>
 
@@ -108,12 +105,10 @@ common_apache2_directory_declarations = <<eos
   Options None
   AllowOverride None
   <Limit GET POST HEAD>
-    Order allow,deny
-    allow from #{property['apache_allow_from']}
+    Require ip #{property['apache_allow_from']}
   </Limit>
   <LimitExcept GET POST HEAD>
-    Order deny,allow
-    Deny from all
+    Require all denied
   </LimitExcept>
 </Directory>
 eos

--- a/spec_tests/spec/vars/development.yml
+++ b/spec_tests/spec/vars/development.yml
@@ -2,3 +2,4 @@
 securedrop_user: vagrant
 securedrop_code: /vagrant/securedrop
 securedrop_data: /var/lib/securedrop
+apache_allow_line: "Require all granted"

--- a/spec_tests/spec/vars/prod.yml
+++ b/spec_tests/spec/vars/prod.yml
@@ -9,4 +9,4 @@ monitor_hostname: mon-prod
 
 apache_listening_address: 127.0.0.1
 apache_source_log: /dev/null
-apache_allow_from: 127.0.0.1
+apache_allow_line: "Require ip 127.0.0.1"

--- a/spec_tests/spec/vars/staging.yml
+++ b/spec_tests/spec/vars/staging.yml
@@ -9,8 +9,7 @@ monitor_hostname: mon-staging
 
 apache_listening_address: 0.0.0.0
 apache_source_log: /var/log/apache2/source-error.log
-apache_allow_from: all
-
+apache_allow_line: "Require all granted"
 # Hard-coding the default interface used in the
 # staging rules for now. In VirtualBox, eth0 is a
 # NAT device used for SSH port forwards. In DigitalOcean,


### PR DESCRIPTION
The old Allow, Deny and Order directives are deprecated: https://httpd.apache.org/docs/2.4/howto/access.html

I haven't had a chance to test this in the staging environment yet due to #1241.
