### PR TITLE
Libvirt support for development machine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,11 +39,9 @@ Vagrant.configure("2") do |config|
     # more memory than the previous version did.
     development.vm.provider "virtualbox" do |v|
       v.memory = 1024
-      v.customize ["modifyvm", :id, "--cpus", available_vcpus]
     end
     development.vm.provider "libvirt" do |lv|
       lv.memory = 1024
-      lv.cpus = available_vcpus
       config.vm.synced_folder './', '/vagrant', type: 'nfs', disabled: false
     end
   end
@@ -76,7 +74,6 @@ Vagrant.configure("2") do |config|
     staging.vm.synced_folder './', '/vagrant', disabled: true
     staging.vm.provider "virtualbox" do |v|
       v.memory = 1024
-      v.customize ["modifyvm", :id, "--cpus", available_vcpus]
     end
     staging.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/securedrop-staging.yml"
@@ -120,7 +117,6 @@ Vagrant.configure("2") do |config|
     prod.vm.synced_folder './', '/vagrant', disabled: true
     prod.vm.provider "virtualbox" do |v|
       v.memory = 1024
-      v.customize ["modifyvm", :id, "--cpus", available_vcpus]
     end
     prod.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/securedrop-prod.yml"
@@ -252,25 +248,4 @@ end
 def internal_network_name
   repo_root = File.expand_path(File.dirname(__FILE__))
   return File.basename(repo_root)
-end
-
-def available_vcpus
-  # Increase number of virtual CPUs in guest VM.
-  # Rather than blindly set it to "2" or similar,
-  # inspect the number of VCPUs on the host and use that,
-  # to minimize compile time.
-  available_vcpus = case RUBY_PLATFORM
-    when /linux/
-      `nproc`.to_i
-    when /darwin/
-      `sysctl -n hw.ncpu`.to_i
-    else
-      1
-    end
-  # If you want to restrict the resources available to the guest VM,
-  # uncomment the return line below, and Vagrant will use half the
-  # number available on the host, rounded down.
-  # (Ruby will correctly return the quotient as an integer.)
-  # return available_vcpus / 2
-  return available_vcpus
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,6 +39,7 @@ Vagrant.configure("2") do |config|
     # more memory than the previous version did.
     development.vm.provider "virtualbox" do |v|
       v.memory = 1024
+      v.customize ["modifyvm", :id, "--cpus", available_vcpus]
     end
     development.vm.provider "libvirt" do |lv|
       lv.memory = 1024
@@ -75,6 +76,7 @@ Vagrant.configure("2") do |config|
     staging.vm.synced_folder './', '/vagrant', disabled: true
     staging.vm.provider "virtualbox" do |v|
       v.memory = 1024
+      v.customize ["modifyvm", :id, "--cpus", available_vcpus]
     end
     staging.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/securedrop-staging.yml"
@@ -118,6 +120,7 @@ Vagrant.configure("2") do |config|
     prod.vm.synced_folder './', '/vagrant', disabled: true
     prod.vm.provider "virtualbox" do |v|
       v.memory = 1024
+      v.customize ["modifyvm", :id, "--cpus", available_vcpus]
     end
     prod.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/securedrop-prod.yml"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,12 +28,16 @@ Vagrant.configure("2") do |config|
         'securedrop:children' => %w(development),
       }
     end
+    # Running the functional tests with Selenium/Firefox has started causing
+    # out-of-memory errors.
+    #
+    # This started around October 14th and was first observed on the task-queue
+    # branch. There are two likely causes: (1) The new job queue backend (redis)
+    # is taking up a significant amount of memory. According to top, it is not
+    # (a couple MB on average). (2) Firefox 33 was released on October 13th:
+    # https://www.mozilla.org/en-US/firefox/33.0/releasenotes/ It may require
+    # more memory than the previous version did.
     development.vm.provider "virtualbox" do |v|
-      # Running the functional tests with Selenium/Firefox has started causing out-of-memory errors.
-      #
-      # This started around October 14th and was first observed on the task-queue branch. There are two likely causes:
-      # 1. The new job queue backend (redis) is taking up a significant amount of memory. According to top, it is not (a couple MB on average).
-      # 2. Firefox 33 was released on October 13th: https://www.mozilla.org/en-US/firefox/33.0/releasenotes/ It may require more memory than the previous version did.
       v.memory = 1024
     end
   end
@@ -65,11 +69,6 @@ Vagrant.configure("2") do |config|
     staging.vm.network "forwarded_port", guest: 8080, host: 8083, auto_correct: true
     staging.vm.synced_folder './', '/vagrant', disabled: true
     staging.vm.provider "virtualbox" do |v|
-      # Running the functional tests with Selenium/Firefox has started causing out-of-memory errors.
-      #
-      # This started around October 14th and was first observed on the task-queue branch. There are two likely causes:
-      # 1. The new job queue backend (redis) is taking up a significant amount of memory. According to top, it is not (a couple MB on average).
-      # 2. Firefox 33 was released on October 13th: https://www.mozilla.org/en-US/firefox/33.0/releasenotes/ It may require more memory than the previous version did.
       v.memory = 1024
     end
     staging.vm.provision "ansible" do |ansible|
@@ -113,11 +112,6 @@ Vagrant.configure("2") do |config|
     prod.vm.network "private_network", ip: "10.0.1.4", virtualbox__intnet: internal_network_name
     prod.vm.synced_folder './', '/vagrant', disabled: true
     prod.vm.provider "virtualbox" do |v|
-      # Running the functional tests with Selenium/Firefox has started causing out-of-memory errors.
-      #
-      # This started around October 14th and was first observed on the task-queue branch. There are two likely causes:
-      # 1. The new job queue backend (redis) is taking up a significant amount of memory. According to top, it is not (a couple MB on average).
-      # 2. Firefox 33 was released on October 13th: https://www.mozilla.org/en-US/firefox/33.0/releasenotes/ It may require more memory than the previous version did.
       v.memory = 1024
     end
     prod.vm.provision "ansible" do |ansible|


### PR DESCRIPTION
* Consolidate comments explaining memory requirements in Vagrantfile.
* Add support for libvirt provider for development machine.
  * ~~Uses new `available_cpus` Ruby function to ensure all CPUs are used.~~
  * Although `config.vm.synced_folder` defaults to the exact settings in this
  commit, if NFS support is not present on the host, Vagrant will fall back
  to unidirectional `rsync` syncing. It's better to fail and make the user
  setup NFS support than leave w/o bidirectional syncing support.*
* Use all available CPUs w/ the Virtualbox provider.

\* See [discussion below](https://github.com/freedomofpress/securedrop/pull/1561#issuecomment-278498306) as to whether this is completely accurate.