### PR TITLE
Ansible syntax update

### DIFF
--- a/install_files/ansible-base/build-deb-pkgs.yml
+++ b/install_files/ansible-base/build-deb-pkgs.yml
@@ -4,4 +4,4 @@
     - { role: build-securedrop-app-code-deb-pkg, tags: [ "app-deb" ] }
     - { role: build-generic-pkg, tags: ["securedrop-ossec-server"], package_name: "securedrop-ossec-server" }
     - { role: build-generic-pkg, tags: ["securedrop-ossec-agent"], package_name: "securedrop-ossec-agent" }
-  sudo: yes
+  become: yes

--- a/install_files/ansible-base/roles/app-test/tasks/apparmor_complain.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/apparmor_complain.yml
@@ -46,4 +46,4 @@
   # Doing it this way keeps the config DRY and will work with future profiles as well.
   when: >
     "/{{ item | regex_replace('\\.', '/') }}" not in apparmor_complaining_profiles_result.stdout_lines
-  with_items: apparmor_profiles
+  with_items: "{{ apparmor_profiles }}"

--- a/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
@@ -9,7 +9,7 @@
   apt:
     name: "{{ item }}"
     state: latest
-  with_items: test_apt_dependencies
+  with_items: "{{ test_apt_dependencies }}"
   tags:
     - apt
 

--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -17,11 +17,12 @@
 - name: Import the SecureDrop Application GPG public key to the Application Server keyring.
   # multiline format for command module, since this is a long command
   command: >
-    su -s /bin/bash -c 'gpg
+    /bin/bash -c 'gpg
     --homedir {{ securedrop_data }}/keys
     --import {{ securedrop_data }}/{{ securedrop_app_gpg_public_key }}' {{ securedrop_user }}
   register: gpg_app_key_import
   changed_when: "'imported: 1' in gpg_app_key_import.stderr"
+  become: yes
   tags:
     - gpg
     - securedrop_config

--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -3,7 +3,7 @@
   apt:
     pkg: "{{ item }}"
     state: latest
-  with_items: appserver_dependencies
+  with_items: "{{ appserver_dependencies }}"
   tags:
     - apt
 

--- a/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
+++ b/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
@@ -5,7 +5,7 @@
     state: latest
     update_cache: yes
     cache_valid_time: 3600
-  with_items: apache_packages
+  with_items: "{{ apache_packages }}"
   tags:
     - apt
     - apache
@@ -16,7 +16,7 @@
     dest: /etc/apache2/{{ item }}
     owner: root
     mode: '0644'
-  with_items: apache_files
+  with_items: "{{ apache_files }}"
   tags:
     - apache
 
@@ -26,7 +26,7 @@
     dest: /etc/apache2/{{ item }}
     owner: root
     mode: '0644'
-  with_items: apache_templates
+  with_items: "{{ apache_templates }}"
   tags:
     - apache
 
@@ -34,7 +34,7 @@
   apache2_module:
     state: present
     name: "{{ item }}"
-  with_items: apache_modules
+  with_items: "{{ apache_modules }}"
   tags:
     - apache
 
@@ -42,7 +42,7 @@
   apache2_module:
     state: absent
     name: "{{ item }}"
-  with_items: apache_disabled_modules
+  with_items: "{{ apache_disabled_modules }}"
   tags:
     - apache
     - hardening

--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/build_securedrop_app_code_deb.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/build_securedrop_app_code_deb.yml
@@ -3,7 +3,7 @@
   apt:
     pkg: "{{ item }}"
     state: latest
-  with_items: development_dependencies
+  with_items: "{{ development_dependencies }}"
   tags:
     - apt
 
@@ -81,7 +81,7 @@
   copy:
     src: "{{ item }}"
     dest: /tmp/{{ securedrop_app_code_deb }}/etc/apparmor.d/{{ item }}
-  with_items: apparmor_profiles
+  with_items: "{{ apparmor_profiles }}"
   tags:
     - build
     - apparmor

--- a/install_files/ansible-base/roles/common/tasks/create_users.yml
+++ b/install_files/ansible-base/roles/common/tasks/create_users.yml
@@ -18,7 +18,7 @@
     name: "{{ item }}"
     shell: /bin/bash
     groups: sudo,ssh
