### PR TITLE
Disable MPROTECT on Firefox and it's plugin container

### DIFF
--- a/install_files/ansible-base/roles/app-test/tasks/disable_mprotect_ff_plugin_container.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/disable_mprotect_ff_plugin_container.yml
@@ -1,0 +1,7 @@
+---
+- name: disable mprotect on firefox and the firefox plugin container
+  command: paxctl -cm /usr/lib/firefox/{{ item }}
+  with_items:
+    - firefox
+    - plugin-container
+  when: ansible_kernel.endswith('-grsec')

--- a/install_files/ansible-base/roles/app-test/tasks/main.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/main.yml
@@ -6,3 +6,5 @@
   tags: non-development,aa-complain
 
 - include: dev_setup_xvfb_for_functional_tests.yml
+
+- include: disable_mprotect_ff_plugin_container.yml


### PR DESCRIPTION
Ensures our functional test suite will not be killed by GrSec when running our
functional tests in an app-staging VM.

Closes #1307.