### PR TITLE
No suid for securedrop init

### DIFF
--- a/tails_files/65-configure-tor-for-securedrop.sh
+++ b/tails_files/65-configure-tor-for-securedrop.sh
@@ -14,4 +14,4 @@ if [ $2 != "up" ]; then
   exit 0
 fi
 
-/home/amnesia/Persistent/.securedrop/securedrop_init
+/usr/bin/python /home/amnesia/Persistent/.securedrop/securedrop_init.py

--- a/tails_files/install.sh
+++ b/tails_files/install.sh
@@ -93,9 +93,6 @@ fi
 
 # set permissions
 chmod 755 $INSTALL_DIR
-chown root:root $SCRIPT_BIN
-chmod 755 $SCRIPT_BIN
-chmod +s $SCRIPT_BIN
 chown root:root $SCRIPT_PY
 chmod 700 $SCRIPT_PY
 chown root:root $ADDITIONS

--- a/tails_files/install.sh
+++ b/tails_files/install.sh
@@ -49,6 +49,12 @@ cp source.desktop $INSTALL_DIR
 cp securedrop_init.py $SCRIPT_PY
 cp 65-configure-tor-for-securedrop.sh $INSTALL_DIR
 
+# Remove binary setuid wrapper from previous tails_files installation, if it exists
+WRAPPER_BIN=$INSTALL_DIR/securedrop_init
+if [ -f $WRAPPER_BIN ]; then
+    rm $WRAPPER_BIN
+fi
+
 if $ADMIN; then
   DOCUMENT=`cat $ANSIBLE/app-document-aths | cut -d ' ' -f 2`
   SOURCE=`cat $ANSIBLE/app-source-ths`

--- a/tails_files/install.sh
+++ b/tails_files/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SecureDrop persistent setup script for Tails 
+# SecureDrop persistent setup script for Tails
 
 set -e
 
@@ -96,7 +96,7 @@ chown root:root $ADDITIONS
 chmod 400 $ADDITIONS
 
 chown amnesia:amnesia $INSTALL_DIR/securedrop_icon.png
-chmod 600 $INSTALL_DIR/securedrop_icon.png 
+chmod 600 $INSTALL_DIR/securedrop_icon.png
 chown amnesia:amnesia $INSTALL_DIR/document.desktop $INSTALL_DIR/source.desktop
 chmod 700 $INSTALL_DIR/document.desktop $INSTALL_DIR/source.desktop
 chown root:root $INSTALL_DIR/65-configure-tor-for-securedrop.sh
@@ -105,11 +105,11 @@ chmod 755 $INSTALL_DIR/65-configure-tor-for-securedrop.sh
 # journalist workstation does not have the *-aths files created by the Ansible playbook, so we must prompt
 # to get the interface .onion addresses to setup launchers, and for the HidServAuth info used by Tor
 if ! $ADMIN; then
-  REGEX="^(HidServAuth [a-z2-7]{16}\.onion [A-Za-z0-9+/.]{22})"                   
-  while [[ ! "$HIDSERVAUTH" =~ $REGEX ]];                                         
-  do                                                                              
+  REGEX="^(HidServAuth [a-z2-7]{16}\.onion [A-Za-z0-9+/.]{22})"
+  while [[ ! "$HIDSERVAUTH" =~ $REGEX ]];
+  do
     HIDSERVAUTH=$(zenity --entry --title="Hidden service authentication setup" --width=600 --window-icon=$INSTALL_DIR/securedrop_icon.png --text="Enter the HidServAuth value to be added to /etc/tor/torrc:")
-  done  
+  done
   echo $HIDSERVAUTH >> $ADDITIONS
   SRC=$(zenity --entry --title="Desktop shortcut setup" --window-icon=$INSTALL_DIR/securedrop_icon.png --text="Enter the Source Interface's .onion address:")
   SOURCE="${SRC#http://}"

--- a/tails_files/install.sh
+++ b/tails_files/install.sh
@@ -15,7 +15,6 @@ PERSISTENT=$HOMEDIR/Persistent
 INSTALL_DIR=$PERSISTENT/.securedrop
 ADDITIONS=$INSTALL_DIR/torrc_additions
 SCRIPT_PY=$INSTALL_DIR/securedrop_init.py
