### PR TITLE
Validates username choice prior to installation

### DIFF
--- a/install_files/ansible-base/roles/validate/defaults/main.yml
+++ b/install_files/ansible-base/roles/validate/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# List of prohibited usernames for use in production contexts.
+# The Admin should set a unique username for the instance, to be
+# used in all subsequent tasks.
+securedrop_validate_disallowed_users:
+  - amnesia
+  - root
+  - vagrant

--- a/install_files/ansible-base/roles/validate/tasks/main.yml
+++ b/install_files/ansible-base/roles/validate/tasks/main.yml
@@ -3,11 +3,7 @@
 #credentials are not used when running the app and mon playbooks for
 #production.
 
-- debug: msg="verifying ssh_users is not set to vagrant"
-  failed_when: ssh_users == "vagrant"
-  tags:
-    - validate
-    - debug
+- include: validate_users.yml
 
 - debug: msg="verifying securedrop_app_gpg_fingerprint is not the journalist test key"
   failed_when: securedrop_app_gpg_fingerprint == "65A1B5FF195B56353CC63DFFCC40EF1228271441"

--- a/install_files/ansible-base/roles/validate/tasks/validate_users.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_users.yml
@@ -1,8 +1,22 @@
 ---
-- name: Validate Admin username.
+# Check the value of `ssh_users` in the prod-specific.yml file to ensure
+# we're using a unique username. If the playbook is running with a username
+# of e.g. `amnesia`, then the vars file has been configured incorrectly.
+- name: Validate Admin username (specified in vars).
   assert:
     that:
       - "ssh_users != item"
       - "ssh_users != ''"
       - "item not in ssh_users"
+  with_items: "{{ securedrop_validate_disallowed_users }}"
+
+# Beyond checking what's declared in the vars file, we must validate the
+# username used to connect to the host. The SSH config forbids SSH connections,
+# so on first run we should not be connecting as root.
+- name: Validate Admin username (used in SSH connection).
+  assert:
+    that:
+      - "ansible_user|default('') != item"
+      - "ansible_ssh_user|default('') != item"
+      - "remote_user|default('') != item"
   with_items: "{{ securedrop_validate_disallowed_users }}"

--- a/install_files/ansible-base/roles/validate/tasks/validate_users.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_users.yml
@@ -1,0 +1,8 @@
+---
+- name: Validate Admin username.
+  assert:
+    that:
+      - "ssh_users != item"
+      - "ssh_users != ''"
+      - "item not in ssh_users"
+  with_items: "{{ securedrop_validate_disallowed_users }}"

--- a/testinfra/ansible/test_validate_users.py
+++ b/testinfra/ansible/test_validate_users.py
@@ -1,0 +1,19 @@
+import pytest
+import os
+
+
+@pytest.mark.skip(reason="Validation not fully implemented yet")
+@pytest.mark.parametrize('username', [
+    'root',
+    'amnesia',
+])
+def test_validate_users(LocalCommand, username):
+    """
+    Check that Ansible halts execution of the playbook if the Admin
+    username is set to any disallowed value.
+    """
+    var_override = "--tags validate --extra-vars ssh_users={}".format(username)
+    os.environ['ANSIBLE_ARGS'] = var_override
+    c = LocalCommand("vagrant provision /staging/")
+
+    assert c.rc != 0


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1029.

Changes proposed in this pull request:

* Strengthens the username validation prior to installing the SecureDrop application.

## Testing

The testing story here is tricky. For ages we've been using `--skip-tags validate` to omit all checks for the validation logic in the local development environment—even in prod. That choice implies the only way to test this change adequately is to check against a hardware instance—since virtualized instances will have username set to `vagrant`, which will fail these checks. I don't expect you to test against hardware while reviewing this PR. 

More substantial changes to the validation implementation, and the testing thereof, will be required in order to satisfy #749. 

## Deployment

Only affects the Admin Workstation. We'll need to test extensively prior to releasing 0.4, including on hardware, but additional changes are coming in response to #749 (and others). At present I've added a sketch of a config test to confirm that bad vars result in playbook failure, but the test is marked as "skipped" for now, since the default staging env requires vars that won't pass validation.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
- [x] Unit and functional tests pass on the app-staging VM

### If you made changes to the system configuration:

- [x] Testinfra tests pass on the development VM
- [x] Testinfra tests pass on the app-staging VM
- [x] Testinfra tests pass on the mon-staging VM
