### PR TITLE
Handle BadTokenException in /admin/2fa

### DIFF
--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -26,6 +26,7 @@ import config
 import crypto_util
 import store
 
+
 LOGIN_HARDENING = True
 # Unfortunately, the login hardening measures mess with the tests in
 # non-deterministic ways.  TODO rewrite the tests so we can more
@@ -348,7 +349,7 @@ class Journalist(Base):
 
         # Only allow each authentication token to be used once. This
         # prevents some MITM attacks.
-        if token == self.last_token and LOGIN_HARDENING:
+        if token == self.last_token:
             raise BadTokenException("previously used token {}".format(token))
         else:
             self.last_token = token

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -18,7 +18,7 @@ import store
 import template_filters
 from db import (db_session, Source, Journalist, Submission, Reply,
                 SourceStar, get_one_or_else, NoResultFound,
-                WrongPasswordException, BadTokenException,
+                WrongPasswordException,
                 LoginThrottledException, InvalidPasswordLength)
 import worker
 
@@ -213,16 +213,13 @@ def admin_new_user_two_factor():
 
     if request.method == 'POST':
         token = request.form['token']
-        try:
-            if user.verify_token(token):
-                flash(
-                    "Two factor token successfully verified for user {}!".format(
-                        user.username),
-                    "notification")
-                return redirect(url_for("admin_index"))
-            else:
-                flash("Two factor token failed to verify", "error")
-        except BadTokenException:
+        if user.verify_token(token):
+            flash(
+                "Two factor token successfully verified for user {}!".format(
+                    user.username),
+                "notification")
+            return redirect(url_for("admin_index"))
+        else:
             flash("Two factor token failed to verify", "error")
 
     return render_template("admin_new_user_two_factor.html", user=user)
@@ -358,15 +355,12 @@ def account_new_two_factor():
 
     if request.method == 'POST':
         token = request.form['token']
-        try:
-            if user.verify_token(token):
-                flash(
-                    "Two factor token successfully verified!",
-                    "notification")
-                return redirect(url_for('edit_account'))
-            else:
-                flash("Two factor token failed to verify", "error")
-        except BadTokenException:
+        if user.verify_token(token):
+            flash(
+                "Two factor token successfully verified!",
+                "notification")
+            return redirect(url_for('edit_account'))
+        else:
             flash("Two factor token failed to verify", "error")
 
     return render_template('account_new_two_factor.html', user=user)

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -213,16 +213,20 @@ def admin_new_user_two_factor():
 
     if request.method == 'POST':
         token = request.form['token']
-        if user.verify_token(token):
-            flash(
-                "Two factor token successfully verified for user {}!".format(
-                    user.username),
-                "notification")
-            return redirect(url_for("admin_index"))
-        else:
+        try:
+            if user.verify_token(token):
+                flash(
+                    "Two factor token successfully verified for user {}!".format(
+                        user.username),
+                    "notification")
+                return redirect(url_for("admin_index"))
+            else:
+                flash("Two factor token failed to verify", "error")
+        except BadTokenException:
             flash("Two factor token failed to verify", "error")
 
     return render_template("admin_new_user_two_factor.html", user=user)
+
 
 @app.route('/admin/reset-2fa-totp', methods=['POST'])
 @admin_required

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -358,12 +358,15 @@ def account_new_two_factor():
 
     if request.method == 'POST':
         token = request.form['token']
-        if user.verify_token(token):
-            flash(
-                "Two factor token successfully verified!",
-                "notification")
-            return redirect(url_for('edit_account'))
-        else:
+        try:
+            if user.verify_token(token):
+                flash(
+                    "Two factor token successfully verified!",
+                    "notification")
+                return redirect(url_for('edit_account'))
+            else:
+                flash("Two factor token failed to verify", "error")
+        except BadTokenException:
             flash("Two factor token failed to verify", "error")
 
     return render_template('account_new_two_factor.html', user=user)

--- a/securedrop/tests/test_2fa.py
+++ b/securedrop/tests/test_2fa.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+import os
+import random
+
+from flask import url_for
+from flask_testing import TestCase
+
+os.environ['SECUREDROP_ENV'] = 'test'
+from db import (db_session, BadTokenException)
+import journalist
+import utils
+
+# Smugly seed the RNG for deterministic testing
+random.seed('¯\_(ツ)_/¯')
+
+
+class TestJournalist2FA(TestCase):
+    def create_app(self):
+        return journalist.app
+
+    def setUp(self):
+        utils.env.setup()
+
+        self.admin, self.admin_pw = utils.db_helper.init_journalist(
+            is_admin=True)
+
+    def tearDown(self):
+        utils.env.teardown()
+        # TODO: figure out why this is necessary here, but unnecessary in all
+        # of the tests in `tests/test_unit_*.py`. Without this, the session
+        # continues to return values even if the underlying database is deleted
+        # (as in `shared_teardown`).
+        db_session.remove()
+
+    def _login_admin(self):
+        valid_token = self.admin.totp.now()
+        resp = self.client.post(url_for('login'),
+                                data=dict(username=self.admin.username,
+                                          password=self.admin_pw,
+                                          token=valid_token))
+
+    def test_bad_token_fails_to_verify_on_admin_new_user_two_factor_page(self):
+        self._login_admin()
+
+        # Create and submit an invalid 2FA token
+        invalid_token = unicode(int(self.admin.totp.now()) + 1)
+        resp = self.client.post(url_for('admin_new_user_two_factor',
+                                        uid=self.admin.id),
+                                data=dict(token=invalid_token))
+
+        self.assertIn('Two factor token failed to verify', resp.data)
+
+        # last_token should be set to the invalid token we just tried to use
+        self.assertEqual(self.admin.last_token, invalid_token)
+
+        # Submit the same invalid token again
+        resp = self.client.post(url_for('admin_new_user_two_factor',
+                                        uid=self.admin.id),
+                                data=dict(token=invalid_token))
+
+        # A flashed message should appear
+        self.assertIn('Two factor token failed to verify', resp.data)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Reset the module variables that were changed to mocks so we don't
+        # break other tests
+        reload(journalist)

--- a/securedrop/tests/test_2fa.py
+++ b/securedrop/tests/test_2fa.py
@@ -6,7 +6,7 @@ from flask import url_for
 from flask_testing import TestCase
 
 os.environ['SECUREDROP_ENV'] = 'test'
-from db import (db_session, BadTokenException)
+from db import db_session
 import journalist
 import utils
 
@@ -43,6 +43,7 @@ class TestJournalist2FA(TestCase):
                                           token=valid_token))
 
     def test_bad_token_fails_to_verify_on_admin_new_user_two_factor_page(self):
+        # Regression test https://github.com/freedomofpress/securedrop/pull/1692
         self._login_admin()
 
         # Create and submit an invalid 2FA token
@@ -65,6 +66,7 @@ class TestJournalist2FA(TestCase):
         self.assertIn('Two factor token failed to verify', resp.data)
 
     def test_bad_token_fails_to_verify_on_new_user_two_factor_page(self):
+        # Regression test https://github.com/freedomofpress/securedrop/pull/1692
         self._login_user()
 
         # Create and submit an invalid 2FA token


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes defect #1687 reported by a SecureDrop user.

Changes proposed in this pull request:
- Adds regression unit test
- Handles the `BadTokenException` in `/admin/2fa` and flashes a message to the user

## Post Mortem

A bug like this can slip into production because:
* Overuse of mocks
* No 2FA unit or functional tests
* "if running the tests do A else do B" logic in app code, meaning that B will never be tested

## Testing

1. Provision development VM
2. Make an administrator account
3. Sign in
4. Click "Admin"
5. Click "Edit" on the admin account
6. Click "Reset two factor authentication (Google Authenticator)"
7. Put in "123456" as the verification code
8. Put in "123456" again as the verification code

You should see a flashed message "Two factor token failed to verify"

## Deployment

No special considerations for deployment

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM


