### PR TITLE
Speed up test workflow on dev VM

### DIFF
--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -74,11 +74,11 @@ def test():  # pragma: no cover
     run_tests([["py.test", "--cov"], "./test.sh"])
 
 
-def test_unit():  # pragma: no cover
+def test_unit(individual_test_or_file):  # pragma: no cover
     """
     Run just the unit tests.
     """
-    run_tests([["py.test", "--cov"]])
+    run_tests([["py.test", individual_test_or_file, "--cov"]])
 
 
 def test_functional():  # pragma: no cover
@@ -234,13 +234,14 @@ def clean_tmp():
 def get_args():  # pragma: no cover
     parser = ArgumentParser(prog=__file__,
                             description='A tool to help admins manage and devs hack')
-
     subparsers = parser.add_subparsers()
 
     run_subparser = subparsers.add_parser('run', help='Run the dev webserver (source & journalist)')
     run_subparser.set_defaults(func=run)
 
     unit_test_subparser = subparsers.add_parser('unit-test', help='Run the unit tests')
+    unit_test_subparser.add_argument('-t', '--tests_to_run', type=str, default='',
+        help='Specify a single unit test or single file of unit tests to run')
     unit_test_subparser.set_defaults(func=test_unit)
 
     functional_test_subparser = subparsers.add_parser('functional-test', help='Run the functional tests')
@@ -267,8 +268,13 @@ def get_args():  # pragma: no cover
 if __name__ == "__main__":  # pragma: no cover
     try:
         args = get_args().parse_args()
-        # calling like this works because all functions take zero arguments
-        args.func()
+
+        # test_unit requires an argument, so let's call func with that argument
+        if vars(args)['func'].__name__ == 'test_unit':
+            args.func(args.tests_to_run)
+        else:
+            # For the remainder of the functions, there are no arguments
+            args.func()
     except KeyboardInterrupt:
         print  # So our prompt appears on a nice new line
         exit(1)

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -58,29 +58,34 @@ def _stop_test_rqworker():  # pragma: no cover
     os.kill(get_pid_from_pidfile(TEST_WORKER_PIDFILE), signal.SIGTERM)
 
 
-def test():  # pragma: no cover
-    """
-    Runs the test suite
-    """
+def run_tests(test_commands):
     os.environ['SECUREDROP_ENV'] = 'test'
     import config
     _start_test_rqworker(config)
-    test_cmds = [["py.test", "--cov"], "./test.sh"]
-    test_rc = int(any([subprocess.call(cmd) for cmd in test_cmds]))
+    test_rc = int(any([subprocess.call(command) for command in test_commands]))
     _stop_test_rqworker()
     sys.exit(test_rc)
+
+
+def test():  # pragma: no cover
+    """
+    Run all tests (unit and functional).
+    """
+    run_tests([["py.test", "--cov"], "./test.sh"])
 
 
 def test_unit():  # pragma: no cover
     """
-    Runs the unit tests.
+    Run just the unit tests.
     """
-    os.environ['SECUREDROP_ENV'] = 'test'
-    import config
-    _start_test_rqworker(config)
-    test_rc = int(subprocess.call(["py.test", "--cov"]))
-    _stop_test_rqworker()
-    sys.exit(test_rc)
+    run_tests([["py.test", "--cov"]])
+
+
+def test_functional():  # pragma: no cover
+    """
+    Run just the functional tests.
+    """
+    run_tests(["./test.sh"])
 
 
 def reset():
@@ -237,6 +242,9 @@ def get_args():  # pragma: no cover
 
     unit_test_subparser = subparsers.add_parser('unit-test', help='Run the unit tests')
     unit_test_subparser.set_defaults(func=test_unit)
+
+    functional_test_subparser = subparsers.add_parser('functional-test', help='Run the functional tests')
+    functional_test_subparser.set_defaults(func=test_functional)
 
     test_subparser = subparsers.add_parser('test', help='Run the full test suite')
     test_subparser.set_defaults(func=test)


### PR DESCRIPTION
Currently there is quite a slow workflow when you're just trying to fix a single failing test: you’ve got to run the entire suite of unit tests all at once. Similarly, if you just want to run the functional tests, you’ve got to also run all the unit tests. This PR makes two small changes to speed this up. 

1) It adds a parser for running just the functional tests:

`$ ./manage.py functional-test`

2) It adds an arg for the unit tests subparser such that we can run just a single file of tests:

`$ ./manage.py unit-test -t tests/test_unit_db.py`

  or just a single unit test:

`$ ./manage.py unit-test -t tests/test_unit_db.py::TestDatabase::test_get_one_or_else_multiple_results`
