### PR TITLE
journalist: tests menu with id instead of text

### DIFF
--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -19,11 +19,11 @@
 
     {% if g.user %}
     <div id="logout">
-      <a href="{{ url_for('edit_account') }}">Edit Account</a> | 
+      <a href="{{ url_for('edit_account') }}" id="link_edit_account">Edit Account</a> |
       {% if g.user and g.user.is_admin %}
-      <a href="{{ url_for('admin_index') }}">Admin</a> | 
+      <a href="{{ url_for('admin_index') }}" id="link_admin_index">Admin</a> |
       {% endif %}
-      <a href="{{ url_for('logout') }}">Logout</a>
+      <a href="{{ url_for('logout') }}" id="link_logout">Logout</a>
     </div>
     <div class="clearfix"></div>
     {% endif %}

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -163,8 +163,8 @@ class TestJournalistApp(TestCase):
                                           password=self.admin_pw,
                                           token='mocked'),
                                 follow_redirects=True)
-        edit_account_link = '<a href="{}">{}</a>'.format(
-            url_for('edit_account'), "Edit Account")
+        edit_account_link = '<a href="{}" id="link_edit_account">'.format(
+            url_for('edit_account'))
         self.assertIn(edit_account_link, resp.data)
 
     def test_user_has_link_to_edit_account_page_in_index_page(self):
@@ -173,8 +173,8 @@ class TestJournalistApp(TestCase):
                                           password=self.user_pw,
                                           token='mocked'),
                                 follow_redirects=True)
-        edit_account_link = '<a href="{}">{}</a>'.format(
-            url_for('edit_account'), "Edit Account")
+        edit_account_link = '<a href="{}" id="link_edit_account">'.format(
+            url_for('edit_account'))
         self.assertIn(edit_account_link, resp.data)
 
     def test_admin_has_link_to_admin_index_page_in_index_page(self):
@@ -183,8 +183,8 @@ class TestJournalistApp(TestCase):
                                           password=self.admin_pw,
                                           token='mocked'),
                                 follow_redirects=True)
-        admin_link = '<a href="{}">{}</a>'.format(
-            url_for('admin_index'), "Admin")
+        admin_link = '<a href="{}" id="link_admin_index">'.format(
+            url_for('admin_index'))
         self.assertIn(admin_link, resp.data)
 
     def test_user_lacks_link_to_admin_index_page_in_index_page(self):
@@ -193,8 +193,8 @@ class TestJournalistApp(TestCase):
                                           password=self.user_pw,
                                           token='mocked'),
                                 follow_redirects=True)
-        admin_link = '<a href="{}">{}</a>'.format(
-            url_for('admin_index'), "Admin")
+        admin_link = '<a href="{}" id="link_admin_index">'.format(
+            url_for('admin_index'))
         self.assertNotIn(admin_link, resp.data)
 
     # WARNING: we are purposely doing something that would not work in


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Looking up the menu text during testing is fragile, use the id instead.

## Testing

pytest tests

## Deployment

Test only no deployment issue.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
