### PR TITLE
[0.4] Journalist Interface: Rename "Download All" to "Download"

### DIFF
--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -8,8 +8,8 @@
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
       <p>
         <div id='index-select-container'></div>
-      <button type="submit" name="action" value="download-unread" class="small"><i class="fa fa-download"></i> Download Unread</button>
-      <button type="submit" name="action" value="download-all" class="small"><i class="fa fa-download"></i> Download All</button>
+        <button type="submit" name="action" value="download-unread" class="small"><i class="fa fa-download"></i> Download Unread</button>
+        <button type="submit" name="action" value="download-all" class="small"><i class="fa fa-download"></i> Download</button>
         <button type="submit" name="action" value="star" class="small"><i class="fa fa-star"></i> Star</button>
         <button type="submit" name="action" value="un-star" class="small"><i class="fa fa-star-half-full"></i> Un-star</button>
         <button type="submit" id="delete_collections" name="action" value="delete" class="small-danger"><i class="fa fa-trash-o"></i> Delete</button>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #1963. Simple fix for confusing UX on "Download All" button. 

## Testing

If you agree that this line of buttons along the top of the table appears to be for selected items only, then this is good to merge:

![screen shot 2017-07-11 at 5 37 29 pm](https://user-images.githubusercontent.com/7832803/28097353-8d52b700-6664-11e7-83ff-9a4381d01e96.png)

## Deployment

No deployment issues

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM