### PR TITLE
Strengthen totp reuse protections

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from base64 import b32encode
+import hmac
 import os
 import subprocess
 
@@ -191,6 +192,24 @@ def decrypt(secret, ciphertext):
     """
     hashed_codename = hash_codename(secret, salt=SCRYPT_GPG_PEPPER)
     return gpg.decrypt(ciphertext, passphrase=hashed_codename).data
+
+
+# Taken from Django Source Code (with some modification)
+def constant_time_compare(val1, val2):
+    """Returns True if the two strings are equal, False otherwise. Tries
+    to use :meth:`hmac.compare_digest()`, but falls back to an
+    implementation from Django if that's not available.
+    """
+    try:
+        hmac.compare_digest(val1, val2)
+    except AttributeError:
+        if len(val1) != len(val2):
+            return False
+        result = 0
+        for x, y in zip(val1, val2):
+            result |= ord(x) ^ ord(y)
+        return result == 0
+
 
 if __name__ == "__main__":
     import doctest

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -194,23 +194,6 @@ def decrypt(secret, ciphertext):
     return gpg.decrypt(ciphertext, passphrase=hashed_codename).data
 
 
-# Taken from Django Source Code (with some modification)
-def constant_time_compare(val1, val2):
-    """Returns True if the two strings are equal, False otherwise. Tries
-    to use :meth:`hmac.compare_digest()`, but falls back to an
-    implementation from Django if that's not available.
-    """
-    try:
-        hmac.compare_digest(val1, val2)
-    except AttributeError:
-        if len(val1) != len(val2):
-            return False
-        result = 0
-        for x, y in zip(val1, val2):
-            result |= ord(x) ^ ord(y)
-        return result == 0
-
-
 if __name__ == "__main__":
     import doctest
     doctest.testmod()

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -4,7 +4,6 @@
 from base64 import b32encode
 import os
 import subprocess
-import hmac
 
 from Crypto.Random import random
 import gnupg
@@ -192,27 +191,6 @@ def decrypt(secret, ciphertext):
     """
     hashed_codename = hash_codename(secret, salt=SCRYPT_GPG_PEPPER)
     return gpg.decrypt(ciphertext, passphrase=hashed_codename).data
-
-
-if hasattr(hmac, "compare_digest"):
-    # Prefer the stdlib implementation, when available.
-    constant_time_compare = hmac.compare_digest
-else:
-    def constant_time_compare(val1, val2):
-        """Returns True if the two strings are equal, False otherwise.
-        The time taken is independent of the number of characters that
-        match. For the sake of simplicity, this function executes in
-        constant time only when the two strings have the same length.
-        Since we use it only to compare hashes and tokens of known
-        expected length, this is acceptable.
-        """
-        val1, val2 = str(val1), str(val2)
-        if len(val1) != len(val2):
-            return False
-        for x, y in zip(val1, val2):
-            result = ord(x) ^ ord(y) | result
-        return result == 0
-
 
 if __name__ == "__main__":
     import doctest

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from base64 import b32encode
-import hmac
 import os
 import subprocess
 
@@ -192,7 +191,6 @@ def decrypt(secret, ciphertext):
     """
     hashed_codename = hash_codename(secret, salt=SCRYPT_GPG_PEPPER)
     return gpg.decrypt(ciphertext, passphrase=hashed_codename).data
-
 
 if __name__ == "__main__":
     import doctest

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -386,18 +386,22 @@ class Journalist(Base):
             return verified
         
         def verify_totp(token):
-            """Constant-time check that a TOTP `token` is valid for the current
-            timecode window, or the preceding or proceeding one (in order to
-            account for client-server time skew).
+            """Constant-time check that a TOTP `token` is valid for the
+            current timecode window, or either of the windows that
+            precede and proceed it. This accounts for client-server time
+            skew of up to 30 seconds in either direction.
 
             Returns: bool
             """
             verified = False
             for_time = datetime.datetime.now()
             for i in range(-1, 2):
-                verified |= self.pyotp.utils.strings_equal(
-                    str(token),
-                    str(self.at(for_time, i)))
+                verified = (
+                    self.pyotp.utils.strings_equal(
+                        str(token),
+                        str(self.at(for_time, i))
+                        )
+                    | verified)
             return verified
 
         def check_token_reuse(token):

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -24,7 +24,6 @@ import qrcode
 import qrcode.image.svg
 
 import config
