### PR TITLE
Explicitly specify html.parser for BeautifulSoup

### DIFF
--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -67,15 +67,16 @@
       <div class="reply">
         <time class="date" title="{{ reply.date|datetimeformat }}" datetime="{{ reply.date }}">{{ reply.date|datetimeformat(relative=True) }}</time>
         <form id="delete" class="message" method="post" action="/delete" autocomplete="off">
-          <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
-          <input type="hidden" name="reply_filename" value="{{ reply.filename }}" autocomplete="off"/>
+          <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+          <input type="hidden" name="reply_filename" value="{{ reply.filename }}" autocomplete="off">
           <a href="#confirm-delete-{{ reply.filename }}" class="delete">
-          <img id="delete-reply-{{ reply.filename }}" src="{{ url_for('static', filename='i/font-awesome/trash-black.png') }}" width="20px" height="20px">
+            <img id="delete-reply-{{ reply.filename }}" src="{{ url_for('static', filename='i/font-awesome/trash-black.png') }}" width="20px" height="20px">
+          </a>
           <div id="confirm-delete-{{ reply.filename }}" class="confirm-prompt">
             <p>Delete this reply?
               <a href="#delete">Cancel</a>
               <button type="submit" class="sd-button btn danger" id="confirm-delete-reply-button-{{ reply.filename }}">DELETE</button>
-              </p>
+            </p>
           </div>
         </form>
         <blockquote>{{ reply.decrypted | nl2br }}</blockquote>

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -79,7 +79,7 @@ class TestIntegration(unittest.TestCase):
         rv = self.journalist_app.get('/')
         self.assertEqual(rv.status_code, 200)
         self.assertIn("Sources", rv.data)
-        soup = BeautifulSoup(rv.data)
+        soup = BeautifulSoup(rv.data, 'html.parser')
 
         # The source should have a "download unread" link that says "1 unread"
         col = soup.select('ul#cols > li')[0]
@@ -89,7 +89,7 @@ class TestIntegration(unittest.TestCase):
         col_url = soup.select('ul#cols > li a')[0]['href']
         resp = self.journalist_app.get(col_url)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         submission_url = soup.select('ul#submissions li a')[0]['href']
         self.assertIn("-msg", submission_url)
         span = soup.select('ul#submissions li span.info span')[0]
@@ -104,7 +104,7 @@ class TestIntegration(unittest.TestCase):
         # delete submission
         resp = self.journalist_app.get(col_url)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         doc_name = soup.select(
             'ul > li > input[name="doc_names_selected"]')[0]['value']
         resp = self.journalist_app.post('/bulk', data=dict(
@@ -114,7 +114,7 @@ class TestIntegration(unittest.TestCase):
         ))
 
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         self.assertIn("The following file has been selected for", resp.data)
 
         # confirm delete submission
@@ -127,7 +127,7 @@ class TestIntegration(unittest.TestCase):
             doc_names_selected=doc_name,
         ), follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         self.assertIn("Submission deleted.", resp.data)
 
         # confirm that submission deleted and absent in list of submissions
@@ -163,7 +163,7 @@ class TestIntegration(unittest.TestCase):
         resp = self.journalist_app.get('/')
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Sources", resp.data)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
 
         # The source should have a "download unread" link that says "1 unread"
         col = soup.select('ul#cols > li')[0]
@@ -173,7 +173,7 @@ class TestIntegration(unittest.TestCase):
         col_url = soup.select('ul#cols > li a')[0]['href']
         resp = self.journalist_app.get(col_url)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         submission_url = soup.select('ul#submissions li a')[0]['href']
         self.assertIn("-doc", submission_url)
         span = soup.select('ul#submissions li span.info span')[0]
@@ -192,7 +192,7 @@ class TestIntegration(unittest.TestCase):
         # delete submission
         resp = self.journalist_app.get(col_url)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         doc_name = soup.select(
             'ul > li > input[name="doc_names_selected"]')[0]['value']
         resp = self.journalist_app.post('/bulk', data=dict(
@@ -202,7 +202,7 @@ class TestIntegration(unittest.TestCase):
         ))
 
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         self.assertIn("The following file has been selected for", resp.data)
 
         # confirm delete submission
@@ -215,7 +215,7 @@ class TestIntegration(unittest.TestCase):
             doc_names_selected=doc_name,
         ), follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         self.assertIn("Submission deleted.", resp.data)
 
         # confirm that submission deleted and absent in list of submissions
@@ -303,7 +303,7 @@ class TestIntegration(unittest.TestCase):
         resp = self.journalist_app.get('/')
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Sources", resp.data)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         col_url = soup.select('ul#cols > li a')[0]['href']
 
         resp = self.journalist_app.get(col_url)
