### PR TITLE
db: flake8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 store.py; popd
+  - pushd securedrop; flake8 db.py store.py; popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -110,7 +110,8 @@ class Source(Base):
             for submission in self.submissions:
                 if submission.filename.endswith('msg.gpg'):
                     self.docs_msgs_count['messages'] += 1
-                elif submission.filename.endswith('doc.gz.gpg') or submission.filename.endswith('doc.zip.gpg'):
+                elif (submission.filename.endswith('doc.gz.gpg') or
+                      submission.filename.endswith('doc.zip.gpg')):
                     self.docs_msgs_count['documents'] += 1
             return self.docs_msgs_count
 
@@ -185,7 +186,8 @@ class SourceStar(Base):
 
     def __eq__(self, other):
         if isinstance(other, SourceStar):
-            return self.source_id == other.source_id and self.id == other.id and self.starred == other.starred
+            return (self.source_id == other.source_id and
+                    self.id == other.id and self.starred == other.starred)
         return NotImplemented
 
     def __init__(self, source, starred=True):
@@ -200,7 +202,8 @@ class InvalidUsernameException(Exception):
 
 class LoginThrottledException(Exception):
 
-    """Raised when a user attempts to log in too many times in a given time period"""
+    """Raised when a user attempts to log in
+    too many times in a given time period"""
 
 
 class WrongPasswordException(Exception):
@@ -343,7 +346,8 @@ class Journalist(Base):
         return ' '.join(chunks).lower()
 
     def _format_token(self, token):
-        """Strips from authentication tokens the whitespace that many clients add for readability"""
+        """Strips from authentication tokens the whitespace
+        that many clients add for readability"""
         return ''.join(token.split())
 
     def verify_token(self, token):

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -339,7 +339,7 @@ class Journalist(Base):
         lowercase and split into four groups of four characters. The secret is
         base32-encoded, so it is case insensitive."""
         sec = self.otp_secret
-        chunks = [sec[i:i + 4] for i in xrange(0, len(sec), 4)]
+        chunks = [sec[i:i + 4] for i in range(0, len(sec), 4)]
         return ' '.join(chunks).lower()
 
     def _format_token(self, token):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes db.py flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop ; python -m astor.rtrip .
* diff -ru tmp_rtrip tmp_rtrip.orig
<pre>
diff -ru tmp_rtrip/db.py tmp_rtrip.orig/db.py
--- tmp_rtrip/db.py	2017-06-29 00:37:55.884309703 +0200
+++ tmp_rtrip.orig/db.py	2017-06-28 17:29:14.024310408 +0200
@@ -159,8 +159,7 @@
 
 
 class LoginThrottledException(Exception):
-    """Raised when a user attempts to log in
-    too many times in a given time period"""
+    """Raised when a user attempts to log in too many times in a given time period"""
 
 
 class WrongPasswordException(Exception):
@@ -275,12 +274,11 @@
         lowercase and split into four groups of four characters. The secret is
         base32-encoded, so it is case insensitive."""
         sec = self.otp_secret
-        chunks = [sec[i:i + 4] for i in range(0, len(sec), 4)]
+        chunks = [sec[i:i + 4] for i in xrange(0, len(sec), 4)]
         return ' '.join(chunks).lower()
 
     def _format_token(self, token):
-        """Strips from authentication tokens the whitespace
-        that many clients add for readability"""
+        """Strips from authentication tokens the whitespace that many clients add for readability"""
         return ''.join(token.split())
 
     def verify_token(self, token):
</pre>

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior