### PR TITLE
Adds linting for Sphinx documentation to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,10 @@ script:
 - sudo chown root:root securedrop/config.py
 - sudo sh -c "export DISPLAY=:1; cd securedrop/ && pytest tests/"
 - ./testinfra/test.py
-- cd docs && make clean && sphinx-build -Wn . _build/html && cd .. # docs linting
+  # Docs linting. Performing this step *after* build VM tests pass, so as not
+  # to alter the pip requirements, which would cause config tests to fail.
+- pip install sphinx sphinx_rtd_theme
+- cd docs && make clean && sphinx-build -Wn . _build/html && cd -
 after_success:
   cd securedrop/ && coveralls && cd ../  # cd back to repo root for srcclr run
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script:
 - sudo chown root:root securedrop/config.py
 - sudo sh -c "export DISPLAY=:1; cd securedrop/ && pytest tests/"
 - ./testinfra/test.py
+- cd docs && make clean && sphinx-build -Wn . _build/html && cd .. # docs linting
 after_success:
   cd securedrop/ && coveralls && cd ../  # cd back to repo root for srcclr run
 addons:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,7 +156,7 @@ else:
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/create_admin_account.rst
+++ b/docs/create_admin_account.rst
@@ -1,5 +1,5 @@
 Create an admin account on the Journalist Interface
-=================================================
+===================================================
 
 In order for any user (administrator or journalist) to access the
 Journalist Interface, they need:

--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -17,6 +17,7 @@ Automated Testing
 
 When a pull request is submitted, we have Travis CI automatically run the
 SecureDrop test suites, which consist of:
+
   #. Unit tests of the Python SecureDrop application code.
   #. Functional tests that use Selenium to drive a web browser to verify the
      function of the application from the user's perspective.

--- a/docs/development/threat_model.rst
+++ b/docs/development/threat_model.rst
@@ -56,7 +56,7 @@ Assumptions about the source's computer
 -  The computer is not compromised by malware.
 
 Assumptions about the *Admin Workstation* and the Journalist Workstation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  The computer correctly executes Tails.
 -  The computer and the Tails device are not compromised by malware.
@@ -64,7 +64,7 @@ Assumptions about the *Admin Workstation* and the Journalist Workstation
    not compromised by malware.
 
 Assumptions about the *Secure Viewing Station*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  The computer is airgapped.
 -  The computer correctly executes Tails.
@@ -107,7 +107,7 @@ Attack Scenarios
 ----------------
 
 What the *Application Server* can achieve
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  The server sees the plaintext codename, used as the login identifier,
    of every source.
@@ -134,7 +134,7 @@ What the *Application Server* can achieve
    passphrase.
 
 What the *Monitor Server* can achieve
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  The server stores the plaintext alerts on disk, data may also reside
    in RAM.
@@ -365,7 +365,7 @@ What a physical seizure of the journalist's property can achieve
    device will allow the attacker to access the Journalist Interface.
 
 What a compromise of the *Application Server* can achieve
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  If the *Application Server* is compromised, the system user the
    attacker has control over defines what kind of information the
@@ -409,7 +409,7 @@ What a compromise of the *Application Server* can achieve
       attacker has access to the encryption key required to do so.
 
 What a physical seizure of the *Application Server* can achieve
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  If the *Application Server* is seized, the attacker will be able to
    view any and all unencrypted files on the server. This includes all
@@ -419,7 +419,7 @@ What a physical seizure of the *Application Server* can achieve
    the hardware.
 
 What a compromise of the *Monitor Server* can achieve
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  If the *Monitor Server* is compromised, the system user the attacker
    has control over defines what kind of information the attacker will
@@ -446,7 +446,7 @@ What a compromise of the *Monitor Server* can achieve
       to the encryption key required to do so.
 
 What a physical seizure of the *Monitor Server* can achieve
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  If the *Monitor Server* is seized, the attacker will be able to view
    any and all unencrypted files on the server. This includes all files
@@ -455,7 +455,7 @@ What a physical seizure of the *Monitor Server* can achieve
    RAM. The attacker can also tamper with the hardware.
 
 What a compromise of the *Secure Viewing Station* can achieve
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  The *Secure Viewing Station* is only useful to an attacker while
    powered on and with the Tails persistent volume mounted. The attacker
@@ -473,7 +473,7 @@ What a compromise of the *Secure Viewing Station* can achieve
       submissions--if the Transfer device is in use.
 
 What a physical seizure of the *Secure Viewing Station* can achieve
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  The *Secure Viewing Station* is only useful to an attacker while
    powered on and with the Tails persistent volume mounted. The attacker

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -200,7 +200,7 @@ Specific Hardware Recommendations
 ---------------------------------
 
 Application and Monitor Servers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Intel NUC (Next Unit of Computing) is a capable, cheap, quiet, and
 low-powered device that can be used for the SecureDrop servers. There
