### PR TITLE
Add explicit height and width to PNG versions of font awesome icons

### DIFF
--- a/securedrop/source_templates/banner_warning_flashed.html
+++ b/securedrop/source_templates/banner_warning_flashed.html
@@ -1,7 +1,7 @@
 {# these are flash messages that appear at the top and are really scary, like if you're using tor2web #}
 {% with messages = get_flashed_messages(with_categories=True, category_filter=["banner-warning"]) %}
   {% for category, message in messages %}
-  <p class="flash {{ category }}"><img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/exclamation-triangle-black.png') }}" width="17px" height="17px">
+  <p class="flash {{ category }}"><img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/exclamation-triangle-black.png') }}" width="20px" height="17px">
  {{ message|safe }}</p>
   {% endfor %}
 {% endwith %}

--- a/securedrop/source_templates/first_submission_flashed_message.html
+++ b/securedrop/source_templates/first_submission_flashed_message.html
@@ -1,4 +1,4 @@
-<img src="{{ url_for('static', filename='i/success_checkmark.png') }}" height=64 width=74>
+<img src="{{ url_for('static', filename='i/success_checkmark.png') }}" height="64px" width="74px">
 <div class="message"><strong>Success!</strong>
   <p>Thank you for sending this information to us. Please check back later for replies.
     <a href="#codename-hint">

--- a/securedrop/source_templates/flashed.html
+++ b/securedrop/source_templates/flashed.html
@@ -4,9 +4,9 @@
     {% if category != 'banner-warning' %}
       <div class="flash {{ category }}">
         {% if category == 'notification' %}
-        <img src="{{ url_for('static', filename='i/font-awesome/info-circle-black.png') }}" width="20px">
+        <img src="{{ url_for('static', filename='i/font-awesome/info-circle-black.png') }}" width="20px" height="16px">
         {% elif category == 'error' %}
-        <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/exclamation-triangle-black.png') }}" width="20px">
+        <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/exclamation-triangle-black.png') }}" width="20px" height="17px">
         {% endif %}
         {{ message }}
       </div>

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -7,7 +7,7 @@
 <hr class="no-line" />
 
 <div class="code">
-  <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/lock-black.png') }}" width="20px" height="20px">
+  <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/lock-black.png') }}" width="20px" height="23px">
   <p id="codename" class="codename">{{ codename }}</p>
   <div class="pull-right">
 

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -35,8 +35,8 @@
           <hr class="cut-out" />
           <p>If this is your first time submitting documents to journalists, start here.</p>
           <a href="/generate" class="sd-button btn alt index" id="submit-documents-button">
-            <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-white.png') }}" width="20px" />
-            <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-blue.png') }}" width="20px" />
+            <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-white.png') }}" width="20px" height="14px" />
+            <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-blue.png') }}" width="20px" height="14px" />
             SUBMIT DOCUMENTS
           </a>
         </div>
@@ -47,8 +47,8 @@
           <hr class="cut-out" />
           <p>If you have already submitted documents in the past, log in here to check for responses.</p>
           <a href="/login" id="login-button" class="sd-button btn primary index">
-            <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/comments-white.png') }}" width="20px" />
-            <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/comments-blue.png') }}" width="20px" />
+            <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/comments-white.png') }}" width="20px" height="16px" />
+            <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/comments-blue.png') }}" width="20px" height="16px" />
             CHECK FOR A RESPONSE
           </a>
         </div>

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -12,8 +12,8 @@
 <div class="pull-right">
   <a href="{{ url_for('index') }}" class="sd-button btn secondary" id="cancel">CANCEL</a>
   <button type="submit" class="sd-button btn primary">
-    <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-white.png') }}" width="18px" />
-    <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-blue.png') }}" width="18px" />
+    <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-white.png') }}" width="18px" height="18px" />
+    <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-blue.png') }}" width="18px" height="18px" />
     CONTINUE
   </button>
 </div>

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -44,8 +44,8 @@
   <div class="pull-right">
     <a href="{{ url_for('lookup') }}" class="btn secondary" id="cancel">CANCEL</a>
     <button type="submit" class="sd-button btn primary" id="submit-doc-button">
-      <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-white.png') }}" width="20px" />
-      <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-blue.png') }}" width="20px" />
+      <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-white.png') }}" width="20px" height="14px" />
+      <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-blue.png') }}" width="20px" height="14px" />
       SUBMIT
     </button>
   </div>
@@ -99,7 +99,7 @@
 <hr class="no-line">
 
 <div class="code-reminder" id="codename-hint">
-  <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/lock-black.png') }}" width="20px" height="20px"> Remember your codename is:
+  <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/lock-black.png') }}" width="17px" height="20px"> Remember your codename is:
   <div id="show" class="show pull-right"></div>
   <span id="content" class="codename"><p class="alert">{{ codename }}</p></span>
 </div>


### PR DESCRIPTION
This resolves #1601, simply setting the heights and widths for all the font awesome icons on the source interface to ensure they are properly rendered. 