### PR TITLE
Makes securedrop-admin messaging more user-friendly

### DIFF
--- a/securedrop-admin
+++ b/securedrop-admin
@@ -63,22 +63,48 @@ def sdconfig(args):
     subprocess.check_call(ansible_cmd, cwd=ANSIBLE_PATH, env=os.environ.copy())
 
 
+def run_command(command):
+    """
+    Wrapper function to display stdout for running command,
+    similar to how shelling out in a Bash script displays rolling output.
+
+    Yields a list of the stdout from the `command`, and raises a
+    CalledProcessError if `command` returns non-zero.
+    """
+    popen = subprocess.Popen(command, stdout=subprocess.PIPE)
+    for stdout_line in iter(popen.stdout.readline, ""):
+        yield stdout_line
+    popen.stdout.close()
+    return_code = popen.wait()
+    if return_code:
+        raise subprocess.CalledProcessError(return_code, command)
+
+
 def envsetup(args):
     """Install SD pre-reqs"""
     # virtualenv doesnt exist? Install dependencies and create
     if not os.path.exists(VENV_ACTIVATION):
-        sdlog.info("Installing dependencies. You'll be prompted for the "
-            "temporary Tails root credentials. This was set on boot-up screen")
-        sdlog.debug(subprocess.check_output(['sudo', 'su', '-c',
-                                            "apt-get update && \
-                                            apt-get install -y \
-                                            python-virtualenv \
-                                            python-pip \
-                                            ccontrol \
-                                            virtualenv \
-                                            libffi-dev \
-                                            libssl-dev \
-                                            libpython2.7-dev"]))
+
+        sdlog.info(("Installing dependencies. You'll be prompted for the"
+                    " temporary Tails admin password,"
+                    " which was set on Tails login screen."))
+
+        apt_command = ['sudo', 'su', '-c',
+                       "apt-get update && \
+                       apt-get install -y \
+                       python-virtualenv \
+                       python-pip \
+                       ccontrol \
+                       virtualenv \
+                       libffi-dev \
+                       libssl-dev \
+                       libpython2.7-dev",
+                       ]
+
+        # Print command results in real-time, to keep Admin apprised
+        # of progress during long-running command.
+        for output_line in run_command(apt_command):
+            sdlog.info(output_line.rstrip())
 
         # Technically you can create a virtualenv from within python
         # but pip can only be run over tor on tails, and debugging that

--- a/securedrop-admin
+++ b/securedrop-admin
@@ -111,8 +111,8 @@ def install_apt_dependencies(args):
         # Tails supports apt persistence, which was used by SecureDrop
         # under Tails 2.x. If updates are being applied, don't try to pile
         # on with more apt requests.
-        sdlog.error(("Cannot lock apt. Tails may be performing automatic"
-                     " updates. Please try again in a few minutes."))
+        sdlog.error(("Failed to install apt dependencies. Check network"
+                     " connection and try again."))
         sys.exit(1)
 
 

--- a/securedrop-admin
+++ b/securedrop-admin
@@ -80,51 +80,98 @@ def run_command(command):
         raise subprocess.CalledProcessError(return_code, command)
 
 
-def envsetup(args):
-    """Install SD pre-reqs"""
-    # virtualenv doesnt exist? Install dependencies and create
-    if not os.path.exists(VENV_ACTIVATION):
+def install_apt_dependencies(args):
+    """
+    Install apt dependencies in Tails. In order to install Ansible in
+    a virtualenv, first there are a number of Python prerequisites.
+    """
+    sdlog.info(("Installing dependencies. You'll be prompted for the"
+                " temporary Tails admin password,"
+                " which was set on Tails login screen."))
 
-        sdlog.info(("Installing dependencies. You'll be prompted for the"
-                    " temporary Tails admin password,"
-                    " which was set on Tails login screen."))
+    apt_command = ['sudo', 'su', '-c',
+                   "apt-get update && \
+                   apt-get install -y \
+                   python-virtualenv \
+                   python-pip \
+                   ccontrol \
+                   virtualenv \
+                   libffi-dev \
+                   libssl-dev \
+                   libpython2.7-dev",
+                   ]
 
-        apt_command = ['sudo', 'su', '-c',
-                       "apt-get update && \
-                       apt-get install -y \
-                       python-virtualenv \
-                       python-pip \
-                       ccontrol \
-                       virtualenv \
-                       libffi-dev \
-                       libssl-dev \
-                       libpython2.7-dev",
-                       ]
-
+    try:
         # Print command results in real-time, to keep Admin apprised
         # of progress during long-running command.
         for output_line in run_command(apt_command):
-            sdlog.info(output_line.rstrip())
+            print(output_line.rstrip())
+    except subprocess.CalledProcessError:
+        # Tails supports apt persistence, which was used by SecureDrop
+        # under Tails 2.x. If updates are being applied, don't try to pile
+        # on with more apt requests.
+        sdlog.error(("Cannot lock apt. Tails may be performing automatic"
+                     " updates. Please try again in a few minutes."))
+        sys.exit(1)
+
+
+def envsetup(args):
+    """
+    Installs all Admin tooling required for managing SecureDrop. Specifically:
+
+        * updates apt-cache
+        * installs apt packages for Python virtualenv
+        * creates virtualenv
+        * installs pip packages inside virtualenv
+
+    The virtualenv is created within the Persistence volume in Tails, so that
+    Ansible is available to the Admin on subsequent boots without requiring
+    installation of packages again.
+    """
+    # virtualenv doesnt exist? Install dependencies and create
+    if not os.path.exists(VENV_ACTIVATION):
+
+        install_apt_dependencies(args)
 
         # Technically you can create a virtualenv from within python
         # but pip can only be run over tor on tails, and debugging that
         # along with instaling a third-party dependency is not worth
         # the effort here.
         sdlog.info("Setting up virtualenv")