@@ -263,7 +263,7 @@ insert the cards into the NUC before it can be used. We recommend:
 	  suspend in the BIOS as well as OS options like "wake on LAN".
 
 *Secure Viewing Station* (*SVS*)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The *Secure Viewing Station* is a machine that is kept offline and only
 ever used together with the Tails operating system. This machine will be

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -37,7 +37,7 @@ instructions to set one up with GnuPG (GPG).
    X <https://support.gpgtools.org/kb/how-to/first-steps-where-do-i-start-where-do-i-begin>`__
 
 Connect to the Journalist Interface
----------------------------------
+-----------------------------------
 
 Each journalist has their own authenticated Tor hidden service URL to
 login to the ``Journalist Interface``. The journalist needs to use the

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -63,7 +63,7 @@ journalists see is different than the codename that sources see.**
 |Journalist Interface|
 
 Move Documents to the *Secure Viewing Station*
---------------------------------------------
+----------------------------------------------
 
 You will only be able to view the documents the source has sent you on
 the *Secure Viewing Station*. After clicking on an individual source
@@ -110,7 +110,7 @@ on the file, and then click "Wipe" to securely wipe the file from your
 device.
 
 Decrypt and work on the *Secure Viewing Station*
-----------------------------------------------
+------------------------------------------------
 
 To decrypt documents, return to your Persistent folder and double-click
 on zipped file folder. After you extract the files, click on each file

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -8,7 +8,7 @@ Both servers
 - iptables: ``/var/log/syslog``
 
 *Application Server*
-----------
+--------------------
 
 - Apache: ``/var/log/apache2/*``
 
@@ -16,7 +16,7 @@ If an event triggers it's in the SecureDrop application log:
 ``/var/www/securedrop/securedrop.log``
 
 *Monitor Server*
---------------
+----------------
 
 - OSSEC ::
 

--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -301,7 +301,7 @@ WebGUI. Uncheck the box labeled **Enable DHCP server on LAN
 interface**, scroll down, and click the **Save** *and then* click Apply.
 
 Assign a static IP address to the *Admin Workstation*
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Now you will need to assign a static IP to the *Admin Workstation*. Use
 the *Admin Workstation* that you selected earlier, and make sure you

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -25,7 +25,7 @@ In order to use SecureDrop, each journalist needs two things:
      access to a *Secure Viewing Station*.
 
 Determine access protocol for the *Secure Viewing Station*
---------------------------------------------------------
+----------------------------------------------------------
 
 Currently, SecureDrop only supports encrypting submissions to a single
 public/private key pair - the *SecureDrop Submission Key*. As a

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -59,7 +59,7 @@ Journalist Workstation. Enable persistence and set an administrator
 password before continuing with the next section.
 
 Set up automatic access to the Journalist Interface
--------------------------------------------------
+---------------------------------------------------
 
 Since the Journalist Interface is an ATHS, we need to set up the
 Journalist Tails USB to auto-configure Tor just as we did with the
@@ -103,7 +103,7 @@ the Journalist Interface. You should be able to connect, and will be
 automatically taken to a login page.
 
 Add an account on the Journalist Interface
-----------------------------------------
+------------------------------------------
 
 Finally, you need to add an account on the Journalist Interface so the journalist
 can log in and access submissions. See the section on :ref:`Adding Users` in

--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -80,8 +80,8 @@ vary and you may require later edits to the Postfix configuration
 (mainly /etc/postfix/main.cf) on the *Monitor Server* in order to get
 alerts to work. You can consult `Postfix's official
 documentation <http://www.postfix.org/documentation.html>`__ for help,
-although we've described some common scenarios in the
-:ref:`troubleshooting section <Troubleshooting>` of this document.
+although we've described some common scenarios in the 
+:ref:`troubleshooting section <troubleshooting_ossec>` of this document.
 
 If you have your GPG public key handy, copy it to
 install\_files/ansible-base and then specify the filename in the
@@ -239,7 +239,7 @@ playbooks.) Save ``prod-specific.yml``, exit the editor and :ref:`proceed
 with the installation <Run the Ansible playbook>` by running the
 playbooks.
 
-.. _Troubleshooting:
+.. _troubleshooting_ossec:
 
 Troubleshooting
 ---------------

--- a/docs/passphrases.rst
+++ b/docs/passphrases.rst
@@ -66,7 +66,7 @@ credential:
    authentication.
 
 *Secure Viewing Station*
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 The journalist will be using the *Secure Viewing Station* with Tails to
 decrypt and view submitted documents. The tasks performed by the

--- a/docs/tails_guide.rst
+++ b/docs/tails_guide.rst
@@ -129,7 +129,7 @@ To use the template:
 -  Save the database in the Tails Persistent folder
 
 Set up easy access to the Journalist Interface
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To complete setup of the *Admin Workstation* or Journalist Workstation, we
 recommend using the scripts in ``tails_files`` to easily configure Tor to
@@ -174,7 +174,7 @@ As long as Tails is booted with the persistent volume enabled then you can open
 the Tor Browser and connect to the Journalist Interface as normal.
 
 Create bookmarks for Source and Journalist Interfaces
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want, you can open the browser and create bookmarks for the Source and
 Journalist Interfaces. Navigate to the site you wish to bookmark, select

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -31,7 +31,7 @@ submitting documents and communicating with journalists. This site is
 hosted on the *Application Server* and can only be accessed over Tor.
 
 Journalist Interface
-------------------
+--------------------
 
 The *Journalist Interface* is the website that journalists will access
 when downloading new documents and communicating with sources. This site

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -9,7 +9,7 @@ define these terms.
 .. todo:: Pictures would be good for many of the objects defined here
 
 Application Server
-----------
+------------------
 
 The *Application Server* runs the SecureDrop application. This server hosts both
 the website that sources access (*Source Interface*) and the website that

--- a/docs/upgrade/0.3.5-to-0.3.6.rst
+++ b/docs/upgrade/0.3.5-to-0.3.6.rst
@@ -20,7 +20,7 @@ Important Changes
 -----------------
 
 Update Expired GPG Signing Key (*Admin Workstation*)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The *Admin Workstation* is used to verify the signed git tag on new
 SecureDrop releases. Prior to running the 0.3.6 upgrade, the Admin
 Workstation should update the signing key.

--- a/docs/upgrade/0.3pre-to-0.3.x.rst
+++ b/docs/upgrade/0.3pre-to-0.3.x.rst
@@ -14,7 +14,7 @@ Important Changes
 -----------------
 
 Journalist Interface Port Change
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To make accessing the journalist interface easier for new users, the
 Journalist Interface port for the onion address has been changed from

--- a/docs/upgrade_to_tails_2x.rst
+++ b/docs/upgrade_to_tails_2x.rst
@@ -182,7 +182,7 @@ unplugging and remounting the Tails device you're trying to upgrade.
 .. |Select Target Device| image:: images/upgrade_to_tails_2x/select_target_device.png
 
 5. Re-install the automatic Tails configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. note:: This step is only applicable to Admin Tails USBs and Journalist Tails
           USBs. If you are upgrading the *Secure Viewing Station* Tails USB, you

--- a/docs/upgrade_to_tails_2x.rst
+++ b/docs/upgrade_to_tails_2x.rst
@@ -192,7 +192,7 @@ Shut down the Tails USB on the airgapped computer and move it to the computer
 you normally use it on. Boot into each newly upgraded Tails USB, enabling
 persistence, and setting a root password. Confirm that the persistent files are
 present on the upgraded Tails USB. If they are not, or something else went
-wrong, see :ref:`Troubleshooting <troubleshooting>`.
+wrong, see :ref:`Troubleshooting <troubleshooting_tails_2x_upgrade>`.
 
 Now that you have successfully upgraded to Tails 2.x with your persistence
 intact, the final step is to re-install the Tails automatic configuration from
@@ -294,7 +294,7 @@ reformat it appropriately.
           smash the device with a hammer until the chips containing its flash
           memory are broken up, then dispose of the pieces in the garbage.
 
-.. _troubleshooting:
+.. _troubleshooting_tails_2x_upgrade:
 
 Troubleshooting
 ---------------

--- a/docs/yubikey_setup.rst
+++ b/docs/yubikey_setup.rst
@@ -1,5 +1,5 @@
 Using YubiKey with the Journalist Interface
-=========================================
+===========================================
 
 This is a quick and dirty guide to using YubiKey for two-factor
 authentication on the Journalist Interface.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1624. Changes proposed in this pull request:

* Adds automatic linting of docs to Travis CI run
* Fixes linting violations throughout the docs

## Testing

For a failed build before all the violations were fixed, see: https://travis-ci.org/freedomofpress/securedrop/builds/228460187 Then confirm that the Travis checks on this PR passed. Wouldn't hurt to take a glance at building the docs locally, but the vast majority of changes here are not rendered (although they can affect rendering badly; see #1683).

## Deployment

No concerns for deployment; just trying to keep the docs as spiffy as possible.

## Checklist

N/A on tests.