### PR TITLE
Adds temporary fix to time skew problems in development VMs

### DIFF
--- a/install_files/ansible-base/securedrop-development.yml
+++ b/install_files/ansible-base/securedrop-development.yml
@@ -6,3 +6,13 @@
     - { role: app, tags: app }
     - { role: app-test, tags: app-test }
   sudo: yes
+# This is a quick fix for the purpose of having everything working for
+# contributors at the Aaron Swartz day hackathon. In both my own and another
+# contributors laptop, we realized we were experiencing time skew in our
+# Virtualbox VMs, which was preventing login access to the Document Interface
+# due to TOTP tokens being out of sink. TODO: resolve this issue properly.
+  tasks:
+    - name: Install NTP.
+      apt:
+        name: ntp
+        state: latest


### PR DESCRIPTION
A temporary fix for the development VM playbook, that fixes a time skew problem that was preventing a contributor and myself from accessing the document interface while working at the Aaron Swartz day hackathon. This should be resolved in a nicer way sometime next week, but is needed to keep things running smooth for this weekend in the meantime.