### PR TITLE
Crypto util coverage

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -22,7 +22,7 @@ if os.environ.get('SECUREDROP_ENV') == 'test':
     # use these settings in production)
     GPG_KEY_LENGTH = 1024
     SCRYPT_PARAMS = dict(N=2**1, r=1, p=1)
-else:
+else: # pragma: no cover
     GPG_KEY_LENGTH = 4096
     SCRYPT_PARAMS = config.SCRYPT_PARAMS
 
@@ -192,6 +192,6 @@ def decrypt(secret, ciphertext):
     hashed_codename = hash_codename(secret, salt=SCRYPT_GPG_PEPPER)
     return gpg.decrypt(ciphertext, passphrase=hashed_codename).data
 
-if __name__ == "__main__":
+if __name__ == "__main__": # pragma: no cover
     import doctest
     doctest.testmod()

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -5,9 +5,9 @@ import unittest
 os.environ['SECUREDROP_ENV'] = 'test'
 import config
 import crypto_util
+import db
 import store
 import utils
-
 
 class TestCryptoUtil(unittest.TestCase):
 
@@ -20,26 +20,160 @@ class TestCryptoUtil(unittest.TestCase):
         utils.env.teardown()
 
     def test_clean(self):
-        with self.assertRaises(crypto_util.CryptoException):
-            crypto_util.clean('foo bar`') # backtick is not currently allowed
-        with self.assertRaises(crypto_util.CryptoException):
-            crypto_util.clean('bar baz~') # tilde is not currently allowed
+        ok = (' !#%$&)(+*-1032547698;:=?@acbedgfihkjmlonqpsrutwvyxzABCDEFGHIJ'
+              'KLMNOPQRSTUVWXYZ')
+        invalid_1 = 'foo bar`'
+        invalid_2 = 'bar baz~'
+
+        self.assertEqual(ok, crypto_util.clean(ok))
+        with self.assertRaisesRegexp(crypto_util.CryptoException,
+                                   'invalid input: {}'.format(invalid_1)):
+            crypto_util.clean(invalid_1)
+        with self.assertRaisesRegexp(crypto_util.CryptoException,
+                                   'invalid input: {}'.format(invalid_2)):
+            crypto_util.clean(invalid_2)
 
     def test_encrypt_success(self):
         source, _ = utils.db_helper.init_source()
-        encrypted = crypto_util.encrypt(str(os.urandom(1)),
-                                        [
-                                            crypto_util.getkey(source.filesystem_id),
-                                            config.JOURNALIST_KEY
-                                        ],
-                                        store.path(source.filesystem_id, 'somefile.gpg'))
-        self.assertGreater(len(encrypted), 0)
+        message = str(os.urandom(1))
+        ciphertext = crypto_util.encrypt(
+            message,
+            [crypto_util.getkey(source.filesystem_id), config.JOURNALIST_KEY],
+            store.path(source.filesystem_id, 'somefile.gpg'))
+
+        self.assertIsInstance(ciphertext, str)
+        self.assertNotEqual(ciphertext, message)
+        self.assertGreater(len(ciphertext), 0)
 
     def test_encrypt_failure(self):
         source, _ = utils.db_helper.init_source()
         with self.assertRaisesRegexp(crypto_util.CryptoException,
                                      'no terminal at all requested'):
-            encrypted = crypto_util.encrypt(str(os.urandom(1)),
-                                            [
-                                            ],
-                                            store.path(source.filesystem_id, 'other.gpg'))
+            crypto_util.encrypt(
+                str(os.urandom(1)),
+                [],
+                store.path(source.filesystem_id, 'other.gpg'))
+
+    def test_encrypt_without_output(self):
+        """We simply do not specify the option output keyword argument
+        to crypto_util.encrypt() here in order to confirm encryption
+        works when it defaults to `None`.
+        """
+        source, codename = utils.db_helper.init_source()
+        message = str(os.urandom(1))
+        ciphertext = crypto_util.encrypt(
+            message,
+            [crypto_util.getkey(source.filesystem_id), config.JOURNALIST_KEY])
+        plaintext = crypto_util.decrypt(codename, ciphertext)
+
+        self.assertEqual(message, plaintext)
+
+    def test_encrypt_binary_stream(self):
+        """Generally, we pass unicode strings (the type form data is
+        returned as) as plaintext to crypto_util.encrypt(). These have
+        to be converted to "binary stream" types (such as `file`) before
+        we can actually call gnupg.GPG.encrypt() on them. This is done
+        in crypto_util.encrypt() with an `if` branch that uses
+        `gnupg._util._is_stream(plaintext)` as the predicate, and calls
+        `gnupg._util._make_binary_stream(plaintext)` if necessary. This
+        test ensures our encrypt function works even if we provide
+        inputs such that this `if` branch is skipped (i.e., the object
+        passed for `plaintext` is one such that
+        `gnupg._util._is_stream(plaintext)` returns `True`).
+        """
+        source, codename = utils.db_helper.init_source()
+        with open(os.path.realpath(__file__)) as fh:
+            ciphertext = crypto_util.encrypt(
+                fh,
+                [crypto_util.getkey(source.filesystem_id),
+                 config.JOURNALIST_KEY],
+                store.path(source.filesystem_id, 'somefile.gpg'))
+        plaintext = crypto_util.decrypt(codename, ciphertext)
+
+        with open(os.path.realpath(__file__)) as fh:
+            self.assertEqual(fh.read(), plaintext)
+
+    def test_encrypt_fingerprints_not_a_list_or_tuple(self):
+        """If passed a single fingerprint as a string, encrypt should
+        correctly place that string in a list, and encryption/
+        decryption should work as intended."""
+        source, codename = utils.db_helper.init_source()
+        message = str(os.urandom(1))
+        ciphertext = crypto_util.encrypt(
+            message,
+            crypto_util.getkey(source.filesystem_id),
+            store.path(source.filesystem_id, 'somefile.gpg'))
+        plaintext = crypto_util.decrypt(codename, ciphertext)
+
+        self.assertEqual(message, plaintext)
+
+    def test_basic_encrypt_then_decrypt_multiple_recipients(self):
+        source, codename = utils.db_helper.init_source()
+        message = str(os.urandom(1))
+        ciphertext = crypto_util.encrypt(
+            message,
+            [crypto_util.getkey(source.filesystem_id),
+             config.JOURNALIST_KEY],
+            store.path(source.filesystem_id, 'somefile.gpg'))
+        plaintext = crypto_util.decrypt(codename, ciphertext)
+
+        self.assertEqual(message, plaintext)
+
+        # Since there's no way to specify which key to use for
+        # decryption to python-gnupg, we delete the `source`'s key and
+        # ensure we can decrypt with the `config.JOURNALIST_KEY`.
+        crypto_util.delete_reply_keypair(source.filesystem_id)
+        plaintext_ = crypto_util.gpg.decrypt(ciphertext).data
+
+        self.assertEqual(message, plaintext_)
+
+    def test_genrandomid(self):
+        id = crypto_util.genrandomid()
+        id_words = id.split()
+
+        self.assertEqual(id, crypto_util.clean(id))
+        self.assertEqual(len(id_words), crypto_util.DEFAULT_WORDS_IN_RANDOM_ID)
+        for word in id_words:
+            self.assertIn(word, crypto_util.words)
+
+    def test_display_id(self):
+        id = crypto_util.display_id()
+        id_words = id.split()
+
+        self.assertEqual(len(id_words), 2)
+        self.assertIn(id_words[0], crypto_util.adjectives)
+        self.assertIn(id_words[1], crypto_util.nouns)
+
+    def test_hash_codename(self):
+        codename = crypto_util.genrandomid()
+        hashed_codename = crypto_util.hash_codename(codename)
+
+        self.assertRegexpMatches(hashed_codename, '^[2-7A-Z]{103}=$')
+
+    def test_genkeypair(self):
+        codename = crypto_util.genrandomid()
+        filesystem_id = crypto_util.hash_codename(codename)
+        journalist_filename = crypto_util.display_id()
+        source = db.Source(filesystem_id, journalist_filename)
+        db.db_session.add(source)
+        db.db_session.commit()
+        crypto_util.genkeypair(source.filesystem_id, codename)
+
+        self.assertIsNotNone(crypto_util.getkey(filesystem_id))
+
+    def test_delete_reply_keypair(self):
+        source, _ = utils.db_helper.init_source()
+        crypto_util.delete_reply_keypair(source.filesystem_id)
+
+        self.assertIsNone(crypto_util.getkey(source.filesystem_id))
+
+    def test_delete_reply_keypair_no_key(self):
+        """No exceptions should be raised when provided a filesystem id that
+        does not exist.
+        """
+        crypto_util.delete_reply_keypair('Reality Winner')
+
+    def test_getkey(self):
+        source, _ = utils.db_helper.init_source()
+
+        self.assertIsNotNone(crypto_util.getkey(source.filesystem_id))


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

* This bumps coverage of crypo_util.py up to 100% overall, and 100% just via running the test_crypto_util.py module.
* Minor fixes to crypto_util. The only change that appears to be of any significance here is removing the `use_agent=True` keyword argument to the `gnupg.GPG()` initializer. This does not really change anything however, as python-gnupg now sets this option for us by default. The ticket linked in the comment this commit removes, isislovecruft/python-gnupg#96 , was resolved years ago, and I have confirmed the logging noise remains absent when it is not explicitly specified.

## Testing

Besides running the tests locally, you could also confirm the logging noise remains absent.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM