### PR TITLE
Adjusts vagrant shared folder behavior under libvirt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,9 +40,9 @@ Vagrant.configure("2") do |config|
     development.vm.provider "virtualbox" do |v|
       v.memory = 1024
     end
-    development.vm.provider "libvirt" do |lv|
+    development.vm.provider "libvirt" do |lv, override|
       lv.memory = 1024
-      config.vm.synced_folder './', '/vagrant', type: 'nfs', disabled: false
+      override.vm.synced_folder './', '/vagrant', type: 'nfs', disabled: false
     end
   end
 


### PR DESCRIPTION
The NFS strategy for mounting /vagrant in the development machine should
only take effect if the libvirt provider is currently active. Let's
reference the `override` pragma, documented here [0], to achieve.

Supplements changes in #1561. Closes #1582.

[0] https://www.vagrantup.com/docs/providers/configuration.html