-        sdlog.debug(subprocess.check_output(['torify', 'virtualenv',
-                                        VENV_DIR], stderr=subprocess.STDOUT))
+        try:
+            sdlog.debug(subprocess.check_output(['torify', 'virtualenv',
+                                                 VENV_DIR],
+                                                stderr=subprocess.STDOUT))
+        except subprocess.CalledProcessError:
+            sdlog.error(("Unable to create virtualenv. Check network settings"
+                         " and try again."))
+            sys.exit(1)
 
+    install_pip_dependencies(args)
+
+
+def install_pip_dependencies(args):
+    """
+    Install Python dependencies via pip into virtualenv.
+    """
     pip_install_cmd = [
             'torify',
             os.path.join(VENV_DIR, 'bin', 'pip'),
             'install',
+            # Specify requirements file.
+            '-r', os.path.join(ANSIBLE_PATH, 'requirements.txt'),
+            '--require-hashes',
+            # Make sure to upgrade packages only if necessary.
+            '-U', '--upgrade-strategy', 'only-if-needed',
             ]
-    requirements_cmd = ['-r', os.path.join(ANSIBLE_PATH, 'requirements.txt'),
-                        '--require-hashes']
-    upgrade = ['-U', '--upgrade-strategy', 'only-if-needed']
 
     sdlog.info("Checking Python dependencies for securedrop-admin")
-    pip_output = subprocess.check_output(pip_install_cmd+upgrade+requirements_cmd)
+    try:
+        pip_output = subprocess.check_output(pip_install_cmd)
+    except subprocess.CalledProcessError:
+        sdlog.error(("Failed to install pip dependencies. Check network"
+                     " connection and try again."))
+        sys.exit(1)
 
     sdlog.debug(pip_output)
     if "Successfully installed" in pip_output:

--- a/securedrop-admin
+++ b/securedrop-admin
@@ -60,6 +60,7 @@ def sdconfig(args):
         ansible_cmd.append('--extra-vars')
         ansible_cmd.append("@{}".format(SITE_CONFIG))
 
+    sdlog.info("Configuring SecureDrop site-specific information")
     subprocess.check_call(ansible_cmd, cwd=ANSIBLE_PATH, env=os.environ.copy())
 
 
@@ -85,9 +86,9 @@ def install_apt_dependencies(args):
     Install apt dependencies in Tails. In order to install Ansible in
     a virtualenv, first there are a number of Python prerequisites.
     """
-    sdlog.info(("Installing dependencies. You'll be prompted for the"
-                " temporary Tails admin password,"
-                " which was set on Tails login screen."))
+    sdlog.info("Installing SecureDrop Admin dependencies")
+    sdlog.info(("You'll be prompted for the temporary Tails admin password,"
+                " which was set on Tails login screen"))
 
     apt_command = ['sudo', 'su', '-c',
                    "apt-get update && \
@@ -146,8 +147,12 @@ def envsetup(args):
             sdlog.error(("Unable to create virtualenv. Check network settings"
                          " and try again."))
             sys.exit(1)
+    else:
+        sdlog.info("Virtualenv already exists, not creating")
 
     install_pip_dependencies(args)
+
+    sdlog.info("Finished installing SecureDrop dependencies")
 
 
 def install_pip_dependencies(args):
@@ -213,6 +218,7 @@ def install_securedrop(args):
 def run_tails_config(args):
     """Configure Tails environment post SD install"""
     activate_venv()
+    sdlog.info("Configuring Tails workstation environment")
     subprocess.check_call([os.path.join(ANSIBLE_PATH, 'securedrop-tails.yml'),
                            "--ask-become-pass",
                            ],


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #1806. Fixes #1834.

Beefs up the exception handling in the new `securedrop-admin` script (#1781) to provide more informative messaging, both for errors in the event of failure, and during normal execution, so it doesn't look like the script has hung when it spends 10 minutes pulling down apt packages in silence.

## Testing

Dust off that Tails USB! 🤠 

### Testing success
1. Boot into Tails with fresh persistence.
2. Run `./securedrop-admin setup` and confirm the output is informative and useful.

### Testing failure
1. Run through all the steps above.
2. Run `rm -rf .venv/` in the securedrop repo to blow away the old virtualenv.
3. In a separate terminal window, run `sudo apt-get install -y emacs`.
4. While the apt installation is running, run `./securedrop-admin setup` and make sure the error is handled well.

In general, treat the script roughly and see if you can find unhandled errors that should have explicit error messages associated with them.

## Deployment

Yes, lots. First-time Admins will use the securedrop-admin script during installation, and existing Admins will use it when porting their Tails sticks 2 -> 3.x (if they've not done so already).

## Checklist

Relying on manual testing in Tails to confirm functionality.
