### PR TITLE
[0.4] journalist: hide select all/none in index when no js

### DIFF
--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -7,7 +7,7 @@
     <form id="process_collections" action="/col/process" method="post">
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
       <p>
-        <span id="select_all" class="select"><i class="fa fa-check-square-o"></i> select all</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> select none</span>
+        <div id='index-select-container'></div>
       <button type="submit" name="action" value="download-unread" class="small"><i class="fa fa-download"></i> Download Unread</button>
       <button type="submit" name="action" value="download-all" class="small"><i class="fa fa-download"></i> Download All</button>
         <button type="submit" name="action" value="star" class="small"><i class="fa fa-star"></i> Star</button>

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -9,6 +9,8 @@ function enhance_ui() {
   // Add the "select {all,none}" buttons
   $('div#select-container').html('<span id="select_all" class="select"><i class="fa fa-check-square-o"></i> select all</span> <span id="select_unread" class="select"><i class="fa fa-check-square-o"></i> select unread</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> select none</span>');
 
+  $('div#index-select-container').replaceWith('<span id="select_all" class="select"><i class="fa fa-check-square-o"></i> select all</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> select none</span>');
+
   // Change the action on the /col pages so we use a Javascript
   // confirmation instead of redirecting to a confirmation page before
   // deleting submissions


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

When javascript is disabled the select all/none buttons do nothing and
must be hidden. Move them to journalist.js using the same method as for
the collection page.

The HTML replaces the div instead of being included into it so that the
DOM is exactly the same as before. Otherwise it would be necessary to
adjust the CSS to preserve the display. The idea is to keep the change
minimal.

## Testing

* deactivate javascript
* login as a journalist and there exists at least one source
* verify the select all / select none buttons are not visible

![journalist-index](https://user-images.githubusercontent.com/433594/28126047-b88d6978-6728-11e7-8efd-0927b0aa90e5.png)

* activate javascript
* verify the select all / select none buttons are visible
* use the select all button and the select none button to verify they work as expected

![journalist-index_javascript](https://user-images.githubusercontent.com/433594/28126127-e64833f2-6728-11e7-8235-0c069254e41c.png)


## Deployment

No deployment issue, this is only a UI

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
