### PR TITLE
Cleans up developer documentation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -248,15 +248,11 @@ def tor_ssh_proxy_command
    def command?(command)
      system("which #{command} > /dev/null 2>&1")
    end
-  # prefer connect-proxy, fall back to netcat,
-  # for use in snapci centos box.
-  if command?("connect")
-    base_cmd = "connect -R remote -5 -S"
-  elsif command?("nc")
+  if command?("nc")
     base_cmd = "nc -x"
   else
     puts "Failed to build proxy command for SSH over Tor."
-    puts "Install 'connect-proxy' or 'netcat'."
+    puts "Install or 'netcat-openbsd'."
     exit(1)
   end
   return "#{base_cmd} 127.0.0.1:9050 %h %p"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,6 +42,11 @@ Vagrant.configure("2") do |config|
   # The staging hosts are just like production but allow non-tor access
   # for the web interfaces and ssh.
   config.vm.define 'mon-staging', autostart: false do |staging|
+    if ENV['SECUREDROP_SSH_OVER_TOR']
+      config.ssh.host = find_ssh_aths("mon-ssh-aths")
+      config.ssh.proxy_command = tor_ssh_proxy_command
+      config.ssh.port = 22
+    end
     staging.vm.hostname = "mon-staging"
     staging.vm.box = "bento/ubuntu-14.04"
     staging.vm.network "private_network", ip: "10.0.1.3", virtualbox__intnet: true
@@ -52,6 +57,11 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define 'app-staging', autostart: false do |staging|
+    if ENV['SECUREDROP_SSH_OVER_TOR']
+      config.ssh.host = find_ssh_aths("app-ssh-aths")
+      config.ssh.proxy_command = tor_ssh_proxy_command
+      config.ssh.port = 22
+    end
     staging.vm.hostname = "app-staging"
     staging.vm.box = "bento/ubuntu-14.04"
     staging.vm.network "private_network", ip: "10.0.1.2", virtualbox__intnet: true

--- a/docs/development/apparmor_profiles.rst
+++ b/docs/development/apparmor_profiles.rst
@@ -8,40 +8,42 @@ Generating AppArmor profiles for Tor and Apache
     sudo su
     cd /var/www/securedrop
 
-(run tests, use the application, restart service, power off power on)
+Run tests, use the application web interface, restart services,
+reboot the VMs via ``vagrant reload /staging/``. The goal is to
+create as much interaction with the system as possible, in order
+to establish an expected baseline of behavior. Then run:
 
-``aa-logprof``
+.. code::
 
-(follow prompts and save at the end)
+    aa-logprof
 
-``aa-complain /etc/apparmor.d/PROFILE_NAME``
+Follow the prompts on screen and save the new configuration.
+Then set the profile to complain mode:
 
-(run tests, use the application, restart service, power off power on)
+.. code::
 
-``aa-logprof``
+    aa-complain /etc/apparmor.d/<PROFILE_NAME>
 
-Repeat.
-
+Rinse and repeat, again running ``aa-logprof`` to update the profile.
 The AppArmor profiles are saved in ``/etc/apparmor.d/``. There are two
 profiles:
 
--  usr.sbin.tor
--  usr.sbin.apache2
+    -  ``/etc/apparmor.d/usr.sbin.tor``
+    -  ``/etc/apparmor.d/usr.sbin.apache2``
 
 After running ``aa-logprof`` you will need to copy the modified profile back to
-your host machine.
+your host machine to include them in the ``securedrop-app-code`` package.
 
 .. code:: sh
 
-   cp /etc/apparmor.d/usr.sbin.apache2 /vagrant/install_files/ansible-base
-   cp /etc/apparmor.d/usr.sbin.tor /vagrant/install_files/ansible-base
+   ansible -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory app-prod -m fetch -a 'flat=yes dest=install_files/ansible-base/ src=/etc/apparmor.d/usr.sbin.apache2'
+   ansible -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory app-prod -m fetch -a 'flat=yes dest=install_files/ansible-base/ src=/etc/apparmor.d/usr.sbin.tor'
 
 .. todo:: Explain the different behavior of the virtual environments (staging
           vs. prod) with regards to the AppArmor profiles.
 