-from crypto_util import constant_time_compare
 import store
 
 LOGIN_HARDENING = True
@@ -292,8 +291,9 @@ class Journalist(Base):
             raise InvalidPasswordLength(password)
         # No check on minimum password length here because some passwords
         # may have been set prior to setting the minimum password length.
-        return constant_time_compare(self._scrypt_hash(password, self.pw_salt),
-                                     self.pw_hash)
+        return pyotp.utils.compare_digest(
+            self._scrypt_hash(password, self.pw_salt),
+            self.pw_hash)
 
     def regenerate_totp_shared_secret(self):
         self.otp_secret = pyotp.random_base32()

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -291,14 +291,9 @@ class Journalist(Base):
             raise InvalidPasswordLength(password)
         # No check on minimum password length here because some passwords
         # may have been set prior to setting the minimum password length.
-<<<<<<< HEAD
         return pyotp.utils.compare_digest(
             self._scrypt_hash(password, self.pw_salt),
             self.pw_hash)
-=======
-        return constant_time_compare(self._scrypt_hash(password, self.pw_salt),
-                                     self.pw_hash)
->>>>>>> Use Python 2.7.6 friendly constant-time string comparator
 
     def regenerate_totp_shared_secret(self):
         self.otp_secret = pyotp.random_base32()
@@ -361,7 +356,6 @@ class Journalist(Base):
         """
         token = self._format_token(token)
 
-<<<<<<< HEAD
         def verify_totp(token, for_time=None):
             """Check the given token against the previous, current, and
             next valid tokens to compensate for potential time skew
@@ -383,26 +377,6 @@ class Journalist(Base):
 
             for counter_val in range(self.hotp_counter,
                                      self.hotp_counter + 20):
-=======
-        # Only allow each authentication token to be used once. This
-        # prevents some MITM attacks.
-        if constant_time_compare(token, self.last_token) and LOGIN_HARDENING:
-            raise BadTokenException("previously used token {}".format(token))
-        else:
-            self.last_token = token
-            db_session.commit()
-
-        if self.is_totp:
-            # Also check the given token against the previous and next
-            # valid tokens, to compensate for potential time skew
-            # between the client and the server. The total valid
-            # window is 1:30s.
-            return self.totp.verify(token, valid_window=1)
-        else:
-            for counter_val in range(
-                    self.hotp_counter,
-                    self.hotp_counter + 20):
->>>>>>> Use Python 2.7.6 friendly constant-time string comparator
                 if self.hotp.verify(token, counter_val):
                     verified = True
                     self.hotp_counter = counter_val + 1

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -2,7 +2,6 @@ import os
 import datetime
 import base64
 import binascii
-import hmac
 
 # Find the best implementation available on this platform
 try:
@@ -24,7 +23,7 @@ import qrcode
 import qrcode.image.svg
 
 import config
-import crypto_util
+from crypto_util import constant_time_compare
 import store
 
 LOGIN_HARDENING = True
@@ -292,8 +291,8 @@ class Journalist(Base):
             raise InvalidPasswordLength(password)
         # No check on minimum password length here because some passwords
         # may have been set prior to setting the minimum password length.
-        return hmac.compare_digest(self._scrypt_hash(password, self.pw_salt),
-                                   self.pw_hash)
+        return constant_time_compare(self._scrypt_hash(password, self.pw_salt),
+                                     self.pw_hash)
 
     def regenerate_totp_shared_secret(self):
         self.otp_secret = pyotp.random_base32()
@@ -350,7 +349,7 @@ class Journalist(Base):
 
         # Only allow each authentication token to be used once. This
         # prevents some MITM attacks.
-        if hmac.compare_digest(token, self.last_token) and LOGIN_HARDENING:
+        if constant_time_compare(token, self.last_token) and LOGIN_HARDENING:
             raise BadTokenException("previously used token {}".format(token))
 
         if self.is_totp:

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -291,9 +291,14 @@ class Journalist(Base):
             raise InvalidPasswordLength(password)
         # No check on minimum password length here because some passwords
         # may have been set prior to setting the minimum password length.
+<<<<<<< HEAD
         return pyotp.utils.compare_digest(
             self._scrypt_hash(password, self.pw_salt),
             self.pw_hash)
