### PR TITLE
Secure tempfile refactor alternative test fix

### DIFF
--- a/securedrop/secure_tempfile.py
+++ b/securedrop/secure_tempfile.py
@@ -1,93 +1,119 @@
+# -*- coding: utf-8 -*-
 import base64
 import os
 from tempfile import _TemporaryFileWrapper
 
+from gnupg._util import _STREAMLIKE_TYPES
 from Crypto.Cipher import AES
 from Crypto.Random import random
 from Crypto.Util import Counter
 
-from gnupg._util import _STREAMLIKE_TYPES
 
-class SecureTemporaryFile(_TemporaryFileWrapper):
+class SecureTemporaryFile(_TemporaryFileWrapper, object):
+    """Temporary file that provides on-the-fly encryption.
 
-    """Temporary file that is ephemerally encrypted on the fly.
+    Buffering large submissions in memory as they come in requires too
+    much memory for too long a period. By writing the file to disk as it
+    comes in using a stream cipher, we are able to minimize memory usage
+    as submissions come in, while minimizing the chances of plaintext
+    recovery through forensic disk analysis. They key used to encrypt
+    each secure temporary file is also ephemeral, and is only stored in
+    memory only for as long as needed.
 
-    Since only encrypted data is ever written to disk, using this
-    classes minimizes the chances of plaintext recovery through
-    forensic disk analysis.
-
-    Adapted from Globaleaks' GLSecureTemporaryFile: https://github.com/globaleaks/GlobaLeaks/blob/master/backend/globaleaks/security.py#L35
+    Adapted from Globaleaks' GLSecureTemporaryFile:
+    https://github.com/globaleaks/GlobaLeaks/blob/master/backend/globaleaks/security.py#L35
 
     WARNING: you can't use this like a normal file object. It supports
-    being written to exactly once, then read from exactly once.
+    being appended to however many times you wish (although content may not be
+    overwritten), and then it's contents may be read only once (although it may
+    be done in chunks) and only after it's been written to.
     """
-
     AES_key_size = 256
     AES_block_size = 128
 
     def __init__(self, store_dir):
+        """Generates an AES key and an initialization vector, and opens
+        a file in the `store_dir` directory with a
+        pseudorandomly-generated filename.
+
+        Args:
+            store_dir (str): the directory to create the secure
+                temporary file under.
+
+        Returns: self
+        """
         self.last_action = 'init'
         self.create_key()
-
         self.tmp_file_id = base64.urlsafe_b64encode(os.urandom(32)).strip('=')
-        self.filepath = os.path.join(
-            store_dir,
-            "{}.aes".format(
-                self.tmp_file_id))
+        self.filepath = os.path.join(store_dir,
+                                     '{}.aes'.format(self.tmp_file_id))
         self.file = open(self.filepath, 'w+b')
-
-        _TemporaryFileWrapper.__init__(
-            self,
-            self.file,
-            self.filepath,
-            delete=True)
+        super(SecureTemporaryFile, self).__init__(self.file, self.filepath)
 
     def create_key(self):
-        """
-        Randomly generate an AES key to encrypt the file
+        """Generates a unique, pseudorandom AES key, stored ephemerally in
+        memory as an instance attribute. Its destruction is ensured by the
+        automatic nightly reboots of the SecureDrop application server combined
+        with the freed memory-overwriting PAX_MEMORY_SANITIZE feature of the
+        grsecurity-patched kernel it uses (for further details consult
+        https://github.com/freedomofpress/securedrop/pull/477#issuecomment-168445450).
         """
         self.key = os.urandom(self.AES_key_size / 8)
         self.iv = random.getrandbits(self.AES_block_size)
         self.initialize_cipher()
 
     def initialize_cipher(self):
+        """Creates the cipher-related objects needed for AES-CTR
+        encryption and decryption.
+        """
         self.ctr_e = Counter.new(self.AES_block_size, initial_value=self.iv)
         self.ctr_d = Counter.new(self.AES_block_size, initial_value=self.iv)
         self.encryptor = AES.new(self.key, AES.MODE_CTR, counter=self.ctr_e)
         self.decryptor = AES.new(self.key, AES.MODE_CTR, counter=self.ctr_d)
 
     def write(self, data):
+        """Write `data` to the secure temporary file. This method may be
+        called any number of times following instance initialization,
+        but after calling :meth:`read`, you cannot write to the file
+        again.
         """
