### PR TITLE
Improve unit test coverage of securedrop app code

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -294,8 +294,16 @@ def admin_edit_user(user_id):
 @admin_required
 def admin_delete_user(user_id):
     user = Journalist.query.get(user_id)
-    db_session.delete(user)
-    db_session.commit()
+    if user:
+        db_session.delete(user)
+        db_session.commit()
+        flash("Deleted user '{}'".format(user.username), "notification")
+    else:
+        app.logger.error(
+            "Admin {} tried to delete nonexistent user with pk={}".format(
+            g.user.username, user_id))
+        abort(404)
+
     return redirect(url_for('admin_index'))
 
 

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -254,7 +254,12 @@ def admin_edit_user(user_id):
 
     if request.method == 'POST':
         if request.form['username'] != "":
-            user.username = request.form['username']
+            new_username = request.form['username']
+            if Journalist.query.filter_by(username=new_username).one_or_none():
+                flash("Username {} is already taken".format(new_username),
+                      "error")
+            else:
+                user.username = new_username
 
         if request.form['password'] != "":
             if request.form['password'] != request.form['password_again']:
@@ -262,6 +267,8 @@ def admin_edit_user(user_id):
                 return redirect(url_for("admin_edit_user", user_id=user_id))
             try:
                 user.set_password(request.form['password'])
+                flash("Password successfully changed for user {} ".format(
+                    user.username), "notification")
             except InvalidPasswordLength:
                 flash("Your password is too long "
                       "(maximum length {} characters)".format(
@@ -270,22 +277,8 @@ def admin_edit_user(user_id):
 
         user.is_admin = bool(request.form.get('is_admin'))
 
-        try:
-            db_session.add(user)
-            db_session.commit()
-            flash("Password successfully changed for user {} ".format(
-                  user.username),
-                  "notification"
-            )
-
-        except Exception as e:
-            db_session.rollback()
-            if "username is not unique" in str(e):
-                flash("That username is already in use", "notification")
-            else:
-                flash(
-                    "An unknown error occurred, please inform your administrator",
-                    "error")
+        db_session.add(user)
+        db_session.commit()
 
     return render_template("admin_edit_user.html", user=user)
 

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -371,10 +371,13 @@ class TestJournalist(TestCase):
     def test_too_long_user_password_change(self):
         self._login_user()
         overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
+
         res = self.client.post(url_for('edit_account'), data=dict(
             password=overly_long_password,
-            password_again=overly_long_password))
-        self.assert_redirects(res, url_for('edit_account'))
+            password_again=overly_long_password),
+            follow_redirects=True)
+
+        self.assertIn('Your password is too long', res.data)
 
     def test_valid_user_password_change(self):
         self._login_user()

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -247,6 +247,59 @@ class TestJournalist(TestCase):
         # any GET req should take a user to the admin_new_user_two_factor page
         self.assertIn('Authenticator', res.data)
 
+    def test_admin_add_user_get_req(self):
+        self._login_admin()
+
+        res = self.client.get(url_for('admin_add_user'))
+
+        # any GET req should take a user to the admin_add_user page
+        self.assertIn('Add user', res.data)
+
+    def test_admin_add_user_success(self):
+        self._login_admin()
+
+        res = self.client.post(url_for('admin_add_user'),
+                               data=dict(username='dellsberg',
+                                         password='pentagonpapers',
+                                         password_again='pentagonpapers',
+                                         is_admin=False))
+
+        self.assert_redirects(res, url_for('admin_new_user_two_factor', uid=3))
+
+    def test_admin_add_user_failure_no_username(self):
+        self._login_admin()
+
+        res = self.client.post(url_for('admin_add_user'),
+                               data=dict(username='',
+                                         password='pentagonpapers',
+                                         password_again='pentagonpapers',
+                                         is_admin=False))
+
+        self.assertIn('Missing username', res.data)
+
+    def test_admin_add_user_failure_passwords_dont_match(self):
+        self._login_admin()
+
+        res = self.client.post(url_for('admin_add_user'),
+                               data=dict(username='dellsberg',
+                                         password='not',
+                                         password_again='thesame',
+                                         is_admin=False))
+
+        self.assertIn('Passwords didn', res.data)
+
+    def test_admin_add_user_failure_password_too_long(self):
+        self._login_admin()
+
+        overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
+        res = self.client.post(url_for('admin_add_user'),
+                               data=dict(username='dellsberg',
+                                         password=overly_long_password,
+                                         password_again=overly_long_password,
+                                         is_admin=False))
+
+        self.assertIn('password is too long', res.data)
+
     def test_admin_authorization_for_gets(self):
         admin_urls = [url_for('admin_index'), url_for('admin_add_user'),
             url_for('admin_edit_user', user_id=1)]

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -187,6 +187,18 @@ class TestJournalist(TestCase):
         self.assert_redirects(res, url_for('admin_edit_user',
                                            user_id=1))
 
+    def test_admin_edits_user_invalid_username(self):
+        self._login_admin()
+
+        res = self.client.post(url_for('admin_edit_user',
+                                       user_id=1),
+                               data=dict(username='admin',
+                                         is_admin=False,
+                                         password='valid',
+                                         password_again='valid'))
+
+        self.assertIn('An unknown error occurred', res.data)
+
     def test_admin_authorization_for_gets(self):
         admin_urls = [url_for('admin_index'), url_for('admin_add_user'),
             url_for('admin_edit_user', user_id=1)]

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -387,8 +387,6 @@ class TestJournalist(TestCase):
         # should redirect to verification page
         self.assert_redirects(res, url_for('account_new_two_factor'))
 
-    # TODO: more tests for admin interface
-
     def test_bulk_download(self):
         sid = 'EQZGCJBRGISGOTC2NZVWG6LILJBHEV3CINNEWSCLLFTUWZJPKJFECLS2NZ4G4U3QOZCFKTTPNZMVIWDCJBBHMUDBGFHXCQ3R'
         source = Source(sid, crypto_util.display_id())

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -173,6 +173,20 @@ class TestJournalist(TestCase):
         self.assert_redirects(res, url_for('admin_edit_user',
                                            user_id=1))
 
+    def test_admin_edits_user_password_too_long(self):
+        self._login_admin()
+        overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
+
+        res = self.client.post(url_for('admin_edit_user',
+                                       user_id=1),
+                               data=dict(username='foo',
+                                         is_admin=False,
+                                         password=overly_long_password,
+                                         password_again=overly_long_password))
+
+        self.assert_redirects(res, url_for('admin_edit_user',
+                                           user_id=1))
+
     def test_admin_authorization_for_gets(self):
         admin_urls = [url_for('admin_index'), url_for('admin_add_user'),
             url_for('admin_edit_user', user_id=1)]

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -197,16 +197,19 @@ class TestJournalist(TestCase):
                                            user_id=1))
 
     def test_admin_edits_user_invalid_username(self):
+        """Test expected error message when admin attempts to change a user's
+        username to a username that is taken by another user."""
         self._login_admin()
 
-        res = self.client.post(url_for('admin_edit_user',
-                                       user_id=1),
-                               data=dict(username='admin',
-                                         is_admin=False,
-                                         password='valid',
-                                         password_again='valid'))
+        new_username = self.admin_user.username
+        res = self.client.post(
+            url_for('admin_edit_user', user_id=self.user.id),
+            data=dict(username=new_username, is_admin=False,
+                      password='', password_again='')
+            )
 
-        self.assertIn('An unknown error occurred', res.data)
+        self.assertIn('Username {} is already taken'.format(new_username),
+                      res.data)
 
     def test_admin_reset_hotp_success(self):
         self._login_admin()

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -231,6 +231,22 @@ class TestJournalist(TestCase):
 
         self.assert_redirects(res, url_for('admin_new_user_two_factor', uid=1))
 
+    def test_admin_new_user_2fa_success(self):
+        self._login_admin()
+
+        res = self.client.post(url_for('admin_new_user_two_factor', uid=1),
+                               data=dict(token=self.user.totp.now()))
+
+        self.assert_redirects(res, url_for('admin_index'))
+
+    def test_admin_new_user_2fa_get_req(self):
+        self._login_admin()
+
+        res = self.client.get(url_for('admin_new_user_two_factor', uid=1))
+
+        # any GET req should take a user to the admin_new_user_two_factor page
+        self.assertIn('Authenticator', res.data)
+
     def test_admin_authorization_for_gets(self):
         admin_urls = [url_for('admin_index'), url_for('admin_add_user'),
             url_for('admin_edit_user', user_id=1)]

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -219,6 +219,18 @@ class TestJournalist(TestCase):
 
         self.assertIn('Change Secret', res.data)
 
