### PR TITLE
Version-locks Ansible in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 - echo HRNGDEVICE=/dev/urandom | sudo tee /etc/default/rng-tools
 - sudo /etc/init.d/rng-tools restart
 install:
-- pip install ansible
+- pip install ansible==1.8.4
 - pip install coveralls
 script:
 - echo localhost > inventory


### PR DESCRIPTION
Rather than install the latest version of Ansible (currently 2.2.0.0), let's install an older version to match what we recommend for developers. Recent syntax deprecations in Ansible v2 cause the current playbooks to fail.

Confirmed a [working branch build](https://travis-ci.org/freedomofpress/securedrop/builds/172730427) based on these changes. Targeting the `merge-0.3.10-into-develop` branch so we can confirm passing tests on #1436 prior to merge.

Closes #1438.