### PR TITLE
Infra-378 CI teardown

### DIFF
--- a/devops/scripts/ci-tester.sh
+++ b/devops/scripts/ci-tester.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+#
+#
+#
+trap "make ci-teardown" ERR
+
+# Quick hack to pass IPs off to testinfra
+for host in app mon; do
+    # tacking xargs at the end strips the trailing space
+    ip=`ssh -F $HOME/.ssh/sshconfig-securedrop-ci-$BUILD_NUM ${host}-$CI_SD_ENV "hostname -I" | xargs`
+    ansible -c local localhost -m lineinfile -a "dest=./testinfra/vars/app-${CI_SD_ENV}.yml line='${host}_ip: $ip' regexp='^${host}_ip'"
+    ansible -c local localhost -m lineinfile -a "dest=./testinfra/vars/mon-${CI_SD_ENV}.yml line='${host}_ip: $ip' regexp='^${host}_ip'"
+done
+
+# Ensure we can SSH to both hosts before kicking off tests
+ansible staging -m ping || exit 1
+
+# Cleanup any possible lingering previous results
+rm -v *results.xml || true
+
+if [ "$?" == "0" ]; then
+    case "$CI_SD_ENV" in
+    "staging")
+        ./testinfra/test.py build
+        ./testinfra/test.py app-$CI_SD_ENV
+        ./testinfra/test.py mon-$CI_SD_ENV
+        ;;
+    "development")
+        ./testinfra/test.py development
+        ;;
+    esac
+fi
+
+if [ -z "$TEST_REPORTS" ]; then
+    export TEST_REPORTS=`pwd`
+fi
+
+# Remove any existing result files
+rm -r $TEST_REPORTS/junit || true
+mkdir $TEST_REPORTS/junit || true
+
+./testinfra/combine-junit.py *results.xml > $TEST_REPORTS/junit/junit.xml

--- a/devops/scripts/spin-run-test.sh
+++ b/devops/scripts/spin-run-test.sh
@@ -14,39 +14,5 @@ if [ ! "$1" == "only_test" ]; then
     make ci-spinup && make ci-run
 fi
 
-# Quick hack to pass IPs off to testinfra
-for host in app mon; do
-    # tacking xargs at the end strips the trailing space
-    ip=`ssh -F $HOME/.ssh/sshconfig-securedrop-ci-$BUILD_NUM ${host}-$CI_SD_ENV "hostname -I" | xargs`
-    ansible -c local localhost -m lineinfile -a "dest=./testinfra/vars/app-${CI_SD_ENV}.yml line='${host}_ip: $ip' regexp='^${host}_ip'"
-    ansible -c local localhost -m lineinfile -a "dest=./testinfra/vars/mon-${CI_SD_ENV}.yml line='${host}_ip: $ip' regexp='^${host}_ip'"
-done
-
-# Ensure we can SSH to both hosts before kicking off tests
-ansible staging -m ping || exit 1
-
-# Cleanup any possible lingering previous results
-rm -v *results.xml || true
-
-if [ "$?" == "0" ]; then
-    case "$CI_SD_ENV" in
-    "staging")
-        ./testinfra/test.py build
-        ./testinfra/test.py app-$CI_SD_ENV
-        ./testinfra/test.py mon-$CI_SD_ENV
-        ;;
-    "development")
-        ./testinfra/test.py development
-        ;;
-    esac
-fi
-
-if [ -z "$TEST_REPORTS" ]; then
-    export TEST_REPORTS=`pwd`
-fi
-
-# Remove any existing result files
-rm -r $TEST_REPORTS/junit || true
-mkdir $TEST_REPORTS/junit || true
-
-./testinfra/combine-junit.py *results.xml > $TEST_REPORTS/junit/junit.xml
+# Run tests
+./devops/scripts/ci-tester.sh

--- a/install_files/ansible-base/group_vars/securedrop.yml
+++ b/install_files/ansible-base/group_vars/securedrop.yml
@@ -56,3 +56,6 @@ install_local_packages: false
 
 # Establish if we are in CI environment
 amazon_builder: "{{ true if 'amazon' in ansible_product_version else false }}"
+
+# Ansible v1 default reference to remote host
+remote_host_ref: "{{ ansible_ssh_host|default(inventory_hostname) }}"

--- a/install_files/ansible-base/roles/common/tasks/apt_upgrade.yml
+++ b/install_files/ansible-base/roles/common/tasks/apt_upgrade.yml
@@ -58,7 +58,7 @@
 - name: Wait for server to come back.
   local_action: wait_for
   args:
-    host: "{{ ansible_ssh_host|default(inventory_hostname) }}"
+    host: "{{ remote_host_ref }}"
     port: "{{ ansible_ssh_port|default(ansible_port|default(22)) }}"
     delay: 20
     search_regex: OpenSSH

--- a/install_files/ansible-base/roles/grsecurity/tasks/from_fpf_repo_install_grsec.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/from_fpf_repo_install_grsec.yml
@@ -96,7 +96,7 @@
 - name: Wait for server to come back.
   local_action:
     module: wait_for
-      host={{ ansible_host }}
+      host={{ remote_host_ref }}
       port={{ ansible_port | default('22')}}
       delay=45
       state=started

--- a/install_files/ansible-base/securedrop-staging.yml
+++ b/install_files/ansible-base/securedrop-staging.yml
@@ -10,6 +10,11 @@
     - name: Extract ec2 vars when in AWS
       ec2_facts:
       when: amazon_builder
+
+    - name: Set remote host for any reboot tasks under AWS
+      set_fact:
+        remote_host_ref: "{{ ansible_ec2_public_hostname }}"
+      when: amazon_builder
   roles:
     - { role: common, tags: common }
     - { role: tor-hidden-services, tags: tor }

--- a/testinfra/app/test_network.py
+++ b/testinfra/app/test_network.py
@@ -40,6 +40,3 @@ def test_app_iptables_rules(SystemInfo, Command, Sudo):
         # Conduct the string comparison of the expected and actual iptables
         # ruleset
         assert iptables_expected == iptables
-
-def test_failnow():
-    assert False

--- a/testinfra/app/test_network.py
+++ b/testinfra/app/test_network.py
@@ -40,3 +40,6 @@ def test_app_iptables_rules(SystemInfo, Command, Sudo):
         # Conduct the string comparison of the expected and actual iptables
         # ruleset
         assert iptables_expected == iptables
+
+def test_failnow():
+    assert False


### PR DESCRIPTION
## Status

Read for review

## Description of Changes

In CI, we have been seeing the issue that any of the `testinfra` tests fail - the clean-up task was not being called. This makes sense upon further investigation of the current bash trap layout.

Changes proposed in this pull request:

To fix this, I broke out the CI testing bash script with it's own clean-up trap. I tried to put this trap at the highest level script in an earlier branch/commit and I remember having issues problems. I'm crossing fingers that these latest changes fix that issue - they did for me locally using the same CI scripts.

## Testing

Nothing to do manually here, just confirm:

- CI environment gets torn down at commit `142a8d5` (which introduced a guaranteed CI failure)
- CI environment gets torn down at commit `fcecb75` (which reverted that CI failure)

## Deployment

N/A - this only affects CI

### If you made changes to the system configuration:

N/A - only affects CI scripts
