### PR TITLE
journalist: gracefully handle HOTP format errors

### DIFF
--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -371,6 +371,44 @@ class TestJournalistApp(TestCase):
         self.assertRedirects(resp,
             url_for('admin_new_user_two_factor', uid=self.user.id))
 
+    def test_admin_resets_user_hotp_format_non_hexa(self):
+        self._login_admin()
+        old_hotp = self.user.hotp.secret
+
+        resp = self.client.post(url_for('admin_reset_two_factor_hotp'),
+                                data=dict(uid=self.user.id, otp_secret='ZZ'))
+        new_hotp = self.user.hotp.secret
+
+        self.assertEqual(old_hotp, new_hotp)
+        self.assertMessageFlashed('Invalid secret format: '
+                                  'Non-hexadecimal digit found', 'error')
+
+    def test_admin_resets_user_hotp_format_odd(self):
+        self._login_admin()
+        old_hotp = self.user.hotp.secret
+
+        resp = self.client.post(url_for('admin_reset_two_factor_hotp'),
+                                data=dict(uid=self.user.id, otp_secret='Z'))
+        new_hotp = self.user.hotp.secret
+
+        self.assertEqual(old_hotp, new_hotp)
+        self.assertMessageFlashed('Invalid secret format: '
+                                  'Odd-length string', 'error')
+
+    @patch('db.Journalist.set_hotp_secret')
+    def test_admin_resets_user_hotp_error(self, mock_set_hotp_secret):
+        self._login_admin()
+        old_hotp = self.user.hotp.secret
+
+        error_message = 'SOMETHING WRONG!'
+        mock_set_hotp_secret.side_effect = TypeError(error_message)
+        with self.assertRaisesRegexp(TypeError, error_message):
+            resp = self.client.post(url_for('admin_reset_two_factor_hotp'),
+                                    data=dict(uid=self.user.id, otp_secret=1234))
+        new_hotp = self.user.hotp.secret
+
+        self.assertEqual(old_hotp, new_hotp)
+
     def test_user_resets_hotp(self):
         self._login_user()
         oldHotp = self.user.hotp


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes: https://github.com/freedomofpress/securedrop/issues/1869

In admin/reset-2fa-hotp, when the token is not properly formatted (odd
number of characters, non hexa character), a python trace is displayed
to the user.

When a known formatting error is detected, a user friendly error message
is displayed instead of the stack trace. Other errors are not caught and
will show a stack trace. Chances are they are not understandable for the
user anyway, even if beautified.

## Testing

pytest -v tests/test_journalist.py

## Deployment

It only changes the user experience and has no impact on deployment.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

![after](https://user-images.githubusercontent.com/433594/27391016-12b852fa-56a3-11e7-8569-c28c9ca8e05c.png)
