### PR TITLE
Removes vagrant-hostmanager plugin from Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,6 @@ Vagrant.configure("2") do |config|
     staging.vm.hostname = "mon-staging"
     staging.vm.box = "trusty64"
     staging.vm.network "private_network", ip: "10.0.1.3", virtualbox__intnet: true
-    staging.hostmanager.aliases = %w(securedrop-monitor-server-alias)
     staging.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
     staging.vm.synced_folder './', '/vagrant', disabled: true
     staging.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
The plugin is not used during VM configuration any longer, nor is the requirement documented in our developer docs. Therefore let's remove the plugin from the Vagrantfile entirely because first-time setup for SecureDrop VMs is a frustrating experience when it's not nearly as simple as `vagrant up` and there are no docs explaining the failure.

Related to #1045, but does not resolve it.