### PR TITLE
source: adjust reply confirmation CSS

### DIFF
--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -180,9 +180,10 @@ p#codename
   .confirm-prompt
     position: absolute
     width: 300px
-    right: 5%
-    top: -9%
+    right: 10%
     font-size: 14px
+    background: white
+    border: 1px solid $color_grey_dark
 
     p
       *


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1895

Adjust the reply confirmation box slightly to the left and to the top so it fits in the reply frame and is nicely readable.

![better](https://user-images.githubusercontent.com/433594/27650709-0295888c-5c36-11e7-9343-a6da50446c7b.png)


## Testing

* Send a message as a source
* Send a reply as a journalist
* Try to remove the reply

## Deployment

This is a GUI fix that has no impact on deployment.
