### PR TITLE
More informative error messages in dynamic inventory

### DIFF
--- a/install_files/ansible-base/inventory-dynamic
+++ b/install_files/ansible-base/inventory-dynamic
@@ -24,6 +24,16 @@ SECUREDROP_SITE_VARS = os.path.join(SECUREDROP_ANSIBLE_DIRECTORY,
 SECUREDROP_SUPPORTED_HOSTNAMES = ['app', 'mon']
 
 
+class ConfigurationError(Exception):
+    """
+    Custom exception for aborting execution if the site-specific
+    vars are not present. The inventory script will look for
+    site-specific info such as SSH username and local IPv4 addresses
+    for the SecureDrop servers.
+    """
+    pass
+
+
 def lookup_local_ipv4_address(hostname):
     """
     Extract local IPv4 addresses from site vars for first-run config.
@@ -37,8 +47,9 @@ def lookup_local_ipv4_address(hostname):
             monitor_ip = site_vars['monitor_ip']
 
     except (IOError, KeyError):
-        msg = "You must run 'secure-admin sdconfig' from root securedrop dir."
-        raise Exception(msg)
+        msg = ("Run `./securedrop-admin sdconfig` to configure"
+               " site-specific information.")
+        raise ConfigurationError(msg)
 
     if hostname == "app":
         return app_ip
@@ -46,7 +57,7 @@ def lookup_local_ipv4_address(hostname):
         return monitor_ip
     else:
         msg = "Unsupported hostname: '{}'".format(hostname)
-        raise Exception(msg)
+        raise ConfigurationError(msg)
 
 
 def lookup_admin_username():
@@ -63,7 +74,8 @@ def lookup_admin_username():
             admin_username = site_vars['ssh_users']
 
     except (IOError, KeyError):
-        msg = "You must run the configure playbook."
+        msg = ("Run `./securedrop-admin sdconfig` to configure"
+               " site-specific information.")
         raise Exception(msg)
 
     try:
@@ -74,7 +86,7 @@ def lookup_admin_username():
         msg = ("The value of `ssh_users` must be a single username,"
                " not a list of usernames. Please update"
                " `{}` and try again.".format(SECUREDROP_SITE_VARS))
-        raise Exception(msg)
+        raise ConfigurationError(msg)
 
     return admin_username
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #1950. Some of the error messages displayed by the `inventory-dynamic` script were incorrect, instructing Admins to run scripts that don't exist. Updated the path names displayed in error messages, and created a reusable custom exception for handling configuration errors.

## Testing

1. Boot Tails Admin workstation.
2. `cd install_files/ansible-base`
3. Remove any site-specific vars: `rm -f group_vars/all/site-specific`
4. Execute inventory script directly: `./inventory-dynamic`
5. Make sure you get an informative error message: "Run \`./securedrop-admin sdconfig\` to configure site-specific information.
 
## Deployment

Improves Admin-facing messaging, so the switch to the `securedrop-admin` tooling is smooth and intuitive. If any errors crop up, the script should accurately state the specific action the Admin should take to resolve.

## Checklist
Relying on manual testing of the Tails environment.