### PR TITLE
tests: 2fa: flake8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py crypto_util.py store.py source.py template_filters.py tests/test_crypto_util.py; popd
+  - pushd securedrop; flake8 db.py crypto_util.py store.py source.py template_filters.py tests/test_2fa.py tests/test_crypto_util.py; popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/tests/test_2fa.py
+++ b/securedrop/tests/test_2fa.py
@@ -4,7 +4,7 @@ import os
 from flask import url_for
 import flask_testing
 
-os.environ['SECUREDROP_ENV'] = 'test'
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 from db import Journalist, BadTokenException
 import journalist
 import utils
@@ -33,10 +33,10 @@ class TestJournalist2FA(flask_testing.TestCase):
         """
         if token is None:
             token = self.admin.totp.now()
-        resp = self.client.post(url_for('login'),
-                                data=dict(username=self.admin.username,
-                                          password=self.admin_pw,
-                                          token=token))
+        self.client.post(url_for('login'),
+                         data=dict(username=self.admin.username,
+                                   password=self.admin_pw,
+                                   token=token))
 
     def _login_user(self, token=None):
         """Analagous to `_login_admin()` except for a non-admin user.
@@ -70,9 +70,9 @@ class TestJournalist2FA(flask_testing.TestCase):
         with self.assertRaises(BadTokenException):
             Journalist.login(self.user.username, self.user_pw, valid_token)
 
-
     def test_bad_token_fails_to_verify_on_admin_new_user_two_factor_page(self):
-        # Regression test https://github.com/freedomofpress/securedrop/pull/1692
+        # Regression test
+        # https://github.com/freedomofpress/securedrop/pull/1692
         self._login_admin()
 
         # Create and submit an invalid 2FA token
@@ -95,7 +95,8 @@ class TestJournalist2FA(flask_testing.TestCase):
         self.assertMessageFlashed('Two-factor token failed to verify', 'error')
 
     def test_bad_token_fails_to_verify_on_new_user_two_factor_page(self):
-        # Regression test https://github.com/freedomofpress/securedrop/pull/1692
+        # Regression test
+        # https://github.com/freedomofpress/securedrop/pull/1692
         self._login_user()
 
         # Create and submit an invalid 2FA token


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes tests/test_2fa.py flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop ; python -m astor.rtrip .
* diff -ru  tmp_rtrip.orig tmp_rtrip
<pre>
diff -ru tmp_rtrip.orig/tests/test_2fa.py tmp_rtrip/tests/test_2fa.py
--- tmp_rtrip.orig/tests/test_2fa.py	2017-06-30 09:03:55.949589471 +0200
+++ tmp_rtrip/tests/test_2fa.py	2017-06-30 09:15:21.773697642 +0200
@@ -31,8 +31,8 @@
         """
         if token is None:
             token = self.admin.totp.now()
-        resp = self.client.post(url_for('login'), data=dict(username=self.
-            admin.username, password=self.admin_pw, token=token))
+        self.client.post(url_for('login'), data=dict(username=self.admin.
+            username, password=self.admin_pw, token=token))
 
     def _login_user(self, token=None):
         """Analagous to `_login_admin()` except for a non-admin user.
</pre>

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior