### PR TITLE
Add "What Makes SecureDrop Unique" guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,7 @@ anonymous sources.
 
    deployment_practices
    getting_the_most_out_of_securedrop
+   what_makes_securedrop_unique
    google_authenticator
    logging
    ossec_alerts

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -138,19 +138,19 @@ give it a file extension.
 Interact With Sources
 ---------------------
 
-Click on the codename to see the page specifically for that source. 
-You will see all of the messages that they have written and documents 
-that they have uploaded. If the name of a source is difficult to say 
-or remember, you can rename a source using the button next to their 
-current codename: 
+Click on the codename to see the page specifically for that source.
+You will see all of the messages that they have written and documents
+that they have uploaded. If the name of a source is difficult to say
+or remember, you can rename a source using the button next to their
+current codename:
 
 |Cycle source codename|
 
-Documents and messages are encrypted to the application's GPG public 
-key. In order to read the messages or look at the documents you 
+Documents and messages are encrypted to the application's GPG public
+key. In order to read the messages or look at the documents you
 will need to transfer them to the *Secure Viewing Station*.
 
-But first, if you'd like to reply to the source, write your message 
+But first, if you'd like to reply to the source, write your message
 in the text field and click ``Submit``.
 
 |Sent reply|
@@ -197,11 +197,11 @@ time you reboot the malware will be gone.
 
 Tails comes with lots of applications that will help you securely work
 with documents, including `The Tor Browser Bundle <https://www.torproject.org/>`__
-, an office suite, graphics tools, desktop publishing tools, audio 
-tools, and printing and scanning tools. Journalists should take care 
-to research submissions using the Tor Browser, ideally in a new 
-Tails session for highly sensitive submissions. For more information, 
-visit `Work on sensitive 
+, an office suite, graphics tools, desktop publishing tools, audio
+tools, and printing and scanning tools. Journalists should take care
+to research submissions using the Tor Browser, ideally in a new
+Tails session for highly sensitive submissions. For more information,
+visit `Work on sensitive
 documents <https://tails.boum.org/doc/sensitive_documents/index.en.html>`__
 on the Tails website.
 
@@ -255,6 +255,10 @@ encrypted documents to it. Decrypt them with ``gnupg``.
 
 Write articles and blog posts, edit video and audio, and publish. Expose
 crimes and corruption, and change the world.
+
+.. tip:: Check out our SecureDrop
+          :doc:`Promotion Guide <getting_the_most_out_of_securedrop>`
+          to read more about how to encourage sources to use SecureDrop.
 
 .. |Journalist Interface Login| image:: images/manual/document6.png
 .. |Journalist Interface| image:: images/manual/document1.png

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -7,6 +7,10 @@ anonymous sources. It was originally created by the late Aaron Swartz and is
 currently managed by `Freedom of the Press Foundation
 <https://freedom.press>`__.
 
+.. tip:: Check out
+          :doc:`What makes SecureDrop Unique <what_makes_securedrop_unique>`
+          to read more about SecureDrop's approach to keeping sources safe.
+
 Technical Summary
 -----------------
 

--- a/docs/what_makes_securedrop_unique.rst
+++ b/docs/what_makes_securedrop_unique.rst
@@ -1,0 +1,105 @@
+What Makes SecureDrop Unique
+============================
+
+SecureDrop attempts to solve or mitigate several problems journalists and sources
+have faced in recent legal investigations, attacks from state actors, and other
+threats to the confidentiality of communications.
+
+No third parties that can secretly be subpoenaed
+------------------------------------------------
+
+For decades, there were very few leak prosecutions in the United States in large
+part because the government would have to subpoena reporters to testify against
+a source to get a conviction. That proved incredibly difficult, if not impossible,
+when reporters regularly refused to testify and threatened to go to jail rather
+than betray a source.
+
+More recently, there have been a record number of leak prosecutions largely because
+the government has learned they don’t need reporters to testify against their
+sources anymore. Instead, they can just secretly subpoena third party services
+like Google or AT&T or Verizon or Facebook and get a treasure trove of digital
+information on reporters and sources’ communications. For example, the Associated
+Press had twenty of their phone lines subpoenaed without their knowledge in order
+to identify a source. The government also got a warrant for Fox News reporter James
+Rosen’s Gmail account without him knowing. In both cases, their alleged sources
+were prosecuted, even though journalists never directly divulged their sources.
+
+SecureDrop completely eliminates third parties from the equation and puts the
+power to challenge such cases back in the hands of reporters. The journalist and
+source communicate exclusively through one server that the news organization owns
+and sits on their property, so any legal order for information must go directly
+to the news organization rather than Google or AT&T. The news organization again
+has the power to contest the order or refuse to comply if they so wish.
+
+Limits the metadata trail as much as possible
+---------------------------------------------
+
+In many leak cases, the metadata of a journalist's communications—where you’re
+located, who you’re talking to, when you’re talking to them, and how often—can
+lead to trouble just as much as the actual content of your conversations.
+
+With SecureDrop, even if a government serves a court order directly to a news
+organization to compel the disclosure of information, SecureDrop logs much less
+information than email providers or phone companies do.
+
+The source can only log into SecureDrop through the Tor Browser, which masks the
+source’s IP address to begin with, so there is no indication who the source is
+(unless they disclose it) and where they are sending information from. The Tor IP
+address, the computer and the browser type that the source is using is not logged
+either.
+
+For each source, only the time and date of each submission is logged on the
+server. When a source sends a new message the time and date of the last message
+is overwritten. This means that there won’t be a trail of metadata showing
+exactly when the source and journalist were talking.
+
+In addition, sources cannot create a custom username that could reveal information
+about them. Instead, SecureDrop automatically generates two random codenames, one
+to show to the source and another to the journalists using the system.
+
+Encrypted and air-gapped
+------------------------
+
+Communications through SecureDrop are both encrypted in transit, so messages cannot
+be easily intercepted and read while they are traversing the internet and are also
+encrypted on the server so if any attacker manages to break into the server, they
+would not be able to read past messages.
+
+In addition, the decryption key for SecureDrop submissions sits on an air-gapped
+computer (not connected to the Internet). This air-gapped computer is the only
+place SecureDrop submissions are decrypted and read so that they are much harder
+for an attacker to access.
+
+Protecting against hackers
+--------------------------
+
+A 2014 study showed that 20 of the top 25 news organization had, at one time or
+another, had their networks compromised by state sponsored hackers.
+
+Because of this threat, SecureDrop completely segments its traffic from a news
+organization’s normal network. Submissions are accessed and downloaded using the
+Tails operating system, which boots off of a USB, does not touch your computer’s
+hard drive, and routes all its internet traffic through Tor.
+
+Submissions are decrypted on an air-gapped computer also using Tails. This
+mitigates against the risk that an attacker could send malware through SecureDrop
+in an attempt to infect the news organization’s normal network as well.
+
+The SecureDrop servers also undergo significant system hardening in order to
+make it as difficult as possible for hackers to break in.
+
+So SecureDrop protects sources against networks that are already compromised and
+also protects a news organization’s normal network from attacks that could
+potentially come through SecureDrop.
+
+Free and open source software
+-----------------------------
+
+100% of SecureDrop’s code is free and open source. Not only does this mean anyone
+can install SecureDrop themselves, but the code is available online for security
+experts to test for vulnerabilities.
+
+SecureDrop has gone through at least four audits by third party penetration
+testing firms and will continue to go through audits when major changes are made
+to the code base in the future. We always publish these audits publicly so everyone
+can be assured that SecureDrop is as safe to use as possible.

