### PR TITLE
Consistently declares file modes throughout Ansible config

### DIFF
--- a/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
@@ -68,7 +68,7 @@
     src: xvfb
     dest: /etc/init.d/xvfb
     owner: root
-    mode: '700'
+    mode: "0700"
   tags:
     - xvfb
     - permissions
@@ -86,7 +86,7 @@
     src: xvfb_display.sh
     dest: /etc/profile.d/xvfb_display.sh
     owner: root
-    mode: '444'
+    mode: "0444"
   tags:
     - xvfb
     - environment

--- a/install_files/ansible-base/roles/app-test/tasks/staging_wsgi_files.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/staging_wsgi_files.yml
@@ -15,7 +15,7 @@
     src: source.wsgi.logging
     dest: /var/www/source.wsgi
     owner: "{{ apache_user }}"
-    mode: '0640'
+    mode: "0640"
   tags:
     - apache
     - non-development

--- a/install_files/ansible-base/roles/app/tasks/configure_securedrop_worker.yml
+++ b/install_files/ansible-base/roles/app/tasks/configure_securedrop_worker.yml
@@ -4,7 +4,7 @@
     src: "securedrop_worker.conf"
     dest: "/etc/supervisor/conf.d/securedrop_worker.conf"
     owner: root
-    mode: 0644
+    mode: "0644"
   notify:
     - reload supervisor
   tags:
@@ -19,7 +19,7 @@
     # should be the same user that the worker runs as
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   tags:
     - supervisor
     - permissions

--- a/install_files/ansible-base/roles/app/tasks/create_app_dirs.yml
+++ b/install_files/ansible-base/roles/app/tasks/create_app_dirs.yml
@@ -2,7 +2,7 @@
 - name: Create SecureDrop app code directory.
   file:
     state: directory
-    mode: 0700
+    mode: "0700"
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
     dest: "{{ securedrop_code }}"
@@ -12,7 +12,7 @@
 - name: Create SecureDrop data directory.
   file:
     state: directory
-    mode: 0700
+    mode: "0700"
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
     dest: "{{ securedrop_data }}"
@@ -22,7 +22,7 @@
 - name: Create SecureDrop data store directory.
   file:
     state: directory
-    mode: 0700
+    mode: "0700"
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
     dest: "{{ securedrop_data }}/store"
@@ -32,7 +32,7 @@
 - name: Create SecureDrop keyring directory.
   file:
     state: directory
-    mode: 0700
+    mode: "0700"
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
     dest: "{{ securedrop_data }}/keys"
@@ -42,7 +42,7 @@
 - name: Create SecureDrop temp directory.
   file:
     state: directory
-    mode: 0700
+    mode: "0700"
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
     dest: "{{ securedrop_data }}/tmp"

--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -51,7 +51,7 @@
     dest: "{{ securedrop_code }}/config.py"
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
-    mode: 0600
+    mode: "0600"
   tags:
     - permissions
     - securedrop_config

--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -182,7 +182,7 @@
     dest: "{{ securedrop_code }}/static/i/logo.png"
     owner: "{{ securedrop_user }}"
     group: "{{ securedrop_user }}"
-    mode: "400"
+    mode: "0400"
     backup: yes
   when: securedrop_header_image is defined and
         securedrop_header_image != ""

--- a/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
+++ b/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
@@ -15,7 +15,7 @@
     src: apache2.conf
     dest: /etc/apache2/apache2.conf
     owner: root
-    mode: '0644'
+    mode: "0644"
   notify:
     - restart apache2
   tags:
@@ -36,7 +36,7 @@
     src: "{{ item }}"
     dest: /etc/apache2/{{ item }}
     owner: root
-    mode: '0644'
+    mode: "0644"
   with_items: "{{ apache_templates }}"
   notify:
     - restart apache2

--- a/install_files/ansible-base/roles/common/tasks/create_users.yml
+++ b/install_files/ansible-base/roles/common/tasks/create_users.yml
@@ -29,7 +29,7 @@
     dest: /etc/profile.d/securedrop_additions.sh
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   tags:
     - users
     - environment

--- a/install_files/ansible-base/roles/common/tasks/create_users.yml
+++ b/install_files/ansible-base/roles/common/tasks/create_users.yml
@@ -5,7 +5,7 @@
     dest: /etc/sudoers
     owner: root
     group: root
-    mode: '0440'
+    mode: "0440"
     backup: yes
     validate: "visudo -cf %s"
   register: sudoers_st

