### PR TITLE
Specify junit test path for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,3 +28,6 @@ jobs:
           name: Teardown environment
           command: make ci-teardown
           when: always
+
+      - store_test_results:
+          path: /root/sd/junit

--- a/devops/playbooks/reboot_and_wait.yml
+++ b/devops/playbooks/reboot_and_wait.yml
@@ -16,7 +16,7 @@
         host: "{{ ansible_ec2_public_hostname }}"
         port: "{{ ansible_port | default(22) }}"
         delay: 20
-        timeout: 400
+        timeout: 600
         search_regex: OpenSSH
         state: started
       # Wait action runs on localhost, and does NOT require sudo.


### PR DESCRIPTION
Doing this will show parsed test results in the CircleCI web UI.

## Status

<del> Work in progress -- Had to pull a PR to initiate CircleCI tests. </del>

Ready :green_heart: for review.

## Description of Changes

* Fixes #1710 - Adds location for CircleCI to scoop up junit test results. Very minor addition to the circleci config file.
* Expanded timeout value for CI reboot playbook.

## Testing

How should the reviewer test this PR? If the tests show up in the circleCI web UI -- :+1: 
![selection_024](https://cloud.githubusercontent.com/assets/1727935/26321313/4dfe8f4e-3ef4-11e7-8bd7-23746c513181.png)



## Deployment

Any special considerations for deployment? Consider both:

N/A - only affects CI

## Checklist

### If you made changes to the app code:

N/A

### If you made changes to the system configuration:

N/A

