### PR TITLE
tests: functional: flake8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py crypto_util.py journalist.py manage.py store.py secure_tempfile.py source.py template_filters.py tests/test_2fa.py tests/conftest.py tests/test_db.py tests/test_manage.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py tests/test_source.py && popd
+  - pushd securedrop; flake8 db.py crypto_util.py journalist.py manage.py store.py secure_tempfile.py source.py template_filters.py tests/functional tests/test_2fa.py tests/conftest.py tests/test_db.py tests/test_manage.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py tests/test_source.py && popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -5,29 +5,24 @@ import mock
 from multiprocessing import Process
 import os
 from os.path import abspath, dirname, join, realpath
-import shutil
 import signal
 import socket
-import sys
 import time
 import traceback
-import unittest
-import urllib2
 
 from Crypto import Random
-import gnupg
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.firefox import firefox_binary
 
-os.environ['SECUREDROP_ENV'] = 'test'
-import config
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 import db
 import journalist
 import source
 import tests.utils.env as env
 
 LOG_DIR = abspath(join(dirname(realpath(__file__)), '..', 'log'))
+
 
 class FunctionalTest():
 
@@ -98,8 +93,8 @@ class FunctionalTest():
 
         # Set window size and position explicitly to avoid potential bugs due
         # to discrepancies between environments.
-        self.driver.set_window_position(0, 0);
-        self.driver.set_window_size(1024, 768);
+        self.driver.set_window_position(0, 0)
+        self.driver.set_window_size(1024, 768)
 
         # Poll the DOM briefly to wait for elements. It appears .click() does
         # not always do a good job waiting for the page to load, or perhaps

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -1,8 +1,6 @@
 import urllib2
 import tempfile
-import zipfile
 import gzip
-import datetime
 
 from selenium.common.exceptions import NoSuchElementException
 
@@ -182,14 +180,15 @@ class JournalistNavigationSteps():
         self.assertEqual('Edit your account', h1s.text)
         # There's no link back to the admin interface.
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_partial_link_text('Back to admin interface')
+            self.driver.find_element_by_partial_link_text(
+                'Back to admin interface')
         # There's no field to change your username.
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_css_selector('#username')
         # There's no checkbox to change the administrator status of your
         # account.
         with self.assertRaises(NoSuchElementException):
-            username_field = self.driver.find_element_by_css_selector('#is_admin')
+            self.driver.find_element_by_css_selector('#is_admin')
         # 2FA reset buttons at the bottom point to the user URLs for reset.
         totp_reset_button = self.driver.find_elements_by_css_selector(
             '#reset-two-factor-totp')[0]
@@ -256,7 +255,8 @@ class JournalistNavigationSteps():
         # Click the "edit user" link for the new user
         # self._edit_user(self.new_user['username'])
         new_user_edit_links = filter(
-            lambda el: el.get_attribute('data-username') == self.new_user['username'],
+            lambda el: (el.get_attribute('data-username') ==
+                        self.new_user['username']),
             self.driver.find_elements_by_tag_name('a'))
         self.assertEquals(len(new_user_edit_links), 1)
         new_user_edit_links[0].click()
@@ -403,7 +403,8 @@ class JournalistNavigationSteps():
         self.assertEqual(self.secret_message, submission)
 
     def _journalist_sends_reply_to_source(self):
-        self.driver.find_element_by_id('reply-text-field').send_keys('Nice docs')
+        self.driver.find_element_by_id('reply-text-field').send_keys(
+            'Nice docs')
 
         self.driver.find_element_by_id('reply-button').click()
 

--- a/securedrop/tests/functional/make_account_changes.py
+++ b/securedrop/tests/functional/make_account_changes.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from functional_test import FunctionalTest
 from journalist_navigation_steps import JournalistNavigationSteps
 
