### PR TITLE
Fixes `sdconfig` subcommand in admin script

### DIFF
--- a/install_files/ansible-base/configure
+++ b/install_files/ansible-base/configure
@@ -34,8 +34,10 @@ site_specific_vars="$(realpath "$(dirname "${BASH_SOURCE[0]}")")/group_vars/all/
 
 # If vars file already exists, let's prepopulate the prompts with those values.
 if [[ -e "${site_specific_vars}" && "${override_previous_vars}" != "yes" ]]; then
-    ansible-playbook securedrop-configure.yml --extra-vars "@${site_specific_vars}"
+    # Passing an empty inventory file to override the automatic dynamic inventory script,
+    # which fails if no site vars are configured.
+    ansible-playbook -i /dev/null securedrop-configure.yml --extra-vars "@${site_specific_vars}"
 # Otherwise we'll run the playbook from scratch and fill in the values.
 else
-    ansible-playbook securedrop-configure.yml
+    ansible-playbook -i /dev/null securedrop-configure.yml
 fi

--- a/install_files/ansible-base/securedrop-configure.yml
+++ b/install_files/ansible-base/securedrop-configure.yml
@@ -60,6 +60,7 @@
 
     - name: securedrop_app_gpg_fingerprint
       prompt: Full fingerprint for the SecureDrop Application GPG Key
+      default: ' '
       private: no
 
     - name: ossec_alert_gpg_public_key
@@ -69,6 +70,7 @@
 
     - name: ossec_gpg_fpr
       prompt: Full fingerprint for the OSSEC alerts GPG public key
+      default: ' '
       private: no
 
     - name: ossec_alert_email


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Closes #1836. The dynamic inventory script helpfully fails with an
informative error message if site vars do not exist, but they won't
exist during run of the configuration subcommand. By passing in an empty
inventory file, we can override the dynamic inventory script declared in
`ansible.cfg` and operate only against localhost.

## Testing

Run the `./securedrop-admin sdconfig` on a fresh Tails instance and confirm you're able to pass in vars with no errors.

## Deployment

Required for first-time instances. Patches behavior pulled in via #1781 and #1774.

## Checklist

Relying on manual testing of Tails environment.