### PR TITLE
Document the need to upgrade rsync on macOS

### DIFF
--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -95,7 +95,13 @@ Install the dependencies for the development environment:
 
 #. Vagrant_
 #. VirtualBox_
-#. Ansible_.
+#. Ansible_
+#. rsync >= 3.1.0
+
+.. note:: Note that the version of rsync installed by default on macOS is
+          extremely out-of-date, as is Apple's custom. We recommend using
+          Homebrew_ to install a modern version (3.1.0 or greater):
+          ``brew install rsync``.
 
 There are several ways to install Ansible on a Mac. We recommend installing it
 to a virtual environment using ``virtualenvwrapper`` and ``pip``, so as not to
@@ -120,6 +126,7 @@ different version, the path to ``virtualenvwrapper.sh`` will differ. Running
 .. _Vagrant: http://www.vagrantup.com/downloads.html
 .. _VirtualBox: https://www.virtualbox.org/wiki/Downloads
 .. _Ansible: http://docs.ansible.com/intro_installation.html
+.. _Homebrew: https://brew.sh/
 
 Clone the repository
 --------------------


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

While working on #1714, I encountered an Ansible error while provisioning the staging environment from the develop branch:

```
TASK [build-securedrop-app-code-deb-pkg : Copy app code to build directory.] ***
fatal: [build]: FAILED! => {"changed": false, "cmd": "/usr/bin/rsync --delay-updates -F --compress --delete-after --archive --rsh 'ssh -i /Users/garrett/.vagrant.d/insecure_private_key -S none -o StrictHostKeyChecking=no -o Port=2202' --rsync-path='sudo rsync' --chmod=u=rwX,g=rX,o=rX --chown=root:root --exclude=*.git --exclude=*aths --exclude=*.deb --out-format='<<CHANGED>>%i %n%L' \"/Users/garrett/code/freedomofpress/securedrop/securedrop/\" \"vagrant@127.0.0.1:/tmp/securedrop-app-code-0.3.12-amd64/var/www/securedrop\"", "failed": true, "msg": "rsync: --chown=root:root: unknown option\nrsync error: syntax or usage error (code 1) at /BuildRoot/Library/Caches/com.apple.xbs/Sources/rsync/rsync-51/rsync/main.c(1337) [client=2.6.9]\n", "rc": 1}
```

A bit of research showed that the playbooks are using Ansible's synchronize module with settings that cause it to invoke `rsync` with the `--chown` option. This option was not added until rsync v3.1.0, but the latest version of macOS (10.12.4) ships with v2.6.9, which causes the `unknown option` error seen in the Ansible output above.

One option would be to modify the playbooks invocation of the `synchronize` module so it does not need the `--chown` option, but that may not be possible, or may require a significant workaround (perhaps @conorsch or @msheiny could comment?). It seems easiest just to ask macOS users to update their local version of rsync. Most macOS developers already have Homebrew, upgrading it is as simple as `brew install rsync`, and the default version is just ancient (over 10 years old!).

## Testing

If you are running macOS on your development machine and are using the default rsync, follow the documentation to [set up the SecureDrop development environment](https://docs.securedrop.org/en/latest/development/getting_started.html) and [provision the staging environment](https://docs.securedrop.org/en/latest/development/virtual_environments.html#staging). You should see the error pasted above.

Update rsync with Homebrew, then re-provision the staging environment. Provisoning should now succeed.

To test the documentation changes, just run `make docs` and look over the rendered output of the changed file. I ran `make docs-lint` and it did not report any formatting violations.

## Deployment

No considerations for deployment, since this only affects the development environment.