### PR TITLE
Remove display of journalist username from replies in source interface

### DIFF
--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -78,7 +78,7 @@
               </p>
           </div>
         </form>
-        <blockquote><h5>From: {{ reply.journalist.username|title }}</h5> {{ reply.decrypted | nl2br }}</blockquote>
+        <blockquote>{{ reply.decrypted | nl2br }}</blockquote>
         <div class="clearfix"></div>
       </div>
     {% endfor %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #1592 for 0.4. 

Changes proposed in this pull request:
* Removes the journalist username from the source interface in order to prevent surprises for journalists in 0.4. See [this comment](https://github.com/freedomofpress/securedrop/issues/1592#issuecomment-296275613) for the full details.

## Testing

1. Provision dev VM.
2. Make journalist account.
3. Submit a document on the source interface.
4. Sign in to the journalist account on the journalist interface and submit a reply to the source.
5. On the source interface, see that the journalist username is not displayed in the reply.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