+
 class MakeAccountChanges(FunctionalTest, JournalistNavigationSteps, TestCase):
     def test_admin_edit_account_html_template_rendering(self):
         """The edit_account.html template is used both when an admin is editing

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -1,7 +1,6 @@
 import tempfile
 
 from selenium.webdriver.common.action_chains import ActionChains
-from selenium.webdriver.common.by import By
 
 
 class SourceNavigationSteps():
@@ -20,7 +19,8 @@ class SourceNavigationSteps():
 
         # It's the source's first time visiting this SecureDrop site, so they
         # choose to "Submit Documents".
-        submit_button = self.driver.find_element_by_id('submit-documents-button')
+        submit_button = self.driver.find_element_by_id(
+            'submit-documents-button')
 
         submit_button_icon = self.driver.find_element_by_css_selector(
             'a#submit-documents-button > img.off-hover')
@@ -30,7 +30,8 @@ class SourceNavigationSteps():
         # of the button changes to encourage them to click it.
         ActionChains(self.driver).move_to_element(submit_button).perform()
 
-        ## Let's make sure toggling the icon image with the hover state is working.
+        # Let's make sure toggling the icon image with the hover state
+        # is working.
         self.assertFalse(submit_button_icon.is_displayed())
         submit_button_hover_icon = self.driver.find_element_by_css_selector(
             'a#submit-documents-button > img.on-hover')
@@ -47,7 +48,8 @@ class SourceNavigationSteps():
     def _source_chooses_to_login(self):
         self.driver.find_element_by_id('login-button').click()
 
-        logins = self.driver.find_elements_by_id('login-with-existing-codename')
+        logins = self.driver.find_elements_by_id(
+            'login-with-existing-codename')
 
         self.assertTrue(len(logins) > 0)
 
@@ -60,7 +62,8 @@ class SourceNavigationSteps():
                          self.driver.title)
 
     def _source_proceeds_to_login(self):
-        codename_input = self.driver.find_element_by_id('login-with-existing-codename')
+        codename_input = self.driver.find_element_by_id(
+            'login-with-existing-codename')
         codename_input.send_keys(self.source_name)
 
         continue_button = self.driver.find_element_by_id('login')
@@ -82,8 +85,8 @@ class SourceNavigationSteps():
             'button#continue-button > img.off-hover')
         self.assertTrue(continue_button_icon.is_displayed())
 
-        ## Hover over the continue button test toggle the icon images with the
-        ## hover state.
+        # Hover over the continue button test toggle the icon images
+        # with the hover state.
         ActionChains(self.driver).move_to_element(continue_button).perform()
         self.assertFalse(continue_button_icon.is_displayed())
 
@@ -103,7 +106,6 @@ class SourceNavigationSteps():
             file.seek(0)
 
             filename = file.name
-            filebasename = filename.split('/')[-1]
 
             file_upload_box = self.driver.find_element_by_css_selector(
                 '[name=fh]')
@@ -112,21 +114,23 @@ class SourceNavigationSteps():
             submit_button = self.driver.find_element_by_id('submit-doc-button')
             ActionChains(self.driver).move_to_element(submit_button).perform()
 
-            toggled_submit_button_icon = self.driver.find_element_by_css_selector(
-                'button#submit-doc-button img.on-hover'
-            )
+            toggled_submit_button_icon = (
+                self.driver.find_element_by_css_selector(
+                    'button#submit-doc-button img.on-hover'))
             self.assertTrue(toggled_submit_button_icon.is_displayed())
 
             submit_button.click()
 
             notification = self.driver.find_element_by_css_selector(
                 '.success')
-            expected_notification = 'Thank you for sending this information to us'
+            expected_notification = (
+                'Thank you for sending this information to us')
             self.assertIn(expected_notification, notification.text)
 
     def _source_submits_a_message(self):
         text_box = self.driver.find_element_by_css_selector('[name=msg]')
-        text_box.send_keys(self.secret_message)  # send_keys = type into text box
+        # send_keys = type into text box
+        text_box.send_keys(self.secret_message)
 
         submit_button = self.driver.find_element_by_id('submit-doc-button')
         submit_button.click()
@@ -138,14 +142,16 @@ class SourceNavigationSteps():
 
     def _source_deletes_a_journalist_reply(self):
         # Get the reply filename so we can use IDs to select the delete buttons
-        reply_filename_element = self.driver.find_element_by_name('reply_filename')
+        reply_filename_element = self.driver.find_element_by_name(
+            'reply_filename')
         reply_filename = reply_filename_element.get_attribute('value')
 
         delete_button_id = 'delete-reply-{}'.format(reply_filename)
         delete_button = self.driver.find_element_by_id(delete_button_id)
         delete_button.click()
 
-        confirm_button_id = 'confirm-delete-reply-button-{}'.format(reply_filename)
+        confirm_button_id = 'confirm-delete-reply-button-{}'.format(
+            reply_filename)
         confirm_button = self.driver.find_element_by_id(confirm_button_id)
         self.assertTrue(confirm_button.is_displayed())
         confirm_button.click()
@@ -154,6 +160,6 @@ class SourceNavigationSteps():
         self.assertIn('Reply deleted', notification.text)
 
     def _source_logs_out(self):
-        logout_button = self.driver.find_element_by_id('logout').click()
+        self.driver.find_element_by_id('logout').click()
         notification = self.driver.find_element_by_css_selector('.important')
         self.assertIn('Thank you for exiting your session!', notification.text)

--- a/securedrop/tests/functional/submission_not_in_memory.py
+++ b/securedrop/tests/functional/submission_not_in_memory.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 from functional_test import FunctionalTest
 import subprocess
-import tempfile
 from source_navigation_steps import SourceNavigationSteps
 import os
 import getpass

--- a/securedrop/tests/functional/test_source_warnings.py
+++ b/securedrop/tests/functional/test_source_warnings.py
@@ -1,4 +1,3 @@
-from selenium import webdriver
 import unittest
 
 import source_navigation_steps
@@ -19,7 +18,8 @@ class SourceInterfaceBannerWarnings(
     def test_warning_appears_if_tor_browser_not_in_use(self):
         self.driver.get(self.source_location)
 
-        warning_banner = self.driver.find_element_by_class_name('use-tor-browser')
+        warning_banner = self.driver.find_element_by_class_name(
+            'use-tor-browser')
 
         self.assertIn("We recommend using Tor Browser to access SecureDrop",
                       warning_banner.text)

--- a/securedrop/tests/functional/test_submit_and_retrieve_message.py
+++ b/securedrop/tests/functional/test_submit_and_retrieve_message.py
@@ -2,7 +2,6 @@ import functional_test
 import source_navigation_steps
 import journalist_navigation_steps
 import unittest
-import urllib2
 
 
 class SubmitAndRetrieveMessage(


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes tests/functional flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop/tests/functional ; python -m astor.rtrip .
* diff -ru tmp_rtrip tmp_rtrip.orig
<pre>
diff -ru tmp_rtrip.orig/functional_test.py tmp_rtrip/functional_test.py
--- tmp_rtrip.orig/functional_test.py	2017-07-17 11:04:49.733303675 +0200
+++ tmp_rtrip/functional_test.py	2017-07-17 11:08:41.405879602 +0200
@@ -3,21 +3,15 @@
 from multiprocessing import Process
 import os
 from os.path import abspath, dirname, join, realpath
-import shutil
 import signal
 import socket
-import sys
 import time
 import traceback
-import unittest
-import urllib2
 from Crypto import Random
-import gnupg
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.firefox import firefox_binary
 os.environ['SECUREDROP_ENV'] = 'test'
-import config
 import db
 import journalist
 import source
diff -ru tmp_rtrip.orig/journalist_navigation_steps.py tmp_rtrip/journalist_navigation_steps.py
--- tmp_rtrip.orig/journalist_navigation_steps.py	2017-07-17 11:04:49.749303716 +0200
+++ tmp_rtrip/journalist_navigation_steps.py	2017-07-17 11:08:41.417879632 +0200
@@ -1,8 +1,6 @@
 import urllib2
 import tempfile
-import zipfile
 import gzip
-import datetime
 from selenium.common.exceptions import NoSuchElementException
 import tests.utils.db_helper as db_helper
 from db import Journalist
@@ -129,8 +127,7 @@
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_css_selector('#username')
         with self.assertRaises(NoSuchElementException):
-            username_field = self.driver.find_element_by_css_selector(
-                '#is_admin')
+            self.driver.find_element_by_css_selector('#is_admin')
         totp_reset_button = self.driver.find_elements_by_css_selector(
             '#reset-two-factor-totp')[0]
         self.assertRegexpMatches(totp_reset_button.get_attribute('action'),
diff -ru tmp_rtrip.orig/source_navigation_steps.py tmp_rtrip/source_navigation_steps.py
--- tmp_rtrip.orig/source_navigation_steps.py	2017-07-17 11:04:49.729303666 +0200
+++ tmp_rtrip/source_navigation_steps.py	2017-07-17 11:08:41.397879583 +0200
@@ -1,6 +1,5 @@
 import tempfile
 from selenium.webdriver.common.action_chains import ActionChains
-from selenium.webdriver.common.by import By
 
 
 class SourceNavigationSteps:
@@ -73,7 +72,6 @@
             file.write(self.secret_message)
             file.seek(0)
             filename = file.name
-            filebasename = filename.split('/')[-1]
             file_upload_box = self.driver.find_element_by_css_selector(
                 '[name=fh]')
             file_upload_box.send_keys(filename)
@@ -114,6 +112,6 @@
         self.assertIn('Reply deleted', notification.text)
 
     def _source_logs_out(self):
-        logout_button = self.driver.find_element_by_id('logout').click()
+        self.driver.find_element_by_id('logout').click()
         notification = self.driver.find_element_by_css_selector('.important')
         self.assertIn('Thank you for exiting your session!', notification.text)
diff -ru tmp_rtrip.orig/submission_not_in_memory.py tmp_rtrip/submission_not_in_memory.py
--- tmp_rtrip.orig/submission_not_in_memory.py	2017-07-17 11:04:49.737303685 +0200
+++ tmp_rtrip/submission_not_in_memory.py	2017-07-17 11:08:41.409879612 +0200
@@ -1,7 +1,6 @@
 from unittest import TestCase
 from functional_test import FunctionalTest
 import subprocess
-import tempfile
 from source_navigation_steps import SourceNavigationSteps
 import os
 import getpass
diff -ru tmp_rtrip.orig/test_source_warnings.py tmp_rtrip/test_source_warnings.py
--- tmp_rtrip.orig/test_source_warnings.py	2017-07-17 11:04:49.757303736 +0200
+++ tmp_rtrip/test_source_warnings.py	2017-07-17 11:08:41.425879652 +0200
@@ -1,4 +1,3 @@
-from selenium import webdriver
 import unittest
 import source_navigation_steps
 import functional_test
diff -ru tmp_rtrip.orig/test_submit_and_retrieve_message.py tmp_rtrip/test_submit_and_retrieve_message.py
--- tmp_rtrip.orig/test_submit_and_retrieve_message.py	2017-07-17 11:04:49.737303685 +0200
+++ tmp_rtrip/test_submit_and_retrieve_message.py	2017-07-17 11:08:41.405879602 +0200
@@ -2,7 +2,6 @@
 import source_navigation_steps
 import journalist_navigation_steps
 import unittest
-import urllib2
 
 
 class SubmitAndRetrieveMessage(unittest.TestCase, functional_test.
</pre>

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior