### PR TITLE
Adds AppArmor allow rule for journalist template files

### DIFF
--- a/install_files/ansible-base/usr.sbin.apache2
+++ b/install_files/ansible-base/usr.sbin.apache2
@@ -128,6 +128,7 @@
   /var/www/securedrop/dictionaries/nouns.txt r,
   /var/www/securedrop/journalist.py r,
   /var/www/securedrop/journalist.pyc rw,
+  /var/www/securedrop/journalist_templates/_source_row.html r,
   /var/www/securedrop/journalist_templates/admin.html r,
   /var/www/securedrop/journalist_templates/admin_add_user.html r,
   /var/www/securedrop/journalist_templates/admin_edit_hotp_secret.html r,


### PR DESCRIPTION
The DRYing out of the Flask templates for the Journalist Interface
in #1501 did not include a required update for the AppArmor profile.
Explicitly granting read access to the new file, otherwise Apache
throws a 500 when failing to read it.

## Status

Ready for review.

## Description of Changes

A single AppArmor allow rule for a new-ish Flask template used in the Journalist Interface. The changes in #1649 should have included this line, but it was missed, even during review. The Selenium tests do not support verifying HTTP status codes (e.g. 500 versus 200, or any non-OK value), so although the application logic properly handled submission and retrieval, the Apache-based serving config did not permit the same process in a web browser. That has substantial implications in terms of shortcomings of the application test suite, but further discussion belongs in a separate issue.

## Testing

1. Create staging environment.
2. Submit test submission to Source Interface.
3. Create Journalist/Admin account.
4. Log in to Journalist Interface to view submissions.
5. Confirm no 500 error when trying to view the submission.

## Deployment

Necessary to ship app code changes to prob hosts, otherwise we'll have lots of problems.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
- [x] Unit and functional tests pass on the app-staging VM

### If you made changes to the system configuration:

- [x] Testinfra tests pass on the development VM
- [x] Testinfra tests pass on the app-staging VM

