### PR TITLE
Update wording for deployment best practices

### DIFF
--- a/docs/deployment_practices.rst
+++ b/docs/deployment_practices.rst
@@ -306,7 +306,7 @@ analysis.
 
 #. Make your entire site available through HTTPS.
 
-   - That way, visits to your landing page won't stand out as the only encrypted traffic.
+   - That way, visits to your landing page won't stand out as the only encrypted traffic to your site.
 
 #. Include an iframe for all (or a random subset of) visitors, loading
    this particular URL (hidden).

--- a/docs/deployment_practices.rst
+++ b/docs/deployment_practices.rst
@@ -304,12 +304,9 @@ Ideally, some or all of the following changes are made to improve the
 overall security of the path to the landing page and obfuscate traffic
 analysis.
 
-#. Make the entire site available under 'ssl.washingtonpost.com'
-   (ideally without the '.ssl' prefix).
+#. Make your entire site available through HTTPS.
 
-   - That way, the domain won't be as suspicious as it is right now. I
-     suspect that this is more or less the only content hosted on the
-     domain.
+   - That way, visits to your landing page won't stand out as the only encrypted traffic.
 
 #. Include an iframe for all (or a random subset of) visitors, loading
    this particular URL (hidden).


### PR DESCRIPTION
Updates a line item under the Whole Site section for Deployment Best Practices.

https://github.com/freedomofpress/securedrop/blob/develop/docs/deployment_practices.rst#whole-site-changes

The Washington Post example no longer applies, since `ssl.washingtonpost.com` just redirects to `www` now, which is served entirely by HTTPS.

Fixes #1337