### PR TITLE
doc: remove extra leading $

### DIFF
--- a/docs/development/testing_continuous_integration.rst
+++ b/docs/development/testing_continuous_integration.rst
@@ -75,7 +75,7 @@ Source the setup script using the following command:
 
 .. code:: sh
 
-    $ source ./devops/scripts/local-setup.sh
+    source ./devops/scripts/local-setup.sh
 
 You will be prompted for the values of the required environment variables. There
 are some defaults set that you may want to change. You will need to determine


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

The SecureDrop documentation style guide's recommendations for quoting shell commands and shell output are not followed consistently throughout the documentation. This pull request applies the recommended formatting consistently across all of the documentation.