### PR TITLE
Idempotence touchups for Development VM

### DIFF
--- a/install_files/ansible-base/group_vars/securedrop_application_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_application_server.yml
@@ -23,13 +23,14 @@ build_app_code_dir: "{{ securedrop_repo }}/securedrop"
 securedrop_pip_requirements: "{{ securedrop_code }}/requirements/securedrop-requirements.txt"
 test_pip_requirements: "{{ securedrop_code }}/requirements/test-requirements.txt"
 development_dependencies:
-  - libssl-dev
   - ipython
+  - libssl-dev
+  - ntp
   - python-dev
   - python-pip
+  - ruby # to ensure `gem` command is available
   - tmux
   - vim
-  - ruby # to ensure `gem` command is available
 
 # Installing the securedrop-app-code.deb package
 securedrop_deb_path: "{{ securedrop_repo }}"

--- a/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
@@ -8,7 +8,7 @@
 - name: Install testing package dependencies.
   apt:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items: "{{ test_apt_dependencies }}"
   tags:
     - apt

--- a/install_files/ansible-base/roles/app/tasks/configure_haveged.yml
+++ b/install_files/ansible-base/roles/app/tasks/configure_haveged.yml
@@ -19,7 +19,7 @@
     dest: /etc/default/haveged
     # Appending newline is necessary for idempotence,
     # since the `lineinfile` task below will add it if not found.
-    content: "{{ haveged_defaults_no_duplicates_result.stdout }}\\n"
+    content: "{{ haveged_defaults_no_duplicates_result.stdout }}\n"
     owner: root
     group: root
     mode: "0644"
@@ -31,8 +31,8 @@
 - name: Increase haveged's low entropy watermark to minimize "flag for reply" flow.
   lineinfile:
     dest: /etc/default/haveged
-    regexp: ^DAEMON_ARGS
-    line: DAEMON_ARGS="-w 2400"
+    regexp: '^DAEMON_ARGS'
+    line: 'DAEMON_ARGS="-w 2400"'
   notify:
     - restart haveged
   tags:

--- a/install_files/ansible-base/roles/development/tasks/main.yml
+++ b/install_files/ansible-base/roles/development/tasks/main.yml
@@ -37,6 +37,10 @@
     fi
   args:
     chdir: '{{ securedrop_repo  }}/securedrop'
+  register: dev_sass_compile_result
+  # Any changed files will be printed to stdout; use that to detect whether
+  # the files have changed.
+  changed_when: "'write ' in dev_sass_compile_result.stdout"
   tags:
     - development
 

--- a/install_files/ansible-base/roles/development/tasks/main.yml
+++ b/install_files/ansible-base/roles/development/tasks/main.yml
@@ -47,15 +47,11 @@
   tags:
     - development
 
-# TODO: Probably better to set this env var in /etc/profile.d,
-# since it doesn't need to be set ONLY for the securedrop user.
-# Warrants further testing (e.g. Travis CI?), so leaving for now.
+# Setting at the system-wide level to apply to all users.
 - name: Set SECUREDROP_ENV in bashrc.
-  lineinfile:
-    dest: /home/{{ securedrop_user }}/.bashrc
-    state: present
-    insertafter: EOF
-    line: "export SECUREDROP_ENV=dev"
+  copy:
+    dest: /etc/profile.d/securedrop_env.sh
+    content: "export SECUREDROP_ENV=dev"
   tags:
     - environment
     - development

--- a/install_files/ansible-base/roles/development/tasks/main.yml
+++ b/install_files/ansible-base/roles/development/tasks/main.yml
@@ -1,11 +1,4 @@
 ---
-- name: Update apt package lists.
-  apt:
-      update_cache: yes
-  tags:
-    - apt
-    - development
-
 - name: Install apt package dependencies for Development environment.
   apt:
     pkg: "{{ item }}"

--- a/install_files/ansible-base/roles/development/tasks/main.yml
+++ b/install_files/ansible-base/roles/development/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install apt package dependencies for Development environment.
   apt:
-    pkg: "{{ item }}"
-    state: latest
+    name: "{{ item }}"
+    state: present
   with_items: "{{ development_dependencies }}"
   tags:
     - apt

--- a/install_files/ansible-base/securedrop-development.yml
+++ b/install_files/ansible-base/securedrop-development.yml
@@ -1,6 +1,16 @@
 ---
 - name: Configure SecureDrop Development machine.
   hosts: development
+  pre_tasks:
+    # Ensure all upgrades are applied. Also updates the apt cache,
+    # which will remain sufficiently fresh to prevent repeated cache updates
+    # in subsequent roles.
+    - name: Update all packages.
+      apt:
+        upgrade: dist
+        update_cache: yes
+        cache_valid_time: 3600
+
   roles:
     - { role: development, tags: development }
     - { role: app, tags: app }

--- a/install_files/ansible-base/securedrop-development.yml
+++ b/install_files/ansible-base/securedrop-development.yml
@@ -16,13 +16,3 @@
     - { role: app, tags: app }
     - { role: app-test, tags: app-test }
   sudo: yes
-# This is a quick fix for the purpose of having everything working for
-# contributors at the Aaron Swartz day hackathon. In both my own and another
-# contributors laptop, we realized we were experiencing time skew in our
-# Virtualbox VMs, which was preventing login access to the Document Interface
-# due to TOTP tokens being out of sink. TODO: resolve this issue properly.
-  tasks:
-    - name: Install NTP.
-      apt:
-        name: ntp
-        state: latest

--- a/testinfra/development/test_development_environment.py
+++ b/testinfra/development/test_development_environment.py
@@ -8,6 +8,7 @@ def test_development_app_dependencies(Package):
     """
     development_apt_dependencies = [
       'libssl-dev',
+      'ntp',
       'python-dev',
       'python-pip',
     ]


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Partial progress toward #1023. These changes affect the `development` VM, and achieve full idempotence for that playbook. Some of the changes are related to the Ansible v2 transition (specifically escaping newline characters with a single, rather than a double, backslash), and will also affect staging. A separate PR will target the staging environment to get that as close to green-across-the-board as possible. Other changes simply refine the provisioning so it's faster, e.g. only refreshing the apt cache once, rather than several times.

## Testing

1. `vagrant destroy -f development && vagrant up development`
2. `vagrant provision development` to run the playbook _again_
3. Confirm that the second playbook run, and any number of subsequent runs at your discretion, reports zero changed tasks.

## Deployment

No concerns for deployment. Some of the logic changes will affect prod installs, but are necessary for the forthcoming transition to Ansible v2 (#1146). 

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [x] Testinfra tests pass on the development VM