### PR TITLE
ansible: remove redundant handler

### DIFF
--- a/install_files/ansible-base/roles/app-test/handlers/main.yml
+++ b/install_files/ansible-base/roles/app-test/handlers/main.yml
@@ -1,10 +1,5 @@
 ---
 ## SecureDrop Interfaces
-- name: restart apache2
-  service:
-    name: apache2
-    state: restarted
-
 - name: start xvfb
   service:
     name: xvfb


### PR DESCRIPTION
"restart apache2" is not used by the app-test role and
is already defined by the "app" role.

## Status

Ready for review.

## Description of Changes

Resubmitting @dachary's #1852, to get the full CI suite to run (as described in #1826). Therefore closes #1852.

## Testing

Validate all CI checks pass. Details of implementation were already hashed out in #1852 discussion thread.