### PR TITLE
Minor documentation formatting fix

### DIFF
--- a/docs/set_up_tails.rst
+++ b/docs/set_up_tails.rst
@@ -86,14 +86,16 @@ Some other things to keep in mind:
 -  Each Tails persistent volume should have an unique and complex
    passphrase that's easy to write down or remember. We recommend using
    `Diceware
-   passphrases. <https://theintercept.com/2015/03/26/passphrases-can-memorize-attackers-cant-guess/>`__
+   passphrases.
+   <https://theintercept.com/2015/03/26/passphrases-can-memorize-attackers-cant-guess/>`__
 
 -  Each journalist will need their own Tails drive with their own
    persistent volume secured with their own passphrase — but :doc:`that comes
    later <onboarding>`.
 
 -  Journalists and admins will eventually need to remember these
-   passphrases. We recommend using `spaced-repetition <https://en.wikipedia.org/wiki/Spaced_repetition>`__  to memorize
+   passphrases. We recommend using `spaced-repetition
+   <https://en.wikipedia.org/wiki/Spaced_repetition>`__  to memorize
    Diceware passphrases.
 
 .. warning:: Make sure that you never use the *Secure Viewing Station*


### PR DESCRIPTION
Wrap lines to 72 characters when possible like rest of docs. Fixes problems existing before and also created by #1362.