### PR TITLE
Include missing link tag for logo in source_templates/index.html

### DIFF
--- a/install_files/ansible-base/usr.sbin.apache2
+++ b/install_files/ansible-base/usr.sbin.apache2
@@ -171,7 +171,6 @@
   /var/www/securedrop/static/css/normalize.css r,
   /var/www/securedrop/static/css/source.css r,
   /var/www/securedrop/static/css/journalist.css r,
-  /var/www/securedrop/static/i/favicon.png r,
   /var/www/securedrop/static/i/logo.png r,
   /var/www/securedrop/static/i/no16-global.png r,
   /var/www/securedrop/static/i/no16.png r,

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -4,6 +4,7 @@
     <title>SecureDrop | Protecting Journalists and Sources</title>
 
     <link rel="stylesheet" href="/static/css/source.css" />
+    <link rel="icon" type="image/png" href="/static/i/favicon.png" >
 
     {% assets filters="jsmin", output="gen/source.js",
       "js/libs/jquery-2.1.4.min.js", "js/source.js" %}


### PR DESCRIPTION
Otherwise, the browser first requests `/favicon.png` and gets a 404, then tries `/static/i/favicon.png`.