### PR TITLE
Safely reload tor service when connecting over Tor

### DIFF
--- a/install_files/ansible-base/roles/tor-hidden-services/handlers/main.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/handlers/main.yml
@@ -1,5 +1,3 @@
 ---
 - name: restart tor
-  service:
-    name: tor
-    state: restarted
+  include: restart-tor-carefully.yml

--- a/install_files/ansible-base/roles/tor-hidden-services/handlers/restart-tor-carefully.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/handlers/restart-tor-carefully.yml
@@ -1,0 +1,35 @@
+---
+# Meta handler to bounce tor service sanely. If the SSH connection
+# for the remote host is over Tor (i.e. host ends in `.onion`), then
+# bounce the tor service via fire-and-forget, wait, then reestablish
+# the connection after polling for the service to come back up.
+
+# Registering a concise variable for use in conditionals, essentially
+# deciding "Are we connected via SSH over Tor or not?"
+- name: Register host name to wait for.
+  set_fact:
+    _hostname_to_wait_for: "{{ ansible_ssh_host|default(ansible_host) }}"
+
+# If we're not connected over Tor, bounce the service as usual.
+- name: restart tor (simple)
+  service:
+    name: tor
+    state: restarted
+  when: not _hostname_to_wait_for.endswith('.onion')
+
+# As of Ansible v2.2, the `service` module is not compatible with the `async`
+# parameter. This was changed in 2.3.
+- name: restart tor (async)
+  shell: sleep 5 && service tor restart
+  async: 3000
+  poll: 0
+  when: _hostname_to_wait_for.endswith('.onion')
+
+# Hardcode a wait value and wait for the entire interval.
+# Cannot use `local_action/wait_for` because it's not smart
+# enough to find the SSH connection info required to connect
+# to the Onion URL.
+- name: Waiting for SSH connection (slow)...
+  pause:
+    seconds: 90
+  when: _hostname_to_wait_for.endswith('.onion')


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #940. (Requires #1700, so review and merge that first.)

Changes proposed in this pull request:

* If connected over tor and the tor service needs to be restarted, don't do so blindly; send the restart command via `async`, then sit down and wait for 90 seconds before attempting to connect again, in order to give the Authenticated Tor Hidden Services for SSH time to come back up.

## Testing

1. Provision staging VMs.
2. Add the ATHS values to your host system's torrc.
3. `export SECUREDROP_SSH_OVER_TOR=1`.
4. Confirm via `vagrant ssh-config app-staging` that the Onion URLs are listed.
5. Edit `install_files/ansible-base/roles/tor-hidden-services/templates/torrc`, e.g. adding comments, then rerun the playbook over Tor `vagrant provision /stag/`. 

Protip: you can use `ANSIBLE_ARGS="--tags tor"` to run _only_ the tor role, which should save a lot of time. _Without_ the new handler, editing the torrc file while connected over tor will cause the playbook to fail. With the new handler, things should proceed well.

It's a shortcoming that we're forced to hardcode the wait time. 90s seems like a sane value; during testing, it never took longer than 60s for the services to come back up (polled them in a bash while loop), so 90s is an attempt to be conservative.

## Deployment

This is designed specifically to prevent Admin frustration if torrc changes land. Right now they haven't, so we can reasonable expect torrc files to be the same between 0.3.12 and 0.4—still, this sound strategy rules out a potential source of frustration and breakage.

## Checklist

Leaning on CI checks here, and I want confirmation from manual testing via vagrant that the reboot works OK over tor. We need manual verification because the prod tests don't run in CI (yet), and prod does SSH over tor.