### PR TITLE
Apparmor: allow Apache ro access to fontawesome-webfont.eot

### DIFF
--- a/install_files/ansible-base/usr.sbin.apache2
+++ b/install_files/ansible-base/usr.sbin.apache2
@@ -182,6 +182,7 @@
   /var/www/securedrop/static/js/journalist.js r,
   /var/www/securedrop/static/js/libs/jquery-2.1.1.min.js r,
   /var/www/securedrop/static/js/source.js r,
+  /var/www/securedrop/static/fonts/fontawesome-webfont.eot r,
   /var/www/securedrop/static/fonts/fontawesome-webfont.ttf r,
   /var/www/securedrop/static/fonts/fontawesome-webfont.woff r,
   /var/www/securedrop/store.py r,


### PR DESCRIPTION
Apache should have read-only access to this embeddable open-type font file we provide and make use of. Fixes #1240.