### PR TITLE
Update developer docs for 0.4 part 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 # Use Ubuntu 14.04 LTS images, and explicitly require sudo.
 # Relevant docs: https://docs.travis-ci.com/user/trusty-ci-environment/
 sudo: required
@@ -5,42 +6,42 @@ dist: trusty
 
 language: python
 python:
-- '2.7'
+  - '2.7'
 
 virtualenv:
   system_site_packages: true
 before_install:
-- 'for e in /.packer-env/*; do echo -n "${e}: "; cat "${e}"; done'
-- sudo apt-get update -qq
-- sudo apt-get install --yes rng-tools
-- sudo rm -f /dev/random
-- sudo mknod -m 0666 /dev/random c 1 9
-- echo HRNGDEVICE=/dev/urandom | sudo tee /etc/default/rng-tools
-- sudo /etc/init.d/rng-tools restart
+  - 'for e in /.packer-env/*; do echo -n "${e}: "; cat "${e}"; done'
+  - sudo apt-get update -qq
+  - sudo apt-get install --yes rng-tools
+  - sudo rm -f /dev/random
+  - sudo mknod -m 0666 /dev/random c 1 9
+  - echo HRNGDEVICE=/dev/urandom | sudo tee /etc/default/rng-tools
+  - sudo /etc/init.d/rng-tools restart
 install:
-- pip freeze -l
-# Preinstalled travis pytest is not tracked by us
-- pip uninstall pytest -y
-- pip install -r testinfra/requirements.txt
+  - pip freeze -l
+  # Preinstalled travis pytest is not tracked by us
+  - pip uninstall pytest -y
+  - pip install -r testinfra/requirements.txt
 script:
-- printf "[development]\nlocalhost\n[travis]\n[development:children]\ntravis" > inventory
-- ansible-playbook -i inventory -vv --syntax-check install_files/ansible-base/securedrop-travis.yml
-- ansible-playbook -i inventory -vv --connection=local --sudo --skip-tags=non-development install_files/ansible-base/securedrop-travis.yml
+  - printf "[development]\nlocalhost\n[travis]\n[development:children]\ntravis" > inventory
+  - ansible-playbook -i inventory -vv --syntax-check install_files/ansible-base/securedrop-travis.yml
+  - ansible-playbook -i inventory -vv --connection=local --sudo --skip-tags=non-development install_files/ansible-base/securedrop-travis.yml
   # For some reason, redis-server does not start automatically when installed
   # on Travis. I believe Travis' service machinery may be interfering. See
   # http://docs.travis-ci.com/user/database-setup/#Redis
-- sudo service redis-server start
+  - sudo service redis-server start
   # travis needs the config.py file ran owned by root in other environments it is the
   # securedrop_user default www-data
-- sudo chown root:root securedrop/config.py
-- sudo sh -c "export DISPLAY=:1; cd securedrop/ && pytest tests/"
-- ./testinfra/test.py
+  - sudo chown root:root securedrop/config.py
+  - sudo sh -c "export DISPLAY=:1; cd securedrop/ && pytest tests/"
+  - ./testinfra/test.py
   # Docs linting. Performing this step *after* build VM tests pass, so as not
   # to alter the pip requirements, which would cause config tests to fail.
-- pip install sphinx sphinx_rtd_theme
-- cd docs && make clean && sphinx-build -Wn . _build/html && cd -
+  - pip install sphinx sphinx_rtd_theme
+  - cd docs && make clean && sphinx-build -Wn . _build/html && cd -
 after_success:
   cd securedrop/ && coveralls && cd ../  # cd back to repo root for srcclr run
 addons:
-    srcclr:
-        debug: true
+  srcclr:
+    debug: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,3 @@ after_success:
 addons:
     srcclr:
         debug: true
-notifications:
-  slack:
-    secure: jmEgJkFg6IVLl78dbLPBUpWkVuHkQ+HtXHNoY4cdgx2Gq5kVDuLtBIuMK5ubbj3zsp99JIJZ9DFQlunCkoLYZ7PAKQ7fhfwLEWNFJiAajMTZF/nNKV2J4i0NyMBHeFQ5eagAe3wrGiY5sblTbnExY4zERcdGoC1S2UImWX0xMRw=

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,26 @@ install:
   - pip uninstall pytest -y
   - pip install -r testinfra/requirements.txt
 script:
-  - printf "[development]\nlocalhost\n[travis]\n[development:children]\ntravis" > inventory
-  - ansible-playbook -i inventory -vv --syntax-check install_files/ansible-base/securedrop-travis.yml
-  - ansible-playbook -i inventory -vv --connection=local --sudo --skip-tags=non-development install_files/ansible-base/securedrop-travis.yml
+  # Using YAML folding operator '>' to aid in readability and avoid
+  # extremely long lines.
+  - >
+      printf
+      "[development]\nlocalhost\n[travis]\n[development:children]\ntravis"
+      > inventory
+  - >
+      ansible-playbook -i inventory -vv --syntax-check
+      install_files/ansible-base/securedrop-travis.yml
+  - >
+      ansible-playbook -i inventory -vv --connection=local
+      --sudo --skip-tags=non-development
+      install_files/ansible-base/securedrop-travis.yml
+
   # For some reason, redis-server does not start automatically when installed
   # on Travis. I believe Travis' service machinery may be interfering. See
   # http://docs.travis-ci.com/user/database-setup/#Redis
   - sudo service redis-server start
-  # travis needs the config.py file ran owned by root in other environments it is the
-  # securedrop_user default www-data
+  # Travis needs the config.py file to be owned by root. In other environments
+  # it's the `securedrop_user` var.
   - sudo chown root:root securedrop/config.py
   - sudo sh -c "export DISPLAY=:1; cd securedrop/ && pytest tests/"
   - ./testinfra/test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ script:
   - ./testinfra/test.py
   # Docs linting. Performing this step *after* build VM tests pass, so as not
   # to alter the pip requirements, which would cause config tests to fail.
-  - pip install sphinx sphinx_rtd_theme
-  - cd docs && make clean && sphinx-build -Wn . _build/html && cd -
+  - pip install -r securedrop/requirements/develop-requirements.txt
+  - make docs-lint
 after_success:
   cd securedrop/ && coveralls && cd ../  # cd back to repo root for srcclr run
 addons:

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,9 @@ ci-test:
 .PHONY: ci-debug
 ci-debug:
 	touch ${HOME}/.FPF_CI_DEBUG
+
+.PHONY: docs-lint
+docs-lint:
+# The `-W` option converts warnings to errors.
+# The `-n` option enables "nit-picky" mode.
+	make -C docs/ clean && sphinx-build -Wn docs/ docs/_build/html

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,8 @@ docs-lint:
 # The `-W` option converts warnings to errors.
 # The `-n` option enables "nit-picky" mode.
 	make -C docs/ clean && sphinx-build -Wn docs/ docs/_build/html
+
+.PHONY: docs
+docs:
+# Spins up livereload environment for editing; blocks.
+	make -C docs/ clean && sphinx-autobuild docs/ docs/_build/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,7 +146,7 @@ else:
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+html_logo = '../securedrop/static/i/favicon.png'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -22,25 +22,28 @@ To get started editing the docs:
    .. code:: sh
 
       git clone https://github.com/freedomofpress/securedrop.git
-      cd securedrop/docs
 
 #. Build the docs and open the index page in your web browser:
 
    .. code:: sh
 
-      sphinx-autobuild . _build/html
+      make docs
 
 You can then can browse the documentation at http://127.0.0.1:8000/.
 As you make changes, the docs will automatically rebuild in the browser
 window, so you don't need to refresh the page manually.
 
-Occasionally, the docs get out of whack and rebuilding them doesn't
-work as it should. You can usually resolve this by clearing out the
-build artifacts and re-building the docs from scratch:
+You can also check the docs for formatting violations by running the linting
+option:
 
-.. code:: sh
+   .. code:: sh
 
-   make clean && sphinx-autobuild . _build/html
+      make docs-lint
+
+The ``make docs`` command will display warnings, but will still build the
+documentation if formatting mistakes are found. Using ``make docs-lint``
+will convert any warnings to errors, causing the build to fail.
+The CI tests will automatically perform linting via the same command.
 
 Integration with Read the Docs
 ------------------------------


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Partial progress toward satisfying dev docs updates listed in #1208. 

Changes proposed in this pull request:

* Provides `Makefile` targets for docs
  * `make docs` runs the live reload logic; very useful when editing
  * `make docs-lint` checks for formatting errors in the Sphinx docs
* Cleans up the Travis YAML config file
  * linting (via `yamllint`)
  * removes broken Slack webhook
  * uses new Makefile targets for docs linting
  * uses new developer requirements pip dependencies file (via #1685)
* Adds tiny SD logo to docs navbar:

### Before SD logo in docs:
![sd-docs-no-logo](https://cloud.githubusercontent.com/assets/657862/25727187/b5397e7e-30dc-11e7-900c-5359cbad803a.png)

### After SD logo in docs:
![sd-docs-with-logo](https://cloud.githubusercontent.com/assets/657862/25727219/dd02d6b2-30dc-11e7-9e3c-4bba5e61671b.png)


## Testing

Build docs locally and confirm everything is lovely. Try out the new Makefile targets (`make docs` and `make docs-lint`) and confirm they work for you. We'll make sure docs linting in Travis still passes, too.

## Deployment

No special considerations for deployment. These changes affect the developer environment and the developer documentation.

## Checklist
The new docs linting logic in Travis CI should still pass; the calls to the linting logic in Travis now make use of the Makefile target.