### PR TITLE
Change delete/download text on Journalist interface

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -23,8 +23,8 @@
     <form action="/bulk" method="post">
       <div class="document-actions">
         <div id='select-container'></div>
-        <button class="sd-button" type="submit" name="action" value="download"></i> DOWNLOAD</button>
-        <button class="sd-button" type="submit" name="action" value="confirm_delete" class="danger" id="delete_selected">DELETE</button>
+        <button class="sd-button" type="submit" name="action" value="download"></i> DOWNLOAD SELECTED</button>
+        <button class="sd-button" type="submit" name="action" value="confirm_delete" class="danger" id="delete_selected">DELETE SELECTED</button>
       </div>
       <ul id="submissions" class="plain submissions">
         {% for doc in source.collection %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1571, targeted for 0.4. Very simple change: right now on the journalist interface if you turn off JavaScript, it's unclear what the purpose of the Download / Delete buttons are. They clearly Download or Delete something, but does the Download button download all source documents? (no) Does the Delete button delete the source and documents? (no).

Changes proposed in this pull request:
* Change "download"/"delete" text to "download selected"/"delete selected".

Note there is another 0.4 issue (#1604) for debating which UI changes from develop should stick around in 0.4, but I'm not attempting to address that here.  

## Testing

Run the journalist interface, check out the workflow, or if you are very familiar with the journalist interface then just look at the screenshots. See if you agree with this change. 

## Screenshots

### Reference: Security Slider Low

![screen shot 2017-04-03 at 3 26 48 pm](https://cloud.githubusercontent.com/assets/7832803/24634804/a83cf874-1884-11e7-8d28-9a0d230b2680.png)

### Before: Security Slider High

![screen shot 2017-04-03 at 3 26 37 pm](https://cloud.githubusercontent.com/assets/7832803/24634787/90da571c-1884-11e7-8358-3974ebe42e71.png)

### After: Security Slider High

![screen shot 2017-04-03 at 3 27 53 pm](https://cloud.githubusercontent.com/assets/7832803/24634795/9d2b5afc-1884-11e7-84bc-0752fa91d63b.png)

### After: Security Slider Low

![screen shot 2017-04-03 at 3 27 41 pm](https://cloud.githubusercontent.com/assets/7832803/24634801/a4457b60-1884-11e7-8ac8-872e1c241c38.png)

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
