### PR TITLE
Fixes for developer docs

### DIFF
--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -117,12 +117,12 @@ If you want to receive OSSEC alerts or change any other settings, you will need
 to fill out your local copy of
 ``./install_files/ansible-base/staging-specific.yml``.
 
-You should first provision the VM required for building the app code
+You should first bring up the VM required for building the app code
 Debian packages on the staging machines:
 
 .. code:: sh
 
-   vagrant up build
+   vagrant up --no-provision build
    vagrant up /staging/
    vagrant ssh app-staging
    sudo su

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -117,8 +117,12 @@ If you want to receive OSSEC alerts or change any other settings, you will need
 to fill out your local copy of
 ``./install_files/ansible-base/staging-specific.yml``.
 
+You should first provision the VM required for building the app code
+Debian packages on the staging machines:
+
 .. code:: sh
 
+   vagrant up build
    vagrant up /staging/
    vagrant ssh app-staging
    sudo su

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ anonymous sources.
    hardware
    before_you_begin
    set_up_tails
-   set_up_*SVS*
+   set_up_svs
    set_up_dtd
    generate_securedrop_application_key
    set_up_admin_tails

--- a/docs/set_up_tails.rst
+++ b/docs/set_up_tails.rst
@@ -44,8 +44,8 @@ You will need to create 3 Tails USBs to perform the SecureDrop installation:
    onto a USB drive, using one of the techniques outlined in the Tails
    documentation. This Tails USB is only used for creating other Tails
    USBs with the **Tails Installer**.
-#. The **Secure Viewing Station* Tails USB*.
-#. The **Admin Workstation* Tails USB*.
+#. The *Secure Viewing Station* Tails USB.
+#. The *Admin Workstation* Tails USB.
 
 .. tip:: This process will take some time, most of which will be spent
 	 waiting around. Once you have the "master" copy of Tails, you


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

1. When one provisions the staging VMs using the instructions in the developer docs, one gets a failure and the direction to provision the build VM. This PR adds this to the step by step instructions for provisioning the staging VMs.

2. The earlier addition of asterisks resulted in a bit of malformed text:

![screen shot 2017-05-03 at 10 48 43 am](https://cloud.githubusercontent.com/assets/7832803/25673971/20b0cd14-2fee-11e7-9640-72f4487c67be.png)

and the removal of the SVS set up instructions from the documentation:

![screen shot 2017-05-03 at 10 48 35 am](https://cloud.githubusercontent.com/assets/7832803/25674035/5a07a9de-2fee-11e7-9b22-66a8344da28c.png)

This PR fixes these asterisks

## Testing

1. Build documentation
2. Verify the SVS set up appears:

![screen shot 2017-05-03 at 10 53 41 am](https://cloud.githubusercontent.com/assets/7832803/25674186/d24f4032-2fee-11e7-80b7-8e54d7a11c01.png)

3. Check that you agree with the build instructions
 