### PR TITLE
Removed TODOs from the docs that might scare sources away

### DIFF
--- a/docs/source.rst
+++ b/docs/source.rst
@@ -1,12 +1,6 @@
 Source Guide
 ============
 
-.. todo:: There's a lot more to it than this, but then we begin to
-          duplicate content from individual organization's landing
-          pages and Micah's Intercept article. For example: what
-          computer should you use? what network should you be on? etc.
-
-	  
 Choose who to submit to
 -----------------------
 
@@ -21,16 +15,6 @@ Most organizations make their landing page prominently accessible from their mai
 
 Get the Tor Browser
 -------------------
-
-.. todo:: There is a classic chicken and egg problem with encouraging
-   sources to use Tor. If their network traffic is already being
-   monitored (e.g. at their workplace by the IT department, at their
-   home by their ISP, anywhere by FVEY...), and they don't know to use
-   Tor from the start (like Snowden did), then their initial interest
-   in using SecureDrop might be enough to make them a target. One
-   partial mitigation might be to make this section the first section
-   in this document, and encourage them to "stop, drop, and Tor
-   Browser" before continuing or clicking any more links.
 
 Each SecureDrop instance has a publicly available *Source Interface*: a website where sources can create anonymous accounts, submit files and messages, and check back for replies.
 


### PR DESCRIPTION
This is one of two solutions that fix the current issue in the docs: the TODOs look like an unprofessional doubt-casting discussion that reduces SecureDrop's credibility.

This solutions hides the aforementioned (open a new GH issue, don't leave it in the docs) and makes it more likely a source will leak the docs.

The other solution would be to say "If you're absolutely worried about your identity being revealed, and you haven't removed documents from their systems, you should stop now because by not using Tor while researching document leaking services, your identity may have already been compromised."

Or something better than the phrasing on either of those because I'm no copy writer.