+    def test_admin_reset_totp_success(self):
+        self._login_admin()
+        old_totp = self.user.totp
+
+        res = self.client.post(url_for('admin_reset_two_factor_totp'),
+                               data=dict(uid=1))
+        new_totp = self.user.totp
+
+        self.assertNotEqual(old_totp, new_totp)
+
+        self.assert_redirects(res, url_for('admin_new_user_two_factor', uid=1))
+
     def test_admin_authorization_for_gets(self):
         admin_urls = [url_for('admin_index'), url_for('admin_add_user'),
             url_for('admin_edit_user', user_id=1)]

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -4,7 +4,6 @@ import os
 from cStringIO import StringIO
 import unittest
 import zipfile
-
 import mock
 
 from flask import url_for
@@ -160,6 +159,19 @@ class TestJournalist(TestCase):
                                          password='valid',
                                          password_again='valid'))
         self.assertIn('Password successfully changed', res.data)
+
+    def test_admin_edits_user_password_dont_match(self):
+        self._login_admin()
+
+        res = self.client.post(url_for('admin_edit_user',
+                                       user_id=1),
+                               data=dict(username='foo',
+                                         is_admin=False,
+                                         password='not',
+                                         password_again='thesame'))
+
+        self.assert_redirects(res, url_for('admin_edit_user',
+                                           user_id=1))
 
     def test_admin_authorization_for_gets(self):
         admin_urls = [url_for('admin_index'), url_for('admin_add_user'),

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -211,19 +211,24 @@ class TestJournalist(TestCase):
         self._login_admin()
         old_hotp = self.user.hotp.secret
 
-        res = self.client.post(url_for('admin_reset_two_factor_hotp'),
-                               data=dict(uid=1, otp_secret=123456))
+        res = self.client.post(
+            url_for('admin_reset_two_factor_hotp'),
+            data=dict(uid=self.user.id, otp_secret=123456)
+            )
 
         new_hotp = self.user.hotp.secret
 
         self.assertNotEqual(old_hotp, new_hotp)
 
-        self.assert_redirects(res, url_for('admin_new_user_two_factor', uid=1))
+        self.assert_redirects(res,
+            url_for('admin_new_user_two_factor', uid=self.user.id))
 
     def test_admin_reset_hotp_empty(self):
         self._login_admin()
-        res = self.client.post(url_for('admin_reset_two_factor_hotp'),
-                               data=dict(uid=1))
+        res = self.client.post(
+            url_for('admin_reset_two_factor_hotp'),
+            data=dict(uid=self.user.id)
+            )
 
         self.assertIn('Change Secret', res.data)
 
@@ -231,26 +236,33 @@ class TestJournalist(TestCase):
         self._login_admin()
         old_totp = self.user.totp
 
-        res = self.client.post(url_for('admin_reset_two_factor_totp'),
-                               data=dict(uid=1))
+        res = self.client.post(
+            url_for('admin_reset_two_factor_totp'),
+            data=dict(uid=self.user.id)
+            )
         new_totp = self.user.totp
 
         self.assertNotEqual(old_totp, new_totp)
 
-        self.assert_redirects(res, url_for('admin_new_user_two_factor', uid=1))
+        self.assert_redirects(res,
+            url_for('admin_new_user_two_factor', uid=self.user.id))
 
     def test_admin_new_user_2fa_success(self):
         self._login_admin()
 
-        res = self.client.post(url_for('admin_new_user_two_factor', uid=1),
-                               data=dict(token=self.user.totp.now()))
+        res = self.client.post(
+            url_for('admin_new_user_two_factor', uid=self.user.id),
+            data=dict(token=self.user.totp.now())
+            )
 
         self.assert_redirects(res, url_for('admin_index'))
 
     def test_admin_new_user_2fa_get_req(self):
         self._login_admin()
 
-        res = self.client.get(url_for('admin_new_user_two_factor', uid=1))
+        res = self.client.get(
+            url_for('admin_new_user_two_factor', uid=self.user.id)
+            )
 
         # any GET req should take a user to the admin_new_user_two_factor page
         self.assertIn('Authenticator', res.data)
@@ -266,33 +278,33 @@ class TestJournalist(TestCase):
     def test_admin_add_user_success(self):
         self._login_admin()
 
-        res = self.client.post(url_for('admin_add_user'),
-                               data=dict(username='dellsberg',
-                                         password='pentagonpapers',
-                                         password_again='pentagonpapers',
-                                         is_admin=False))
+        res = self.client.post(
+            url_for('admin_add_user'),
+            data=dict(username='dellsberg',
+                      password='pentagonpapers',
+                      password_again='pentagonpapers',
+                      is_admin=False)
+            )
 
         self.assert_redirects(res, url_for('admin_new_user_two_factor', uid=3))
 
     def test_admin_add_user_failure_no_username(self):
         self._login_admin()
 
-        res = self.client.post(url_for('admin_add_user'),
-                               data=dict(username='',
-                                         password='pentagonpapers',
-                                         password_again='pentagonpapers',
-                                         is_admin=False))
+        res = self.client.post(
+            url_for('admin_add_user'),
+            data=dict(username='', password='pentagonpapers',
+                      password_again='pentagonpapers', is_admin=False))
 
         self.assertIn('Missing username', res.data)
 
     def test_admin_add_user_failure_passwords_dont_match(self):
         self._login_admin()
 
-        res = self.client.post(url_for('admin_add_user'),
-                               data=dict(username='dellsberg',
-                                         password='not',
-                                         password_again='thesame',
-                                         is_admin=False))
+        res = self.client.post(
+            url_for('admin_add_user'),
+            data=dict(username='dellsberg', password='not',
+                      password_again='thesame', is_admin=False))
 
         self.assertIn('Passwords didn', res.data)
 
@@ -300,17 +312,16 @@ class TestJournalist(TestCase):
         self._login_admin()
 
         overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
-        res = self.client.post(url_for('admin_add_user'),
-                               data=dict(username='dellsberg',
-                                         password=overly_long_password,
-                                         password_again=overly_long_password,
-                                         is_admin=False))
+        res = self.client.post(
+            url_for('admin_add_user'),
+            data=dict(username='dellsberg', password=overly_long_password,
+                      password_again=overly_long_password, is_admin=False))
 
         self.assertIn('password is too long', res.data)
 
     def test_admin_authorization_for_gets(self):
         admin_urls = [url_for('admin_index'), url_for('admin_add_user'),
-            url_for('admin_edit_user', user_id=1)]
+            url_for('admin_edit_user', user_id=self.user.id)]
 
         self._login_user()
         for admin_url in admin_urls:
