### PR TITLE
Use a more up-to-date point release of Ubuntu

### DIFF
--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -15,9 +15,9 @@ Install Ubuntu
 
 The *Admin Workstation*, running Tails, should be used to download and verify
 Ubuntu Server.  The *Application Server* and the *Monitor Server* specifically
-require the 64-bit version of `Ubuntu Server 14.04.2 LTS (Trusty Tahr)
-<http://old-releases.ubuntu.com/releases/14.04.2/>`__. The image you want to get
-is named ``ubuntu-14.04.2-server-amd64.iso``. In order to verify the
+require the 64-bit version of `Ubuntu Server 14.04.5 LTS (Trusty Tahr)
+<http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-amd64.iso>`__. The image you want to get
+is named ``ubuntu-14.04.5-server-amd64.iso``. In order to verify the
 installation media, you should also download the files named ``SHA256SUMS`` and
 ``SHA256SUMS.gpg``.
 


### PR DESCRIPTION
It saves quite some download and upgrade time for the admin, especially if it's done over Tor, when getting a more recent iso of Ubuntu 14.04. I couldn't find a generic link. We're upgrading everything nightly anyway, and I tested this as well.