### PR TITLE
Updated Terminology page for clarity and to add role descriptions

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -102,7 +102,7 @@ computer.
 	  :doc:`Terminology Guide <terminology>` provides more-precise
           definitions of these and other terms. SecureDrop is designed against
           a comprehensive :doc:`development/threat_model`, and has a specific
-          notion of the :doc:`roles <passphrases>` that are involved in its
+          notion of the :doc:`roles <terminology>` that are involved in its
           operation.
 
 Operation

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -2,42 +2,73 @@ Terminology
 ===========
 
 A number of terms used in this guide, and in the `SecureDrop workflow
-diagram <https://freedom.press/securedrop-files/SecureDrop_complex.png>`__,
+diagram <https://docs.securedrop.org/en/latest/overview.html#infrastructure>`__,
 are specific to SecureDrop. The list below attempts to enumerate and
 define these terms.
 
 .. todo:: Pictures would be good for many of the objects defined here
 
+Source
+------
+
+The *Source* is the person who submits documents to SecureDrop, and may use
+SecureDrop to communicate with a *Journalist*. A *Source* will always
+access SecureDrop through the *Source Interface*, and must do so using Tor.
+
+Instructions for using SecureDrop as a *Source* are available in our
+`Source Guide <https://docs.securedrop.org/en/latest/source.html>`__.
+
+Journalist
+----------
+
+The *Journalist* uses SecureDrop to communicate with and download documents
+submitted by the *Source*. Journalists do this by using the *Journalist
+Workstation* to connect to the *Journalist Interface* over Tor.
+
+The *Journalist* also uses a *Transfer Device* to move documents to the *Secure
+Viewing Station*. If a *Journalist* chooses to release any of these documents,
+they can be prepared for publication on the *Secure Viewing Station* before
+being transferred to an Internet-connected computer.
+
+Instructions for using SecureDrop as a *Journalist* are available in our
+`Journalist Guide <https://docs.securedrop.org/en/latest/journalist.html>`__.
+
 Application Server
 ------------------
 
 The *Application Server* runs the SecureDrop application. This server hosts both
-the website that sources access (*Source Interface*) and the website that
-journalists access (*Journalist Interface*). You may only connect to this server
-using Tor.
+the website that sources access (the *Source Interface*) and the website that
+journalists access (the *Journalist Interface*). Sources, journalists, and
+administrators may only connect to this server using Tor.
 
 Monitor Server
 --------------
 
 The *Monitor Server* keeps track of the *Application Server* and sends out an
-email alert if something seems wrong. You may only connect to this
-server using Tor.
+email alert if something seems wrong. Only system administrators connect
+to this server, and they may only do so using Tor.
 
 Source Interface
 ----------------
 
-The *Source Interface* is the website that sources will access when
-submitting documents and communicating with journalists. This site is
+The *Source Interface* is the website that sources will access to
+submit documents and communicate with journalists. This site is
 hosted on the *Application Server* and can only be accessed over Tor.
+
+Instructions for using the *Source Interface* are available in our `Source Guide
+<https://docs.securedrop.org/en/latest/source.html>`__.
 
 Journalist Interface
 --------------------
 
-The *Journalist Interface* is the website that journalists will access
-when downloading new documents and communicating with sources. This site
-is hosted on the *Application Server* and can only be accessed over Tor. In previous
-releases, this was called the *Document Interface*, but we have renamed it
-to avoid ambiguity.
+The *Journalist Interface* is the website that journalists access to download
+new documents and communicate with sources. This site is hosted on the
+*Application Server* and can only be accessed over Tor. In previous releases,
+this was called the *Document Interface*, but we have renamed it to avoid
+ambiguity.
+
+Instructions for using the *Journalist Interface* are available in our
+`Journalist Guide <https://docs.securedrop.org/en/latest/journalist.html>`__.
 
 Journalist Workstation
 ----------------------
@@ -47,6 +78,9 @@ together with the Tails operating system on the *online* USB stick. This
 machine will be used to connect to the *Journalist Interface*, download
 documents, and move them to the *Secure Viewing Station* using the
 *Transfer Device*.
+
+Instructions for using the *Journalist Workstation* are available in our
+`Journalist Guide <https://docs.securedrop.org/en/latest/journalist.html>`__.
 
 Admin Workstation
 -----------------
@@ -94,8 +128,8 @@ The *Transfer Device* is the physical media used to transfer encrypted
 documents from the *Journalist Workstation* to the *Secure Viewing
 Station*. Examples: a dedicated USB stick, CD-R, DVD-R, or SD card.
 
-If you use a USB stick for the transfer device, we recommend using a
-small one (4GB or less). You will want to securely wipe the entire
+If you use a USB stick for the *Transfer Device*, we recommend using a
+small one (4GB or less). It will be necessary to securely wipe the entire
 device at times, and this process takes longer for larger devices.
 
 Depending on your threat model, you may wish to only use one-time use
@@ -106,4 +140,4 @@ sensitive data, such as the private key used to decrypt submissions or
 the content of decrypted submissions.
 
 When we use the phrase "sneakernet" we mean physically moving documents
-on the Transfer Device from one computer to another.
+with the *Transfer Device* from one computer to another.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1131 .

Changes proposed in this pull request:

Mostly minor grammar changes for clarity, but also notably adding several links to the existing Source and Journalist guides, and adding a description of those Roles to the Terminology page. Ultimately I think that we should not consider the "Passphrases" page the canonical description of the roles, which might require expanding their description here and changing a link on the Overview page, but I will explain that more in #1131.

## Testing

I've already checked it through docs-lint but because this is a little bit substantive everybody should feel free to read through and propose significant changes. I think the (short) length of the descriptions for most elements is good, but I could be convinced otherwise.

