### PR TITLE
Raises main stack gap 64KB -> 1MB via sysctl

### DIFF
--- a/install_files/ansible-base/roles/grsecurity/defaults/main.yml
+++ b/install_files/ansible-base/roles/grsecurity/defaults/main.yml
@@ -6,4 +6,8 @@ grsec_sysctl_flags:
     # rest will not be applied
   - name: "kernel.grsecurity.grsec_lock"
     value: "1"
-
+    # Stack clash mitigation, increasing main stack gap to 1MB.
+    # Storing as part of grsecurity vars, because sysctl option won't
+    # exist otherwise.
+  - name: "vm.heap_stack_gap"
+    value: "1048576"

--- a/testinfra/common/test_grsecurity.py
+++ b/testinfra/common/test_grsecurity.py
@@ -84,6 +84,7 @@ def test_grsecurity_kernel_is_running(Command):
 @pytest.mark.parametrize('sysctl_opt', [
   ('kernel.grsecurity.grsec_lock', 1),
   ('kernel.grsecurity.rwxmap_logging', 0),
+  ('vm.heap_stack_gap', 1048576),
 ])
 def test_grsecurity_sysctl_options(Sysctl, Sudo, sysctl_opt):
     """


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

We're already setting this value via the `securedrop-grsec` metapackage, as described in #1861 and implemented in the grsec repo [0]. Let's also ensure it at install time by setting it directly along with the other
sysctl options.

Included a config test so that test suite will fail if the sysctl doesn't stick during CI or local development.

[0] https://github.com/freedomofpress/ansible-role-grsecurity/pull/100

Fixes #1861.

## Testing
CI it not sufficient here, since the CI hosts don't use grsecurity-patched kernels. Run through the provisioning with staging VMs, and confirm manually that `sudo sysctl vm.heap_stack_gap` shows `1048576`.

## Deployment

We already posted the new kernel packages in the apt repo, and the sysctl setting is set in the `securedrop-grsec` metapackage, so we're good to go for deployed instances. Adding the setting within Ansible is simply to guard against regressions, and also allows us to clean up the metapackage in the future.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [x] Doc linting passed locally
