### PR TITLE
Fix SSH connection timeout in Vagrant

### DIFF
--- a/install_files/ansible-base/roles/tor-hidden-services/handlers/restart-tor-carefully.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/handlers/restart-tor-carefully.yml
@@ -43,7 +43,7 @@
   local_action: wait_for
   args:
     host: "{{ _hostname_to_wait_for }}"
-    port: "{{ ansible_port|default(22) }}"
+    port: "{{ ansible_ssh_port|default(ansible_port|default(22)) }}"
     delay: 30
     search_regex: OpenSSH
     state: started


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1977 per @conorsch's suggestion in https://github.com/freedomofpress/securedrop/issues/1977#issuecomment-315229919.

We might also want to double-check that this still works on Tails and in CI, where Ansible's behavior is apparently different (uses `ansible_port` instead of the deprecated `ansible_ssh_port`) than it is in Vagrant (which apparently is still using the deprecated `ansible_ssh_port`).

## Testing

A clean provision of the staging environment (`vagrant destroy -f /staging/ && vagrant up /staging/`) should complete successfully.