### PR TITLE
Test request limit size on JI

### DIFF
--- a/testinfra/app/apache/test_apache_journalist_interface.py
+++ b/testinfra/app/apache/test_apache_journalist_interface.py
@@ -93,6 +93,7 @@ common_apache2_directory_declarations = """
   'WSGIScriptAlias / /var/www/journalist.wsgi/',
   'AddType text/html .py',
   'XSendFile        On',
+  'LimitRequestBody 524288000',
   'XSendFilePath    /var/lib/securedrop/store/',
   'XSendFilePath    /var/lib/securedrop/tmp/',
   'ErrorLog /var/log/apache2/journalist-error.log',


### PR DESCRIPTION
We set this parameter for the JI Apache config, but do not validate it, as we do for the SI. Since staging is in big churn right now as far as local spin up goes, I'm testing this change by making a PR.
