### PR TITLE
unify two-factor spelling

### DIFF
--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -113,7 +113,7 @@ Two-Factor Authenticator
 There are several places in the SecureDrop architecture where two-factor
 authentication is used to protect access to sensitive information or
 systems. These instances use the standard TOTP and/or HOTP algorithms,
-and so a variety of devices can be used to provide two factor
+and so a variety of devices can be used to provide two-factor
 authentication for devices. We recommend using one of:
 
 -  An Android or iOS device with `Google

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -417,7 +417,7 @@ class JournalistLoginAttempt(Base):
 
     """This model keeps track of journalist's login attempts so we can
     rate limit them in order to prevent attackers from brute forcing
-    passwords or two factor tokens."""
+    passwords or two-factor tokens."""
     __tablename__ = "journalist_login_attempt"
     id = Column(Integer, primary_key=True)
     timestamp = Column(DateTime, default=datetime.datetime.utcnow)

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -214,12 +214,12 @@ def admin_new_user_two_factor():
         token = request.form['token']
         if user.verify_token(token):
             flash(
-                "Two factor token successfully verified for user {}!".format(
+                "Two-factor token successfully verified for user {}!".format(
                     user.username),
                 "notification")
             return redirect(url_for("admin_index"))
         else:
-            flash("Two factor token failed to verify", "error")
+            flash("Two-factor token failed to verify", "error")
 
     return render_template("admin_new_user_two_factor.html", user=user)
 
@@ -351,10 +351,10 @@ def account_new_two_factor():
     if request.method == 'POST':
         token = request.form['token']
         if g.user.verify_token(token):
-            flash("Two factor token successfully verified!", "notification")
+            flash("Two-factor token successfully verified!", "notification")
             return redirect(url_for('edit_account'))
         else:
-            flash("Two factor token failed to verify", "error")
+            flash("Two-factor token failed to verify", "error")
 
     return render_template('account_new_two_factor.html', user=g.user)
 

--- a/securedrop/journalist_templates/account_new_two_factor.html
+++ b/securedrop/journalist_templates/account_new_two_factor.html
@@ -2,7 +2,7 @@
 {% block body %}
 {% if user.is_totp %}
 <h1>Enable Google Authenticator</h1>
-<p>You're almost done! To finish resetting your two factor authentication, follow the instructions below to set up Google Authenticator. Once you've added the entry for your account in the app, enter one of the 6-digit codes from the app to confirm that two factor authentication is set up correctly.</p>
+<p>You're almost done! To finish resetting your two-factor authentication, follow the instructions below to set up Google Authenticator. Once you've added the entry for your account in the app, enter one of the 6-digit codes from the app to confirm that two factor authentication is set up correctly.</p>
 
 <ol>
   <li>Install Google Authenticator on your phone</li>

--- a/securedrop/journalist_templates/admin_new_user_two_factor.html
+++ b/securedrop/journalist_templates/admin_new_user_two_factor.html
@@ -2,7 +2,7 @@
 {% block body %}
 {% if user.is_totp %}
 <h1>Enable Google Authenticator</h1>
-<p>You're almost done! To finish adding this new user, have them follow the instructions below to set up two factor authentication with Google Authenticator. Once they've added an entry for this account in the app, have them enter one of the 6-digit codes from the app to confirm that two factor authentication is set up correctly.</p>
+<p>You're almost done! To finish adding this new user, have them follow the instructions below to set up two-factor authentication with Google Authenticator. Once they've added an entry for this account in the app, have them enter one of the 6-digit codes from the app to confirm that two factor authentication is set up correctly.</p>
 <ol>
   <li>Install Google Authenticator on your phone</li>
   <li>Open the Google Authenticator app</li>

--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -48,20 +48,20 @@
 
 <hr class="no-line">
 
-<h2>Reset Two Factor Authentication</h2>
+<h2>Reset Two-Factor Authentication</h2>
 
 {% if user %}
-<p>If a user's two factor authentication credentials have been lost or
+<p>If a user's two-factor authentication credentials have been lost or
 compromised, you can reset them here. <em>If you do this, make sure the user is
-present and ready to set up their device with the new two factor credentials.
+present and ready to set up their device with the new two-factor credentials.
 Otherwise, they will be locked out of their account.</em></p>
 {% else %}
-<p>If your two factor authentication credentials have been lost or compromised,
+<p>If your two-factor authentication credentials have been lost or compromised,
 or you got a new device, you can reset your credentials here. <em>If you do
 this, make sure you are ready to set up your new device, otherwise you will be
 locked out of your account.</em></p>
 {% endif %}
-<p>To reset two factor authentication for mobile apps such as Google
+<p>To reset two-factor authentication for mobile apps such as Google
 Authenticator or FreeOTP, choose the first option. For hardware tokens like the
 Yubikey, choose the second.</p>
 
@@ -83,10 +83,10 @@ Yubikey, choose the second.</p>
 </form>
 {%- endmacro %}
 
-{{ twofa_reset(user, totp_reset_url, "totp", "RESET TWO FACTOR AUTHENTICATION
+{{ twofa_reset(user, totp_reset_url, "totp", "RESET TWO-FACTOR AUTHENTICATION
 (APP)")}}
 <br />
-{{ twofa_reset(user, hotp_reset_url, "hotp", "RESET TWO FACTOR AUTHENTICATION
+{{ twofa_reset(user, hotp_reset_url, "hotp", "RESET TWO-FACTOR AUTHENTICATION
 (HARDWARE TOKEN)")}}
 
 {% endblock %}

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -97,9 +97,9 @@ $(function () {
       return confirm("Are you sure you want to delete the user " + username + "?");
   });
 
-  // Confirm before resetting two factor authentication on edit user page
+  // Confirm before resetting two-factor authentication on edit user page
   $('form#reset-two-factor').submit(function(event) {
-      return confirm("Are you sure to want to reset this user's two factor authentication?");
+      return confirm("Are you sure to want to reset this user's two-factor authentication?");
   });
 
 });

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -121,7 +121,7 @@ class JournalistNavigationSteps():
         self.new_user['orm_obj'] = Journalist.query.filter(
             Journalist.username == self.new_user['username']).one()
 
-        # Verify the two factor authentication
+        # Verify the two-factor authentication
         token_field = self.driver.find_element_by_css_selector(
             'input[name="token"]')
         token_field.send_keys('mocked')
@@ -132,7 +132,7 @@ class JournalistNavigationSteps():
         # Successfully verifying the code should redirect to the admin
         # interface, and flash a message indicating success
         flashed_msgs = self.driver.find_elements_by_css_selector('.flash')
-        self.assertIn(("Two factor token successfully verified for user"
+        self.assertIn(("Two-factor token successfully verified for user"
                        " {}!").format(self.new_user['username']),
                       [el.text for el in flashed_msgs])
 

--- a/securedrop/tests/test_2fa.py
+++ b/securedrop/tests/test_2fa.py
@@ -82,7 +82,7 @@ class TestJournalist2FA(flask_testing.TestCase):
                                 data=dict(token=invalid_token))
 
         self.assert200(resp)
-        self.assertMessageFlashed('Two factor token failed to verify', 'error')
+        self.assertMessageFlashed('Two-factor token failed to verify', 'error')
         # last_token should be set to the invalid token we just tried to use
         self.assertEqual(self.admin.last_token, invalid_token)
 
@@ -92,7 +92,7 @@ class TestJournalist2FA(flask_testing.TestCase):
                                 data=dict(token=invalid_token))
 
         # A flashed message should appear
-        self.assertMessageFlashed('Two factor token failed to verify', 'error')
+        self.assertMessageFlashed('Two-factor token failed to verify', 'error')
 
     def test_bad_token_fails_to_verify_on_new_user_two_factor_page(self):
         # Regression test https://github.com/freedomofpress/securedrop/pull/1692
@@ -104,7 +104,7 @@ class TestJournalist2FA(flask_testing.TestCase):
                                 data=dict(token=invalid_token))
 
         self.assert200(resp)
-        self.assertMessageFlashed('Two factor token failed to verify', 'error')
+        self.assertMessageFlashed('Two-factor token failed to verify', 'error')
         # last_token should be set to the invalid token we just tried to use
         self.assertEqual(self.user.last_token, invalid_token)
 
@@ -113,7 +113,7 @@ class TestJournalist2FA(flask_testing.TestCase):
                                 data=dict(token=invalid_token))
 
         # A flashed message should appear
-        self.assertMessageFlashed('Two factor token failed to verify', 'error')
+        self.assertMessageFlashed('Two-factor token failed to verify', 'error')
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Change "two factor" in "two-factor" so it is unified in the
documentation and the user visible messages.

https://en.wiktionary.org/wiki/2fa

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to documentation:

- [x] Doc linting passed locally
