### PR TITLE
source,journalist: pidfiles are not used anymore

### DIFF
--- a/securedrop/config.py.example
+++ b/securedrop/config.py.example
@@ -28,8 +28,6 @@ WORD_LIST = os.path.join(SECUREDROP_ROOT, 'wordlist')
 NOUNS = os.path.join(SECUREDROP_ROOT, 'dictionaries/nouns.txt')
 ADJECTIVES = os.path.join(SECUREDROP_ROOT, './dictionaries/adjectives.txt')
 
-JOURNALIST_PIDFILE = "/tmp/journalist.pid"
-SOURCE_PIDFILE = "/tmp/source.pid"
 WORKER_PIDFILE = "/tmp/securedrop_worker.pid"
 
 # "head -c 32 /dev/urandom | base64" for constructing public ID from source codename

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -738,13 +738,6 @@ def flag():
                            codename=g.source.journalist_designation)
 
 
-def write_pidfile():
-    pid = str(os.getpid())
-    with open(config.JOURNALIST_PIDFILE, 'w') as fp:
-        fp.write(pid)
-
-
 if __name__ == "__main__":  # pragma: no cover
-    write_pidfile()
     debug = getattr(config, 'env', 'prod') != 'prod'
     app.run(debug=debug, host='0.0.0.0', port=8081)

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -444,13 +444,6 @@ def internal_error(error):
     return render_template('error.html'), 500
 
 
-def write_pidfile():
-    pid = str(os.getpid())
-    with open(config.SOURCE_PIDFILE, 'w') as fp:
-        fp.write(pid)
-
-
 if __name__ == "__main__":  # pragma: no cover
-    write_pidfile()
     debug = getattr(config, 'env', 'prod') != 'prod'
     app.run(debug=debug, host='0.0.0.0', port=8080)

--- a/testinfra/app/test_appenv.py
+++ b/testinfra/app/test_appenv.py
@@ -21,6 +21,11 @@ def test_app_wsgi(File, Sudo):
         assert f.contains("^import logging$")
         assert f.contains("^logging\.basicConfig(stream=sys\.stderr)$")
 
+def test_pidfile(File):
+    """ ensure there are no pid files """
+    assert not File('/tmp/journalist.pid').exists
+    assert not File('/tmp/source.pid').exists
+
 @pytest.mark.parametrize('app_dir', sdvars.app_directories)
 def test_app_directories(File, Sudo, app_dir):
     """ ensure securedrop app directories exist with correct permissions """


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

Remove the dead code and verify the pid files are not created.

## Testing

In addition to running config tests ( testinfra/app/test_appenv.py ),  the journalist and source app should be run from the development environment to verify they start and manually check there is no /tmp/*.pid file.

## Deployment

1. Upgrading existing production instances: the existing `{SOURCE,JOURNALIST}_PID` variables in config.py remain and are a noop.
2. New installs: the config.py copied over from config.py.example does not have `{SOURCE,JOURNALIST}_PID` but the installation procedure is otherwise unchanged since it does not mention these variables.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
