### PR TITLE
docs: recommend vagrant 1.8.5 instead of >= 1.8

### DIFF
--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -28,7 +28,7 @@ We recommend using the latest stable version of Vagrant, ``1.8.5`` at the time
 of this writing, which might be newer than what is in your distro's package
 repositories. Older versions of Vagrant has been known to cause problems
 (`GitHub #932`_, `GitHub #1381`_). If ``apt-cache policy vagrant`` says your
-candidate version is not at least 1.8, you should download the current version
+candidate version is not at least 1.8.5, you should download the current version
 from the `Vagrant Downloads page`_ and then install it.
 
 .. code:: sh


### PR DESCRIPTION
The instructions to bring up the virtual machines makes use of regular
expressions (vagrant up /staging/). It does not work with vagrant 1.8.1
which is the default supported version for the recommended operating
system version (Ubuntu 16.04).

Although the recommended version is 1.8.5, the check suggested with
apt-cache policy suggests that any version above 1.8 is going to
work. Raise the minimum version to 1.8.5 to avoid this pitfall.