+=======
+        return constant_time_compare(self._scrypt_hash(password, self.pw_salt),
+                                     self.pw_hash)
+>>>>>>> Use Python 2.7.6 friendly constant-time string comparator
 
     def regenerate_totp_shared_secret(self):
         self.otp_secret = pyotp.random_base32()
@@ -356,6 +361,7 @@ class Journalist(Base):
         """
         token = self._format_token(token)
 
+<<<<<<< HEAD
         def verify_totp(token, for_time=None):
             """Check the given token against the previous, current, and
             next valid tokens to compensate for potential time skew
@@ -377,6 +383,26 @@ class Journalist(Base):
 
             for counter_val in range(self.hotp_counter,
                                      self.hotp_counter + 20):
+=======
+        # Only allow each authentication token to be used once. This
+        # prevents some MITM attacks.
+        if constant_time_compare(token, self.last_token) and LOGIN_HARDENING:
+            raise BadTokenException("previously used token {}".format(token))
+        else:
+            self.last_token = token
+            db_session.commit()
+
+        if self.is_totp:
+            # Also check the given token against the previous and next
+            # valid tokens, to compensate for potential time skew
+            # between the client and the server. The total valid
+            # window is 1:30s.
+            return self.totp.verify(token, valid_window=1)
+        else:
+            for counter_val in range(
+                    self.hotp_counter,
+                    self.hotp_counter + 20):
+>>>>>>> Use Python 2.7.6 friendly constant-time string comparator
                 if self.hotp.verify(token, counter_val):
                     verified = True
                     self.hotp_counter = counter_val + 1

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -1,5 +1,6 @@
 import os
 import datetime
+from functools import partial
 import base64
 import binascii
 
@@ -239,7 +240,7 @@ class Journalist(Base):
     otp_secret = Column(String(16), default=pyotp.random_base32)
     is_totp = Column(Boolean, default=True)
     hotp_counter = Column(Integer, default=0)
-    last_token = Column(String(6))
+    last_token = Column(String(6)) # deprecated
 
     created_on = Column(DateTime, default=datetime.datetime.utcnow)
     last_access = Column(DateTime)
@@ -344,36 +345,51 @@ class Journalist(Base):
         """Strips from authentication tokens the whitespace that many clients add for readability"""
         return ''.join(token.split())
 
-    def verify_token(self, token):
+    def verify_token(self, token, for_time=None):
+        """Verify a HOTP/TOTP token, allowing for client/ server skew.
+        For TOTP, you may specify a time to check the token for.
+
+        Args:
+            for_time: An optional :obj:`datetime.datetime` to
+                check the token for.
+        Returns: bool
+        """
         token = self._format_token(token)
 
-        # Only allow each authentication token to be used once. This
-        # prevents some MITM attacks.
-        if constant_time_compare(token, self.last_token) and LOGIN_HARDENING:
-            raise BadTokenException("previously used token {}".format(token))
+        def verify_totp(token, for_time=None):
+            """Check the given token against the previous, current, and
+            next valid tokens to compensate for potential time skew
+            between the client and the server. The total valid window is
+            1:30s.
 
-        if self.is_totp:
-            # Also check the given token against the previous and next
-            # valid tokens, to compensate for potential time skew
-            # between the client and the server. The total valid
-            # window is 1:30s.
-            verified = self.totp.verify(token, valid_window=1)
+            Args:
+                for_time: An optional :obj:`datetime.datetime` to
+                    check the token for.
+            Returns: bool
+            """
+            return self.totp.verify(token, for_time=for_time, valid_window=1)
 
-        else:
+        def verify_hotp(token):
+            """Check the given token against the current and next 20
+            tokens.
+            """
             verified = False
+
             for counter_val in range(self.hotp_counter,
                                      self.hotp_counter + 20):
                 if self.hotp.verify(token, counter_val):
                     verified = True
                     self.hotp_counter = counter_val + 1
+                    db_session.add(self)
+                    db_session.commit()
                     break
 
-        if verified:
-            self.last_token = token
-            db_session.commit()
+            return verified
 
-        return verified
- 
+        verifier = (partial(verify_totp, for_time=for_time) if self.is_totp
+                    else verify_hotp)
+
+        return verifier(token)
 
     @classmethod
     def throttle_login(cls, user):
@@ -398,6 +414,23 @@ class Journalist(Base):
 
     @classmethod
     def login(cls, username, password, token):