--- a/docs/what_makes_securedrop_unique.rst
+++ b/docs/what_makes_securedrop_unique.rst
@@ -38,18 +38,18 @@ In many leak cases, the metadata of a journalist's communications—where you’
 located, who you’re talking to, when you’re talking to them, and how often—can
 lead to trouble just as much as the actual content of your conversations.
 
-With SecureDrop, even if a government serves a court order directly to a news
-organization to compel the disclosure of information, SecureDrop logs much less
-information than email providers or phone companies do.
+Even if a government serves a court order directly to a news organization to
+compel the disclosure of information, SecureDrop logs much less information than
+email providers or phone companies do.
 
 The source can only log into SecureDrop through the Tor Browser, which masks the
 source’s IP address to begin with, so there is no indication who the source is
 (unless they disclose it) and where they are sending information from. The Tor IP
-address, the computer and the browser type that the source is using is not logged
+address, the computer, and the browser type that the source is using is not logged
 either.
 
 For each source, only the time and date of each submission is logged on the
-server. When a source sends a new message the time and date of the last message
+server. When a source sends a new message, the time and date of the last message
 is overwritten. This means that there won’t be a trail of metadata showing
 exactly when the source and journalist were talking.
 
@@ -61,7 +61,7 @@ Encrypted and air-gapped
 ------------------------
 
 Communications through SecureDrop are both encrypted in transit, so messages cannot
-be easily intercepted and read while they are traversing the internet and are also
+be easily intercepted and read while they are traversing the Internet and are also
 encrypted on the server so if any attacker manages to break into the server, they
 would not be able to read past messages.
 
@@ -74,12 +74,12 @@ Protecting against hackers
 --------------------------
 
 A 2014 study showed that 20 of the top 25 news organization had, at one time or
-another, had their networks compromised by state sponsored hackers.
+another, their networks compromised by state sponsored hackers.
 
 Because of this threat, SecureDrop completely segments its traffic from a news
 organization’s normal network. Submissions are accessed and downloaded using the
 Tails operating system, which boots off of a USB, does not touch your computer’s
-hard drive, and routes all its internet traffic through Tor.
+hard drive, and routes all its Internet traffic through Tor.
 
 Submissions are decrypted on an air-gapped computer also using Tails. This
 mitigates against the risk that an attacker could send malware through SecureDrop
@@ -88,9 +88,11 @@ in an attempt to infect the news organization’s normal network as well.
 The SecureDrop servers also undergo significant system hardening in order to
 make it as difficult as possible for hackers to break in.
 
-So SecureDrop protects sources against networks that are already compromised and
-also protects a news organization’s normal network from attacks that could
-potentially come through SecureDrop.
+The SecureDrop servers also undergo significant system hardening in order to make
+it as difficult as possible for hackers to break in. By doing so, SecureDrop
+protects sources against networks that are already compromised, as well as a news
+organization’s normal network from attacks that could potentially come through
+SecureDrop.
 
 Free and open source software
 -----------------------------
@@ -99,7 +101,7 @@ Free and open source software
 can install SecureDrop themselves, but the code is available online for security
 experts to test for vulnerabilities.
 
-SecureDrop has gone through at least four audits by third party penetration
-testing firms and will continue to go through audits when major changes are made
-to the code base in the future. We always publish these audits publicly so everyone
-can be assured that SecureDrop is as safe to use as possible.
+SecureDrop has gone through four audits by third party penetration testing firms
+and will continue to go through audits when major changes are made to the code
+base in the future. We always publish these audits publicly so everyone can be
+assured that SecureDrop is as safe to use as possible.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds the "What Makes SecureDrop Unique" guide written by @trevortimm during last week's docs sprint. Closes #469. This is also the kind of information we should be adding to update securedrop.org's FAQ.

## Testing

Double check any spelling/grammar/typesetting issues. @conorsch and I have both reviewed the content, but feel free to make any comments.

## Checklist

- [x] Docs linting passes locally
