### PR TITLE
Adds manage.py aliases and updates tmp dir cleaning cron job

### DIFF
--- a/install_files/ansible-base/roles/app/tasks/setup_cron.yml
+++ b/install_files/ansible-base/roles/app/tasks/setup_cron.yml
@@ -1,7 +1,16 @@
 ---
-- name: Add cron job to clean SecureDrop tmp dir daily.
+- name: Remove cron job to clean SecureDrop tmp dir daily (old manage.py syntax).
   cron:
     name: cleanup SecureDrop temp dir
+    job: "{{ securedrop_code }}/manage.py clean_tmp"
+    special_time: daily
+    state: absent
+  tags:
+    - cron
+
+- name: Add cron job to clean SecureDrop tmp dir daily (new manage.py syntax).
+  cron:
+    name: Cleanup SecureDrop temporary directory.
     job: "{{ securedrop_code }}/manage.py clean-tmp"
     special_time: daily
   tags:

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -224,12 +224,18 @@ def get_args():
     admin_subp = subps.add_parser('add-admin', help='Add an admin to the '
                                   'application.')
     admin_subp.set_defaults(func=add_admin)
+    admin_subp_a = subps.add_parser('add_admin', help='^')
+    admin_subp_a.set_defaults(func=add_admin)
     journalist_subp = subps.add_parser('add-journalist', help='Add a '
                                        'journalist to the application.')
     journalist_subp.set_defaults(func=add_journalist)
+    journalist_subp_a = subps.add_parser('add_journalist', help='^')
+    journalist_subp_a.set_defaults(func=add_journalist)
     delete_user_subp = subps.add_parser('delete-user', help='Delete a user '
                                         'from the application.')
     delete_user_subp.set_defaults(func=delete_user)
+    delete_user_subp_a = subps.add_parser('delete_user', help='^')
+    delete_user_subp_a.set_defaults(func=delete_user)
 
     # Reset application state
     reset_subp = subps.add_parser('reset', help='DANGER!!! Clears the '
@@ -239,6 +245,8 @@ def get_args():
     clean_tmp_subp = subps.add_parser('clean-tmp', help='Cleanup the '
                                       'SecureDrop temp directory.')
     clean_tmp_subp.set_defaults(func=clean_tmp)
+    clean_tmp_subp_a = subps.add_parser('clean_tmp', help='^')
+    clean_tmp_subp_a.set_defaults(func=clean_tmp)
 
     return parser
 

--- a/testinfra/development/test_development_application_settings.py
+++ b/testinfra/development/test_development_application_settings.py
@@ -109,15 +109,20 @@ def test_development_app_directories_exist(File):
 
 def test_development_clean_tmp_cron_job(Command, Sudo):
     """
-    Ensure cron job for cleaning the temporary directory for the app code exists.
+    Ensure cron job for cleaning the temporary directory for the app code
+    exists. Also, ensure that the older format for the cron job is absent,
+    since we updated manage.py subcommands to use hyphens instead of
+    underscores (e.g. `clean_tmp` -> `clean-tmp`).
     """
 
     with Sudo():
         c = Command.check_output('crontab -l')
-    # TODO: this should be using property, but the ansible role
-    # doesn't use a var, it's hard-coded. update ansible, then fix test.
-    # it { should have_entry "@daily #{property['securedrop_code']}/manage.py clean-tmp" }
     assert "@daily {}/manage.py clean-tmp".format(sd_test_vars.securedrop_code) in c
+    assert "@daily {}/manage.py clean_tmp".format(sd_test_vars.securedrop_code) not in c
+    assert "clean_tmp".format(sd_test_vars.securedrop_code) not in c
+    # Make sure that the only cron lines are a comment and the actual job.
+    # We don't want any duplicates.
+    assert len(c.split("\n")) == 2
 
 
 def test_development_default_logo_exists(File):


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #1675.

Changes proposed in this pull request:

## Testing

Reviewers can test `manage.py` in any VM. To test the playbook changes, provision a staging VM using `master`, then switch to this branch and re-provision. You should see the old cronjob commented out and the new one present.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] Testinfra tests pass on the development VM