-  with_items: ssh_users
+  with_items: "{{ ssh_users }}"
   tags:
     - users
     - sudoers
@@ -45,7 +45,7 @@
     dest: /home/{{ item }}/.bashrc
     line: '. /etc/bashrc.securedrop_additions'
     state: absent
-  with_items: ssh_users
+  with_items: "{{ ssh_users }}"
   tags:
     - users
     - environment

--- a/install_files/ansible-base/roles/common/tasks/cron_apt.yml
+++ b/install_files/ansible-base/roles/common/tasks/cron_apt.yml
@@ -94,6 +94,6 @@
       state=started
   when: reboot_required.stat.exists
   # Wait action runs on localhost, and does NOT require sudo.
-  sudo: false
+  become: false
   tags:
     - reboot

--- a/install_files/ansible-base/roles/common/tasks/remove_kernel_modules.yml
+++ b/install_files/ansible-base/roles/common/tasks/remove_kernel_modules.yml
@@ -3,7 +3,7 @@
   modprobe:
     name: "{{ item }}"
     state: absent
-  with_items: disabled_kernel_modules
+  with_items: "{{ disabled_kernel_modules }}"
   tags:
     - kernel
     - hardening
@@ -13,7 +13,7 @@
     dest: /etc/modprobe.d/blacklist.conf
     line: "blacklist {{ item }}"
     insertafter: EOF
-  with_items: disabled_kernel_modules
+  with_items: "{{ disabled_kernel_modules }}"
   tags:
     - kernel
     - hardening

--- a/install_files/ansible-base/roles/common/tasks/setup_etc_hosts.yml
+++ b/install_files/ansible-base/roles/common/tasks/setup_etc_hosts.yml
@@ -32,7 +32,7 @@
     regexp: "{{ item.hostname }}"
     line: "{{ item.ip }}  {{ item.hostname }}"
     backup: yes
-  with_items: ip_info
+  with_items: "{{ ip_info }}"
   tags:
     - host_aliases
     - static-hosts

--- a/install_files/ansible-base/roles/common/tasks/sysctl.yml
+++ b/install_files/ansible-base/roles/common/tasks/sysctl.yml
@@ -8,7 +8,7 @@
     sysctl_set: yes
     state: present
     reload: yes
-  with_items: sysctl_flags
+  with_items: "{{ sysctl_flags }}"
   tags:
     - sysctl
     - hardening

--- a/install_files/ansible-base/roles/development/tasks/main.yml
+++ b/install_files/ansible-base/roles/development/tasks/main.yml
@@ -10,7 +10,7 @@
   apt:
     pkg: "{{ item }}"
     state: latest
-  with_items: development_dependencies
+  with_items: "{{ development_dependencies }}"
   tags:
     - apt
     - development

--- a/install_files/ansible-base/roles/grsecurity/tasks/apply_grsec_lock.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/apply_grsec_lock.yml
@@ -43,7 +43,7 @@
     sysctl_set: yes
     state: present
     reload: yes
-  with_items: grsec_sysctl_flags
+  with_items: "{{ grsec_sysctl_flags }}"
   become: yes
   tags:
     - hardening

--- a/install_files/ansible-base/roles/grsecurity/tasks/apply_grsec_lock.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/apply_grsec_lock.yml
@@ -7,7 +7,7 @@
   poll: 0
   ignore_errors: true
   when: not running_grsec.stat.exists
-  sudo: yes
+  become: yes
   tags:
     - reboot
 
@@ -26,13 +26,13 @@
   # Local wait action, doesn't require sudo privileges,
   # `wait_for` essentially means "do nothing for a while."
   # Since the top-level playbook (e.g. securedrop-prod.yml)
-  # sets `sudo: true`, the sudo parameter must be explicitly
+  # sets `become: true`, the sudo parameter must be explicitly
   # overridden on a per-task basis. If sudo remains true
   # for this task, Ansible will prompt for the sudo password
   # of the host machine (i.e. the machine running the playbook)
   # in order to proceed. This would be annoying and is
   # completely unnecessary for a simple wait action.
-  sudo: false
+  become: false
   tags:
     - reboot
 
@@ -44,7 +44,7 @@
     state: present
     reload: yes
   with_items: grsec_sysctl_flags
-  sudo: yes
+  become: yes
   tags:
     - hardening
     - grsec

--- a/install_files/ansible-base/roles/grsecurity/tasks/from_fpf_repo_install_grsec.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/from_fpf_repo_install_grsec.yml
@@ -100,7 +100,7 @@
       port={{ ansible_ssh_port }}
       delay=45
       state=started
-  sudo: false
+  become: false
   when: not running_grsec.stat.exists
   tags:
     - reboot

--- a/install_files/ansible-base/roles/grsecurity/tasks/paxctl.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/paxctl.yml
@@ -21,7 +21,7 @@
 
 - name: Adjust paxctl headers on grub binaries.
   command: paxctl -Cpm {{ item.item }}
-  with_items: paxctl_grub_header_check.results
+  with_items: "{{ paxctl_grub_header_check.results }}"
   # The desired flags should include:
   #   - p NOPAGEEXEC
   #   - m NOMPROTECT

--- a/install_files/ansible-base/roles/install-fpf-repo/tasks/main.yml
+++ b/install_files/ansible-base/roles/install-fpf-repo/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install FPF apt repo GPG signing key.
+- name: Install SecureDrop apt repo GPG signing key.
   apt_key:
     state: present
     data: "{{ lookup('file', 'fpf-signing-key.pub') }}"

--- a/install_files/ansible-base/roles/install-local-packages/tasks/main.yml
+++ b/install_files/ansible-base/roles/install-local-packages/tasks/main.yml
@@ -6,7 +6,7 @@
   copy:
     src: ../../build/{{ item }}
     dest: /root/
-  with_items: local_deb_packages
+  with_items: "{{ local_deb_packages }}"
 
 # There's a known bug in Ansible that causes installing
 # .deb packages via the apt module to fail when invoked

--- a/install_files/ansible-base/roles/manage-groups/tasks/main.yml
+++ b/install_files/ansible-base/roles/manage-groups/tasks/main.yml
@@ -8,14 +8,14 @@
     name: "{{ item }}"
     groups: securedrop,securedrop_application_server
   when: item.startswith('app')
-  with_items: play_hosts
+  with_items: "{{ play_hosts }}"
 
 - name: Configure role list for SecureDrop Monitor Server.
   add_host:
     name: "{{ item }}"
     groups: securedrop,securedrop_monitor_server
   when: item.startswith('mon')
-  with_items: play_hosts
+  with_items: "{{ play_hosts }}"
 
 # Failsafe to ensure that dynamic group population worked as expected.
 # Since we're adding the "app" and "mon" production hosts via the above

--- a/install_files/ansible-base/roles/ossec-agent/tasks/agent_config.yml
+++ b/install_files/ansible-base/roles/ossec-agent/tasks/agent_config.yml
@@ -22,7 +22,7 @@
     regexp: "{{ item }}"
     line: "{{ item }}"
   notify: reload iptables rules
-  with_items: agent_auth_rules
+  with_items: "{{ agent_auth_rules }}"
   when: hostvars[groups.securedrop_monitor_server.0].ossec_agent_already_registered == false and
         iptables_rules_check_result.stat.exists == true
   tags:
@@ -49,7 +49,7 @@
   notify:
     - reload iptables rules
     - restart ossec
-  with_items: agent_auth_rules
+  with_items: "{{ agent_auth_rules }}"
   when: hostvars[groups.securedrop_monitor_server.0].ossec_agent_already_registered == false and
         iptables_rules_check_result.stat.exists == true
   tags:

--- a/install_files/ansible-base/roles/ossec-agent/tasks/cleanup_authd.yml
+++ b/install_files/ansible-base/roles/ossec-agent/tasks/cleanup_authd.yml
@@ -29,7 +29,7 @@
   # It's technically possible that pgrep will return more than one PID.
   # Let's be careful and kill each process, even though in most cases there
   # will be only one, if any.
-  with_items: ossec_authd_running_check.stdout_lines
+  with_items: "{{ ossec_authd_running_check.stdout_lines }}"
   delegate_to: "{{ groups.securedrop_monitor_server.0 }}"
   when: ossec_authd_running_check.rc == 0 and
         ossec_authd_running_check.stdout != ""

