### PR TITLE
Migrates Document -> Journalist interface via preinst

### DIFF
--- a/install_files/securedrop-app-code/DEBIAN/preinst
+++ b/install_files/securedrop-app-code/DEBIAN/preinst
@@ -46,6 +46,32 @@ function permanently_disable_swap() {
     perl -i -apne '$F[2] eq "swap" && /^[^\s#]+?/ && s/^/#/g' /etc/fstab
 }
 
+function convert_document_to_journalist_interface() {
+    # Helper function to migrate the old "Document Interface" config files
+    # to the new "Journalist Interface" naming scheme. Affects tor and apache.
+
+    if [[ -d /var/lib/tor/services/document ]]; then
+        # Move tor service hostname and keys.
+        mv /var/lib/tor/services/document /var/lib/tor/services/journalist
+        # Update torrc to use new tor service hostname directory.
+        perl -pi -e 's#^(HiddenServiceDir /var/lib/tor/services/)document#$1journalist#' /etc/tor/torrc
+        # Bounce tor service.
+        service tor restart
+    fi
+
+    if [[ -f /etc/apache2/sites-available/document.conf ]]; then
+        # Stop apache prior to migrating vhost.
+        service apache2 stop
+        # Convert apache vhost settings to use the new interface name.
+        perl -p -e 's/document/journalist/' /etc/apache2/sites-available/document.conf \
+            > /etc/apache2/sites-available/journalist.conf
+        rm -f /etc/apache2/sites-available/document.conf
+        rm -f /etc/apache2/sites-enabled/document.conf
+        # Enable new site; don't start apache, since `postinst` will start it.
+        a2ensite journalist
+    fi
+}
+
 case "$1" in
     install)
       permanently_disable_swap
@@ -54,6 +80,7 @@ case "$1" in
     upgrade)
 
       permanently_disable_swap
+      convert_document_to_journalist_interface
 
       if [ -n "$2" ] && [ "$2" = "0.3" ] ; then
         # Copy the custom logo (workaround due to #911)


### PR DESCRIPTION
Implements a hook-based migration strategy for renaming the Document
Interface to Journalist Interface (for consistency with the role-based
"Source Interface" name). Services migrated include:

  * ATHS config
  * Apache vhost config

These config updates are performed as part of the `preinst` stage in the
`securedrop-app-code` deb package. Care has been taken to ensure that
the config update logic is idempotent, so that the same preinst hooks
can run on any future version of SecureDrop and ensure the same results.

## Status

Ready for review.

## Description of Changes

Fixes #1614.

## Testing

1. Provision staging VMs based on the 0.3.12 tag.
2. Check out this PR and install locally build deb packages.
3. Run all config and app test suites, confirm passing.

In manual testing locally, config test suites showed green across the board, save a single failure on App Staging and Mon Staging, caused by an iptables rule being updated between 0.3.12 and current develop. That's an acceptable failure; rerunning the Ansible playbooks in their entirety would resolve.

## Deployment

The strategy here is to migrate currently running production instances over to the new Interface naming scheme (i.e. Document -> Journalist interface). We cannot coordinate with Admins to install the 0.4 update manually, since the servers will automatically install any new deb packages via the nightly updates. Thus the migration logic must exist in the app-code package, or be backed out of develop. See #1614 for discussion.

## Checklist

### If you made changes to the app code:

Will update the testing results after #1649 is merged. Rebasing on top of that branch locally, test output was great. Omitting that successful feedback from the manual test confirmation below until the passing is true of the PR branch.

- [x] Unit and functional tests pass on the development VM
- [ ] Unit and functional tests pass on the app-staging VM

### If you made changes to the system configuration:

- [x] Testinfra tests pass on the development VM
- [x] Testinfra tests pass on the build VM
- [ ] Testinfra tests pass on the app-staging VM
- [ ] Testinfra tests pass on the mon-staging VM
