### PR TITLE
Stick to Tails defaults for GPG keyserver options

### DIFF
--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -100,7 +100,7 @@ fingerprint:
 
 Download your key and import it into the local keyring: ::
 
-    gpg --keyserver hkp://qdigse2yzvuglcix.onion --recv-key "<fingerprint>"
+    gpg --recv-key "<fingerprint>"
 
 .. note:: It is important you type this out correctly. If you are not
           copy-pasting this command, we recommend you double-check you have

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -34,7 +34,7 @@ integrity with cryptographic signatures and hashes.
 First, we will download *Ubuntu Image Signing Key* and verify its
 *fingerprint*. ::
 
-    gpg --keyserver hkp://qdigse2yzvuglcix.onion --recv-key "C598 6B4F 1257 FFA8 6632 CBA7 4618 1433 FBB7 5451"
+    gpg --recv-key "C598 6B4F 1257 FFA8 6632 CBA7 4618 1433 FBB7 5451"
 
 .. note:: It is important you type this out correctly. If you are not
           copy-pasting this command, we recommend you double-check you have

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -60,7 +60,7 @@ Signing Key*.
 
 .. code:: sh
 
-    gpg --keyserver hkp://qdigse2yzvuglcix.onion --recv-key "B89A 29DB 2128 160B 8E4B 1B4C BADD E0C7 FC9F 6818"
+    gpg --recv-key "B89A 29DB 2128 160B 8E4B 1B4C BADD E0C7 FC9F 6818"
 
 .. note:: It is important you type this out correctly. If you are not
           copy-pasting this command, we recommend you double-check you have

--- a/docs/upgrade/0.3.5-to-0.3.6.rst
+++ b/docs/upgrade/0.3.5-to-0.3.6.rst
@@ -65,7 +65,7 @@ Greeter*.
 #. Update the Freedom of the Press signing key
    (these commands are from the :doc:`../set_up_admin_tails` guide) ::
 
-    gpg --keyserver pool.sks-keyservers.net --recv-key B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
+    gpg --recv-key B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
     gpg --fingerprint B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
 
    .. tip:: The GPG Master Signing Key is also available from the

--- a/docs/upgrade/0.3.5-to-0.3.6.rst
+++ b/docs/upgrade/0.3.5-to-0.3.6.rst
@@ -65,8 +65,7 @@ Greeter*.
 #. Update the Freedom of the Press signing key
    (these commands are from the :doc:`../set_up_admin_tails` guide) ::
 
-    gpg --recv-key B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
-    gpg --fingerprint B89A29DB2128160B8E4B1B4CBADDE0C7FC9F6818
+    gpg --recv-key "B89A 29DB 2128 160B 8E4B 1B4C BADD E0C7 FC9F 6818"
 
    .. tip:: The GPG Master Signing Key is also available from the
             `Freedom of the Press website 


### PR DESCRIPTION
In our last docs release, we switched to a hidden service SKS mirror. The
reasons for doing so were:

* Traffic never leaves the Tor network
* End-to-end TLS w/ self-authentication via the .onion URL

The hidden service keyserver has since gone down and this has caused a problem
for users trying to install SecureDrop, especially because GPG doesn't actually
inform the user when they specify an invalid keyserver address. Instead, they
are told that the operation they wanted to perform (e.g., `--search-keys`,
`--recv-key`) failed.

--

I propose we remove the `--keyserver` option altogether for the reasons that
follow.

In the Tails `gpg.conf` they default to using the SKS keyserver pool over
SSL/TLS (HKPS). The configuration file also specifies to replace the default
certificate store with just the singular self-signed certificate that is shared
among the TLS-capable SKS keyservers. This solves the CA problem in a different
way than the use of hidden services does. Traffic does leave the Tor network,
but only in encrypted form.

Further, the configuration specifies the `no-try-dns-srv` keyserver-option,
which though only documented in an upstream commit, prevents the leaking of DNS
(see https://trac.torproject.org/projects/tor/ticket/2846).

Lastly, sticking with the Tails `gpg.conf` defaults will be reliable since I
don't expect the entire SKS keyserver infrastructure to go down anytime soon.
Any problems our users have will be affecting all Tails and/ or SKS users, so we
can expect a timely fix in the unlikely chance of future problems.

--

One final thing to consider is the case that it has been discovered that the SKS
keyserver certificate is compromised. In this case, the certificate file will
not be replaced until the next version of Tails. It will be big news if this
does happen, so I'm sure we'll find out and quickly push a warning and
workaround to the documentation. Further, the risks implied by this problem are
still present with the use of hidden services, HKPS w/ the system certificate
store (as opposed to a self-signed cert file), and with no HKPS at all.

Signed-off-by: Noah Vesely <noah@freedom.press>