-SCRIPT_BIN=$INSTALL_DIR/securedrop_init
 TAILSCFG=/live/persistence/TailsData_unlocked
 DOTFILES=$TAILSCFG/dotfiles
 DESKTOP=$HOMEDIR/Desktop
@@ -42,11 +41,6 @@ else
 fi
 
 mkdir -p $INSTALL_DIR
-
-# install deps and compile
-apt-get update
-apt-get install -y build-essential
-gcc -o $SCRIPT_BIN securedrop_init.c
 
 # copy icon, launchers and scripts
 cp securedrop_icon.png $INSTALL_DIR
@@ -177,7 +171,7 @@ cp -p $INSTALL_DIR/65-configure-tor-for-securedrop.sh $TAILSCFG/custom-nm-hooks
 cp -p $INSTALL_DIR/65-configure-tor-for-securedrop.sh /etc/NetworkManager/dispatcher.d/
 
 # set torrc and reload Tor
-$INSTALL_DIR/securedrop_init
+/usr/bin/python $INSTALL_DIR/securedrop_init.py
 
 # finished
 echo ""

--- a/tails_files/securedrop_init.c
+++ b/tails_files/securedrop_init.c
@@ -1,8 +1,0 @@
-#include <unistd.h>
-
-int main(int argc, char* argv) {
-   setuid(0);
-   // Use absolute path to the Python binary and execl to avoid $PATH or symlink trickery
-   execl("/usr/bin/python2.7", "python2.7", "/home/amnesia/Persistent/.securedrop/securedrop_init.py", (char*)NULL);
-   return 0;
-}

--- a/tails_files/securedrop_init.py
+++ b/tails_files/securedrop_init.py
@@ -1,50 +1,49 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 import os
 import sys
 import subprocess
 
 
-if __name__ == '__main__':
-    # check for root
-    if os.geteuid() != 0:
-        sys.exit('You need to run this as root')
+# check for root
+if os.geteuid() != 0:
+    sys.exit('You need to run this as root')
 
-    # paths
-    path_torrc_additions = '/home/amnesia/Persistent/.securedrop/torrc_additions'
-    path_torrc_backup = '/etc/tor/torrc.bak'
-    path_torrc = '/etc/tor/torrc'
+# paths
+path_torrc_additions = '/home/amnesia/Persistent/.securedrop/torrc_additions'
+path_torrc_backup = '/etc/tor/torrc.bak'
+path_torrc = '/etc/tor/torrc'
 
-    # load torrc_additions
-    if os.path.isfile(path_torrc_additions):
-        torrc_additions = open(path_torrc_additions).read()
+# load torrc_additions
+if os.path.isfile(path_torrc_additions):
+    torrc_additions = open(path_torrc_additions).read()
+else:
+    sys.exit('Error opening {0} for reading'.format(path_torrc_additions))
+
+# load torrc
+if os.path.isfile(path_torrc_backup):
+    torrc = open(path_torrc_backup).read()
+else:
+    if os.path.isfile(path_torrc):
+        torrc = open(path_torrc).read()
     else:
-        sys.exit('Error opening {0} for reading'.format(path_torrc_additions))
+        sys.exit('Error opening {0} for reading'.format(path_torrc))
 
-    # load torrc
-    if os.path.isfile(path_torrc_backup):
-        torrc = open(path_torrc_backup).read()
-    else:
-        if os.path.isfile(path_torrc):
-            torrc = open(path_torrc).read()
-        else:
-            sys.exit('Error opening {0} for reading'.format(path_torrc))
+    # save a backup
+    open(path_torrc_backup, 'w').write(torrc)
 
-        # save a backup
-        open(path_torrc_backup, 'w').write(torrc)
+# append the additions
+open(path_torrc, 'w').write(torrc + torrc_additions)
 
-    # append the additions
-    open(path_torrc, 'w').write(torrc + torrc_additions)
+# reload tor
+subprocess.call(['/usr/sbin/service', 'tor', 'reload'])
 
