### PR TITLE
doc: documentation_guidelines: clone before pip install

### DIFF
--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -11,17 +11,17 @@ repository under the ``docs/`` directory.
 
 To get started editing the docs:
 
-#. Install the dependencies:
-
-   .. code:: sh
-
-      pip install -r securedrop/requirements/develop-requirements.txt
-
 #. Clone the SecureDrop repository:
 
    .. code:: sh
 
       git clone https://github.com/freedomofpress/securedrop.git
+
+#. Install the dependencies:
+
+   .. code:: sh
+
+      pip install -r securedrop/requirements/develop-requirements.txt
 
 #. Build the docs and open the index page in your web browser:
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Cloning the repository must be done before accessing the files it
contains.
