### PR TITLE
Remove never used crypto_util.get_key_by_fingerprint fxn

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -139,13 +139,6 @@ def getkey(name):
     return None
 
 
-def get_key_by_fingerprint(fingerprint):
-    matches = filter(
-        lambda k: k['fingerprint'] == fingerprint,
-        gpg.list_keys())
-    return matches[0] if matches else None
-
-
 def encrypt(plaintext, fingerprints, output=None):
     # Verify the output path
     if output:


### PR DESCRIPTION
This function was added in
https://github.com/freedomofpress/securedrop/pull/177/commits/254ddf07dffda90775af37624540eed7c139301c,
but was not needed or actually used to implement the functionality described in
that PR--namely, the ability to download the JOURNALIST_KEY (i.e., the SVS
public key).

I confirmed it was not used anywhere with `ag`, and confirmed it had never been used anywhere with the git pickaxe ( `g log -p -S get_key`).