### PR TITLE
Reject empty replies

### DIFF
--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -57,6 +57,25 @@ Base.query = db_session.query_property()
 
 
 def get_one_or_else(query, logger, failure_method):
+    """Takes a query object, logger, and failure method. If the query
+    object contains exactly one object, that object is returned. If it
+    contains multiple objects, an error is logged and the server returns
+    a 500 error. If it is empty, an error is logged and the exception is
+    re-raised for handling elsewhere.
+
+    Args:
+        query (sqlalchemy.orm.query.Query): The query object.
+        logger (logging.Logger): The logger.
+        failure_method: Any Flask app object method that returns a
+            response.
+
+    Returns:
+        Base: an instance belonging to a child class of Base
+            is returned only when the query contains exactly one object.
+
+    Raises:
+        NoResultFound: when the query object is empty.
+    """
     try:
         return query.one()
     except MultipleResultsFound as e:
@@ -66,7 +85,7 @@ def get_one_or_else(query, logger, failure_method):
         failure_method(500)
     except NoResultFound as e:
         logger.error("Found none when one was expected: %s" % (e,))
-        failure_method(404)
+        raise
 
 
 class Source(Base):

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -599,9 +599,7 @@ def reply():
         flash("An unexpected error occurred! Please check the application "
               "logs or inform your adminstrator.", "error")
         # We take a cautious approach to logging here because we're dealing
-        # with responses to sources. TODO: It may be possible to provide more
-        # detailed/ informative log errors here, but we'll need to ensure no
-        # confidential or possibly deanonymizing information ends up there.
+        # with responses to sources.
         app.logger.error("Reply from '{}' failed: {}!".format(g.user,
                                                               exc.__class__))
         db_session.rollback()

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -595,7 +595,7 @@ def reply():
         db_session.add(g.source)
         db_session.add(reply)
         db_session.commit()
-    except:
+    except Exception as exc:
         flash("An unexpected error occurred! Please check the application "
               "logs or inform your adminstrator.", "error")
         # We take a cautious approach to logging here because we're dealing

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -592,7 +592,6 @@ def reply():
     reply = Reply(g.user, g.source, filename)
 
     try:
-        db_session.add(g.source)
         db_session.add(reply)
         db_session.commit()
     except Exception as exc:

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -607,7 +607,8 @@ def reply():
         db_session.rollback()
     else:
         flash("Thanks! Your reply has been stored.", "notification")
-        return redirect(url_for('col', sid=g.sid))
+
+    return redirect(url_for('col', sid=g.sid))
 
 
 @app.route('/regenerate-code', methods=('POST',))

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -628,14 +628,15 @@ def reply():
     try:
         db_session.add(reply)
         db_session.commit()
-
     except Exception as exc:
         flash("An unexpected error occurred! Please check the application "
               "logs or inform your adminstrator.", "error")
         # We take a cautious approach to logging here because we're dealing
         # with responses to sources.
-        app.logger.error("Reply from '{}' failed: {}!".format(g.user,
-                                                              exc.__class__))
+        app.logger.error(
+            "Reply from '{}' (id {}) failed: {}!".format(g.user.username,
+                                                         g.user.id,
+                                                         exc.__class__))
         db_session.rollback()
     else:
         flash("Thanks! Your reply has been stored.", "notification")

--- a/securedrop/tests/test_db.py
+++ b/securedrop/tests/test_db.py
@@ -49,11 +49,11 @@ class TestDatabase(TestCase):
         query = Journalist.query.filter(Journalist.username == "alice")
 
         with mock.patch('logger') as mock_logger:
-            selected_journos = get_one_or_else(query, mock_logger,
-                                               mock)
+            with self.assertRaises(NoResultFound):
+                selected_journos = get_one_or_else(query, mock_logger, mock)
+
         log_line = 'Found none when one was expected: No row was found for one()'
         mock_logger.error.assert_called_with(log_line)
-        mock.assert_called_with(404)
 
     # Check __repr__ do not throw exceptions
 

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -41,6 +41,24 @@ class TestJournalistApp(TestCase):
     def tearDown(self):
         utils.env.teardown()
 
+    def test_empty_replies_are_rejected(self):
+        source, _ = utils.db_helper.init_source()
+        sid = source.filesystem_id
+        self._login_user()
+        resp = self.client.post(url_for('reply'),
+                                data={'sid': sid, 'msg': ''},
+                                follow_redirects=True)
+        self.assertIn("You cannot send an empty reply!", resp.data)
+
+    def test_nonempty_replies_are_accepted(self):
+        source, _ = utils.db_helper.init_source()
+        sid = source.filesystem_id
+        self._login_user()
+        resp = self.client.post(url_for('reply'),
+                                data={'sid': sid, 'msg': '_'},
+                                follow_redirects=True)
+        self.assertNotIn("You cannot send an empty reply!", resp.data)
+
     def test_unauthorized_access_redirects_to_login(self):
         resp = self.client.get(url_for('index'))
         self.assertRedirects(resp, url_for('login'))


### PR DESCRIPTION
## Status

So ready.

## Description of Changes

Flashes warning about and rejects zero-length replies. Fixes #1715.

Also, does proper logging and rollback in case of error (e.g., one journalist may delete a source while another is writing a reply). Logging is cautious because of the sensitive nature of replies. See in-line comment for details.

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM