### PR TITLE
Bump up current release in Set up Admin Tails doc

### DIFF
--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -81,8 +81,8 @@ key:
 .. code:: sh
 
     cd securedrop/
-    git checkout 0.3.6
-    git tag -v 0.3.6
+    git checkout 0.3.7
+    git tag -v 0.3.7
 
 You should see ``Good signature from "Freedom of the Press Foundation
 Master Signing Key"`` in the output of that last command.


### PR DESCRIPTION
Reported in #1325. The 'Set up the Admin Workstation' guide is not tracking the current release. 