### PR TITLE
fail travis when flake8 fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py crypto_util.py manage.py store.py secure_tempfile.py source.py template_filters.py tests/test_2fa.py tests/conftest.py tests/test_db.py tests/test_manage.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py; popd
+  - pushd securedrop; flake8 db.py crypto_util.py manage.py store.py secure_tempfile.py source.py template_filters.py tests/test_2fa.py tests/conftest.py tests/test_db.py tests/test_manage.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py && popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -42,6 +42,7 @@ def do_runtime_tests():
     except subprocess.CalledProcessError:
         pass
 
+
 do_runtime_tests()
 
 gpg = gnupg.GPG(binary='gpg2', homedir=config.GPG_KEY_DIR)
@@ -180,6 +181,7 @@ def decrypt(secret, ciphertext):
     """
     hashed_codename = hash_codename(secret, salt=SCRYPT_GPG_PEPPER)
     return gpg.decrypt(ciphertext, passphrase=hashed_codename).data
+
 
 if __name__ == "__main__":  # pragma: no cover
     import doctest

--- a/securedrop/secure_tempfile.py
+++ b/securedrop/secure_tempfile.py
@@ -113,6 +113,7 @@ class SecureTemporaryFile(_TemporaryFileWrapper, object):
         else:
             return self.decryptor.decrypt(self.file.read())
 
+
 # python-gnupg will not recognize our SecureTemporaryFile as a stream-like type
 # and will attempt to call encode on it, thinking it's a string-like type. To
 # avoid this we append it the list of stream-like types.

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -7,7 +7,7 @@ import subprocess
 import psutil
 import pytest
 
-os.environ['SECUREDROP_ENV'] = 'test'
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 import config
 
 # TODO: the PID file for the redis worker is hard-coded below.

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -5,7 +5,6 @@ import mock
 from StringIO import StringIO
 import sys
 import unittest
-import __builtin__
 
 import utils
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

There are a few flake8 leftovers because ... flake8 xxx ; popd never fails. Using flake8 xxx && popd instead

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop ; python -m astor.rtrip .
* diff -ru tmp_rtrip tmp_rtrip.orig
<pre>
diff -ru tmp_rtrip.orig/tests/test_manage.py tmp_rtrip/tests/test_manage.py
--- tmp_rtrip.orig/tests/test_manage.py	2017-07-04 21:44:11.867220445 +0200
+++ tmp_rtrip/tests/test_manage.py	2017-07-04 21:44:54.047279603 +0200
@@ -3,7 +3,6 @@
 from StringIO import StringIO
 import sys
 import unittest
-import __builtin__
 import utils
</pre>

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior