### PR TITLE
[0.4.1] source: fix inconsistent output when exiting from use-tor

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -399,7 +399,7 @@ def logout():
     if logged_in():
         session.clear()
         msg = render_template('logout_flashed_message.html')
-        flash(Markup(msg), "important")
+        flash(Markup(msg), "important hide-if-not-tor-browser")
     return redirect(url_for('index'))
 
 

--- a/securedrop/static/js/source.js
+++ b/securedrop/static/js/source.js
@@ -50,6 +50,7 @@ $(function(){
   } else {
     // If the user is not using Tor Browser, we want to encourage them to do so.
     $('.use-tor-browser').show();
+    $('.hide-if-not-tor-browser').hide();
     $('#use-tor-browser-close').click(function(){
       $('.use-tor-browser').hide(200);
     });

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -161,5 +161,4 @@ class SourceNavigationSteps():
 
     def _source_logs_out(self):
         self.driver.find_element_by_id('logout').click()
-        notification = self.driver.find_element_by_css_selector('.important')
-        assert 'Thank you for exiting your session!' in notification.text
+        assert self.driver.find_element_by_css_selector('.important')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1978 

When exiting a session from /use-tor, the login page shows
a flash message recommending to do some tor specific actions. This
should not be displayed if not using tor.

## Testing

The test environment does not have a tor browser and pretending firefox is a tor browser is non trivial. The change can be tested manually:

* in the development vm ./manage.py run
* with a web browser that is not tor
  * go to http://127.0.0.1:8080
  * go to http://127.0.0.1:8080/generate
  * go to http://127.0.0.1:8080/use-tor
  * click exit
  * verify the display is as follows:

![good](https://user-images.githubusercontent.com/433594/28264401-1266b3e4-6aeb-11e7-9d24-e0da99bafa59.png)

* with a tor web browser
  * go to http://127.0.0.1:8080
  * go to http://127.0.0.1:8080/generate
  * go to http://127.0.0.1:8080/use-tor
  * click exit
  * verify the display is as follows:

![goodtor](https://user-images.githubusercontent.com/433594/28264605-f73908aa-6aeb-11e7-99d9-efff5320cf32.png)


## Deployment

This is a user facing change only with no impact on deployment.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
