### PR TITLE
Missing username deploying ansible-playbook in doc

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -111,7 +111,7 @@ perform the backup:
 .. code:: sh
 
    cd install_files/ansible-base
-   ansible-playbook -i inventory -t backup securedrop-prod.yml -e perform_backup=true
+   ansible-playbook -i inventory -u <SSH username> -t backup securedrop-prod.yml -e perform_backup=true
 
 .. todo:: Test this on a real Admin Workstation
 


### PR DESCRIPTION
It wouldn't connect if not specifying your SSH username, when it's different as your current username.