### PR TITLE
Fixes dev reminder about build VM in staging env

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,7 +83,7 @@ Vagrant.configure("2") do |config|
       ansible.verbose = 'v'
       # Taken from the parallel execution tips and tricks
       # https://docs.vagrantup.com/v2/provisioning/ansible.html
-      ansible.limit = 'all'
+      ansible.limit = 'all,localhost'
       ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
       ansible.groups = {
         'securedrop_application_server' => %w(app-staging),

--- a/install_files/ansible-base/build-deb-pkgs.yml
+++ b/install_files/ansible-base/build-deb-pkgs.yml
@@ -11,7 +11,7 @@
   tasks:
     - name: Check for "build" machine in inventory.
       fail:
-        msg: >
+        msg: >-
           The "build" VM is not reachable, but is required for building the
           app code Debian packages on the staging machines. Run `vagrant up build`,
           then `vagrant provision /staging/`. Thereafter you can run


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The switch from Ansible v1 to v2 broke the helpful message instructing
developers to up the build VM prior to provisioning the staging
machines. The play targeting localhost to inspect the available machines
was simply being skipped. The solution turns out to be extending the
`--limit` argument as specified in the Vagrantfile from "all" to
"all,localhost". Credit to a helpful blogger [0] for sussing out that
the issue was Vagrant-specific.

Also removed a trailing newline on the message itself, simply to clean
it up a bit, since the default output includes a literal '\n'.

[0] http://blog.indrek.io/articles/ansible-skipping-localhost-when-using-vagrant/

## Testing

1. `vagrant destroy -f build`
2. `vagrant provision /staging/` (or `vagrant up /staging/` if machines don't exist)
3. Confirm you see a helpful error message about the build VM missing.

## Deployment

Only affects dev env.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] Testinfra tests pass on the development VM

