### PR TITLE
Remove port forwarding for the web applications in staging

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,8 +69,6 @@ Vagrant.configure("2") do |config|
     staging.vm.hostname = "app-staging"
     staging.vm.box = "bento/ubuntu-14.04"
     staging.vm.network "private_network", ip: "10.0.1.2", virtualbox__intnet: internal_network_name
-    staging.vm.network "forwarded_port", guest: 80, host: 8082, auto_correct: true
-    staging.vm.network "forwarded_port", guest: 8080, host: 8083, auto_correct: true
     staging.vm.synced_folder './', '/vagrant', disabled: true
     staging.vm.provider "virtualbox" do |v|
       v.memory = 1024

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -45,8 +45,8 @@ they are configured to detect code changes and automatically reload whenever a
 file is saved. They are made available on your host machine by forwarding the
 following ports:
 
-* Source Interface: ``localhost:8080``
-* Journalist Interface: ``localhost::8081``
+* Source Interface: `localhost:8080 <http://localhost:8080>`__
+* Journalist Interface: `localhost:8081 <http://localhost:8081>`__
 
 Staging
 -------

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -1,81 +1,19 @@
 Virtual Environments
 ====================
 
+There are three predefined virtual environments in the Vagrantfile:
+
+1. Development
+2. Staging
+3. Production
+
+This document explains the purpose of, and how to get started working with, each
+one.
+
 .. note:: If you have errors with mounting shared folders in the Vagrant guest
           machine, you should look at `GitHub #1381`_.
 
 .. _`GitHub #1381`: https://github.com/freedomofpress/securedrop/issues/1381
-
-Overview
---------
-
-There are several predefined virtual environments in the Vagrantfile:
-development, staging, and prod (production).
-
-development
-    For working on the application code. Forwarded ports:
-
-    -  Source Interface: localhost:8080
-    -  Journalist Interface: localhost:8081
-
-app-staging
-    For working on the application code in a more realistic environment,
-    with most system hardening active.
-    The interfaces and SSH are also available over Tor.
-    A copy of the the Onion URLs for Source and Journalist Interfaces,
-    as well as SSH access, are written to the Vagrant host's
-    ``install_files/ansible-base`` directory, named:
-
-    - ``app-source-ths``
-    - ``app-journalist-aths``
-    - ``app-ssh-aths``
-
-    Forwarded ports:
-
-    -  Source Interface: localhost:8082
-    -  Journalist Interface: localhost:8083
-
-mon-staging
-    For working on OSSEC monitoring rules, with most system hardening active.
-    OSSEC alert configuration is in
-    ``install_files/ansible-base/staging-specific.yml``.
-    A copy of the the Onion URL for SSH acces is written to the Vagrant host's
-    ``install_files/ansible-base`` directory, named:
-
-    - ``mon-ssh-aths``
-
-    Direct SSH access is still available via Vagrant for staging hosts, so you
-    can use ``vagrant ssh app-staging`` and ``vagrant ssh mon-staging``
-    to start an interactive session.
-
-app-prod
-    This is like a production installation with all of the system
-    hardening active, but virtualized, rather than running on hardware.
-    A copy of the the Onion URLs for Source and Journalist Interfaces,
-    as well as SSH access, are written to the Vagrant host's
-    ``install_files/ansible-base`` directory, named:
-
-    - ``app-source-ths``
-    - ``app-journalist-aths``
-    - ``app-ssh-aths``
-
-    There are no active forwarded ports for the Journalist and Source Interfaces
-    on ``app-prod``. You must use the Onion URLs to view the pages over Tor.
-
-mon-prod
-    This is like a production installation with all of the system
-    hardening active, but virtualized, rather than running on hardware.
-    You will need to configure prod-like secrets in
-    ``install_files/ansible-base/group_vars/all/site-specific``, or export
-    ``ANSIBLE_ARGS=="--skip-tags validate"`` to skip the tasks
-    that prevent the prod playbook from running with Vagrant-specific info.
-
-    Direct SSH access is not available in the prod environment.
-    You will need to log in over Tor after initial provisioning. See
-    :ref:`ssh_over_tor` for more info.
-
-If you plan to alter the configuration of any of these machines, make sure to
-review the :ref:`config_tests` documentation.
 
 Development
 -----------
@@ -85,9 +23,11 @@ syncs the top level of the SecureDrop repo to the ``/vagrant`` directory on the
 VM, which means you can use your favorite editor on your host machine to edit
 the code. This machine has no security hardening or monitoring.
 
-This is the default VM, so you don't need to specify the ``development``
-machine name when running commands like ``vagrant up`` and ``vagrant ssh``. Of
-course, you can specify the name if you want to.
+.. tip:: This is the default VM, so you don't need to specify the
+   ``development`` machine name when running commands like ``vagrant up`` and
+   ``vagrant ssh``. Of course, you can specify the name if you want to.
+
+To get started working with the development environment:
 
 .. code:: sh
 
@@ -100,22 +40,28 @@ course, you can specify the name if you want to.
    pytest -v tests/        # run the unit and functional tests
 
 SecureDrop consists of two separate web applications (the Source Interface and
-the Journalist Interface) that run concurrently. The development servers will
-detect code changes when they are saved and automatically reload.
+the Journalist Interface) that run concurrently. In the Development environment
+they are configured to detect code changes and automatically reload whenever a
+file is saved. They are made available on your host machine by forwarding the
+following ports:
+
+* Source Interface: ``localhost:8080``
+* Journalist Interface: ``localhost::8081``
 
 Staging
 -------
 
-The staging environment is almost identical to the production, but the security
-hardening is weakened slightly to allow direct access (without Tor) to SSH and
-the web server. This is a convenient environment to test how changes work
-across the full stack.
+A compromise between the development and production environments. This
+configuration can be thought of as identical to the production enviornment, with
+a few exceptions:
 
-.. todo:: Explain why we allow direct access on the staging environment
+* The Debian packages are built from your local copy of the code, instead of
+  installing the current stable release packages from https://apt.freedom.press.
+* The production environment only allows SSH over an Authenticated Tor Hidden
+  Service (ATHS), but the staging environment allows direct SSH access so it's
+  more ergonomic for developers to interact with the system during debugging.
 
-If you want to receive OSSEC alerts or change any other settings, you will need
-to fill out your local copy of
-``./install_files/ansible-base/staging-specific.yml``.
+This is a convenient environment to test how changes work across the full stack.
 
 You should first bring up the VM required for building the app code
 Debian packages on the staging machines:
@@ -179,16 +125,36 @@ local git repository and then installed on the staging servers.
           This will increase the maximum open file limits system wide on Mac
           OS X (last tested on 10.11.6).
 
-Prod
-----
+The web interfaces and SSH are available over Tor. A copy of the the Onion URLs
+for Source and Journalist Interfaces, as well as SSH access, are written to the
+Vagrant host's ``install_files/ansible-base`` directory, named:
 
-You will need to fill out the production configuration file at
-``install_files/ansible-base/group_vars/all/site-specific`` with custom secrets.
-The production playbook validates that staging values are not used in
-production. One of the values it verifies is that the user Ansible runs as is
-not ``vagrant`` To be able to run this playbook in a virtualized environment
-for testing, you will need to disable the ``validate`` role, which you can do
-by running ``export ANSIBLE_ARGS="--skip-tags validate"`` before provisioning.
+* ``app-source-ths``
+* ``app-journalist-aths``
+* ``app-ssh-aths``
+
+For working on OSSEC monitoring rules with most system hardening active, update
+the OSSEC-related configuration in
+``install_files/ansible-base/staging-specific.yml`` so you receive the OSSEC
+alert emails.
+
+A copy of the the Onion URL for SSH access to the *Monitor Server* is written to
+the Vagrant host's ``install_files/ansible-base`` directory, named:
+
+* ``mon-ssh-aths``
+
+Direct SSH access is available via Vagrant for staging hosts, so you can use
+``vagrant ssh app-staging`` and ``vagrant ssh mon-staging`` to start an
+interactive session on either server.
+
+Production
+----------
+
+This is a production installation with all of the system hardening active, but
+virtualized, rather than running on hardware. You will need to
+:ref:`configure prod-like secrets<configure_securedrop>`, or export
+``ANSIBLE_ARGS=="--skip-tags validate"`` to skip the tasks that prevent the prod
+playbook from running with Vagrant-specific info.
 
 To create only the prod servers, run:
 
@@ -200,6 +166,17 @@ To create only the prod servers, run:
    cd /var/www/securedrop/
    ./manage.py add-admin
 
