### PR TITLE
Add minimum password strength

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -186,8 +186,9 @@ def admin_add_user():
                 db_session.commit()
             except InvalidPasswordLength:
                 form_valid = False
-                flash("Your password is too long (maximum length {} characters)".format(
-                        Journalist.MAX_PASSWORD_LEN), "error")
+                flash("Your password must be between {} and {} characters.".format(
+                        Journalist.MIN_PASSWORD_LEN, Journalist.MAX_PASSWORD_LEN
+                    ), "error")
             except IntegrityError as e:
                 form_valid = False
                 if "username is not unique" in str(e):
@@ -259,8 +260,9 @@ def edit_account_password(user, password, password_again):
         try:
             user.set_password(password)
         except InvalidPasswordLength:
-            flash("Password must be less than {} characters!".format(
-                Journalist.MAX_PASSWORD_LEN), 'error')
+            flash("Your password must be between {} and {} characters.".format(
+                    Journalist.MIN_PASSWORD_LEN, Journalist.MAX_PASSWORD_LEN
+                ), "error")
             raise
 
 

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -79,6 +79,12 @@ def _add_user(is_admin=False): # pragma: no cover
                   'password.'.format(Journalist.MAX_PASSWORD_LEN))
             continue
 
+        if len(password) < Journalist.MIN_PASSWORD_LEN:
+            print('Error: Password needs to be at least {} characters.'.format(
+                Journalist.MIN_PASSWORD_LEN
+            ))
+            continue
+
         if password == password_again:
             break
         print("Passwords didn't match!")
@@ -159,9 +165,9 @@ def delete_user(): # pragma: no cover
             selected_user = Journalist.query.filter_by(username=username).one()
         except NoResultFound:
             pass
-        else: 
+        else:
             raise
-        
+
     print('User "{}" successfully deleted'.format(username))
     return 0
 

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -49,7 +49,7 @@ class TestIntegration(unittest.TestCase):
 
         # Add a test user to the journalist interface and log them in
         # print Journalist.query.all()
-        self.user_pw = "bar"
+        self.user_pw = "longpassword"
         self.user = Journalist(username="foo",
                                password=self.user_pw)
         db_session.add(self.user)
@@ -532,8 +532,8 @@ class TestIntegration(unittest.TestCase):
 
         # change password
         self.journalist_app.post('/account', data=dict(
-            password='newpass',
-            password_again='newpass'
+            password='newlongpassword',
+            password_again='newlongpassword'
         ))
 
         # logout
@@ -542,7 +542,7 @@ class TestIntegration(unittest.TestCase):
         # login with new credentials should redirect to index page
         resp = self.journalist_app.post('/login', data=dict(
             username=self.user.username,
-            password='newpass',
+            password='newlongpassword',
             token='mocked',
             follow_redirects=True))
         self.assertEqual(resp.status_code, 302)
@@ -561,7 +561,7 @@ class TestIntegration(unittest.TestCase):
 
         # log out
         self.journalist_app.get('/logout')
-        
+
         # login with new 2fa secret should redirect to index page
         resp = self.journalist_app.post('/login', data=dict(
             username=self.user.username,

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -227,6 +227,14 @@ class TestJournalistApp(TestCase):
                     username="My Password is Too Big!",
                     password=overly_long_password)
 
+    def test_min_password_length(self):
+        """Creating a Journalist with a password that is smaller than the
+        minimum password length should raise an exception"""
+        with self.assertRaises(InvalidPasswordLength):
+            temp_journalist = Journalist(
+                    username="My Password is Too Small!",
+                    password='tiny')
+
     def test_admin_edits_user_password_too_long_warning(self):
         self._login_admin()
         overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -179,15 +179,16 @@ class TestJournalistApp(TestCase):
         resp = self.client.post(
             url_for('admin_edit_user', user_id=self.user.id),
             data=dict(username=self.user.username, is_admin=False,
-                      password='valid', password_again='valid'))
+                      password='validlongpassword',
+                      password_again='validlongpassword'))
 
         self.assertMessageFlashed("Account successfully updated!", 'success')
 
     def test_user_edits_password_success_reponse(self):
         self._login_user()
         resp = self.client.post(url_for('edit_account'),
-                                data=dict(password='valid',
-                                          password_again='valid'))
+                                data=dict(password='validlongpassword',
+                                          password_again='validlongpassword'))
         self.assertMessageFlashed("Account successfully updated!", 'success')
 
     def test_admin_edits_user_password_mismatch_warning(self):
@@ -447,8 +448,8 @@ class TestJournalistApp(TestCase):
     def test_valid_user_password_change(self):
         self._login_user()
         res = self.client.post(url_for('edit_account'), data=dict(
-            password='valid',
-            password_again='valid'))
+            password='validlongpassword',
+            password_again='validlongpassword'))
         self.assertMessageFlashed("Account successfully updated!", 'success')
 
     def test_regenerate_totp(self):

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -246,8 +246,9 @@ class TestJournalistApp(TestCase):
                       password_again=overly_long_password),
             follow_redirects=True)
 
-        self.assertMessageFlashed('Password must be less than {} '
-                                  'characters!'.format(
+        self.assertMessageFlashed('Your password must be between {} and {} '
+                                  'characters.'.format(
+                                      Journalist.MIN_PASSWORD_LEN,
                                       Journalist.MAX_PASSWORD_LEN), 'error')
 
     def test_user_edits_password_too_long_warning(self):
@@ -259,8 +260,9 @@ class TestJournalistApp(TestCase):
                                           password_again=overly_long_password),
                                 follow_redirects=True)
 
-        self.assertMessageFlashed('Password must be less than {} '
-                                  'characters!'.format(
+        self.assertMessageFlashed('Your password must be between {} and {} '
+                                  'characters.'.format(
+                                      Journalist.MIN_PASSWORD_LEN,
                                       Journalist.MAX_PASSWORD_LEN), 'error')
 
     def test_admin_add_user_password_too_long_warning(self):
@@ -272,7 +274,7 @@ class TestJournalistApp(TestCase):
             data=dict(username='dellsberg', password=overly_long_password,
                       password_again=overly_long_password, is_admin=False))
 
-        self.assertIn('password is too long', resp.data)
+        self.assertIn('Your password must be between', resp.data)
 
     def test_admin_edits_user_invalid_username(self):
         """Test expected error message when admin attempts to change a user's
@@ -449,8 +451,9 @@ class TestJournalistApp(TestCase):
             password_again=overly_long_password),
             follow_redirects=True)
 
-        self.assertMessageFlashed('Password must be less than {} '
-                                  'characters!'.format(
+        self.assertMessageFlashed('Your password must be between {} and {} '
+                                  'characters.'.format(
+                                      Journalist.MIN_PASSWORD_LEN,
                                       Journalist.MAX_PASSWORD_LEN), 'error')
 
     def test_valid_user_password_change(self):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Steps towards #980 that in our internal engineering meeting on 3/9/17 we decided would be a good addition for 0.4 prior to merge of #1509. 

Changes proposed in this pull request:
* Adds a minimum password length requirement for new journalist users

## Testing

1. Provision dev VM
2. Attempt to make a journalist account with a weak password

## Deployment

Note that this PR does not require the reset of weak passwords that have already been set. We can also do that, but it should probably be done in a followup issue and PR, and I would argue _not_ for 0.4. 

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