@@ -319,10 +330,13 @@ class TestJournalist(TestCase):
 
     def test_admin_authorization_for_posts(self):
         admin_urls = [url_for('admin_reset_two_factor_totp'),
-            url_for('admin_reset_two_factor_hotp'), url_for('admin_add_user', user_id=1),
-            url_for('admin_new_user_two_factor'), url_for('admin_reset_two_factor_totp'),
-            url_for('admin_reset_two_factor_hotp'), url_for('admin_edit_user', user_id=1),
-            url_for('admin_delete_user', user_id=1)]
+            url_for('admin_reset_two_factor_hotp'),
+            url_for('admin_add_user', user_id=self.user.id),
+            url_for('admin_new_user_two_factor'),
+            url_for('admin_reset_two_factor_totp'),
+            url_for('admin_reset_two_factor_hotp'),
+            url_for('admin_edit_user', user_id=self.user.id),
+            url_for('admin_delete_user', user_id=self.user.id)]
         self._login_user()
         for admin_url in admin_urls:
             res = self.client.post(admin_url)
@@ -340,7 +354,8 @@ class TestJournalist(TestCase):
         urls = [url_for('add_star', sid='1'), url_for('remove_star', sid='1'),
                 url_for('col_process'), url_for('col_delete_single', sid='1'),
                 url_for('reply'), url_for('generate_code'), url_for('bulk'),
-                url_for('account_new_two_factor'), url_for('account_reset_two_factor_totp'),
+                url_for('account_new_two_factor'),
+                url_for('account_reset_two_factor_totp'),
                 url_for('account_reset_two_factor_hotp')]
         for url in urls:
             res = self.client.post(url)
@@ -385,8 +400,10 @@ class TestJournalist(TestCase):
         self._login_user()
         oldHotp = self.user.hotp
 
