### PR TITLE
manage: clean-tmp removes old files to avoid races

### DIFF
--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -10,7 +10,6 @@ import signal
 import sys
 import traceback
 
-import psutil
 import qrcode
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -172,32 +171,8 @@ def delete_user():  # pragma: no cover
     return 0
 
 
-def clean_tmp():  # pragma: no cover
-    """Cleanup the SecureDrop temp directory. This is intended to be run
-    as an automated cron job. We skip files that are currently in use to
-    avoid deleting files that are currently being downloaded."""
-    # Inspired by http://stackoverflow.com/a/11115521/1093000
-    def file_in_use(fname):
-        for proc in psutil.process_iter():
-            try:
-                open_files = proc.open_files()
-                in_use = False or any([open_file.path == fname
-                                       for open_file in open_files])
-                # Early return for perf
-                if in_use:
-                    break
-            except psutil.NoSuchProcess:
-                # This catches a race condition where a process ends before we
-                # can examine its files. Ignore this - if the process ended, it
-                # can't be using fname, so this won't cause an error.
-                pass
-
-        return in_use
-
-    def listdir_fullpath(d):
-        # Thanks to http://stackoverflow.com/a/120948/1093000
-        return [os.path.join(d, f) for f in os.listdir(d)]
-
+def clean_tmp():
+    """Cleanup the SecureDrop temp directory. """
     try:
         os.stat(config.TEMP_DIR)
     except OSError:

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -22,7 +22,7 @@ logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s')
 log = logging.getLogger(__name__)
 
 
-def reset():  # pragma: no cover
+def reset(args):  # pragma: no cover
     """Clears the SecureDrop development applications' state, restoring them to
     the way they were immediately after running `setup_dev.sh`. This command:
     1. Erases the development sqlite database file.
@@ -57,11 +57,11 @@ def reset():  # pragma: no cover
     return 0
 
 
-def add_admin():  # pragma: no cover
+def add_admin(args):  # pragma: no cover
     return _add_user(is_admin=True)
 
 
-def add_journalist():  # pragma: no cover
+def add_journalist(args):  # pragma: no cover
     return _add_user()
 
 
@@ -133,7 +133,7 @@ def _add_user(is_admin=False):  # pragma: no cover
         return 0
 
 
-def delete_user():  # pragma: no cover
+def delete_user(args):  # pragma: no cover
     """Deletes a journalist or administrator from the application."""
     # Select user to delete
     username = raw_input('Username to delete: ')
@@ -171,7 +171,7 @@ def delete_user():  # pragma: no cover
     return 0
 
 
-def clean_tmp():
+def clean_tmp(args):
     """Cleanup the SecureDrop temp directory. """
     try:
         os.stat(config.TEMP_DIR)
@@ -237,8 +237,8 @@ def setup_verbosity(args):
 def _run_from_commandline():  # pragma: no cover
     try:
         args = get_args().parse_args()
-        rc = args.func()
         setup_verbosity(args)
+        rc = args.func(args)
         sys.exit(rc)
     except KeyboardInterrupt:
         sys.exit(signal.SIGINT)

--- a/securedrop/management/run.py
+++ b/securedrop/management/run.py
@@ -140,7 +140,7 @@ class DevServerProcessMonitor(object):  # pragma: no cover
                 proc.terminate()
 
 
-def run():  # pragma: no cover
+def run(args):  # pragma: no cover
     """
     Starts development servers for both the Source Interface and the
     Journalist Interface concurrently. Their output is collected,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1849

A file is considered old if it has not been modified in seven days (or
--days) and is removed from config.TEMP_DIR (or --directory).

The files in config.TEMP_DIR are for preparing downloads and they must
not be deleted before the user gets a chance to start the download. The
preparation of the file may be long for large collections but it will
always take less than a week.

It is not impossible for a the download to take more than a week if the
network is slow. However, once the download has begun it does not matter
if the file is removed: the server still has an open file descriptor and
keeps serving its content.

## Testing

The test_manage.py has been modified to test the new implementation.

## Deployment

1. Upgrading existing production instances.

The new implementation will leave temporary files for a week longer than the previous one.

2. New installs.

Nothing special.
