### PR TITLE
Clean up UI for SecureDrop 0.4

### DIFF
--- a/securedrop/journalist_templates/admin.html
+++ b/securedrop/journalist_templates/admin.html
@@ -3,7 +3,7 @@
 <h1>Admin Interface</h1>
 
 <form action="{{ url_for('admin_add_user') }}">
-  <button class="sd-button" type="submit" class="btn" id="add-user">ADD USER</button>
+  <button class="sd-button" type="submit" class="btn" id="add-user"><i class="fa fa-plus"></i> ADD USER</button>
 </form>
 
 <hr class="no-line" />

--- a/securedrop/journalist_templates/admin_add_user.html
+++ b/securedrop/journalist_templates/admin_add_user.html
@@ -18,6 +18,6 @@
     <label for="is_hotp">I'm using a Yubikey </label>
     <input name="otp_secret" type="text" placeholder="HOTP Secret" size="60"><br />
   </p>
-  <button type="submit" class="sd-button">ADD USER</button>
+  <button type="submit" class="sd-button"><i class="fa fa-plus"></i> ADD USER</button>
 </form>
 {% endblock %}

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -21,11 +21,12 @@
   {% if source.collection %}
     <p>The documents are stored encrypted for security. To read them, you will need to decrypt them using GPG.</p>
     <form action="/bulk" method="post">
-      <div class="document-actions">
+      <p>
         <div id='select-container'></div>
-        <button class="sd-button" type="submit" name="action" value="download"></i> DOWNLOAD SELECTED</button>
-        <button class="sd-button" type="submit" name="action" value="confirm_delete" class="danger" id="delete_selected">DELETE SELECTED</button>
-      </div>
+        <button type="submit" name="action" value="download" class="small"><i class="fa fa-download"></i> Download Selected</button>
+        <button type="submit" name="action" value="confirm_delete" id="delete_selected" class="small danger"><i class="fa fa-trash-o"></i> Delete Selected</button>
+      </p>
+
       <ul id="submissions" class="plain submissions">
         {% for doc in source.collection %}
           <li class="submission">
@@ -97,7 +98,7 @@
     <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
     <input type="hidden" name="sid" value="{{ sid }}"/>
     <input type="hidden" name="col_name" value="{{ source.journalist_designation }}"/>
-    <button type="submit" class="sd-button danger">DELETE COLLECTION</button>
+    <button type="submit" class="sd-button danger"><i class="fa fa-trash-o"></i> DELETE COLLECTION</button>
   </form>
 
 </div>

--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -79,7 +79,7 @@ Yubikey, choose the second.</p>
   <input name="uid" type="hidden" value="{{ user.id }}"/>
   {% endif %}
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
-  <button class="sd-button" type="submit" class="pull-right">{{ button_text }}</button>
+  <button class="sd-button" type="submit" class="pull-right"><i class="fa fa-refresh"></i> {{ button_text }}</button>
 </form>
 {%- endmacro %}
 

--- a/securedrop/journalist_templates/login.html
+++ b/securedrop/journalist_templates/login.html
@@ -8,7 +8,7 @@
   <p class="center"><input type="text" name="username" autocomplete="off" placeholder="Username" autofocus></p>
   <p class="center"><input type="password" name="password" placeholder="Password"></p>
   <p class="center"><input name="token" id="token" type="text" placeholder="Two-factor Code"></p>
-  <p class="pull-right"><button class="sd-button" type="submit">LOG IN</i></button></p>
+  <p class="pull-right"><button class="sd-button" type="submit"><i class="fa fa-arrow-circle-o-right"></i> LOG IN</button></p>
 </form>
 
 {% endblock %}

--- a/securedrop/sass/_button-rules.sass
+++ b/securedrop/sass/_button-rules.sass
@@ -67,9 +67,9 @@
     &.index
       display: block
       position: absolute
-      bottom: 5%
-      left: 10%
-      right: 10%
+      bottom: 8%
+      left: 8%
+      right: 8%
 
   button.block, a.btn.block
     text-decoration: none


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #1604 for 0.4. This PR adds a few icons back to the journalist interface (note: this PR is not intended to make the journalist interface nicely fail when JavaScript is not present, nor is that an issue targeted for 0.4) and cleans up some CSS issues:  

### Uses a unified button style between the source and submission views

All buttons along the top of each table are consistent:

#### Sources

![screen shot 2017-04-24 at 6 04 02 pm](https://cloud.githubusercontent.com/assets/7832803/25364893/57a96aa4-291a-11e7-91f5-9bbc30f72bc7.png)

#### Submissions

![screen shot 2017-04-24 at 6 04 06 pm](https://cloud.githubusercontent.com/assets/7832803/25364897/6091c7a6-291a-11e7-82a6-ed12e588eef7.png)

### Aligns the buttons on the source interface index

#### Before

![screen shot 2017-04-24 at 3 15 53 pm](https://cloud.githubusercontent.com/assets/7832803/25364918/890a08b0-291a-11e7-8456-1fda51359ddc.png)

#### After

![screen shot 2017-04-24 at 6 03 05 pm](https://cloud.githubusercontent.com/assets/7832803/25364929/957b93ca-291a-11e7-91ab-dc3a104c5dd1.png)

## Testing

1. Provision development VM
2. Make an admin account, submit some documents.
3. Click around both the source and journalist interfaces and see if you notice any issues. 

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