-        We track the internal status and don't allow writing after reading.
-        It might be possible to be smarter about this.
-        """
-        assert self.last_action != 'read', "You cannot write after read!"
+        assert self.last_action != 'read', 'You cannot write after reading!'
         self.last_action = 'write'
 
-        try:
-            if isinstance(data, unicode):
-                data = data.encode('utf-8')
-            self.file.write(self.encryptor.encrypt(data))
-        except Exception as err:
-            raise err
+        if isinstance(data, unicode):
+            data = data.encode('utf-8')
+
+        self.file.write(self.encryptor.encrypt(data))
 
     def read(self, count=None):
+        """Read `data` from the secure temporary file. This method may
+        be called any number of times following instance initialization
+        and once :meth:`write has been called at least once, but not
+        before.
+        
+        Before the first read operation, `seek(0, 0)` is called. So
+        while you can call this method any number of times, the full
+        contents of the file can only be read once. Additional calls to
+        read will return an empty str, which is desired behavior in that
+        it matches :class:`file` and because other modules depend on
+        this behavior to let them know they've reached the end of the
+        file.
+
+        Args:
+            count (int): the number of bytes to try to read from the
+                file from the current position.
         """
-        The first time 'read' is called after a write, automatically seek(0).
-        """
+        assert self.last_action != 'init', 'You must write before reading!'
         if self.last_action == 'write':
             self.seek(0, 0)
             self.last_action = 'read'
 
-        if count is None:
-            return self.decryptor.decrypt(self.file.read())
-        else:
+        if count:
             return self.decryptor.decrypt(self.file.read(count))
-
-    def close(self):
-        return _TemporaryFileWrapper.close(self)
+        else:
+            return self.decryptor.decrypt(self.file.read())
 
 # python-gnupg will not recognize our SecureTemporaryFile as a stream-like type
 # and will attempt to call encode on it, thinking it's a string-like type. To
-# avoid this we add it the list of stream-like types.
+# avoid this we append it the list of stream-like types.
 _STREAMLIKE_TYPES.append(_TemporaryFileWrapper)

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+import os
+import unittest
+
+from gnupg._util import _is_stream
+
+os.environ['SECUREDROP_ENV'] = 'test'
+import config
+import secure_tempfile
+import utils
+
+
+class TestSecureTempfile(unittest.TestCase):
+    def setUp(self):
+        utils.env.setup()
+        self.f = secure_tempfile.SecureTemporaryFile(config.STORE_DIR)
+        self.msg = '410,757,864,530'
+
+    def tearDown(self):
+        utils.env.teardown()
+
+    def test_write_then_read_twice(self):
+        self.f.write(self.msg)
+        self.f.read()
+
+        self.assertEqual(self.f.read(), '')
+
+    def test_read_before_writing(self):
+        with self.assertRaisesRegexp(AssertionError,
+                                     'You must write before reading!'):
+            self.f.read()
+        
+    def test_write_then_read_once(self):
+        self.f.write(self.msg)
+
+        self.assertEqual(self.f.read(), self.msg)
+
+    def test_write_twice_then_read_once(self):
+        self.f.write(self.msg)
+        self.f.write(self.msg)
+
+        self.assertEqual(self.f.read(), self.msg*2)
+
+    def test_write_then_read_twice(self):
+        self.f.write(self.msg)
+
+        self.assertEqual(self.f.read(), self.msg)
+        self.assertEqual(self.f.read(), '')
+
+    def test_write_then_read_then_write(self):
+        self.f.write(self.msg)
+        self.f.read()
+
+        with self.assertRaisesRegexp(AssertionError,
+                                     'You cannot write after reading!'):
+            self.f.write('BORN TO DIE')
+
+    def test_read_write_unicode(self):
+        unicode_msg = u'鬼神 Kill Em All 1989'
+        self.f.write(unicode_msg)
+        
+        self.assertEqual(self.f.read().decode('utf-8'), unicode_msg)
+
+    def test_file_seems_encrypted(self):
+        self.f.write(self.msg)
+        with open(self.f.filepath, 'rb') as fh:
+            contents = fh.read().decode()
+
+        self.assertNotIn(self.msg, contents)
+
+    def test_file_is_removed_from_disk(self):
+        fp = self.f.filepath
+        self.f.write(self.msg)
+        self.f.read()
+
+        self.assertTrue(os.path.exists(fp))
+
+        self.f.close()
+
+        self.assertFalse(os.path.exists(fp))
+
+    def test_SecureTemporaryFile_is_a_STREAMLIKE_TYPE(self):
+        self.assertTrue(_is_stream(secure_tempfile.SecureTemporaryFile('/tmp')))
+
+    def test_buffered_read(self):
+        msg = self.msg * 1000
+        self.f.write(msg)
+        str = ''
+        while True:
+            char = self.f.read(1024)
+            if char:
+                str += char
+            else:
+                break
+
+        self.assertEqual(str, msg)
+
+    def test_tmp_file_id_omits_invalid_chars(self):
+        """The `SecureTempFile.tmp_file_id` instance attribute is used as the filename
+        for the secure temporary file. This attribute should not contain
+        invalid characters such as '/' and '\0' (null)."""
+        self.assertNotIn('/', self.f.tmp_file_id)
+        self.assertNotIn('\0', self.f.tmp_file_id)

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from cStringIO import StringIO
+import gzip
 from mock import patch, ANY
 import os
 import re
@@ -247,7 +248,7 @@ class TestSourceApp(TestCase):
             self.assertEqual(resp.status_code, 200)
             self.assertIn("All replies have been deleted", resp.data)
 
-    @patch('gzip.GzipFile')
+    @patch('gzip.GzipFile', wraps=gzip.GzipFile)
     def test_submit_sanitizes_filename(self, gzipfile):
         """Test that upload file name is sanitized"""
         insecure_filename = '../../bin/gpg'


### PR DESCRIPTION
Minimal alternative fix for broken tests in #1810.

I do not think this should necessarily supersede #1810; I am just posting it as an alternative way to fix the tests. @fowlslegs' work in #1810 seems to me to be a good start on unit tests for `store.save_file_submission`, so I think ideally my work from this branch would be incorporated into #1810, which would then be merged.

@fowlslegs What do you think?