### PR TITLE
doc: git describe --exact-match may fail

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -55,8 +55,8 @@ Backing Up
 
 Open a **Terminal** on the *Admin Workstation* and ``cd`` to your clone of the
 SecureDrop git repository (usually ``~/Persistent/securedrop``). Ensure you have
-SecureDrop version 0.3.7 or later checked out (you can run ``git describe
---exact-match`` to see what Git tag you've checked out).
+SecureDrop version 0.3.7 or later checked out (you can run ``git describe``
+to see what Git tag you've checked out).
 
 .. note:: The backups are stored in the *Admin Workstation*'s persistent volume.
           **You should verify that you have enough space to store the backups


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

When not on a tag, it will fail with:

    fatal: no tag exactly matches 'dc301206cd38e5f1c30a1687f19d2d0b7b5054cf'

which is not very useful. Changing to `git describe` alone which will show the tag if it matches the current commit or something like

    0.3.11-2103-gdc301206

otherwise which gives some kind of indication regarding the latest release.

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
