### PR TITLE
DRY up journalist interface index template using include

### DIFF
--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -1,0 +1,47 @@
+{% set docs = source.documents_messages_count()['documents'] %}
+{% set msgs = source.documents_messages_count()['messages'] %}
+<li class="source" data-source-designation="{{ source.journalist_designation|lower }}">
+  <time class="date" title="{{ source.last_updated|datetimeformat }}" datetime="{{ source.last_updated|datetimeformat(fmt="%Y-%m-%d %H:%M:%S%Z") }}">{{ source.last_updated|datetimeformat(relative=True) }}</time>
+  <div class="designation">
+    {% if source.star.starred %}
+      <button class="button-star starred" type="submit" formaction="/col/remove_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
+      <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
+      <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="starred-source-link-{{ loop_index }}">{{ source.journalist_designation }}</a></span>
+    {% else %}
+      <button class="button-star un-starred" type="submit" formaction="/col/add_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
+      <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
+      <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="un-starred-source-link-{{ loop_index }}">{{ source.journalist_designation }}</a></span>
+    {% endif %}
+  </div>
+  <div class="submission-count">
+    <span><i class="fa fa-file-archive-o"></i> {{ docs }} docs</span>
+    <span><i class="fa fa-file-text-o"></i> {{ msgs }} messages</span>
+    {% if source.num_unread > 0 %}
+      <span class="unread">
+        <a class="btn small" href='/download_unread/{{ source.filesystem_id }}' ><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
+      </span>
+    {% endif %}
+  </div>
+  <div id="{{ source.filesystem_id }}-assignment" class="assignment">
+    <div class="assign-current">
+      <p>Assigned:</p>
+      {% if source.journalist %}
+        <p>{{ source.journalist.username }}</p>
+      {% else %}
+        <p>nobody</p>
+      {% endif %}
+      <a href="#{{ source.filesystem_id }}-reassign">Reassign</a>
+    </div>
+    <div id="{{ source.filesystem_id }}-reassign" class="assign-select">
+      <p>Assign new journalist:</p>
+      <select name="journalist">
+        <option value="none">nobody</option>
+        {% for journalist in journalists %}
+        <option value="{{ journalist.username }}">{{ journalist.username }}</option>
+        {% endfor %}
+      </select>
+      <button formaction="/change-assignment/{{ source.filesystem_id }}">Apply</button>
+      <a class="btn" href="#{{ source.filesystem_id }}-assignment">Cancel</a>
+    </div>
+  </div>
+</li>

--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -5,11 +5,11 @@
   <div class="designation">
     {% if source.star.starred %}
       <button class="button-star starred" type="submit" formaction="/col/remove_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
-      <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
+      <input id="checkbox" type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
       <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="starred-source-link-{{ loop_index }}">{{ source.journalist_designation }}</a></span>
     {% else %}
       <button class="button-star un-starred" type="submit" formaction="/col/add_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
-      <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
+      <input id="checkbox" type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
       <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="un-starred-source-link-{{ loop_index }}">{{ source.journalist_designation }}</a></span>
     {% endif %}
   </div>

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -18,47 +18,10 @@
       {% if starred %}
         <ul id="cols" class="plain starred">
           {% for source in starred %}
