### PR TITLE
i18n: add Flask-Babel requirement

### DIFF
--- a/securedrop/requirements/securedrop-requirements.in
+++ b/securedrop/requirements/securedrop-requirements.in
@@ -1,5 +1,6 @@
 cssmin
 Flask-Assets
+Flask-Babel
 Flask-WTF
 Flask
 gnupg

--- a/securedrop/requirements/securedrop-requirements.txt
+++ b/securedrop/requirements/securedrop-requirements.txt
@@ -4,9 +4,11 @@
 #
 #    pip-compile --output-file securedrop-requirements.txt securedrop-requirements.in
 #
+babel==2.4.0              # via flask-babel
 click==6.7                # via flask, rq
 cssmin==0.2.0
 flask-assets==0.12
+flask-babel==0.11.2
 flask-wtf==0.14.2
 flask==0.12.2             # via flask-assets, flask-wtf
 gnupg==2.3.0
@@ -17,6 +19,7 @@ markupsafe==1.0           # via jinja2
 psutil==5.2.2
 pycrypto==2.6.1
 pyotp==2.2.5
+pytz==2017.2              # via babel
 qrcode==5.3
 redis==2.10.5
 rq==0.8.0


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

add Flask-Babel requirement

## Testing

vagrant up development # will install from securedrop-requirements.txt

## Deployment

1. Upgrading existing production instances.
2. New installs.

It will install new python modules that will not be used and will not interfere with existing or new deployment.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