--- a/install_files/ansible-base/roles/ossec-server/handlers/main.yml
+++ b/install_files/ansible-base/roles/ossec-server/handlers/main.yml
@@ -7,7 +7,7 @@
     insertafter: "^:LOGNDROP"
     regexp: "{{ item }}"
     line: "{{ item }}"
-  with_items: authd_rules
+  with_items: "{{ authd_rules }}"
 
 - name: reload authd iptables
   shell: iptables-restore < /etc/network/iptables/rules_v4

--- a/install_files/ansible-base/roles/ossec-server/tasks/mon_install_postfix.yml
+++ b/install_files/ansible-base/roles/ossec-server/tasks/mon_install_postfix.yml
@@ -3,7 +3,7 @@
   apt:
     pkg: "{{ item }}"
     state: latest
-  with_items: ossec_postfix_dependencies
+  with_items: "{{ ossec_postfix_dependencies }}"
   tags:
     - apt
     - postfix

--- a/install_files/ansible-base/roles/reboot/tasks/main.yml
+++ b/install_files/ansible-base/roles/reboot/tasks/main.yml
@@ -4,6 +4,6 @@
   async: 0
   poll: 0
   ignore_errors: true
-  sudo: yes
+  become: yes
   tags:
     - reboot

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
@@ -4,7 +4,7 @@
     state: present
     path: "{{ tor_hidden_services_parent_dir }}/{{ item.service }}/hostname"
     delay: 5
-  with_items: tor_instances
+  with_items: "{{ tor_instances }}"
   tags:
     - tor
 
@@ -13,7 +13,7 @@
   register: tor_hidden_service_hostname_lookup
   # Read-only task, so don't report changed.
   changed_when: false
-  with_items: tor_instances
+  with_items: "{{ tor_instances }}"
   tags:
     - tor
     - admin
@@ -25,7 +25,7 @@
     src: ths_config.j2
   # Local action, so we don't want elevated privileges
   become: no
-  with_items: tor_hidden_service_hostname_lookup.results
+  with_items: "{{ tor_hidden_service_hostname_lookup.results }}"
   tags:
     - tor
     - admin

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
@@ -24,7 +24,7 @@
     dest: "{{ role_path }}/../../{{ item.item.filename }}"
     src: ths_config.j2
   # Local action, so we don't want elevated privileges
-  sudo: no
+  become: no
   with_items: tor_hidden_service_hostname_lookup.results
   tags:
     - tor

--- a/install_files/ansible-base/roles/tor-hidden-services/tasks/configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/tasks/configure_tor_hidden_services.yml
@@ -16,7 +16,7 @@
     owner: "{{ tor_user }}"
     group: "{{ tor_user }}"
     mode: '0700'
-  with_items: tor_instances
+  with_items: "{{ tor_instances }}"
   tags:
     - tor
 

--- a/install_files/ansible-base/roles/upgrade/handlers/main.yml
+++ b/install_files/ansible-base/roles/upgrade/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: reload tor for port change
   service: name=tor state=reloaded
-  sudo: yes
+  become: yes

--- a/install_files/ansible-base/roles/upgrade/tasks/0-3pre-upgrade.yml
+++ b/install_files/ansible-base/roles/upgrade/tasks/0-3pre-upgrade.yml
@@ -4,15 +4,15 @@
 - name: stop the apache service prior to upgrade tasks
   service: name=apache2 state=stopped
   when: server_role == 'app'
-  sudo: yes
+  become: yes
 
 - name: copy upgrade script to servers
   copy: src="0.3pre_upgrade.py" dest="/tmp" owner="root" mode="740"
-  sudo: yes
+  become: yes
 
 - name: run the upgrade script
   shell: "/tmp/0.3pre_upgrade.py {{ server_role }}"
-  sudo: yes
+  become: yes
 
 - name: remove old 0.3 packages to avoid version error
   apt: name={{ item }} state=absent
@@ -21,11 +21,11 @@
     - securedrop-grsec
     - securedrop-ossec-agent
     - securedrop-ossec-server
-  sudo: yes
+  become: yes
 
 - name: remove the previous signing key
   apt_key: id=BD67D096 state=absent
-  sudo: yes
+  become: yes
 
   # This will update the App servers torrc config file for changing the
   # document interface tor port from 8080 to 80. As of this release the prod
@@ -46,7 +46,7 @@
     backrefs: yes
     line: 'HiddenServicePort 80 127.0.0.1:8080'
   notify: reload tor for port change
-  sudo: yes
+  become: yes
 
   # If the config changed, reload tor now instead of after all the remaining
   # upgrade tasks are run so the next task can verify
@@ -55,4 +55,4 @@
 
 - name: ensure tor is running
   service: name=tor state=running
-  sudo: yes
+  become: yes

--- a/install_files/ansible-base/securedrop-development.yml
+++ b/install_files/ansible-base/securedrop-development.yml
@@ -5,4 +5,4 @@
     - { role: development, tags: development }
     - { role: app, tags: app }
     - { role: app-test, tags: app-test }
-  sudo: yes
+  become: yes

--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -18,7 +18,7 @@
     - prod-specific.yml
   roles:
     - { role: validate, tags: validate }
-  sudo: yes
+  become: yes
 
 - name: Add FPF apt repository and install base packages.
   hosts: securedrop
@@ -28,7 +28,7 @@
     - { role: common, tags: common }
     - { role: grsecurity, when: grsecurity, tags: [grsec, grsecurity] }
     - { role: tor-hidden-services, tags: tor }
-  sudo: yes
+  become: yes
 
 - name: Configure SecureDrop Monitor Server.
   hosts: securedrop_monitor_server
@@ -36,7 +36,7 @@
     - prod-specific.yml
   roles:
     - { role: ossec-server, tags: [ ossec, ossec_server ] }
-  sudo: yes
+  become: yes
 
 - name: Configure SecureDrop Application Server.
   hosts: securedrop_application_server
@@ -53,7 +53,7 @@
             (restore_file is defined and restore_file != '')
       tags: backup
 
-  sudo: yes
+  become: yes
 
   # This section will put the ssh and iptables rules in place
   # It will then add any staging exemptions required
@@ -67,7 +67,7 @@
     - prod-specific.yml
   roles:
     - { role: restrict-direct-access, tags: [ common, restrict-direct-access ] }
-  sudo: yes
+  become: yes
 
 - name: Reboot Application and Monitor Servers.
   hosts: securedrop
@@ -75,4 +75,4 @@
     - prod-specific.yml
   roles:
     - { role: reboot, tags: reboot }
-  sudo: yes
+  become: yes

--- a/install_files/ansible-base/securedrop-snapci.yml
+++ b/install_files/ansible-base/securedrop-snapci.yml
@@ -3,4 +3,4 @@
   hosts: snapci
   roles:
     - { role: snapci, tags: snapci }
-  sudo: yes
+  become: yes

--- a/install_files/ansible-base/securedrop-staging.yml
+++ b/install_files/ansible-base/securedrop-staging.yml
@@ -7,13 +7,13 @@
     - { role: install-local-packages, tags: install_local_packages,
         when: install_local_packages }
     - { role: tor-hidden-services, tags: tor }
-  sudo: yes
+  become: yes
 
 - name: Configure OSSEC manager.
   hosts: mon-staging
   roles:
     - { role: ossec-server, tags: [ ossec, ossec_server ] }
-  sudo: yes
+  become: yes
 
 - name: Configure SecureDrop Application Server.
   hosts: app-staging
@@ -28,7 +28,7 @@
       when: (perform_backup is defined and perform_backup == true) or
             (restore_file is defined and restore_file != '')
       tags: backup
-  sudo: yes
+  become: yes
 
   # Set iptables rules with exemptions for staging that permit direct access for SSH.
   # The overrides that permit direct access are managed in group_vars/staging.yml,
@@ -37,4 +37,4 @@
   hosts: staging
   roles:
     - { role: restrict-direct-access, tags: [ common, restrict-direct-access ] }
-  sudo: yes
+  become: yes

--- a/install_files/ansible-base/securedrop-travis.yml
+++ b/install_files/ansible-base/securedrop-travis.yml
@@ -12,4 +12,4 @@
     - { role: app, tags: app }
     - { role: app-test, tags: app-test }
 
-  sudo: yes
+  become: yes


### PR DESCRIPTION
Resolves #1427. Updates Ansible syntax, so it stops spitting out deprecation warnings at us. Will help in migrations to Ansible 2.

Note: I have not been able to test this comprehensively yet because doing so is blocking on https://github.com/freedomofpress/securedrop/issues/1430.