### PR TITLE
[0.4] source: not found page content is empty

### DIFF
--- a/securedrop/source_templates/error.html
+++ b/securedrop/source_templates/error.html
@@ -1,11 +1,8 @@
 {% extends "base.html" %}
 {% block body %}
-<div id="content">
-
 <h1>Server error</h1>
 
 <p>Sorry, the website encountered an error and was unable to complete your request.</p>
 
 <p><a href="/login">Look up a codename...</a></p>
-</div>
 {% endblock %}

--- a/securedrop/source_templates/notfound.html
+++ b/securedrop/source_templates/notfound.html
@@ -1,11 +1,8 @@
 {% extends "base.html" %}
 {% block body %}
-<div id="content">
-
 <h1>Page not found</h1>
 
-<p>Sorry, we couldn't locate what you requested.</p>
+<p id="page_not_found">Sorry, we couldn't locate what you requested.</p>
 
 <p><a href="/login">Look up a codename...</a></p>
-</div>
 {% endblock %}

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -157,3 +157,8 @@ class SourceNavigationSteps():
         logout_button = self.driver.find_element_by_id('logout').click()
         notification = self.driver.find_element_by_css_selector('.important')
         self.assertIn('Thank you for exiting your session!', notification.text)
+
+    def _source_not_found(self):
+        self.driver.get(self.source_location + "/unlikely")
+        message = self.driver.find_element_by_id('page_not_found')
+        self.assertTrue(message.is_displayed())

--- a/securedrop/tests/functional/test_source_notfound.py
+++ b/securedrop/tests/functional/test_source_notfound.py
@@ -1,0 +1,19 @@
+import unittest
+
+import source_navigation_steps
+import functional_test
+
+
+class SourceInterfaceBannerWarnings(
+        unittest.TestCase,
+        functional_test.FunctionalTest,
+        source_navigation_steps.SourceNavigationSteps):
+
+    def setUp(self):
+        functional_test.FunctionalTest.setUp(self)
+
+    def tearDown(self):
+        functional_test.FunctionalTest.tearDown(self)
+
+    def test_not_found(self):
+        self._source_not_found()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The #content id is set to hide its content by default, which is good
when used to hide the codename in the lookup.html page. Unfortunately
the same id (#content) is also used in the error.html and notfound.html
templates and hide their content.

Remove the extra <div id="content"> in both error.html and
notfound.html. Also add a functional test to verify the message is
visible when notfound.html is displayed.

## Testing

* navigate to the url /unlikely in the source interface
* see that it is an empty page

![notfound](https://user-images.githubusercontent.com/433594/28234432-c8f8d076-68ff-11e7-8bd0-2dc12cc49495.png)

* apply the patch and see the not found page contains the expected text

![expected-notfound](https://user-images.githubusercontent.com/433594/28234452-fef3f58e-68ff-11e7-9934-a72cb4a30581.png)

## Deployment

This is a GUI only issue with no deployment side effect

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
