### PR TITLE
journalist: gracefully handle TOTP regeneration errors

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -240,9 +240,16 @@ def admin_reset_two_factor_totp():
     uid = request.form['uid']
     user = Journalist.query.get(uid)
     user.is_totp = True
-    user.regenerate_totp_shared_secret()
-    db_session.commit()
-    return redirect(url_for('admin_new_user_two_factor', uid=uid))
+    try:
+        user.regenerate_totp_shared_secret()
+    except Exception as e:
+        flash("An unexpected error occurred! Please check the application "
+              "logs or inform your adminstrator.", "error")
+        app.logger.error("Reset TOTP for '{}' failed: {}".format(uid, e))
+        return redirect(url_for("admin_edit_user", user_id=uid))
+    else:
+        db_session.commit()
+        return redirect(url_for('admin_new_user_two_factor', uid=uid))
 
 
 @app.route('/admin/reset-2fa-hotp', methods=['POST'])

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -399,9 +399,17 @@ def account_new_two_factor():
 @login_required
 def account_reset_two_factor_totp():
     g.user.is_totp = True
-    g.user.regenerate_totp_shared_secret()
-    db_session.commit()
-    return redirect(url_for('account_new_two_factor'))
+    uid = g.user.id
+    try:
+        g.user.regenerate_totp_shared_secret()
+    except Exception as e:
+        flash("An unexpected error occurred! Please check the application "
+              "logs or inform your adminstrator.", "error")
+        app.logger.error("Reset TOTP for '{}' failed: {}".format(uid, e))
+        return redirect(url_for('edit_account'))
+    else:
+        db_session.commit()
+        return redirect(url_for('account_new_two_factor'))
 
 
 @app.route('/account/reset-2fa-hotp', methods=['POST'])

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -470,6 +470,30 @@ class TestJournalistApp(TestCase):
             resp,
             url_for('admin_new_user_two_factor', uid=self.user.id))
 
+    @patch('db.Journalist.regenerate_totp_shared_secret',
+           side_effect=Exception('ERROR'))
+    @patch('journalist.app.logger.error')
+    def test_admin_resets_user_totp_error(
+            self,
+            mocked_error_logger,
+            mocked_regenerate_totp_shared_secret):
+        self._login_admin()
+        old_totp = self.user.totp
+
+        resp = self.client.post(
+            url_for('admin_reset_two_factor_totp'),
+            data=dict(uid=self.user.id))
+        new_totp = self.user.totp
+
+        mocked_error_logger.assert_called_once_with(
+            "Reset TOTP for '{}' failed: {}".format(self.user.id, 'ERROR'))
+        self.assertRedirects(resp,
+                             url_for("admin_edit_user", user_id=self.user.id))
+        self.assertEqual(old_totp.secret, new_totp.secret)
+        self.assertMessageFlashed(
+            "An unexpected error occurred! Please check the application "
+            "logs or inform your adminstrator.", "error")
+
     def test_user_resets_totp(self):
         self._login_user()
         old_totp = self.user.totp

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -507,6 +507,26 @@ class TestJournalistApp(TestCase):
         # should redirect to verification page
         self.assertRedirects(resp, url_for('account_new_two_factor'))
 
+    @patch('db.Journalist.regenerate_totp_shared_secret',
+           side_effect=Exception('ERROR'))
+    @patch('journalist.app.logger.error')
+    def test_user_resets_totp_error(self,
+                                    mocked_error_logger,
+                                    mocked_regenerate_totp_shared_secret):
+        self._login_user()
+        old_totp = self.user.totp
+
+        resp = self.client.post(url_for('account_reset_two_factor_totp'))
+        new_totp = self.user.totp
+
+        mocked_error_logger.assert_called_once_with(
+            "Reset TOTP for '{}' failed: {}".format(self.user.id, 'ERROR'))
+        self.assertRedirects(resp, url_for("edit_account"))
+        self.assertEqual(old_totp.secret, new_totp.secret)
+        self.assertMessageFlashed(
+            "An unexpected error occurred! Please check the application "
+            "logs or inform your adminstrator.", "error")
+
     def test_admin_resets_hotp_with_missing_otp_secret_key(self):
         self._login_admin()
         resp = self.client.post(url_for('admin_reset_two_factor_hotp'),


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The db.Journalist.regenerate_totp_shared_secret ultimately calls os.urandom which may throw a NotImplementedError exception if the randomness source is not found. Log the error and display a user message suggesting to contact the administrator

## Testing

pytest -v -k test_admin_resets_user_totp_error tests/test_journalist.py
pytest -v -k test_user_resets_totp_error tests/test_journalist.py