### PR TITLE
gpg key verification

### DIFF
--- a/install_files/ansible-base/files/validate-gpg-key.sh
+++ b/install_files/ansible-base/files/validate-gpg-key.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# Verifies a key at at given path matches a fingerprint
+# Does so by importing the key into gpg2 and checking output
+
+# Exit codes
+# 0 - fingerprint matches key
+# 1 - otherwise
+
+declare -r key_location="$1"
+declare -r fingerprint="$2"
+
+: {key_location:?'A path to a key must be provided (arg 1)'}
+: {fingerprint:?'A fingerprint must be provided (arg 2)'}
+
+# check if fingerprint is formatted correctly
+echo "$fingerprint" | egrep -q '^[0-9A-F]{40}$'
+
+# validate key against fingerprint
+gpg2 --import "$key_location"
+gpg2 --list-keys --fingerprint "$fingerprint" | \
+  grep 'Key fingerprint =' | \
+  sed -e 's/ //g' | \
+  grep -q "$fingerprint"
+
+exit 0

--- a/install_files/ansible-base/roles/validate/tasks/main.yml
+++ b/install_files/ansible-base/roles/validate/tasks/main.yml
@@ -50,3 +50,19 @@
   tags:
     - validate
     - debug
+
+- name: verify application GPG key matches fingerprint
+  local_action: script validate-gpg-key.sh {{ securedrop_app_gpg_public_key }} {{ securedrop_app_gpg_fingerprint }}
+  changed_when: false
+  sudo: no
+  tags:
+    - validate
+    - debug
+
+- name: verify OSSEC GPG key matches fingerprint
+  local_action: script validate-gpg-key.sh {{ ossec_alert_gpg_public_key }} {{ ossec_gpg_fpr }}
+  changed_when: false
+  sudo: no
+  tags:
+    - validate
+    - debug


### PR DESCRIPTION
Fixes #1257 by importing the keys into `gpg2` on the admin work station and then checking the fingerprints it outputs.

This is slightly better than having the user provide just the key and then using `gpg2` to extract the fingerprint and using `set_fact` as it means the user has to screw up twice to cause the application to do Bad Things.
