### PR TITLE
Eliminate need for source.generate_unique_codename

### DIFF
--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -86,7 +86,6 @@ class Source(Base):
     interaction_count = Column(Integer, default=0, nullable=False)
 
     # Don't create or bother checking excessively long codenames to prevent DoS
-    NUM_WORDS = 7
     MAX_CODENAME_LEN = 128
 
     def __init__(self, filesystem_id=None, journalist_designation=None):

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -128,31 +128,6 @@ def index():
                            'CUSTOM_NOTIFICATION', ''))
 
 
-def generate_unique_codename():
-    """Generate random codenames until we get an unused one"""
-    while True:
-        codename = crypto_util.genrandomid(Source.NUM_WORDS)
-
-        # The maximum length of a word in the wordlist is 9 letters and the
-        # codename length is 7 words, so it is currently impossible to
-        # generate a codename that is longer than the maximum codename length
-        # (currently 128 characters). This code is meant to be defense in depth
-        # to guard against potential future changes, such as modifications to
-        # the word list or the maximum codename length.
-        if len(codename) > Source.MAX_CODENAME_LEN:
-            app.logger.warning(
-                    "Generated a source codename that was too long, "
-                    "skipping it. This should not happen. "
-                    "(Codename='{}')".format(codename))
-            continue
-
-        sid = crypto_util.hash_codename(codename)  # scrypt (slow)
-        matching_sources = Source.query.filter(
-            Source.filesystem_id == sid).all()
-        if len(matching_sources) == 0:
-            return codename
-
-
 @app.route('/generate', methods=('GET', 'POST'))
 def generate():
     if logged_in():
@@ -160,7 +135,7 @@ def generate():
               "to create a new account, you should log out first.", "notification")
         return redirect(url_for('lookup'))
 
-    codename = generate_unique_codename()
+    codename = crypto_util.genrandomid()
     session['codename'] = codename
     return render_template('generate.html', codename=codename)
 

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -10,14 +10,39 @@ import store
 import utils
 
 class TestCryptoUtil(unittest.TestCase):
-
-    """The set of tests for crypto_util.py."""
+    """The set of tests for crypto_util.py.
+    """
 
     def setUp(self):
         utils.env.setup()
 
     def tearDown(self):
         utils.env.teardown()
+
+    def test_word_lists_imports(self):
+        """Make sure word count for each list is correct and Guard
+        against regressions regarding not stripping file contents
+        correctly.
+        """
+        words = crypto_util.words
+        nouns = crypto_util.nouns
+        adjectives = crypto_util.adjectives
+        self.assertEqual(len(words), 7603)
+        self.assertEqual(len(adjectives), 8222)
+        self.assertEqual(len(nouns), 17949)
+        self.assertNotIn('', words + nouns + adjectives)
+
+    def test_genrandomid_result_cannot_exceed_max_codename_len(self):
+        """It should be impossible to generate an id longer than
+        :attr:`db.Source.MAX_CODENAME_LENGTH` using the default number
+        of words `crypto_util.NUM_CODENAME_WORDS`.
+        """
+        longest_word_len = max([len(word) for word in crypto_util.words])
+        longest_codename_len = len(' '.join(
+            ['_' * longest_word_len
+             for _ in xrange(crypto_util.NUM_CODENAME_WORDS)]))
+        self.assertLessEqual(longest_codename_len,
+                             db.Source.MAX_CODENAME_LEN)
 
     def test_clean(self):
         ok = (' !#%$&)(+*-1032547698;:=?@acbedgfihkjmlonqpsrutwvyxzABCDEFGHIJ'
@@ -132,7 +157,7 @@ class TestCryptoUtil(unittest.TestCase):
         id_words = id.split()
 
         self.assertEqual(id, crypto_util.clean(id))
-        self.assertEqual(len(id_words), crypto_util.DEFAULT_WORDS_IN_RANDOM_ID)
+        self.assertEqual(len(id_words), crypto_util.NUM_CODENAME_WORDS)
         for word in id_words:
             self.assertIn(word, crypto_util.words)
 

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup
 from flask import session, escape
 from flask_testing import TestCase
 
+import crypto_util
 from db import Source
 import source
 import version
@@ -51,7 +52,7 @@ class TestSourceApp(TestCase):
             session_codename = session['codename']
         self.assertIn("This codename is what you will use in future visits", resp.data)
         codename = self._find_codename(resp.data)
-        self.assertEqual(len(codename.split()), Source.NUM_WORDS)
+        self.assertEqual(len(codename.split()), crypto_util.NUM_CODENAME_WORDS)
         # codename is also stored in the session - make sure it matches the
         # codename displayed to the source
         self.assertEqual(codename, escape(session_codename))


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Inspired by #1812.

* By verifying that it's impossible for `crypto_util.genrandomid()` to generate a codename longer than our maximum in our tests, we no longer have to rely on the not-so-great `source.generate_unique_codename()` function.
* While writing this test I discovered that a failure to correctly strip the contents of our wordlist files resulted in the last "word" of each list object being `''`, the empty string. In addition to fixing this I wrote a test
  to prevent regressions.
* While it would be nice to keep NUM_CODENAME_WORDS together with MAX_CODENAME_LEN, that produced a circular imports problem. I resolved it in the clearest way I could think of that did not require significant refactoring.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM