### PR TITLE
Fix deprecation warning on CsrfProtect

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -6,7 +6,7 @@ import functools
 
 from flask import (Flask, request, render_template, send_file, redirect, flash,
                    url_for, g, abort, session)
-from flask_wtf.csrf import CsrfProtect
+from flask_wtf.csrf import CSRFProtect
 from flask_assets import Environment
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.exc import IntegrityError
@@ -24,7 +24,7 @@ import worker
 
 app = Flask(__name__, template_folder=config.JOURNALIST_TEMPLATES_DIR)
 app.config.from_object(config.JournalistInterfaceFlaskConfig)
-CsrfProtect(app)
+CSRFProtect(app)
 
 assets = Environment(app)
 

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -8,7 +8,7 @@ from threading import Thread
 import operator
 from flask import (Flask, request, render_template, session, redirect, url_for,
                    flash, abort, g, send_file, Markup, make_response)
-from flask_wtf.csrf import CsrfProtect
+from flask_wtf.csrf import CSRFProtect
 from flask_assets import Environment
 
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
@@ -38,7 +38,7 @@ assets = Environment(app)
 # The default CSRF token expiration is 1 hour. Since large uploads can
 # take longer than an hour over Tor, we increase the valid window to 24h.
 app.config['WTF_CSRF_TIME_LIMIT'] = 60 * 60 * 24
-CsrfProtect(app)
+CSRFProtect(app)
 
 app.jinja_env.globals['version'] = version.__version__
 if getattr(config, 'CUSTOM_HEADER_IMAGE', None):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In lepture/flask-wtf#271, Flask renamed
CsrfProtect to CSRFProtect and added a deprecation warning.
This PR updates our Flask apps to use the new name
and thus remove the warning.

## Testing

How should the reviewer test this PR?
 * Run the source and journalist interface (or just run the tests) and verify you see no deprecation warnings re: CsrfProtect

## Deployment

No special considerations for deployment

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
