### PR TITLE
Update Python dependencies before 0.3.9-rc2

### DIFF
--- a/securedrop/requirements/securedrop-requirements.txt
+++ b/securedrop/requirements/securedrop-requirements.txt
@@ -7,19 +7,18 @@
 click==6.6                # via flask, rq
 Flask-WTF==0.12
 Flask==0.11.1             # via flask-wtf
-future==0.15.2            # via pyotp
 gnupg==2.0.2
 itsdangerous==0.24        # via flask
 Jinja2==2.8               # via flask
 MarkupSafe==0.23          # via jinja2
 psutil==4.3.0
 pycrypto==2.6.1
-pyotp==2.1.1
+pyotp==2.2.1
 qrcode==5.3
 redis==2.10.5
 rq==0.6.0
 scrypt==0.7.1
 six==1.10.0               # via qrcode
 SQLAlchemy==1.0.14
-Werkzeug==0.11.10         # via flask, flask-wtf
+Werkzeug==0.11.11         # via flask, flask-wtf
 WTForms==2.1              # via flask-wtf

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -17,7 +17,7 @@ mock==2.0.0
 pbr==1.10.0               # via mock
 pip-tools==1.7.0
 py==1.4.31
-pytest==2.9.2
+pytest==3.0.1
 selenium==2.53.6
 six==1.10.0               # via mock, pip-tools
-Werkzeug==0.11.10         # via flask
+Werkzeug==0.11.11         # via flask


### PR DESCRIPTION
Normally, we're hesistant to issue an update for dependencies when we've already
entered the release candidate(s) stage of the release process. In this case, the
changes I'm adding are all minor bug fixes that I've reviewed. Two of the fixes
were labeled as security issues, however, they don't really affect us as
explained below.

* Werkzeug
  * A bug that allowed XSS attacks on the debug page has been fixed (we
    don't run Flask in debug mode in production) -
    https://github.com/pallets/werkzeug/pull/1001
  * Invalid Content-Type makes for parsing throw ValueError exception (the fix
    returns an invalid request 400 Bad Request page instead of an internal
    server error when the content-type field of a HTTP request is bad--such as
    ' ' or ',') - https://github.com/pallets/werkzeug/issues/995
  * Raise BadRequestKeyError instead of IndexError in MultiDict when calling
    __getitem__ on a key with an empty associated list of values (Flask returns
    forms and query strings as MultiDicts. This is just better error-handling,
    no real bug being fixed here.) -
    https://github.com/pallets/werkzeug/issues/979

* pytop
  * The string comparison function now no longer leaks string length (shouldn't
    affect SD because the length of our TOTP codes are already known) -
    https://github.com/pyotp/pyotp/pull/28