### PR TITLE
Removes duplicate Apache config file

### DIFF
--- a/install_files/ansible-base/group_vars/securedrop_application_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_application_server.yml
@@ -71,10 +71,6 @@ apache_packages:
   - libapache2-mod-wsgi
   - libapache2-mod-xsendfile
 
-apache_files:
-  - 'apache2.conf'
-  - 'security'
-
 apache_templates:
   - 'ports.conf'
   - 'sites-available/journalist.conf'

--- a/install_files/ansible-base/roles/app/files/security
+++ b/install_files/ansible-base/roles/app/files/security
@@ -1,3 +1,0 @@
-ServerTokens Prod
-ServerSignature Off
-TraceEnable Off

--- a/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
+++ b/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
@@ -10,15 +10,24 @@
     - apt
     - apache
 
-- name: Copy Apache configuration and security files.
+- name: Copy Apache configuration file.
   copy:
-    src: "{{ item }}"
-    dest: /etc/apache2/{{ item }}
+    src: apache2.conf
+    dest: /etc/apache2/apache2.conf
     owner: root
     mode: '0644'
-  with_items: "{{ apache_files }}"
   notify:
     - restart apache2
+  tags:
+    - apache
+
+  # Previous versions of the Ansible config (prior to 0.4) created this
+  # unnecessary file, so let's clean it up.
+- name: Remove deprecated Apache configuration file.
+  file:
+    path: /etc/apache2/security
+    state: absent
+  # Not notifying a handler since the config file was never included.
   tags:
     - apache
 

--- a/testinfra/app/apache/test_apache_system_config.py
+++ b/testinfra/app/apache/test_apache_system_config.py
@@ -27,39 +27,13 @@ def test_apache_apt_packages(Package, package):
     assert Package(package).is_installed
 
 
-@pytest.mark.parametrize("apache_opt", [
-    "ServerTokens Prod",
-    "ServerSignature Off",
-    "TraceEnable Off",
-])
-def test_apache_security_config(File, apache_opt):
-    """
-    Ensure required apache2 security config file is present.
-
-    Refer to #643, which states that /etc/apache2/security
-    is superfluous, and not even used in our config right now.
-    We should update the Ansible config to move the file
-    to /etc/apache2/conf-available/security.conf.
-    """
-    f = File("/etc/apache2/security")
-    assert f.is_file
-    assert f.user == "root"
-    assert f.group == "root"
-    assert oct(f.mode) == "0644"
-
-    assert f.contains("^{}$".format(apache_opt))
-
-
-# OK to fail here, pending updates to Ansible config.
-@pytest.mark.xfail
 def test_apache_security_config_deprecated(File):
     """
-    Ensure that /etc/apache2/security is absent. See #643 for discussion.
-    Tokens set in that file should be moved to
-    /etc/apache2/conf-available/security.conf.
+    Ensure that /etc/apache2/security is absent, since it was setting
+    redundant options already presentin /etc/apache2/apache2.conf.
+    See #643 for discussion.
     """
     assert not File("/etc/apache2/security").exists
-    assert File("/etc/apache2/config-available/security.conf").exists
 
 
 @pytest.mark.parametrize("apache_opt", [


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1622.

Removes the unused `/etc/apache2/security` file via the Ansible config. This file was not explicitly included anywhere in the Apache config, and the options it contained were already set in `/etc/apache2/apache2.conf`, which _is_ used. Updates the config tests to ensure absence of the unused file.

Also reorganized the relevant vars, removing them from the top-level group_vars, since they were used in only one place: the `app` role, when installing Apache. Over time (particularly in #1023), more of these vars may be moved, but that's out of scope for this PR.

## Testing

Make sure app-staging provisions cleanly and all tests pass.

## Deployment

We _could_ ensure absence of this file via the app-code preinst, but I don't think that's necessary. For one thing, I don't want to lean too heavily on overloading those install-time bash scripts, and the config file removed in this PR wasn't active in the Apache implementation, so it's not a priority to clean up.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
- [x] Unit and functional tests pass on the app-staging VM
### If you made changes to the system configuration:

- [x] Testinfra tests pass on the development VM
- [x] Testinfra tests pass on the app-staging VM
