### PR TITLE
Misc test cleanup

### DIFF
--- a/install_files/ansible-base/group_vars/securedrop_application_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_application_server.yml
@@ -136,7 +136,6 @@ agent_auth_rules:
   - "-A INPUT -s {{ monitor_ip }} -p tcp --sport 1515 -m state --state ESTABLISHED,RELATED -j ACCEPT"
 
 test_apt_dependencies:
-  - firefox
   - xvfb
 
 worker_logs_dir: "/var/log/securedrop_worker"

--- a/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
@@ -19,7 +19,7 @@
 # decided to play it as safe as possible by downgrading Firefox to the latest
 # version (46.0.1) that is compatible with the last 2.X series Selenium release
 # (2.53.6). After the Hackathon, we'll resolve the geckodriver business and
-# remove the following two tasks (as well as add firefox back to the
+# remove the following three tasks (as well as add firefox back to the
 # `test_apt_dependencies` list).
 - name: Download Firefox 46.0.1 for compatibility with Selenium 2.53.6.
   sudo: no
@@ -30,6 +30,18 @@
     dest: /home/vagrant/
     url: https://launchpad.net/~ubuntu-mozilla-security/+archive/ubuntu/ppa/+build/9727836/+files/firefox_46.0.1+build1-0ubuntu0.14.04.3_amd64.deb
     sha256sum: 88d25053306d33658580973b063cd459a56e3596a3a298c1fb8ab1d52171d860
+  tags:
+    - apt
+
+- name: Install dependencies for Firefox 46.0.1.
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - libasound2
+    - libcairo-gobject2
+    - libgtk-3-0
+    - libstartup-notification0
   tags:
     - apt
 

--- a/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
@@ -29,6 +29,7 @@
     # crutch anyway, I've just hardcoded /home/vagrant.
     dest: /home/vagrant/
     url: https://launchpad.net/~ubuntu-mozilla-security/+archive/ubuntu/ppa/+build/9727836/+files/firefox_46.0.1+build1-0ubuntu0.14.04.3_amd64.deb
+    sha256sum: 88d25053306d33658580973b063cd459a56e3596a3a298c1fb8ab1d52171d860
   tags:
     - apt
 

--- a/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
@@ -36,7 +36,6 @@
 - name: Install dependencies for Firefox 46.0.1.
   apt:
     name: "{{ item }}"
-    state: present
   with_items:
     - libasound2
     - libcairo-gobject2
@@ -46,7 +45,8 @@
     - apt
 
 - name: Install Firefox 46.0.1 for compatibility with Selenium 2.53.6.
-  command: dpkg -i /home/vagrant/firefox_46.0.1+build1-0ubuntu0.14.04.3_amd64.deb
+  apt:
+    deb: /home/vagrant/firefox_46.0.1+build1-0ubuntu0.14.04.3_amd64.deb
   tags:
     - apt
 

--- a/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
@@ -13,6 +13,30 @@
   tags:
     - apt
 
+# Selenium 3 makes breaking changes with the 2.X API, and requires the
+# installation of the Mozilla geckodriver. Since the Aaron Swartz Day Hackathon
+# is approaching, which will involve many new external contributors, we've
+# decided to play it as safe as possible by downgrading Firefox to the latest
+# version (46.0.1) that is compatible with the last 2.X series Selenium release
+# (2.53.6). After the Hackathon, we'll resolve the geckodriver business and
+# remove the following two tasks (as well as add firefox back to the
+# `test_apt_dependencies` list).
+- name: Download Firefox 46.0.1 for compatibility with Selenium 2.53.6.
+  sudo: no
+  get_url:
+    # Since the whole tasklisk is run as root, the ansible_env.HOME fact is
+    # /root. Since this command doesn't need to be run as root and is part of a
+    # crutch anyway, I've just hardcoded /home/vagrant.
+    dest: /home/vagrant/
+    url: https://launchpad.net/~ubuntu-mozilla-security/+archive/ubuntu/ppa/+build/9727836/+files/firefox_46.0.1+build1-0ubuntu0.14.04.3_amd64.deb
+  tags:
+    - apt
+
+- name: Install Firefox 46.0.1 for compatibility with Selenium 2.53.6.
+  command: dpkg -i /home/vagrant/firefox_46.0.1+build1-0ubuntu0.14.04.3_amd64.deb
+  tags:
+    - apt
+
 - name: Copy xvfb init script.
   copy:
     src: xvfb

--- a/securedrop/requirements/test-requirements.in
+++ b/securedrop/requirements/test-requirements.in
@@ -5,4 +5,4 @@ pip-tools
 py
 pytest
 pytest-cov
