### PR TITLE
Removes hardcoded Ansible version from dev docs

### DIFF
--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -72,8 +72,8 @@ you have the latest stable version.
 The version of Ansible recommended to provision SecureDrop VMs may not be the
 same as the version in your distro's repos, or may at some point flux out of
 sync. For this reason, and also just as a good general development practice, we
-recommend using a Python virtual environment to install version 1.8.4 of
-Ansible. Using `virtualenvwrapper
+recommend using a Python virtual environment to install Ansible and other
+development-related tooling. Using `virtualenvwrapper
 <http://virtualenvwrapper.readthedocs.io/en/stable/>`_:
 
 .. code:: sh


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Quick fix to the dev docs. 

We're now specifying the appropriate Python package versions in requirements files, located in securedrop/requirements/`. For developers, the correct file is `securedrop/requirements/develop-requirements.txt`. Therefore let's remove all mention of hardcoded versions, so that the requirements files
themselves are the canonical source of truth for the "correct" version.

## Testing

Read the text and make sure there are no typos or mistakes.

## Deployment

None whatsoever, these changes only affect the docs for the dev env.

## Checklist

Relying on manual review, plus of course docs linting via CI.