### PR TITLE
Docs: remove reference to "Roles" section that no longer exists

### DIFF
--- a/docs/before_you_begin.rst
+++ b/docs/before_you_begin.rst
@@ -2,7 +2,7 @@ Before you begin
 ================
 
 Before you get started, you should familiarize yourself with the
-:doc:`overview`, :doc:`terminology`, and the :doc:`Roles
+:doc:`overview`, :doc:`terminology`, and the :doc:`Passphrases
 <passphrases>` involved in SecureDrop's operations. You may wish to
 leave these documents open in other tabs for reference as you work.
 
@@ -32,5 +32,3 @@ make sure you use the appropriate values for your instance.
 Once you're familiar with SecureDrop, you've made your plan, your
 organization is ready to follow-through and you have the required
 hardware assembled before you, you're ready to begin.
-
-


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Noticed there was a reference to the old "Roles" document that is now called "Passphrases" while running through the install docs

## Testing

Check there are no other references to "Roles" in the docs

## Deployment

None, docs only

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
