### PR TITLE
Utilize db.InvalidPasswordLength.__str__

### DIFF
--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -220,14 +220,23 @@ class InvalidPasswordLength(Exception):
 
     def __init__(self, password):
         self.pw_len = len(password)
+        # Defend against inconsistencies in when this exception should be
+        # raised.
+        if (Journalist.MIN_PASSWORD_LEN <= self.pw_len
+            <= Journalist.MAX_PASSWORD_LEN):
+            raise ValueError("The InvalidPasswordLength exception should only "
+                             "be raised when password length is not between "
+                             "{Journalist.MIN_PASSWORD_LEN} and "
+                             "{Journalist.MAX_PASSWORD_LEN} "
+                             "characters.".format(**globals()))
 
     def __str__(self):
         if self.pw_len > Journalist.MAX_PASSWORD_LEN:
-            return "Password too long (len={})".format(self.pw_len)
-        if self.pw_len < Journalist.MIN_PASSWORD_LEN:
-            return "Password needs to be at least {} characters".format(
-                Journalist.MIN_PASSWORD_LEN
-            )
+            return "Password cannot exceed {} characters!".format(
+                Journalist.MAX_PASSWORD_LEN)
+        else:
+            return "Password needs to be at least {} characters!".format(
+                Journalist.MIN_PASSWORD_LEN)
 
 
 class Journalist(Base):
@@ -274,21 +283,23 @@ class Journalist(Base):
     MAX_PASSWORD_LEN = 128
     MIN_PASSWORD_LEN = 12
 
+    @classmethod
+    def check_password_length(cls, password):
+        # Enforce a reasonable maximum length for passwords to avoid DoS and a
+        # minimum length as a basic security measure.
+        if not cls.MIN_PASSWORD_LEN <= len(password) <= cls.MAX_PASSWORD_LEN:
+            raise InvalidPasswordLength(password)
+
     def set_password(self, password):
+        self.check_password_length(password)
         # Don't do anything if user's password hasn't changed.
         if self.pw_hash and self.valid_password(password):
             return
-        # Enforce a reasonable maximum length for passwords to avoid DoS
-        if len(password) > self.MAX_PASSWORD_LEN:
-            raise InvalidPasswordLength(password)
-        # Enforce a reasonable minimum length for new passwords
-        if len(password) < self.MIN_PASSWORD_LEN:
-            raise InvalidPasswordLength(password)
         self.pw_salt = self._gen_salt()
         self.pw_hash = self._scrypt_hash(password, self.pw_salt)
 
     def valid_password(self, password):
-        # Avoid hashing passwords that are over the maximum length
+        # Avoid hashing passwords that are over the maximum length.
         if len(password) > self.MAX_PASSWORD_LEN:
             raise InvalidPasswordLength(password)
         # No check on minimum password length here because some passwords

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -184,11 +184,9 @@ def admin_add_user():
                                       otp_secret=otp_secret)
                 db_session.add(new_user)
                 db_session.commit()
-            except InvalidPasswordLength:
+            except InvalidPasswordLength as exc:
                 form_valid = False
-                flash("Your password must be between {} and {} characters.".format(
-                        Journalist.MIN_PASSWORD_LEN, Journalist.MAX_PASSWORD_LEN
-                    ), "error")
+                flash(str(exc), 'error')
             except IntegrityError as e:
                 form_valid = False
                 if "username is not unique" in str(e):
@@ -259,10 +257,8 @@ def edit_account_password(user, password, password_again):
             raise PasswordMismatchError
         try:
             user.set_password(password)
-        except InvalidPasswordLength:
-            flash("Your password must be between {} and {} characters.".format(
-                    Journalist.MIN_PASSWORD_LEN, Journalist.MAX_PASSWORD_LEN
-                ), "error")
+        except InvalidPasswordLength as exc:
+            flash(str(exc), 'error')
             raise
 
 

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 os.environ['SECUREDROP_ENV'] = 'dev'
 import config
-from db import db_session, init_db, Journalist
+from db import db_session, init_db, InvalidPasswordLength, Journalist
 from management import run
 
 
@@ -73,16 +73,10 @@ def _add_user(is_admin=False): # pragma: no cover
         password = getpass('Password: ')
         password_again = getpass('Confirm Password: ')
 
-        if len(password) > Journalist.MAX_PASSWORD_LEN:
-            print('Your password is too long (maximum length {} characters). '
-                  'Please pick a shorter '
-                  'password.'.format(Journalist.MAX_PASSWORD_LEN))
-            continue
-
-        if len(password) < Journalist.MIN_PASSWORD_LEN:
-            print('Error: Password needs to be at least {} characters.'.format(
-                Journalist.MIN_PASSWORD_LEN
-            ))
+        try:
+            Journalist.check_password_length(password)
+        except InvalidPasswordLength as exc:
+            print(str(exc))
             continue
 
         if password == password_again:

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -246,10 +246,8 @@ class TestJournalistApp(TestCase):
                       password_again=overly_long_password),
             follow_redirects=True)
 
-        self.assertMessageFlashed('Your password must be between {} and {} '
-                                  'characters.'.format(
-                                      Journalist.MIN_PASSWORD_LEN,
-                                      Journalist.MAX_PASSWORD_LEN), 'error')
+        self.assertMessageFlashed(
+            str(InvalidPasswordLength(overly_long_password)), 'error')
 
     def test_user_edits_password_too_long_warning(self):
         self._login_user()
@@ -260,10 +258,8 @@ class TestJournalistApp(TestCase):
                                           password_again=overly_long_password),
                                 follow_redirects=True)
 
-        self.assertMessageFlashed('Your password must be between {} and {} '
-                                  'characters.'.format(
-                                      Journalist.MIN_PASSWORD_LEN,
-                                      Journalist.MAX_PASSWORD_LEN), 'error')
+        self.assertMessageFlashed(
+            str(InvalidPasswordLength(overly_long_password)), 'error')
 
     def test_admin_add_user_password_too_long_warning(self):
         self._login_admin()
@@ -274,7 +270,8 @@ class TestJournalistApp(TestCase):
             data=dict(username='dellsberg', password=overly_long_password,
                       password_again=overly_long_password, is_admin=False))
 
-        self.assertIn('Your password must be between', resp.data)
+        self.assertIn(str(InvalidPasswordLength(overly_long_password)),
+                      resp.data)
 
     def test_admin_edits_user_invalid_username(self):
         """Test expected error message when admin attempts to change a user's
@@ -451,10 +448,8 @@ class TestJournalistApp(TestCase):
             password_again=overly_long_password),
             follow_redirects=True)
 
-        self.assertMessageFlashed('Your password must be between {} and {} '
-                                  'characters.'.format(
-                                      Journalist.MIN_PASSWORD_LEN,
-                                      Journalist.MAX_PASSWORD_LEN), 'error')
+        self.assertMessageFlashed(str(InvalidPasswordLength(overly_long_password)),
+                                  'error')
 
     def test_valid_user_password_change(self):
         self._login_user()


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

* Makes better use of the fact we have re-implemented the `__str__()` special method of the `db.InvalidPasswordLength` exception class (DRY).
* Adds a check in the initializer of this `db.InvalidPasswordLength` to help ensure the conditions we raise this exception under are consistent (defense in depth--written specifically because I made a mistake during development that this would have caught earlier).

Changes proposed in this pull request:

## Testing

Manual review. Run the tests locally if you wish, but IMO Travis is sufficient for this one.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM