### PR TITLE
Fix tor crashing on Admin Workstation due to duplicate ATHS values

### DIFF
--- a/install_files/ansible-base/roles/tails-config/defaults/main.yml
+++ b/install_files/ansible-base/roles/tails-config/defaults/main.yml
@@ -41,3 +41,7 @@ tails_config_deprecated_directories:
 tails_config_deprecated_config_files:
   - 70-tor-reload.sh
   - 99-tor-reload.sh
+
+# Exclude deprecated document-aths file leftover from SD versions <0.3.12
+# but continue to find all other aths files
+tails_config_aths_pattern: ".*(?<!document)-aths$"

--- a/install_files/ansible-base/roles/tails-config/tasks/configure_torrc_additions.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/configure_torrc_additions.yml
@@ -6,7 +6,8 @@
     patterns:
       # Collect all files that end in `-aths`, since only ATHS services
       # contain HidServAuth info that must be added to torrc.
-      - '*-aths'
+      - '{{ tails_config_aths_pattern }}'
+    use_regex: true
   register: find_aths_info_result
 
 # We need at least one ATHS value, for the Journalist Interface.
@@ -26,7 +27,7 @@
   become: yes
   assemble:
     src: "{{ tails_config_ansible_base }}"
-    regexp: '.*-aths$'
+    regexp: '{{ tails_config_aths_pattern }}'
     dest: "{{ tails_config_torrc_additions }}"
     owner: root
     group: root

--- a/install_files/ansible-base/roles/tails-config/tasks/configure_torrc_additions.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/configure_torrc_additions.yml
@@ -4,8 +4,6 @@
     paths:
       - "{{ tails_config_ansible_base }}"
     patterns:
-      # Collect all files that end in `-aths`, since only ATHS services
-      # contain HidServAuth info that must be added to torrc.
       - '{{ tails_config_aths_pattern }}'
     use_regex: true
   register: find_aths_info_result
@@ -25,10 +23,11 @@
 
 - name: Assemble ATHS info into torrc additions.
   become: yes
-  assemble:
-    src: "{{ tails_config_ansible_base }}"
-    regexp: '{{ tails_config_aths_pattern }}'
+  lineinfile:
+    line: "{{ lookup('file', item) }}"
     dest: "{{ tails_config_torrc_additions }}"
     owner: root
     group: root
     mode: "0400"
+  # Create list of file-paths from find task at top
+  with_items: "{{ find_aths_info_result.files | map(attribute='path') | list }}"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1976 

Changes proposed in this pull request:

I added a regex pattern to filter out the deprecated `app-document-aths` file. I've also swapped `assemble` with `lineinfile` which is a little bit friendly to debug with :)

## Testing

* Open up this branch from tails
* Ensure you have an `app-document-aths` with duplicate content as an `app-journalist-aths` file under install-files/ansible_base (by the way, that switch between `-` and `_` is super annoying)
* Run `./securedrop-admin tailsconfig` from the root and ensure `~/Persistent/.securedrop/torrc_additions` does not come up with duplicate lines AND that the tor service is running (`sudo systemctl status tor@default.service`)

## Deployment

Any special considerations for deployment? Consider both:

Nooppee - Only affects admin workstation on tails