### PR TITLE
Updates Vagrant version requirement in developer docs

### DIFF
--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -23,7 +23,7 @@ Ubuntu/Debian
 
    sudo apt-get install -y dpkg-dev virtualbox-dkms linux-headers-$(uname -r) build-essential git
 
-We recommend using the latest stable version of Vagrant (``1.7.4`` at the time
+We recommend using the latest stable version of Vagrant (``1.8.4`` at the time
 of this writing), which might be newer than what is in your distro's package
 repositories.
 

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -38,13 +38,14 @@ then install it.
     # OR this, if your OS vagrant is recent enough
     sudo apt-get install vagrant
 
-We *do not* recommend using a version of Vagrant older than 1.7. For instance,
+We *do not* recommend using a version of Vagrant older than 1.8.4. For instance,
 the version of Vagrant currently in the Ubuntu Trusty repositories is 1.5.4,
 which is signficantly out of date and known not to work with SecureDrop (`Github
-#932`_).
+#932`_, `Github #1381`_).
 
 .. _`Vagrant Downloads page`: https://www.vagrantup.com/downloads.html
 .. _`GitHub #932`: https://github.com/freedomofpress/securedrop/pull/932
+.. _`GitHub #1381`: https://github.com/freedomofpress/securedrop/issues/1381
 
 .. warning:: We do not recommend installing vagrant-cachier. It destroys apt’s
             state unless the VMs are always shut down/rebooted with Vagrant,

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -231,7 +231,7 @@ to fill out your local copy of
 
 .. code:: sh
 
-   vagrant up /staging$/
+   vagrant up /staging/
    vagrant ssh app-staging
    sudo su
    cd /var/www/securedrop
@@ -253,7 +253,7 @@ To create only the prod servers, run:
 
 .. code:: sh
 
-   vagrant up /prod$/
+   vagrant up /prod/
    vagrant ssh app-prod
    sudo su
    cd /var/www/securedrop/

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -23,7 +23,7 @@ Ubuntu/Debian
 
    sudo apt-get install -y dpkg-dev virtualbox-dkms linux-headers-$(uname -r) build-essential git
 
-We recommend using the latest stable version of Vagrant (``1.8.4`` at the time
+We recommend using the latest stable version of Vagrant (``1.8.5`` at the time
 of this writing), which might be newer than what is in your distro's package
 repositories.
 


### PR DESCRIPTION
Updates the required version for Vagrant in the developer documentation. Newer versions of Vagrant have fixed the regression that broke the regular expression syntax for targeting hosts. The docs now demand that a sufficiently recent version of Vagrant is installed.

Note that this PR will only update the docs in the ["latest" tag on RTD](https://docs.securedrop.org/en/latest/development/getting_started.html). That's appropriate for developers, just pointing it out for clarity's sake.

Closes #1241. See also #1381.