### PR TITLE
Fix flashed messages

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -146,6 +146,17 @@ Vagrant.configure("2") do |config|
         'securedrop:children' => %w(development),
       }
     end
+
+    # TODO: For some reason, the build VM is defaulting to using 1GB of RAM.
+    # It does not need this much RAM, and the staging environment has been
+    # causing issues (hangs and crashes) on developer machines that have <= 8GB
+    # RAM, so hopefully setting this to a smaller value will help with that
+    # issue. We should look into why this is being automatically allocated 1GB
+    # of RAM instead of the expected 512MB default.
+    build.vm.provider "virtualbox" do |v|
+      v.memory = 512
+    end
+
     build.vm.provider "libvirt" do |lv, override|
       override.vm.synced_folder './', '/vagrant', type: 'nfs', disabled: false
     end

--- a/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
@@ -1,18 +1,27 @@
 ServerName {{ apache_listening_address | default('127.0.0.1') }}
 <VirtualHost {{ apache_listening_address | default('127.0.0.1') }}:8080>
 
-DocumentRoot /var/www/securedrop/static
-Alias /static /var/www/securedrop/static
 WSGIDaemonProcess journalist processes=2 threads=30 display-name=%{GROUP} python-path=/var/www/securedrop
 WSGIProcessGroup journalist
-WSGIScriptAlias / /var/www/journalist.wsgi/
-AddType text/html .py
+WSGIScriptAlias / /var/www/journalist.wsgi
+
+# Tell the browser not to cache HTML responses in order to minimize the chance
+# of the inadvertent release or retention of sensitive data. For more, see
+# https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.2.
+Header set Cache-Control "no-store"
+
+Alias /static /var/www/securedrop/static
+<Directory /var/www/securedrop/static>
+  Order allow,deny
+  Allow from all
+  # Cache static resources for 1 hour
+  Header set Cache-Control "max-age=3600"
+</Directory>
 
 XSendFile        On
 XSendFilePath    /var/lib/securedrop/store/
 XSendFilePath    /var/lib/securedrop/tmp/
 
-Header set Cache-Control "max-age=1800"
 Header edit Set-Cookie ^(.*)$ $1;HttpOnly
 Header always append X-Frame-Options: DENY
 Header set X-XSS-Protection: "1; mode=block"

--- a/install_files/ansible-base/roles/app/templates/sites-available/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/source.conf
@@ -1,16 +1,25 @@
 ServerName {{ apache_listening_address | default('127.0.0.1') }}
 <VirtualHost {{ apache_listening_address | default('127.0.0.1') }}:80>
 
-DocumentRoot /var/www/securedrop/static
-Alias /static /var/www/securedrop/static
 WSGIDaemonProcess source  processes=2 threads=30 display-name=%{GROUP} python-path=/var/www/securedrop
 WSGIProcessGroup source
-WSGIScriptAlias / /var/www/source.wsgi/
-AddType text/html .py
+WSGIScriptAlias / /var/www/source.wsgi
+
+# Tell the browser not to cache HTML responses in order to minimize the chance
+# of the inadvertent release or retention of sensitive data. For more, see
+# https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.2.
+Header set Cache-Control "no-store"
+
+Alias /static /var/www/securedrop/static
+<Directory /var/www/securedrop/static>
+  Order allow,deny
+  Allow from all
+  # Cache static resources for 1 hour
+  Header set Cache-Control "max-age=3600"
+</Directory>
 
 XSendFile        Off
 
-Header set Cache-Control "max-age=1800, must-revalidate"
 Header edit Set-Cookie ^(.*)$ $1;HttpOnly
 Header always append X-Frame-Options: DENY
 Header set X-XSS-Protection: "1; mode=block"

--- a/testinfra/app/apache/test_apache_journalist_interface.py
+++ b/testinfra/app/apache/test_apache_journalist_interface.py
@@ -84,14 +84,20 @@ common_apache2_directory_declarations = """
 
 # declare journalist-specific apache configs
 @pytest.mark.parametrize("apache_opt", [
-  'Header set Cache-Control "max-age=1800"',
   "<VirtualHost {}:8080>".format(securedrop_test_vars['apache_listening_address']),
-  "DocumentRoot {}/static".format(securedrop_test_vars['securedrop_code']),
-  "Alias /static {}/static".format(securedrop_test_vars['securedrop_code']),
-  "WSGIDaemonProcess journalist processes=2 threads=30 display-name=%{GROUP}"+" python-path={}".format(securedrop_test_vars['securedrop_code']),
+  "WSGIDaemonProcess journalist processes=2 threads=30 display-name=%{{GROUP}} python-path={}".format(securedrop_test_vars['securedrop_code']),
   'WSGIProcessGroup journalist',
-  'WSGIScriptAlias / /var/www/journalist.wsgi/',
-  'AddType text/html .py',
+  'WSGIScriptAlias / /var/www/journalist.wsgi',
+  'Header set Cache-Control "no-store"',
+  "Alias /static {}/static".format(securedrop_test_vars['securedrop_code']),
+  """
+<Directory {}/static>
+  Order allow,deny
+  Allow from all
+  # Cache static resources for 1 hour
+  Header set Cache-Control "max-age=3600"
+</Directory>
+""".strip('\n').format(securedrop_test_vars['securedrop_code']),
   'XSendFile        On',
   'LimitRequestBody 524288000',
   'XSendFilePath    /var/lib/securedrop/store/',


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1763.

* Only use `Cache-Control` on static assets; do not cache HTML in the browser
* Updates the testinfra tests to reflect the changes to the Apache configuration
* Add a stopgap to reduce the memory consumption of the build VM in the staging environment. The overall memory pressure of the staging environment has been causing lockups and crashes on developer machines with <= 8GB of RAM.

## Testing

How should the reviewer test this PR?

1. `vagrant provision /staging/ && vagrant reload /staging/`
2. For both the Source Interface and the Journalist Interface:
    1. Navigate the interface in the Tor Browser. Use the Network panel to confirm that HTML responses have `Cache-Control: "no-store"` while other response types have `Cache-Control: "max-age=3600".
    2. Confirm that flashed notifications are now working as expected (e.g. original STR from #1763).

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.

Since this is a modification to the Apache configuration, administrators of existing instances will need to re-run the updated Ansible playbooks to deploy this change.

Note that since #1763 was never deployed to production, this is not currently a bug in production. Production still works just fine, although the user experience is suboptimal because of the lack of caching (see #1152).

2. New installs.

No special considerations.

## Checklist

### If you made changes to the system configuration:

- [x] Testinfra tests pass on the app-staging VM
