### PR TITLE
Changed references to 'data transfer device' or 'dtd'

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ anonymous sources.
    before_you_begin
    set_up_tails
    set_up_svs
-   set_up_dtd
+   set_up_transfer_device
    generate_securedrop_application_key
    set_up_admin_tails
    network_firewall

--- a/docs/set_up_svs.rst
+++ b/docs/set_up_svs.rst
@@ -7,8 +7,8 @@ respond to SecureDrop submissions. Once submissions are encrypted on the
 decrypt them. The *Secure Viewing Station* is never connected to the
 internet or a local network, and only ever runs from a dedicated Tails
 drive. Journalists download encrypted submissions using their
-*Journalist Workstation*, copy them to a *Data Transfer Device* (a USB
-drive or a DVD) and physically transfer the *Data Transfer Device* to
+*Journalist Workstation*, copy them to a *Transfer Device* (a USB
+drive or a DVD) and physically transfer the *Transfer Device* to
 the *Secure Viewing Station*.
 
 Since the *Secure Viewing Station* never uses a network connection or an

--- a/docs/set_up_transfer_device.rst
+++ b/docs/set_up_transfer_device.rst
@@ -1,37 +1,37 @@
-Set up the Data Transfer Device
-===============================
+Set up the Transfer Device
+==========================
 
 Journalists copy submissions from their *Journalist Workstation* to the
-*Secure Viewing Station* using the *Data Transfer Device* which can be a
+*Secure Viewing Station* using the *Transfer Device* which can be a
 DVD or a USB drive.
 
 Select DVDs or USBs
 ~~~~~~~~~~~~~~~~~~~
 
-Using DVDs as the *Data Transfer Device* provides some protection
+Using DVDs as the *Transfer Device* provides some protection
 against certain kinds of esoteric USB-based attacks on the *Secure
 Viewing Station*, but requires that you have blank DVDs, a
 dedicated DVD drive for the *Secure Viewing Station*, DVD drives for use
 with *Journalist Workstation*\ s, and a shredder capable of destroying
-DVDs. Unless you are certain that you need to use DVDs as the *Data
-Transfer Device*, you should use USB drives instead. If you have chosen
-to use DVDs instead, there is nothing to set up now — just make sure
-that you have all the hardware on hand.
+DVDs. Unless you are certain that you need to use DVDs as the *Transfer Device*,
+you should use USB drives instead. If you have chosen to use DVDs instead, there
+is nothing to set up now — just make sure that you have all the hardware on
+hand.
 
-USB Data Transfer Device Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+USB Transfer Device Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The easiest and recommended option for a *Data Transfer Device* is a USB
+The easiest and recommended option for a *Transfer Device* is a USB
 drive. If you have a large team of journalists you may want to :doc:`create
 several <onboarding>` of these. Here we'll just walk through
-making one *Data Transfer Device* [#]_.
+making one *Transfer Device* [#]_.
 
-Create a USB Data Transfer Device
----------------------------------
+Create a USB Transfer Device
+----------------------------
 
 .. note:: This process will destroy all data currently on the drive.
 
-First, label your USB drive “SecureDrop Data Transfer Device”.
+First, label your USB drive “SecureDrop Transfer Device”.
 
 On the *Secure Viewing Station*, open the
 **Applications** menu in the top left corner and select
@@ -40,7 +40,7 @@ On the *Secure Viewing Station*, open the
 |screenshot of the Applications menu in Tails, highlighting Disk
 Utility|
 
-Connect your *Data Transfer Device* then pick your device in the menu on
+Connect your *Transfer Device* then pick your device in the menu on
 the left. Since we're going to destroy all the data on this drive, it's
 important that you pick the right drive. It should be named something
 that sounds similar to the manufacturer's label on the outside of the
@@ -60,7 +60,7 @@ Once you're sure you have the right drive, click the interlocking gears, then
 |screenshot of the menu to create a new partition in the Disk Utility
 application|
 
-Give the partition on your *Data Transfer Device* a descriptive name
+Give the partition on your *Transfer Device* a descriptive name
 like “Transfer Device” and select the options as in the following screenshot:
 
 |screenshot of passphrase selection prompt in the Disk Utility
@@ -69,18 +69,18 @@ application|
 You won't need to memorize this passphrase or type it more than a few
 times, so feel free to make a good long one. Then click **Format** to continue.
 The Disks utility will ask you if you are sure: click **Format** to continue.
-After a few seconds, you new *Data Transfer Device* should be ready for use.
+After a few seconds, you new *Transfer Device* should be ready for use.
 If you haven't already, make sure to label it.
 
-Set up the USB Data Transfer Device on each workstation
--------------------------------------------------------
+Set up the USB Transfer Device on each workstation
+--------------------------------------------------
 
 On each *Journalist Workstation* and *Secure Viewing Station* you'd like to use
-the *Data Transfer Device* you will securely save the passphrase on the
+the *Transfer Device* you will securely save the passphrase on the
 persistent volume. This ensures that you will only have to type in the
 passphrase once during initial set up and it will be automatic thereafter:
 
-  #. Insert the Data Transfer Device
+  #. Insert the Transfer Device
   #. Go to **Places ▸ Computer** and click the USB drive in the left column.
   #. Type in the passphrase and click "Remember Password":
 
@@ -89,7 +89,7 @@ passphrase once during initial set up and it will be automatic thereafter:
 Remember to first do this on the *Secure Viewing Station* you just used to
 create the device!
 
-After you've done this on each computer you wish to use the *Data Transfer
+After you've done this on each computer you wish to use the *Transfer
 Device* with, you're good to go!
 
 .. |Disk Utility icon| image:: images/icons/disk-utility.png


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Basically just rewrote all references to "data transfer device" or "DTD" to instead say "transfer device."

Fixes #1744 .

Changes proposed in this pull request:

## Testing

One thing that should be double-checked is the change I made to the docs TOC. Haven't done that before and not sure if there's another place I have to update things.

