### PR TITLE
Fix coveralls checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
 - sudo sh -c "export DISPLAY=:1; cd securedrop/ && pytest tests/"
 - ./testinfra/test.py
 after_success:
-  cd tests/ && coveralls && cd ..  # cd back to repo root for srcclr run
+  cd securedrop/ && coveralls && cd ../  # cd back to repo root for srcclr run
 addons:
     srcclr:
         debug: true

--- a/securedrop/.coveragerc
+++ b/securedrop/.coveragerc
@@ -1,3 +1,4 @@
 [run]
 branch = True
 source = ../securedrop
+omit = tests/*


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Small followup PR to recent changes to the SecureDrop application tests: 
* Coveralls checks were not working due to an outdated relative path in `.travis.yml`, which means that the coverage results were not sent to Coveralls. 
* The SecureDrop application tests were being included in the coverage calculation. 

## Testing

1. Look at the checks. 
2. Notice that Coveralls is working. 
3. Merge this PR! :sparkles:

