### PR TITLE
Update developer docs on tests

### DIFF
--- a/docs/development/testing_application_tests.rst
+++ b/docs/development/testing_application_tests.rst
@@ -72,7 +72,7 @@ file, class, and test name:
 
 
 Updating the application tests
-==============================
+------------------------------
 
 Unit tests are stored in the ``securedrop/tests/`` directory and functional
 tests are stored in the functional test directory::

--- a/docs/development/testing_application_tests.rst
+++ b/docs/development/testing_application_tests.rst
@@ -9,23 +9,18 @@ The application test suite uses:
   * Selenium_
   * Coveralls_
 
+The application tests consist of unit tests for the Python application code
+and functional tests that verify the functionality of the application code
+from the perspective of the user through a web browser.
+
 The functional tests use an outdated version of Firefox chosen specifically
-for compatibility with Selenium, and a rough approximation of the most recent
-Tor Browser.
+for compatibility with Selenium 2, and a rough approximation of the most
+recent Tor Browser.
 
 .. note:: We're working on running the Selenium tests in Tor Browser.
           See `GitHub #1629`_ for more info.
 
 .. _`GitHub #1629`: https://github.com/freedomofpress/securedrop/pull/1629
-
-.. todo:: Flesh out explanation of the application tests. Decide what's
-          important for devs to know; at a high-level, organization could be:
-
-            * Installation
-            * Running the application tests
-            * any relevant info on editing them
-
-          which matches the layout used for the Config tests.
 
 .. _Pytest: https://docs.pytest.org/en/latest/
 .. _Selenium: http://docs.seleniumhq.org/docs/
@@ -61,3 +56,43 @@ Or the app-staging VM:
 
 For explanation of the difference between these machines, see
 :doc:`virtual_environments`.
+
+If you just want to run the functional tests, you can use:
+
+.. code:: sh
+
+    pytest -v tests/functional/
+
+Similarly, if you want to run a single test, you can specify it through the
+file, class, and test name:
+
+.. code:: sh
+
+    pytest tests/test_journalist.py::TestJournalistApp::test_invalid_credentials
+
+
+Updating the application tests
+==============================
+
+Unit tests are stored in the ``securedrop/tests/`` directory and functional
+tests are stored in the functional test directory::
+
+    securedrop/tests/
+    ├── functional
+    │   ├── test_admin_interface.py
+    │   ├── test_submit_and_retrieve_file.py
+    │   │               ...
+    │   └── submission_not_in_memory.py
+    ├── utils
+    │   ├── db_helper.py
+    │   ├── env.py
+    │   └── async.py
+    ├── test_journalist.py
+    ├── test_source.py
+    │        ...
+    └── test_store.py
+
+``securedrop/tests/utils`` contains helper functions for writing tests.
+If you want to add a test, you should see if there is an existing file
+appropriate for the kind of test, e.g. a new unit testing ``manage.py``
+should go in ``test_manage.py``.

--- a/docs/development/testing_configuration_tests.rst
+++ b/docs/development/testing_configuration_tests.rst
@@ -20,11 +20,17 @@ Running the config tests
 ------------------------
 
 In order to run the tests, first create and provision the VM you intend
-to test:
+to test. For the development VM:
 
 .. code:: sh
 
     vagrant up development
+
+For the staging VMs:
+
+.. code:: sh
+
+    vagrant up build --no-provision
     vagrant up /staging/
 
 .. note:: The staging machines must be rebooted via in order to finalize


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
  * Adds note that one needs to start the build VM before provisioning the staging VMs locally and running testinfra tests
  * Fleshes out the description of the application tests a bit for developers (an inline TODO in the docs)

## Testing

Build the docs, check for typesetting/spelling/grammar errors. Verify that the developer docs make sense to you.
