### PR TITLE
Download All submissions (based on #1181)

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -584,8 +584,11 @@ def bulk():
     action = request.form['action']
 
     doc_names_selected = request.form.getlist('doc_names_selected')
-    selected_docs = [doc for doc in g.source.collection
-                     if (doc.filename in doc_names_selected) or action == 'download_all']
+    if action == 'download_all':
+        selected_docs = g.source.collection
+    else:
+        selected_docs = [doc for doc in g.source.collection
+                         if doc.filename in doc_names_selected]
     if selected_docs == []:
         if action == 'download':
             flash("No collections selected to download!", "error")

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -585,7 +585,7 @@ def download_all_unread():
     if docs == []:
         flash("No unread documents in collections!", "error")
         return redirect(url_for('index'))
-    return bulk_dl('all_unread_' + g.user.username, docs)
+    return bulk_dl('all_unread', docs)
 
 
 @app.route('/bulk', methods=('POST',))
@@ -642,6 +642,7 @@ def bulk_delete(sid, items_selected):
 def bulk_download(sid, items_selected):
     source = get_source(sid)
     return bulk_dl(source.journalist_filename, items_selected)
+
 
 def bulk_dl(zip_directory, items_selected):
     filenames = [store.path(item.source.filesystem_id, item.filename)

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -585,16 +585,17 @@ def bulk():
 
     doc_names_selected = request.form.getlist('doc_names_selected')
     selected_docs = [doc for doc in g.source.collection
-                     if doc.filename in doc_names_selected]
-
+                     if (doc.filename in doc_names_selected) or action == 'download_all']
     if selected_docs == []:
         if action == 'download':
             flash("No collections selected to download!", "error")
+        elif action == 'download_all':
+            flash("No collections available to download!", "error")
         elif action == 'delete' or action == 'confirm_delete':
             flash("No collections selected to delete!", "error")
         return redirect(url_for('col', sid=g.sid))
 
-    if action == 'download':
+    if action == 'download' or action == 'download_all':
         return bulk_download(g.sid, selected_docs)
     elif action == 'delete':
         return bulk_delete(g.sid, selected_docs)

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -608,7 +608,7 @@ def bulk():
             flash("No collections selected to delete!", "error")
         return redirect(url_for('col', sid=g.sid))
 
-    if action == 'download' or action == 'download_all':
+    if action in ('download', 'download_all'):
         return bulk_download(g.sid, selected_docs)
     elif action == 'delete':
         return bulk_delete(g.sid, selected_docs)

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -21,11 +21,12 @@
   {% if source.collection %}
     <p>The documents are stored encrypted for security. To read them, you will need to decrypt them using GPG.</p>
     <form action="/bulk" method="post">
-      <div class="document-actions">
-        <div id='select-container'></div>
-        <button type="submit" name="action" value="download"><i class="fa fa-download"></i> Download selected</button>
-        <button type="submit" name="action" value="confirm_delete" class="danger" id="delete_selected"><i class="fa fa-times"></i> Delete selected</button>
-      </div>
+    <div class="document-actions">
+      <div id='select-container'></div>
+      <button type="submit" name="action" value="download_all"><i class="fa fa-download"></i> Download all</button>
+      <button type="submit" name="action" value="download"><i class="fa fa-download"></i> Download selected</button>
+      <button type="submit" name="action" value="confirm_delete" class="danger" id="delete_selected"><i class="fa fa-times"></i> Delete selected</button>
+    </div>
       <ul id="submissions" class="plain submissions">
         {% for doc in source.collection %}
           <li class="submission"><input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check"/>

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -21,12 +21,12 @@
   {% if source.collection %}
     <p>The documents are stored encrypted for security. To read them, you will need to decrypt them using GPG.</p>
     <form action="/bulk" method="post">
-    <div class="document-actions">
-      <div id='select-container'></div>
-      <button type="submit" name="action" value="download_all"><i class="fa fa-download"></i> Download all</button>
-      <button type="submit" name="action" value="download"><i class="fa fa-download"></i> Download selected</button>
-      <button type="submit" name="action" value="confirm_delete" class="danger" id="delete_selected"><i class="fa fa-times"></i> Delete selected</button>
-    </div>
+      <div class="document-actions">
+        <div id='select-container'></div>
+        <button type="submit" name="action" value="download_all"><i class="fa fa-download"></i> Download all</button>
+        <button type="submit" name="action" value="download"><i class="fa fa-download"></i> Download selected</button>
+        <button type="submit" name="action" value="confirm_delete" class="danger" id="delete_selected"><i class="fa fa-times"></i> Delete selected</button>
+      </div>
       <ul id="submissions" class="plain submissions">
         {% for doc in source.collection %}
           <li class="submission"><input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check"/>

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -8,6 +8,7 @@
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
       <p>
         <span id="select_all" class="select"><i class="fa fa-check-square-o"></i> select all</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> select none</span>
+        <a href="{{ url_for('download_all_unread') }}" class="btn small">Download all unread</a>
         <button type="submit" id="delete_collections" name="action" value="delete" class="small"><i class="fa fa-minus-circle"></i> Delete selected</button>
         <button type="submit" name="action" value="star" class="small"><i class="fa fa-minus-circle"></i> Star Selected</button>
         <button type="submit" name="action" value="un-star" class="small"><i class="fa fa-minus-circle"></i> Un-star Selected</button>

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -423,7 +423,7 @@ class TestJournalist(TestCase):
         files = ['1-abc1-msg.gpg', '2-abc2-msg.gpg', '3-abc3-msg.gpg', '4-abc4-msg.gpg']
         selected_files = files[:2]
         unselected_files = files[2:]
-        filenames = common.setup_test_docs(sid, files)
+        common.setup_test_docs(sid, files)
 
         self._login_user()
         rv = self.client.post('/bulk', data=dict(
@@ -450,15 +450,13 @@ class TestJournalist(TestCase):
             else:
                 self.assertTrue(False)
 
-
-
     def test_download_all_bulk_download(self):
         sid = 'EQZGCJBRGISGOTC2NZVWG6LILJBHEV3CINNEWSCLLFTUWZJPKJFECLS2NZ4G4U3QOZCFKTTPNZMVIWDCJBBHMUDBGFHXCQ3R'
         source = Source(sid, crypto_util.display_id())
         db_session.add(source)
         db_session.commit()
         files = ['1-abc1-msg.gpg', '2-abc2-msg.gpg', '3-abc3-msg.gpg', '4-abc4-msg.gpg']
-        filenames = common.setup_test_docs(sid, files)
+        common.setup_test_docs(sid, files)
 
         self._login_user()
         rv = self.client.post('/bulk', data=dict(

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -7,7 +7,7 @@ import zipfile
 import mock
 
 from flask_testing import TestCase
-from flask import url_for, escape
+from flask import url_for, escape, g
 
 import crypto_util
 import journalist

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -474,6 +474,50 @@ class TestJournalist(TestCase):
                  os.path.join(source.journalist_filename, file)
             ))
 
+    def test_download_bulk_download_nothing_selected(self):
+        sid = 'EQZGCJBRGISGOTC2NZVWG6LILJBHEV3CINNEWSCLLFTUWZJPKJFECLS2NZ4G4U3QOZCFKTTPNZMVIWDCJBBHMUDBGFHXCQ3R'
+        source = Source(sid, crypto_util.display_id())
+        db_session.add(source)
+        db_session.commit()
+        files = ['1-abc1-msg.gpg', '2-abc2-msg.gpg', '3-abc3-msg.gpg', '4-abc4-msg.gpg']
+        common.setup_test_docs(sid, files)
+
+        self._login_user()
+        rv = self.client.post('/bulk', data=dict(
+                action='download',
+                sid=sid,
+                doc_names_selected = []
+        ))
+        self.assertRedirects(rv, url_for('col', sid=sid))
+
+    def test_download_bulk_download_all_no_submissions(self):
+        sid = 'EQZGCJBRGISGOTC2NZVWG6LILJBHEV3CINNEWSCLLFTUWZJPKJFECLS2NZ4G4U3QOZCFKTTPNZMVIWDCJBBHMUDBGFHXCQ3R'
+        source = Source(sid, crypto_util.display_id())
+        db_session.add(source)
+        db_session.commit()
+
+        self._login_user()
+        rv = self.client.post('/bulk', data=dict(
+                action='download_all',
+                sid=sid,
+        ))
+        self.assertRedirects(rv, url_for('col', sid=sid))
+
+    def test_delete_bulk_delete_nothing_selected(self):
+        sid = 'EQZGCJBRGISGOTC2NZVWG6LILJBHEV3CINNEWSCLLFTUWZJPKJFECLS2NZ4G4U3QOZCFKTTPNZMVIWDCJBBHMUDBGFHXCQ3R'
+        source = Source(sid, crypto_util.display_id())
+        db_session.add(source)
+        db_session.commit()
+        files = ['1-abc1-msg.gpg', '2-abc2-msg.gpg', '3-abc3-msg.gpg', '4-abc4-msg.gpg']
+        common.setup_test_docs(sid, files)
+
+        self._login_user()
+        rv = self.client.post('/bulk', data=dict(
+                action='delete',
+                sid=sid,
+                doc_names_selected = []
+        ))
+        self.assertRedirects(rv, url_for('col', sid=sid))
 
     def test_download_all(self):
         sid = 'EQZGCJBRGISGOTC2NZVWG6LILJBHEV3CINNEWSCLLFTUWZJPKJFECLS2NZ4G4U3QOZCFKTTPNZMVIWDCJBBHMUDBGFHXCQ3R'
@@ -483,7 +527,7 @@ class TestJournalist(TestCase):
         files = ['1-abc1-msg.gpg', '2-abc2-msg.gpg', '3-abc3-msg.gpg', '4-abc4-msg.gpg']
         selected_files = files[::2]
         unselected_files = files[1::2]
-        filenames = common.setup_test_docs(sid, files)
+        common.setup_test_docs(sid, files)
 
         self._login_user()
         rv = self.client.post('/bulk', data=dict(
@@ -500,6 +544,22 @@ class TestJournalist(TestCase):
             self.assertTrue(zipfile.ZipFile(StringIO(rv.data)).getinfo(
                 os.path.join('all_unread_'+g.user.username, file
             )))
+
+    def test_download_all_with_no_unread_submissions(self):
+        sid = 'EQZGCJBRGISGOTC2NZVWG6LILJBHEV3CINNEWSCLLFTUWZJPKJFECLS2NZ4G4U3QOZCFKTTPNZMVIWDCJBBHMUDBGFHXCQ3R'
+        source = Source(sid, crypto_util.display_id())
+        db_session.add(source)
+        db_session.commit()
+        files = ['1-abc1-msg.gpg', '2-abc2-msg.gpg', '3-abc3-msg.gpg', '4-abc4-msg.gpg']
+        common.setup_test_docs(sid, files)
+
+        self._login_user()
+        rv = self.client.post('/bulk', data=dict(
+                action='download_all',
+                sid=sid,
+        ))
+        rv = self.client.get('/download_all_unread')
+        self.assertRedirects(rv, url_for('index'))
 
     def test_max_password_length(self):
         """Creating a Journalist with a password that is greater than the

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -449,7 +449,7 @@ class TestJournalist(TestCase):
                 pass
             else:
                 self.assertTrue(False)
-            
+
 
 
     def test_download_all_bulk_download(self):
@@ -474,6 +474,32 @@ class TestJournalist(TestCase):
                  os.path.join(source.journalist_filename, file)
             ))
 
+
+    def test_download_all(self):
+        sid = 'EQZGCJBRGISGOTC2NZVWG6LILJBHEV3CINNEWSCLLFTUWZJPKJFECLS2NZ4G4U3QOZCFKTTPNZMVIWDCJBBHMUDBGFHXCQ3R'
+        source = Source(sid, crypto_util.display_id())
+        db_session.add(source)
+        db_session.commit()
+        files = ['1-abc1-msg.gpg', '2-abc2-msg.gpg', '3-abc3-msg.gpg', '4-abc4-msg.gpg']
+        selected_files = files[::2]
+        unselected_files = files[1::2]
+        filenames = common.setup_test_docs(sid, files)
+
+        self._login_user()
+        rv = self.client.post('/bulk', data=dict(
+                action='download',
+                sid=sid,
+                doc_names_selected=selected_files
+        ))
+        rv = self.client.get('/download_all_unread')
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.content_type, 'application/zip')
+        self.assertTrue(len(zipfile.ZipFile(StringIO(rv.data)).namelist()) == \
+                        len(unselected_files))
+        for file in unselected_files:
+            self.assertTrue(zipfile.ZipFile(StringIO(rv.data)).getinfo(
+                os.path.join('all_unread_'+g.user.username, file
+            )))
 
     def test_max_password_length(self):
         """Creating a Journalist with a password that is greater than the

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -540,7 +540,7 @@ class TestJournalist(TestCase):
                         len(unselected_files))
         for file in unselected_files:
             self.assertTrue(zipfile.ZipFile(StringIO(rv.data)).getinfo(
-                os.path.join('all_unread_'+g.user.username, file
+                os.path.join('all_unread', file
             )))
 
     def test_download_all_with_no_unread_submissions(self):


### PR DESCRIPTION
This PR takes #1181, rebases develop onto it, and adds further test.

This allows for a Journalist to click "Download all unread" from the submissions index view and download all unread submissions in one zip file.

Related to #1354 