### PR TITLE
Updates all apt packages for the build VM

### DIFF
--- a/install_files/ansible-base/build-deb-pkgs.yml
+++ b/install_files/ansible-base/build-deb-pkgs.yml
@@ -35,6 +35,12 @@
     - group_vars/securedrop_application_server.yml
     - group_vars/development.yml
   pre_tasks:
+    - name: Ensure all packages are up to date.
+      apt:
+        upgrade: dist
+        update_cache: yes
+        cache_valid_time: 3600
+
     # These packages are necessary for running the `update_version.sh` script.
     - name: Install required build tools.
       apt:

--- a/testinfra/build/test_build_dependencies.py
+++ b/testinfra/build/test_build_dependencies.py
@@ -72,4 +72,13 @@ def test_build_directories(File, directory):
     assert File(directory).is_directory
 
 
-
+def test_build_all_packages_updated(Command):
+    """
+    Ensure a dist-upgrade has already been run, by checking that no
+    packages are eligible for upgrade currently. This will ensure that
+    all upgrades, security and otherwise, have been applied to the VM
+    used to build packages.
+    """
+    c = Command('aptitude --simulate -y dist-upgrade')
+    assert c.rc == 0
+    assert "No packages will be installed, upgraded, or removed." in c.stdout


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Ensures that the latest security updates have been installed in the build environment prior to building the deb packages. Handles the update idempotently, and only refreshes the apt cache (to check for new updates) once every hour. That will keep repeated builds snappy.

Closes #1644.

## Testing

How should the reviewer test this PR?

1.Run the build VM: `vagrant destroy -f build && vagrant up build`
2. Confirm that there are no packages to upgrade: `vagrant ssh build -c 'sudo aptitude dist-upgrade -y --simulate'` should list zero packages to be upgraded.
3. Profit!

## Deployment

No concerns; prior builds have had package updates applied manually (by moi).

## Checklist

### If you made changes to the system configuration:

- [x] Testinfra tests pass on the build VM