-            {% set docs = source.documents_messages_count()['documents'] %}
-            {% set msgs = source.documents_messages_count()['messages'] %}
-            <li class="source" data-source-designation="{{ source.journalist_designation|lower }}">
-              <time class="date" title="{{ source.last_updated|datetimeformat }}" datetime="{{ source.last_updated|datetimeformat(fmt="%Y-%m-%d %H:%M:%S%Z") }}">{{ source.last_updated|datetimeformat(relative=True) }}</time>
-              <div class="designation">
-                <button class="button-star starred" type="submit" formaction="/col/remove_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
-                <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
-                <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="starred-source-link-{{loop.index}}">{{ source.journalist_designation }}</a></span>
-              </div>
-              <div class="submission-count">
-                <span><i class="fa fa-file-archive-o"></i> {{ docs }} docs</span>
-                <span><i class="fa fa-file-text-o"></i> {{ msgs }} messages</span>
-                {% if source.num_unread > 0 %}
-                  <span class="unread">
-                    <a class="btn small" href='/download_unread/{{ source.filesystem_id }}'><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
-                  </span>
-                {% endif %}
-              </div>
-              <div id="{{ source.filesystem_id }}-assignment" class="assignment">
-                <div class="assign-current">
-                  <p>Assigned:</p>
-                  {% if source.journalist %}
-                    <p>{{ source.journalist.username }}</p>
-                  {% else %}
-                    <p>nobody</p>
-                  {% endif %}
-                  <a href="#{{ source.filesystem_id }}-reassign">Reassign</a>
-                </div>
-                <div id="{{ source.filesystem_id }}-reassign" class="assign-select">
-                  <p>Assign new journalist:</p>
-                  <select name="journalist">
-                    <option value="none">nobody</option>
-                    {% for journalist in journalists %}
-                    <option value="{{ journalist.username }}">{{ journalist.username }}</option>
-                    {% endfor %}
-                  </select>
-                  <button formaction="/change-assignment/{{ source.filesystem_id }}">Apply</button>
-                  <a class="btn" href="#{{ source.filesystem_id }}-assignment">Cancel</a>
-                </div>
-              </div>
-            </li>
+            {% with %}
+              {% set loop_index = loop.index %}
+              {% include '_source_row.html' %}
+            {% endwith %}
           {% endfor %}
         </ul>
       {% endif %}
@@ -66,47 +29,10 @@
       {% if unstarred %}
         <ul id="cols" class="plain unstarred">
           {% for source in unstarred %}
