### PR TITLE
Back out deletion of submissions when a source is deleted

### DIFF
--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -132,7 +132,7 @@ class Submission(Base):
     source_id = Column(Integer, ForeignKey('sources.id'))
     source = relationship(
         "Source",
-        backref=backref("submissions", order_by=id, cascade="delete")
+        backref=backref("submissions", order_by=id)
         )
 
     filename = Column(String(255), nullable=False)
@@ -162,7 +162,7 @@ class Reply(Base):
     source_id = Column(Integer, ForeignKey('sources.id'))
     source = relationship(
         "Source",
-        backref=backref("replies", order_by=id, cascade="delete")
+        backref=backref("replies", order_by=id)
         )
 
     filename = Column(String(255), nullable=False)

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -507,17 +507,6 @@ class TestJournalistApp(TestCase):
                                                           source.filesystem_id).one()
         self.assertEqual(self.user.username, source_assigned.journalist.username)
 
-
-    def test_delete_source_deletes_submissions(self):
-        """Verify that when a source is deleted, the submissions that
-        correspond to them are also deleted."""
-
-        self._delete_collection_setup()
-        journalist.delete_collection(self.source.filesystem_id)
-
-        # Source should be gone
-        results = db_session.query(Source).filter(Source.id == self.source.id).all()
-
     def _delete_collection_setup(self):
         self.source, _ = utils.db_helper.init_source()
         utils.db_helper.submit(self.source, 2)
@@ -530,10 +519,6 @@ class TestJournalistApp(TestCase):
         self._delete_collection_setup()
         journalist.delete_collection(self.source.filesystem_id)
         results = Source.query.filter(Source.id == self.source.id).all()
-        self.assertEqual(results, [])
-        results = db_session.query(Submission.source_id == self.source.id).all()
-        self.assertEqual(results, [])
-        results = db_session.query(Reply.source_id == self.source.id).all()
         self.assertEqual(results, [])
 
     def test_delete_source_deletes_source_key(self):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This was a addition in #1440, but similarly to #1671 until we have a migration path
for making changes like this to the database we cannot ship this yet
to instances (it adds an ON DELETE CASCADE constraint). 

Pushed to 0.4.x release series.

Added to checklist in #1658. 

## Testing

1. Provision dev VM.
2. Make sure dev tests pass locally.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM


