### PR TITLE
convert functional tests to pytest

### DIFF
--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -42,11 +42,10 @@ class FunctionalTest():
         firefox = firefox_binary.FirefoxBinary(log_file=log_file)
         return webdriver.Firefox(firefox_binary=firefox)
 
-    def setUp(self):
+    def setup(self):
         # Patch the two-factor verification to avoid intermittent errors
-        patcher = mock.patch('journalist.Journalist.verify_token')
-        self.addCleanup(patcher.stop)
-        self.mock_journalist_verify_token = patcher.start()
+        self.patcher = mock.patch('journalist.Journalist.verify_token')
+        self.mock_journalist_verify_token = self.patcher.start()
         self.mock_journalist_verify_token.return_value = True
 
         signal.signal(signal.SIGUSR1, lambda _, s: traceback.print_stack(s))
@@ -103,7 +102,8 @@ class FunctionalTest():
 
         self.secret_message = 'blah blah blah'
 
-    def tearDown(self):
+    def teardown(self):
+        self.patcher.stop()
         env.teardown()
         self.driver.quit()
         self.source_process.terminate()

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -8,8 +8,8 @@ class SourceNavigationSteps():
     def _source_visits_source_homepage(self):
         self.driver.get(self.source_location)
 
-        self.assertEqual("SecureDrop | Protecting Journalists and Sources",
-                         self.driver.title)
+        assert ("SecureDrop | Protecting Journalists and Sources" ==
+                self.driver.title)
 
     def _source_chooses_to_submit_documents(self):
         # First move the cursor to a known position in case it happens to
@@ -24,7 +24,7 @@ class SourceNavigationSteps():
 
         submit_button_icon = self.driver.find_element_by_css_selector(
             'a#submit-documents-button > img.off-hover')
-        self.assertTrue(submit_button_icon.is_displayed())
+        assert submit_button_icon.is_displayed()
 
         # The source hovers their cursor over the button, and the visual style
         # of the button changes to encourage them to click it.
@@ -32,17 +32,17 @@ class SourceNavigationSteps():
 
         # Let's make sure toggling the icon image with the hover state
         # is working.
-        self.assertFalse(submit_button_icon.is_displayed())
+        assert submit_button_icon.is_displayed() is False
         submit_button_hover_icon = self.driver.find_element_by_css_selector(
             'a#submit-documents-button > img.on-hover')
-        self.assertTrue(submit_button_hover_icon.is_displayed())
+        assert submit_button_hover_icon.is_displayed()
 
         # The source clicks the submit button.
         submit_button.click()
 
         codename = self.driver.find_element_by_css_selector('#codename')
 
-        self.assertTrue(len(codename.text) > 0)
+        assert len(codename.text) > 0
         self.source_name = codename.text
 
     def _source_chooses_to_login(self):
@@ -51,15 +51,15 @@ class SourceNavigationSteps():
         logins = self.driver.find_elements_by_id(
             'login-with-existing-codename')
 
-        self.assertTrue(len(logins) > 0)
+        assert len(logins) > 0
 
     def _source_hits_cancel_at_login_page(self):
         self.driver.find_element_by_id('cancel').click()
 
         self.driver.get(self.source_location)
 
-        self.assertEqual("SecureDrop | Protecting Journalists and Sources",
-                         self.driver.title)
+        assert ("SecureDrop | Protecting Journalists and Sources" ==
+                self.driver.title)
 
     def _source_proceeds_to_login(self):
         codename_input = self.driver.find_element_by_id(
@@ -69,36 +69,36 @@ class SourceNavigationSteps():
         continue_button = self.driver.find_element_by_id('login')
         continue_button.click()
 
-        self.assertEqual("SecureDrop | Protecting Journalists and Sources",
-                         self.driver.title)
+        assert ("SecureDrop | Protecting Journalists and Sources" ==
+                self.driver.title)
 
     def _source_hits_cancel_at_submit_page(self):
         self.driver.find_element_by_id('cancel').click()
 
         headline = self.driver.find_element_by_class_name('headline')
-        self.assertEqual('Submit Materials', headline.text)
+        assert 'Submit Materials' == headline.text
 
     def _source_continues_to_submit_page(self):
         continue_button = self.driver.find_element_by_id('continue-button')
 
         continue_button_icon = self.driver.find_element_by_css_selector(
             'button#continue-button > img.off-hover')
-        self.assertTrue(continue_button_icon.is_displayed())
+        assert continue_button_icon.is_displayed()
 
         # Hover over the continue button test toggle the icon images
         # with the hover state.
         ActionChains(self.driver).move_to_element(continue_button).perform()
-        self.assertFalse(continue_button_icon.is_displayed())
+        assert continue_button_icon.is_displayed() is False
 
         continue_button_hover_icon = self.driver.find_element_by_css_selector(
             'button#continue-button img.on-hover'
         )
-        self.assertTrue(continue_button_hover_icon.is_displayed())
+        assert continue_button_hover_icon.is_displayed()
 
         continue_button.click()
 
         headline = self.driver.find_element_by_class_name('headline')
-        self.assertEqual('Submit Materials', headline.text)
+        assert 'Submit Materials' == headline.text
 
     def _source_submits_a_file(self):
         with tempfile.NamedTemporaryFile() as file:
@@ -117,7 +117,7 @@ class SourceNavigationSteps():
             toggled_submit_button_icon = (
                 self.driver.find_element_by_css_selector(
                     'button#submit-doc-button img.on-hover'))
-            self.assertTrue(toggled_submit_button_icon.is_displayed())
+            assert toggled_submit_button_icon.is_displayed()
 
             submit_button.click()
 
@@ -125,7 +125,7 @@ class SourceNavigationSteps():
                 '.success')
             expected_notification = (
                 'Thank you for sending this information to us')