-selenium
+selenium < 3

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -18,8 +18,8 @@ mock==2.0.0
 pbr==1.10.0               # via mock
 pip-tools==1.7.0
 py==1.4.31
-pytest-cov==2.3.1
-pytest==3.0.2
+pytest-cov==2.4.0
+pytest==3.0.3
 selenium==2.53.6
 six==1.10.0               # via mock, pip-tools
 Werkzeug==0.11.11         # via flask

--- a/securedrop/tests/common.py
+++ b/securedrop/tests/common.py
@@ -5,6 +5,8 @@ import subprocess
 
 import gnupg
 
+# Set environment variable so config.py uses a test environment
+os.environ['SECUREDROP_ENV'] = 'test'
 import config
 from db import init_db, db_session, Source, Submission
 import crypto_util

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -26,8 +26,6 @@ from datetime import datetime
 import time
 import mock
 
-os.environ['SECUREDROP_ENV'] = 'test'
-
 
 class FunctionalTest():
 

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -11,6 +11,8 @@ import urllib2
 import sys
 
 
+# Set environment variable so config.py uses a test environment
+os.environ['SECUREDROP_ENV'] = 'test'
 import config
 
 import source

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -57,7 +57,7 @@ class JournalistNavigationSteps():
 
         self._login_user(test_user_info['username'],
                          test_user_info['password'],
-                         test_user.totp.now())
+                         'mocked')
 
         headline = self.driver.find_element_by_css_selector('span.headline')
         self.assertIn('Sources', headline.text)
@@ -78,7 +78,7 @@ class JournalistNavigationSteps():
 
         self._login_user(admin_user_info['username'],
                          admin_user_info['password'],
-                         admin_user.totp.now())
+                         'mocked')
 
         # Admin user should log in to the same interface as a normal user,
         # since there may be users who wish to be both journalists and admins.
@@ -149,7 +149,7 @@ class JournalistNavigationSteps():
         # Verify the two factor authentication
         token_field = self.driver.find_element_by_css_selector(
             'input[name="token"]')
-        token_field.send_keys(self.new_user['orm_obj'].totp.now())
+        token_field.send_keys('mocked')
         submit_button = self.driver.find_element_by_css_selector(
             'button[type=submit]')
         submit_button.click()
@@ -179,19 +179,6 @@ class JournalistNavigationSteps():
         # Test that the new user was logged in successfully
         self.assertIn('Sources', self.driver.page_source)
 
-    def _check_login_with_skewed_otp(self):
-        interval = 30
-
-        # Client is behind server
-        otp = self.new_user['orm_obj'].totp.at(
-            datetime.datetime.now() - datetime.timedelta(seconds=interval))
-        self._check_login_with_otp(otp)
-
-        # Client is ahead of server
-        otp = self.new_user['orm_obj'].totp.at(
-            datetime.datetime.now() + datetime.timedelta(seconds=interval))
-        self._check_login_with_otp(otp)
-
     def _new_user_can_log_in(self):
         # Log the admin user out
         self._logout()
@@ -199,7 +186,7 @@ class JournalistNavigationSteps():
         # Log the new user in
         self._login_user(self.new_user['username'],
                          self.new_user['password'],
-                         self.new_user['orm_obj'].totp.now())
+                         'mocked')
 
         # Test that the new user was logged in successfully
         self.assertIn('Sources', self.driver.page_source)
@@ -209,9 +196,6 @@ class JournalistNavigationSteps():
         self.assertRaises(NoSuchElementException,
                           self.driver.find_element_by_link_text,
                           'Admin')
-
-        # Check that the user can log in with slightly skewed OTP tokens
-        self._check_login_with_skewed_otp()
 
     def _edit_user(self, username):
         new_user_edit_links = filter(
@@ -226,7 +210,7 @@ class JournalistNavigationSteps():
 
         self._login_user(self.admin_user['username'],
                          self.admin_user['password'],
-                         self.admin_user['orm_obj'].totp.now())
+                         'mocked')
 
         # Go to the admin interface
         admin_interface_link = self.driver.find_element_by_link_text('Admin')
@@ -266,7 +250,7 @@ class JournalistNavigationSteps():
         self._logout()
         self._login_user(self.new_user['username'],
                          self.new_user['password'],
-                         self.new_user['orm_obj'].totp.now())
+                         'mocked')
         self.wait_for(
             lambda: self.assertIn('Sources', self.driver.page_source)
         )