--- a/install_files/ansible-base/roles/common/tasks/cron_apt.yml
+++ b/install_files/ansible-base/roles/common/tasks/cron_apt.yml
@@ -53,7 +53,7 @@
   template:
     src: cron-apt-cron-job.j2
     dest: /etc/cron.d/cron-apt
-    mode: '644'
+    mode: "0644"
     owner: root
   tags:
     - apt

--- a/install_files/ansible-base/roles/ossec-server/tasks/mon_install_postfix.yml
+++ b/install_files/ansible-base/roles/ossec-server/tasks/mon_install_postfix.yml
@@ -29,7 +29,7 @@
   template:
     src: sasl_passwd
     dest: /etc/postfix/sasl_passwd
-    mode: 0400
+    mode: "0400"
   notify: update sasl_passwd db
   tags:
     - postfix

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/iptables.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/iptables.yml
@@ -20,7 +20,7 @@
     src: load_iptables
     dest: /etc/network/if-up.d/load_iptables
     owner: root
-    mode: '0744'
+    mode: "0744"
   tags:
     - iptables
     - permissions
@@ -41,7 +41,7 @@
     src: rules_v4
     dest: /etc/network/iptables/rules_v4
     owner: root
-    mode: '0644'
+    mode: "0644"
   tags:
     - iptables
     - permissions
@@ -51,7 +51,7 @@
     src: iptables_rules_v6
     dest: /etc/network/iptables/rules_v6
     owner: root
-    mode: '0644'
+    mode: "0644"
   tags:
     - iptables
     - permissions

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/iptables.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/iptables.yml
@@ -28,7 +28,7 @@
 - name: Create iptables directory.
   file:
     state: directory
-    mode: 0700
+    mode: "0700"
     owner: root
     group: root
     dest: /etc/network/iptables

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/ssh.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/ssh.yml
@@ -14,7 +14,7 @@
     src: ssh_config
     dest: /etc/ssh/ssh_config
     owner: root
-    mode: '0644'
+    mode: "0644"
   tags:
     - ssh
     - 2fa
@@ -25,7 +25,7 @@
     src: sshd_config
     dest: /etc/ssh/sshd_config
     owner: root
-    mode: '0644'
+    mode: "0644"
   tags:
     - ssh
     - 2fa
@@ -36,7 +36,7 @@
     src: common-auth
     dest: /etc/pam.d/
     owner: root
-    mode: '0644'
+    mode: "0644"
   tags:
     - ssh
     - pam

--- a/install_files/ansible-base/roles/tor-hidden-services/tasks/configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/tasks/configure_tor_hidden_services.yml
@@ -5,7 +5,7 @@
     dest: "{{ tor_hidden_services_parent_dir }}"
     owner: "{{ tor_user }}"
     group: "{{ tor_user }}"
-    mode: '0700'
+    mode: "0700"
   tags:
     - tor
 
@@ -15,7 +15,7 @@
     dest: "{{ tor_hidden_services_parent_dir }}/{{ item.service }}"
     owner: "{{ tor_user }}"
     group: "{{ tor_user }}"
-    mode: '0700'
+    mode: "0700"
   with_items: "{{ tor_instances }}"
   tags:
     - tor
@@ -26,7 +26,7 @@
     dest: /etc/tor/torrc
     owner: "{{ tor_user }}"
     group: "{{ tor_user }}"
-    mode: '0644'
+    mode: "0644"
   notify:
     - restart tor
   tags:


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

All declarations of file modes are now standardized to use four-digit octal modes in double-quoted YAML syntax. Using single quotes would have been just as well, but in the interested of consistency, a single choice had to be made. 

Note that these changes do not affect the file modes as configured on the remote host—these are strictly stylistic changes intended to minimize developer confusion and avoid misconfigurations of the type described in #1006. 

There still remain some OSSEC-related changes that I've documented in #1468. Therefore, closes #1006.

## Testing

The most important aspect of this change is to understand the rationale, so give #1006 a close read. If you don't give #1006 a close read, then just remember this: 

> All file modes in Ansible should be declared as four-digit, double-quoted strings.

At some point in the future we can consider using [ansible-lint](https://github.com/willthames/ansible-lint) to confirm our config matches best practices, but we've got a long way to go there.

## Deployment

Only affects the Ansible config, and remains consistent with the modes we've already declared are expected in the config test suite.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
- [ ] Unit and functional tests pass on the app-staging VM
### If you made changes to the system configuration:

- [x] Testinfra tests pass on the development VM
- [x] Testinfra tests pass on the app-staging VM
- [x] Testinfra tests pass on the mon-staging VM
- [x] Testinfra tests pass on the build VM


