### PR TITLE
Fix SSH connections breaking when tor is restarted

### DIFF
--- a/install_files/ansible-base/roles/tor-hidden-services/handlers/restart-tor-carefully.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/handlers/restart-tor-carefully.yml
@@ -25,11 +25,26 @@
   poll: 0
   when: _hostname_to_wait_for.endswith('.onion')
 
-# Hardcode a wait value and wait for the entire interval.
-# Cannot use `local_action/wait_for` because it's not smart
-# enough to find the SSH connection info required to connect
-# to the Onion URL.
-- name: Waiting for SSH connection (slow)...
-  pause:
-    seconds: 90
+# It's critical that we eliminate existing SSH connections, otherwise Ansible
+# will try to reuse the stale ControlPersist files, which no longer have an
+# active socket, causing a connection timeout, and halting execution of the
+# playbook with a cryptic message.
+- name: Clear out SSH sessions, to prevent reuse of stale ControlPersist file.
+  local_action:
+    module: file
+    args:
+      path: /home/amnesia/.ansible/cp
+      state: absent
+  run_once: yes
+  sudo: no
   when: _hostname_to_wait_for.endswith('.onion')
+
+- name: Waiting for SSH connection (slow)...
+  local_action: wait_for
+  args:
+    host: "{{ _hostname_to_wait_for }}"
+    port: "{{ ansible_ssh_port|default(ansible_port|default(22)) }}"
+    delay: 30
+    search_regex: OpenSSH
+    state: started
+  sudo: no

--- a/install_files/ansible-base/roles/tor-hidden-services/handlers/restart-tor-carefully.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/handlers/restart-tor-carefully.yml
@@ -8,7 +8,7 @@
 # deciding "Are we connected via SSH over Tor or not?"
 - name: Register host name to wait for.
   set_fact:
-    _hostname_to_wait_for: "{{ ansible_ssh_host|default(ansible_host) }}"
+    _hostname_to_wait_for: "{{ remote_host_ref|default(ansible_host) }}"
 
 # If we're not connected over Tor, bounce the service as usual.
 - name: restart tor (simple)

--- a/install_files/ansible-base/roles/tor-hidden-services/handlers/restart-tor-carefully.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/handlers/restart-tor-carefully.yml
@@ -36,15 +36,15 @@
       path: /home/amnesia/.ansible/cp
       state: absent
   run_once: yes
-  sudo: no
+  become: no
   when: _hostname_to_wait_for.endswith('.onion')
 
 - name: Waiting for SSH connection (slow)...
   local_action: wait_for
   args:
     host: "{{ _hostname_to_wait_for }}"
-    port: "{{ ansible_ssh_port|default(ansible_port|default(22)) }}"
+    port: "{{ ansible_port|default(22) }}"
     delay: 30
     search_regex: OpenSSH
     state: started
-  sudo: no
+  become: no

--- a/install_files/ansible-base/roles/tor-hidden-services/templates/torrc
+++ b/install_files/ansible-base/roles/tor-hidden-services/templates/torrc
@@ -1,7 +1,6 @@
 SocksPort 0
 SafeLogging 1
 RunAsDaemon 1
-Sandbox 1
 
 {% if 'securedrop_application_server' in group_names %}
 HiddenServiceDir /var/lib/tor/services/source

--- a/testinfra/common/test_tor_config.py
+++ b/testinfra/common/test_tor_config.py
@@ -53,7 +53,6 @@ def test_tor_service_running(Command, File, Sudo):
     'SocksPort 0',
     'SafeLogging 1',
     'RunAsDaemon 1',
-    'Sandbox 1',
 ])
 def test_tor_torrc_options(File, torrc_option):
     """
@@ -68,6 +67,19 @@ def test_tor_torrc_options(File, torrc_option):
     assert f.user == "debian-tor"
     assert oct(f.mode) == "0644"
     assert f.contains("^{}$".format(torrc_option))
+
+
+def test_tor_torrc_sandbox(File):
+    """
+    Check that the `Sandbox 1` declaration is not present in the torrc.
+    The torrc manpage states this option is experimental, and although we
+    use it already on Tails workstations, further testing is required
+    before we push it out to servers. See issues #944 and #1969.
+    """
+    f = File("/etc/tor/torrc")
+    # Only `Sandbox 1` will enable, but make sure there are zero occurrances
+    # of "Sandbox", otherwise we may have a regression somewhere.
+    assert not f.contains("^.*Sandbox.*$")
 
 
 def test_tor_signing_key_fingerprint(Command):


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Since SSH connections in SecureDrop are routed over Authenticated Tor Hidden Services (ATHS), restarts of the tor daemon will sever existing SSH connections, thereby breaking Ansible playbook runs if a handler to restart tor is notified. Although we take care to ensure that tor service restart action completes successfully (#1707), the subsequent reconnection by Ansible is affected by SSH ControlPersist files.

When tor is restarted, the SSH connection is never formally severed, so SSH reasonably believes that the ControlPersist files on the Admin Workstation represent still-active connections to the remote machines. Once tor is restarted, this is no longer true. The solution is to clear out any existing ControlPersist files whenever tor is restarted. Subsequent Ansible tasks will then be forced to open a new ControlMaster, and fresh ControlPersist files will be automatically created, and the play will continue as normal.

Fixes #1969.

## Testing

1. Provision prod VMs on 0.3.12.
2. Set up access to the apt-test repo for 0.4-rc1 debs.
3. Update to 0.4-rc1 via `cron-apt -i -s`.
4. Checkout the release/0.4 branch. 
5. On the Tails Admin Workstation, run `./securedrop-admin setup` (to get the latest tooling).
6. Run `./securedrop-admin install` and confirm no breakage of tor.

There's a shortcut to 6) that is sufficient for testing: manually activate the virtualenv and run `ansible-playbook -vv --diff securedrop-prod.yml --tags tor` to isolate the tor-related tasks. 

## Deployment

Ensures that Admins upgrading from 0.3.12 to 0.4 can run the Ansible playbooks without breakage. 

## Checklist
Relying on manual testing of the Tails Admin Workstation environment, as well as upgrade-specific testing that does not exist in CI.