@@ -351,7 +351,7 @@ class TestIntegration(unittest.TestCase):
             resp = journalist_app.get(col_url)
             self.assertIn("reply-", resp.data)
 
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
 
         # Download the reply and verify that it can be decrypted with the
         # journalist's key as well as the source's reply key
@@ -390,7 +390,7 @@ class TestIntegration(unittest.TestCase):
                     "You have received a reply. To protect your identity",
                     resp.data)
                 self.assertIn(test_reply, resp.data)
-                soup = BeautifulSoup(resp.data)
+                soup = BeautifulSoup(resp.data, 'html.parser')
                 msgid = soup.select(
                     'form.message > input[name="reply_filename"]')[0]['value']
                 resp = source_app.post('/delete', data=dict(
@@ -419,13 +419,13 @@ class TestIntegration(unittest.TestCase):
 
         resp = self.journalist_app.get('/')
         # navigate to the collection page
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         first_col_url = soup.select('ul#cols > li a')[0]['href']
         resp = self.journalist_app.get(first_col_url)
         self.assertEqual(resp.status_code, 200)
 
         # find the delete form and extract the post parameters
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         delete_form_inputs = soup.select('form#delete_collection')[0]('input')
         sid = delete_form_inputs[1]['value']
         col_name = delete_form_inputs[2]['value']
@@ -458,7 +458,7 @@ class TestIntegration(unittest.TestCase):
 
         resp = self.journalist_app.get('/')
         # get all the checkbox values
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         checkbox_values = [checkbox['value'] for checkbox in
                            soup.select('input[name="cols_selected"]')]
         resp = self.journalist_app.post('/col/process', data=dict(
@@ -482,13 +482,13 @@ class TestIntegration(unittest.TestCase):
 
         # navigate to the collection page
         resp = self.journalist_app.get('/')
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         first_col_url = soup.select('ul#cols > li a')[0]['href']
         resp = self.journalist_app.get(first_col_url)
         self.assertEqual(resp.status_code, 200)
 
         # test filenames and sort order
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         submission_filename_re = r'^{0}-[a-z0-9-_]+(-msg|-doc\.gz)\.gpg$'
         for i, submission_link in enumerate(
                 soup.select('ul#submissions li a .filename')):
@@ -505,16 +505,16 @@ class TestIntegration(unittest.TestCase):
 
         # navigate to the collection page
         resp = self.journalist_app.get('/')
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         first_col_url = soup.select('ul#cols > li a')[0]['href']
         resp = self.journalist_app.get(first_col_url)
         self.assertEqual(resp.status_code, 200)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
 
         # delete file #2
         self.helper_filenames_delete(soup, 1)
         resp = self.journalist_app.get(first_col_url)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
 
         # test filenames and sort order
         submission_filename_re = r'^{0}-[a-z0-9-_]+(-msg|-doc\.gz)\.gpg$'

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -69,7 +69,7 @@ class TestSourceApp(TestCase):
         """
         resp = self.client.get('/generate')
         self.assertIn("ALREADY HAVE A CODENAME?", resp.data)
-        soup = BeautifulSoup(resp.data)
+        soup = BeautifulSoup(resp.data, 'html.parser')
         already_have_codename_link = soup.select('a#already-have-codename')[0]
         self.assertEqual(already_have_codename_link['href'], '/login')
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1820. Supersedes #1829. Fixes #1899. The reasoning for preferring `html.parser` is laid out in https://github.com/freedomofpress/securedrop/pull/1829#pullrequestreview-44945766.

* Explicitly specify the built-in `html.parser` for the BeautifulSoup constructor in the tests
* Fix test breakage caused by switching parsers, as discussed in https://github.com/freedomofpress/securedrop/pull/1829#pullrequestreview-44945766 and https://github.com/freedomofpress/securedrop/pull/1829#issuecomment-311758865.

## Testing

If the tests reliably pass locally and on CI, and the `UserWarning` that was previously being printed by BeautifulSoup is no longer being printed, then this PR should be ready to merge.

The most important consequence of this change is that we may run in to problems if we ever try to run the test suite with a version of Python less than 2.7.3 (see BeautifulSoup's [documentation on choosing a parser](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#installing-a-parser) for why). Ubuntu 14.04 includes Python 2.7.6, so the only environment where this might be a problem is Travis CI (I pushed this so we could see if that might indeed be an issue).

## Deployment

There are no special considerations for production deployment because this only affects tests and is local to the SecureDrop web application test code.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
