### PR TITLE
Finalizes Tails upgrade docs for 0.3.7

### DIFF
--- a/docs/upgrade/0.3.6-to-0.3.7.rst
+++ b/docs/upgrade/0.3.6-to-0.3.7.rst
@@ -42,7 +42,7 @@ latest release (0.3.7 or later),
 .. code:: sh
 
    git stash save "site specific configs"
-   git pull
+   git fetch
    git tag -v 0.3.7
 
 .. warning:: The output of ``git tag -v`` should include ``Good signature from

--- a/docs/upgrade_to_tails_2x.rst
+++ b/docs/upgrade_to_tails_2x.rst
@@ -33,6 +33,10 @@ the exposure of sensitive data to networked computers, thereby reducing the
 threat of compromise by adversaries who wish to gain access to your SecureDrop
 instance.
 
+The airgapped machine should have 3 USB ports, so you can plug in all 3 devices
+at the same time. If you don't have 3 USB ports available, you can use a USB
+hub, which may reduce transfer speeds.
+
 Upgrade each Tails device
 -------------------------
 


### PR DESCRIPTION
Addresses a few eleventh hour changes to the docs that should lend clarity. Most egregious is the git pull -> git fetch transition, due to git v2 being installed by default under Tails v2.

Closes #1315.