### PR TITLE
Falls back to old Ubuntu Trusty image in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@
 # Relevant docs: https://docs.travis-ci.com/user/trusty-ci-environment/
 sudo: required
 dist: trusty
+# Use old Trusty images, since new ones are failing Selenium tests.
+# Must be updated by 2017-09-01. More info:
+# https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch
+group: deprecated-2017Q2
 
 language: python
 python:


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

We've recently started seeing failures in the Travis run, related to the
functional Selenium application tests. Since the underlying Ubuntu
Trusty image used by Travis was just updated [0], let's fall back to the
deprecated image that was working well, and reassess in the near future.

Fixes #1874.

[0] https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch

## Testing

Make sure Travis CI run passes! (As usual, _all_ CI checks must pass for merge.)

## Deployment

No considerations for deployment, only affects the CI environment.