### PR TITLE
[0.4] Docs: Add KeePass database 1->2 migration guide

### DIFF
--- a/docs/upgrade_to_tails_3x.rst
+++ b/docs/upgrade_to_tails_3x.rst
@@ -227,7 +227,21 @@ Workstation* drives:
 
 .. |Terminal| image:: images/terminal.png
 
-5. Verify the Upgrades
+5. Upgrade KeePassX Database
+----------------------------
+
+Your password databases will be in KeePass 1 database format (a file that ends
+in ``.kdb``). You should upgrade them to the new format by following these steps:
+
+   #. Open KeePassX.
+   #. Navigate to **Database** and then **Import KeePass 1 database**.
+   #. Select your password database and click **Open**.
+   #. Put in a master password if necessary to open the database.
+   #. Then navigate to **Database** and then **Save database as** to save the
+      database in its new format (a file ending in ``.kdbx``) in the same folder
+      as the previous database.
+
+6. Verify the Upgrades
 ----------------------
 
 Verify the Journalist Workstation and SVS USB Drives Are Successfully Updated


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1970, adds description to Tails 3 migration guide about updating password databases to `kdbx` format.

## Testing

Check that the steps here are accurate. Provision docs locally, check this renders fine

## Deployment

Docs only

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
