### PR TITLE
cleanup: journalist: remove useless NoResultFound import

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -17,8 +17,7 @@ import crypto_util
 import store
 import template_filters
 from db import (db_session, Source, Journalist, Submission, Reply,
-                SourceStar, get_one_or_else, NoResultFound,
-                WrongPasswordException,
+                SourceStar, get_one_or_else, WrongPasswordException,
                 LoginThrottledException, InvalidPasswordLength)
 import worker
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

NoResultFound imported from journalist.py actually is the same
as the previously imported exception by the same name from sqlalchemy

