### PR TITLE
Update Training resources in docs

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -44,6 +44,8 @@ These computers should all physically be in your organization's office.
 
 .. _`Tails operating system`: https://tails.boum.org
 
+.. _securedrop_architecture_diagram:
+
 Infrastructure
 --------------
 

--- a/docs/training_schedule.rst
+++ b/docs/training_schedule.rst
@@ -50,14 +50,15 @@ recipients and anyone else interested
 -  Physical security of servers and SVS
 -  How to securely publicize the organization's Source Interface Tor URL
 -  Distribute important info:
--  Third-party security mailing lists to subscribe to
--  https://freedom.press/about/staff
--  https://securedrop.org
--  https://docs.securedrop.org
--  Hardware for SecureDrop
--  SecureDrop Deployment Best Practices
--  Source Best Practice Guide
--  Journalist Best Practice Guide
+
+   -  Third-party security mailing lists to subscribe to
+   -  https://freedom.press/about/staff
+   -  https://securedrop.org
+   -  https://docs.securedrop.org
+   -  Hardware for SecureDrop
+   -  SecureDrop Deployment Best Practices
+   -  Source Best Practice Guide
+   -  Journalist Best Practice Guide
 -  Answering the client vs. server side crypto debate
 -  Link to security audits
 

--- a/docs/training_schedule.rst
+++ b/docs/training_schedule.rst
@@ -30,7 +30,7 @@ Participants: journalists, editors, SecureDrop admins, OSSEC alert
 recipients and anyone else interested
 
 -  Go over the SecureDrop `FAQs <https://securedrop.org/faq>`__
--  Go over the SecureDrop environment diagrams
+-  Go over the SecureDrop :ref:`environment diagrams <securedrop_architecture_diagram>`
 -  Importance of the landing page security and Twitter feedback
 -  Demo the source submission process
 -  Demo the journalist's processes for checking the Document Interface

--- a/docs/training_schedule.rst
+++ b/docs/training_schedule.rst
@@ -59,8 +59,6 @@ recipients and anyone else interested
 -  Journalist Best Practice Guide
 -  Answering the client vs. server side crypto debate
 -  Link to security audits
--  Bunch of other in-progress docs are on securedrop.hackpad.com, many
-   are still in draft form
 
 Questions
 ~~~~~~~~~

--- a/docs/training_schedule.rst
+++ b/docs/training_schedule.rst
@@ -53,6 +53,7 @@ recipients and anyone else interested
 -  Third-party security mailing lists to subscribe to
 -  https://freedom.press/about/staff
 -  https://securedrop.org
+-  https://docs.securedrop.org
 -  Hardware for SecureDrop
 -  SecureDrop Deployment Best Practices
 -  Source Best Practice Guide

--- a/docs/training_schedule.rst
+++ b/docs/training_schedule.rst
@@ -55,10 +55,11 @@ recipients and anyone else interested
    -  https://freedom.press/about/staff
    -  https://securedrop.org
    -  https://docs.securedrop.org
-   -  Hardware for SecureDrop
-   -  SecureDrop Deployment Best Practices
-   -  Source Best Practice Guide
-   -  Journalist Best Practice Guide
+   -  :doc:`Hardware for SecureDrop <hardware>`
+   -  :doc:`SecureDrop Deployment Best Practices <deployment_practices>`
+   -  :doc:`Source Best Practice Guide <source>`
+   -  :doc:`Journalist Best Practice Guide <journalist>`
+   -  :doc:`Admin Best Practice Guide <admin>`
 -  Answering the client vs. server side crypto debate
 -  Link to security audits
 


### PR DESCRIPTION
Minor touch-ups to the [Training documentation](https://docs.securedrop.org/en/stable/training_schedule.html) to make use of cross-linking. Since the switch to ReadTheDocs (#1158), we have the ability to link directly to subpages within the docs. Added a custom label to jump straight to the architecture diagram, and snipped out mention of Hackpad altogether.

Closes #1255.