-            self.assertIn(expected_notification, notification.text)
+            assert expected_notification in notification.text
 
     def _source_submits_a_message(self):
         text_box = self.driver.find_element_by_css_selector('[name=msg]')
@@ -137,8 +137,8 @@ class SourceNavigationSteps():
 
         notification = self.driver.find_element_by_css_selector(
             '.success')
-        self.assertIn('Thank you for sending this information to us',
-                      notification.text)
+        assert ('Thank you for sending this information to us' in
+                notification.text)
 
     def _source_deletes_a_journalist_reply(self):
         # Get the reply filename so we can use IDs to select the delete buttons
@@ -153,13 +153,13 @@ class SourceNavigationSteps():
         confirm_button_id = 'confirm-delete-reply-button-{}'.format(
             reply_filename)
         confirm_button = self.driver.find_element_by_id(confirm_button_id)
-        self.assertTrue(confirm_button.is_displayed())
+        assert confirm_button.is_displayed()
         confirm_button.click()
 
         notification = self.driver.find_element_by_class_name('notification')
-        self.assertIn('Reply deleted', notification.text)
+        assert 'Reply deleted' in notification.text
 
     def _source_logs_out(self):
         self.driver.find_element_by_id('logout').click()
         notification = self.driver.find_element_by_css_selector('.important')
-        self.assertIn('Thank you for exiting your session!', notification.text)
+        assert 'Thank you for exiting your session!' in notification.text

--- a/securedrop/tests/functional/submission_not_in_memory.py
+++ b/securedrop/tests/functional/submission_not_in_memory.py
@@ -46,7 +46,7 @@ class SubmissionNotInMemoryTest(TestCase, FunctionalTest,
         secrets_in_memory = self._num_strings_in(self.secret_message,
                                                  memory_dump)
 
-        self.assertLess(secrets_in_memory, 1)
+        assert secrets_in_memory < 1
 
     def test_file_upload_is_not_retained_in_memory(self):
         self._source_visits_source_homepage()
@@ -60,4 +60,4 @@ class SubmissionNotInMemoryTest(TestCase, FunctionalTest,
         secrets_in_memory = self._num_strings_in(self.secret_message,
                                                  memory_dump)
 
-        self.assertLess(secrets_in_memory, 1)
+        assert secrets_in_memory < 1

--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -1,18 +1,10 @@
 import functional_test
 import journalist_navigation_steps
-import unittest
 
 
-class AdminInterface(
-        unittest.TestCase,
+class TestAdminInterface(
         functional_test.FunctionalTest,
         journalist_navigation_steps.JournalistNavigationSteps):
-
-    def setUp(self):
-        functional_test.FunctionalTest.setUp(self)
-
-    def tearDown(self):
-        functional_test.FunctionalTest.tearDown(self)
 
     def test_admin_interface(self):
         self._admin_logs_in()

--- a/securedrop/tests/functional/test_source_warnings.py
+++ b/securedrop/tests/functional/test_source_warnings.py
@@ -1,19 +1,10 @@
-import unittest
-
 import source_navigation_steps
 import functional_test
 
 
-class SourceInterfaceBannerWarnings(
-        unittest.TestCase,
+class TestSourceInterfaceBannerWarnings(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationSteps):
-
-    def setUp(self):
-        functional_test.FunctionalTest.setUp(self)
-
-    def tearDown(self):
-        functional_test.FunctionalTest.tearDown(self)
 
     def test_warning_appears_if_tor_browser_not_in_use(self):
         self.driver.get(self.source_location)
@@ -21,5 +12,5 @@ class SourceInterfaceBannerWarnings(
         warning_banner = self.driver.find_element_by_class_name(
             'use-tor-browser')
 
-        self.assertIn("We recommend using Tor Browser to access SecureDrop",
-                      warning_banner.text)
+        assert ("We recommend using Tor Browser to access SecureDrop" in
+                warning_banner.text)

--- a/securedrop/tests/functional/test_submit_and_retrieve_file.py
+++ b/securedrop/tests/functional/test_submit_and_retrieve_file.py
@@ -1,20 +1,12 @@
-import unittest
 import source_navigation_steps
 import journalist_navigation_steps
 import functional_test
 
 
-class SubmitAndRetrieveFile(
-        unittest.TestCase,
+class TestSubmitAndRetrieveFile(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationSteps,
         journalist_navigation_steps.JournalistNavigationSteps):
-
-    def setUp(self):
-        functional_test.FunctionalTest.setUp(self)
-
-    def tearDown(self):
-        functional_test.FunctionalTest.tearDown(self)
 
     def test_submit_and_retrieve_happy_path(self):
         self._source_visits_source_homepage()

--- a/securedrop/tests/functional/test_submit_and_retrieve_message.py
+++ b/securedrop/tests/functional/test_submit_and_retrieve_message.py
@@ -1,20 +1,12 @@
 import functional_test
 import source_navigation_steps
 import journalist_navigation_steps
-import unittest
 
 
-class SubmitAndRetrieveMessage(
-        unittest.TestCase,
+class TestSubmitAndRetrieveMessage(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationSteps,
         journalist_navigation_steps.JournalistNavigationSteps):
-
-    def setUp(self):
-        functional_test.FunctionalTest.setUp(self)
-
-    def tearDown(self):
-        functional_test.FunctionalTest.tearDown(self)
 
     def test_submit_and_retrieve_happy_path(self):
         self._source_visits_source_homepage()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1987 

Convert all of tests/functional to use pytest instead of unittest.

## Testing

pytest -v tests/functional

## Deployment

This is test only and has no impact on deployment.

## Checklist

- [x] Unit and functional tests pass on the development VM
