### PR TITLE
No longer include todos in Sphinx output

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,7 +105,7 @@ pygments_style = 'sphinx'
 #keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------


### PR DESCRIPTION
This addresses https://github.com/freedomofpress/securedrop/pull/1262.
Basically, our 'todos' are notes we put in place for potential improvements of
the documenation, with the Aaron Swartz hackathon in mind. For next year, we can
simply switch back this setting if we'd like to encourage people to help us with
our docs again.

Signed-off-by: Noah Vesely <noah@freedom.press>