### PR TITLE
Hardcode the use of virtualbox in the Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# Make sure to use virtualbox
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
 Vagrant.configure("2") do |config|
 
   # Vagrant 1.7.0+ removes the insecure_private_key by default


### PR DESCRIPTION
Without this, a developer (such as myself) may unknowingly
use a different provider (e.g. vmware) where it is advised to
use virtualbox.