-In order to access the servers after the install is completed you will need to
-install and configure a proxy tool to
-:ref:`proxy your SSH connection over Tor<ssh_over_tor>`.
+A copy of the the Onion URLs for Source and Journalist Interfaces, as well as
+SSH access, are written to the Vagrant host's ``install_files/ansible-base``
+directory, named:
+
+* ``app-source-ths``
+* ``app-journalist-aths``
+* ``app-ssh-aths``
+* ``mon-ssh-aths``
+
+Direct SSH access is not available in the prod environment. You will need to log
+in over Tor after initial provisioning. See :ref:`ssh_over_tor` for more info.
+
+If you plan to alter the configuration of any of these machines, make sure to
+review the :ref:`config_tests` documentation.

--- a/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
@@ -101,10 +101,6 @@
 -A OUTPUT -o {{ ansible_default_ipv4.interface }}  -p tcp -m owner --uid-owner root --sport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
 -A OUTPUT -p udp --dport 53 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
 -A INPUT -p udp --sport 53 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
--A INPUT -i {{ ansible_default_ipv4.interface }} -p tcp --dport 80 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
--A OUTPUT -o {{ ansible_default_ipv4.interface }} -p tcp --sport 80 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
--A INPUT -i {{ ansible_default_ipv4.interface }} -p tcp --dport 8080 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
--A OUTPUT -o {{ ansible_default_ipv4.interface }} -p tcp --sport 8080 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
 
 {% elif 'securedrop_monitor_server' in group_names %}
 -A INPUT -i {{ ansible_default_ipv4.interface }} -p tcp --dport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT

--- a/testinfra/app/iptables-app-staging.j2
+++ b/testinfra/app/iptables-app-staging.j2
@@ -14,8 +14,6 @@
 -A INPUT -s {{ mon_ip }}/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
 -A INPUT -i eth0 -p tcp -m tcp --dport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -p udp -m udp --sport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
--A INPUT -i eth0 -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
--A INPUT -i eth0 -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -i lo -m comment --comment "Allow lo to lo traffic all protocols" -j ACCEPT
 -A INPUT -p tcp -m state --state INVALID -m comment --comment "drop but do not log inbound invalid state packets" -j DROP
 -A INPUT -m comment --comment "Drop and log all other incoming traffic" -j LOGNDROP
@@ -36,8 +34,6 @@
 -A OUTPUT -d {{ mon_ip }}/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
 -A OUTPUT -o eth0 -p tcp -m owner --uid-owner 0 -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
 -A OUTPUT -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
--A OUTPUT -o eth0 -p tcp -m tcp --sport 80 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
--A OUTPUT -o eth0 -p tcp -m tcp --sport 8080 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
 -A OUTPUT -o lo -m comment --comment "Allow lo to lo traffic all protocols" -j ACCEPT
 -A OUTPUT -m comment --comment "Drop all other outgoing traffic" -j DROP
 -A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-tcp-options --log-ip-options --log-uid


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #1764.

In addition to updating the documentation to be accurate in regards to removing the port forwarding, this PR also substantially reworks the "Virtual Environments" page of the documentation, reducing redundancy between sections and generally making it easier to read and navigate.

## Testing

Should be straightfoward. If I missed any references in the documentation to port forwarding the web applications in staging, let me know! I did a Project-wide Find for a couple of relevant terms and think I got everything, but may have missed a few spots...

## Deployment

No deployment considerations because this only affects the staging environment and developer documentation.

## Checklist

### If you made changes to the system configuration:

- [ ] Testinfra tests pass on the app-staging VM

@conorsch @msheiny I fixed the obvious test breakage by updating the expected output from iptables on app-staging. However, `test_apache_logging_journalist_interface` is failing because it expects to be able to `curl http://127.0.0.1:8080` to trigger some logging on the journalist interface. There are a couple of problems with this:

* How did this test ever pass for app-staging? `8080` was never being forwarded in the staging environment. If this test was ever passing, it raises concerns about its reliability.
* After this PR, you won't be able to `curl` any of the web interfaces on app-staging, so you'll have to figure out another way to get this test working.

[Output](https://gist.github.com/garrettr/2461c60f3a2699790a7ca09d63929b41) of `./testinfra/test.py app-staging` showing 1 remaining test failure to resolve.