### PR TITLE
journalist: flake8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py crypto_util.py manage.py store.py secure_tempfile.py source.py template_filters.py tests/test_2fa.py tests/conftest.py tests/test_db.py tests/test_manage.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py tests/test_source.py && popd
+  - pushd securedrop; flake8 db.py crypto_util.py journalist.py manage.py store.py secure_tempfile.py source.py template_filters.py tests/test_2fa.py tests/conftest.py tests/test_db.py tests/test_manage.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py tests/test_source.py && popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import os
 from datetime import datetime
 import functools
 
@@ -8,7 +7,7 @@ from flask import (Flask, request, render_template, send_file, redirect, flash,
                    url_for, g, abort, session)
 from flask_wtf.csrf import CSRFProtect
 from flask_assets import Environment
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import IntegrityError
 
 import config
@@ -17,8 +16,8 @@ import crypto_util
 import store
 import template_filters
 from db import (db_session, Source, Journalist, Submission, Reply,
-                SourceStar, get_one_or_else, WrongPasswordException,
-                LoginThrottledException, InvalidPasswordLength)
+                SourceStar, get_one_or_else, LoginThrottledException,
+                InvalidPasswordLength)
 import worker
 
 app = Flask(__name__, template_folder=config.JOURNALIST_TEMPLATES_DIR)

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -9,6 +9,7 @@ from flask_wtf.csrf import CSRFProtect
 from flask_assets import Environment
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql.expression import false
 
 import config
 import version
@@ -511,7 +512,7 @@ def col_download_unread(cols_selected):
     submissions = []
     for sid in cols_selected:
         id = Source.query.filter(Source.filesystem_id == sid).one().id
-        submissions += Submission.query.filter(Submission.downloaded == False,
+        submissions += Submission.query.filter(Submission.downloaded == false(),
                                                Submission.source_id == id).all()
     if submissions == []:
         flash("No unread submissions in collections selected!", "error")
@@ -663,7 +664,7 @@ def generate_code():
 def download_unread_sid(sid):
     id = Source.query.filter(Source.filesystem_id == sid).one().id
     submissions = Submission.query.filter(Submission.source_id == id,
-                                          Submission.downloaded == False).all()
+                                          Submission.downloaded == false()).all()
     if submissions == []:
         flash("No unread submissions for this source!")
         return redirect(url_for('col', sid=sid))

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -123,7 +123,9 @@ def login():
                     user = Journalist.query.filter_by(
                         username=request.form['username']).one()
                     if user.is_totp:
-                        login_flashed_msg += " Please wait for a new two-factor token before logging in again."
+                        login_flashed_msg += (
+                            " Please wait for a new two-factor token"
+                            " before logging in again.")
                 except:
                     pass
 
@@ -188,9 +190,11 @@ def admin_add_user():
                 db_session.commit()
             except InvalidPasswordLength:
                 form_valid = False
-                flash("Your password must be between {} and {} characters.".format(
-                        Journalist.MIN_PASSWORD_LEN, Journalist.MAX_PASSWORD_LEN
-                    ), "error")
+                flash("Your password must be "
+                      "between {} and {} characters.".format(
+                          Journalist.MIN_PASSWORD_LEN,
+                          Journalist.MAX_PASSWORD_LEN
+                      ), "error")
             except IntegrityError as e:
                 db_session.rollback()
                 form_valid = False
@@ -318,7 +322,7 @@ def admin_edit_user(user_id):
             if new_username == user.username:
                 pass
             elif Journalist.query.filter_by(
-                username=new_username).one_or_none():
+                    username=new_username).one_or_none():
                 flash('Username "{}" is already taken!'.format(new_username),
                       "error")
                 return redirect(url_for("admin_edit_user", user_id=user_id))
@@ -349,7 +353,7 @@ def admin_delete_user(user_id):
     else:
         app.logger.error(
             "Admin {} tried to delete nonexistent user with pk={}".format(
-            g.user.username, user_id))
+                g.user.username, user_id))
         abort(404)
 
     return redirect(url_for('admin_index'))
@@ -512,8 +516,9 @@ def col_download_unread(cols_selected):
     submissions = []
     for sid in cols_selected:
         id = Source.query.filter(Source.filesystem_id == sid).one().id
-        submissions += Submission.query.filter(Submission.downloaded == false(),
-                                               Submission.source_id == id).all()
+        submissions += Submission.query.filter(
+            Submission.downloaded == false(),
+            Submission.source_id == id).all()
     if submissions == []:
         flash("No unread submissions in collections selected!", "error")
         return redirect(url_for('index'))
@@ -525,7 +530,8 @@ def col_download_all(cols_selected):
     submissions = []
     for sid in cols_selected:
         id = Source.query.filter(Source.filesystem_id == sid).one().id
-        submissions += Submission.query.filter(Submission.source_id == id).all()
+        submissions += Submission.query.filter(
+            Submission.source_id == id).all()
     return download("all", submissions)
 
 
@@ -663,8 +669,9 @@ def generate_code():
 @login_required
 def download_unread_sid(sid):
     id = Source.query.filter(Source.filesystem_id == sid).one().id
-    submissions = Submission.query.filter(Submission.source_id == id,
-                                          Submission.downloaded == false()).all()
+    submissions = Submission.query.filter(
+        Submission.source_id == id,
+        Submission.downloaded == false()).all()
     if submissions == []:
         flash("No unread submissions for this source!")
         return redirect(url_for('col', sid=sid))


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes journalist.py flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop ; python -m astor.rtrip .
* diff -ru tmp_rtrip tmp_rtrip.orig
<pre>
diff -ru tmp_rtrip.orig/journalist.py tmp_rtrip/journalist.py
--- tmp_rtrip.orig/journalist.py	2017-07-07 09:43:01.081228354 +0200
+++ tmp_rtrip/journalist.py	2017-07-07 09:43:29.213265795 +0200
@@ -1,17 +1,17 @@
-import os
 from datetime import datetime
 import functools
 from flask import Flask, request, render_template, send_file, redirect, flash, url_for, g, abort, session
 from flask_wtf.csrf import CSRFProtect
 from flask_assets import Environment
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql.expression import false
 import config
 import version
 import crypto_util
 import store
 import template_filters
-from db import db_session, Source, Journalist, Submission, Reply, SourceStar, get_one_or_else, WrongPasswordException, LoginThrottledException, InvalidPasswordLength
+from db import db_session, Source, Journalist, Submission, Reply, SourceStar, get_one_or_else, LoginThrottledException, InvalidPasswordLength
 import worker
 app = Flask(__name__, template_folder=config.JOURNALIST_TEMPLATES_DIR)
 app.config.from_object(config.JournalistInterfaceFlaskConfig)
@@ -449,7 +449,7 @@
     for sid in cols_selected:
         id = Source.query.filter(Source.filesystem_id == sid).one().id
         submissions += Submission.query.filter(Submission.downloaded ==
-            False, Submission.source_id == id).all()
+            false(), Submission.source_id == id).all()
     if submissions == []:
         flash('No unread submissions in collections selected!', 'error')
         return redirect(url_for('index'))
@@ -580,7 +580,7 @@
 def download_unread_sid(sid):
     id = Source.query.filter(Source.filesystem_id == sid).one().id
     submissions = Submission.query.filter(Submission.source_id == id, 
-        Submission.downloaded == False).all()
+        Submission.downloaded == false()).all()
     if submissions == []:
         flash('No unread submissions for this source!')
         return redirect(url_for('col', sid=sid))
</pre>

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior