### PR TITLE
Adds error handling to OSSEC encrypted email script

### DIFF
--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -326,6 +326,18 @@ after the first playbook run, try setting ``ossec_from_address`` in
 ``prod-specific.yml`` to the full email address used for sending the alerts,
 then run the playbook again.
 
+Message failed to encrypt
+~~~~~~~~~~~~~~~~~~~~~~~~~
+If OSSEC cannot encrypt the alert to the GPG public key for the Admin
+email address (configured as ``ossec_alert_email`` in ``prod-specific.yml``),
+the system will send a static message instead of the scheduled alert:
+
+  Failed to encrypt OSSEC alert. Investigate the mailing configuration on the Monitor Server.
+
+Check the GPG configuration vars in ``prod-specific.yml``. In particular,
+make sure the GPG fingerprint matches that of the public key file you
+exported.
+
 Troubleshooting SMTP TLS
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/install_files/ansible-base/roles/ossec-server/templates/send_encrypted_alarm.sh
+++ b/install_files/ansible-base/roles/ossec-server/templates/send_encrypted_alarm.sh
@@ -1,5 +1,49 @@
 #!/bin/bash
+# Handler script to encrypt OSSEC alerts prior to mailing.
+# Called via the `.procmailrc` for user `ossec`.
 
-/usr/bin/formail -I "" | \
-    /usr/bin/gpg --homedir /var/ossec/.gnupg --trust-model always -ear "{{ ossec_gpg_fpr }}" | \
-    /usr/bin/mail -s "$(echo $SUBJECT | sed -r 's/([0-9]{1,3}\.){3}[0-9]{1,3}\s?//g' )" {{ ossec_alert_email }}
+# Intentionally NOT setting `set -e`, since we'll do our own error handling.
+# Rather than exit immediately on errors, we should gracefully inform
+# the Admin that there was a problem encrypting a message.
+#set -e
+set -o pipefail
+
+
+# Read alert message content from STDIN, as passed by OSSEC. Store the message
+# in a var so we can iteratively process it, halting execution before sending
+# if the GPG encryption command failed. If we simply chain a bunch of pipes
+# together, then the email will be sent with an empty body, should the GPG
+# encryption fail.
+ossec_alert_text="$(< /dev/stdin)"
+
+# Primary "send email to Admin" functionality.
+function send_encrypted_alert() {
+
+    local encrypted_alert_text
+    # Try to encrypt the alert message. We'll inspect the exit status of the
+    # pipeline to decide whether to send the alert text, or the default
+    # failure message.
+    encrypted_alert_text="$(printf "${ossec_alert_text}" | \
+        /usr/bin/formail -I '' | \
+        /usr/bin/gpg --homedir /var/ossec/.gnupg --trust-model always -ear '{{ ossec_gpg_fpr }}')"
+
+    # Error handling.
+    if [[ -z "${encrypted_alert_text}" || $? -ne 0 ]]; then
+        send_plaintext_fail_message
+    else
+        echo "${encrypted_alert_text}" | \
+            /usr/bin/mail -s "$(echo $SUBJECT | sed -r 's/([0-9]{1,3}\.){3}[0-9]{1,3}\s?//g' )" '{{ ossec_alert_email }}'
+    fi
+}
+
+# Failover alerting function, in case the primary function failed.
+# Usually a failure is related to GPG balking on the encryption step;
+# that may be due to a missing pubkey or something reason.
+function send_plaintext_fail_message() {
+    printf "Failed to encrypt OSSEC alert. Investigate the mailing configuration on the Monitor Server." | \
+        /usr/bin/formail -I "" | \
+        /usr/bin/mail -s "$(echo $SUBJECT | sed -r 's/([0-9]{1,3}\.){3}[0-9]{1,3}\s?//g' )" '{{ ossec_alert_email }}'
+}
+
+# Encrypt the OSSEC notification and pass to mailer for sending.
+send_encrypted_alert

--- a/install_files/ansible-base/roles/validate/tasks/main.yml
+++ b/install_files/ansible-base/roles/validate/tasks/main.yml
@@ -5,29 +5,10 @@
 
 - include: validate_users.yml
 
-- debug: msg="verifying securedrop_app_gpg_fingerprint is not the journalist test key"
-  failed_when: securedrop_app_gpg_fingerprint == "65A1B5FF195B56353CC63DFFCC40EF1228271441"
-  tags:
-    - validate
-    - debug
-
-- debug: msg="verifying securedrop_app_gpg_fingerprint is not the admin test key"
-  failed_when: securedrop_app_gpg_fingerprint == "600BC6D5142C68F35DDBCEA87B597104EDDDC102"
-  tags:
-    - validate
-    - debug
-
-- debug: msg="verifying ossec_gpg_fpr is not the journalist test key"
-  failed_when: securedrop_app_gpg_fingerprint == "65A1B5FF195B56353CC63DFFCC40EF1228271441"
-  tags:
-    - validate
-    - debug
-
-- debug: msg="verifying ossec_gpg_fpr is not the admin test key"
-  failed_when: ossec_gpg_fpr == "600BC6D5142C68F35DDBCEA87B597104EDDDC102"
-  tags:
-    - validate
-    - debug
+- include: validate_gpg_info.yml
+  with_items:
+    - "{{ securedrop_app_gpg_fingerprint }}"
+    - "{{ ossec_gpg_fpr }}"
 
 - debug: msg="verifying ossec_alert_email is not the test value"
   failed_when: ossec_alert_email == "ossec@ossec.test"

--- a/install_files/ansible-base/roles/validate/tasks/validate_gpg_info.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_gpg_info.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Validate GPG info.
+  assert:
+     that:
+       # Should not match the fingerprint for the TEST Journalist pubkey.
+       - item != "65A1B5FF195B56353CC63DFFCC40EF1228271441"
+       # Should not match the fingerprint for the TEST Admin pubkey.
+       - item != "600BC6D5142C68F35DDBCEA87B597104EDDDC102"
+       # Should not contain whitespace.
+       - "' ' not in item"
+       # Must be a full-length fingerprint.
+       - item|length == 40
+       # Must contain only hex characters
+       - item == item|regex_replace('[^A-F0-9]', '')
+  tags:
+    - validate
+    - debug


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #858.

Changes proposed in this pull request:

* Validates the GPG fingerprint vars in `prod-specific.yml` before attempting to use the values in templates. This is designed to prevent known-bad values from landing on the servers.
* Makes the encrypted email notification script more resilient to failure, sending a simple plaintext email if encryption failed. This is designed to inform the Admin about bad values that somehow slipped into the Monitor Server.
* Updates documentation with explicit reference to the new OSSEC email error message.

A few notes on the implementation here. The validation logic via `assert` is rather straightforward, and chips away at the long list of concerns documented in #749. There are substantial changes to the `send_encrypted_alarm.sh` script, however. I _really_ didn't want to make major edits to such a simple script, but it was necessary to avoid the situation of encryption errors meaning that empty emails are sent. 

The problem with the old implementation is that the pipeline (i.e. chain of commands all joined by `|`) approach _always_ sends mail regardless of what is passed through to the `/usr/bin/mail` program. Mail _does_ have a convenient option `-E` that silently discards empty messages, which would have prevented the empty emails. Simply avoiding sending empty messages isn't enough, though: we want to inform the Admin that something is awry, to encourage investigation and resolution.

So we're _not_ using the `-E` option, instead we'll build the message body, encrypt it, then ensure both that the body is not an empty string, and that the pipeline exited non-zero. If those conditions are satisfied, we send the encrypted message as normal. If either of those conditions are not satisfied, then we fail over to sending the general "you should check it out" message.

## Testing

1. Edit `install_files/ansible-base/group_vars/staging.yml` and add working GPG key info and OSSEC email info. You'll need working OSSEC email delivery in order to test this PR! (Don't forget about the new `ossec_from_address` var, added in #1565; you'll probably need to set that to the "from" address.)
2. Provision staging servers.
3. Confirm receipt of encrypted OSSEC alerts via email, and that you can decrypt them.
4. SSH into `mon-staging` and edit `/var/ossec/send_encrypted_alarm.sh`; remove a single character from the fingerprint, to make it invalid (GPG will fail).
5. Confirm that next OSSEC alerts are plaintext and contain the message `Failed to encrypt OSSEC alert. Investigate the mailing configuration on the Monitor Server.`

Tip: `service ossec restart` is a convenient way to trigger an alert to fire; works on both App and Mon machines.

## Deployment

Since these changes only apply to the Ansible config, existing instances will not get the benefit of the additional error handling automatically—they'll need to run the playbook again. That's OK by me, and I don't think we need to require Admins to run the playbook to get this specific update, since it's mostly useful for first-time Admins performing the initial installation—that's when the OSSEC configuration is most painful. Hopefully the docs update will alleviate some of that pain.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] Testinfra tests pass on the development VM

