### PR TITLE
Travis badge now shows state of develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="/docs/images/logo.png" width="350" height="350">
 </p>
 
-[![Build Status](https://travis-ci.org/freedomofpress/securedrop.png)](http://travis-ci.org/freedomofpress/securedrop)
+[![Build Status](https://travis-ci.org/freedomofpress/securedrop.svg?branch=develop)](https://travis-ci.org/freedomofpress/securedrop)
 [![Coverage Status](https://coveralls.io/repos/freedomofpress/securedrop/badge.svg?branch=develop&service=github)](https://coveralls.io/github/freedomofpress/securedrop?branch=develop)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/freedomofpress/securedrop?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 


### PR DESCRIPTION
Just noticed our Travis badge was not showing the state of the develop branch, which may make people unnecessarily worried if we have a recent build that is failing in a PR