### PR TITLE
source: set Source.NUM_WORDS to 7

### DIFF
--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -86,6 +86,7 @@ class Source(Base):
     interaction_count = Column(Integer, default=0, nullable=False)
 
     # Don't create or bother checking excessively long codenames to prevent DoS
+    NUM_WORDS = 7
     MAX_CODENAME_LEN = 128
 
     def __init__(self, filesystem_id=None, journalist_designation=None):

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -128,13 +128,13 @@ def index():
                            'CUSTOM_NOTIFICATION', ''))
 
 
-def generate_unique_codename(num_words=7):
+def generate_unique_codename():
     """Generate random codenames until we get an unused one"""
     while True:
-        codename = crypto_util.genrandomid(num_words)
+        codename = crypto_util.genrandomid(Source.NUM_WORDS)
 
-        # The maximum length of a word in the wordlist is 6 letters and the
-        # maximum codename length is 10 words, so it is currently impossible to
+        # The maximum length of a word in the wordlist is 9 letters and the
+        # codename length is 7 words, so it is currently impossible to
         # generate a codename that is longer than the maximum codename length
         # (currently 128 characters). This code is meant to be defense in depth
         # to guard against potential future changes, such as modifications to

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -51,8 +51,7 @@ class TestSourceApp(TestCase):
             session_codename = session['codename']
         self.assertIn("This codename is what you will use in future visits", resp.data)
         codename = self._find_codename(resp.data)
-        # default codename length is 7 words
-        self.assertEqual(len(codename.split()), 7)
+        self.assertEqual(len(codename.split()), Source.NUM_WORDS)
         # codename is also stored in the session - make sure it matches the
         # codename displayed to the source
         self.assertEqual(codename, escape(session_codename))


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Instead of keeping the constant in generate_unique_codename
argument (which is never called with anything but the default), create a
NUM_WORDS constant (next to MAX_CODENAME_LEN). The two are related since
MAX_CODENAME_LEN is a safeguard that assumes a given number of words and
a given average word length.

Also modify the test that had the same constant accordingly.