### PR TITLE
Quickfix for messy output from apt-get install

### DIFF
--- a/securedrop-admin
+++ b/securedrop-admin
@@ -94,7 +94,7 @@ def install_apt_dependencies(args):
 
     apt_command = ['sudo', 'su', '-c',
                    "apt-get update && \
-                   apt-get install -y \
+                   apt-get -q -o=Dpkg::Use-Pty=0 install -y \
                    python-virtualenv \
                    python-pip \
                    ccontrol \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1947. This is a quick fix that explicitly disables the use of TTY-specific functionality in `dpkg`, and was inspired by this [Ask Ubuntu answer](https://askubuntu.com/questions/258219/how-do-i-make-apt-get-install-less-noisy/668859#668859).

A more thorough fix would involve investigating why `dpkg` mistakenly believes it is connected to a TTY when it is run by `securedrop-admin`, but I think this resolution is sufficient for the 0.4 release and any further research or implementation of a more sophisticated solution should be deferred to a later release.

## Testing

1. Boot into Tails 3 environment.
2. Run `./securedrop-admin setup` from the root of the securedrop repo.
3. Wait until the output line: `dpkg-preconfigure: unable to re-open stdin: No such file or directory`
4. Observe that the subsequent lines are readable and not garbled.

## Deployment

There are no deployment-specific concerns because this PR fixes a bug in the 0.4 release candidate and that bug has not yet been shipped as part of a release.