### PR TITLE
source: flake8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py store.py; popd
+  - pushd securedrop; flake8 db.py store.py source.py; popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -215,7 +215,7 @@ def lookup():
         try:
             reply.decrypted = crypto_util.decrypt(
                 g.codename,
-                file(reply_path).read()).decode('utf-8')
+                open(reply_path).read()).decode('utf-8')
         except UnicodeDecodeError:
             app.logger.error("Could not decode reply %s" % reply.filename)
         else:

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -73,7 +73,8 @@ def login_required(f):
 
 
 def ignore_static(f):
-    """Only executes the wrapped function if we're not loading a static resource."""
+    """Only executes the wrapped function if we're not loading
+    a static resource."""
     @wraps(f)
     def decorated_function(*args, **kwargs):
         if request.path.startswith('/static'):
@@ -112,8 +113,8 @@ def setup_g():
 @app.before_request
 @ignore_static
 def check_tor2web():
-        # ignore_static here so we only flash a single message warning about Tor2Web,
-        # corresponding to the intial page load.
+    # ignore_static here so we only flash a single message warning
+    # about Tor2Web, corresponding to the intial page load.
     if 'X-tor2web' in request.headers:
         flash('<strong>WARNING:</strong> You appear to be using Tor2Web. '
               'This <strong>does not</strong> provide anonymity. '
@@ -124,8 +125,8 @@ def check_tor2web():
 @app.route('/')
 def index():
     return render_template('index.html',
-                           custom_notification=getattr(config,
-                           'CUSTOM_NOTIFICATION', ''))
+                           custom_notification=getattr(
+                               config, 'CUSTOM_NOTIFICATION', ''))
 
 
 def generate_unique_codename():
@@ -156,8 +157,9 @@ def generate_unique_codename():
 @app.route('/generate', methods=('GET', 'POST'))
 def generate():
     if logged_in():
-        flash("You were redirected because you are already logged in. If you want "
-              "to create a new account, you should log out first.", "notification")
+        flash("You were redirected because you are already logged in. "
+              "If you want to create a new account, you should log out first.",
+              "notification")
         return redirect(url_for('lookup'))
 
     codename = generate_unique_codename()
@@ -255,7 +257,8 @@ def normalize_timestamps(sid):
         rc = subprocess.call(args)
         if rc != 0:
             app.logger.warning(
-                "Couldn't normalize submission timestamps (touch exited with %d)" %
+                "Couldn't normalize submission "
+                "timestamps (touch exited with %d)" %
                 rc)
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes db.py flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop ; python -m astor.rtrip .
* diff -ru tmp_rtrip tmp_rtrip.orig
<pre>
diff -ru tmp_rtrip.orig/source.py tmp_rtrip/source.py
--- tmp_rtrip.orig/source.py	2017-06-28 17:29:13.956310744 +0200
+++ tmp_rtrip/source.py	2017-06-29 00:57:45.518421711 +0200
@@ -60,7 +60,8 @@
 
 
 def ignore_static(f):
-    """Only executes the wrapped function if we're not loading a static resource."""
+    """Only executes the wrapped function if we're not loading
+    a static resource."""
 
     @wraps(f)
     def decorated_function(*args, **kwargs):
@@ -177,7 +178,7 @@
     for reply in g.source.replies:
         reply_path = store.path(g.sid, reply.filename)
         try:
-            reply.decrypted = crypto_util.decrypt(g.codename, file(
+            reply.decrypted = crypto_util.decrypt(g.codename, open(
                 reply_path).read()).decode('utf-8')
         except UnicodeDecodeError:
             app.logger.error('Could not decode reply %s' % reply.filename)
</pre>

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior