### PR TITLE
Fix usage of shutil.rmtree()

### DIFF
--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -45,11 +45,9 @@ def reset(): # pragma: no cover
         pass
     else:
         for source_dir in os.listdir(config.STORE_DIR):
-            try:
-                # Each entry in STORE_DIR is a directory corresponding to a source
-                shutil.rmtree(os.path.join(config.STORE_DIR, source_dir))
-            except OSError as exc:
-                pass
+            # Each entry in STORE_DIR is a directory corresponding to a source
+            shutil.rmtree(os.path.join(config.STORE_DIR, source_dir),
+                          ignore_errors=True)
     return 0
 
 

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -54,7 +54,4 @@ def _get_pid_from_file(pid_file_name):
 def _cleanup_test_securedrop_dataroot(config):
     # Keyboard interrupts or dropping to pdb after a test failure sometimes
     # result in the temporary test SecureDrop data root not being deleted.
-    try:
-        shutil.rmtree(config.SECUREDROP_DATA_ROOT)
-    except OSError:
-        pass
+    shutil.rmtree(config.SECUREDROP_DATA_ROOT, ignore_errors=True)

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -261,28 +261,28 @@ class TestIntegration(unittest.TestCase):
         # to use it to test whether a message is decryptable with a specific
         # key.
         gpg_tmp_dir = tempfile.mkdtemp()
-        gpg = gnupg.GPG(homedir=gpg_tmp_dir)
+        try:
+            gpg = gnupg.GPG(homedir=gpg_tmp_dir)
 
-        # Export the key of interest from the application's keyring
-        pubkey = self.gpg.export_keys(key_fpr)
-        seckey = self.gpg.export_keys(key_fpr, secret=True)
-        # Import it into our isolated temporary GPG directory
-        for key in (pubkey, seckey):
-            gpg.import_keys(key)
+            # Export the key of interest from the application's keyring
+            pubkey = self.gpg.export_keys(key_fpr)
+            seckey = self.gpg.export_keys(key_fpr, secret=True)
+            # Import it into our isolated temporary GPG directory
+            for key in (pubkey, seckey):
+                gpg.import_keys(key)
 
-        # Attempt decryption with the given key
-        if passphrase:
-            passphrase = crypto_util.hash_codename(
-                passphrase,
-                salt=crypto_util.SCRYPT_GPG_PEPPER)
-        decrypted_data = gpg.decrypt(msg, passphrase=passphrase)
-        self.assertTrue(
-            decrypted_data.ok,
-            "Could not decrypt msg with key, gpg says: {}".format(
-                decrypted_data.stderr))
-
-        # We have to clean up the temporary GPG dir
-        shutil.rmtree(gpg_tmp_dir)
+            # Attempt decryption with the given key
+            if passphrase:
+                passphrase = crypto_util.hash_codename(
+                    passphrase,
+                    salt=crypto_util.SCRYPT_GPG_PEPPER)
+            decrypted_data = gpg.decrypt(msg, passphrase=passphrase)
+            self.assertTrue(
+                decrypted_data.ok,
+                "Could not decrypt msg with key, gpg says: {}".format(
+                    decrypted_data.stderr))
+        finally:
+            shutil.rmtree(gpg_tmp_dir, ignore_errors=True)
 
     def helper_test_reply(self, test_reply, expected_success=True):
         test_msg = "This is a test message."

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -60,8 +60,4 @@ def setup():
 
 def teardown():
     db_session.remove()
-    try:
-        shutil.rmtree(config.SECUREDROP_DATA_ROOT)
-    except OSError as exc:
-        if 'No such file or directory' not in exc:
-            raise
+    shutil.rmtree(config.SECUREDROP_DATA_ROOT, ignore_errors=True)


### PR DESCRIPTION
## Status

Ready for review.

## Description

* Use of the `ignore_errors` keyword argument simpler than manually catching :exc:`OSError`s and letting them `pass`.
* Fixes intermittent errors cause by racing teardown scripts (e.g., https://travis-ci.org/freedomofpress/securedrop/builds/243419555#L870).
* Ensures that `shutil.rmtree()` is always run in the `_can_decrypt_with_key` helper function in the `test_integration.py` module.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM