### PR TITLE
Idempotence touchups for Staging environment

### DIFF
--- a/install_files/ansible-base/roles/app-test/tasks/disable_mprotect_ff_plugin_container.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/disable_mprotect_ff_plugin_container.yml
@@ -1,7 +1,23 @@
 ---
-- name: disable mprotect on firefox and the firefox plugin container
-  command: paxctl -cm /usr/lib/firefox/{{ item }}
-  with_items:
-    - firefox
-    - plugin-container
+- name: Check paxctl headers on Firefox binaries.
+  command: paxctl -vQ {{ item }}
+  # Read-only task, so don't report changed
+  changed_when: false
+  # The first time this task is run, the grub binaries won't have
+  # their headers converted yet, which will cause paxctl to exit 1.
+  # We'll catch that error and respond accordingly in the next task.
+  failed_when: false
+  register: paxctl_firefox_header_check
   when: ansible_kernel.endswith('-grsec')
+  with_items:
+    - /usr/lib/firefox/firefox
+    - /usr/lib/firefox/plugin-container
+
+# Flags as snagged from app-staging: '-----m-x-e--'
+- name: Adjust paxctl headers on firefox binaries.
+  command: paxctl -zcm {{ item.item }}
+  with_items: "{{ paxctl_firefox_header_check.results }}"
+  when:
+    # Chained conditional; only inspect command results if running under grsecurity.
+    - ansible_kernel.endswith('-grsec')
+    - "item.stdout != '- PaX flags: -----m-x---- [{{ item.item }}]' or item.rc != 0"

--- a/install_files/ansible-base/roles/common/tasks/setup_etc_hosts.yml
+++ b/install_files/ansible-base/roles/common/tasks/setup_etc_hosts.yml
@@ -18,7 +18,7 @@
     dest: /etc/hosts
     # Appending newline is necessary for idempotence,
     # since the `lineinfile` task below will add it if not found.
-    content: "{{ etc_hosts_no_duplicates_result.stdout }}\\n"
+    content: "{{ etc_hosts_no_duplicates_result.stdout }}\n"
     owner: root
     group: root
     mode: "0644"

--- a/install_files/ansible-base/roles/grsecurity/tasks/clean_packages.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/clean_packages.yml
@@ -2,33 +2,17 @@
 # After installing securedrop-grsec, remove
 # old generic kernels to avoid accidental
 # boots into a less secure environment.
-- name: Remove generic kernel metapackages.
+- name: Remove generic kernel packages.
   apt:
-    name: "{{item}}"
+    name: "{{ item }}"
     state: absent
   with_items:
     - linux-signed-generic
     - linux-signed-generic-lts-utopic
     - linux-signed-image-generic
     - linux-signed-image-generic-lts-utopic
-  tags:
-    - apt
-
-- name: Remove remaining generic kernels.
-  command: apt-get -y remove '^linux-image-.*generic$'
-  register: linux_image_removal
-  # Output is extremely verbose, so let's just report changed status.
-  no_log: true
-  changed_when: "'0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.' not in linux_image_removal.stdout"
-  tags:
-    - apt
-
-- name: Remove remaining kernel headers.
-  command: apt-get -y remove '^linux-headers-.*'
-  register: linux_headers_removal
-  # Output is extremely verbose, so let's just report changed status.
-  no_log: true
-  changed_when: "'0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.' not in linux_headers_removal.stdout"
+    - 'linux-image-*generic'
+    - 'linux-headers-*'
   tags:
     - apt
 
@@ -44,6 +28,6 @@
 - name: Clean old apt packages.
   command: apt-get -y autoremove
   register: apt_autoremove_all
-  changed_when: "'0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.' not in apt_autoremove_all.stdout"
+  changed_when: "'The following packages will be REMOVED' in apt_autoremove_all.stdout"
   tags:
     - apt

--- a/install_files/ansible-base/roles/grsecurity/tasks/clean_packages.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/clean_packages.yml
@@ -17,6 +17,8 @@
 - name: Remove remaining generic kernels.
   command: apt-get -y remove '^linux-image-.*generic$'
   register: linux_image_removal
+  # Output is extremely verbose, so let's just report changed status.
+  no_log: true
   changed_when: "'0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.' not in linux_image_removal.stdout"
   tags:
     - apt
@@ -24,6 +26,8 @@
 - name: Remove remaining kernel headers.
   command: apt-get -y remove '^linux-headers-.*'
   register: linux_headers_removal
+  # Output is extremely verbose, so let's just report changed status.
+  no_log: true
   changed_when: "'0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.' not in linux_headers_removal.stdout"
   tags:
     - apt

--- a/install_files/ansible-base/roles/install-local-packages/tasks/hold_debs.yml
+++ b/install_files/ansible-base/roles/install-local-packages/tasks/hold_debs.yml
@@ -12,10 +12,15 @@
 # Using apt-mark only applies to `apt` or `apt-get` actions, so we'll use a two-pass
 # approach to hold the locally built packages, so that neither apt nor aptitude
 # tries to upgrade them on subsequent playbook runs.
+
 - name: Mark packages as held, so they aren't upgraded automatically (via apt).
   command: apt-mark hold {{ item.stdout }}
   register: apt_mark_hold_result
-  changed_when: not apt_mark_hold_result.stdout.endswith('already set on hold.')
+  # The packages will have the "hold" state cleared during the previous task
+  # for `dpkg -i <deb>`. Therefore let's determine changed state by comparing
+  # to the value prior to installation.
+  changed_when: item.stdout not in apt_mark_showhold_result.stdout_lines
+  when: item.stdout not in apt_mark_showhold_result.stdout_lines
   with_items: "{{ local_deb_packages_name_check.results }}"
 
 - name: Mark packages as held, so they aren't upgraded automatically (via aptitude).

--- a/install_files/ansible-base/roles/install-local-packages/tasks/main.yml
+++ b/install_files/ansible-base/roles/install-local-packages/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+# Installing via `dpkg -i` wipes hold state, so look it up prior to installing
+# in order to show "changed" status accurately. The `hold_debs` logic will
+# reference the registered variable.
+- name: Look up packages already marked as held.
+  command: apt-mark showhold
+  register: apt_mark_showhold_result
+  changed_when: false
+
 - include: install_debs.yml
 
 - include: hold_debs.yml

--- a/install_files/ansible-base/roles/ossec-server/tasks/mon_configure_ossec_gpg_alerts.yml
+++ b/install_files/ansible-base/roles/ossec-server/tasks/mon_configure_ossec_gpg_alerts.yml
@@ -41,9 +41,9 @@
   template:
     src: send_encrypted_alarm.sh
     dest: /var/ossec/send_encrypted_alarm.sh
-    mode: "0750"
-    owner: ossec
-    group: root
+    mode: "0550"
+    owner: root
+    group: ossec
   tags:
     - procmail
     - permissions
@@ -83,7 +83,7 @@
   copy:
     src: procmailrc
     dest: /var/ossec/.procmailrc
-    owner: ossec
-    group: root
+    owner: root
+    group: ossec
   tags:
     - procmail

--- a/testinfra/common/test_grsecurity.py
+++ b/testinfra/common/test_grsecurity.py
@@ -141,18 +141,13 @@ def test_grub_pc_marked_manual(Command):
     assert c.stdout == "grub-pc"
 
 
-# The app-staging host has an outdated version of Firefox installed manually,
-# for compatibility with Selenium. Let's skip only on that host.
-@pytest.mark.skipif(
-        os.environ['SECUREDROP_TESTINFRA_TARGET_HOST'] == "app-staging",
-        reason="app-staging uses old version of Firefox for Selenium")
 def test_apt_autoremove(Command):
     """
     Ensure old packages have been autoremoved.
     """
     c = Command('apt-get --dry-run autoremove')
     assert c.rc == 0
-    assert "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded" in c.stdout
+    assert "The following packages will be REMOVED" not in c.stdout
 
 
 @pytest.mark.skipif(os.environ.get('FPF_GRSEC','true') == "false",


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes


Complements #1755. Closes #1023. These changes affect the staging VMs, and achieve near idempotence for both app-staging and mon-staging:

```
PLAY RECAP *********************************************************************
app-staging                : ok=117  changed=3    unreachable=0    failed=0
build                      : ok=66   changed=34   unreachable=0    failed=0
localhost                  : ok=0    changed=0    unreachable=0    failed=0
mon-staging                : ok=90   changed=2    unreachable=0    failed=0
```

The remaining tasks that show changed status are:

* Enable logging for Source Interface 
This task runs only on app-staging, and resolving it would require substantial changes to the build logic for the deb packages, e.g. using a template for var interpolation. Such changes would require large amounts of QA, and the task is only relevant to the staging environment, not prod, so punting for now. 

* Copy locally built deb packages to server (Staging only)
* Install locally built deb packages (via dpkg)
These tasks runs on both hosts (mon-staging and app-staging) and are expected to change every time, since locally-built deb packages are installed on every playbook run (#1464) and the package build process is not deterministic (#308).

Naturally the build VM still shows many changed tasks, since it rebuilds the deb packages from scratch on every run. That's expected and intended. There are further changes that should be made to the OSSEC file permissions, but that's out of scope for this issue. Opened #1756 to track.

## Testing
1. Provision staging environment.
2. Reprovision staging environment.
3. Confirm changed tasks output is 3 for app-staging and 2 for mon-staging.
4. Confirm testinfra tests past on all three staging hosts (build, app-staging, mon-staging).

## Deployment

No concerns for deployment. 

## Checklist

### If you made changes to the app code:

- :white_check_mark:  Unit and functional tests pass on the development VM
- :red_circle: Unit and functional tests pass on the app-staging VM (failing locally due to #1736, should pass in CI)

### If you made changes to the system configuration:

- :white_check_mark: Testinfra tests pass on the development VM
- :white_check_mark:  Testinfra tests pass on the build VM
- :white_check_mark:  Testinfra tests pass on the app-staging VM
- :white_check_mark:  Testinfra tests pass on the mon-staging VM
