### PR TITLE
Sounder fetching of THS config files

### DIFF
--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
@@ -18,20 +18,11 @@
     - tor
     - admin
 
-  # The results of the multiple `cat` commands above are stored
-  # in a list, and can be iterated over when writing via the `copy` module.
-  # The cat-then-copy approach allows formatting the config lines prior
-  # to writing, therefore ensuring idempotence, so the task only reports
-  # changed if the contents have indeed changed.
 - name: Write Tor hidden service hostname files to Admin Workstation.
   local_action:
-    module: copy
+    module: template
     dest: ./{{ item.item.filename }}
-    # The `content` parameter does not automatically append a newline, so
-    # force adding one. Doing so ensures that the resulting files can be
-    # concatenated into the torrc. We also only want the "HidServAuth"
-    # string for ATHS URLs, but not for THS urls.
-    content: "{% if item.item.filename.endswith('-aths') %}HidServAuth {% endif %}{{ item.stdout }}\\n"
+    src: ths_config.j2
   # Local action, so we don't want elevated privileges
   sudo: no
   with_items: tor_hidden_service_hostname_lookup.results

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
@@ -21,7 +21,7 @@
 - name: Write Tor hidden service hostname files to Admin Workstation.
   local_action:
     module: template
-    dest: ./{{ item.item.filename }}
+    dest: "{{ role_path }}/../../{{ item.item.filename }}"
     src: ths_config.j2
   # Local action, so we don't want elevated privileges
   sudo: no

--- a/install_files/ansible-base/roles/restrict-direct-access/templates/ths_config.j2
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/ths_config.j2
@@ -1,0 +1,1 @@
+{% if item.item.filename.endswith('-aths') %}HidServAuth {% endif %}{{ item.stdout }}


### PR DESCRIPTION
The handling of trailing newlines, particularly in the `content` parameter to the `copy` module, changed in Ansible v2. Although our docs recommend using Ansible 1.9.4, it behooves us to maintain compatibility as much as possible. To that end, the task for formatting THS and ATHS config files on the Ansible controller has been updated to use a simple one-line template, rather than `copy` with `content`.

The resultant files now correctly concatenate via the torrc additions `cat` command in `tails_failes/install.sh`:

```
echo "# HidServAuth lines for SecureDrop's authenticated hidden services" | cat - install_files/ansible-base/*ths
# HidServAuth lines for SecureDrop's authenticated hidden services
HidServAuth mpow5h7uezf5hl25.onion RSL9GLpddnEZpJVY49mHjh # client: journalist
rxpplvg765hgzfq4.onion
HidServAuth wlzznpecmxxp4757.onion OG3OxC5uy3sX1l9lWEddoR # client: admin
HidServAuth 52srmo7w7hil6wuz.onion 0jvmrws+NmDYWxCzvtTr8R # client: admin
```

Tested against Ansible 1.9.4, 2.0.1, and 2.0.2, and all now render the THS config files the same way. 

Closes #1278.