### PR TITLE
updated docs for sources on deleting old conversations

### DIFF
--- a/docs/source.rst
+++ b/docs/source.rst
@@ -144,8 +144,10 @@ The next page will ask for your secret codename. Enter it and click
 
 If a journalist has responded, their message will appear on the
 next page. This page also allows you to upload another document or send
-another message to the journalist. Be sure to delete any messages here
-before navigating away.
+another message to the journalist. Before leaving the page, you should
+delete any replies. In the unlikely event that someone learns
+your codename, this will keep your identity secret as no one will be
+able to see the previous correspondences you had with journalists.
 
 |Check for a reply|
 

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -151,6 +151,10 @@ p#codename
     border-radius: 5px
     position: relative
 
+    p
+      color: #777
+      font-style: italic
+
     .date
       float: right
       background-color: $color_grey_medium
@@ -171,9 +175,6 @@ p#codename
       &:hover
         color: #FA6E6E
 
-  p
-    color: #777
-    font-style: italic
 
   .confirm-prompt
     position: absolute

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -41,7 +41,11 @@
 
 <div id="replies">
   {% if replies %}
-    <p>You have received a reply. For your security, please delete all replies when you're done with them. This also lets us know that you have received our reply. You can respond by submitting a new message above.</p>
+    <aside>
+      <p>You have received a reply. To protect your identity in the unlikely event someone learns your codename,
+        please delete all replies when you're done with them. This also lets us know that you have received our reply.
+        You can respond by submitting a new message above.</p>
+    </aside>
     <hr class="no-line">
     {% for reply in replies %}
       <div class="reply">
@@ -66,7 +70,7 @@
       <a class="sd-button btn" href="#delete-all-confirm">DELETE ALL REPLIES</a>
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
       <div id="delete-all-confirm" class="hidden-prompt">
-        <p>Are you finished with the replies?</p>
+        <p><strong>Are you finished with the replies?</strong></p>
         <button class="sd-button danger" type="submit">YES, DELETE ALL REPLIES</button>
         <a class="sd-button btn cancel" href="#delete-all">NO, NOT YET</a>
       </div>

--- a/securedrop/tests/test_unit_integration.py
+++ b/securedrop/tests/test_unit_integration.py
@@ -391,7 +391,7 @@ class TestIntegration(unittest.TestCase):
                 self.assertNotIn("You have received a reply.", resp.data)
             else:
                 self.assertIn(
-                    "You have received a reply. For your security, please delete all replies when you're done with them.",
+                    "You have received a reply. To protect your identity",
                     resp.data)
                 self.assertIn(test_reply, resp.data)
                 soup = BeautifulSoup(resp.data)


### PR DESCRIPTION
Small change to explain why a source might want to delete old replies in the source interface. @ninavizz might want to take a peek at this to make sure the language is user friendly since (hopefully) sources will see this before using SD.

Related, should there be a yellow `Tip` on the actual interface suggesting that sources delete replies?

fixes #553