### PR TITLE
Update Grub PaX flags in grsecurity role

### DIFF
--- a/install_files/ansible-base/roles/grsecurity/tasks/paxctl.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/paxctl.yml
@@ -23,15 +23,5 @@
 - name: Adjust paxctl headers on grub binaries.
   command: paxctl -zCE {{ item.item }}
   with_items: "{{ paxctl_grub_header_check.results }}"
-  # The desired flags should include:
-  #   - p NOPAGEEXEC
-  #   - m NOMPROTECT
-  #   - x NORANDEXEC
-  #   - e NOEMUTRAMP
-  # After running `paxctl -Cpm` in VirtualBox, all four of those flags are set.
-  # However, the current paxctl command only enforces p and m.
-  # The x and e flags are present by default, but can be removed via
-  # `paxctl -z <binary>`. TODO: We may want to update the command
-  # to set -Cpmxe explicitly. Warrants further testing on hardware.
-  when: "item.stdout != '- PaX flags: -p---m--E--- [{{ item.item }}]' or
+  when: "item.stdout != '- PaX flags: --------E--- [{{ item.item }}]' or
          item.rc != 0"

--- a/install_files/ansible-base/roles/grsecurity/tasks/paxctl.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/paxctl.yml
@@ -18,9 +18,10 @@
   with_items:
     - /usr/sbin/grub-probe
     - /usr/sbin/grub-mkdevicemap
+    - /usr/bin/grub-script-check
 
 - name: Adjust paxctl headers on grub binaries.
-  command: paxctl -Cpm {{ item.item }}
+  command: paxctl -zCE {{ item.item }}
   with_items: "{{ paxctl_grub_header_check.results }}"
   # The desired flags should include:
   #   - p NOPAGEEXEC
@@ -32,5 +33,5 @@
   # The x and e flags are present by default, but can be removed via
   # `paxctl -z <binary>`. TODO: We may want to update the command
   # to set -Cpmxe explicitly. Warrants further testing on hardware.
-  when: "item.stdout != '- PaX flags: -p---m-x-e-- [{{ item.item }}]' or
+  when: "item.stdout != '- PaX flags: -p---m--E--- [{{ item.item }}]' or
          item.rc != 0"

--- a/testinfra/common/test_grsecurity.py
+++ b/testinfra/common/test_grsecurity.py
@@ -141,11 +141,6 @@ def test_apt_autoremove(Command):
     assert "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded" in c.stdout
 
 
-# Expecting failure here, since the Ansible config doesn't set the same
-# flags in via the playbook as were recently declared in the securedrop-grsec
-# metapackage. The playbook in the SecureDrop install process should be updated
-# to match the PaX flags enforced via the metapackage.
-@pytest.mark.xfail
 @pytest.mark.parametrize("binary", [
     "/usr/sbin/grub-probe",
     "/usr/sbin/grub-mkdevicemap",
@@ -166,7 +161,9 @@ def test_pax_flags(Command, File, binary):
     c = Command("paxctl -v {}".format(binary))
     assert c.rc == 0
 
-    assert "- PaX flags: -p---m--E--- [{}]".format(binary) in c.stdout
-    assert "PAGEEXEC is disabled" in c.stdout
-    assert "MPROTECT is disabled" in c.stdout
+    assert "- PaX flags: --------E--- [{}]".format(binary) in c.stdout
     assert "EMUTRAMP is enabled" in c.stdout
+    # Tracking regressions; previous versions of the Ansible config set
+    # the "p" and "m" flags.
+    assert "PAGEEXEC is disabled" not in c.stdout
+    assert "MPROTECT is disabled" not in c.stdout


### PR DESCRIPTION
PaX flags here now match what we set in the securedrop-grsec metapackage (see
https://github.com/freedomofpress/ansible-role-grsecurity/pull/91/commits/406078267426faf01c16e21eb5a32f129795a045). Fixes #1621.