### PR TITLE
doc: remove extra leading $

### DIFF
--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -319,7 +319,7 @@ First, generate the new SSH keypair:
 
 ::
 
-    $ ssh-keygen -t rsa -b 4096
+    ssh-keygen -t rsa -b 4096
 
 You'll be asked to "enter file in which to save the key." Type
 **Enter** to use the default location.
@@ -348,8 +348,8 @@ server, authenticating with your password:
 
 .. code:: sh
 
-    $ ssh-copy-id <username>@<App IP address>
-    $ ssh-copy-id <username>@<Mon IP address>
+    ssh-copy-id <username>@<App IP address>
+    ssh-copy-id <username>@<Mon IP address>
 
 Verify that you are able to authenticate to both servers by running
 the below commands. You should not be prompted for a passphrase

--- a/docs/test_the_installation.rst
+++ b/docs/test_the_installation.rst
@@ -10,15 +10,15 @@ SSH to both servers over Tor
 On the *Admin Workstation*, you should be able to SSH to the App
 Server and the *Monitor Server*. ::
 
-   $ ssh app
-   $ ssh mon
+   ssh app
+   ssh mon
 
 The SSH aliases should have been configured automatically by running
 the ``./securedrop-admin tailsconfig`` tool. If you're unable to connect via aliases,
 try using the verbose command format to troubleshoot: ::
 
-   $ ssh <username>@<app .onion>
-   $ ssh <username>@<mon .onion>
+   ssh <username>@<app .onion>
+   ssh <username>@<mon .onion>
 
 .. tip:: You can find the Onion URLs for SSH in ``app-ssh-aths`` and
          ``mon-ssh-aths`` inside the ``install_files/ansible-base`` directory.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The SecureDrop documentation style guide's recommendations for quoting shell commands and shell output are not followed consistently throughout the documentation. This pull request applies the recommended formatting consistently across all of the documentation.
