### PR TITLE
tests: crypto_util: flake8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py crypto_util.py store.py source.py; popd
+  - pushd securedrop; flake8 db.py crypto_util.py store.py source.py tests/test_crypto_util.py; popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -2,12 +2,13 @@
 import os
 import unittest
 
-os.environ['SECUREDROP_ENV'] = 'test'
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 import config
 import crypto_util
 import db
 import store
 import utils
+
 
 class TestCryptoUtil(unittest.TestCase):
 
@@ -27,10 +28,10 @@ class TestCryptoUtil(unittest.TestCase):
 
         self.assertEqual(ok, crypto_util.clean(ok))
         with self.assertRaisesRegexp(crypto_util.CryptoException,
-                                   'invalid input: {}'.format(invalid_1)):
+                                     'invalid input: {}'.format(invalid_1)):
             crypto_util.clean(invalid_1)
         with self.assertRaisesRegexp(crypto_util.CryptoException,
-                                   'invalid input: {}'.format(invalid_2)):
+                                     'invalid input: {}'.format(invalid_2)):
             crypto_util.clean(invalid_2)
 
     def test_encrypt_success(self):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes tests/test_crypto_util.py flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop ; python -m astor.rtrip .
* diff -ru  tmp_rtrip.orig tmp_rtrip (no change)

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior