### PR TITLE
Repair docstring newlines in admin -help output

### DIFF
--- a/securedrop-admin
+++ b/securedrop-admin
@@ -119,8 +119,7 @@ def install_apt_dependencies(args):
 
 
 def envsetup(args):
-    """
-    Installs all Admin tooling required for managing SecureDrop. Specifically:
+    """Installs Admin tooling required for managing SecureDrop. Specifically:
 
         * updates apt-cache
         * installs apt packages for Python virtualenv
@@ -228,9 +227,14 @@ def run_tails_config(args):
 
 
 if __name__ == "__main__":
+    class ArgParseFormatterCombo(argparse.ArgumentDefaultsHelpFormatter,
+                                 argparse.RawTextHelpFormatter):
+        """Needed to combine formatting classes for help output"""
+        pass
 
     # Processing argument parsing logic -- yuck
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=ArgParseFormatterCombo)
     parser.add_argument('-v', action='store_true', default=False,
                             help="Increase verbosity on output")
     parser.add_argument('-d', action='store_true', default=False,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1960 

Changes proposed in this pull request:

## Testing

Run `securedrop-admin -h` under  `python 2.7.13` (what is currently on Tails 3.0.1).

## Deployment

Only affects securedrop journalist workstation.

Screen-shot of formatting changes: (see original format in #1960 ticket)

![selection_026](https://user-images.githubusercontent.com/1727935/28076037-6427513a-662b-11e7-8e83-cd1fb5ae4001.png)
