### PR TITLE
Replace confusing "Learn how to disable it" text on landing bar

### DIFF
--- a/docs/source.rst
+++ b/docs/source.rst
@@ -64,11 +64,11 @@ Slider to "High".
 
 |Security Slider|
 
-Click the ``Learn how to disable it`` link in the warning banner and a message
-bubble will pop up explaining how to disable Javascript and turn up the Slider.
-Follow the instructions and the page should refresh automatically. Note that
-this will change the slider and disable Javascript for every page in your Tor
-Browser, and this setting will persist across browser sessions.
+Click the ``Learn how to set it to high`` link in the warning banner and a
+message bubble will pop up explaining how to disable Javascript and turn up the
+Slider. Follow the instructions and the page should refresh automatically. Note
+that this will change the slider and disable Javascript for every page in your
+Tor Browser, and this setting will persist across browser sessions.
 
 |Fix Javascript warning|
 

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -12,7 +12,7 @@
     {% endassets %}
   </head>
   <body>
-    <div class="warning"><strong>We recommend turning the Security Slider to High to protect your anonymity:</strong> <a id="disable-js" href="/howto-disable-js">Learn how to disable it</a>, or ignore this warning to continue. <img id="warning-close" src="{{ url_for('static', filename='i/font-awesome/times-white.png') }}" width="12px" height="12px"></div>
+    <div class="warning"><strong>We recommend turning the Security Slider to High to protect your anonymity:</strong> <a id="disable-js" href="/howto-disable-js">Learn how to set it to high</a>, or ignore this warning to continue. <img id="warning-close" src="{{ url_for('static', filename='i/font-awesome/times-white.png') }}" width="12px" height="12px"></div>
 
     {% include 'banner_warning_flashed.html' %}
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1713.

Changes proposed in this pull request:
  *  This landing bar used to tell the source to disable JavaScript. However once Tor Browser introduced its security slider, we started telling sources to turn the security slider to high instead. Unfortunately when we did this we didn't update the link text from "Learn how to disable it" [Javascript] to "Learn how to set it to high", leading to a confusing situation for users. 

## Testing

Check the text is changed on the source interface and that you agree with the new text. 

## Screenshot

![screen shot 2017-05-18 at 2 18 42 pm](https://cloud.githubusercontent.com/assets/7832803/26224379/e9c4a43e-3bd6-11e7-9545-4c5b79f59a4e.png)

## Checklist

- [x] Unit and functional tests pass on the development VM
- [x] Testinfra tests pass on the development VM