@@ -275,7 +259,7 @@ class JournalistNavigationSteps():
         self._logout()
         self._login_user(self.admin_user['username'],
                          self.admin_user['password'],
-                         self.admin_user['orm_obj'].totp.now())
+                         'mocked')
 
         # Go to the admin interface
         admin_interface_link = self.driver.find_element_by_link_text('Admin')
@@ -308,7 +292,7 @@ class JournalistNavigationSteps():
         self._logout()
         self._login_user(self.new_user['username'],
                          self.new_user['password'],
-                         self.new_user['orm_obj'].totp.now())
+                         'mocked')
         self.wait_for(
             lambda: self.assertIn('Sources', self.driver.page_source)
         )

--- a/securedrop/tests/test_unit_integration.py
+++ b/securedrop/tests/test_unit_integration.py
@@ -41,7 +41,7 @@ class TestIntegration(unittest.TestCase):
         self.journalist_app.post('/login', data=dict(
             username=self.user.username,
             password=self.user_pw,
-            token=self.user.totp.now()),
+            token='mocked'),
             follow_redirects=True)
 
     def _wait_for(self, function_with_assertion, timeout=5):
@@ -570,29 +570,7 @@ class TestIntegration(unittest.TestCase):
         rv = self.journalist_app.post('/login', data=dict(
             username=self.user.username,
             password='newpass',
-            token=self.user.totp.now(),
-            follow_redirects=True))
-        self.assertEqual(rv.status_code, 302)
-
-    def test_login_after_regenerate_totp(self):
-        """Test that journalists can login after resetting their Google Authenticator 2fa"""
-
-        # regenerate totp
-        self.journalist_app.post('/account/reset-2fa-totp')
-      
-        # successful verification should redirect to /account
-        rv = self.journalist_app.post('/account/2fa', data=dict(
-            token=self.user.totp.now()))
-        self.assertEqual(rv.status_code, 302)
-      
-        # log out
-        common.logout(self.journalist_app)
-
-        # login with new 2fa secret should redirect to index page
-        rv = self.journalist_app.post('/login', data=dict(
-            username=self.user.username,
-            password=self.user_pw,
-            token=self.user.totp.now(),
+            token='mocked',
             follow_redirects=True))
         self.assertEqual(rv.status_code, 302)
 

--- a/securedrop/tests/test_unit_integration.py
+++ b/securedrop/tests/test_unit_integration.py
@@ -17,6 +17,8 @@ import gnupg
 from flask import session, g, escape
 from bs4 import BeautifulSoup
 
+# Set environment variable so config.py uses a test environment
+os.environ['SECUREDROP_ENV'] = 'test'
 import config
 import crypto_util
 import source
@@ -25,8 +27,6 @@ import common
 from db import db_session, Journalist
 import store
 
-# Set environment variable so config.py uses a test environment
-os.environ['SECUREDROP_ENV'] = 'test'
 
 
 def _block_on_reply_keypair_gen(codename):

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -55,7 +55,7 @@ class TestJournalist(TestCase):
         res = self.client.post(url_for('login'), data=dict(
             username='invalid',
             password='invalid',
-            token='123456'))
+            token='mocked'))
         self.assert200(res)
         self.assertIn("Login failed", res.data)
 
@@ -63,7 +63,7 @@ class TestJournalist(TestCase):
         res = self.client.post(url_for('login'), data=dict(
             username=self.user.username,
             password=self.user_pw,
-            token=self.user.totp.now()),
+            token='mocked'),
             follow_redirects=True)
 
         self.assert200(res)  # successful login redirects to index
@@ -75,20 +75,20 @@ class TestJournalist(TestCase):
         res = self.client.post(url_for('login'), data=dict(
             username=self.user.username,
             password=self.user_pw,
-            token=self.user.totp.now()))
+            token='mocked'))
         self.assertRedirects(res, url_for('index'))
 
         res = self.client.post(url_for('login'), data=dict(
             username=self.admin_user.username,
             password=self.admin_user_pw,
-            token=self.admin_user.totp.now()))
+            token='mocked'))
         self.assertRedirects(res, url_for('index'))
 
     def test_admin_user_has_admin_link_in_index(self):
         res = self.client.post(url_for('login'), data=dict(
             username=self.admin_user.username,
             password=self.admin_user_pw,
-            token=self.admin_user.totp.now()),
+            token='mocked'),
             follow_redirects=True)
         admin_link = '<a href="{}">{}</a>'.format(
             url_for('admin_index'),
@@ -99,7 +99,7 @@ class TestJournalist(TestCase):
         res = self.client.post(url_for('login'), data=dict(
             username=self.user.username,
             password=self.user_pw,
-            token=self.user.totp.now()),
+            token='mocked'),
             follow_redirects=True)
         edit_account_link = '<a href="{}">{}</a>'.format(
             url_for('edit_account'),
@@ -110,14 +110,14 @@ class TestJournalist(TestCase):
         self.client.post(url_for('login'), data=dict(
             username=self.user.username,
             password=self.user_pw,
-            token=self.user.totp.now()),
+            token='mocked'),
             follow_redirects=True)
 
     def _login_admin(self):
         self.client.post(url_for('login'), data=dict(
             username=self.admin_user.username,
             password=self.admin_user_pw,
-            token=self.admin_user.totp.now()),
+            token='mocked'),
             follow_redirects=True)
 
     def test_user_logout(self):
