### PR TITLE
crypto_util: flake8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py store.py source.py; popd
+  - pushd securedrop; flake8 db.py crypto_util.py store.py source.py; popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -46,9 +46,9 @@ do_runtime_tests()
 
 gpg = gnupg.GPG(binary='gpg2', homedir=config.GPG_KEY_DIR)
 
-words = file(config.WORD_LIST).read().split('\n')
-nouns = file(config.NOUNS).read().split('\n')
-adjectives = file(config.ADJECTIVES).read().split('\n')
+words = open(config.WORD_LIST).read().split('\n')
+nouns = open(config.NOUNS).read().split('\n')
+adjectives = open(config.ADJECTIVES).read().split('\n')
 
 
 class CryptoException(Exception):

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -22,7 +22,7 @@ if os.environ.get('SECUREDROP_ENV') == 'test':
     # use these settings in production)
     GPG_KEY_LENGTH = 1024
     SCRYPT_PARAMS = dict(N=2**1, r=1, p=1)
-else: # pragma: no cover
+else:  # pragma: no cover
     GPG_KEY_LENGTH = 4096
     SCRYPT_PARAMS = config.SCRYPT_PARAMS
 
@@ -181,6 +181,6 @@ def decrypt(secret, ciphertext):
     hashed_codename = hash_codename(secret, salt=SCRYPT_GPG_PEPPER)
     return gpg.decrypt(ciphertext, passphrase=hashed_codename).data
 
-if __name__ == "__main__": # pragma: no cover
+if __name__ == "__main__":  # pragma: no cover
     import doctest
     doctest.testmod()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes crypto_util.py flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop ; python -m astor.rtrip .
* diff -ru tmp_rtrip tmp_rtrip.orig
<pre>
diff -ru tmp_rtrip/crypto_util.py tmp_rtrip.orig/crypto_util.py
--- tmp_rtrip/crypto_util.py	2017-06-29 12:10:57.436500707 +0200
+++ tmp_rtrip.orig/crypto_util.py	2017-06-29 11:54:00.649566823 +0200
@@ -30,9 +30,9 @@
 
 do_runtime_tests()
 gpg = gnupg.GPG(binary='gpg2', homedir=config.GPG_KEY_DIR)
-words = open(config.WORD_LIST).read().split('\n')
-nouns = open(config.NOUNS).read().split('\n')
-adjectives = open(config.ADJECTIVES).read().split('\n')
+words = file(config.WORD_LIST).read().split('\n')
+nouns = file(config.NOUNS).read().split('\n')
+adjectives = file(config.ADJECTIVES).read().split('\n')
 
 
 class CryptoException(Exception):
</pre>

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior