### PR TITLE
Prefer use of yaml.safe_load

### DIFF
--- a/install_files/ansible-base/inventory-dynamic
+++ b/install_files/ansible-base/inventory-dynamic
@@ -42,7 +42,7 @@ def lookup_local_ipv4_address(hostname):
     """
     try:
         with open(SECUREDROP_SITE_VARS, 'r') as f:
-            site_vars = yaml.load(f)
+            site_vars = yaml.safe_load(f)
             app_ip = site_vars['app_ip']
             monitor_ip = site_vars['monitor_ip']
 


### PR DESCRIPTION
## Status

Ready for review, but needs more local testing. Wanted to figure out what needs to be done there, but wanted to briefly consult my good friend @conorsch first.

## Description of Changes

Always prefer `yaml.safe_load()` to `yaml.load()`. I can't really imagine a time where we'd need to use the latter, anyway.

## Testing

Maybe @conorsch could help with the story here. It seems like as long as you can provision and SSH into all the machines we can confirm this change doesn't break anything. Let me know if you agree that's sufficient, or there's more this could affect.