### PR TITLE
Restore hyperlinks to non-THS resources

### DIFF
--- a/securedrop/source_templates/howto-disable-js.html
+++ b/securedrop/source_templates/howto-disable-js.html
@@ -3,7 +3,7 @@
 
 <h1>Disable JavaScript to Protect Your Anonymity</h1>
 
-<p>JavaScript is a widely used programming language for creating interactive web pages. Unfortunately, JavaScript is also the most common source of security vulnerabilities in browsers. In August 2013, the FBI wrote malware that used a JavaScript exploit to de-anonymize Tor users (http://www.wired.com/threatlevel/2013/09/freedom-hosting-fbi). JavaScript exploits are also mentioned in documents describing the NSA's Egotistical Giraffe (http://www.theguardian.com/world/interactive/2013/oct/04/egotistical-giraffe-nsa-tor-document) program, which also has the goal of targeting and de-anonymizing Tor users.</p>
+<p>JavaScript is a widely used programming language for creating interactive web pages. Unfortunately, JavaScript is also the most common source of security vulnerabilities in browsers. In August 2013, the FBI wrote malware that used a JavaScript exploit to <a href='http://www.wired.com/threatlevel/2013/09/freedom-hosting-fbi'>de-anonymize Tor users</a>. JavaScript exploits are also mentioned in documents describing the NSA's <a href='http://www.theguardian.com/world/interactive/2013/oct/04/egotistical-giraffe-nsa-tor-document'>Egotistical Giraffe</a> program, which also has the goal of targeting and de-anonymizing Tor users.</p>
 
 <p>We encourage SecureDrop users to disable JavaScript to protect themselves from malware that would use it to attack their browser and potentially de-anonymize them. There are other ways to get hacked, but given the use of JavaScript-based attacks recently, we believe it is prudent to disable it at this time.</p>
 

--- a/securedrop/source_templates/tor2web-warning.html
+++ b/securedrop/source_templates/tor2web-warning.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block body %}
 <h2>Why is there a warning about Tor2Web?</h2>
-<p>Tor2Web (http://tor2web.org) is a proxy service that lets you browse Tor Hidden Services (.onion sites) without installing Tor. It was designed to facilitate anonymous publishing.</p>
+<p><a href='https://tor2web.org'>Tor2Web</a> is a proxy service that lets you browse Tor Hidden Services (.onion sites) without installing Tor. It was designed to facilitate anonymous publishing.</p>
 <p>Tor2Web only protects publishers, not readers. If you upload documents to us using Tor2Web, you are <strong>not anonymous</strong> and could be identified by your ISP or the Tor2Web proxy operators. Additionally, since Tor2Web sites typically use HTTPS, it is possible that your connection could be MITM'ed by a capable adversary.</p>
-<p>If you want to submit information, we <strong>strongly advise you</strong> to install Tor (https://www.torproject.org/download.html.en) and use it to access our site safely and anonymously.</p>
+<p>If you want to submit information, we <strong>strongly advise you</strong> to install <a href='https://www.torproject.org/download.html.en'>Tor</a> and use it to access our site safely and anonymously.</p>
 {% endblock %}

--- a/securedrop/source_templates/why-journalist-key.html
+++ b/securedrop/source_templates/why-journalist-key.html
@@ -7,7 +7,7 @@
 <li><a href="/journalist-key">Download</a> the public key. The public key is a text file with the extension <code>.asc</code></li>
 <li>Import it into your GPG keyring.
 <ul>
-<li>If you are using Tails (https://tails.boum.org/), you can double-click the <code>.asc</code> file you just downloaded and it will be automatically imported to your keyring.</li>
+<li>If you are using <a href='https://tails.boum.org/'>Tails</a>, you can double-click the <code>.asc</code> file you just downloaded and it will be automatically imported to your keyring.</li>
 <li>If you are using Mac/Linux, open the Terminal. You can import the key with <code>gpg --import /path/to/key.asc</code>.</li>
 </ul>
 </li>


### PR DESCRIPTION
https://github.com/freedomofpress/securedrop/pull/516 is no longer necessary
as of TBB 5.0.4, which spoofs referer from .onion sites.