### PR TITLE
template_filters: flake8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py crypto_util.py store.py source.py tests/test_crypto_util.py; popd
+  - pushd securedrop; flake8 db.py crypto_util.py store.py source.py template_filters.py tests/test_crypto_util.py; popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/template_filters.py
+++ b/securedrop/template_filters.py
@@ -19,7 +19,8 @@ def _relative_timestamp(dt):
     """
     delta = datetime.utcnow() - dt
     diff = (
-        delta.microseconds + (delta.seconds + delta.days * 24 * 3600) * 1e6) / 1e6
+        delta.microseconds + (delta.seconds +
+                              delta.days * 24 * 3600) * 1e6) / 1e6
     if diff < 45:
         return '{} second{}'.format(int(diff), '' if int(diff) == 1 else 's')
     elif diff < 90:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes template_filters.py flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop ; python -m astor.rtrip .
* diff -ru  tmp_rtrip.orig tmp_rtrip (no change)

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior