### PR TITLE
Wrap vars in with_items: statements

### DIFF
--- a/install_files/ansible-base/roles/app-test/tasks/apparmor_complain.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/apparmor_complain.yml
@@ -46,4 +46,4 @@
   # Doing it this way keeps the config DRY and will work with future profiles as well.
   when: >
     "/{{ item | regex_replace('\\.', '/') }}" not in apparmor_complaining_profiles_result.stdout_lines
-  with_items: apparmor_profiles
+  with_items: "{{ apparmor_profiles }}"

--- a/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
@@ -9,7 +9,7 @@
   apt:
     name: "{{ item }}"
     state: latest
-  with_items: test_apt_dependencies
+  with_items: "{{ test_apt_dependencies }}"
   tags:
     - apt
 

--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -3,7 +3,7 @@
   apt:
     pkg: "{{ item }}"
     state: latest
-  with_items: appserver_dependencies
+  with_items: "{{ appserver_dependencies }}"
   tags:
     - apt
 

--- a/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
+++ b/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
@@ -5,7 +5,7 @@
     state: latest
     update_cache: yes
     cache_valid_time: 3600
-  with_items: apache_packages
+  with_items: "{{ apache_packages }}"
   tags:
     - apt
     - apache
@@ -16,7 +16,7 @@
     dest: /etc/apache2/{{ item }}
     owner: root
     mode: '0644'
-  with_items: apache_files
+  with_items: "{{ apache_files }}"
   tags:
     - apache
 
@@ -26,7 +26,7 @@
     dest: /etc/apache2/{{ item }}
     owner: root
     mode: '0644'
-  with_items: apache_templates
+  with_items: "{{ apache_templates }}"
   tags:
     - apache
 
@@ -34,7 +34,7 @@
   apache2_module:
     state: present
     name: "{{ item }}"
-  with_items: apache_modules
+  with_items: "{{ apache_modules }}"
   tags:
     - apache
 
@@ -42,7 +42,7 @@
   apache2_module:
     state: absent
     name: "{{ item }}"
-  with_items: apache_disabled_modules
+  with_items: "{{ apache_disabled_modules }}"
   tags:
     - apache
     - hardening

--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/build_securedrop_app_code_deb.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/build_securedrop_app_code_deb.yml
@@ -3,7 +3,7 @@
   apt:
     pkg: "{{ item }}"
     state: latest
-  with_items: development_dependencies
+  with_items: "{{ development_dependencies }}"
   tags:
     - apt
 
@@ -81,7 +81,7 @@
   copy:
     src: "{{ item }}"
     dest: /tmp/{{ securedrop_app_code_deb }}/etc/apparmor.d/{{ item }}
-  with_items: apparmor_profiles
+  with_items: "{{ apparmor_profiles }}"
   tags:
     - build
     - apparmor

--- a/install_files/ansible-base/roles/common/tasks/create_users.yml
+++ b/install_files/ansible-base/roles/common/tasks/create_users.yml
@@ -18,7 +18,7 @@
     name: "{{ item }}"
     shell: /bin/bash
     groups: sudo,ssh
-  with_items: ssh_users
+  with_items: "{{ ssh_users }}"
   tags:
     - users
     - sudoers
@@ -45,7 +45,7 @@
     dest: /home/{{ item }}/.bashrc
     line: '. /etc/bashrc.securedrop_additions'
     state: absent
-  with_items: ssh_users
+  with_items: "{{ ssh_users }}"
   tags:
     - users
     - environment

--- a/install_files/ansible-base/roles/common/tasks/remove_kernel_modules.yml
+++ b/install_files/ansible-base/roles/common/tasks/remove_kernel_modules.yml
@@ -3,7 +3,7 @@
   modprobe:
     name: "{{ item }}"
     state: absent
-  with_items: disabled_kernel_modules
+  with_items: "{{ disabled_kernel_modules }}"
   tags:
     - kernel
     - hardening
@@ -13,7 +13,7 @@
     dest: /etc/modprobe.d/blacklist.conf
     line: "blacklist {{ item }}"
     insertafter: EOF
-  with_items: disabled_kernel_modules
+  with_items: "{{ disabled_kernel_modules }}"
   tags:
     - kernel
     - hardening

--- a/install_files/ansible-base/roles/common/tasks/setup_etc_hosts.yml
+++ b/install_files/ansible-base/roles/common/tasks/setup_etc_hosts.yml
@@ -32,7 +32,7 @@
     regexp: "{{ item.hostname }}"
     line: "{{ item.ip }}  {{ item.hostname }}"
     backup: yes
-  with_items: ip_info
+  with_items: "{{ ip_info }}"
   tags:
     - host_aliases
     - static-hosts

--- a/install_files/ansible-base/roles/common/tasks/sysctl.yml
+++ b/install_files/ansible-base/roles/common/tasks/sysctl.yml
@@ -8,7 +8,7 @@
     sysctl_set: yes
     state: present
     reload: yes
-  with_items: sysctl_flags
+  with_items: "{{ sysctl_flags }}"
   tags:
     - sysctl
     - hardening

--- a/install_files/ansible-base/roles/development/tasks/main.yml
+++ b/install_files/ansible-base/roles/development/tasks/main.yml
@@ -10,7 +10,7 @@
   apt:
     pkg: "{{ item }}"
     state: latest
-  with_items: development_dependencies
+  with_items: "{{ development_dependencies }}"
   tags:
     - apt
     - development

--- a/install_files/ansible-base/roles/grsecurity/tasks/apply_grsec_lock.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/apply_grsec_lock.yml
@@ -43,7 +43,7 @@
     sysctl_set: yes
     state: present
     reload: yes
-  with_items: grsec_sysctl_flags
+  with_items: "{{ grsec_sysctl_flags }}"
   sudo: yes
   tags:
     - hardening

--- a/install_files/ansible-base/roles/grsecurity/tasks/paxctl.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/paxctl.yml
@@ -21,7 +21,7 @@
 
 - name: Adjust paxctl headers on grub binaries.
   command: paxctl -Cpm {{ item.item }}
-  with_items: paxctl_grub_header_check.results
+  with_items: "{{ paxctl_grub_header_check.results }}"
   # The desired flags should include:
   #   - p NOPAGEEXEC
   #   - m NOMPROTECT

--- a/install_files/ansible-base/roles/install-fpf-repo/tasks/main.yml
+++ b/install_files/ansible-base/roles/install-fpf-repo/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install FPF apt repo GPG signing key.
+- name: Install SecureDrop apt repo GPG signing key.
   apt_key:
     state: present
     data: "{{ lookup('file', 'fpf-signing-key.pub') }}"

--- a/install_files/ansible-base/roles/install-local-packages/tasks/main.yml
+++ b/install_files/ansible-base/roles/install-local-packages/tasks/main.yml
@@ -6,7 +6,7 @@
   copy:
     src: ../../build/{{ item }}
     dest: /root/
-  with_items: local_deb_packages
+  with_items: "{{ local_deb_packages }}"
 
 # There's a known bug in Ansible that causes installing
 # .deb packages via the apt module to fail when invoked

--- a/install_files/ansible-base/roles/manage-groups/tasks/main.yml
+++ b/install_files/ansible-base/roles/manage-groups/tasks/main.yml
@@ -8,14 +8,14 @@
     name: "{{ item }}"
     groups: securedrop,securedrop_application_server
   when: item.startswith('app')
-  with_items: play_hosts
+  with_items: "{{ play_hosts }}"
 
 - name: Configure role list for SecureDrop Monitor Server.
   add_host:
     name: "{{ item }}"
     groups: securedrop,securedrop_monitor_server
   when: item.startswith('mon')
-  with_items: play_hosts
+  with_items: "{{ play_hosts }}"
 
 # Failsafe to ensure that dynamic group population worked as expected.
 # Since we're adding the "app" and "mon" production hosts via the above