-        res = self.client.post(url_for('account_reset_two_factor_hotp'), data=dict(
-            otp_secret=123456))
+        res = self.client.post(
+            url_for('account_reset_two_factor_hotp'),
+            data=dict(otp_secret=123456)
+            )
         newHotp = self.user.hotp
 
         # check that hotp is different

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -418,6 +418,17 @@ class TestJournalist(TestCase):
                     username="My Password is Too Big!",
                     password=overly_long_password)
 
+    def test_add_star(self):
+        self._login_user()
+
+        sid = 'EQZGCJBRGISGOTC2NZVWG6LILJBHEV3CINNEWSCLLFTUWZJPKJFECLS2NZ4G4U3QOZCFKTTPNZMVIWDCJBBHMUDBGFHXCQ3R'
+        source = Source(sid, crypto_util.display_id())
+        db_session.add(source)
+        db_session.commit()
+
+        res = self.client.post(url_for('add_star', sid=sid))
+        self.assert_redirects(res, url_for('index'))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -121,6 +121,16 @@ class TestJournalist(TestCase):
             token=self.admin_user.totp.now()),
             follow_redirects=True)
 
+    def test_user_logout(self):
+        self._login_user()
+        res = self.client.get(url_for('logout'))
+        self.assert_redirects(res, url_for('index'))
+
+    def test_admin_logout(self):
+        self._login_admin()
+        res = self.client.get(url_for('logout'))
+        self.assert_redirects(res, url_for('index'))
+
     def test_admin_index(self):
         self._login_admin()
         res = self.client.get(url_for('admin_index'))

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -369,7 +369,7 @@ class TestJournalist(TestCase):
 
         # check that totp is different
         self.assertNotEqual(oldTotp, newTotp)
-        
+
         # should redirect to verification page
         self.assert_redirects(res, url_for('account_new_two_factor'))
 
@@ -381,7 +381,7 @@ class TestJournalist(TestCase):
             otp_secret=123456))
         newHotp = self.user.hotp
 
-        # check that hotp is different 
+        # check that hotp is different
         self.assertNotEqual(oldHotp, newHotp)
 
         # should redirect to verification page

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -6,8 +6,8 @@ import unittest
 import zipfile
 import mock
 
-from flask import url_for
 from flask_testing import TestCase
+from flask import url_for, escape
 
 import crypto_util
 import journalist
@@ -139,15 +139,24 @@ class TestJournalist(TestCase):
     def test_admin_delete_user(self):
         self._login_admin()
 
-        user_id = 1  # journalist foo
-        user = Journalist.query.get(user_id)
-        res = self.client.post(url_for('admin_delete_user',
-                                       user_id=user_id))
-        self.assert_redirects(res, url_for('admin_index'))
+        res = self.client.post(
+            url_for('admin_delete_user', user_id=self.user.id),
+            follow_redirects=True)
+        self.assert200(res)
+        self.assertIn(escape("Deleted user '{}'".format(self.user.username)),
+                      res.data)
 
         # verify journalist foo is no longer in the database
-        user = Journalist.query.get(user_id)
+        user = Journalist.query.get(self.user.id)
         self.assertEqual(user, None)
+
+    def test_admin_delete_invalid_user(self):
+        self._login_admin()
+
+        invalid_user_pk = max([user.id for user in Journalist.query.all()]) + 1
+        res = self.client.post(url_for('admin_delete_user',
+                                       user_id=invalid_user_pk))
+        self.assert404(res)
 
     def test_admin_edits_user_password_valid(self):
         self._login_admin()

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -199,6 +199,19 @@ class TestJournalist(TestCase):
 
         self.assertIn('An unknown error occurred', res.data)
 
+    def test_admin_reset_hotp_success(self):
+        self._login_admin()
+        old_hotp = self.user.hotp.secret
+
+        res = self.client.post(url_for('admin_reset_two_factor_hotp'),
+                               data=dict(uid=1, otp_secret=123456))
+
+        new_hotp = self.user.hotp.secret
+
+        self.assertNotEqual(old_hotp, new_hotp)
+
+        self.assert_redirects(res, url_for('admin_new_user_two_factor', uid=1))
+
     def test_admin_authorization_for_gets(self):
         admin_urls = [url_for('admin_index'), url_for('admin_add_user'),
             url_for('admin_edit_user', user_id=1)]

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -161,40 +161,36 @@ class TestJournalist(TestCase):
     def test_admin_edits_user_password_valid(self):
         self._login_admin()
 
-        res = self.client.post(url_for('admin_edit_user',
-                                       user_id=1),
-                               data=dict(username='foo',
-                                         is_admin=False,
-                                         password='valid',
-                                         password_again='valid'))
+        res = self.client.post(
+            url_for('admin_edit_user', user_id=self.user.id),
+            data=dict(username='foo', is_admin=False,
+                      password='valid', password_again='valid'))
+
         self.assertIn('Password successfully changed', res.data)
 
     def test_admin_edits_user_password_dont_match(self):
         self._login_admin()
 
-        res = self.client.post(url_for('admin_edit_user',
-                                       user_id=1),
-                               data=dict(username='foo',
-                                         is_admin=False,
-                                         password='not',
-                                         password_again='thesame'))
+        res = self.client.post(
+            url_for('admin_edit_user', user_id=self.user.id),
+            data=dict(username='foo', is_admin=False, password='not',
+                      password_again='thesame'),
+            follow_redirects=True)
 
-        self.assert_redirects(res, url_for('admin_edit_user',
-                                           user_id=1))
+        self.assertIn(escape("Passwords didn't match"), res.data)
 
     def test_admin_edits_user_password_too_long(self):
         self._login_admin()
         overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
 
-        res = self.client.post(url_for('admin_edit_user',
-                                       user_id=1),
-                               data=dict(username='foo',
-                                         is_admin=False,
-                                         password=overly_long_password,
-                                         password_again=overly_long_password))
+        res = self.client.post(
+            url_for('admin_edit_user', user_id=self.user.id),
+            data=dict(username='foo', is_admin=False,
+                      password=overly_long_password,
+                      password_again=overly_long_password),
+            follow_redirects=True)
 
-        self.assert_redirects(res, url_for('admin_edit_user',
-                                           user_id=1))
+        self.assertIn('Your password is too long', res.data)
 
     def test_admin_edits_user_invalid_username(self):
         """Test expected error message when admin attempts to change a user's

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -212,6 +212,13 @@ class TestJournalist(TestCase):
 
         self.assert_redirects(res, url_for('admin_new_user_two_factor', uid=1))
 
+    def test_admin_reset_hotp_empty(self):
+        self._login_admin()
+        res = self.client.post(url_for('admin_reset_two_factor_hotp'),
+                               data=dict(uid=1))
+
+        self.assertIn('Change Secret', res.data)
+
     def test_admin_authorization_for_gets(self):
         admin_urls = [url_for('admin_index'), url_for('admin_add_user'),
             url_for('admin_edit_user', user_id=1)]

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -181,7 +181,15 @@ class TestJournalist(TestCase):
             password='not',
             password_again='thesame'))
         self.assert_redirects(res, url_for('edit_account'))
-        
+
+    def test_too_long_user_password_change(self):
+        self._login_user()
+        overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
+        res = self.client.post(url_for('edit_account'), data=dict(
+            password=overly_long_password,
+            password_again=overly_long_password))
+        self.assert_redirects(res, url_for('edit_account'))
+
     def test_valid_user_password_change(self):
         self._login_user()
         res = self.client.post(url_for('edit_account'), data=dict(

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -137,6 +137,30 @@ class TestJournalist(TestCase):
         self.assert200(res)
         self.assertIn("Admin Interface", res.data)
 
+    def test_admin_delete_user(self):
+        self._login_admin()
+
+        user_id = 1  # journalist foo
+        user = Journalist.query.get(user_id)
+        res = self.client.post(url_for('admin_delete_user',
+                                       user_id=user_id))
+        self.assert_redirects(res, url_for('admin_index'))
+
+        # verify journalist foo is no longer in the database
+        user = Journalist.query.get(user_id)
+        self.assertEqual(user, None)
+
+    def test_admin_edits_user_password_valid(self):
+        self._login_admin()
+
+        res = self.client.post(url_for('admin_edit_user',
+                                       user_id=1),
+                               data=dict(username='foo',
+                                         is_admin=False,
+                                         password='valid',
+                                         password_again='valid'))
+        self.assertIn('Password successfully changed', res.data)
+
     def test_admin_authorization_for_gets(self):
         admin_urls = [url_for('admin_index'), url_for('admin_add_user'),
             url_for('admin_edit_user', user_id=1)]

--- a/securedrop/tests/test_unit_store.py
+++ b/securedrop/tests/test_unit_store.py
@@ -47,6 +47,22 @@ class TestStore(unittest.TestCase):
             zipped_file_content = archive.read(archived_file)
             self.assertEquals(zipped_file_content, actual_file_content)
 
+    def test_rename_valid_submission(self):
+        sid = 'EQZGCJBRGISGOTC2NZVWG6LILJBHEV3CINNEWSCLLFTUWZJPKJFECLS2NZ4G4U3QOZCFKTTPNZMVIWDCJBBHMUDBGFHXCQ3R'
+
+        source_dir = os.path.join('/tmp/securedrop/store/', sid)
+        if not os.path.exists(source_dir):
+            os.makedirs(source_dir)
+
+        old_filename = '1-abc1-msg.gpg'
+        with open(os.path.join(source_dir, old_filename), 'w'):
+            pass
+
+        new_filestem = 'abc2'
+        expected_filename = '1-abc2-msg.gpg'
+        actual_filename = store.rename_submission(sid, old_filename,
+                                                  new_filestem)
+        self.assertEquals(actual_filename, expected_filename)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/securedrop/tests/test_unit_template_filters.py
+++ b/securedrop/tests/test_unit_template_filters.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from datetime import datetime, timedelta
+import os
+import unittest
+
+import template_filters
+
+# Set environment variable so config.py uses a test environment
+os.environ['SECUREDROP_ENV'] = 'test'
+
+
+class TestTemplateFilters(unittest.TestCase):
+
+    def test_relative_timestamp_seconds(self):
+        test_time = datetime.utcnow() - timedelta(seconds=5)
+        result = template_filters._relative_timestamp(test_time)
+        self.assertIn("seconds", result)
+
+    def test_relative_timestamp_one_minute(self):
+        test_time = datetime.utcnow() - timedelta(minutes=1)
+        result = template_filters._relative_timestamp(test_time)
+        self.assertEquals("a minute", result)
+
+    def test_relative_timestamp_minutes(self):
+        test_time = datetime.utcnow() - timedelta(minutes=10)
+        result = template_filters._relative_timestamp(test_time)
+        self.assertEquals("10 minutes", result)
+
+    def test_relative_timestamp_one_hour(self):
+        test_time = datetime.utcnow() - timedelta(hours=1)
+        result = template_filters._relative_timestamp(test_time)
+        self.assertEquals("an hour", result)
+
+    def test_relative_timestamp_hours(self):
+        test_time = datetime.utcnow() - timedelta(hours=10)
+        result = template_filters._relative_timestamp(test_time)
+        self.assertEquals("10 hours", result)
+
+    def test_relative_timestamp_one_day(self):
+        test_time = datetime.utcnow() - timedelta(days=1)
+        result = template_filters._relative_timestamp(test_time)
+        self.assertEquals("a day", result)
+
+    def test_relative_timestamp_days(self):
+        test_time = datetime.utcnow() - timedelta(days=4)
+        result = template_filters._relative_timestamp(test_time)
+        self.assertEquals("4 days", result)
+
+    def test_relative_timestamp_none(self):
+        test_time = datetime.utcnow() - timedelta(days=999)
+        result = template_filters._relative_timestamp(test_time)
+        self.assertEquals(None, result)

--- a/securedrop/tests/test_unit_template_filters.py
+++ b/securedrop/tests/test_unit_template_filters.py
@@ -12,6 +12,15 @@ os.environ['SECUREDROP_ENV'] = 'test'
 
 class TestTemplateFilters(unittest.TestCase):
 
+    def test_datetimeformat_default_fmt(self):
+        result = template_filters.datetimeformat(datetime(2016, 1, 1, 1, 1, 1))
+        self.assertEquals("Jan 01, 2016 01:01 AM", result)
+
+    def test_datetimeformat_unusual_fmt(self):
+        result = template_filters.datetimeformat(datetime(2016, 1, 1, 1, 1, 1),
+                                                 fmt="%b %d %Y")
+        self.assertEquals("Jan 01 2016", result)
+
     def test_relative_timestamp_seconds(self):
         test_time = datetime.utcnow() - timedelta(seconds=5)
         result = template_filters._relative_timestamp(test_time)


### PR DESCRIPTION
This PR adds some more unit tests for the securedrop app code mostly for the admin interface which was an old "TODO" in the code (seen in the diff below). There are new tests for the functionality in `store.py`, `journalist.py` and `template_filters.py`. 
