### PR TITLE
Change yml config file paths to allow for copy-paste from dev docs

### DIFF
--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -199,7 +199,7 @@ across the full stack.
 
 If you want to receive OSSEC alerts or change any other settings, you will need
 to fill out your local copy of
-``securedrop/install_files/ansible_base/staging-specific.yml``.
+``./install_files/ansible_base/staging-specific.yml``.
 
 .. code:: sh
 
@@ -214,7 +214,7 @@ Prod
 ~~~~
 
 You will need to fill out the production configuration file:
-``securedrop/install_files/ansible_base/prod-specific.yml``.  Part of the
+``./install_files/ansible_base/prod-specific.yml``.  Part of the
 production playbook validates that staging values are not used in
 production. One of the values it verifies is that the user Ansible runs as is
 not ``vagrant`` To be able to run this playbook in a virtualized environment


### PR DESCRIPTION
Perhaps in the past the install_files dir was a subdir of the securedrop dir...