### PR TITLE
Fixes App play in prod playbook (develop)

### DIFF
--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -53,7 +53,7 @@
   # So iptables will not be reloaded until the exemptions are applied
   # for production the last task is apply iptables. This will break their
   # connection. After that point the admin will to proxy traffic over tor.
-  name: Lock down firewall configuration for Application and Monitor Servers.
+- name: Lock down firewall configuration for Application and Monitor Servers.
   hosts: securedrop
   vars_files:
     - prod-specific.yml

--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -41,8 +41,7 @@
 - name: Configure SecureDrop Application Server.
   hosts: securedrop_application_server
   vars_files:
-   - prod-specific.yml
-  vars:
+    - prod-specific.yml
   roles:
     - { role: ossec-agent, tags: [ ossec, ossec_agent ] }
     - { role: app, tags: app }


### PR DESCRIPTION
A typo was causing the App play in the prod playbook to be skipped, since the YAML declaration was concatenating two plays into one, overriding the dict keys with the last declared. The app tests failed brutally in the prod environment, since the app deb package wasn't installed. Only affects develop.

Fixes #1268.