### PR TITLE
Added batch delete to source interface

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -350,7 +350,7 @@ def delete():
 @app.route('/delete-all', methods=('POST',))
 @login_required
 def batch_delete():
-    replies = Reply.query.filter(Reply.source_id == g.source.id).all()
+    replies = g.source.replies
     if len(replies) == 0:
         app.logger.error("Found no replies when at least one was expected")
         return redirect(url_for('lookup'))

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -347,6 +347,20 @@ def delete():
     flash("Reply deleted", "notification")
     return redirect(url_for('lookup'))
 
+@app.route('/delete-all', methods=('POST',))
+@login_required
+def batch_delete():
+    replies = Reply.query.filter(Reply.source_id == g.source.id).all()
+    if len(replies) == 0:
+        app.logger.error("Found no replies when at least one was expected")
+        return redirect(url_for('lookup'))
+    for reply in replies:
+        store.secure_unlink(store.path(g.sid, reply.filename))
+        db_session.delete(reply)
+    db_session.commit()
+
+    flash("All replies have been deleted", "notification")
+    return redirect(url_for('lookup'))
 
 def valid_codename(codename):
     # Ignore codenames that are too long to avoid DoS

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -59,6 +59,15 @@
         <div class="clearfix"></div>
       </div>
     {% endfor %}
+    <form id="delete-all" method="post" action="/delete-all">
+      <a class="btn" href="#delete-all-confirm">Delete all replies</a>
+      <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+      <div id="delete-all-confirm" class="hidden-prompt">
+        <p>Are you finished with the replies?</p>
+        <button class="danger" type="submit">Yes, delete all replies</button>
+        <a class="btn cancel" href="#delete-all">No, not yet</a>
+      </div>
+    </form>
   {% else %}
     <p id="no-replies">There are no replies at this time.</p>
   {% endif %}

--- a/securedrop/static/css/source.css
+++ b/securedrop/static/css/source.css
@@ -485,6 +485,42 @@ p#codename {
   border: 0;
 }
 
+#delete-all .btn:first-child {
+  display: block;
+  padding: 2%;
+  margin: auto;
+  width: 80%;
+}
+
+#delete-all .hidden-prompt {
+  margin: 0;
+  padding: 0;
+  height: 0;
+  overflow: hidden;
+  text-align: center;
+}
+
+#delete-all .hidden-prompt:target {
+  margin: auto;
+  padding: auto;
+  height: auto;
+  overflow: visible;
+}
+
+#delete-all .danger, #delete-all .cancel {
+  display: inline-block;
+  width: 30%;
+}
+
+#delete-all .cancel {
+  background-color: #999;
+}
+
+#delete-all .cancel:hover {
+  color: #999;
+  background-color: white;
+}
+
 #replies .reply {
   border: 1px solid #999999;
   text-align: left;


### PR DESCRIPTION
Resolves #879 by adding a delete all button with a confirmation prompt to the source interface. Pictures attached:
![batch_delete_button](https://cloud.githubusercontent.com/assets/19742137/15983117/0e49f346-2f52-11e6-97ae-a2b06c3bf0ce.png)
![batch_delete_confirmation](https://cloud.githubusercontent.com/assets/19742137/15983118/114b2e02-2f52-11e6-85a8-ebf17c221435.png)

