### PR TITLE
Standardizes on single Admin username

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -75,11 +75,9 @@ the SecureDrop servers.
 
 .. code:: sh
 
+   source .venv/bin/activate
    cd install_files/ansible-base
-   ansible -u <SSH username> -m ping all
-
-.. tip:: If you forgot your SSH username, it is the value of the ``ssh_users``
-         variable in ``group_vars/all/site-specific``.
+   ansible -m ping all
 
 If this command fails (usually with an error like "SSH Error: data could not be
 sent to the remote host. Make sure this host can be reached over ssh"), you need
@@ -110,8 +108,9 @@ perform the backup:
 
 .. code:: sh
 
+   source .venv/bin/activate
    cd install_files/ansible-base
-   ansible-playbook -u <SSH username> -K -t backup securedrop-prod.yml -e perform_backup=true
+   ansible-playbook -t backup securedrop-prod.yml -e perform_backup=true
 
 .. todo:: Test this on a real *Admin Workstation*
 
@@ -159,8 +158,9 @@ backup:
 
 .. code:: sh
 
+   source .venv/bin/activate
    cd install_files/ansible-base
-   ansible-playbook -u <SSH username> -K -t backup securedrop-prod.yml -e restore_file="<your backup archive filename>"
+   ansible-playbook -t backup securedrop-prod.yml -e restore_file="<your backup archive filename>"
 
 This actually performs a backup, followed by a restore. A backup is done before
 the restore as an emergency precaution, to ensure you can recover the server in

--- a/install_files/ansible-base/inventory-dynamic
+++ b/install_files/ansible-base/inventory-dynamic
@@ -37,7 +37,7 @@ def lookup_local_ipv4_address(hostname):
             monitor_ip = site_vars['monitor_ip']
 
     except (IOError, KeyError):
-        msg = "You must run the configure playbook."
+        msg = "You must run 'secure-admin sdconfig' from root securedrop dir."
         raise Exception(msg)
 
     if hostname == "app":

--- a/install_files/ansible-base/inventory-dynamic
+++ b/install_files/ansible-base/inventory-dynamic
@@ -49,6 +49,36 @@ def lookup_local_ipv4_address(hostname):
         raise Exception(msg)
 
 
+def lookup_admin_username():
+    """
+    Read the username for the Admin account on the SecureDrop servers
+    from the site-specific YAML vars file. Prior to SecureDrop 0.4,
+    the `ssh_users` var could have been a list, so handle the transition
+    gracefully and provide an informative error message if the site-specific
+    vars file contains a list for this value.
+    """
+    try:
+        with open(SECUREDROP_SITE_VARS, 'r') as f:
+            site_vars = yaml.safe_load(f)
+            admin_username = site_vars['ssh_users']
+
+    except (IOError, KeyError):
+        msg = "You must run the configure playbook."
+        raise Exception(msg)
+
+    try:
+        # Strong typing in Python is generally a bad idea, but simply checking
+        # for "not list" doesn't include other edge cases, such as dict.
+        assert type(admin_username) is str
+    except AssertionError:
+        msg = ("The value of `ssh_users` must be a single username,"
+               " not a list of usernames. Please update"
+               " `{}` and try again.".format(SECUREDROP_SITE_VARS))
+        raise Exception(msg)
+
+    return admin_username
+
+
 def lookup_tor_hostname(hostname):
     """
     Extract Onion URL from HidServAuth file that was fetched back locally.
@@ -115,7 +145,8 @@ def build_inventory():
         "_meta": {
             "hostvars": {
                 h: {
-                    "ansible_ssh_host": lookup_ssh_address(h)
+                    "ansible_ssh_host": lookup_ssh_address(h),
+                    "ansible_ssh_user": lookup_admin_username(),
                 } for h in SECUREDROP_SUPPORTED_HOSTNAMES
             },
         },

--- a/install_files/ansible-base/roles/tails-config/templates/ssh_config.j2
+++ b/install_files/ansible-base/roles/tails-config/templates/ssh_config.j2
@@ -1,4 +1,6 @@
 Host app
+  User {{ ssh_users }}
   Hostname {{ app_ssh_lookup_result.stdout }}
 Host mon
+  User {{ ssh_users }}
   Hostname {{ mon_ssh_lookup_result.stdout }}

--- a/install_files/ansible-base/roles/validate/tasks/validate_users.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_users.yml
@@ -10,7 +10,6 @@
       - "item not in ssh_users"
       # Make sure we have a string, not a list.
       - "ssh_users|list != ssh_users"
-      - "ssh_users|list == ssh_users"
     msg: >-
       The Admin username for SSH connections to the servers failed
       to validate. {{ securedrop_validate_error_msg_start }} the

--- a/install_files/ansible-base/roles/validate/tasks/validate_users.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_users.yml
@@ -8,6 +8,9 @@
       - "ssh_users != item"
       - "ssh_users != ''"
       - "item not in ssh_users"
+      # Make sure we have a string, not a list.
+      - "ssh_users|list != ssh_users"
+      - "ssh_users|list == ssh_users"
     msg: >-
       The Admin username for SSH connections to the servers failed
       to validate. {{ securedrop_validate_error_msg_start }} the

--- a/securedrop-admin
+++ b/securedrop-admin
@@ -102,12 +102,11 @@ def install_securedrop(args):
     import yaml
 
     try:
+        # Attempt to read site-specific vars file, specifically
+        # for informative messaging via exception handling.
         with open(SITE_CONFIG) as site_config_file:
             site_config_vars = yaml.safe_load(site_config_file.read())
 
-        # Username may have been provided as `--user`, but try to fall back
-        # to YAML vars files if not.
-        ansible_user = args.user or site_config_vars['ssh_users']
     except IOError:
         sdlog.error("Config file missing, re-run with sdconfig")
         sys.exit(1)
@@ -120,7 +119,6 @@ def install_securedrop(args):
         sudo_prompt = "Sudo password for servers [blank if not needed]: "
         ansible_password = getpass.getpass(prompt=sudo_prompt)
         subprocess.check_call([os.path.join(ANSIBLE_PATH, 'securedrop-prod.yml'),
-                         '-u '+ansible_user,
                          "-e ansible_become_pass={}".format(ansible_password),
                          ],
                         cwd=ANSIBLE_PATH)
@@ -151,8 +149,6 @@ if __name__ == "__main__":
 
     parse_install = subparsers.add_parser('install',
                                           help=install_securedrop.__doc__)
-    parse_install.add_argument('--user', type=str, default=None,
-                               help="Over-ride user defined in vars")
     parse_install.set_defaults(func=install_securedrop)
 
     parse_tailsconfig = subparsers.add_parser('tailsconfig',


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #1796.

Forces via validation that the `ssh_users` var declare a single username for the Admin to log into the remote SecureDrop servers. Most of the configuration logic assumes this is a string, but Admins managing production instances _may_ have entered a list of usernames here. Therefore it's critical that we provide informative error messaging about the breaking change, so that it's clear to current Admins what action must be taken to log into the servers.

## Testing

### Confirm good vars work well
1. Boot up Tails instance. 
2. Run through the `./securedrop-admin sdconfig` flow and declare a username for the servers. (You can use Vagrant VMs for the target boxes, and enter the relevant IP addresses accordingly. You'll also need to copy in the SSH private key. In this case, "vagrant" should be the value of `ssh_users`.)
3. Run `source .venv/bin/activate` to get access to the ansible binary, then `cd install_files/ansible-base`.
4. Run `ansible -m ping app-staging` and confirm a green OK message.

### Confirm bad vars fail well
1. Run through all the steps above.
2. Edit `ssh_users` to be a list, e.g. `ssh_users: ['vagrant', 'dummy']`.
3. Rerun `ansible -m ping app-staging` and confirm an informative error message is displayed.

Example failure message:

```
Using /home/amnesia/Persistent/securedrop/install_files/ansible-base/ansible.cfg as config file
ERROR! Attempted to execute "inventory-dynamic" as inventory script: Inventory script (inventory-dynamic) had an execution error: Traceback (most recent call last):
  File "/home/amnesia/Persistent/securedrop/install_files/ansible-base/inventory-dynamic", line 167, in <module>
    inventory = build_inventory()
  File "/home/amnesia/Persistent/securedrop/install_files/ansible-base/inventory-dynamic", line 148, in build_inventory
    } for h in SECUREDROP_SUPPORTED_HOSTNAMES
  File "/home/amnesia/Persistent/securedrop/install_files/ansible-base/inventory-dynamic", line 148, in <dictcomp>
    } for h in SECUREDROP_SUPPORTED_HOSTNAMES
  File "/home/amnesia/Persistent/securedrop/install_files/ansible-base/inventory-dynamic", line 75, in lookup_admin_username
    raise Exception(msg)
Exception: The value of `ssh_users` must be a single username, not a list of usernames. Please update `/home/amnesia/Persistent/securedrop/install_files/ansible-base/group_vars/all/site-specific` and try again.
```

## Deployment

In general these changes should make managing SecureDrop instances more straightforward for Admins. In the handful of cases (we've no firm data on percentage) where Admins have declared `ssh_users` as a list of usernames, we'll rely on the informative messaging to guide Admins to make the correct updates.

## Checklist
Relying on manual testing in Tails to confirm working config.

### If you made changes to documentation:

- [x] Doc linting passed locally