### PR TITLE
Document workaround for potential `gpg --recv-key` failure

### DIFF
--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -69,8 +69,13 @@ First, download and verify the **SecureDrop Release Signing Key**.
 .. tip:: If the ``--recv-key`` command fails, first double-check that
    `Tails is connected to Tor`_.
 
-   If you're connected to Tor but ``gpg --recv-key`` is failing, it could
-   indicate the default GPG key servers are down or unreachable. As a
+   Once you've confirmed that you're successfully connected to Tor, try
+   re-running the ``--recv-key`` command a few times. The default GPG
+   configuration on Tails uses a keyserver pool, which may occasionally return
+   a malfunctioning keyserver, causing the ``--recv-key`` command to fail.
+
+   If the command is consistently failing after a few tries, it could
+   indicate that the default GPG key servers are down or unreachable. As a
    workaround, another keyserver can be specified by adding the ``--keyserver``
    option to the ``gpg --recv-key`` command. In our experience, the SKS HKPS
    keyserver pool is usually a reliable alternative, so try:
@@ -78,6 +83,9 @@ First, download and verify the **SecureDrop Release Signing Key**.
    .. code:: sh
 
       gpg --keyserver hkps://hkps.pool.sks-keyservers.net --recv-key "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
+
+   Again, this is a keyserver pool, so you may need to retry the command a
+   couple of times before it succeeds.
 
 .. _Tails is connected to Tor: https://tails.boum.org/doc/anonymous_internet/tor_status/index.en.html
 

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -66,6 +66,15 @@ First, download and verify the **SecureDrop Release Signing Key**.
           copy-pasting this command, we recommend you double-check you have
           entered it correctly before pressing enter.
 
+.. note:: If the command hangs and evenutally fails with a timeout, it
+          could indicate the default GPG key server is down or
+          unreachable. As a workaround, another keyserver can be
+          specified by adding the --keyserver option to the
+          gpg --recv-key command. In our experience, the SKS keyserver
+          pool is usually a reliable alternative, so try re-running
+          the command with ``--keyserver
+          hkp://pool.sks-keyservers.net``.
+
 When passing the full public key fingerprint to the ``--recv-key`` command, GPG
 will implicitly verify that the fingerprint of the key received matches the
 argument passed.

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -66,14 +66,20 @@ First, download and verify the **SecureDrop Release Signing Key**.
           copy-pasting this command, we recommend you double-check you have
           entered it correctly before pressing enter.
 
-.. note:: If the command hangs and evenutally fails with a timeout, it
-          could indicate the default GPG key server is down or
-          unreachable. As a workaround, another keyserver can be
-          specified by adding the --keyserver option to the
-          gpg --recv-key command. In our experience, the SKS keyserver
-          pool is usually a reliable alternative, so try re-running
-          the command with ``--keyserver
-          hkp://pool.sks-keyservers.net``.
+.. tip:: If the ``--recv-key`` command fails, first double-check that
+   `Tails is connected to Tor`_.
+
+   If you're connected to Tor but ``gpg --recv-key`` is failing, it could
+   indicate the default GPG key servers are down or unreachable. As a
+   workaround, another keyserver can be specified by adding the ``--keyserver``
+   option to the ``gpg --recv-key`` command. In our experience, the SKS HKPS
+   keyserver pool is usually a reliable alternative, so try:
+
+   .. code:: sh
+
+      gpg --keyserver hkps://hkps.pool.sks-keyservers.net --recv-key "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
+
+.. _Tails is connected to Tor: https://tails.boum.org/doc/anonymous_internet/tor_status/index.en.html
 
 When passing the full public key fingerprint to the ``--recv-key`` command, GPG
 will implicitly verify that the fingerprint of the key received matches the


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

I got tired of the back and forth in #1804 and I decided it would be quicker and easier to make the addition to the documentation myself. This is based on #1804, so @dachary still gets credit for his initial work.

* Resolves #1797.
* Supersedes #1804.

## Deployment

No special considerations for deployment.

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
