### PR TITLE
Update Flask-Assets import statement; old syntax deprecated

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -7,7 +7,7 @@ import functools
 from flask import (Flask, request, render_template, send_file, redirect, flash,
                    url_for, g, abort, session)
 from flask_wtf.csrf import CsrfProtect
-from flask.ext.assets import Environment
+from flask_assets import Environment
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.exc import IntegrityError
 

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -11,7 +11,7 @@ import operator
 from flask import (Flask, request, render_template, session, redirect, url_for,
                    flash, abort, g, send_file)
 from flask_wtf.csrf import CsrfProtect
-from flask.ext.assets import Environment
+from flask_assets import Environment
 
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.exc import IntegrityError


### PR DESCRIPTION
Importing `flask.ext.assets` has been deprecated in favor of `flask_assets`.