### PR TITLE
secure_tempfile: flake8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py crypto_util.py store.py source.py template_filters.py tests/test_2fa.py tests/conftest.py tests/test_integration.py tests/test_crypto_util.py tests/test_journalist.py; popd
+  - pushd securedrop; flake8 db.py crypto_util.py store.py secure_tempfile.py source.py template_filters.py tests/test_2fa.py tests/conftest.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py; popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/secure_tempfile.py
+++ b/securedrop/secure_tempfile.py
@@ -80,7 +80,7 @@ class SecureTemporaryFile(_TemporaryFileWrapper, object):
         assert self.last_action != 'read', 'You cannot write after reading!'
         self.last_action = 'write'
 
-        if isinstance(data, unicode):
+        if isinstance(data, unicode):  # noqa
             data = data.encode('utf-8')
 
         self.file.write(self.encryptor.encrypt(data))
@@ -90,7 +90,7 @@ class SecureTemporaryFile(_TemporaryFileWrapper, object):
         be called any number of times following instance initialization
         and once :meth:`write has been called at least once, but not
         before.
-        
+
         Before the first read operation, `seek(0, 0)` is called. So
         while you can call this method any number of times, the full
         contents of the file can only be read once. Additional calls to


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes secure_tempfile.py flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop ; python -m astor.rtrip .
* diff -ru  tmp_rtrip.orig tmp_rtrip
<pre>
diff -ru tmp_rtrip.orig/secure_tempfile.py tmp_rtrip/secure_tempfile.py
--- tmp_rtrip.orig/secure_tempfile.py	2017-06-29 11:54:00.629566922 +0200
+++ tmp_rtrip/secure_tempfile.py	2017-06-29 14:33:49.782443821 +0200
@@ -86,7 +86,7 @@
         be called any number of times following instance initialization
         and once :meth:`write has been called at least once, but not
         before.
-        
+
         Before the first read operation, `seek(0, 0)` is called. So
         while you can call this method any number of times, the full
         contents of the file can only be read once. Additional calls to
</pre>

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior