### PR TITLE
more unix-y cli for manage.py

### DIFF
--- a/docs/create_admin_account.rst
+++ b/docs/create_admin_account.rst
@@ -35,12 +35,12 @@ To create the first admin account, SSH to the App Server, then:
 
    $ sudo su
    $ cd /var/www/securedrop
-   $ ./manage.py add_admin
+   $ ./manage.py add-admin
 
 Follow the prompts.
 
 .. todo:: Clarify how to set up TOTP/HOTP through ``./manage.py
-          add_admin``.
+          add-admin``.
 	  
 Once that's done, you should open the Tor Browser |TorBrowser| and
 navigate to the Document Interface's .onion address. Verify that you

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -208,7 +208,7 @@ course, you can specify the name if you want to.
    ./manage.py run         # run development servers
    ./manage.py test        # run the unit and functional tests
    ./manage.py reset       # resets the state of the development instance
-   ./manage.py add_admin   # create a user to use when logging in to the Document Interface
+   ./manage.py add-admin   # create a user to use when logging in to the Document Interface
 
 SecureDrop consists of two separate web appications (the Source Interface and
 the Document Interface) that run concurrently. The development servers will
@@ -234,7 +234,7 @@ to fill out your local copy of
    vagrant ssh app-staging
    sudo su
    cd /var/www/securedrop
-   ./manage.py add_admin
+   ./manage.py add-admin
    ./manage.py test
 
 Prod
@@ -256,7 +256,7 @@ To create only the prod servers, run:
    vagrant ssh app-prod
    sudo su
    cd /var/www/securedrop/
-   ./manage.py add_admin
+   ./manage.py add-admin
 
 In order to access the servers after the install is completed you will need to
 install and configure a proxy tool to proxy your SSH connection over Tor.

--- a/docs/upgrade/0.2.1-to-0.3.x.rst
+++ b/docs/upgrade/0.2.1-to-0.3.x.rst
@@ -58,7 +58,7 @@ Upgrade Procedure
 
 #. Ensure that you've completed the installation process for the latest stable
    version of SecureDrop, and ensure that you've created at least one user on
-   the Document Interface (with ``./manage.py add_admin``) before continuing.
+   the Document Interface (with ``./manage.py add-admin``) before continuing.
 
 #. Once you've successfully installed 0.3.x, copy ``sdbackup.tar.gz`` to any
    location on the 0.3.x app server. You will also need to copy the

--- a/docs/yubikey_setup.rst
+++ b/docs/yubikey_setup.rst
@@ -66,7 +66,7 @@ manage.py
 If you have just installed SecureDrop, you will need to add the first
 admin user to the Document Interface with ``manage.py``. ``cd`` to the
 ``SECUREDROP_ROOT``, which is ``/vagrant/securedrop`` in development and
-``/var/www/securedrop`` in production. Run ``./manage.py add_admin``.
+``/var/www/securedrop`` in production. Run ``./manage.py add-admin``.
 Fill in the username and password prompts. When it asks "Is this admin
 using a YubiKey [HOTP]? (y/N)", type "y", then enter. At the "Please
 configure your YubiKey and enter the secret:" prompt, enter the Secret

--- a/install_files/ansible-base/roles/app/tasks/setup_cron.yml
+++ b/install_files/ansible-base/roles/app/tasks/setup_cron.yml
@@ -2,7 +2,7 @@
 - name: Add cron job to clean SecureDrop tmp dir daily.
   cron:
     name: cleanup SecureDrop temp dir
-    job: "{{ securedrop_code }}/manage.py clean_tmp"
+    job: "{{ securedrop_code }}/manage.py clean-tmp"
     special_time: daily
   tags:
     - cron

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -212,8 +212,6 @@ def get_args():
                             description='A tool to help admins manage and devs hack')
 
     subparsers = parser.add_subparsers()
-    subparsers.required = True
-    subparsers.dest = 'subcommand'
 
     run_subparser = subparsers.add_parser('run', help='Run the dev webserver (source & journalist)')
     run_subparser.set_defaults(func=run)

--- a/securedrop/tests/test_unit_manage.py
+++ b/securedrop/tests/test_unit_manage.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import manage
+import unittest
+
+
+class TestManagePy(unittest.TestCase):
+
+    def test_parse_args(self):
+        # just test that the arg parser is stable
+        manage.get_args()

--- a/spec_tests/spec/app-general/securedrop_app_spec.rb
+++ b/spec_tests/spec/app-general/securedrop_app_spec.rb
@@ -46,7 +46,7 @@ end
 
 # ensure cron job for securedrop tmp dir cleanup is enabled
 describe cron do
-  it { should have_entry "@daily #{property['securedrop_code']}/manage.py clean_tmp" }
+  it { should have_entry "@daily #{property['securedrop_code']}/manage.py clean-tmp" }
 end
 
 # ensure directory for worker logs is present

--- a/spec_tests/spec/development/securedrop_app_dev_spec.rb
+++ b/spec_tests/spec/development/securedrop_app_dev_spec.rb
@@ -58,8 +58,8 @@ end
 describe cron do
   # TODO: this should be using property, but the ansible role
   # doesn't use a var, it's hard-coded. update ansible, then fix test.
-  # it { should have_entry "@daily #{property['securedrop_code']}/manage.py clean_tmp" }
-  it { should have_entry "@daily /vagrant/securedrop/manage.py clean_tmp" }
+  # it { should have_entry "@daily #{property['securedrop_code']}/manage.py clean-tmp" }
+  it { should have_entry "@daily /vagrant/securedrop/manage.py clean-tmp" }
 end
 
 


### PR DESCRIPTION
Uses `argparse` module instead of homebrewed argument parsing. Help reads nicer now. Also, removes some unused imports.

All credit goes to @heartsucker who originally submitted this in https://github.com/freedomofpress/securedrop/pull/1347. I just cleaned out a couple unecessary lines.