### PR TITLE
Autoremove unused pip dependencies in app code postinst script

### DIFF
--- a/install_files/securedrop-app-code/DEBIAN/control
+++ b/install_files/securedrop-app-code/DEBIAN/control
@@ -6,5 +6,5 @@ Homepage: https://freedom.press/securedrop
 Package: securedrop-app-code
 Version: 0.3.6
 Architecture: amd64
-Depends: python-pip,apparmor-utils,gnupg2,haveged,python,python-pip,secure-delete,sqlite,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor
+Depends: apparmor-utils,bash,gnupg2,haveged,python,python-pip,secure-delete,sqlite,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor
 Description: Packages the SecureDrop application code pip dependencies and apparmor profiles. This package will put the apparmor profiles in enforce mode. This package does use pip to install the pip wheelhouse

--- a/install_files/securedrop-app-code/DEBIAN/postinst
+++ b/install_files/securedrop-app-code/DEBIAN/postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # postinst script for securedrop-app-code
 #
 # see: dh_installdeb(1)
@@ -16,9 +16,37 @@ set -x
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
+REQUIREMENTS="/var/www/securedrop/requirements/securedrop-requirements.txt"
+
+# Helper fn for array membership testing
+containsElement () {
+  local e
+  for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
+  return 1
+}
+
 case "$1" in
     configure)
-    pip install --no-index --find-links=/var/securedrop/wheelhouse -r /var/www/securedrop/requirements/securedrop-requirements.txt
+    # Install all wheels shipped in the deb over the old ones
+    pip install --no-index --find-links=/var/securedrop/wheelhouse -r $REQUIREMENTS
+
+    # Add all current requirements to pip whitelist
+    pip_whitelist=()
+    for p in $(grep -oh '^[[:alnum:]-]*' $REQUIREMENTS)
+    do
+      pip_whitelist+=("$p")
+    done
+
+    # Uninstall all dependencies not in pip whitelist. pip will not let you
+    # uninstall python packages provided by system packages, so we don't have to worry about that
+    for p in $(pip list | awk '{print $1}')
+    do
+      if ! containsElement "$p" "${pip_whitelist[@]}"; then
+        # pip lacks a '-y' argument until version 7.1.2, Ubuntu 14.04 is still
+        # on 1.X and will never make it there
+        yes | pip uninstall $p
+      fi
+    done
 
     chown -R www-data:www-data /var/www/securedrop
     chown www-data:www-data /var/www/document.wsgi


### PR DESCRIPTION
This addition to the `postinst` script in the app code package removes all pip
packages that neither belong to the OS (i.e., were installed by system packages)
nor are present in the requirements file in the package that was just unpacked.
The script itself just tries to uninstall all pip packages not declared in the
requirements file, but pip is smart and will not let you uninstall OS owned
packages.

Use of arrays required bash, which has been added to the `Depends:` just to be
thorough. And a duplicate copy of `python-pip` was removed from `Depends:` as
well.