-    # reload tor
-    subprocess.call(['/usr/sbin/service', 'tor', 'reload'])
-
-    # success
-    subprocess.call(['/usr/bin/sudo',
-                     '-u',
-                     'amnesia',
-                     '/usr/bin/notify-send',
-                     '-i',
-                     '/home/amnesia/Persistent/.securedrop/securedrop_icon.png',
-                     'Updated torrc!',
-                     'You can now connect to your SecureDrop\ndocument interface.'])
+# success
+subprocess.call(['/usr/bin/sudo',
+                 '-u',
+                 'amnesia',
+                 '/usr/bin/notify-send',
+                 '-i',
+                 '/home/amnesia/Persistent/.securedrop/securedrop_icon.png',
+                 'Updated torrc!',
+                 'You can now connect to your SecureDrop\ndocument interface.'])

--- a/tails_files/securedrop_init.py
+++ b/tails_files/securedrop_init.py
@@ -36,14 +36,12 @@ else:
 open(path_torrc, 'w').write(torrc + torrc_additions)
 
 # reload tor
-subprocess.call(['systemctl', 'reload', 'tor@default.service'])
+try:
+    subprocess.check_call(['systemctl', 'reload', 'tor@default.service'])
+except subprocess.CalledProcessError:
+    sys.exit('Error reloading Tor')
 
-# success
-subprocess.call(['/usr/bin/sudo',
-                 '-u',
-                 'amnesia',
-                 '/usr/bin/notify-send',
-                 '-i',
-                 '/home/amnesia/Persistent/.securedrop/securedrop_icon.png',
-                 'Updated torrc!',
-                 'You can now connect to your SecureDrop\ndocument interface.'])
+# notify the user
+subprocess.call(['tails-notify-user',
+                 'SecureDrop successfully auto-configured!',
+                 'You can now access the Document Interface.\nIf you are an admin, you can now SSH to the servers.'])

--- a/tails_files/securedrop_init.py
+++ b/tails_files/securedrop_init.py
@@ -36,7 +36,7 @@ else:
 open(path_torrc, 'w').write(torrc + torrc_additions)
 
 # reload tor
-subprocess.call(['/usr/sbin/service', 'tor', 'reload'])
+subprocess.call(['systemctl', 'reload', 'tor@default.service'])
 
 # success
 subprocess.call(['/usr/bin/sudo',


### PR DESCRIPTION
Originally, the custom Tails configuration for SecureDrop was in a script run by the normal Tails user (amnesia). At first, it was run from a desktop launcher. Later, there was a (failed) experiment to auto-run the custom configuration from the amnesia user's `~/.xsessionrc`.

In both cases, the user running the script was the unprivileged `amnesia`, but it needed to modify the system-wide `/etc/tor/torrc` owned by root. The solution was to create a setuid wrapper in C for the configuration script (since you cannot setuid a script). Since the Tails configuration *install script* (`tails_files/install.sh`) was run as root, it could build and setuid on the binary wrapper that, when run, would setuid, then call the custom configuration script (as root).

After some discussion with the Tails developers, we learned that Tails' persistence had a secret option for custom NetworkManager hooks. This was obviously a natural place for our custom Tor configuration to go, so we migrated to that, which allowed us to auto-run the custom configuration for SecureDrop while avoiding the issues we were having with the `~/.xsessionrc`-based solution. We switched to using a NetworkManager script instead of `~/.xsessionrc~`, leaving everything else unchanged.

However, switching to a NetworkManager hook makes the setuid wrapper unnecessary, since these hooks are run as root by default. This pull request removes the setuid wrapper, which:

* Simplifies the SecureDrop custom configuration
* Greatly speeds up `tails_files/install.sh`, since there is no need to update packages and install gcc (just to build a 5-line C setuid wrapper binary... 😭)
* Avoids potential security risks from setuid programs

The changes to `securedrop_init.py` are just to remove `if __name__ == '__main__'`, which is unnecessary because this is a single use script and does not define anything that another script could conceivably import. There appear to be a lot of changes, but all I did was reindent most of the file after removing that unnecessary conditional.

This PR also removes some trailing whitespace that I encountered in this area of the code.