-The AppArmor profiles are packaged with the securedrop-app-code.
-
-The securedrop-app-code postinst puts the AppArmor profiles in enforce mode.
-
-The ``app-test`` Ansible module (which is run as part of staging but not prod)
-puts the AppArmor profiles in enforce mode.
+The AppArmor profiles are packaged with the ``securedrop-app-code``.
+The ``securedrop-app-code`` ``postinst`` puts the AppArmor profiles in enforce mode
+on production hosts. In the staging environment, the ``app-test`` Ansible role
+puts the AppArmor profiles in complain mode, to faciliate the development workflow
+with ``aa-logprof`` outlined above.

--- a/docs/development/apt_repo.rst
+++ b/docs/development/apt_repo.rst
@@ -1,24 +1,27 @@
 SecureDrop apt repository
 =========================
 
-This document contains a brief description of the Debian packages which are 
-hosted and maintained by Freedom of the Press Foundation in our apt repository 
+This document contains a brief description of the Debian packages which are
+hosted and maintained by Freedom of the Press Foundation in our apt repository
 at `apt.freedom.press`_.
 
 linux-image-3.14.*-grsec
     This package contains the Linux kernel image, patched with grsecurity.
+    Listed as a dependency of ``securedrop-grsec``.
 
 linux-headers-3.14.*-grsec
     Header files related to the Linux kernel.
 
-`ossec-agent <https://github.com/freedomofpress/ossec>`_                        
-    Installs the OSSEC agent.
-                                                                                
-`ossec-server <https://github.com/freedomofpress/ossec>`_ 
-    Installs the OSSEC manager.
+`ossec-agent <https://github.com/freedomofpress/ossec>`_
+    Installs the OSSEC agent, repackaged for Ubuntu.
+    Listed as a dependency of ``securedrop-ossec-agent``.
+
+`ossec-server <https://github.com/freedomofpress/ossec>`_
+    Installs the OSSEC manager, repackaged for Ubuntu.
+    Listed as a dependency of ``securedrop-ossec-server``.
 
 securedrop-app-code
-    Packages the SecureDrop application code, Python pip dependencies and 
+    Packages the SecureDrop application code, Python pip dependencies and
     AppArmor profiles.
 
 securedrop-ossec-agent
@@ -28,12 +31,13 @@ securedrop-ossec-server
     Installs the SecureDrop-specific OSSEC configuration for the Mon Server.
 
 `securedrop-grsec <https://github.com/freedomofpress/grsec>`_
-    SecureDrop grsec kernel (metapackage depending on the latest version).
+    SecureDrop grsecurity kernel metapackage, depending on the latest version
+    of ``linux-image-3.14-*-grsec``.
 
-.. note:: To be added in the future: 
+securedrop-keyring
+    Packages the public signing key used conjunction with this apt repository.
+    Allows for managed key rotation via automatic updates, as implemented in
+    `SecureDrop 0.3.10`_.
 
-          `securedrop-keyring <https://github.com/freedomofpress/securedrop-keyring>`_    
-              Packages the public signing key used in conjunction with this apt           
-              repository.               
-
+.. _SecureDrop 0.3.10: https://github.com/freedomofpress/securedrop/blob/c5b4220e04e3c81ad6f92d5e8a92798f07f0aca2/changelog.md#0310
 .. _apt.freedom.press: https://apt.freedom.press

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -1,15 +1,6 @@
 Documentation Guidelines
 ========================
 
-.. caution:: This is an early draft. Our documentation guidelines are
-             subject to change at any time until this notice is removed.
-
-.. warning:: We recently auto-converted the documentation from
-             Markdown to ReST, and are still cleaning up the output
-             from that auto-conversion. If you find style issues,
-             broken links or references, or any other similar issues,
-             pull requests are welcome!
-
 SecureDrop's documentation is written in `ReStructuredText`_ (ReST),
 and is built by and hosted on `Read the Docs`_ (RTD). The
 documentation files are stored in the primary SecureDrop git
@@ -37,13 +28,11 @@ To get started editing the docs:
 
    .. code:: sh
 
-      $ make html
-      $ open _build/html/index.html
+      $ sphinx-autobuild . _build/html
 
-   .. tip:: You can use ``sphinx-autobuild`` to automatically rebuild
-            and reload your docs as you work on them. Run
-            ``sphinx-autobuild . _build/html``.
-
+You can then can browse the documentation at http://127.0.0.1:8000/.
+As you make changes, the docs will automatically rebuild in the browser
+window, so you don't need to refresh the page manually.
 
 Occasionally, the docs get out of whack and rebuilding them doesn't
 work as it should. You can usually resolve this by clearing out the
@@ -51,8 +40,7 @@ build artifacts and re-building the docs from scratch:
 
 .. code:: sh
 
-   $ make clean && make html
-
+   $ make clean && sphinx-autobuild . _build/html
 
 Integration with Read the Docs
 ------------------------------
@@ -69,29 +57,33 @@ branch.
 Style Guide
 -----------
 
-* When specific elements from a user interface are mentioned by name or by label, **bold** it.
+When specific elements from a user interface are mentioned by name or by label, **bold** it.
 
     "Once you’re sure you have the right drive, click **Format Drive**."
 
-* When SecureDrop-specific :doc:`terminology <../terminology>` is used, *italicize* it.
+When SecureDrop-specific :doc:`terminology <../terminology>` is used, *italicize* it.
 
     "To get started, you’ll need two Tails drives: one for the *Admin Workstation* and one for the *Secure Viewing Station*."
 
   .. todo:: I don't love this convention for a couple of reasons:
 
-	    1. If there are a lot of references to terminology in the
-               same area of text, all of the short bursts of italics
-               makes it hard to read.
-	    2. The default style for document references is also
-               italicized, which is confusing when used near
-               references to the terminology.
+         1. If there are a lot of references to terminology in the
+            same area of text, all of the short bursts of italics
+            makes it hard to read.
+         2. The default style for document references is also
+            italicized, which is confusing when used near
+            references to the terminology.
 
