### PR TITLE
Change yml config file paths to allow for copy-paste from dev docs

### DIFF
--- a/docs/configure_admin_workstation_post_install.rst
+++ b/docs/configure_admin_workstation_post_install.rst
@@ -25,7 +25,7 @@ service setup process.
 In order to access an ATHS, you need to add one or more "auth-cookie" values 
 to your Tor configuration file (``torrc``) and restart Tor. Doing this manually 
 is annoying and error-prone, so SecureDrop includes a set of scripts in 
-``securedrop/tails_files`` that can set up a Tails instance to automatically 
+``./tails_files`` that can set up a Tails instance to automatically 
 configure Tor to access a set of ATHS. In order to persist these changes across 
 reboots, the Tails instance must have persistence enabled (specifically, the 
 "dotfiles persistence").

--- a/docs/development/documentation.rst
+++ b/docs/development/documentation.rst
@@ -86,3 +86,12 @@ Style Guide
                italicized, which is confusing when used near
                references to the terminology.
 
+* Use absolute paths when referring to files outside the SecureDrop repository.
+  Exceptions made for when it's clear from the surrounding context what the
+  intended working directory is. For files inside the SecureDrop directory,
+  write them as `./some_dir/file`, where `.` is the top level directory of the
+  SecureDrop repo. Since by default the git repo will be cloned under the name
+  `securedrop` and it also contains a `securedrop` subdirectory this is intended
+  to avoid confusion.  Exceptions made for when it's clear from the context
+  we're outside of the SecureDrop repo, but would like to somehow interact with
+  it (e.g., we just cloned the repo and now we're going to `cd` into it).

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -199,7 +199,7 @@ across the full stack.
 
 If you want to receive OSSEC alerts or change any other settings, you will need
 to fill out your local copy of
-``securedrop/install_files/ansible_base/staging-specific.yml``.
+``./install_files/ansible_base/staging-specific.yml``.
 
 .. code:: sh
 
@@ -214,7 +214,7 @@ Prod
 ~~~~
 
 You will need to fill out the production configuration file:
-``securedrop/install_files/ansible_base/prod-specific.yml``.  Part of the
+``./install_files/ansible_base/prod-specific.yml``.  Part of the
 production playbook validates that staging values are not used in
 production. One of the values it verifies is that the user Ansible runs as is
 not ``vagrant`` To be able to run this playbook in a virtualized environment

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -76,7 +76,7 @@ Workstation. The easiest way to do this is to copy the
 to the
 Journalist Workstation with the Data Transfer Device.
 
-Now you need the Tails setup scripts (``securedrop/tails_files``) that
+Now you need the Tails setup scripts (``./tails_files``) that
 you used to :doc:`Configure the Admin Workstation Post-Install
 <configure_admin_workstation_post_install>`. The easiest way to do
 this is to clone (and verify) the SecureDrop repository on the


### PR DESCRIPTION
>... it makes sense to make the files/ paths relative to being inside the top level repo dir versus inside the parent dir of the top level repo dir. Besides the fact this avoids the confusion of there being securedrop/securedrop dir (which becomes ./securedrop), it also makes sense to cd into the top level dir of a repo you're going to be working with, and from there you should be able to copy-paste the filenames/ commands from the dev docs.

-- https://github.com/freedomofpress/securedrop/pull/1289#issuecomment-217563245