### PR TITLE
Encode UTF-8 and/or convert to BytesIO stream all GPG input

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -5,6 +5,7 @@ from base64 import b32encode
 
 from Crypto.Random import random
 import gnupg
+from gnupg._util import _is_stream, _make_binary_stream
 import scrypt
 
 import config
@@ -154,6 +155,9 @@ def encrypt(plaintext, fingerprints, output=None):
         fingerprints = [fingerprints, ]
     fingerprints = [fpr.replace(' ', '') for fpr in fingerprints]
 
+    if not _is_stream(plaintext):
+        plaintext = _make_binary_stream(plaintext, "utf_8")
+
     out = gpg.encrypt(plaintext,
                       *fingerprints,
                       output=output,
@@ -165,7 +169,7 @@ def encrypt(plaintext, fingerprints, output=None):
         raise CryptoException(out.stderr)
 
 
-def decrypt(secret, plain_text):
+def decrypt(secret, ciphertext):
     """
     >>> key = genkeypair('randomid', 'randomid')
     >>> decrypt('randomid', 'randomid',
@@ -174,8 +178,7 @@ def decrypt(secret, plain_text):
     'Goodbye, cruel world!'
     """
     hashed_codename = hash_codename(secret, salt=SCRYPT_GPG_PEPPER)
-    return gpg.decrypt(plain_text, passphrase=hashed_codename).data
-
+    return gpg.decrypt(ciphertext, passphrase=hashed_codename).data
 
 if __name__ == "__main__":
     import doctest

--- a/securedrop/tests/test_unit_integration.py
+++ b/securedrop/tests/test_unit_integration.py
@@ -257,8 +257,21 @@ class TestIntegration(unittest.TestCase):
     def test_reply_normal(self):
         self.helper_test_reply("This is a test reply.", True)
 
-    def test_reply_unicode(self):
-        self.helper_test_reply("Teşekkürler", True)
+    def test_unicode_reply_with_ansi_env(self):
+        # This makes python-gnupg handle encoding equivalent to if we were
+        # running SD in an environment where os.getenv("LANG") == "C".
+        # Unfortunately, with the way our test suite is set up simply setting
+        # that env var here will not have the desired effect. Instead we
+        # monkey-patch the GPG object that is called crypto_util to imitate the
+        # _encoding attribute it would have had it been initialized in a "C"
+        # environment. See
+        # https://github.com/freedomofpress/securedrop/issues/1360 for context.
+        old_encoding = crypto_util.gpg._encoding
+        crypto_util.gpg._encoding = "ansi_x3.4_1968"
+        try:
+            self.helper_test_reply("ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ", True)
+        finally:
+            crypto_util.gpg._encoding = old_encoding
 
     def _can_decrypt_with_key(self, msg, key_fpr, passphrase=None):
         """


### PR DESCRIPTION
This converts plaintext inputs for encryption to `_io.BytesIO` streams before passing to `python-gnupg`'s encrypt function. This should resolve #1360 and #1343--duplicate issues--, however, it would be wise to additionally change the encoding used by mod_wsgi so it's `UTF-8` instead of `C` (as mentioned in https://github.com/freedomofpress/securedrop/issues/1360#issuecomment-239593607) and also to submit a PR upstream to `python-gnupg` so that we can uniformly pass `_io.BytesIO` streams to all `python-gnupg` functions we use, as discussed in the commit message of 56f2308 here.