-* Use absolute paths when referring to files outside the SecureDrop repository.
-  Exceptions made for when it's clear from the surrounding context what the
-  intended working directory is. For files inside the SecureDrop directory,
-  write them as `./some_dir/file`, where `.` is the top level directory of the
-  SecureDrop repo. Since by default the git repo will be cloned under the name
-  `securedrop` and it also contains a `securedrop` subdirectory this is intended
-  to avoid confusion.  Exceptions made for when it's clear from the context
-  we're outside of the SecureDrop repo, but would like to somehow interact with
-  it (e.g., we just cloned the repo and now we're going to `cd` into it).
+Try to keep your lines wrapped to near 80 characters when editing the docs.
+Some exceptions are warranted, such as complex code blocks showing example
+commands, or long URLs, but in general the docs should be tightly wrapped.
+
+Use absolute paths when referring to files outside the SecureDrop repository.
+Exceptions made for when it's clear from the surrounding context what the
+intended working directory is. For files inside the SecureDrop directory,
+write them as `./some_dir/file`, where `.` is the top level directory of the
+SecureDrop repo. Since by default the git repo will be cloned under the name
+`securedrop` and it also contains a `securedrop` subdirectory this is intended
+to avoid confusion.  Exceptions made for when it's clear from the context
+we're outside of the SecureDrop repo, but would like to somehow interact with
+it (e.g., we just cloned the repo and now we're going to `cd` into it).

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -72,26 +72,13 @@ The version of Ansible recommended to provision SecureDrop VMs may not be the
 same as the version in your distro's repos, or may at some point flux out of
 sync. For this reason, and also just as a good general development practice, we
 recommend using a Python virtual environment to install version 1.8.4 of
-Ansible. We provide instructions using `virtualenvwrapper
-<http://virtualenvwrapper.readthedocs.io/en/stable/>`_ and `virtualenv
-<https://virtualenv.readthedocs.io/en/latest/>`_.
-
-Using virtualenvwrapper:
+Ansible. Using `virtualenvwrapper
+<http://virtualenvwrapper.readthedocs.io/en/stable/>`_:
 
 .. code:: sh
 
     sudo apt-get install virtualenvwrapper
     mkvirtualenv -p python2.7 securedrop
-    pip install ansible==1.8.4
-
-Using virtualenv (we recommend you `cd` into the  base directory of the repo
-before running these commands):
-
-.. code:: sh
-
-    sudo apt-get install virtualenv
-    virtualenv -p python2.7 .
-    . bin/activate
     pip install ansible==1.8.4
 
 Mac OS X

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -90,16 +90,17 @@ Install the dependencies for the development environment:
 #. VirtualBox_
 #. Ansible_.
 
-There are several ways to install Ansible on a Mac. We recommend setting up a
-virtualenv to install Ansible since we are currently using Ansible 1.8.4:
+There are several ways to install Ansible on a Mac. We recommend setting up a virtual environment to install Ansible since we are currently using Ansible 1.8.4:
 
 .. code:: sh
 
-    pip install virtualenv
-    # From the base directory of securedrop
-    virtualenv -p python2.7 .
-    . bin/activate
+    pip install virtualenvwrapper
+    mkvirtualenv -p python2.7 securedrop
     pip install ansible==1.8.4
+
+.. note:: If you install ``virtualenvwrapper`` and get a ``mkvirtualenv: 
+          command not found`` error, make sure 
+          ``source /usr/local/bin/virtualenvwrapper.sh`` is in your ``~/.bashrc``.
 
 .. _Vagrant: http://www.vagrantup.com/downloads.html
 .. _VirtualBox: https://www.virtualbox.org/wiki/Downloads

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -90,7 +90,8 @@ Install the dependencies for the development environment:
 #. VirtualBox_
 #. Ansible_.
 
-There are several ways to install Ansible on a Mac. We recommend setting up a virtualenv to install Ansible since we are currently using Ansible 1.8.4:
+There are several ways to install Ansible on a Mac. We recommend setting up a
+virtualenv to install Ansible since we are currently using Ansible 1.8.4:
 
 .. code:: sh
 

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -90,16 +90,15 @@ Install the dependencies for the development environment:
 #. VirtualBox_
 #. Ansible_.
 
-There are several ways to install Ansible on a Mac. We recommend installing
-from PyPi using ``pip`` so you will get the latest stable version:
-
-.. todo:: The pip install task under OS X uses `sudo`, which is not a good
-          idea. We should update the OS X install workflow to reference brew
-          and virtualenv, similar to the Linux setup docs.
+There are several ways to install Ansible on a Mac. We recommend setting up a virtualenv to install Ansible since we are currently using Ansible 1.8.4:
 
 .. code:: sh
 
-    sudo easy_install pip && sudo pip install -U ansible==1.8.4
+    pip install virtualenv
+    # From the base directory of securedrop
+    virtualenv -p python2.7 .
+    . bin/activate
+    pip install ansible==1.8.4
 
 .. _Vagrant: http://www.vagrantup.com/downloads.html
 .. _VirtualBox: https://www.virtualbox.org/wiki/Downloads

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -17,26 +17,24 @@ your development workstation.
 Ubuntu/Debian
 ~~~~~~~~~~~~~
 
-.. note:: Tested on: Ubuntu 14.04 and Debian Stretch
+.. note:: Tested on: Ubuntu 16.04 and Debian Stretch
 
 .. code:: sh
 
-   sudo apt-get install -y dpkg-dev virtualbox-dkms linux-headers-$(uname -r) build-essential git
+   sudo apt-get install -y build-essential dpkg-dev git linux-headers-$(uname -r) virtualbox
 
 We recommend using the latest stable version of Vagrant (``1.8.5`` at the time
 of this writing), which might be newer than what is in your distro's package
-repositories.
-
-If ``apt-cache policy vagrant`` says your candidate version is not at least 1.7,
-you should download the current version from the `Vagrant Downloads page`_ and
-then install it.
+repositories. If ``apt-cache policy vagrant`` says your candidate version
+is not at least 1.8, you should download the current version from the
+`Vagrant Downloads page`_ and then install it.
 
 .. code:: sh
 
-    # If you downloaded vagrant.deb from vagrantup.com
-    sudo dpkg -i vagrant.deb
-    # OR this, if your OS vagrant is recent enough
+    # If your OS vagrant is recent enough
     sudo apt-get install vagrant
+    # OR this, if you downloaded the deb package.
+    sudo dpkg -i vagrant.deb
 
 We *do not* recommend using a version of Vagrant older than 1.8.4. For instance,
 the version of Vagrant currently in the Ubuntu Trusty repositories is 1.5.4,
@@ -61,12 +59,6 @@ which is signficantly out of date and known not to work with SecureDrop (`GitHub
           Build our own base boxes to dramatically cut down on provisioning
           times (ii) Remove this note as well as the commented vagrant-cachier
           lines from the Vagrantfile
-
-Either way, once you've installed Vagrant you should run:
-
-.. code:: sh
-
-    sudo dpkg-reconfigure virtualbox-dkms
 
 Finally, install Ansible so it can be used with Vagrant to automatically
 provision VMs. We recommend installing Ansible from PyPi with ``pip`` to ensure

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -90,12 +90,16 @@ Install the dependencies for the development environment:
 #. VirtualBox_
 #. Ansible_.
 
-   There are several ways to install Ansible on a Mac. We recommend installing
-   from PyPi using ``pip`` so you will get the latest stable version:
+There are several ways to install Ansible on a Mac. We recommend installing
+from PyPi using ``pip`` so you will get the latest stable version:
 
-   .. code:: sh
+.. todo:: The pip install task under OS X uses `sudo`, which is not a good
+          idea. We should update the OS X install workflow to reference brew
+          and virtualenv, similar to the Linux setup docs.
 
-      sudo easy_install pip && sudo pip install -U ansible
+.. code:: sh
+
+    sudo easy_install pip && sudo pip install -U ansible==1.8.4
 
 .. _Vagrant: http://www.vagrantup.com/downloads.html
 .. _VirtualBox: https://www.virtualbox.org/wiki/Downloads

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -23,11 +23,12 @@ Ubuntu/Debian
 
    sudo apt-get install -y build-essential dpkg-dev git linux-headers-$(uname -r) virtualbox
 
-We recommend using the latest stable version of Vagrant (``1.8.5`` at the time
-of this writing), which might be newer than what is in your distro's package
-repositories. If ``apt-cache policy vagrant`` says your candidate version
-is not at least 1.8, you should download the current version from the
-`Vagrant Downloads page`_ and then install it.
+We recommend using the latest stable version of Vagrant, ``1.8.5`` at the time
+of this writing, which might be newer than what is in your distro's package
+repositories. Older versions of Vagrant has been known to cause problems
+(`GitHub #932`_, `GitHub #1381`_). If ``apt-cache policy vagrant`` says your
+candidate version is not at least 1.8, you should download the current version
+from the `Vagrant Downloads page`_ and then install it.
 
 .. code:: sh
 
@@ -36,10 +37,6 @@ is not at least 1.8, you should download the current version from the
     # OR this, if you downloaded the deb package.
     sudo dpkg -i vagrant.deb
 
-We *do not* recommend using a version of Vagrant older than 1.8.4. For instance,
-the version of Vagrant currently in the Ubuntu Trusty repositories is 1.5.4,
-which is signficantly out of date and known not to work with SecureDrop (`GitHub
-#932`_, `GitHub #1381`_).
 
 .. _`Vagrant Downloads page`: https://www.vagrantup.com/downloads.html
 .. _`GitHub #932`: https://github.com/freedomofpress/securedrop/pull/932
@@ -59,6 +56,9 @@ which is signficantly out of date and known not to work with SecureDrop (`GitHub
           Build our own base boxes to dramatically cut down on provisioning
           times (ii) Remove this note as well as the commented vagrant-cachier
           lines from the Vagrantfile
+
+VirtualBox should be at least version 5.x. See `GitHub #1381`_ for documentation
+of incompatibility with the older VirtualBox 4.x release series.
 
 Finally, install Ansible so it can be used with Vagrant to automatically
 provision VMs. We recommend installing Ansible from PyPi with ``pip`` to ensure

--- a/docs/development/spec_tests.rst
+++ b/docs/development/spec_tests.rst
@@ -42,13 +42,15 @@ machines for faster testing:
     bundle exec rake --tasks # check output for desired machine
     bundle exec rake spec:development
 
-.. note:: If you run into an error regarding the version of ``bundler`` such as "Bundler could not find compatible versions", then you can install and run a particular version of ``bundler`` via:
+.. note:: If you run into an error regarding the version of
+          ``bundler`` such as "Bundler could not find compatible versions",
+          then you can install and run a particular version of ``bundler`` via:
 
-    .. code:: sh
+          .. code:: sh
 
-        gem install bundler -v 1.12.5
-        bundle _1.12.5_ install
-        bundle _1.12.5_ exec rake spec:development
+              gem install bundler -v 1.12.5
+              bundle _1.12.5_ install
+              bundle _1.12.5_ exec rake spec:development
 
 Updating the tests
 ------------------

--- a/docs/development/spec_tests.rst
+++ b/docs/development/spec_tests.rst
@@ -7,7 +7,7 @@ spectest.
 
 .. _serverspec: http://serverspec.org
 
-Install directions (Ubuntu)
+Install directions (Ubuntu/Debian)
 ---------------------------
 
 .. code:: sh
@@ -15,32 +15,6 @@ Install directions (Ubuntu)
     apt-get install bundler
     cd spec_tests/
     bundle update
-
-Running the tests
------------------
-
-.. code:: sh
-
-    cd spec_tests/
-    bundle exec rake spec
-
-This will run the tests against all configured hosts, specifically:
-
--  development
--  app-staging
--  mon-staging
--  build
-
-In order to run the tests, each VM will be created and provisioned, if
-necessary.  Running all VMs concurrently may cause performance
-problems if you have less than 8GB of RAM. You can isolate specific
-machines for faster testing:
-
-.. code:: sh
-
-    cd spec_tests
-    bundle exec rake --tasks # check output for desired machine
-    bundle exec rake spec:development
 
 .. note:: If you run into an error regarding the version of
           ``bundler`` such as "Bundler could not find compatible versions",
@@ -51,6 +25,40 @@ machines for faster testing:
               gem install bundler -v 1.12.5
               bundle _1.12.5_ install
               bundle _1.12.5_ exec rake spec:development
+
+
+Running the tests
+-----------------
+
+In order to run the tests, each VM will be created and provisioned, if
+necessary.  Running all VMs concurrently may cause performance
+problems if you have less than 8GB of RAM. You can isolate specific
+machines for faster testing:
+
+.. code:: sh
+
+    $ cd spec_tests
+    $ bundle exec rake --tasks # check output for desired machine
+    rake spec:app-prod     # Run spectests against app-prod
+    rake spec:app-staging  # Run spectests against app-staging
+    rake spec:build        # Run spectests against build
+    rake spec:development  # Run spectests against development
+    rake spec:mon-prod     # Run spectests against mon-prod
+    rake spec:mon-staging  # Run spectests against mon-staging
+
+    $ bundle exec rake spec:staging
+
+The invocation above will run tests only against the ``staging`` VMs.
+You can run against multiple environments in a single invocation:
+
+.. code:: sh
+
+    $ cd spec_tests
+    $ bundle exec rake spec:development spec:staging
+
+Test failure against any host will cause Serverspec to exit, and stop
+executing tests against subsequent hosts. In order to run the ``spec:prod``
+task, you will need to configure :ref:`SSH access over Tor <ssh_over_tor>`.
 
 Updating the tests
 ------------------

--- a/docs/development/tips_and_tricks.rst
+++ b/docs/development/tips_and_tricks.rst
@@ -35,6 +35,8 @@ exception to allow Tor Browser to access localhost:
 You should now be able to access the development server in the Tor
 Browser by navigating to ``127.0.0.1:8080`` and ``127.0.0.1:8081``.
 
+.. _ssh_over_tor:
+
 Connecting to VMs via SSH over Tor
 ----------------------------------
 

--- a/docs/development/tips_and_tricks.rst
+++ b/docs/development/tips_and_tricks.rst
@@ -40,21 +40,20 @@ Browser by navigating to ``127.0.0.1:8080`` and ``127.0.0.1:8081``.
 Connecting to VMs via SSH over Tor
 ----------------------------------
 
-.. todo:: Replace all of this with nc, which is simpler, works well with
-	  OpenSSH's ProxyCommand, and is included by default on Ubuntu and Mac
-	  OS X.
-
-connect-proxy (Ubuntu only)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ubuntu/Debian setup
+~~~~~~~~~~~~~~~~~~~
+You will need to install a specific variant of the ``nc`` tool
+in order to support the ``-x`` option for specifying a proxy host.
+Mac OS X already runs the OpenBSD variant by default.
 
 .. code:: sh
 
-   sudo apt-get install connect-proxy
+   sudo apt-get install netcat-openbsd
 
-After installing connect-proxy via apt-get and appending the tor config options
-to your local config, you can export the environment variable
+After installing ``netcat-openbsd`` and appending the Tor config options
+to your local torrc, you can export the environment variable
 ``SECUREDROP_SSH_OVER_TOR=1`` in order to use ``vagrant ssh`` to access the
-prod instances.  Here is an example of how that works:
+staging or prod instances over Tor. Here is an example of how that works:
 
 .. code:: sh
 
@@ -70,8 +69,10 @@ prod instances.  Here is an example of how that works:
       IdentityFile /home/conor/.vagrant.d/insecure_private_key
       IdentitiesOnly yes
       LogLevel FATAL
+
     $ vagrant ssh app-prod -c 'echo hello'   # will fail due to incorrect ssh-config
     ssh_exchange_identification: read: Connection reset by peer
+
     $ export SECUREDROP_SSH_OVER_TOR=1       # instruct Vagrant to use Tor for SSH
     $ vagrant ssh-config app-prod            # will show correct info, with ProxyCommand
     Host app-prod
@@ -84,43 +85,20 @@ prod instances.  Here is an example of how that works:
       IdentityFile /home/conor/.vagrant.d/insecure_private_key
       IdentitiesOnly yes
       LogLevel FATAL
-      ProxyCommand connect -R remote -5 -S 127.0.0.1:9050 %h %p
+      ProxyCommand nc -x 127.0.0.1:9050 %h %p
+
     $ # ensure ATHS values are active in local Tor config:
     $ cat *-aths | sudo tee -a /etc/tor/torrc > /dev/null && sudo service tor reload
     $ vagrant ssh app-prod -c 'echo hello'   # works
     hello
     Connection to l57xhqhltlu323vi.onion closed.
 
-If ``SECUREDROP_SSH_OVER_TOR`` is declared, Vagrant will look up the ATHS URLs
-and ``HidServAuth`` values for each server by examining the contents of
-``app-ssh-aths`` and ``mon-ssh-aths`` in ``./install_files/ansible-base``. You
-can manually inspect these files to append values to your local ``torrc``, as
-in the ``cat`` example above.  Note that the ``cat`` example above will also
-add the ATHS info for the Document Interface, as well, which is useful for
-testing.
-
-torify (Ubuntu and Mac OS X)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-- Ubuntu
-
-  ``torsocks`` should be installed by the tor package. If it is not installed,
-  make sure you are using tor from the `Tor Project's repo
-  <https://www.torproject.org/docs/debian.html.en>`__, and not Ubuntu's
-  package.
-
-- Mac OS X (Homebrew)
-
-  .. code:: sh
-
-     brew install torsocks
-
-If you have torify on your system (``which torify``) and you're Tor running
-in the background, simply prepend it to the SSH command:
-
-.. code:: sh
-
-    torify ssh admin@examplenxu7x5ifm.onion
+If ``SECUREDROP_SSH_OVER_TOR`` is true, Vagrant will look up the ATHS URLs
+for each server by examining the contents of ``app-ssh-aths`` and ``mon-ssh-aths``
+in ``./install_files/ansible-base``. You can manually inspect these files
+to append values to your local ``torrc``, as in the ``cat`` example above.
+Note that the ``cat`` example above will also add the ATHS info for the
+Document Interface, as well, which is useful for testing.
 
 Architecture Diagrams
 ---------------------

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -74,7 +74,7 @@ mon-prod
 
     Direct SSH access is not available in the prod environment.
     You will need to log in over Tor after initial provisioning. See
-    :doc:`Tips & Tricks` for more info.
+    :ref:`ssh_over_tor` for more info.
 
 If you plan to alter the configuration of any of these machines, make sure to
 review the :doc:`Development Guide for Serverspec Tests <spec_tests>`.
@@ -131,13 +131,13 @@ to fill out your local copy of
 Prod
 ----
 
-You will need to fill out the production configuration file:
-``./install_files/ansible_base/prod-specific.yml``.  Part of the
-production playbook validates that staging values are not used in
+You will need to fill out the production configuration file at
+``install_files/ansible_base/prod-specific.yml`` with custom secrets.
+The production playbook validates that staging values are not used in
 production. One of the values it verifies is that the user Ansible runs as is
 not ``vagrant`` To be able to run this playbook in a virtualized environment
 for testing, you will need to disable the ``validate`` role, which you can do
-by running ``export SECUREDROP_PROD_SKIP_TAGS=validate`` before provisioning.
+by running ``export ANSIBLE_ARGS="--skip-tags validate"`` before provisioning.
 
 To create only the prod servers, run:
 
@@ -150,6 +150,5 @@ To create only the prod servers, run:
    ./manage.py add-admin
 
 In order to access the servers after the install is completed you will need to
-install and configure a proxy tool to proxy your SSH connection over Tor.
-Torify and connect-proxy are two tools that can be used to proxy SSH
-connections over Tor.
+install and configure a proxy tool to
+:ref:`proxy your SSH connection over Tor<ssh_over_tor>`.

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -6,42 +6,75 @@ Virtual Environments
 
 .. _`GitHub #1381`: https://github.com/freedomofpress/securedrop/issues/1381
 
+Overview
+--------
+
 There are several predefined virtual environments in the Vagrantfile:
 development, staging, and prod (production).
 
--  **development**: for working on the application code
+development
+    For working on the application code. Forwarded ports:
 
-   -  Source Interface: localhost:8080
-   -  Document Interface: localhost:8081
+    -  Source Interface: localhost:8080
+    -  Document Interface: localhost:8081
 
--  **app-staging**: for working on the environment and hardening
+app-staging
+    For working on the application code in a more realistic environment,
+    with most system hardening active.
+    The interfaces and SSH are also available over Tor.
+    A copy of the the Onion URLs for Source and Document Interfaces,
+    as well as SSH access, are written to the Vagrant host's
+    ``install_files/ansible-base`` directory, named:
 
-   -  Source Interface: localhost:8082
-   -  Document Interface: localhost:8083
-   -  The interfaces and SSH are also available over Tor.
-   -  A copy of the the onion URLs for source, document and SSH access
-      are written to the Vagrant host's ansible-base directory. The
-      files will be named: app-source-ths, app-document-aths,
-      app-ssh-aths
+    - ``app-source-ths``
+    - ``app-document-aths``
+    - ``app-ssh-aths``
 
--  **mon-staging**: for working on the environment and hardening
+    The AppArmor profiles run complain mode to aid in debugging.
 
-   -  OSSEC alert configuration is in
-      install\_files/ansible-base/staging-specific.yml
+    Forwarded ports:
 
--  **app-prod**: This is like a production installation with all of the
-   hardening applied but virtualized
+    -  Source Interface: localhost:8082
+    -  Document Interface: localhost:8083
 
-   -  A copy of the the onion URLs for source, document and SSH access
-      are written to the Vagrant host's ansible-base directory. The
-      files will be named: app-source-ths, app-document-aths,
-      app-ssh-aths
-   -  Putting the AppArmor profiles in complain mode (default) or
-      enforce mode can be done with the Ansible tags apparmor-complain
-      or apparmor-enforce.
+mon-staging
+    For working on OSSEC monitoring rules, with most system hardening active.
+    OSSEC alert configuration is in
+    ``install_files/ansible-base/staging-specific.yml``.
+    A copy of the the Onion URL for SSH acces is written to the Vagrant host's
+    ``install_files/ansible-base`` directory, named:
 
--  **mon-prod**: This is like a production installation with all of the
-   hardening applied but virtualized
+    - ``mon-ssh-aths``
+
+    Direct SSH access is still available via Vagrant for staging hosts, so you
+    can use ``vagrant ssh app-staging`` and ``vagrant ssh mon-staging``
+    to start an interactive session.
+
+app-prod
+    This is like a production installation with all of the system
+    hardening active, but virtualized, rather than running on hardware.
+    A copy of the the Onion URLs for Source and Document Interfaces,
+    as well as SSH access, are written to the Vagrant host's
+    ``install_files/ansible-base`` directory, named:
+
+    - ``app-source-ths``
+    - ``app-document-aths``
+    - ``app-ssh-aths``
+
+    There are no active forwarded ports for the Document and Source Interfaces
+    on ``app-prod``. You must use the Onion URLs to view the pages over Tor.
+
+mon-prod
+    This is like a production installation with all of the system
+    hardening active, but virtualized, rather than running on hardware.
+    You will need to configure prod-like secrets in 
+    ``install_files/ansible-base/prod-specific.yml``, or export
+    ``ANSIBLE_ARGS=="--skip-tags validate"`` to skip the tasks
+    that prevent the prod playbook from running with Vagrant-specific info.
+
+    Direct SSH access is not available in the prod environment.
+    You will need to log in over Tor after initial provisioning. See
+    :doc:`Tips & Tricks` for more info.
 
 If you plan to alter the configuration of any of these machines, make sure to
 review the :doc:`Development Guide for Serverspec Tests <spec_tests>`.


### PR DESCRIPTION
Stepped through all of the developer documentation post-reorg in #1441. These changes are now up-to-date with expectations about modern developer workstations. A few recommended versions are bumped, but in general the content editing was focused on improving readability via formatting, and enhancing clarity via rephrasing.

The only non-docs change is to the `Vagrantfile`, to add optional support for logging in via SSH over Tor, same as is required on the prod machines. Removed a TODO about simplifying the SSH over Tor setup docs—the only supported proxy command is now `nc -x`, which requires installation of `netcat-openbsd` for Debian/Ubuntu hosts, and no extra packages at all for Mac OS X.

Related to #1208. There are a few unchecked items in that issue not accounted for here, but that's because the features described aren't fully implemented yet.