### PR TITLE
Adds version check to tails_files

### DIFF
--- a/docs/configure_admin_workstation_post_install.rst
+++ b/docs/configure_admin_workstation_post_install.rst
@@ -30,6 +30,8 @@ configure Tor to access a set of ATHS. In order to persist these changes across
 reboots, the Tails instance must have persistence enabled (specifically, the 
 "dotfiles persistence").
 
+We also require that you are using Tails 2.x or greater.
+
 To install the auto-connect configuration, start by navigating to the directory 
 with these scripts, and run the install script:
 

--- a/docs/tails_guide.rst
+++ b/docs/tails_guide.rst
@@ -15,7 +15,8 @@ If you already know how to boot the *admin Tails USB* or the *journalist Tails
 USB* with persistence, you can skip down to the step 'download the repository'.
 
 Note that for all of these instructions to work, you should have already 
-installed the main SecureDrop application.
+installed the main SecureDrop application. It is also required that you use
+Tails version 2.x or greater.
 
 Installing Tails on USB sticks
 ------------------------------

--- a/tails_files/install.sh
+++ b/tails_files/install.sh
@@ -21,6 +21,13 @@ DESKTOP=$HOMEDIR/Desktop
 ANSIBLE=$PERSISTENT/securedrop/install_files/ansible-base
 SSH_ALIASES=false
 
+# check for Tails 2.x
+source /etc/os-release
+if [[ $TAILS_VERSION_ID =~ ^1\..* ]]; then
+  echo "This script must be used on Tails version 2.x or greater." 1>&2
+  exit 1
+fi
+
 # check for persistence
 if [ ! -d "$TAILSCFG" ]; then
   echo "This script must be run on Tails with a persistent volume." 1>&2


### PR DESCRIPTION
The systemd-specific changes in d413ac6 will only work on Tails 2.x which is based on Debian jessie. This introduces a Tails version check to prevent the user from proceeding further if they are running Tails 1.x.