### PR TITLE
Add note on removing speakers from the SVS

### DIFF
--- a/docs/set_up_svs.rst
+++ b/docs/set_up_svs.rst
@@ -18,12 +18,12 @@ adapters. If the machine has network ports you can't physically remove, you
 should clearly cover these ports with labels noting not to use them. For an even
 safer approach, fill a port with epoxy to physically disable it. We also
 recommend you remove the speakers from the device (or just cut the audio cables
-if that's easier) . This is to prevent exfiltration of data from the airgap via
-ultrasonic (i.e., above the range of human hearing) waves (for more read
-https://arstechnica.com/security/2013/12/scientist-developed-malware-covertly-jumps-air-gaps-using-inaudible-sound/).
-If you have questions about repurposing hardware for the *Secure Viewing
-Station*, contact the `Freedom of the Press Foundation
-<https://securedrop.org/help>`__.
+if that's easier). This is to prevent `exfiltration of data from the airgap via
+ultrasonic audio
+<https://arstechnica.com/security/2013/12/scientist-developed-malware-covertly-jumps-air-gaps-using-inaudible-sound/>`__,
+which cannot be heard by humans. If you have questions about repurposing
+hardware for the *Secure Viewing Station*, contact the `Freedom of the Press
+Foundation <https://securedrop.org/help>`__.
 
 You should have a Tails drive clearly labeled “SecureDrop Secure Viewing
 Station”. If it's not labeled, label it right now, then boot it on the

--- a/docs/set_up_svs.rst
+++ b/docs/set_up_svs.rst
@@ -21,6 +21,9 @@ epoxy to physically disable it. If you have questions about repurposing
 hardware for the *Secure Viewing Station*, contact the `Freedom of the
 Press Foundation <https://securedrop.org/help>`__.
 
+We also recommend you remove all speakers from the device, instead using
+earphones to listen to audio submissions.
+
 You should have a Tails drive clearly labeled “SecureDrop Secure Viewing
 Station”. If it's not labeled, label it right now, then boot it on the
 *Secure Viewing Station*. After it loads, you should see a "Welcome to

--- a/docs/set_up_svs.rst
+++ b/docs/set_up_svs.rst
@@ -12,17 +12,18 @@ drive or a DVD) and physically transfer the *Data Transfer Device* to
 the *Secure Viewing Station*.
 
 Since the *Secure Viewing Station* never uses a network connection or an
-internal hard drive, we recommend that you physically remove any any
-internal storage devices or networking hardware such as wireless cards
-or Bluetooth adapters. If the machine has network ports you can't
-physically remove, you should clearly cover these ports with labels
-noting not to use them. For an even safer approach, fill a port with
-epoxy to physically disable it. If you have questions about repurposing
-hardware for the *Secure Viewing Station*, contact the `Freedom of the
-Press Foundation <https://securedrop.org/help>`__.
-
-We also recommend you remove all speakers from the device, instead using
-earphones to listen to audio submissions.
+internal hard drive, we recommend that you physically remove any any internal
+storage devices or networking hardware such as wireless cards or Bluetooth
+adapters. If the machine has network ports you can't physically remove, you
+should clearly cover these ports with labels noting not to use them. For an even
+safer approach, fill a port with epoxy to physically disable it. We also
+recommend you remove the speakers from the device (or just cut the audio cables
+if that's easier) . This is to prevent exfiltration of data from the airgap via
+ultrasonic (i.e., above the range of human hearing) waves (for more read
+https://arstechnica.com/security/2013/12/scientist-developed-malware-covertly-jumps-air-gaps-using-inaudible-sound/).
+If you have questions about repurposing hardware for the *Secure Viewing
+Station*, contact the `Freedom of the Press Foundation
+<https://securedrop.org/help>`__.
 
 You should have a Tails drive clearly labeled “SecureDrop Secure Viewing
 Station”. If it's not labeled, label it right now, then boot it on the


### PR DESCRIPTION
Wanted to get more feedback on this before we consider merge. Should we include information on why this is a good idea and helps enforce the airgap? (It's because of cooperative side-channels for information exfiltration using ultrasonic frequencies.) Also, should I just merge this line into the paragraph above it if we're not going to expand on it?

My inclinations, responding to my own questions, are no and yes, respectively.

And one more--is this process too difficult on some machines to expect of admins?