### PR TITLE
Fixes inference of THS info in install.sh script

### DIFF
--- a/tails_files/install.sh
+++ b/tails_files/install.sh
@@ -219,7 +219,7 @@ function lookup_document_aths_url()
   # Last shot before prompting: check for an existing desktop icon specifically
   # for the Document Interface. If found, we can extract the URL from there.
   elif [ -e "${amnesia_desktop}/document.desktop" ] ; then
-    app_document_aths="$(grep ^Exec=/usr/local/bin/tor-browser | awk '{ print $2 }')"
+    app_document_aths="$(grep ^Exec=/usr/local/bin/tor-browser "${amnesia_desktop}/document.desktop" | awk '{ print $2 }')"
   # Couldn't find it anywhere. We'll have to prompt!
   else
     echo "Could not find Document Interface ATHS info, prompting interactively..." 1>&2
@@ -240,7 +240,7 @@ function lookup_source_ths_url()
     app_source_ths="$source_ths_url_global"
   # Failing that, check for the public THS URL in an existing Desktop icon.
   elif grep -q -P '^Exec=/usr/local/bin/tor-browser\s+[a-z2-7]{16}\.onion' "${amnesia_desktop}/source.desktop" ; then
-    app_source_ths="$(grep ^Exec=/usr/local/bin/tor-browser | awk '{ print $2 }')"
+    app_source_ths="$(grep ^Exec=/usr/local/bin/tor-browser "${amnesia_desktop}/source.desktop" | awk '{ print $2 }')"
   # Couldn't find it anywhere. We'll have to prompt!
   else
     echo "Could not find Source Interface Onion URL, prompting interactively..." 1>&2


### PR DESCRIPTION
The `tails_files/install.sh` script contains logic to find existing
information about Tor Hidden Services for the Application Server, and
use that information if it already exists when creating desktop icons,
and configuring the /etc/tor/torrc file in Tails. In two cases, the grep
commands to extract THS info inappropriately omitted the target file to
read from, which caused the script to hang indefinitely if those
commands were run. Fixed by specifying the target files for both the
Source Interface and the Document Interface files.

Closes #1394.