### PR TITLE
Adds unread submission icon and select all unread button to source view

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -438,7 +438,8 @@ def index():
 def col(sid):
     source = get_source(sid)
     source.has_key = crypto_util.getkey(sid)
-    return render_template("col.html", sid=sid, source=source)
+    unread_subs = [submission for submission in source.submissions if not submission.downloaded]
+    return render_template("col.html", sid=sid, source=source, unread_subs=unread_subs)
 
 
 def delete_collection(source_id):

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -28,7 +28,15 @@
       </div>
       <ul id="submissions" class="plain submissions">
         {% for doc in source.collection %}
-          <li class="submission"><input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check"/>
+          <li class="submission">
+            <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check"/>
+            {% if unread_subs %}
+              {% if doc in unread_subs %}
+                <span title="Unread" class="unread"><i class="fa fa-envelope"></i></span>
+              {% else %}
+                <span class="unread"></span>
+              {% endif %}
+            {% endif %}
             {% if doc.filename.endswith('reply.gpg') %}
               <span class="file reply"><span class="filename">{{ doc.filename }}</span></span>
               <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat(binary=True) }}</span></span>

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -29,13 +29,16 @@
       <ul id="submissions" class="plain submissions">
         {% for doc in source.collection %}
           <li class="submission">
-            <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check"/>
             {% if unread_subs %}
               {% if doc in unread_subs %}
+                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb"/>
                 <span title="Unread" class="unread"><i class="fa fa-envelope"></i></span>
               {% else %}
+                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check"/>
                 <span class="unread"></span>
               {% endif %}
+            {% else %}
+              <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check"/>
             {% endif %}
             {% if doc.filename.endswith('reply.gpg') %}
               <span class="file reply"><span class="filename">{{ doc.filename }}</span></span>

--- a/securedrop/static/css/journalist.css
+++ b/securedrop/static/css/journalist.css
@@ -498,6 +498,11 @@ p#no-replies {
   font-size: 12px;
   color: #666666;
 }
+.submission .unread {
+  display: inline-block;
+  width: 3.5%;
+  color: #7985aa;
+}
 
 ul.plain {
   list-style: none;

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -7,7 +7,7 @@ function enhance_ui() {
   $('div#filter-container').html('<input id="filter" type="text" placeholder="filter by codename" autofocus >');
 
   // Add the "select {all,none}" buttons
-  $('div#select-container').html('<span id="select_all" class="select"><i class="fa fa-check-square-o"></i> select all</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> select none</span>');
+  $('div#select-container').html('<span id="select_all" class="select"><i class="fa fa-check-square-o"></i> select all</span> <span id="select_unread" class="select"><i class="fa fa-check-square-o"></i> select unread</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> select none</span>');
 
   // Change the action on the /col pages so we use a Javascript
   // confirmation instead of redirecting to a confirmation page before
@@ -20,9 +20,11 @@ $(function () {
 
   var all = $("#select_all");
   var none = $("#select_none");
+  var unread = document.getElementById("select_unread");
 
   all.css('cursor', 'pointer');
   none.css('cursor', 'pointer');
+  unread.style.cursor = "pointer";
 
   all.click(function() {
     var checkboxes = $(":checkbox").filter(":visible");
@@ -32,6 +34,15 @@ $(function () {
     var checkboxes = $(":checkbox").filter(":visible");
     checkboxes.prop('checked', false);
   });
+  unread.onclick = function() {
+    var checkboxes = document.querySelectorAll(".submission > [type='checkbox']");
+    for (var i = 0; i < checkboxes.length; i++) {
+        if (checkboxes[i].className.includes("unread-cb"))
+            checkboxes[i].checked = true;
+        else
+            checkboxes[i].checked = false;
+    }
+  };
 
   $("#delete_collection").submit(function () {
     return confirm("Are you sure you want to delete this collection?");


### PR DESCRIPTION
Resolves #1353. Only adds space for an icon if there's at least one unread submission. If all submissions have been read, then the page appears as it would before this PR. Not sure if it's better this way or if it's better to just have an empty space regardless. I was planning on using an open envelope icon for read submissions, making it more clear what the icon means, but, surprisingly, font awesome doesn't have one.

Planning to make the "select all unread" button as well. Also considering adding javascript that removes the icon when the journalist clicks the download button.

Screenshot:
![unread](https://cloud.githubusercontent.com/assets/19742137/16637593/fa31d55c-4394-11e6-80a5-b267c565f9fa.png)