--- a/install_files/ansible-base/roles/ossec-agent/tasks/agent_config.yml
+++ b/install_files/ansible-base/roles/ossec-agent/tasks/agent_config.yml
@@ -22,7 +22,7 @@
     regexp: "{{ item }}"
     line: "{{ item }}"
   notify: reload iptables rules
-  with_items: agent_auth_rules
+  with_items: "{{ agent_auth_rules }}"
   when: hostvars[groups.securedrop_monitor_server.0].ossec_agent_already_registered == false and
         iptables_rules_check_result.stat.exists == true
   tags:
@@ -49,7 +49,7 @@
   notify:
     - reload iptables rules
     - restart ossec
-  with_items: agent_auth_rules
+  with_items: "{{ agent_auth_rules }}"
   when: hostvars[groups.securedrop_monitor_server.0].ossec_agent_already_registered == false and
         iptables_rules_check_result.stat.exists == true
   tags:

--- a/install_files/ansible-base/roles/ossec-agent/tasks/cleanup_authd.yml
+++ b/install_files/ansible-base/roles/ossec-agent/tasks/cleanup_authd.yml
@@ -29,7 +29,7 @@
   # It's technically possible that pgrep will return more than one PID.
   # Let's be careful and kill each process, even though in most cases there
   # will be only one, if any.
-  with_items: ossec_authd_running_check.stdout_lines
+  with_items: "{{ ossec_authd_running_check.stdout_lines }}"
   delegate_to: "{{ groups.securedrop_monitor_server.0 }}"
   when: ossec_authd_running_check.rc == 0 and
         ossec_authd_running_check.stdout != ""

--- a/install_files/ansible-base/roles/ossec-server/handlers/main.yml
+++ b/install_files/ansible-base/roles/ossec-server/handlers/main.yml
@@ -7,7 +7,7 @@
     insertafter: "^:LOGNDROP"
     regexp: "{{ item }}"
     line: "{{ item }}"
-  with_items: authd_rules
+  with_items: "{{ authd_rules }}"
 
 - name: reload authd iptables
   shell: iptables-restore < /etc/network/iptables/rules_v4

--- a/install_files/ansible-base/roles/ossec-server/tasks/mon_install_postfix.yml
+++ b/install_files/ansible-base/roles/ossec-server/tasks/mon_install_postfix.yml
@@ -3,7 +3,7 @@
   apt:
     pkg: "{{ item }}"
     state: latest
-  with_items: ossec_postfix_dependencies
+  with_items: "{{ ossec_postfix_dependencies }}"
   tags:
     - apt
     - postfix

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
@@ -4,7 +4,7 @@
     state: present
     path: "{{ tor_hidden_services_parent_dir }}/{{ item.service }}/hostname"
     delay: 5
-  with_items: tor_instances
+  with_items: "{{ tor_instances }}"
   tags:
     - tor
 
@@ -13,7 +13,7 @@
   register: tor_hidden_service_hostname_lookup
   # Read-only task, so don't report changed.
   changed_when: false
-  with_items: tor_instances
+  with_items: "{{ tor_instances }}"
   tags:
     - tor
     - admin
@@ -25,7 +25,7 @@
     src: ths_config.j2
   # Local action, so we don't want elevated privileges
   sudo: no
-  with_items: tor_hidden_service_hostname_lookup.results
+  with_items: "{{ tor_hidden_service_hostname_lookup.results }}"
   tags:
     - tor
     - admin

--- a/install_files/ansible-base/roles/tor-hidden-services/tasks/configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/tasks/configure_tor_hidden_services.yml
@@ -16,7 +16,7 @@
     owner: "{{ tor_user }}"
     group: "{{ tor_user }}"
     mode: '0700'
-  with_items: tor_instances
+  with_items: "{{ tor_instances }}"
   tags:
     - tor
 


### PR DESCRIPTION
The use of raw vars in Ansible with_items statements has been deprecated because
of it's ambiguity: is a a string or a var?! To help make ourselves compatible
with future Ansible verions and get rid of some of those pesky deprecation
warnings (#1427), we're appropriately wrapping them in handlebars. Helps resolve
#1427.