### PR TITLE
Added source-assignment functionality

### DIFF
--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -77,6 +77,8 @@ class Source(Base):
     flagged = Column(Boolean, default=False)
     last_updated = Column(DateTime, default=datetime.datetime.utcnow)
     star = relationship("SourceStar", uselist=False, backref="source")
+    journalist_id = Column(Integer, ForeignKey('journalists.id'))
+    journalist = relationship("Journalist", backref="assigned")
 
     # sources are "pending" and don't get displayed to journalists until they
     # submit something

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -430,8 +430,27 @@ def index():
             Submission.query.filter_by(source_id=source.id,
                                        downloaded=False).all())
 
-    return render_template('index.html', unstarred=unstarred, starred=starred)
+    journalists = Journalist.query.order_by(Journalist.username).all()
 
+    return render_template('index.html', unstarred=unstarred, starred=starred, journalists=journalists)
+
+@app.route('/change-assignment/<sid>', methods=('POST',))
+@login_required
+def change_assignment(sid):
+    source = get_source(sid)
+
+    if request.form[sid + "-journalist"] == "none":
+        source.journalist = None
+        db_session.commit()
+        return redirect(url_for('index'))
+
+    journalist_query = Journalist.query.filter(Journalist.username == request.form[sid + "-journalist"])
+    journalist = get_one_or_else(journalist_query, app.logger, abort)
+
+    source.journalist = journalist
+    db_session.commit()
+
+    return redirect(url_for('index'))
 
 @app.route('/col/<sid>')
 @login_required

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -34,6 +34,28 @@
                   </span>
                 {% endif %}
               </div>
+              <div id="{{ source.filesystem_id }}-assignment" class="assignment">
+                <div class="assign-current">
+                  <p>Assigned:</p>
+                  {% if source.journalist %}
+                    <p>{{ source.journalist.username }}</p>
+                  {% else %}
+                    <p>nobody</p>
+                  {% endif %}
+                  <a href="#{{ source.filesystem_id }}-reassign">Reassign</a>
+                </div>
+                <div id="{{ source.filesystem_id }}-reassign" class="assign-select">
+                  <p>Assign new journalist:</p>
+                  <select name="{{ source.filesystem_id }}-journalist">
+                    <option value="none">nobody</option>
+                    {% for journalist in journalists %}
+                    <option value="{{ journalist.username }}">{{ journalist.username }}</option>
+                    {% endfor %}
+                  </select>
+                  <button formaction="/change-assignment/{{ source.filesystem_id }}">Apply</button>
+                  <a class="btn" href="#{{ source.filesystem_id }}-assignment">Cancel</a>
+                </div>
+              </div>
             </li>
           {% endfor %}
         </ul>
@@ -59,6 +81,28 @@
                     <a class="btn small" href='/download_unread/{{ source.filesystem_id }}' ><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
                   </span>
                 {% endif %}
+              </div>
+              <div id="{{ source.filesystem_id }}-assignment" class="assignment">
+                <div class="assign-current">
+                  <p>Assigned:</p>
+                  {% if source.journalist %}
+                    <p>{{ source.journalist.username }}</p>
+                  {% else %}
+                    <p>nobody</p>
+                  {% endif %}
+                  <a href="#{{ source.filesystem_id }}-reassign">Reassign</a>
+                </div>
+                <div id="{{ source.filesystem_id }}-reassign" class="assign-select">
+                  <p>Assign new journalist:</p>
+                  <select name="{{ source.filesystem_id }}-journalist">
+                    <option value="none">nobody</option>
+                    {% for journalist in journalists %}
+                    <option value="{{ journalist.username }}">{{ journalist.username }}</option>
+                    {% endfor %}
+                  </select>
+                  <button formaction="/change-assignment/{{ source.filesystem_id }}">Apply</button>
+                  <a class="btn" href="#{{ source.filesystem_id }}-assignment">Cancel</a>
+                </div>
               </div>
             </li>
           {% endfor %}

--- a/securedrop/static/css/journalist.css
+++ b/securedrop/static/css/journalist.css
@@ -399,6 +399,53 @@ p#codename {
 #cols li.source:last-child {
   border-bottom: none;
 }
+#cols li.source .assignment p {
+  margin: 0;
+  display: inline-block;
+}
+#cols li.source .assignment .assign-current {
+  margin-left: 7%;
+  font-size: 0.8em;
+}
+#cols li.source .assignment .assign-current a {
+  margin-left: 1%;
+}
+#cols li.source .assignment .btn {
+  padding: .3%;
+  width: 10%;
+  display: inline-block;
+}
+#cols li.source .assignment button {
+  margin-left: 3%;
+  padding: .3%;
+  width: 10%;
+}
+#cols li.source .assign-select {
+  height: 0;
+  overflow: hidden;
+}
+#cols li.source .assign-select:target {
+  height: auto;
+  overflow: visible;
+  margin-top: 1%;
+  text-align: center;
+}
+#cols li.source .assign-select p {
+  font-weight: bold;
+  font-style: italic;
+}
+#cols li.source .assign-select select {
+  margin-left: 2%;
+  width: 23%;
+}
+#cols li.source .assign-select .btn {
+  background-color: #999
+}
+#cols li.source .assign-select .btn:hover {
+  color: #999;
+  background-color: white;
+}
+
 #cols li.source .date {
   float: right;
   background-color: #999999;


### PR DESCRIPTION
Spent a little time on #1355. This implements a simple version of journalist assignment. 

This links a journalist to sources in the database, displays the current value in index.html and gives a reassign link that opens up a dropdown to pick a new journalist. It probably needs some UX improvement to be merged, though. 

Using a select dropdown might work if you have a small number of journalists, but if you have a lot, it's probably cumbersome. Maybe a combo box is the way to go? I also thought of making some sort of journalist directory that opens up, but would that be overkill? Not sure how many journalists the average user has. It might also be a good idea to give the option to add names for journalist users. Going only by username could make it less than clear who is being assigned to a source.

This is also implemented without javascript. I'm not really sure what the guidelines are for javascript on document interface. The javascript here seems very minimal. Is this by design? This PR would probably be better with some javascript.

Let me know if you guys have any suggestions.

![assignment1](https://cloud.githubusercontent.com/assets/19742137/16759186/92152d5e-47ca-11e6-9bae-c0c31c5e4583.png)

Journalist assignment:
![assignment2](https://cloud.githubusercontent.com/assets/19742137/16759191/9640a584-47ca-11e6-9cf5-6286f060446d.png)
