### PR TITLE
Removing timing information from login

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from base64 import b32encode
+import hmac
 import os
 import subprocess
 
@@ -191,6 +192,24 @@ def decrypt(secret, ciphertext):
     """
     hashed_codename = hash_codename(secret, salt=SCRYPT_GPG_PEPPER)
     return gpg.decrypt(ciphertext, passphrase=hashed_codename).data
+
+
+# Taken from Django Source Code (with some modification)
+def constant_time_compare(val1, val2):
+    """Returns True if the two strings are equal, False otherwise. Tries
+    to use :meth:`hmac.compare_digest()`, but falls back to an
+    implementation from Django if that's not available.
+    """
+    try:
+        hmac.compare_digest(val1, val2)
+    except AttributeError:
+        if len(val1) != len(val2):
+            return False
+        result = 0
+        for x, y in zip(val1, val2):
+            result |= ord(x) ^ ord(y)
+        return result == 0
+
 
 if __name__ == "__main__":
     import doctest

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from base64 import b32encode
-import hmac
 import os
 import subprocess
 
@@ -192,24 +191,6 @@ def decrypt(secret, ciphertext):
     """
     hashed_codename = hash_codename(secret, salt=SCRYPT_GPG_PEPPER)
     return gpg.decrypt(ciphertext, passphrase=hashed_codename).data
-
-
-# Taken from Django Source Code (with some modification)
-def constant_time_compare(val1, val2):
-    """Returns True if the two strings are equal, False otherwise. Tries
-    to use :meth:`hmac.compare_digest()`, but falls back to an
-    implementation from Django if that's not available.
-    """
-    try:
-        hmac.compare_digest(val1, val2)
-    except AttributeError:
-        if len(val1) != len(val2):
-            return False
-        result = 0
-        for x, y in zip(val1, val2):
-            result |= ord(x) ^ ord(y)
-        return result == 0
-
 
 if __name__ == "__main__":
     import doctest

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -2,6 +2,7 @@ import os
 import datetime
 import base64
 import binascii
+import hmac
 
 # Find the best implementation available on this platform
 try:
@@ -292,7 +293,8 @@ class Journalist(Base):
             raise InvalidPasswordLength(password)
         # No check on minimum password length here because some passwords
         # may have been set prior to setting the minimum password length.
-        return self._scrypt_hash(password, self.pw_salt) == self.pw_hash
+        return hmac.compare_digest(self._scrypt_hash(password, self.pw_salt),
+                                   self.pw_hash)
 
     def regenerate_totp_shared_secret(self):
         self.otp_secret = pyotp.random_base32()

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -23,7 +23,6 @@ import qrcode
 import qrcode.image.svg
 
 import config
-from crypto_util import constant_time_compare
 import store
 
 
@@ -292,8 +291,9 @@ class Journalist(Base):
             raise InvalidPasswordLength(password)
         # No check on minimum password length here because some passwords
         # may have been set prior to setting the minimum password length.
-        return constant_time_compare(self._scrypt_hash(password, self.pw_salt),
-                                     self.pw_hash)
+        return pyotp.utils.compare_digest(
+            self._scrypt_hash(password, self.pw_salt),
+            self.pw_hash)
 
     def regenerate_totp_shared_secret(self):
         self.otp_secret = pyotp.random_base32()

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -402,7 +402,7 @@ class Journalist(Base):
 
         # Prevent TOTP token reuse
         if user.last_token is not None:
-            if pytop.utils.compare_digest(token == user.last_token):
+            if pyotp.utils.compare_digest(token, user.last_token):
                 raise BadTokenException("previously used token "
                                         "{}".format(token))
         if not user.verify_token(token):

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -2,7 +2,6 @@ import os
 import datetime
 import base64
 import binascii
-import hmac
 
 # Find the best implementation available on this platform
 try:
@@ -24,7 +23,7 @@ import qrcode
 import qrcode.image.svg
 
 import config
-import crypto_util
+from crypto_util import constant_time_compare
 import store
 
 
@@ -293,8 +292,8 @@ class Journalist(Base):
             raise InvalidPasswordLength(password)
         # No check on minimum password length here because some passwords
         # may have been set prior to setting the minimum password length.
-        return hmac.compare_digest(self._scrypt_hash(password, self.pw_salt),
-                                   self.pw_hash)
+        return constant_time_compare(self._scrypt_hash(password, self.pw_salt),
+                                     self.pw_hash)
 
     def regenerate_totp_shared_secret(self):
         self.otp_secret = pyotp.random_base32()

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -400,8 +400,11 @@ class Journalist(Base):
         if LOGIN_HARDENING:
             cls.throttle_login(user)
 
-        if token == user.last_token:  # Prevent OTP token reuse
-            raise BadTokenException("previously used token {}".format(token))
+        # Prevent TOTP token reuse
+        if user.last_token is not None:
+            if pytop.utils.compare_digest(token == user.last_token):
+                raise BadTokenException("previously used token "
+                                        "{}".format(token))
         if not user.verify_token(token):
             raise BadTokenException("invalid token")
         if not user.valid_password(password):


### PR DESCRIPTION
## Status

Ready for review!

## Description of Changes

Removes non-exploitable timing information from `valid_password()`, and negligibly useful--but hypothetically exploitable in a highly specific context--timing information from `verify_token()`. See commit messages for more detailed information.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM