### PR TITLE
i18n: do not gitignore .pot translation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,6 @@ coverage.xml
 
 # Translations
 *.mo
-*.pot
 
 # Flask stuff:
 instance/


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Although they could be re-created from sources and do not need to be
commited in the repository, external translation tools such as weblate
need them.
