### PR TITLE
added metadata route to source app

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -7,7 +7,7 @@ import subprocess
 from threading import Thread
 import operator
 from flask import (Flask, request, render_template, session, redirect, url_for,
-                   flash, abort, g, send_file, Markup)
+                   flash, abort, g, send_file, Markup, make_response)
 from flask_wtf.csrf import CsrfProtect
 from flask_assets import Environment
 
@@ -15,6 +15,7 @@ from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.exc import IntegrityError
 
 import config
+import json
 import version
 import crypto_util
 import store
@@ -428,6 +429,16 @@ def download_journalist_pubkey():
 @app.route('/why-journalist-key')
 def why_download_journalist_pubkey():
     return render_template("why-journalist-key.html")
+
+
+@app.route('/metadata')
+def metadata():
+    meta = {'gpg_fpr': config.JOURNALIST_KEY,
+            'sd_version': version.__version__,
+            }
+    resp = make_response(json.dumps(meta))
+    resp.headers['Content-Type'] = 'application/json'
+    return resp
 
 
 @app.errorhandler(404)

--- a/securedrop/tests/test_unit_source.py
+++ b/securedrop/tests/test_unit_source.py
@@ -12,7 +12,9 @@ from flask_testing import TestCase
 
 from db import Source
 import source
+import version
 import utils
+import json
 
 
 class TestSourceApp(TestCase):
@@ -275,6 +277,12 @@ class TestSourceApp(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Turn the Security Slider to High to Protect Your "
                       "Anonymity", resp.data)
+
+    def test_metadata_route(self):
+        resp = self.client.get('/metadata')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers.get('Content-Type'), 'application/json')
+        self.assertEqual(json.loads(resp.data.decode('utf-8')).get('sd_version'), version.__version__)
 
     @patch('crypto_util.hash_codename')
     def test_login_with_overly_long_codename(self, mock_hash_codename):


### PR DESCRIPTION
In part fixes https://github.com/freedomofpress/securedrop/issues/972. This gives a bare minimum solution so that automation can quickly check the PGP fingerprint and app code version. This leaks zero information that can't be quickly scraped from the web interface with `grep` anyway.