### PR TITLE
tests: functional: wait for app to respond

### DIFF
--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -9,6 +9,7 @@ import signal
 import socket
 import time
 import traceback
+import requests
 
 from Crypto import Random
 from selenium import webdriver
@@ -89,6 +90,15 @@ class FunctionalTest():
         self.journalist_process.start()
 
         self.driver = self._create_webdriver()
+
+        for tick in range(30):
+            try:
+                requests.get(self.source_location)
+                requests.get(self.journalist_location)
+            except:
+                time.sleep(1)
+            else:
+                break
 
         # Set window size and position explicitly to avoid potential bugs due
         # to discrepancies between environments.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

There is a race between the navigator and the apps. Although rare, it is
possible the app are not responding yet when the first .get() is issued
to the browser. If that happens the test will just stop and fail instead
of waiting for all elements to load.

Poll the app URLs for 30 seconds before returning so there is no race
between the navigator and the apps.

## Testing

pytest tests/functional

## Deployment

this is for tests only, no side effect on deployment

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
