### PR TITLE
Add "Admin Responsibilities" section to Administrator Guide

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -2,8 +2,8 @@ Administrator Guide
 =====================
 
 You (the administrator) should have your own username and password, plus
-two-factor authentication through either the Google Authenticator app on
-your smartphone or a YubiKey.
+two-factor authentication through either the Google Authenticator app
+on your smartphone or a YubiKey.
 
 .. _Responsibilities:
 
@@ -27,9 +27,9 @@ subscribing to the `SecureDrop RSS Feed`_ to stay apprised of new updates.
 
 Most often, the SecureDrop server will automatically update via apt. However,
 occasionally you will need to run the Ansible playbooks. We will inform you in
-the release blog when this is the case. If you are onboarded to our support portal,
-we will let you know in advance of major releases if manual intervention will be
-required.
+the release blog when this is the case. If you are onboarded to our `SecureDrop
+Support Portal`_, we will let you know in advance of major releases if manual
+intervention will be required.
 
 .. _`SecureDrop Release Blog`: https://securedrop.org/news
 .. _`SecureDrop RSS Feed`: https://securedrop.org/news/feed
@@ -43,9 +43,12 @@ network, you will want to ensure that critical security patches are applied.
 Be informed of potential updates to your network firewall. If you're using the
 suggested network firewall by FPF you can subscribe to the `Netgate RSS Feed`_
 to be alerted when releases occur. If critical security updates need to be
-applied, you can do so through the firewall's pfSense WebGUI.
+applied, you can do so through the firewall's pfSense WebGUI. Refer to our
+:ref:`Keeping pfSense up to date` documentation or the official `pfSense
+Upgrade Docs`_ for further details on how to update the suggested firewall.
 
 .. _`Netgate RSS Feed`: https://www.netgate.com/feed.xml
+.. _`pfSense Upgrade Docs`: https://doc.pfsense.org/index.php/Upgrade_Guide
 
 Keep your Tails Drives Updated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -64,8 +67,14 @@ Monitor OSSEC alerts for Unusual Activity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You should decrypt and read your OSSEC alerts. Report any suspicious events to
-FPF through the support portal. See the :doc:`OSSEC Guide <ossec_alerts>` for
-more information on common OSSEC alerts.
+FPF through the `SecureDrop Support Portal`_. See the :doc:`OSSEC Guide <ossec_alerts>`
+for more information on common OSSEC alerts.
+
+.. warning:: Do not post logs or alerts to public forums without first carefully
+    examining and redacting any sensitive information.
+
+.. _`SecureDrop Support Portal`: https://securedrop-support.readthedocs.io/en/latest/
+
 
 .. _Adding Users:
 
@@ -96,6 +105,11 @@ username and password for themselves, select whether you would like them
 to also be an administrator (this allows them to add or delete other
 journalist accounts), and whether they will be using Google
 Authenticator or a YubiKey for two-factor authentication.
+
+.. tip:: Consider using the alternative `FreeOTP`_ application for mobile
+   two-factor authentication.
+
+.. _`FreeOTP`: https://freeotp.github.io/
 
 Google Authenticator
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -1,9 +1,71 @@
 Administrator Guide
 =====================
 
-At this point, you (the administrator) should have your own username and
-password, plus two-factor authentication through either the Google
-Authenticator app on your smartphone or a YubiKey.
+You (the administrator) should have your own username and password, plus
+two-factor authentication through either the Google Authenticator app on
+your smartphone or a YubiKey.
+
+.. _Responsibilities:
+
+Responsibilities
+----------------
+
+The SecureDrop architecture contains multiple hardened servers, and while we have
+automated many of the installation and maintenance tasks, a skilled Linux
+administrator and some manual intervention is required to responsibly run the system.
+
+This section outlines the tasks the administrator is responsible for in order to
+ensure that the SecureDrop server continues to be a safe place for sources to
+talk to journalists.
+
+Keep your SecureDrop Server Updated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You should maintain awareness of SecureDrop updates and take any required
+manual action if requested in the `SecureDrop Release Blog`_. We recommend
+subscribing to the `SecureDrop RSS Feed`_ to stay apprised of new updates.
+
+Most often, the SecureDrop server will automatically update via apt. However,
+occasionally you will need to run the Ansible playbooks. We will inform you in
+the release blog when this is the case. If you are onboarded to our support portal,
+we will let you know in advance of major releases if manual intervention will be
+required.
+
+.. _`SecureDrop Release Blog`: https://securedrop.org/news
+.. _`SecureDrop RSS Feed`: https://securedrop.org/news/feed
+
+Keep your Network Firewall Updated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Given all traffic first hits the network firewall as it faces the non-Tor public
+network, you will want to ensure that critical security patches are applied.
+
+Be informed of potential updates to your network firewall. If you're using the
+suggested network firewall by FPF you can subscribe to the `Netgate RSS Feed`_
+to be alerted when releases occur. If critical security updates need to be
+applied, you can do so through the firewall's pfSense WebGUI.
+
+.. _`Netgate RSS Feed`: https://www.netgate.com/feed.xml
+
+Keep your Tails Drives Updated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You should apply updates to your Tails drives as they are released, as they
+can contain critical security fixes. Subscribe to the `Tails RSS Feed`_ to be
+alerted of new releases. The online Tails drives, once booted and connected to Tor,
+will alert you if upgrades are available. Follow the `Tails Upgrade Documentation`_
+on how to upgrade the drives.
+
+.. _`Tails RSS Feed`: https://tails.boum.org/news/index.en.rss
+.. _`Tails
+   Upgrade Documentation`: https://tails.boum.org/doc/first_steps/upgrade/index.en.html
+
+Monitor OSSEC alerts for Unusual Activity
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You should decrypt and read your OSSEC alerts. Report any suspicious events to
+FPF through the support portal. See the :doc:`OSSEC Guide <ossec_alerts>` for
+more information on common OSSEC alerts.
 
 .. _Adding Users:
 

--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -516,6 +516,8 @@ Here are some general tips for setting up pfSense firewall rules:
    very helpful. You can find them in the WebGUI in *Status → System
    Logs → Firewall*.
 
+.. _Keeping pfSense up to date:
+
 Keeping pfSense up to date
 --------------------------
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #1727.

Changes proposed in this pull request:
  * Adds an admin responsibilities guide to clearly delineate which maintenance tasks are required and expected for SecureDrop admins.

## Testing

Are there responsibilities we want to add here? Are there other useful tips we can be providing?

Otherwise review for spelling, grammar, typesetting issues.

## Checklist

- [x] Docs linting passing locally