+        """Takes a username, password, and OTP token (strings) and tries
+        to authenticate the user. Unless the SECUREDROP_ENV environment
+        variable is set to 'test' login attempts are rate-limited, and
+        OTP tokens that were just used, or precede/ proceed a token that
+        was just used are rejected.
+
+        Returns: :obj:`Journalist`
+
+        Raises:
+            InvalidUsernameException: If no user can be found with the
+                specified `username`.
+            LoginThrottledException: If the user has exceeded the login
+                rate-limiting threshold.
+            BadTokenException: If the `token` is invalid, was just used,
+                or precedes/proceeds a token that was just used.
+            WrongPasswordException: If the user's `password` is invalid.
+        """
         try:
             user = Journalist.query.filter_by(username=username).one()
         except NoResultFound:
@@ -406,11 +439,21 @@ class Journalist(Base):
 
         if LOGIN_HARDENING:
             cls.throttle_login(user)
+            if (user.is_totp
+                and user.verify_token(token, for_time=user.last_access)):
+                raise BadTokenException(
+                    "Token valid, but was just used, or precedes/ proceeds "
+                    "a token that was just used.")
 
         if not user.verify_token(token):
             raise BadTokenException("invalid token")
         if not user.valid_password(password):
             raise WrongPasswordException("invalid password")
+
+        user.last_access = datetime.datetime.utcnow()
+        db_session.add(user)
+        db_session.commit()
+
         return user
 
 

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -191,31 +191,30 @@ class SourceStar(Base):
         self.source_id = source.id
         self.starred = starred
 
+class LoginException(Exception):
+    """Generic exception for errors during login."""
 
-class InvalidUsernameException(Exception):
+class InvalidUsernameException(LoginException):
+    """Raised when a user logs in with an invalid username."""
 
-    """Raised when a user logs in with an invalid username"""
+class LoginThrottledException(LoginException):
+    """Raised when a user attempts to log in too many times in a given
+    time period."""
 
+class WrongPasswordException(LoginException):
+    """Raised when a user logs in with an incorrect password."""
 
-class LoginThrottledException(Exception):
+class BadTokenException(LoginException):
+    """Raised when a user logs in with an invalid TOTP token."""
 
-    """Raised when a user attempts to log in too many times in a given time period"""
-
-
-class WrongPasswordException(Exception):
-
-    """Raised when a user logs in with an incorrect password"""
-
-
-class BadTokenException(Exception):
-
-    """Raised when a user logins in with an incorrect TOTP token"""
-
+class TokenReuseException(LoginException):
+    """Raised when a user attempts to re-use a token, or to use a token
+    that preceds or proceeds a token that has been used."""
 
 class InvalidPasswordLength(Exception):
-    """Raised when attempting to create a Journalist or log in with an invalid
-    password length"""
-
+    """Raised when attempting to create a Journalist or log in with an
+    invalid password length.
+    """
     def __init__(self, password):
         self.pw_len = len(password)
 
@@ -354,6 +353,8 @@ class Journalist(Base):
         Raises:
             BadTokenException: If `token` is not a six digit numeric string
                 or is not valid for the given time window.
+            TokenReuseException: If the token has been reused or precedes or
+                proceeds a used token.
         """
         token = self._format_token(token)
         if not isinstance(token, str):
@@ -451,6 +452,8 @@ class Journalist(Base):
                 rate-limiting threshold, or if the user is a TOTP user
                 and has just successfully logged in within 60s.
             BadTokenException: If the `token` is invalid.
+            TokenReuseException: If the `token` is a TOTP token that has
+                already been used, or precedes or proceeds a used token.
             WrongPasswordException: If the user's `password` is invalid.
         """
         try:

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -440,6 +440,7 @@ class Journalist(Base):
         if LOGIN_HARDENING:
             cls.throttle_login(user)
             if (user.is_totp
+                and user.last_access is not None
                 and user.verify_token(token, for_time=user.last_access)):
                 raise BadTokenException(
                     "Token valid, but was just used, or precedes/ proceeds "

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -115,9 +115,9 @@ def login():
                 request.form['username'], exc))
             login_flashed_msg = "Login failed."
 
-            if isinstance(exc, (BadTokenException, LoginThrottledException)):
-                login_flashed_msg += ("Please wait at least 60 seconds before "
-                                      "logging in again.")
+            if isinstance(exc, LoginThrottledException):
+                login_flashed_msg += (" Please wait at least 60 seconds "
+                                      "before logging in again.")
 
             flash(login_flashed_msg, "error")
         else:

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -109,31 +109,20 @@ def login():
             user = Journalist.login(request.form['username'],
                                     request.form['password'],
                                     request.form['token'])
