### PR TITLE
Harden optional HTTPS config for Source Interface

### DIFF
--- a/install_files/ansible-base/roles/app/defaults/main.yml
+++ b/install_files/ansible-base/roles/app/defaults/main.yml
@@ -42,6 +42,21 @@ securedrop_app_https_certificate_cert_src: securedrop_source_onion.crt
 securedrop_app_https_certificate_key_src: securedrop_source_onion.key
 securedrop_app_https_certificate_chain_src: DigiCertCA.crt
 
+# List of SSL ciphers honored by Source Interface vhost. Order matters!
+# The `SSLHonorCipherOrder` option is set to true, so ciphers below are
+# listed in order of preference.
+securedrop_app_https_ssl_ciphers:
+  - ECDHE-ECDSA-AES256-GCM-SHA384
+  - ECDHE-RSA-AES256-GCM-SHA384
+  - ECDHE-ECDSA-CHACHA20-POLY1305
+  - ECDHE-RSA-CHACHA20-POLY1305
+  - ECDHE-ECDSA-AES128-GCM-SHA256
+  - ECDHE-RSA-AES128-GCM-SHA256
+  - ECDHE-ECDSA-AES256-SHA384
+  - ECDHE-RSA-AES256-SHA384
+  - ECDHE-ECDSA-AES128-SHA256
+  - ECDHE-RSA-AES128-SHA256
+
 # Apt packages for configuring Apache service.
 apache_packages:
   - apache2-mpm-worker

--- a/install_files/ansible-base/roles/app/templates/sites-available/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/source.conf
@@ -13,10 +13,10 @@ SSLCertificateFile /var/lib/ssl/{{ securedrop_app_https_certificate_cert_src|bas
 SSLCertificateKeyFile /var/lib/ssl/{{ securedrop_app_https_certificate_key_src|basename }}
 SSLCertificateChainFile /var/lib/ssl/{{ securedrop_app_https_certificate_chain_src|basename }}
 
-SSLProtocol all -SSLv2 -SSLv3
+SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+SSLCipherSuite {{ securedrop_app_https_ssl_ciphers|join(':') }}
 SSLHonorCipherOrder on
 SSLCompression off
-SSLCipherSuite EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5
 {% endif %}
 
 WSGIDaemonProcess source  processes=2 threads=30 display-name=%{GROUP} python-path=/var/www/securedrop


### PR DESCRIPTION
## Status

Ready for review.


## Description of Changes

Fixes #1929.

Used the Mozilla Web Server Config Generator [0] with our explicit Apache and OpenSSL versions. Formatting the ciphers via a YAML list var, more for readability and concision than for override capability.

[0] https://mozilla.github.io/server-side-tls/ssl-config-generator/

## Testing

1. Provision HTTPS on the Source Interface as described in #1928.
2. Include the new cipher suite changes in this PR.
3. Confirm via manual testing with Tor Browser that the application is served well without any issues.

## Deployment

Any Admins opting in to HTTPS for the Source Interface in 0.4 should have a decent SSL config from the outset. Updating the SSL Cipher options is tricky: we must require that the Admin rerun the Ansible config, since we can't ship unattended upgrades to these files safely. 

## Checklist

### If you made changes to the app code:

Relying on manual testing with Tor Browser to confirm proper behavior.