### PR TITLE
Make backups work

### DIFF
--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -49,7 +49,9 @@
       # By default backups will NOT run, since they can claim a substantial
       # amount of disk space. Enable backups explicitly via a backup var, or
       # implicitly if performing a restore.
-      when: (perform_backup is defined and perform_backup == true) or
+      # Due to ansible version in current Tails, we have to pipe to bool
+      # https://github.com/ansible/ansible/issues/9369
+      when: (perform_backup is defined and perform_backup|bool == true) or
             (restore_file is defined and restore_file != '')
       tags: backup
 


### PR DESCRIPTION
On close examination, backups were not being made. The test in the backuprole perform_backup == true was not evaluated as expected. Known ansible problem, fixed upstream, but we're using the slightly older packaged version in Tails. See https://github.com/ansible/ansible/issues/9369
Evaluates to false:
(perform_backup is defined and perform_backup == true)
Compares the string:
(perform_backup is defined and perform_backup == 'true')
Or uhm, make it look like php:
(perform_backup is defined and perform_backup|bool == true)
