### PR TITLE
Add custom_notification to the development host vars

### DIFF
--- a/install_files/ansible-base/host_vars/development.yml
+++ b/install_files/ansible-base/host_vars/development.yml
@@ -10,3 +10,6 @@ securedrop_app_gpg_fingerprint: "65A1B5FF195B56353CC63DFFCC40EF1228271441"
 # the application code directly out of the local repo.
 securedrop_app_install_from_repo: False
 securedrop_app_configure_apache: False
+
+# Custom text on source interface
+custom_notification_text: "This is an insecure SecureDrop Development server for testing ONLY. Do NOT submit documents here."


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #1736. 

## Testing

Provision development VM locally and verify `test_custom_notification` passes ✨ 

## Deployment

None, dev environment only

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass