### PR TITLE
Migrate site-specific config on Tails workstations for 0.4

### DIFF
--- a/install_files/ansible-base/roles/tails-config/tasks/main.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/main.yml
@@ -4,6 +4,8 @@
 
 - include: cleanup_legacy_artifacts.yml
 
+- include: migrate_existing_config.yml
+
 - include: copy_dotfiles.yml
 
 - include: configure_torrc_additions.yml

--- a/install_files/ansible-base/roles/tails-config/tasks/migrate_existing_config.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/migrate_existing_config.yml
@@ -1,0 +1,12 @@
+---
+# Between 0.3.12 and 0.4, the "Document Interface" was renamed to
+# "Journalist Interface". Since multiple scripts expect to readfrom this file,
+# we'll rename the old file to handle the transition gracefully.
+- name: Migrate Document Interface ATHS file (upgrade only).
+  command: >-
+    mv --no-clobber
+    "{{ tails_config_ansible_base }}/app-document-aths"
+    "{{ tails_config_ansible_base }}/app-journalist-aths"
+  args:
+    # Only run this command if the deprecated file is present.
+    removes: "{{ tails_config_ansible_base }}/app-document-aths"

--- a/install_files/ansible-base/roles/tails-config/tasks/migrate_existing_config.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/migrate_existing_config.yml
@@ -10,3 +10,24 @@
   args:
     # Only run this command if the deprecated file is present.
     removes: "{{ tails_config_ansible_base }}/app-document-aths"
+
+# Between 0.3.12 and 0.4, the `prod-specific.yml` vars file was deprecated
+# in favor of `group_vars/all/site-specific`. The latter is not version
+# controlled, and so will not exist by default.
+- name: Migrate site-specific configuration to new location.
+  command: >-
+    cp
+    "{{ tails_config_ansible_base }}/prod-specific.yml"
+    "{{ tails_config_ansible_base }}/group_vars/all/site-specific"
+  register: site_specific_vars_migration_result
+  args:
+    # Only run this command if no site-specific vars exist. First-time
+    # installs will create the vars via `./securedrop-admin sdconfig`.
+    creates: "{{ tails_config_ansible_base }}/group_vars/all/site-specific"
+
+# If the site-specific vars file was migrated in the previous task, we must
+# explicitly include it, since it wasn't present in group_vars/all/ at the
+# start of the play, so none of its variables will be defined.
+- name: Import newly migrated sites-specific configuration.
+  include_vars: "{{ tails_config_ansible_base }}/group_vars/all/site-specific"
+  when: site_specific_vars_migration_result|changed

--- a/securedrop-admin
+++ b/securedrop-admin
@@ -220,9 +220,16 @@ def run_tails_config(args):
     """Configure Tails environment post SD install"""
     activate_venv(args)
     sdlog.info("Configuring Tails workstation environment")
-    subprocess.check_call([os.path.join(ANSIBLE_PATH, 'securedrop-tails.yml'),
-                           "--ask-become-pass",
-                           ],
+    sdlog.info(("You'll be prompted for the temporary Tails admin password,"
+                " which was set on Tails login screen"))
+    ansible_cmd = [
+        os.path.join(ANSIBLE_PATH, 'securedrop-tails.yml'),
+        "--ask-become-pass",
+        # Passing an empty inventory file to override the automatic dynamic
+        # inventory script, which fails if no site vars are configured.
+        '-i', '/dev/null',
+    ]
+    subprocess.check_call(ansible_cmd,
                           cwd=ANSIBLE_PATH)
 
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #1976. Fixes #1951. Supersedes and therefore closes #1979.

Implements sane migration of instance configuration for Admins upgrading from 0.3.12 -> 0.4 (and therefore from Tails 2 to Tails 3). Previously we were not gracefully handling the rename from `app-document-aths` -> `app-journalist-aths` on the Tails workstations, nor were we helpfully copying over the deprecated `prod-specific.yml` vars info to the new location at `group_vars/all/site-specific`. Both are now handled, idempotently, and will only run for Admins performing the upgrade. 

Additional documentation is required to guide Admins about the proper upgrade flow—handling that separately in #1997 to keep review light. 

## Testing

1. Check out 0.3.12 tag.
2. Provision prod VMs.
3. Hop into Tails 3 workstation **with fresh persistence**.
4. Grab this script and run it in a separate terminal window: https://gist.github.com/conorsch/15aea09f4f5ac512b068542b9451b0a7
5. Check out this feature branch.
6. Run `./securedrop-admin setup` to install the new tooling.
7. Run `./securedrop-admin tailsconfig` to perform the config migration.
8. Verify that the output of the script in step 4 says "New Document ATHS created!" and "prod-specific.yml migrated!"
9. Run `./securedrop-admin tailsconfig` again and confirm zero changes reported.

## Deployment

Substantial implications for deployment, specifically for Admins upgrading from 0.3.12 -> 0.4 (and therefore likely Tails 2 -> Tails 3 for the same time). While we still need more comprehensive documentation of the upgrade flow (#1997), these functionality changes must land before the docs can be written.

## Checklist
Manual testing is required to validate behavior on the Tails workstations.