### PR TITLE
Explicitly select bs4 HTML parser

### DIFF
--- a/securedrop/requirements/test-requirements.in
+++ b/securedrop/requirements/test-requirements.in
@@ -2,6 +2,7 @@ beautifulsoup4
 blinker
 coveralls
 Flask-Testing
+html5lib
 mock
 pip-tools
 py

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -16,18 +16,20 @@ first==2.0.1              # via pip-tools
 flask-testing==0.6.2
 flask==0.12.2             # via flask-testing
 funcsigs==1.0.2           # via mock
+html5lib==0.999999999
 idna==2.5                 # via requests
 itsdangerous==0.24        # via flask
 jinja2==2.9.6             # via flask
 markupsafe==1.0           # via jinja2
 mock==2.0.0
-pbr==3.0.1                # via mock
+pbr==3.1.1                # via mock
 pip-tools==1.9.0
 py==1.4.34
 pytest-cov==2.5.1
-pytest==3.1.1
-requests==2.17.3          # via coveralls
+pytest==3.1.2
+requests==2.18.1          # via coveralls
 selenium==2.53.6
-six==1.10.0               # via mock, pip-tools
+six==1.10.0               # via html5lib, mock, pip-tools
 urllib3==1.21.1           # via requests
+webencodings==0.5.1       # via html5lib
 werkzeug==0.12.2          # via flask

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -70,7 +70,8 @@
           <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
           <input type="hidden" name="reply_filename" value="{{ reply.filename }}" autocomplete="off"/>
           <a href="#confirm-delete-{{ reply.filename }}" class="delete">
-          <img src="{{ url_for('static', filename='i/font-awesome/trash-black.png') }}" width="20px" height="20px">
+            <img src="{{ url_for('static', filename='i/font-awesome/trash-black.png') }}" width="20px" height="20px">
+          </a>
           <div id="confirm-delete-{{ reply.filename }}" class="confirm-prompt">
             <p>Delete this reply?
               <a href="#delete">Cancel</a>

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -80,7 +80,7 @@ class TestIntegration(unittest.TestCase):
         rv = self.journalist_app.get('/')
         self.assertEqual(rv.status_code, 200)
         self.assertIn("Sources", rv.data)
-        soup = BeautifulSoup(rv.data)
+        soup = BeautifulSoup(rv.data, 'html5lib')
 
         # The source should have a "download unread" link that says "1 unread"
         col = soup.select('ul#cols > li')[0]
@@ -90,7 +90,7 @@ class TestIntegration(unittest.TestCase):
         col_url = soup.select('ul#cols > li a')[0]['href']
         resp = self.journalist_app.get(col_url)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         submission_url = soup.select('ul#submissions li a')[0]['href']
         self.assertIn("-msg", submission_url)
         span = soup.select('ul#submissions li span.info span')[0]
@@ -105,7 +105,7 @@ class TestIntegration(unittest.TestCase):
         # delete submission
         resp = self.journalist_app.get(col_url)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         doc_name = soup.select(
             'ul > li > input[name="doc_names_selected"]')[0]['value']
         resp = self.journalist_app.post('/bulk', data=dict(
@@ -115,7 +115,7 @@ class TestIntegration(unittest.TestCase):
         ))
 
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         self.assertIn("The following file has been selected for", resp.data)
 
         # confirm delete submission
@@ -128,7 +128,7 @@ class TestIntegration(unittest.TestCase):
             doc_names_selected=doc_name,
         ), follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         self.assertIn("Submission deleted.", resp.data)
 
         # confirm that submission deleted and absent in list of submissions
@@ -164,7 +164,7 @@ class TestIntegration(unittest.TestCase):
         resp = self.journalist_app.get('/')
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Sources", resp.data)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
 
         # The source should have a "download unread" link that says "1 unread"
         col = soup.select('ul#cols > li')[0]
@@ -174,7 +174,7 @@ class TestIntegration(unittest.TestCase):
         col_url = soup.select('ul#cols > li a')[0]['href']
         resp = self.journalist_app.get(col_url)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         submission_url = soup.select('ul#submissions li a')[0]['href']
         self.assertIn("-doc", submission_url)
         span = soup.select('ul#submissions li span.info span')[0]
@@ -193,7 +193,7 @@ class TestIntegration(unittest.TestCase):
         # delete submission
         resp = self.journalist_app.get(col_url)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         doc_name = soup.select(
             'ul > li > input[name="doc_names_selected"]')[0]['value']
         resp = self.journalist_app.post('/bulk', data=dict(
@@ -203,7 +203,7 @@ class TestIntegration(unittest.TestCase):
         ))
 
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         self.assertIn("The following file has been selected for", resp.data)
 
         # confirm delete submission
@@ -216,7 +216,7 @@ class TestIntegration(unittest.TestCase):
             doc_names_selected=doc_name,
         ), follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         self.assertIn("Submission deleted.", resp.data)
 
         # confirm that submission deleted and absent in list of submissions
@@ -304,7 +304,7 @@ class TestIntegration(unittest.TestCase):
         resp = self.journalist_app.get('/')
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Sources", resp.data)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         col_url = soup.select('ul#cols > li a')[0]['href']
 
         resp = self.journalist_app.get(col_url)
@@ -352,7 +352,7 @@ class TestIntegration(unittest.TestCase):
             resp = journalist_app.get(col_url)
             self.assertIn("reply-", resp.data)
 
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
 
         # Download the reply and verify that it can be decrypted with the
         # journalist's key as well as the source's reply key
@@ -391,7 +391,8 @@ class TestIntegration(unittest.TestCase):
                     "You have received a reply. To protect your identity",
                     resp.data)
                 self.assertIn(test_reply, resp.data)
-                soup = BeautifulSoup(resp.data)
+                soup = BeautifulSoup(resp.data, 'html5lib')
+                # import pdb; pdb.set_trace()
                 msgid = soup.select(
                     'form.message > input[name="reply_filename"]')[0]['value']
                 resp = source_app.post('/delete', data=dict(
@@ -420,13 +421,13 @@ class TestIntegration(unittest.TestCase):
 
         resp = self.journalist_app.get('/')
         # navigate to the collection page
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         first_col_url = soup.select('ul#cols > li a')[0]['href']
         resp = self.journalist_app.get(first_col_url)
         self.assertEqual(resp.status_code, 200)
 
         # find the delete form and extract the post parameters
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         delete_form_inputs = soup.select('form#delete_collection')[0]('input')
         sid = delete_form_inputs[1]['value']
         col_name = delete_form_inputs[2]['value']
@@ -458,7 +459,7 @@ class TestIntegration(unittest.TestCase):
 
         resp = self.journalist_app.get('/')
         # get all the checkbox values
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         checkbox_values = [checkbox['value'] for checkbox in
                            soup.select('input[name="cols_selected"]')]
         resp = self.journalist_app.post('/col/process', data=dict(
@@ -481,13 +482,13 @@ class TestIntegration(unittest.TestCase):
 
         # navigate to the collection page
         resp = self.journalist_app.get('/')
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         first_col_url = soup.select('ul#cols > li a')[0]['href']
         resp = self.journalist_app.get(first_col_url)
         self.assertEqual(resp.status_code, 200)
 
         # test filenames and sort order
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         submission_filename_re = r'^{0}-[a-z0-9-_]+(-msg|-doc\.gz)\.gpg$'
         for i, submission_link in enumerate(
                 soup.select('ul#submissions li a .filename')):
@@ -504,16 +505,16 @@ class TestIntegration(unittest.TestCase):
 
         # navigate to the collection page
         resp = self.journalist_app.get('/')
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         first_col_url = soup.select('ul#cols > li a')[0]['href']
         resp = self.journalist_app.get(first_col_url)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
 
         # delete file #2
         self.helper_filenames_delete(soup, 1)
         resp = self.journalist_app.get(first_col_url)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
 
         # test filenames and sort order
         submission_filename_re = r'^{0}-[a-z0-9-_]+(-msg|-doc\.gz)\.gpg$'

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -69,7 +69,7 @@ class TestSourceApp(TestCase):
         """
         resp = self.client.get('/generate')
         self.assertIn("ALREADY HAVE A CODENAME?", resp.data)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html5lib')
         already_have_codename_link = soup.select('a#already-have-codename')[0]
         self.assertEqual(already_have_codename_link['href'], '/login')
 

--- a/testinfra/development/test_development_environment.py
+++ b/testinfra/development/test_development_environment.py
@@ -30,13 +30,16 @@ def test_development_app_dependencies(Package):
     ('funcsigs', '1.0.2'),
     ('itsdangerous', '0.24'),
     ('mock', '2.0.0'),
-    ('pbr', '3.0.1'),
+    ('pbr', '3.1.1'),
     ('pip-tools', '1.9.0'),
     ('py', '1.4.34'),
     ('pytest-cov', '2.5.1'),
-    ('pytest', '3.1.1'),
+    ('pytest', '3.1.2'),
     ('selenium', '2.53.6'),
     ('six', '1.10.0'),
+    ('html5lib', '0.999999999'),
+    ('webencodings', '0.5.1'),
+    ('requests', '2.18.1'),
 ])
 def test_development_pip_dependencies(Command, pip_package, version):
     """


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #1820.

Adding this to get rid of the pytest warning the latest version of bs4 throws if you do not specifically select your HTML parser.