### PR TITLE
tests: db: flake8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py crypto_util.py store.py secure_tempfile.py source.py template_filters.py tests/test_2fa.py tests/conftest.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py; popd
+  - pushd securedrop; flake8 db.py crypto_util.py store.py secure_tempfile.py source.py template_filters.py tests/test_2fa.py tests/conftest.py tests/test_db.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py; popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/tests/test_db.py
+++ b/securedrop/tests/test_db.py
@@ -1,16 +1,11 @@
 # -*- coding: utf-8 -*-
-import os
-import unittest
-
 from flask_testing import TestCase
 import mock
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 import journalist
-import crypto_util
 from utils import db_helper, env
-from db import (db_session, Journalist, Submission, Source, Reply,
-                get_one_or_else, LoginThrottledException)
+from db import (Journalist, Submission, Reply, get_one_or_else,
+                LoginThrottledException)
 
 
 class TestDatabase(TestCase):
@@ -28,7 +23,8 @@ class TestDatabase(TestCase):
     def test_get_one_or_else_returns_one(self, mock):
         new_journo, _ = db_helper.init_journalist()
 
-        query = Journalist.query.filter(Journalist.username == new_journo.username)
+        query = Journalist.query.filter(
+            Journalist.username == new_journo.username)
         with mock.patch('logger') as mock_logger:
             selected_journo = get_one_or_else(query, mock_logger, mock)
         self.assertEqual(new_journo, selected_journo)
@@ -39,8 +35,7 @@ class TestDatabase(TestCase):
         journo_2, _ = db_helper.init_journalist()
 
         with mock.patch('logger') as mock_logger:
-            selected_journos = get_one_or_else(Journalist.query, mock_logger,
-                                               mock)
+            get_one_or_else(Journalist.query, mock_logger, mock)
         mock_logger.error.assert_called()  # Not specifying very long log line
         mock.assert_called_with(500)
 
@@ -49,9 +44,9 @@ class TestDatabase(TestCase):
         query = Journalist.query.filter(Journalist.username == "alice")
 
         with mock.patch('logger') as mock_logger:
-            selected_journos = get_one_or_else(query, mock_logger,
-                                               mock)
-        log_line = 'Found none when one was expected: No row was found for one()'
+            get_one_or_else(query, mock_logger, mock)
+        log_line = ('Found none when one was expected: '
+                    'No row was found for one()')
         mock_logger.error.assert_called_with(log_line)
         mock.assert_called_with(404)
 
@@ -59,7 +54,7 @@ class TestDatabase(TestCase):
 
     def test_submission_string_representation(self):
         source, _ = db_helper.init_source()
-        submissions = db_helper.submit(source, 2)
+        db_helper.submit(source, 2)
 
         test_submission = Submission.query.first()
         test_submission.__repr__()
@@ -67,7 +62,7 @@ class TestDatabase(TestCase):
     def test_reply_string_representation(self):
         journalist, _ = db_helper.init_journalist()
         source, _ = db_helper.init_source()
-        replies = db_helper.reply(journalist, source, 2)
+        db_helper.reply(journalist, source, 2)
         test_reply = Reply.query.first()
         test_reply.__repr__()
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes tests/test_db.py flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop ; python -m astor.rtrip .
* diff -ru  tmp_rtrip.orig tmp_rtrip
<pre>
diff -ru tmp_rtrip.orig/tests/test_db.py tmp_rtrip/tests/test_db.py
--- tmp_rtrip.orig/tests/test_db.py	2017-06-29 11:54:00.701566568 +0200
+++ tmp_rtrip/tests/test_db.py	2017-06-29 16:01:30.736452645 +0200
@@ -1,12 +1,8 @@
-import os
-import unittest
 from flask_testing import TestCase
 import mock
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 import journalist
-import crypto_util
 from utils import db_helper, env
-from db import db_session, Journalist, Submission, Source, Reply, get_one_or_else, LoginThrottledException
+from db import Journalist, Submission, Reply, get_one_or_else, LoginThrottledException
 
 
 class TestDatabase(TestCase):
@@ -34,8 +30,7 @@
         journo_1, _ = db_helper.init_journalist()
         journo_2, _ = db_helper.init_journalist()
         with mock.patch('logger') as mock_logger:
-            selected_journos = get_one_or_else(Journalist.query,
-                mock_logger, mock)
+            get_one_or_else(Journalist.query, mock_logger, mock)
         mock_logger.error.assert_called()
         mock.assert_called_with(500)
 
@@ -43,7 +38,7 @@
     def test_get_one_or_else_no_result_found(self, mock):
         query = Journalist.query.filter(Journalist.username == 'alice')
         with mock.patch('logger') as mock_logger:
-            selected_journos = get_one_or_else(query, mock_logger, mock)
+            get_one_or_else(query, mock_logger, mock)
         log_line = (
             'Found none when one was expected: No row was found for one()')
         mock_logger.error.assert_called_with(log_line)
@@ -51,14 +46,14 @@
 
     def test_submission_string_representation(self):
         source, _ = db_helper.init_source()
-        submissions = db_helper.submit(source, 2)
+        db_helper.submit(source, 2)
         test_submission = Submission.query.first()
         test_submission.__repr__()
 
     def test_reply_string_representation(self):
         journalist, _ = db_helper.init_journalist()
         source, _ = db_helper.init_source()
-        replies = db_helper.reply(journalist, source, 2)
+        db_helper.reply(journalist, source, 2)
         test_reply = Reply.query.first()
         test_reply.__repr__()
</pre>

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior