### PR TITLE
Replace deprecated remaining flask.ext.* syntax cases

### DIFF
--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -8,7 +8,7 @@ import zipfile
 import mock
 
 from flask import url_for
-from flask.ext.testing import TestCase
+from flask_testing import TestCase
 
 import crypto_util
 import journalist

--- a/securedrop/tests/test_unit_source.py
+++ b/securedrop/tests/test_unit_source.py
@@ -7,7 +7,7 @@ import unittest
 from cStringIO import StringIO
 
 from bs4 import BeautifulSoup
-from flask.ext.testing import TestCase
+from flask_testing import TestCase
 from flask import session, escape
 from mock import patch, ANY
 import source


### PR DESCRIPTION
The old flask.ext.* syntax has been deprecated for Flask extensions. In
https://github.com/freedomofpress/securedrop/pull/1421/files
(e211107d6f324eef41157a0828ad41476333a8c1) this change was made for Flask
Assets. I ran `ag 'flask.ext' securedrop/` to find these two as the only
remaining cases of using the old syntax.