### PR TITLE
Spit out Travis build env parameters in test output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 - pip install coveralls
 - pip install ansible==1.8.4
 script:
+- 'for e in /.packer-env/*; do echo -n "${e}: "; cat "${e}"; done'
 - echo localhost > inventory
 - ansible-playbook -i inventory --syntax-check install_files/ansible-base/securedrop-travis.yml
 - ansible-playbook -i inventory --connection=local --sudo --skip-tags=non-development install_files/ansible-base/securedrop-travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 virtualenv:
   system_site_packages: true
 before_install:
+- 'for e in /.packer-env/*; do echo -n "${e}: "; cat "${e}"; done'
 - sudo apt-get update -qq
 - sudo apt-get install --yes rng-tools
 - sudo rm -f /dev/random
@@ -19,7 +20,6 @@ install:
 - pip install coveralls
 - pip install ansible==1.8.4
 script:
-- 'for e in /.packer-env/*; do echo -n "${e}: "; cat "${e}"; done'
 - echo localhost > inventory
 - ansible-playbook -i inventory --syntax-check install_files/ansible-base/securedrop-travis.yml
 - ansible-playbook -i inventory --connection=local --sudo --skip-tags=non-development install_files/ansible-base/securedrop-travis.yml


### PR DESCRIPTION
During packer builds, parameters having to do with the original build
environment are shoved in `/.packer-env` by default. Let's spit these
out to stdout so it will assist us in recreating the dev environment
when necessary in the future.

Example output looks like this:

```bash
$ for e in /.packer-env/*; do echo -n "${e}: "; cat "${e}"; done
/.packer-env/PACKER_BUILDER_TYPE: googlecompute
/.packer-env/PACKER_BUILD_NAME: googlecompute
/.packer-env/PACKER_TEMPLATES_BRANCH: master
/.packer-env/PACKER_TEMPLATES_SHA: 0f241c1
/.packer-env/TRAVIS_COOKBOOKS_BRANCH: 
/.packer-env/TRAVIS_COOKBOOKS_DIR: /tmp/chef-stuff/travis-cookbooks
/.packer-env/TRAVIS_COOKBOOKS_SHA: 998099c
```