### PR TITLE
Fixes Ansible group membership in prod VMs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -124,10 +124,11 @@ Vagrant.configure("2") do |config|
       ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
       # Taken from the parallel execution tips and tricks
       # https://docs.vagrantup.com/v2/provisioning/ansible.html
-      ansible.limit = 'all'
+      ansible.limit = 'all,localhost'
       ansible.groups = {
         'securedrop_application_server' => %w(app-prod),
         'securedrop_monitor_server' => %w(mon-prod),
+        'securedrop' => %w(app-prod mon-prod)
       }
     end
   end


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Closes #1943.

The changes presented in #1774 updated the prod inventory to use a dynamic inventory script, but did not include corresponding changes to the Vagrantfile for the prod VMs. Implemented here, specifically the "securedrop" group addition, which is used to target both the Application and the Monitor Servers in production.

In addition to the "securedrop" addition, also amended the "limit" option in the Ansible config for the prod VMs to include "localhost", which unintuitively is not considered when handling a limit of "all".
The explicit override enables localhost to be targeted by plays, e.g. the vars validation logic in the prod playbook.

## Testing

1. `vagrant destroy -f /prod/`
2 `ANSIBLE_ARGS="--skip-tags validate" vagrant up /prod/`
3. Confirm that the playbook executes normally.

Be advised that if you are not using the apt-test repo (for release candidate packages), then the playbook will fail upon installing the securedrop-app-code deb package at version 0.3.12 in the app role. This is OK. If you made it that far, the problem is resolved.

## Deployment

Only affects the dev env.

## Checklist

We don't run prod in CI yet, so relying on manual testing to confirm desired behavior.