### PR TITLE
Added zxcvbn lib for password strength checking

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -10,6 +10,7 @@ import scrypt
 
 import config
 import store
+import zxcvbn
 
 # to fix gpg error #78 on production
 os.environ['USERNAME'] = 'www-data'
@@ -175,6 +176,16 @@ def decrypt(secret, ciphertext):
     """
     hashed_codename = hash_codename(secret, salt=SCRYPT_GPG_PEPPER)
     return gpg.decrypt(ciphertext, passphrase=hashed_codename).data
+
+
+def check_password_strength(password):
+    """
+    >>> check_password_strength('hunter2')
+    False
+    >>> check_password_strength('correct horse battery staple')
+    True
+    """
+    return zxcvbn.main.password_strength(password)['score'] >= 3
 
 if __name__ == "__main__":
     import doctest

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -224,6 +224,10 @@ class InvalidPasswordLength(Exception):
             return "Password too long (len={})".format(self.pw_len)
 
 
+class WeakPasswordError(Exception):
+    """Raised when attempting to create a Journalist with a weak password"""
+
+
 class Journalist(Base):
     __tablename__ = "journalists"
     id = Column(Integer, primary_key=True)
@@ -271,6 +275,8 @@ class Journalist(Base):
         # Enforce a reasonable maximum length for passwords to avoid DoS
         if len(password) > self.MAX_PASSWORD_LEN:
             raise InvalidPasswordLength(password)
+        if not crypto_util.check_password_strength(password):
+            raise WeakPasswordError()
         self.pw_salt = self._gen_salt()
         self.pw_hash = self._scrypt_hash(password, self.pw_salt)
 

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -13,6 +13,7 @@ from getpass import getpass
 from argparse import ArgumentParser
 from db import db_session, Journalist
 from management import run
+from crypto_util import check_password_strength
 
 # We need to import config in each function because we're running the tests
 # directly, so it's important to set the environment correctly, depending on
@@ -118,13 +119,19 @@ def add_admin():
 
     while True:
         password = getpass("Password: ")
-        password_again = getpass("Confirm Password: ")
+
+        if not check_password_strength(password):
+            print('Your password is too weak. Try adding numbers, special '
+                  'characters, or more words. Diceware is a nice option.')
+            continue
 
         if len(password) > Journalist.MAX_PASSWORD_LEN:
             print ("Your password is too long (maximum length {} characters). "
                    "Please pick a shorter password.".format(
                    Journalist.MAX_PASSWORD_LEN))
             continue
+
+        password_again = getpass("Confirm Password: ")
 
         if password == password_again:
             break

--- a/securedrop/requirements/securedrop-requirements.in
+++ b/securedrop/requirements/securedrop-requirements.in
@@ -14,3 +14,4 @@ rq
 scrypt
 SQLAlchemy
 Werkzeug
+zxcvbn

--- a/securedrop/requirements/securedrop-requirements.txt
+++ b/securedrop/requirements/securedrop-requirements.txt
@@ -26,3 +26,4 @@ SQLAlchemy==1.0.15
 webassets==0.12.0         # via flask-assets
 Werkzeug==0.11.11         # via flask, flask-wtf
 WTForms==2.1              # via flask-wtf
+zxcvbn==1.0

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -50,7 +50,7 @@ class JournalistNavigationSteps():
         # Create a test user for logging in
         test_user_info = dict(
             username='test',
-            password='test')
+            password='correct horse battery staple')
         test_user = Journalist(**test_user_info)
         db_session.add(test_user)
         db_session.commit()
@@ -66,7 +66,7 @@ class JournalistNavigationSteps():
         # Create a test admin user for logging in
         admin_user_info = dict(
             username='admin',
-            password='admin',
+            password='admin! correct horse battery staple',
             is_admin=True)
         admin_user = Journalist(**admin_user_info)
         db_session.add(admin_user)
@@ -132,7 +132,7 @@ class JournalistNavigationSteps():
 
         self.new_user = dict(
             username='dellsberg',
-            password='pentagonpapers')
+            password='correct horse battery staple')
 
         self._add_user(self.new_user['username'], self.new_user['password'])
 

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -91,7 +91,7 @@ class TestJournalistLogin(unittest.TestCase):
         self.mock_journalist_verify_token.return_value = True
 
         self.username = "test user"
-        self.password = "test password"
+        self.password = "correct horse battery staple"
         self.user = Journalist(
                 username=self.username,
                 password=self.password)

--- a/securedrop/tests/test_unit_integration.py
+++ b/securedrop/tests/test_unit_integration.py
@@ -73,7 +73,7 @@ class TestIntegration(unittest.TestCase):
 
         # Add a test user to the journalist interface and log them in
         # print Journalist.query.all()
-        self.user_pw = "bar"
+        self.user_pw = "correct horse battery staple"
         self.user = Journalist(username="foo",
                                password=self.user_pw)
         db_session.add(self.user)
@@ -559,8 +559,8 @@ class TestIntegration(unittest.TestCase):
 
         # change password
         self.journalist_app.post('/account', data=dict(
-            password='newpass',
-            password_again='newpass'
+            password='new correct horse battery staple',
+            password_again='new correct horse battery staple'
         ))
 
         # logout
@@ -569,7 +569,7 @@ class TestIntegration(unittest.TestCase):
         # login with new credentials should redirect to index page
         rv = self.journalist_app.post('/login', data=dict(
             username=self.user.username,
-            password='newpass',
+            password='new correct horse battery staple',
             token='mocked',
             follow_redirects=True))
         self.assertEqual(rv.status_code, 302)

--- a/securedrop/tests/test_unit_journalist.py
+++ b/securedrop/tests/test_unit_journalist.py
@@ -18,6 +18,7 @@ import common
 import config
 import crypto_util
 import journalist
+import random
 from db import (db_session, InvalidPasswordLength, Journalist, Reply, Source,
                 Submission)
 
@@ -56,10 +57,10 @@ class TestJournalist(TestCase):
         self.mock_journalist_verify_token.return_value = True
 
         # Set up test users
-        self.user_pw = "bar"
+        self.user_pw = "correct horse battery staple"
         self.user = Journalist(username="foo",
                                password=self.user_pw)
-        self.admin_user_pw = "admin"
+        self.admin_user_pw = "ADMIN! correct horse battery staple"
         self.admin_user = Journalist(username="admin",
                                      password=self.admin_user_pw,
                                      is_admin=True)
@@ -187,7 +188,8 @@ class TestJournalist(TestCase):
         res = self.client.post(
             url_for('admin_edit_user', user_id=self.user.id),
             data=dict(username='foo', is_admin=False,
-                      password='valid', password_again='valid'))
+                      password='correct horse battery staple',
+                      password_again='correct horse battery staple'))
 
         self.assertIn('Password successfully changed', res.data)
 
@@ -204,7 +206,9 @@ class TestJournalist(TestCase):
 
     def test_admin_edits_user_password_too_long(self):
         self._login_admin()
-        overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
+        overly_long_password =  ''.join([random.choice(
+            'abcdefghijklmnopqrstuvxyz01234567890')
+            for _ in range(Journalist.MAX_PASSWORD_LEN + 1)])
 
         res = self.client.post(
             url_for('admin_edit_user', user_id=self.user.id),
@@ -304,8 +308,8 @@ class TestJournalist(TestCase):
         res = self.client.post(
             url_for('admin_add_user'),
             data=dict(username='dellsberg',
-                      password='pentagonpapers',
-                      password_again='pentagonpapers',
+                      password='correct horse battery staple',
+                      password_again='correct horse battery staple',
                       is_admin=False)
             )
 
@@ -316,8 +320,10 @@ class TestJournalist(TestCase):
 
         res = self.client.post(
             url_for('admin_add_user'),
-            data=dict(username='', password='pentagonpapers',
-                      password_again='pentagonpapers', is_admin=False))
+            data=dict(username='',
+                      password='correct horse battery staple',
+                      password_again='correct horse battery staple',
+                      is_admin=False))
 
         self.assertIn('Missing username', res.data)
 
@@ -334,7 +340,9 @@ class TestJournalist(TestCase):
     def test_admin_add_user_failure_password_too_long(self):
         self._login_admin()
 
-        overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
+        overly_long_password =  ''.join([random.choice(
+            'abcdefghijklmnopqrstuvxyz01234567890')
+            for _ in range(Journalist.MAX_PASSWORD_LEN + 1)])
         res = self.client.post(
             url_for('admin_add_user'),
             data=dict(username='dellsberg', password=overly_long_password,
@@ -394,7 +402,9 @@ class TestJournalist(TestCase):
 
     def test_too_long_user_password_change(self):
         self._login_user()
-        overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
+        overly_long_password =  ''.join([random.choice(
+            'abcdefghijklmnopqrstuvxyz01234567890')
+             for _ in range(Journalist.MAX_PASSWORD_LEN + 1)])
 
         res = self.client.post(url_for('edit_account'), data=dict(
             password=overly_long_password,
@@ -406,8 +416,8 @@ class TestJournalist(TestCase):
     def test_valid_user_password_change(self):
         self._login_user()
         res = self.client.post(url_for('edit_account'), data=dict(
-            password='valid',
-            password_again='valid'))
+            password='correct horse battery staple',
+            password_again='correct horse battery staple'))
         self.assertIn("Password successfully changed", res.data)
 
     def test_regenerate_totp(self):
@@ -625,7 +635,9 @@ class TestJournalist(TestCase):
     def test_max_password_length(self):
         """Creating a Journalist with a password that is greater than the
         maximum password length should raise an exception"""
-        overly_long_password = 'a'*(Journalist.MAX_PASSWORD_LEN + 1)
+        overly_long_password =  ''.join([random.choice(
+            'abcdefghijklmnopqrstuvxyz01234567890')
+            for _ in range(Journalist.MAX_PASSWORD_LEN + 1)])
         with self.assertRaises(InvalidPasswordLength):
             temp_journalist = Journalist(
                     username="My Password is Too Big!",


### PR DESCRIPTION
Dropbox has the library `zxcvbn` that does password strength checking in a number of ways (dictionary attacks, 1337 sp34k, etc.) and gives an all around score (0-4). The app checks that this score is at least 3 before accepting a journalist password. Diceware (n>=4) and KeePass passwords score high enough to pass.

This PR **only** addresses new users/admins. It does not attempt to warn current users/admins that their passwords are weak. I could add something that forces password resets, but given the heightened focus on UX, I'm holding off on that until someone give a second opinion.

Mostly fixes #980