### PR TITLE
Fix parsing of wordlists

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -46,9 +46,9 @@ do_runtime_tests()
 
 gpg = gnupg.GPG(binary='gpg2', homedir=config.GPG_KEY_DIR)
 
-words = open(config.WORD_LIST).read().split('\n')
-nouns = open(config.NOUNS).read().split('\n')
-adjectives = open(config.ADJECTIVES).read().split('\n')
+words = open(config.WORD_LIST).read().rstrip('\n').split('\n')
+nouns = open(config.NOUNS).read().rstrip('\n').split('\n')
+adjectives = open(config.ADJECTIVES).read().rstrip('\n').split('\n')
 
 
 class CryptoException(Exception):

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -20,6 +20,11 @@ class TestCryptoUtil(unittest.TestCase):
     def tearDown(self):
         utils.env.teardown()
 
+    def test_word_list_does_not_contain_empty_strings(self):
+        self.assertNotIn('', (crypto_util.words
+                              + crypto_util.nouns
+                              + crypto_util.adjectives))
+
     def test_clean(self):
         ok = (' !#%$&)(+*-1032547698;:=?@acbedgfihkjmlonqpsrutwvyxzABCDEFGHIJ'
               'KLMNOPQRSTUVWXYZ')


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #1900.

Without stripping the final newline character, each of these lists ends up with an empty string as its last element.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM