### PR TITLE
tests: journalist: flake8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py crypto_util.py store.py source.py template_filters.py tests/test_2fa.py tests/conftest.py tests/test_crypto_util.py; popd
+  - pushd securedrop; flake8 db.py crypto_util.py store.py source.py template_filters.py tests/test_2fa.py tests/conftest.py tests/test_journalist.py tests/test_crypto_util.py; popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -55,8 +55,7 @@ class TestJournalistApp(TestCase):
 
         with patch('db.db_session.commit',
                    side_effect=exception_class(exception_msg)):
-            resp = self.client.post(url_for('reply'),
-                                    data={'sid': sid, 'msg': '_'})
+            self.client.post(url_for('reply'), data={'sid': sid, 'msg': '_'})
 
         # Notice the "potentially sensitive" exception_msg is not present in
         # the log event.
@@ -73,8 +72,7 @@ class TestJournalistApp(TestCase):
         exception_class = StaleDataError
 
         with patch('db.db_session.commit', side_effect=exception_class()):
-            resp = self.client.post(url_for('reply'),
-                                    data={'sid': sid, 'msg': '_'})
+            self.client.post(url_for('reply'), data={'sid': sid, 'msg': '_'})
 
         self.assertMessageFlashed('An unexpected error occurred! Please check '
                 'the application logs or inform your adminstrator.', 'error')
@@ -257,7 +255,7 @@ class TestJournalistApp(TestCase):
     def test_admin_edits_user_password_success_response(self):
         self._login_admin()
 
-        resp = self.client.post(
+        self.client.post(
             url_for('admin_edit_user', user_id=self.user.id),
             data=dict(username=self.user.username, is_admin=False,
                       password='validlongpassword',
@@ -267,15 +265,15 @@ class TestJournalistApp(TestCase):
 
     def test_user_edits_password_success_reponse(self):
         self._login_user()
-        resp = self.client.post(url_for('edit_account'),
-                                data=dict(password='validlongpassword',
-                                          password_again='validlongpassword'))
+        self.client.post(url_for('edit_account'),
+                         data=dict(password='validlongpassword',
+                                   password_again='validlongpassword'))
         self.assertMessageFlashed("Account successfully updated!", 'success')
 
     def test_admin_edits_user_password_mismatch_warning(self):
         self._login_admin()
 
-        resp = self.client.post(
+        self.client.post(
             url_for('admin_edit_user', user_id=self.user.id),
             data=dict(username=self.user.username, is_admin=False,
                       password='not', password_again='thesame'),
@@ -313,23 +311,21 @@ class TestJournalistApp(TestCase):
         maximum password length should raise an exception"""
         overly_long_password = 'a'*(Journalist.MAX_PASSWORD_LEN + 1)
         with self.assertRaises(InvalidPasswordLength):
-            temp_journalist = Journalist(
-                    username="My Password is Too Big!",
-                    password=overly_long_password)
+            Journalist(username="My Password is Too Big!",
+                       password=overly_long_password)
 
     def test_min_password_length(self):
         """Creating a Journalist with a password that is smaller than the
         minimum password length should raise an exception"""
         with self.assertRaises(InvalidPasswordLength):
-            temp_journalist = Journalist(
-                    username="My Password is Too Small!",
-                    password='tiny')
+            Journalist(username="My Password is Too Small!",
+                       password='tiny')
 
     def test_admin_edits_user_password_too_long_warning(self):
         self._login_admin()
         overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
 
-        resp = self.client.post(
+        self.client.post(
             url_for('admin_edit_user', user_id=self.user.id),
             data=dict(username=self.user.username, is_admin=False,
                       password=overly_long_password,
@@ -345,10 +341,10 @@ class TestJournalistApp(TestCase):
         self._login_user()
         overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
 
-        resp = self.client.post(url_for('edit_account'),
-                                data=dict(password=overly_long_password,
-                                          password_again=overly_long_password),
-                                follow_redirects=True)
+        self.client.post(url_for('edit_account'),
+                         data=dict(password=overly_long_password,
+                                   password_again=overly_long_password),
+                         follow_redirects=True)
 
         self.assertMessageFlashed('Your password must be between {} and {} '
                                   'characters.'.format(
@@ -372,7 +368,7 @@ class TestJournalistApp(TestCase):
         self._login_admin()
         new_username = self.admin.username
 
-        resp = self.client.post(
+        self.client.post(
             url_for('admin_edit_user', user_id=self.user.id),
             data=dict(username=new_username, is_admin=False,
                       password='', password_again=''))
@@ -398,8 +394,8 @@ class TestJournalistApp(TestCase):
         self._login_admin()
         old_hotp = self.user.hotp.secret
 
-        resp = self.client.post(url_for('admin_reset_two_factor_hotp'),
-                                data=dict(uid=self.user.id, otp_secret='ZZ'))
+        self.client.post(url_for('admin_reset_two_factor_hotp'),
+                         data=dict(uid=self.user.id, otp_secret='ZZ'))
         new_hotp = self.user.hotp.secret
 
         self.assertEqual(old_hotp, new_hotp)
@@ -411,8 +407,8 @@ class TestJournalistApp(TestCase):
         self._login_admin()
         old_hotp = self.user.hotp.secret
 
-        resp = self.client.post(url_for('admin_reset_two_factor_hotp'),
-                                data=dict(uid=self.user.id, otp_secret='Z'))
+        self.client.post(url_for('admin_reset_two_factor_hotp'),
+                         data=dict(uid=self.user.id, otp_secret='Z'))
         new_hotp = self.user.hotp.secret
 
         self.assertEqual(old_hotp, new_hotp)
@@ -432,8 +428,8 @@ class TestJournalistApp(TestCase):
         mock_set_hotp_secret.side_effect = TypeError(error_message)
 
         otp_secret = '1234'
-        resp = self.client.post(url_for('admin_reset_two_factor_hotp'),
-                                data=dict(uid=self.user.id, otp_secret=otp_secret))
+        self.client.post(url_for('admin_reset_two_factor_hotp'),
+                         data=dict(uid=self.user.id, otp_secret=otp_secret))
         new_hotp = self.user.hotp.secret
 
         self.assertEqual(old_hotp, new_hotp)
@@ -540,11 +536,11 @@ class TestJournalistApp(TestCase):
                                             mocked_error_logger):
         self._login_admin()
 
-        resp = self.client.post(url_for('admin_add_user'),
-                                data=dict(username='username',
-                                          password='pentagonpapers',
-                                          password_again='pentagonpapers',
-                                          is_admin=False))
+        self.client.post(url_for('admin_add_user'),
+                         data=dict(username='username',
+                                   password='pentagonpapers',
+                                   password_again='pentagonpapers',
+                                   is_admin=False))
 
         mocked_error_logger.assert_called_once_with(
             "Adding user 'username' failed: (__builtin__.NoneType) "
@@ -608,7 +604,7 @@ class TestJournalistApp(TestCase):
         self._login_user()
         overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
 
-        res = self.client.post(url_for('edit_account'), data=dict(
+        self.client.post(url_for('edit_account'), data=dict(
             password=overly_long_password,
             password_again=overly_long_password),
             follow_redirects=True)
@@ -620,7 +616,7 @@ class TestJournalistApp(TestCase):
 
     def test_valid_user_password_change(self):
         self._login_user()
-        res = self.client.post(url_for('edit_account'), data=dict(
+        self.client.post(url_for('edit_account'), data=dict(
             password='validlongpassword',
             password_again='validlongpassword'))
         self.assertMessageFlashed("Account successfully updated!", 'success')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes tests/test_journalist.py flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop ; python -m astor.rtrip .
* diff -ru  tmp_rtrip.orig tmp_rtrip
<pre>
diff -ru tmp_rtrip.orig/tests/test_journalist.py tmp_rtrip/tests/test_journalist.py
--- tmp_rtrip.orig/tests/test_journalist.py	2017-06-30 09:03:55.889589812 +0200
+++ tmp_rtrip/tests/test_journalist.py	2017-06-30 09:13:01.990488827 +0200
@@ -1,7 +1,6 @@
 from cStringIO import StringIO
 import os
 import random
-import time
 import unittest
 import zipfile
 from flask import url_for, escape
@@ -43,8 +42,7 @@
         exception_msg = 'Potentially sensitive content!'
         with patch('db.db_session.commit', side_effect=exception_class(
             exception_msg)):
-            resp = self.client.post(url_for('reply'), data={'sid': sid,
-                'msg': '_'})
+            self.client.post(url_for('reply'), data={'sid': sid, 'msg': '_'})
         mocked_error_logger.assert_called_once_with(
             "Reply from '{}' (id {}) failed: {}!".format(self.user.username,
             self.user.id, exception_class))
@@ -55,8 +53,7 @@
         self._login_user()
         exception_class = StaleDataError
         with patch('db.db_session.commit', side_effect=exception_class()):
-            resp = self.client.post(url_for('reply'), data={'sid': sid,
-                'msg': '_'})
+            self.client.post(url_for('reply'), data={'sid': sid, 'msg': '_'})
         self.assertMessageFlashed(
             'An unexpected error occurred! Please check the application logs or inform your adminstrator.'
             , 'error')
@@ -195,22 +192,22 @@
 
     def test_admin_edits_user_password_success_response(self):
         self._login_admin()
-        resp = self.client.post(url_for('admin_edit_user', user_id=self.
-            user.id), data=dict(username=self.user.username, is_admin=False,
-            password='validlongpassword', password_again='validlongpassword'))
+        self.client.post(url_for('admin_edit_user', user_id=self.user.id),
+            data=dict(username=self.user.username, is_admin=False, password
+            ='validlongpassword', password_again='validlongpassword'))
         self.assertMessageFlashed('Account successfully updated!', 'success')
 
     def test_user_edits_password_success_reponse(self):
         self._login_user()
-        resp = self.client.post(url_for('edit_account'), data=dict(password
-            ='validlongpassword', password_again='validlongpassword'))
+        self.client.post(url_for('edit_account'), data=dict(password=
+            'validlongpassword', password_again='validlongpassword'))
         self.assertMessageFlashed('Account successfully updated!', 'success')
 
     def test_admin_edits_user_password_mismatch_warning(self):
         self._login_admin()
-        resp = self.client.post(url_for('admin_edit_user', user_id=self.
-            user.id), data=dict(username=self.user.username, is_admin=False,
-            password='not', password_again='thesame'), follow_redirects=True)
+        self.client.post(url_for('admin_edit_user', user_id=self.user.id),
+            data=dict(username=self.user.username, is_admin=False, password
+            ='not', password_again='thesame'), follow_redirects=True)
         self.assertMessageFlashed("Passwords didn't match!", 'error')
 
     def test_user_edits_password_mismatch_redirect(self):
@@ -238,23 +235,22 @@
         maximum password length should raise an exception"""
         overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
         with self.assertRaises(InvalidPasswordLength):
-            temp_journalist = Journalist(username='My Password is Too Big!',
-                password=overly_long_password)
+            Journalist(username='My Password is Too Big!', password=
+                overly_long_password)
 
     def test_min_password_length(self):
         """Creating a Journalist with a password that is smaller than the
         minimum password length should raise an exception"""
         with self.assertRaises(InvalidPasswordLength):
-            temp_journalist = Journalist(username=
-                'My Password is Too Small!', password='tiny')
+            Journalist(username='My Password is Too Small!', password='tiny')
 
     def test_admin_edits_user_password_too_long_warning(self):
         self._login_admin()
         overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
-        resp = self.client.post(url_for('admin_edit_user', user_id=self.
-            user.id), data=dict(username=self.user.username, is_admin=False,
-            password=overly_long_password, password_again=
-            overly_long_password), follow_redirects=True)
+        self.client.post(url_for('admin_edit_user', user_id=self.user.id),
+            data=dict(username=self.user.username, is_admin=False, password
+            =overly_long_password, password_again=overly_long_password),
+            follow_redirects=True)
         self.assertMessageFlashed(
             'Your password must be between {} and {} characters.'.format(
             Journalist.MIN_PASSWORD_LEN, Journalist.MAX_PASSWORD_LEN), 'error')
@@ -262,8 +258,8 @@
     def test_user_edits_password_too_long_warning(self):
         self._login_user()
         overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
-        resp = self.client.post(url_for('edit_account'), data=dict(password
-            =overly_long_password, password_again=overly_long_password),
+        self.client.post(url_for('edit_account'), data=dict(password=
+            overly_long_password, password_again=overly_long_password),
             follow_redirects=True)
         self.assertMessageFlashed(
             'Your password must be between {} and {} characters.'.format(
@@ -282,9 +278,9 @@
         username to a username that is taken by another user."""
         self._login_admin()
         new_username = self.admin.username
-        resp = self.client.post(url_for('admin_edit_user', user_id=self.
-            user.id), data=dict(username=new_username, is_admin=False,
-            password='', password_again=''))
+        self.client.post(url_for('admin_edit_user', user_id=self.user.id),
+            data=dict(username=new_username, is_admin=False, password='',
+            password_again=''))
         self.assertMessageFlashed('Username "{}" is already taken!'.format(
             new_username), 'error')
 
@@ -301,8 +297,8 @@
     def test_admin_resets_user_hotp_format_non_hexa(self):
         self._login_admin()
         old_hotp = self.user.hotp.secret
-        resp = self.client.post(url_for('admin_reset_two_factor_hotp'),
-            data=dict(uid=self.user.id, otp_secret='ZZ'))
+        self.client.post(url_for('admin_reset_two_factor_hotp'), data=dict(
+            uid=self.user.id, otp_secret='ZZ'))
         new_hotp = self.user.hotp.secret
         self.assertEqual(old_hotp, new_hotp)
         self.assertMessageFlashed(
@@ -312,8 +308,8 @@
     def test_admin_resets_user_hotp_format_odd(self):
         self._login_admin()
         old_hotp = self.user.hotp.secret
-        resp = self.client.post(url_for('admin_reset_two_factor_hotp'),
-            data=dict(uid=self.user.id, otp_secret='Z'))
+        self.client.post(url_for('admin_reset_two_factor_hotp'), data=dict(
+            uid=self.user.id, otp_secret='Z'))
         new_hotp = self.user.hotp.secret
         self.assertEqual(old_hotp, new_hotp)
         self.assertMessageFlashed(
@@ -329,8 +325,8 @@
         error_message = 'SOMETHING WRONG!'
         mock_set_hotp_secret.side_effect = TypeError(error_message)
         otp_secret = '1234'
-        resp = self.client.post(url_for('admin_reset_two_factor_hotp'),
-            data=dict(uid=self.user.id, otp_secret=otp_secret))
+        self.client.post(url_for('admin_reset_two_factor_hotp'), data=dict(
+            uid=self.user.id, otp_secret=otp_secret))
         new_hotp = self.user.hotp.secret
         self.assertEqual(old_hotp, new_hotp)
         self.assertMessageFlashed(
@@ -412,8 +408,8 @@
     def test_admin_add_user_integrity_error(self, mock_journalist,
         mocked_error_logger):
         self._login_admin()
-        resp = self.client.post(url_for('admin_add_user'), data=dict(
-            username='username', password='pentagonpapers', password_again=
+        self.client.post(url_for('admin_add_user'), data=dict(username=
+            'username', password='pentagonpapers', password_again=
             'pentagonpapers', is_admin=False))
         mocked_error_logger.assert_called_once_with(
             "Adding user 'username' failed: (__builtin__.NoneType) None [SQL: 'STATEMENT'] [parameters: 'PARAMETERS']"
@@ -471,7 +467,7 @@
     def test_too_long_user_password_change(self):
         self._login_user()
         overly_long_password = 'a' * (Journalist.MAX_PASSWORD_LEN + 1)
-        res = self.client.post(url_for('edit_account'), data=dict(password=
+        self.client.post(url_for('edit_account'), data=dict(password=
             overly_long_password, password_again=overly_long_password),
             follow_redirects=True)
         self.assertMessageFlashed(
@@ -480,7 +476,7 @@
 
     def test_valid_user_password_change(self):
         self._login_user()
-        res = self.client.post(url_for('edit_account'), data=dict(password=
+        self.client.post(url_for('edit_account'), data=dict(password=
             'validlongpassword', password_again='validlongpassword'))
         self.assertMessageFlashed('Account successfully updated!', 'success')
 </pre>

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior