### PR TITLE
More convenient update version script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -134,7 +134,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define 'build', autostart: false do |build|
-    build.vm.box = "build"
+    build.vm.hostname = "build"
     build.vm.box = "bento/ubuntu-14.04"
     build.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/build-deb-pkgs.yml"

--- a/install_files/ansible-base/build-deb-pkgs.yml
+++ b/install_files/ansible-base/build-deb-pkgs.yml
@@ -34,6 +34,15 @@
     - group_vars/securedrop.yml
     - group_vars/securedrop_application_server.yml
     - group_vars/development.yml
+  pre_tasks:
+    # These packages are necessary for running the `update_version.sh` script.
+    - name: Install required build tools.
+      apt:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - devscripts
+        - git
   roles:
     - { role: build-securedrop-app-code-deb-pkg, tags: [ "app-deb" ] }
     - { role: build-generic-pkg, tags: ["securedrop-ossec-server"], package_name: "securedrop-ossec-server" }

--- a/testinfra/build/test_build_dependencies.py
+++ b/testinfra/build/test_build_dependencies.py
@@ -25,6 +25,8 @@ build_directories = get_build_directories()
 
 
 @pytest.mark.parametrize("package", [
+    "devscripts",
+    "git",
     "libssl-dev",
     "python-dev",
     "python-pip",
@@ -32,6 +34,9 @@ build_directories = get_build_directories()
 def test_build_dependencies(Package, package):
     """
     Ensure development apt dependencies are installed.
+    The devscripts and git packages are required for running the
+    `update_version.sh` script, which should be executed inside the
+    build VM, so let's make sure they're present.
     """
     assert Package(package).is_installed
 
@@ -65,5 +70,6 @@ def test_build_directories(File, directory):
     if '{}' in directory:
         directory = directory.format(securedrop_test_vars.securedrop_version)
     assert File(directory).is_directory
+
 
 

--- a/update_version.sh
+++ b/update_version.sh
@@ -6,18 +6,23 @@ set -e
 
 # Only run this on the Vagrant build VM, with dch and git available
 if [[ "$(whoami)" != 'vagrant' ]]; then
-  echo 'Only run this on the Vagrant build VM'
+  echo 'Only run this on the Vagrant build VM!'
   exit 1
 fi
 
-sudo apt-get install devscripts git -qq
+# Since we're running in a VM, we won't have access to ~/.gitconfig. So the
+# repo-level git user config file must be set.
+$(grep -q '^\[user\]' /vagrant/.git/config) || echo 'Please set your git' \
+	'user config in /vagrant/.git/config and retry!'
 
-NEW_VERSION=$1
+readonly NEW_VERSION=$1
 
 if [ -z "$NEW_VERSION" ]; then
   echo "You must specify the new version!"
   exit 1
 fi
+
+sudo apt-get install devscripts git -qq
 
 # Get the old version from securedrop/version.py
 old_version_regex="^__version__ = '(.*)'$"

--- a/update_version.sh
+++ b/update_version.sh
@@ -2,17 +2,15 @@
 ## Usage: ./update_version.sh <version>
 
 # Only run this on the Vagrant build VM, with dch and git available
-command -v dch > /dev/null
-dch_installed=$?
-command -v git > /dev/null
-git_installed=$?
-if [ $dch_installed -ne 0 ] || [ $git_installed -ne 0 ]; then
-  echo "You must run this on a system with dch and git available (in order to edit the Debian package changelog and commit message)"
-  echo "If you are on Debian/Ubuntu, apt-get install devscripts git"
+set -e
+
+# Only run this on the Vagrant build VM, with dch and git available
+if [[ "$(whoami)" != 'vagrant' ]]; then
+  echo 'Only run this on the Vagrant build VM'
   exit 1
 fi
 
-set -e
+sudo apt-get install devscripts git -qq
 
 NEW_VERSION=$1
 

--- a/update_version.sh
+++ b/update_version.sh
@@ -41,7 +41,8 @@ sed -i "s/$OLD_VERSION/$NEW_VERSION/" docs/set_up_admin_tails.rst
 sed -i "s/$OLD_VERSION/$NEW_VERSION/" docs/conf.py
 
 # Update the changelog
-vi changelog.md
+sed -i 's/\(## '$OLD_VERSION'\)/## '$NEW_VERSION'\n\n\n\n\1/g' changelog.md
+vim +5 changelog.md
 
 export DEBEMAIL="${DEBEMAIL:-securedrop@freedom.press}"
 export DEBFULLNAME="${DEBFULLNAME:-SecureDrop Team}"

--- a/update_version.sh
+++ b/update_version.sh
@@ -24,8 +24,6 @@ if [ -z "$NEW_VERSION" ]; then
   exit 1
 fi
 
-sudo apt-get install devscripts git -qq
-
 # Get the old version from securedrop/version.py
 old_version_regex="^__version__ = '(.*)'$"
 [[ `cat securedrop/version.py` =~ $old_version_regex ]]

--- a/update_version.sh
+++ b/update_version.sh
@@ -12,8 +12,10 @@ fi
 
 # Since we're running in a VM, we won't have access to ~/.gitconfig. So the
 # repo-level git user config file must be set.
-$(grep -q '^\[user\]' /vagrant/.git/config) || echo 'Please set your git' \
-	'user config in /vagrant/.git/config and retry!'
+if ! grep -q '^\[user\]' /vagrant/.git/config; then
+    echo 'Please set your git user config in /vagrant/.git/config and retry!'
+    exit 1
+fi
 
 readonly NEW_VERSION=$1
 

--- a/update_version.sh
+++ b/update_version.sh
@@ -5,7 +5,7 @@
 set -e
 
 # Only run this on the Vagrant build VM, with dch and git available
-if [[ "$(whoami)" != 'vagrant' ]]; then
+if [[ "$USER" != 'vagrant' || "$(hostname)" != 'build' ]]; then
   echo 'Only run this on the Vagrant build VM!'
   exit 1
 fi


### PR DESCRIPTION
- Exits if we aren't running as Vagrant.
- Consequently, allows us to simplify package installation logic a bit because we know we're in Ubuntu.
- Puts the header for the current version in `CHANGELOG.md` for us, drops us in the line we want to start writing from, and uses vim instead of vi.
