### PR TITLE
docs: passphrase is asked twice when no passphrase

### DIFF
--- a/docs/generate_securedrop_application_key.rst
+++ b/docs/generate_securedrop_application_key.rst
@@ -61,7 +61,7 @@ Create the key
 
    |OK to generate|
 
-#. A box will pop up asking you to type a passphrase. Since the key is
+#. A box will pop up (twice) asking you to type a passphrase. Since the key is
    protected by the encryption on the Tails persistent volume, it is safe to
    simply click **OK** without entering a passphrase.
 #. The software will ask you if you are sure. Click **Yes, protection is not


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

When the passphrase is omitted it is not cached and will pop up twice
when running gpg --full-generate-key

## Testing

* run gpg --full-generate-key according to https://docs.securedrop.org/en/latest/generate_securedrop_application_key.html
* follow instructions
* verify pinentry shows twice asking for a passphrase.
