### PR TITLE
Deprecate `prod-specific.yml` vars file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 securedrop-app-conf.yml
 securedrop-mon-conf.yml
 
+# ignore site-specific vars file, since we can't predict contents
+install_files/ansible-base/group_vars/all/site-specific
+
 # ignore securedrop-app-code wheelhouse archive
 wheelhouse
 

--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -79,7 +79,7 @@ the SecureDrop servers.
    ansible -i inventory -u <SSH username> -m ping all
 
 .. tip:: If you forgot your SSH username, it is the value of the ``ssh_users``
-         variable in ``prod-specific.yml``.
+         variable in ``group_vars/all/site-specific``.
 
 If this command fails (usually with an error like "SSH Error: data could not be
 sent to the remote host. Make sure this host can be reached over ssh"), you need

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -66,7 +66,7 @@ mon-prod
     This is like a production installation with all of the system
     hardening active, but virtualized, rather than running on hardware.
     You will need to configure prod-like secrets in
-    ``install_files/ansible-base/prod-specific.yml``, or export
+    ``install_files/ansible-base/group_vars/all/site-specific``, or export
     ``ANSIBLE_ARGS=="--skip-tags validate"`` to skip the tasks
     that prevent the prod playbook from running with Vagrant-specific info.
 
@@ -183,7 +183,7 @@ Prod
 ----
 
 You will need to fill out the production configuration file at
-``install_files/ansible-base/prod-specific.yml`` with custom secrets.
+``install_files/ansible-base/group_vars/all/site-specific`` with custom secrets.
 The production playbook validates that staging values are not used in
 production. One of the values it verifies is that the user Ansible runs as is
 not ``vagrant`` To be able to run this playbook in a virtualized environment

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,6 +16,8 @@ Tor. Once that's done, you can install Ansible:
     sudo apt-get update
     sudo apt-get install ansible
 
+.. _configure_securedrop:
+
 Configure the Installation
 --------------------------
 
@@ -71,43 +73,26 @@ Edit the inventory file, ``inventory``, and update the default IP
 addresses with the ones you chose for app and mon. When you're done,
 save the file.
 
-Edit the file ``prod-specific.yml`` and fill it out with values that
-match your environment. At a minimum, you will need to provide the
-following:
+Run the configuration playbook and answer the prompts with values that
+match your environment: ::
 
--  User allowed to connect to both servers with SSH: ``ssh_users``
--  IP address of the *Monitor Server*: ``monitor_ip``
--  Hostname of the *Monitor Server*: ``monitor_hostname``
--  Hostname of the *Application Server*: ``app_hostname``
--  IP address of the *Application Server*: ``app_ip``
--  The SecureDrop Submission Key public key file:
-   ``securedrop_app_gpg_public_key``
--  The SecureDrop Submission Key fingerprint:
-   ``securedrop_app_gpg_fingerprint``
--  GPG public key used when encrypting OSSEC alerts:
-   ``ossec_alert_gpg_public_key``
--  Fingerprint for key used when encrypting OSSEC alerts:
-   ``ossec_gpg_fpr``
--  The email address that will receive alerts from OSSEC:
-   ``ossec_alert_email``
--  The reachable hostname of your SMTP relay: ``smtp_relay``
--  The secure SMTP port of your SMTP relay: ``smtp_relay_port``
-   (typically 25, 587, or 465. Must support TLS encryption)
--  Email username to authenticate to the SMTP relay: ``sasl_username``
--  Domain name of the email used to send OSSEC alerts: ``sasl_domain``
--  Password of the email used to send OSSEC alerts: ``sasl_password``
--  The fingerprint of your SMTP relay (optional):
-   ``smtp_relay_fingerprint``
+    ansible-playbook securedrop-configure.yml
 
-Optionally, you can also have custom notification text be displayed on the
+The script will automatically validate the answers you provided, and display
+error messages if any problems were detected. The answers you provided will be
+written to the file ``group_vars/all/site-specific``, which you can edit
+manually to provide further customization.
+
+For example, you can have custom notification text be displayed on the
 source interface. The source interface with a custom notification message is
 shown here (the custom notification appears after the bolded "Note:"):
 
 |Custom notification|
 
 This custom notification can be configured by providing the desired message in
-``custom_notification_text`` in ``prod-specific.yml``. For example, this can be
-used to notify potential sources that an instance is for testing purposes only.
+``custom_notification_text`` in ``group_vars/all/site-specific``. For example,
+this can be used to notify potential sources that an instance is for
+testing purposes only.
 
 When you're done, save the file and quit the editor.
 

--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -17,8 +17,8 @@ settings to Ansible in the playbook for your environment. If you don't
 already have a working mail server or don't know what to do, then see
 the section below about using Gmail as a fallback option. We assume that
 you're working out of the 'securedrop' directory you cloned the code
-into, and editing install\_files/ansible-base/prod-specific.yml prior to
-installing SecureDrop.
+into, and editing ``install_files/ansible-base/group_vars/all/site-specific``
+prior to installing SecureDrop.
 
 What you need:
 
@@ -47,7 +47,10 @@ The SMTP relay that you use should support SASL authentication and SMTP
 TLS protocols TLSv1.2, TLSv1.1, and TLSv1. Most enterprise email
 solutions should be able to meet those requirements.
 
-These are the values you must specify in ``prod-specific.yml``:
+Below are the values you must specify in to configure OSSEC correctly.
+For first-time installs, you can use the
+:ref:`configuration playbook<configure_securedrop>`, or edit
+``install_files/ansible-base/group_vars/all/site-specific`` manually.
 
 - GPG public key used to encrypt OSSEC alerts:
   ``ossec_alert_gpg_public_key``
@@ -84,8 +87,9 @@ although we've described some common scenarios in the
 :ref:`troubleshooting section <troubleshooting_ossec>`.
 
 If you have your GPG public key handy, copy it to
-install\_files/ansible-base and then specify the filename in the
-``ossec_alert_gpg_public_key`` line of prod-specific.yml.
+``install_files/ansible-base`` and then specify the filename, e.g.
+``ossec.pub``, in the ``ossec_alert_gpg_public_key`` line of
+``group_vars/all/site-specific``.
 
 If you don't have your GPG key ready, you can run GnuPG on the command line in
 order to find, import, and export your public key. It's best to copy the key
@@ -151,7 +155,7 @@ requires both a valid certificate and STARTTLS support on the SMTP
 relay. By default the system CAs will be used for validating the relay
 certificate. If you need to provide a custom CA to perform the
 validation, copy the cert file to ``install_files/ansible-base`` add a
-new variable to ``prod-specific.yml``: ::
+new variable to ``group_vars/all/site-specific``: ::
 
     smtp_relay_cert_override_file: MyOrg.crt
 
@@ -159,7 +163,7 @@ where ``MyOrg.crt`` is the filename. The file will be copied to the
 server in ``/etc/ssl/certs_local`` and the system CAs will be ignored
 when validating the SMTP relay TLS certificate.
 
-Save ``prod-specific.yml``, exit the editor and :ref:`proceed with the
+Save ``group_vars/all/site-specific``, exit the editor and :ref:`proceed with the
 installation <Run the Ansible playbook>` by running the playbooks.
 
 Using Gmail for OSSEC alerts
@@ -227,7 +231,7 @@ following:
 
     6D:87:EE:CB:D0:37:2F:88:B8:29:06:FB:35:F4:65:00:7F:FD:84:29
 
-Finally, add a new variable to ``prod-specific.yml`` as
+Finally, add a new variable to ``group_vars/all/site-specific`` as
 ``smtp_relay_fingerprint``, like so: ::
 
     smtp_relay_fingerprint: "6D:87:EE:CB:D0:37:2F:88:B8:29:06:FB:35:F4:65:00:7F:FD:84:29"
@@ -235,8 +239,8 @@ Finally, add a new variable to ``prod-specific.yml`` as
 Specifying the fingerprint will configure Postfix to use it for
 verification on the next playbook run. (To disable fingerprint
 verification, simply delete the variable line you added, and rerun the
-playbooks.) Save ``prod-specific.yml``, exit the editor and :ref:`proceed
-with the installation <Run the Ansible playbook>` by running the
+playbooks.) Save ``group_vars/all/site-specific``, exit the editor and
+:ref:`proceed with the installation <Run the Ansible playbook>` by running the
 playbooks.
 
 .. _troubleshooting_ossec:
@@ -286,7 +290,7 @@ OSSEC service.
 
 .. tip:: If you change the SMTP relay port after installation for any
          reason, you must update the ``smtp_relay_port`` variable in the
-         ``prod-specific.yml`` file, then rerun the Ansible playbook.
+         ``group_vars/all/site-specific`` file, then rerun the Ansible playbook.
          As a general best practice, we recommend modifying and
          rerunning the Ansible playbook instead of manually editing
          the files live on the servers, since values like ``smtp_relay_port``
@@ -321,20 +325,20 @@ that authenticated to send mail. By default the *Monitor Server* will use
 ``ossec@ossec.server`` for the from line, but your mail provider may not support
 the mismatch between the domain of that value and your real mail host.
 If the Admin email address (configured as ``ossec_alert_email`` in
-``prod-specific.yml``) does not start receiving OSSEC alerts updates shortly
+``group_vars/all/site-specific``) does not start receiving OSSEC alerts updates shortly
 after the first playbook run, try setting ``ossec_from_address`` in
-``prod-specific.yml`` to the full email address used for sending the alerts,
+``group_vars/all/site-specific`` to the full email address used for sending the alerts,
 then run the playbook again.
 
 Message failed to encrypt
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 If OSSEC cannot encrypt the alert to the GPG public key for the Admin
-email address (configured as ``ossec_alert_email`` in ``prod-specific.yml``),
+email address (configured as ``ossec_alert_email`` in ``group_vars/all/site-specific``),
 the system will send a static message instead of the scheduled alert:
 
   Failed to encrypt OSSEC alert. Investigate the mailing configuration on the Monitor Server.
 
-Check the GPG configuration vars in ``prod-specific.yml``. In particular,
+Check the GPG configuration vars in ``group_vars/all/site-specific``. In particular,
 make sure the GPG fingerprint matches that of the public key file you
 exported.
 
@@ -356,7 +360,7 @@ email send failures.
 
 In either case, start by attempting to make a STARTTLS connection to
 your chosen ``smtp_relay:smtp_relay_port`` (get the values from your
-``prod-specific.yml`` file). On a machine running Ubuntu, run the
+``group_vars/all/site-specific`` file). On a machine running Ubuntu, run the
 following ``openssl`` command, replacing ``smtp_relay`` and
 ``smtp_relay_port`` with your specific values: ::
 
@@ -413,7 +417,7 @@ intentionally do not want to use a certificate signed by one of the
 default CA's in Ubuntu, you can still use ``openssl`` to test whether
 you can successfully negotiate a secure connection. Begin by copying
 your certificate file (``smtp_relay_cert_override_file`` from
-``prod-specific.yml``) to the computer you are using for testing. You
+``group_vars/all/site-specific``) to the computer you are using for testing. You
 can use ``-CAfile`` to test if your connection will succeed using your
 custom root certificate: ::
 

--- a/docs/upgrade_to_tails_2x.rst
+++ b/docs/upgrade_to_tails_2x.rst
@@ -247,7 +247,7 @@ To test the *Admin Workstation*, make sure you can still SSH into the servers:
     mon
 
 .. tip:: If you forgot, your SSH username is in
-         ``install_files/ansible-base/prod-specific.yml`` as the value of the
+         ``install_files/ansible-base/group_vars/all/site-specific`` as the value of the
          ``ssh_users`` variable. The .onion addresses for SSH for each server
          are in ``install_files/ansible-base/app-ssh-aths`` and
          ``install_files/ansible-base/mon-ssh-aths``, respectively.

--- a/install_files/ansible-base/configure
+++ b/install_files/ansible-base/configure
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -u
+set -e
+
+
+
+# Whether to clobber a pre-existing vars file.
+override_previous_vars="no"
+
+function usage() {
+    printf "Usage: %s [-f|--force]\n" "$0"
+    printf "\tConfigure SecureDrop environment via variables.\n"
+    printf "\tUse --force to overwrite preexisting vars.\n"
+}
+# Parse arguments.
+while [[ $# -gt 0 ]]; do
+    for arg in "$@"; do
+        case "${arg}" in
+            -h|--help)
+            usage
+            exit 0
+            ;;
+            -f|--force)
+            override_previous_vars="yes"
+            shift
+            ;;
+        esac
+    done
+done
+
+# Declare path to site-specific vars file.
+site_specific_vars="$(realpath "$(dirname "${BASH_SOURCE[0]}")")/group_vars/all/site-specific"
+
+# If vars file already exists, let's prepopulate the prompts with those values.
+if [[ -e "${site_specific_vars}" && "${override_previous_vars}" != "yes" ]]; then
+    ansible-playbook securedrop-configure.yml --extra-vars "@${site_specific_vars}"
+# Otherwise we'll run the playbook from scratch and fill in the values.
+else
+    ansible-playbook securedrop-configure.yml
+fi

--- a/install_files/ansible-base/group_vars/securedrop_application_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_application_server.yml
@@ -2,7 +2,7 @@
 #securedop_repo is defined in site-specific.yml config
 # Only the development and travis playbooks use a non-default value for
 # securedrop_code and securedrop_user variables. Setting a default values
-# allows us not to define these two variables in the prod-specific and
+# allows us not to define these two variables in the site-specific and
 # staging-specific yml configs.
 securedrop_code: "{{ non_default_securedrop_code | default('/var/www/securedrop') }}"
 securedrop_user: "{{ non_default_securedrop_user | default('www-data') }}"

--- a/install_files/ansible-base/roles/ossec-server/templates/main.cf
+++ b/install_files/ansible-base/roles/ossec-server/templates/main.cf
@@ -8,7 +8,7 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 {% if smtp_relay_fingerprint is defined and
       smtp_relay_fingerprint != '' %}
 # Retain support for 'fingerprint' security level.
-# `smtp_relay_fingerprint` must be set (e.g. in `prod-specific.yml`),
+# `smtp_relay_fingerprint` must be set (e.g. in `group-vars/all/site-specific`),
 # otherwise this block is skipped. Providing a fingerprint overrides
 # the default SMTP TLS security level of 'secure', set below.
 smtp_tls_security_level = fingerprint

--- a/install_files/ansible-base/roles/validate/defaults/main.yml
+++ b/install_files/ansible-base/roles/validate/defaults/main.yml
@@ -5,4 +5,3 @@
 securedrop_validate_disallowed_users:
   - amnesia
   - root
-  - vagrant

--- a/install_files/ansible-base/roles/validate/tasks/validate_gpg_info.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_gpg_info.yml
@@ -2,17 +2,19 @@
 
 - name: Validate GPG info.
   assert:
-     that:
-       # Should not match the fingerprint for the TEST Journalist pubkey.
-       - item != "65A1B5FF195B56353CC63DFFCC40EF1228271441"
-       # Should not match the fingerprint for the TEST Admin pubkey.
-       - item != "600BC6D5142C68F35DDBCEA87B597104EDDDC102"
-       # Should not contain whitespace.
-       - "' ' not in item"
-       # Must be a full-length fingerprint.
-       - item|length == 40
-       # Must contain only hex characters
-       - item == item|regex_replace('[^A-F0-9]', '')
+    that:
+      # Should not match the fingerprint for the TEST Journalist pubkey.
+      - item != "65A1B5FF195B56353CC63DFFCC40EF1228271441"
+      # Should not match the fingerprint for the TEST Admin pubkey.
+      - item != "600BC6D5142C68F35DDBCEA87B597104EDDDC102"
+      # Should not contain whitespace.
+      - "' ' not in item"
+      # Must be a full-length fingerprint.
+      - item|length == 40
+      # Must contain only hex characters
+      - item == item|regex_replace('[^A-F0-9]', '')
+    msg: >-
+      GPG fingerprints must be full-length (40 characters), with no whitespace.
   tags:
     - validate
     - debug

--- a/install_files/ansible-base/roles/validate/tasks/validate_users.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_users.yml
@@ -1,5 +1,5 @@
 ---
-# Check the value of `ssh_users` in the prod-specific.yml file to ensure
+# Check the value of `ssh_users` in site-specific vars to ensure
 # we're using a unique username. If the playbook is running with a username
 # of e.g. `amnesia`, then the vars file has been configured incorrectly.
 - name: Validate Admin username (specified in vars).

--- a/install_files/ansible-base/securedrop-configure.yml
+++ b/install_files/ansible-base/securedrop-configure.yml
@@ -105,10 +105,6 @@
         msg: >-
           Validating user-entered variables...
 
-  roles:
-    - role: validate
-      tags: validate
-
   tasks:
     - name: Initialize site-specific vars file.
       copy:
@@ -162,3 +158,11 @@
           var_value: "{{ sasl_username }}"
         - var_name: sasl_password
           var_value: "{{ sasl_password }}"
+
+- name: Validate site-specific information.
+  hosts: localhost
+  connection: local
+  gather_facts: yes
+  roles:
+    - role: validate
+      tags: validate

--- a/install_files/ansible-base/securedrop-configure.yml
+++ b/install_files/ansible-base/securedrop-configure.yml
@@ -1,0 +1,158 @@
+---
+- name: Display message about upcoming interactive prompts.
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+    - debug:
+        msg: >-
+          You will need to fill out the following prompts in order
+          to configure your SecureDrop instance. After entering
+          all prompts, the variables will be validated and any
+          failures displayed. See the docs for more information
+          https://docs.securedrop.org/en/stable
+
+- name: Prompt for required site-specific information.
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  vars_prompt:
+    - name: ssh_users
+      prompt: Username for SSH access to the servers
+      default: sd
+      private: no
+
+    - name: app_ip
+      prompt: Local IPv4 address for the Application Server
+      default: "10.20.2.2"
+      private: no
+
+    - name: monitor_ip
+      prompt: Local IPv4 address for the Monitor Server
+      default: "10.20.3.2"
+      private: no
+
+    - name: app_hostname
+      prompt: Hostname for Application Server.
+      default: app
+      private: no
+
+    - name: monitor_hostname
+      prompt: Hostname for Monitor Server.
+      default: mon
+      private: no
+
+    - name: dns_server
+      prompt: DNS server specified during installation.
+      default: "8.8.8.8"
+      private: no
+
+    - name: securedrop_header_image
+      prompt: >-
+        Local filepath to your organization's logo,
+        to be displayed on the Source Interface
+      private: no
+
+    - name: securedrop_app_gpg_public_key
+      prompt: Local filepath to public key for SecureDrop Application GPG public key
+      default: SecureDrop.asc
+      private: no
+
+    - name: securedrop_app_gpg_fingerprint
+      prompt: Full fingerprint for the SecureDrop Application GPG Key
+      private: no
+
+    - name: ossec_alert_gpg_public_key
+      prompt: Local filepath to OSSEC alerts GPG public key
+      default: ossec.pub
+      private: no
+
+    - name: ossec_gpg_fpr
+      prompt: Full fingerprint for the OSSEC alerts GPG public key
+      private: no
+
+    - name: ossec_alert_email
+      prompt: Admin email address for receiving OSSEC alerts
+      private: no
+
+    - name: smtp_relay
+      prompt: SMTP relay for sending OSSEC alerts
+      default: "smtp.gmail.com"
+      private: no
+
+    - name: smtp_relay_port
+      prompt: SMTP port for sending OSSEC alerts
+      default: "587"
+      private: no
+
+    - name: sasl_domain
+      prompt: SASL domain for sending OSSEC alerts
+      default: "gmail.com"
+      private: no
+
+    - name: sasl_username
+      prompt: SASL username for sending OSSEC alerts
+      default: ""
+      private: no
+
+    - name: sasl_password
+      prompt: SASL password for sending OSSEC alerts
+      default: ""
+      private: yes
+
+  pre_tasks:
+    - debug:
+        msg: >-
+          Validating user-entered variables...
+
+  roles:
+    - role: validate
+      tags: validate
+
+  tasks:
+    - name: Save site-specific information as local vars file.
+      lineinfile:
+        regexp: "^{{ item.var_name }}:"
+        line: "{{ item.var_name }}: {{ item.var_value }}"
+        dest: "{{ playbook_dir }}/group_vars/all/site-specific"
+        create: yes
+      # Don't erase variables if undefined in this playbook. The validate role
+      # will handle ensuring proper definitions.
+      when: item.var_value is defined and item.var_value != ""
+      # Non-DRY approach to looping over all vars, but helps to ensure that we
+      # don't clobber site-specific customizations made by an Admin.
+      with_items:
+        - var_name: ssh_users
+          var_value: "{{ ssh_users }}"
+        - var_name: app_ip
+          var_value: "{{ app_ip }}"
+        - var_name: monitor_ip
+          var_value: "{{ monitor_ip }}"
+        - var_name: app_hostname
+          var_value: "{{ app_hostname }}"
+        - var_name: monitor_hostname
+          var_value: "{{ monitor_hostname }}"
+        - var_name: dns_server
+          var_value: "{{ dns_server }}"
+        - var_name: securedrop_header_image
+          var_value: "{{ securedrop_header_image }}"
+        - var_name: securedrop_app_gpg_public_key
+          var_value: "{{ securedrop_app_gpg_public_key }}"
+        - var_name: securedrop_app_gpg_fingerprint
+          var_value: "{{ securedrop_app_gpg_fingerprint }}"
+        - var_name: ossec_alert_gpg_public_key
+          var_value: "{{ ossec_alert_gpg_public_key }}"
+        - var_name: ossec_gpg_fpr
+          var_value: "{{ ossec_gpg_fpr }}"
+        - var_name: ossec_alert_email
+          var_value: "{{ ossec_alert_email }}"
+        - var_name: smtp_relay
+          var_value: "{{ smtp_relay }}"
+        - var_name: smtp_relay_port
+          var_value: "{{ smtp_relay_port }}"
+        - var_name: sasl_domain
+          var_value: "{{ sasl_domain }}"
+        - var_name: sasl_username
+          var_value: "{{ sasl_username }}"
+        - var_name: sasl_password
+          var_value: "{{ sasl_password }}"

--- a/install_files/ansible-base/securedrop-configure.yml
+++ b/install_files/ansible-base/securedrop-configure.yml
@@ -110,6 +110,12 @@
       tags: validate
 
   tasks:
+    - name: Initialize site-specific vars file.
+      copy:
+        content: "---"
+        force: no
+        dest: "{{ playbook_dir }}/group_vars/all/site-specific"
+
     - name: Save site-specific information as local vars file.
       lineinfile:
         regexp: "^{{ item.var_name }}:"

--- a/install_files/ansible-base/securedrop-configure.yml
+++ b/install_files/ansible-base/securedrop-configure.yml
@@ -163,6 +163,13 @@
   hosts: localhost
   connection: local
   gather_facts: yes
+  pre_tasks:
+    # Use a first-found loop to avoid erroring out if the vars file doesn't
+    # exist when the playbook is invoked, which is true on first run.
+    - name: Include site-specific vars.
+      include_vars: "{{ item }}"
+      with_first_found:
+        - group_vars/all/site-specific
   roles:
     - role: validate
       tags: validate

--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -24,19 +24,12 @@
 
 - name: Validate instance-specific variables before provisioning.
   hosts: securedrop
-  # Manual include for the production vars file, since we don't have support
-  # for "group_vars" for prod-specific yet. Must be included on all plays
-  # for the SecureDrop Application and Monitor Servers.
-  vars_files:
-    - prod-specific.yml
   roles:
     - { role: validate, tags: validate }
   sudo: yes
 
 - name: Add FPF apt repository and install base packages.
   hosts: securedrop
-  vars_files:
-    - prod-specific.yml
   roles:
     - { role: common, tags: common }
     - { role: tor-hidden-services, tags: tor }
@@ -45,16 +38,12 @@
 
 - name: Configure SecureDrop Monitor Server.
   hosts: securedrop_monitor_server
-  vars_files:
-    - prod-specific.yml
   roles:
     - { role: ossec-server, tags: [ ossec, ossec_server ] }
   sudo: yes
 
 - name: Configure SecureDrop Application Server.
   hosts: securedrop_application_server
-  vars_files:
-    - prod-specific.yml
   roles:
     - { role: ossec-agent, tags: [ ossec, ossec_agent ] }
     - { role: app, tags: app }
@@ -67,7 +56,6 @@
       when: (perform_backup is defined and perform_backup|bool == true) or
             (restore_file is defined and restore_file != '')
       tags: backup
-
   sudo: yes
 
   # This section will put the ssh and iptables rules in place
@@ -78,16 +66,12 @@
   # connection. After that point the admin will to proxy traffic over tor.
 - name: Lock down firewall configuration for Application and Monitor Servers.
   hosts: securedrop
-  vars_files:
-    - prod-specific.yml
   roles:
     - { role: restrict-direct-access, tags: [ common, restrict-direct-access ] }
   sudo: yes
 
 - name: Reboot Application and Monitor Servers.
   hosts: securedrop
-  vars_files:
-    - prod-specific.yml
   roles:
     - { role: reboot, tags: reboot }
   sudo: yes

--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -1,4 +1,17 @@
 ---
+- name: Migrate site-specific information in vars files.
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+    - name: Copy deprecated prod-specific.yml vars file.
+      command: >
+        cp "{{ playbook_dir }}/prod-specific.yml"
+        "{{ playbook_dir }}/group_vars/all/site-specific"
+      # Don't clobber new vars file with old, just create it.
+      args:
+        creates: "{{ playbook_dir }}/group_vars/all/site-specific"
+
 - name: Validate presence of Application and Monitor Servers.
   hosts: [ mon, app, mon-prod, app-prod ]
   # The manage-groups role dynamically adds hosts to groups,


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #1758. Migrates away from the long-standing `prod-specific.yml` vars file, used for providing site-specific variables and optional customizations. The new file is called `group_vars/all/site-specific`. Includes a new dedicated playbook called `securedrop-configure.yml` that interactively prompts for site-specific secrets, validates them via the `validate` role, then writes them to disk, in a non-version-controlled file.

Admins who previously filled out the `prod-specific.yml` playbook need not take any special action. The first time the `securedrop-prod.yml` playbook is run after upgrading to 0.4, the old vars file will be automatically copied to the new location, and its contents read from there for the remainder of the playbook.

Also updated the docs throughout, to use the new filename where appropriate, and also to reference the new playbook in the install docs. Avoided expanding the validation logic, since we have separate issues for those (e.g. #749).

## Testing

### Scenario 1: upgrades
1. Check out `0.3.12` and fill out the `prod-specific.yml` file with production-like secrets.
2. Provision prod VMs.
3. Check out this feature branch and reprovision the prod VMs.
4. Confirm that the second provisioning run completed successfully (no undefined vars anywhere).
5. Confirm that the `group_vars/all/site-specific` file was created and its values match those in the `prod-specific.yml` file you manually edited previously.

### Scenario 2: new installs
1. Check out this feature branch, and ensure you have a clean repo (no customizations to `prod-specific.yml`).
2. Hop into the `install_files/ansible-base` directory and run the new configuration playbook: `ansible-playbook securedrop-configure.yml`. 
3. Fill out all the prompts, with the same secrets you used in Scenario 1.
4. Confirm no errors with the validation prompts (playbook will fail if errors are found).
5. Confirm values in `group_vars/all/site-specific` are formatted correctly.
6. Confirm you can provision VMs with the new vars file.

## Deployment

Ensured that existing Admins will not need to take special action to migrate the vars—the new prod playbook will handle that for them. The big win is for first-time Admins on the initial install: the combination of interactive prompts and built-in variable validation should provide bumpers enough that misconfigurations do not slip in. 