### PR TITLE
Added expiration to sessions

### DIFF
--- a/securedrop/config.py.example
+++ b/securedrop/config.py.example
@@ -89,3 +89,6 @@ DATABASE_FILE = os.path.join(SECUREDROP_DATA_ROOT, 'db.sqlite')
 #SUPPORTED_LOCALES = ['en_US', 'fr_FR', 'nb_NO']
 # Which of the available locales should be displayed by default ?
 DEFAULT_LOCALE = 'en_US'
+
+# How long a session is valid before it expires and logs a user out
+SESSION_EXPIRATION_MINUTES = 30

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 import config
 
 from source_app import create_app

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from flask import (Flask, render_template, flash, Markup, request, g, session,
                    url_for, redirect)
 from flask_babel import gettext
@@ -75,6 +76,16 @@ def create_app(config):
         g.text_direction = i18n.get_text_direction(g.locale)
         g.html_lang = i18n.locale_to_rfc_5646(g.locale)
         g.locales = i18n.get_locale2name()
+
+        if 'expires' in session and datetime.utcnow() >= session['expires']:
+            session.clear()
+            flash(gettext('You have been logged out due to inactivity'),
+                  'error')
+
+        session['expires'] = datetime.utcnow() + \
+            timedelta(minutes=getattr(config,
+                                      'SESSION_EXPIRATION_MINUTES',
+                                      30))
 
         # ignore_static here because `crypto_util.hash_codename` is scrypt
         # (very time consuming), and we don't need to waste time running if

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -166,7 +166,11 @@ class TestSourceApp(TestCase):
             self.assertEqual(resp.status_code, 200)
             self.assertTrue(session['logged_in'])
             resp = c.get('/logout', follow_redirects=True)
+
+            # sessions always have 'expires', so pop it for the next check
+            session.pop('expires', None)
             self.assertTrue(not session)
+
             self.assertIn('Thank you for exiting your session!', resp.data)
 
     def test_user_must_log_in_for_protected_views(self):

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -144,15 +144,11 @@ def submit(source, num_submissions):
     return submissions
 
 
-# NOTE: this method is potentially dangerous to rely on for now due
-# to the fact flask_testing.TestCase only uses on request context
-# per method (see
-# https://github.com/freedomofpress/securedrop/issues/1444).
 def new_codename(client, session):
     """Helper function to go through the "generate codename" flow.
     """
-    with client as c:
-        c.get('/generate')
-        codename = session['codename']
-        c.post('/create')
+    client.get('/generate')
+    print(session)
+    codename = session['codename']
+    client.post('/create')
     return codename

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -147,8 +147,10 @@ def submit(source, num_submissions):
 def new_codename(client, session):
     """Helper function to go through the "generate codename" flow.
     """
+    # clear the session because our tests have implicit reliance on each other
+    session.clear()
+
     client.get('/generate')
-    print(session)
     codename = session['codename']
     client.post('/create')
     return codename


### PR DESCRIPTION
A quick fix to #880. Also, this should be compatible with with the fix @fowlslegs is proposing in https://github.com/freedomofpress/securedrop/issues/204#issuecomment-260478199.

It works by manually setting a session expiration time in the cookie's data and then checks it before each request either extending it or logging the user out. Sessions are set to expire after 30 minutes.