### PR TITLE
Finalizes install.sh tails script

### DIFF
--- a/tails_files/install.sh
+++ b/tails_files/install.sh
@@ -209,23 +209,20 @@ function lookup_document_aths_url()
   # The Admin Workstation will certainly have this file, and the Journalist
   # Workstation probably, but not definitely.
   if [ -f "${securedrop_ansible_base}/app-document-aths" ] ; then
-    echo "Found Document Interface ATHS info in '${securedrop_ansible_base}/app-document-aths'..."
     app_document_aths="$(awk '{ print $2 }' ${securedrop_ansible_base}/app-document-aths)"
   # Failing that, check for ATHS info in the existing Tor config. A previously
   # configured Journalist Workstation will already have the value in torrc.
   # Since we know we're in a Journalist Workstation, assume there's only one
   # ATHS value in the torrc, and use the first.
   elif grep -q -P '^HidServAuth [a-z2-7]{16}\.onion [A-Za-z0-9+/.]{22}' /etc/tor/torrc ; then
-    echo "Found Document Interface ATHS info in '/etc/tor/torrc'..."
     app_document_aths="$(grep ^HidServAuth /etc/tor/torrc | head -n 1 | awk '{ print $2 }')"
   # Last shot before prompting: check for an existing desktop icon specifically
   # for the Document Interface. If found, we can extract the URL from there.
   elif [ -e "${amnesia_desktop}/document.desktop" ] ; then
-    echo "Found Document Interface ATHS info in '${amnesia_desktop}/document.desktop'..."
     app_document_aths="$(grep ^Exec=/usr/local/bin/tor-browser | awk '{ print $2 }')"
   # Couldn't find it anywhere. We'll have to prompt!
   else
-    echo "Could not find Document Interface ATHS info, prompting interactively..."
+    echo "Could not find Document Interface ATHS info, prompting interactively..." 1>&2
     app_document_aths="$(prompt_for_document_aths_info | awk '{ print $2 }')"
   fi
   echo "$app_document_aths"
@@ -237,18 +234,16 @@ function lookup_source_ths_url()
   # containing the exact value we want. The Admin Workstation will certainly
   # have this file, and the Journalist Workstation probably, but not definitely.
   if [ -f "${securedrop_ansible_base}/app-source-ths" ] ; then
-    echo "Found Source Interface Onion URL in '${securedrop_ansible_base}/app-source-ths'..."
     app_source_ths="$(cat ${securedrop_ansible_base}/app-source-ths)"
   # Check if global var is populated (from prompting previously).
   elif [ -n $source_ths_url_global ] ; then
     app_source_ths="$source_ths_url_global"
   # Failing that, check for the public THS URL in an existing Desktop icon.
   elif grep -q -P '^Exec=/usr/local/bin/tor-browser\s+[a-z2-7]{16}\.onion' "${amnesia_desktop}/source.desktop" ; then
-    echo "Found Source Interface Onion URL in '${amnesia_desktop}/source.desktop'..."
     app_source_ths="$(grep ^Exec=/usr/local/bin/tor-browser | awk '{ print $2 }')"
   # Couldn't find it anywhere. We'll have to prompt!
   else
-    echo "Could not find Source Interface Onion URL, prompting interactively..."
+    echo "Could not find Source Interface Onion URL, prompting interactively..." 1>&2
     app_source_ths="$(prompt_for_source_ths_url)"
   fi
   echo "$app_source_ths"
@@ -261,7 +256,7 @@ function configure_ssh_aliases()
   # Don't clobber an existing SSH config file; only run if none exists.
   if [[ -d "${amnesia_home}/.ssh" && ! -f "${amnesia_home}/.ssh/config" ]]; then
     # Rather than try to parse the YAML vars file in Bash, let's prompt for username.
-    echo "Creating SSH aliases for SecureDrop servers in ~/.ssh/config..."
+    echo "Creating SSH aliases for SecureDrop servers in ~/.ssh/config..." 1>&2
     admin_ssh_username="$(zenity --entry \
         --title='Admin SSH user' \
         --window-icon=${securedrop_dotfiles}/securedrop_icon.png \
@@ -278,7 +273,7 @@ EOL
     chmod 600 "${securedrop_dotfiles}/ssh_config"
     cp -pf "${securedrop_dotfiles}/ssh_config" "${amnesia_home}/.ssh/config"
   else
-    echo "SSH config already exists, not overwriting..."
+    echo "SSH config already exists, not overwriting..." 1>&2
   fi
 }
 

--- a/tails_files/install.sh
+++ b/tails_files/install.sh
@@ -154,7 +154,7 @@ function prompt_for_document_aths_info()
         --title='Hidden service authentication setup' \
         --width=600 \
         --window-icon=${securedrop_dotfiles}/securedrop_icon.png \
-        --text='Enter the HidServAuth value to be added to /etc/tor/torrc:')"
+        --text='Enter the HidServAuth value to be added to /etc/tor/torrc:' 2> /dev/null)"
     done
   # The global var is populated, so use it for the function var.
   else
@@ -179,7 +179,7 @@ function prompt_for_source_ths_url()
         --title='Hidden service authentication setup' \
         --width=600 \
         --window-icon=${securedrop_dotfiles}/securedrop_icon.png \
-        --text='Enter the Source Interface Onion URL:')"
+        --text='Enter the Source Interface Onion URL:' 2> /dev/null)"
     done
     # Store value in script global for reuse without prompting.
     source_ths_url_global="$ths_url"
@@ -265,7 +265,7 @@ function configure_ssh_aliases()
     admin_ssh_username="$(zenity --entry \
         --title='Admin SSH user' \
         --window-icon=${securedrop_dotfiles}/securedrop_icon.png \
-        --text='Enter your username on the App and Monitor server:')"
+        --text='Enter your username on the App and Monitor server:' 2> /dev/null)"
     cat > "${securedrop_dotfiles}/ssh_config" <<EOL
 Host app
   Hostname $(lookup_app_ssh_aths_url)


### PR DESCRIPTION
Implements eleventh hour cleanup for the new `tails_files/install.sh` script (originally provided in #1309). Briefly:

* removes verbose logging messages to avoid cluttering terminal output
* silences STDERR for `zenity` prompts to avoid cluttering terminal outut
* preserves informative messaging around needing to prompt, but redirects to STDERR rather than STDOUT.

See #1316 for verbose explanations of the rationale behind these changes. Closes #1316.