-            {% set docs = source.documents_messages_count()['documents'] %}
-            {% set msgs = source.documents_messages_count()['messages'] %}
-            <li class="source" data-source-designation="{{ source.journalist_designation|lower }}">
-              <time class="date" title="{{ source.last_updated|datetimeformat }}" datetime="{{ source.last_updated|datetimeformat(fmt="%Y-%m-%d %H:%M:%S%Z") }}">{{ source.last_updated|datetimeformat(relative=True) }}</time>
-              <div class="designation">
-                <button class="button-star un-starred" type="submit" formaction="/col/add_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
-                <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
-                <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="un-starred-source-link-{{loop.index}}">{{ source.journalist_designation }}</a></span>
-              </div>
-              <div class="submission-count">
-                <span><i class="fa fa-file-archive-o"></i> {{ docs }} docs</span>
-                <span><i class="fa fa-file-text-o"></i> {{ msgs }} messages</span>
-                {% if source.num_unread > 0 %}
-                  <span class="unread">
-                    <a class="btn small" href='/download_unread/{{ source.filesystem_id }}' ><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
-                  </span>
-                {% endif %}
-              </div>
-              <div id="{{ source.filesystem_id }}-assignment" class="assignment">
-                <div class="assign-current">
-                  <p>Assigned:</p>
-                  {% if source.journalist %}
-                    <p>{{ source.journalist.username }}</p>
-                  {% else %}
-                    <p>nobody</p>
-                  {% endif %}
-                  <a href="#{{ source.filesystem_id }}-reassign">Reassign</a>
-                </div>
-                <div id="{{ source.filesystem_id }}-reassign" class="assign-select">
-                  <p>Assign new journalist:</p>
-                  <select name="journalist">
-                    <option value="none">nobody</option>
-                    {% for journalist in journalists %}
-                    <option value="{{ journalist.username }}">{{ journalist.username }}</option>
-                    {% endfor %}
-                  </select>
-                  <button formaction="/change-assignment/{{ source.filesystem_id }}">Apply</button>
-                  <a class="btn" href="#{{ source.filesystem_id }}-assignment">Cancel</a>
-                </div>
-              </div>
-            </li>
+            {% with %}
+              {% set loop_index = loop.index %}
+              {% include '_source_row.html' %}
+            {% endwith %}
           {% endfor %}
         </ul>
       {% endif %}

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -20,11 +20,11 @@ $(function () {
 
   var all = $("#select_all");
   var none = $("#select_none");
-  var unread = document.getElementById("select_unread");
+  var unread = $("#select_unread");
 
   all.css('cursor', 'pointer');
   none.css('cursor', 'pointer');
-  unread.style.cursor = "pointer";
+  unread.css('cursor', 'pointer');
 
   all.click(function() {
     var checkboxes = $(":checkbox").filter(":visible");
@@ -34,15 +34,15 @@ $(function () {
     var checkboxes = $(":checkbox").filter(":visible");
     checkboxes.prop('checked', false);
   });
-  unread.onclick = function() {
-    var checkboxes = document.querySelectorAll(".submission > [type='checkbox']");
-    for (var i = 0; i < checkboxes.length; i++) {
-        if (checkboxes[i].className.includes("unread-cb"))
-            checkboxes[i].checked = true;
-        else
-            checkboxes[i].checked = false;
-    }
-  };
+  unread.click(function() {
+      var checkboxes = document.querySelectorAll(".submission > [type='checkbox']");
+      for (var i = 0; i < checkboxes.length; i++) {
+          if (checkboxes[i].className.includes("unread-cb"))
+              checkboxes[i].checked = true;
+          else
+              checkboxes[i].checked = false;
+      }
+    });
 
   $("#delete_collection").submit(function () {
     return confirm("Are you sure you want to delete this collection?");

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -308,6 +308,21 @@ class JournalistNavigationSteps():
         unread_span = self.driver.find_element_by_css_selector('span.unread')
         self.assertIn("1 unread", unread_span.text)
 
+    def _journalist_stars_and_unstars_message(self):
+        # Message begins unstarred
+        with self.assertRaises(NoSuchElementException):
+            self.driver.find_element_by_id('starred-source-link-1')
+
+        # Journalist stars the message
+        self.driver.find_element_by_class_name('button-star').click()
+        starred = self.driver.find_elements_by_id('starred-source-link-1')
+        self.assertEquals(1, len(starred))
+
+        # Journalist unstars the message
+        self.driver.find_element_by_class_name('button-star').click()
+        with self.assertRaises(NoSuchElementException):
+            self.driver.find_element_by_id('starred-source-link-1')
+
     def _journalist_downloads_message(self):
         self.driver.find_element_by_css_selector(
             '#un-starred-source-link-1').click()

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -308,7 +308,7 @@ class JournalistNavigationSteps():
         unread_span = self.driver.find_element_by_css_selector('span.unread')
         self.assertIn("1 unread", unread_span.text)
 
-    def _journalist_stars_and_unstars_message(self):
+    def _journalist_stars_and_unstars_single_message(self):
         # Message begins unstarred
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_id('starred-source-link-1')
@@ -322,6 +322,17 @@ class JournalistNavigationSteps():
         self.driver.find_element_by_class_name('button-star').click()
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_id('starred-source-link-1')
+
+    def _journalist_selects_all_sources_then_selects_none(self):
+        self.driver.find_element_by_id('select_all').click()
+        checkboxes = self.driver.find_elements_by_id('checkbox')
+        for checkbox in checkboxes:
+            self.assertTrue(checkbox.is_selected())
+
+        self.driver.find_element_by_id('select_none').click()
+        checkboxes = self.driver.find_elements_by_id('checkbox')
+        for checkbox in checkboxes:
+            self.assertFalse(checkbox.is_selected())
 
     def _journalist_downloads_message(self):
         self.driver.find_element_by_css_selector(

--- a/securedrop/tests/functional/submit_and_retrieve_file.py
+++ b/securedrop/tests/functional/submit_and_retrieve_file.py
@@ -24,7 +24,8 @@ class SubmitAndRetrieveFile(
         self._source_logs_out()
         self._journalist_logs_in()
         self._journalist_checks_messages()
-        self._journalist_stars_and_unstars_message()
+        self._journalist_stars_and_unstars_single_message()
+        self._journalist_selects_all_sources_then_selects_none()
         self._journalist_downloads_message()
 
 

--- a/securedrop/tests/functional/submit_and_retrieve_file.py
+++ b/securedrop/tests/functional/submit_and_retrieve_file.py
@@ -24,4 +24,9 @@ class SubmitAndRetrieveFile(
         self._source_logs_out()
         self._journalist_logs_in()
         self._journalist_checks_messages()
+        self._journalist_stars_and_unstars_message()
         self._journalist_downloads_message()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This PR is to use Jinja2's `include` statement to DRY up the journalist interface index. This prevents (almost) duplicating the code within the `for source in starred` and `for source in unstarred` loops. This is worth merging before e.g. #1422 adds more features to the journalist interface. 