-        except Exception as e:
-            app.logger.error("Login for '{}' failed: {}".format(
-                request.form['username'], e))
+        except Exception as exc:
+            app.logger.error(
+                "Login attempt with username '{}' failed: {}".format(
+                request.form['username'], exc))
             login_flashed_msg = "Login failed."
 
-            if isinstance(e, LoginThrottledException):
-                login_flashed_msg += " Please wait at least 60 seconds before logging in again."
-            else:
-                try:
-                    user = Journalist.query.filter_by(
-                        username=request.form['username']).one()
-                    if user.is_totp:
-                        login_flashed_msg += " Please wait for a new two-factor token before logging in again."
-                except:
-                    pass
+            if isinstance(exc, (BadTokenException, LoginThrottledException)):
+                login_flashed_msg += ("Please wait at least 60 seconds before "
+                                      "logging in again.")
 
             flash(login_flashed_msg, "error")
         else:
             app.logger.info("Successful login for '{}' with token {}".format(
                 request.form['username'], request.form['token']))
-
-            # Update access metadata
-            user.last_access = datetime.utcnow()
-            db_session.add(user)
-            db_session.commit()
 
             session['uid'] = user.id
             return redirect(url_for('index'))

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -19,7 +19,8 @@ import template_filters
 from db import (db_session, Source, Journalist, Submission, Reply,
                 SourceStar, get_one_or_else, NoResultFound,
                 WrongPasswordException, BadTokenException,
-                LoginThrottledException, InvalidPasswordLength)
+                LoginThrottledException, InvalidPasswordLength,
+                LoginException, TokenReuseException)
 import worker
 
 app = Flask(__name__, template_folder=config.JOURNALIST_TEMPLATES_DIR)
@@ -109,13 +110,13 @@ def login():
             user = Journalist.login(request.form['username'],
                                     request.form['password'],
                                     request.form['token'])
-        except Exception as exc:
+        except LoginException as exc:
             app.logger.error(
                 "Login attempt with username '{}' failed: {}".format(
                 request.form['username'], exc))
             login_flashed_msg = "Login failed."
 
-            if isinstance(exc, LoginThrottledException):
+            if isinstance(exc, (LoginThrottledException, TokenReuseException)):
                 login_flashed_msg += (" Please wait at least 60 seconds "
                                       "before logging in again.")
 


### PR DESCRIPTION
## Status

This PR depends on #1676 and  #1676 is merged. That said, it is ready for review, but you might just want to wait for the rebase to happen so the diff is more clear.

## Description of Changes

Strengthens TOTP protections:

* Protection is only applied to TOTP users because I believe the process of updating the HOTP counter is sufficient to defend against such attacks.
* Once a TOTP token has been used as part of a valid login process, that token, as well as the previous and following tokens are rejected. This is to prevent MitM and shoulder-surfing type attacks. Since in practice it seems unlikely a journalist would login and logout just to login again within a ~60s window, this shouldn't be of inconvenience.
* Since we're using `last_access` in place of `last_token`, I (i) added a "`# deprecated`" comment to the relevant column to remind us to remove it when we do our next database migration and (ii) moved the updating of last access from the journalist app code to the database code, where it seems to fit better, and helps the reader understand the protection.
* Protection is applied in the `login()` function instead of the `verify_token()` function because `verify_token()` is called from other functions, and with the re-implementation this could create problems in the case a user logs in and then tries to re-generate a TOTP token.
* Since the class of and conditions under which exceptions are raised slightly changed in `db.Journalist.login()`, I updated `journalist.login()` to reflect that.
* Adds Google-style docstrings.

## Testing

Since `LOGIN_HARDENING` is set to `False` during the tests, this will require manual review. With both the `development` and `staging` machines, create a `Journalist`, and try logging in, out, and back in again. You should be flashed a warning on your second login attempt notifying you to wait 60 seconds. Wait that long and then try again. Login should succeed.

We could create tests which temporary set `LOGIN_HARDENING` to `True`, to make sure a token can't be re-used. I think by mocking `datetime` we could do thorough testing without making such a test take forever. Thoughts?

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] Testinfra tests pass on the development VM