@@ -252,7 +252,7 @@ class TestJournalist(TestCase):
 
         res = self.client.post(
             url_for('admin_new_user_two_factor', uid=self.user.id),
-            data=dict(token=self.user.totp.now())
+            data=dict(token='mocked')
             )
 
         self.assertRedirects(res, url_for('admin_index'))

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -49,7 +49,7 @@ class TestJournalist(TestCase):
 
     def test_index_should_redirect_to_login(self):
         res = self.client.get(url_for('index'))
-        self.assert_redirects(res, url_for('login'))
+        self.assertRedirects(res, url_for('login'))
 
     def test_invalid_user_login_should_fail(self):
         res = self.client.post(url_for('login'), data=dict(
@@ -76,13 +76,13 @@ class TestJournalist(TestCase):
             username=self.user.username,
             password=self.user_pw,
             token=self.user.totp.now()))
-        self.assert_redirects(res, url_for('index'))
+        self.assertRedirects(res, url_for('index'))
 
         res = self.client.post(url_for('login'), data=dict(
             username=self.admin_user.username,
             password=self.admin_user_pw,
             token=self.admin_user.totp.now()))
-        self.assert_redirects(res, url_for('index'))
+        self.assertRedirects(res, url_for('index'))
 
     def test_admin_user_has_admin_link_in_index(self):
         res = self.client.post(url_for('login'), data=dict(
@@ -123,12 +123,12 @@ class TestJournalist(TestCase):
     def test_user_logout(self):
         self._login_user()
         res = self.client.get(url_for('logout'))
-        self.assert_redirects(res, url_for('index'))
+        self.assertRedirects(res, url_for('index'))
 
     def test_admin_logout(self):
         self._login_admin()
         res = self.client.get(url_for('logout'))
-        self.assert_redirects(res, url_for('index'))
+        self.assertRedirects(res, url_for('index'))
 
     def test_admin_index(self):
         self._login_admin()
@@ -220,7 +220,7 @@ class TestJournalist(TestCase):
 
         self.assertNotEqual(old_hotp, new_hotp)
 
-        self.assert_redirects(res,
+        self.assertRedirects(res,
             url_for('admin_new_user_two_factor', uid=self.user.id))
 
     def test_admin_reset_hotp_empty(self):
@@ -244,7 +244,7 @@ class TestJournalist(TestCase):
 
         self.assertNotEqual(old_totp, new_totp)
 
-        self.assert_redirects(res,
+        self.assertRedirects(res,
             url_for('admin_new_user_two_factor', uid=self.user.id))
 
     def test_admin_new_user_2fa_success(self):
@@ -255,7 +255,7 @@ class TestJournalist(TestCase):
             data=dict(token=self.user.totp.now())
             )
 
-        self.assert_redirects(res, url_for('admin_index'))
+        self.assertRedirects(res, url_for('admin_index'))
 
     def test_admin_new_user_2fa_get_req(self):
         self._login_admin()
@@ -286,7 +286,7 @@ class TestJournalist(TestCase):
                       is_admin=False)
             )
 
-        self.assert_redirects(res, url_for('admin_new_user_two_factor', uid=3))
+        self.assertRedirects(res, url_for('admin_new_user_two_factor', uid=3))
 
     def test_admin_add_user_failure_no_username(self):
         self._login_admin()
@@ -326,7 +326,7 @@ class TestJournalist(TestCase):
         self._login_user()
         for admin_url in admin_urls:
             res = self.client.get(admin_url)
-            self.assert_status(res, 302)
+            self.assertStatus(res, 302)
 
     def test_admin_authorization_for_posts(self):
         admin_urls = [url_for('admin_reset_two_factor_totp'),
@@ -340,7 +340,7 @@ class TestJournalist(TestCase):
         self._login_user()
         for admin_url in admin_urls:
             res = self.client.post(admin_url)
-            self.assert_status(res, 302)
+            self.assertStatus(res, 302)
 
     def test_user_authorization_for_gets(self):
         urls = [url_for('index'), url_for('col', sid='1'),
@@ -348,7 +348,7 @@ class TestJournalist(TestCase):
 
         for url in urls:
             res = self.client.get(url)
-            self.assert_status(res, 302)
+            self.assertStatus(res, 302)
 
     def test_user_authorization_for_posts(self):
         urls = [url_for('add_star', sid='1'), url_for('remove_star', sid='1'),
@@ -359,14 +359,14 @@ class TestJournalist(TestCase):
                 url_for('account_reset_two_factor_hotp')]
         for url in urls:
             res = self.client.post(url)
-            self.assert_status(res, 302)
+            self.assertStatus(res, 302)
 
     def test_invalid_user_password_change(self):
         self._login_user()
         res = self.client.post(url_for('edit_account'), data=dict(
             password='not',
             password_again='thesame'))
-        self.assert_redirects(res, url_for('edit_account'))
+        self.assertRedirects(res, url_for('edit_account'))
 
     def test_too_long_user_password_change(self):
         self._login_user()
@@ -397,7 +397,7 @@ class TestJournalist(TestCase):
         self.assertNotEqual(oldTotp, newTotp)
 
         # should redirect to verification page
-        self.assert_redirects(res, url_for('account_new_two_factor'))
+        self.assertRedirects(res, url_for('account_new_two_factor'))
 
     def test_edit_hotp(self):
         self._login_user()
@@ -413,7 +413,7 @@ class TestJournalist(TestCase):
         self.assertNotEqual(oldHotp, newHotp)
 
         # should redirect to verification page
-        self.assert_redirects(res, url_for('account_new_two_factor'))
+        self.assertRedirects(res, url_for('account_new_two_factor'))
 
     def test_bulk_download(self):
         sid = 'EQZGCJBRGISGOTC2NZVWG6LILJBHEV3CINNEWSCLLFTUWZJPKJFECLS2NZ4G4U3QOZCFKTTPNZMVIWDCJBBHMUDBGFHXCQ3R'
@@ -455,7 +455,7 @@ class TestJournalist(TestCase):
         db_session.commit()
 
         res = self.client.post(url_for('add_star', sid=sid))
-        self.assert_redirects(res, url_for('index'))
+        self.assertRedirects(res, url_for('index'))
 
 
 if __name__ == "__main__":

--- a/securedrop/tests/test_unit_store.py
+++ b/securedrop/tests/test_unit_store.py
@@ -3,14 +3,13 @@
 import os
 import unittest
 import zipfile
+# Set environment variable so config.py uses a test environment
+os.environ['SECUREDROP_ENV'] = 'test'
 import config
 import store
 import common
 from db import db_session, Source
 import crypto_util
-
-# Set environment variable so config.py uses a test environment
-os.environ['SECUREDROP_ENV'] = 'test'
 
 
 class TestStore(unittest.TestCase):

--- a/securedrop/tests/test_unit_store.py
+++ b/securedrop/tests/test_unit_store.py
@@ -49,13 +49,12 @@ class TestStore(unittest.TestCase):
     def test_rename_valid_submission(self):
         sid = 'EQZGCJBRGISGOTC2NZVWG6LILJBHEV3CINNEWSCLLFTUWZJPKJFECLS2NZ4G4U3QOZCFKTTPNZMVIWDCJBBHMUDBGFHXCQ3R'
 
-        source_dir = os.path.join('/tmp/securedrop/store/', sid)
+        source_dir = os.path.join(config.STORE_DIR, sid)
         if not os.path.exists(source_dir):
             os.makedirs(source_dir)
 
         old_filename = '1-abc1-msg.gpg'
-        with open(os.path.join(source_dir, old_filename), 'w'):
-            pass
+        open(os.path.join(source_dir, old_filename), 'w').close()
 
         new_filestem = 'abc2'
         expected_filename = '1-abc2-msg.gpg'


### PR DESCRIPTION
* Updates some syntax.
* Imports config after setting `SECUREDROP_ENV`.
* Gets the test suite working again by fetching an old version of Firefox from the Ubuntu archives that's still compatible with the last Selenium 2 release. We want to avoid switching to Selenium 3 before the Aaron Swartz day Hackathon this weekend.
* Replaces a hardcoded path with a `config` attr.
* Removes a couple test methods and a lot of TOTP values that were doing nothing because the verification is mocked.