### PR TITLE
Add Apparmor rule to allow Apache to execute uname

### DIFF
--- a/install_files/ansible-base/usr.sbin.apache2
+++ b/install_files/ansible-base/usr.sbin.apache2
@@ -11,6 +11,7 @@
 
   /bin/dash rix,
   /bin/touch rix,
+  /bin/uname rix,
   /dev/null w,
   /dev/urandom r,
   /etc/apache2/apache2.conf r,


### PR DESCRIPTION
At some point Apache started shelling out to the uname tool to gather some info about the system as observed in https://github.com/freedomofpress/securedrop/issues/1331. We've decided it should be fine for Apache to run uname and to add a rule to the AppArmor profile to allow for this to happen. This will fix the OSSEC alerts triggered by the Apparmor denial events. Resolves #1331.