### PR TITLE
Peg CI systemd image to digest hash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: msheiny/pressfreedomci:latest
+      - image: quay.io/freedomofpress/circleci-docker@sha256:3919aa22af019f6a5db04ecd7320841401652b0ed93a1c3834cd604685242ce7
         environment:
           FPF_CI: true
           CI_SD_ENV: staging

--- a/devops/playbooks/aws-ci-startup.yml
+++ b/devops/playbooks/aws-ci-startup.yml
@@ -5,12 +5,6 @@
   become: no
   gather_facts: true
   tasks:
-    - name: Pull in systemd-enabled docker base image.
-      docker_image:
-        name: "{{ docker_image_sd_build }}"
-      when: "{{ docker_instances != [] }}"
-      tags: docker
-
     - name: Start Tor docker proxy for use in functional app tests.
       docker_container:
         name: tor
@@ -19,11 +13,12 @@
       when: "{{ docker_instances != [] }}"
       tags: docker
 
-    - name: Start CI-specific build containers.
+    - name: Start CI containers.
       docker_container:
         name: "{{ item }}"
         hostname: "{{ item }}"
-        image: "{{ docker_image_sd_build }}"
+        image: "{{ docker_image_ci }}@{{ docker_image_ci_version }}"
+        pull: true
         command: /lib/systemd/systemd
         devices:
           - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
@@ -34,7 +29,8 @@
       tags: docker
   vars:
     ci_environment: "{{ ansible_env.CI_SD_ENV | mandatory }}"
-    docker_image_sd_build: "msheiny/debian-jessie-systemd"
+    docker_image_ci_version: "sha256:540e74955e3491b16c6345da1a848ddb9d2503cce4358813b864494fff9464d0"
+    docker_image_ci: "quay.io/freedomofpress/debian-jessie-systemd"
   vars_files:
     - "../vars/{{ ci_environment }}.yml"
 


### PR DESCRIPTION
## Status

Work in progress 🚧  - waiting for CI to pass, still need to test locally

## Description of Changes

Fixes #1877  

Changes proposed in this pull request: During process of this commit, I rebuilt the CI systemd image, pushed it to our team repo at `quay.io`, and recorded the digest hash. Reason for doing this was to move it to a team controlled repository and to better version control which image is being pulled.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Deployment

Only affects CI