### PR TITLE
Document SecureDrop 0.4 upgrade process for Admins

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,10 +63,11 @@ anonymous sources.
    backup_workstations
 
 .. toctree::
-   :caption: Upgrade Guides
+   :caption: Upgrade SecureDrop
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/0.3.x_to_0.4.rst
    upgrade_to_tails_2x.rst
    upgrade_to_tails_3x.rst
 

--- a/docs/upgrade/0.3.x_to_0.4.rst
+++ b/docs/upgrade/0.3.x_to_0.4.rst
@@ -60,8 +60,26 @@ instance.
    ./securedrop-admin setup
    ./securedrop-admin tailsconfig
 
-After both commands have completed successfully, you can continue to verifying
-the upgrade worked on all drives.
+Clean up old version-controlled site config
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``tailsconfig`` task copied the site-specific configuration for your
+SecureDrop instance to a new location: ``install_files/ansible-base/group_vars/all/site-specific``.
+You should open this file and confirm that the information there matches the
+contents of ``install_files/ansible-base/prod-specific.yml``.
+
+.. warning::
+   The ``git checkout prod-specific.yml`` command will effectively delete the
+   old configuration file. Make sure the contents of that file were copied
+   to the new location before proceeding.
+
+Once you have confirmed the config exists in the new location, run: ::
+
+   git checkout prod-specific.yml
+
+During subsequent upgrades to the SecureDrop Admin configuration, you will no longer need to perform
+``git stash`` and ``git pop`` as described above. The site-specific configuration for your instance
+will continue to persist in the new file location.
 
 Verify the Upgrades
 ----------------------

--- a/docs/upgrade/0.3.x_to_0.4.rst
+++ b/docs/upgrade/0.3.x_to_0.4.rst
@@ -3,16 +3,23 @@ Upgrade from 0.3.x to 0.4
 
 SecureDrop 0.4 requires the use of Tails 3. It includes substantial
 changes to the Admin tooling used for managing the configuration
-for the Application and Monitor Servers.
+for the Application and Monitor Servers, and modifies the location
+of the configuration on Admin Workstation to prevent conflicts
+in the future.
 
 .. _0.4-upgrade-procedure:
 
-Upgrade Procedure
-------------------
+  .. note::
+    All Admin and Journalist Workstations must be upgraded to Tails 3 for use
+    with SecureDrop 0.4. Follow the :doc:`/upgrade_to_tails_3x` guide for
+    detailed instructions on upgrading if you have not already done so.
 
-All Admin and Journalist Workstations must be upgraded to Tails 3 for use with
-SecureDrop 0.4. Follow the :doc:`/upgrade_to_tails_3x` guide for detailed
-instructions.
+The steps below should be performed on **both the Admin and all Journalist
+Workstations**  associated with your SecureDrop instance. You do not need to
+run these steps on the *Secure Viewing Station*.
+
+Pull the latest release
+-----------------------
 
 Open a **Terminal** and navigate to your SecureDrop directory.
 
@@ -21,7 +28,7 @@ Open a **Terminal** and navigate to your SecureDrop directory.
    cd ~/Persistent/securedrop
 
 Stash your local configuration, fetch the latest code, and verify the tag for the
-latest release (0.4),
+latest release (0.4):
 
 .. code:: sh
 
@@ -29,7 +36,7 @@ latest release (0.4),
    git fetch
    git tag -v 0.4
 
-The output of ``git tag -v`` should include ``Good signature from
+The output of the above commands should include ``Good signature from
 "Freedom of the Press Foundation Master Signing Key"``. If it does
 not, please contact us immediately at support@freedom.press.
 
@@ -41,4 +48,47 @@ configuration back into place:
    git checkout 0.4
    git stash pop
 
-- Upgrading to Tails 3.x: :doc:`/upgrade_to_tails_3x`
+Upgrade the Tails Persistence Configuration
+----------------------------------------------
+SecureDrop 0.4 provides more convenient tooling for configuring the ATHS info
+required to access the Journalist Interface. Run the following commands
+to install the required packages and set up the access to your SecureDrop
+instance.
+
+.. code:: sh
+
+   ./securedrop-admin setup
+   ./securedrop-admin tailsconfig
+
+After both commands have completed successfully, you can continue to verifying
+the upgrade worked on all drives.
+
+Verify the Upgrades
+----------------------
+
+Verify the Journalist Workstation and SVS USB Drives Are Successfully Updated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After you upgrade your `Journalist Workstation` and `Secure Viewing Station`,
+do the following to make sure they were upgraded successfully.
+
+  #. Submit a test document to the source interface.
+  #. Log in to the journalist interface.
+  #. Download the test document.
+  #. Transfer the test document over to the SVS.
+  #. Decrypt the test document.
+  #. Delete the submission.
+
+If you are able to successfully download and decrypt your test submission, then
+your upgrade was successful!
+
+Verify the Admin Workstation USB Drive Was Successfully Updated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After you upgrade your `Admin Workstation`, ensure that you are able to SSH
+into both servers. Remember you can use the following shortcuts:
+
+.. code:: sh
+
+   ssh mon
+   ssh app

--- a/docs/upgrade/0.3.x_to_0.4.rst
+++ b/docs/upgrade/0.3.x_to_0.4.rst
@@ -1,0 +1,44 @@
+Upgrade from 0.3.x to 0.4
+=========================
+
+SecureDrop 0.4 requires the use of Tails 3. It includes substantial
+changes to the Admin tooling used for managing the configuration
+for the Application and Monitor Servers.
+
+.. _0.4-upgrade-procedure:
+
+Upgrade Procedure
+------------------
+
+All Admin and Journalist Workstations must be upgraded to Tails 3 for use with
+SecureDrop 0.4. Follow the :doc:`/upgrade_to_tails_3x` guide for detailed
+instructions.
+
+Open a **Terminal** and navigate to your SecureDrop directory.
+
+.. code:: sh
+
+   cd ~/Persistent/securedrop
+
+Stash your local configuration, fetch the latest code, and verify the tag for the
+latest release (0.4),
+
+.. code:: sh
+
+   git stash save "site specific configs"
+   git fetch
+   git tag -v 0.4
+
+The output of ``git tag -v`` should include ``Good signature from
+"Freedom of the Press Foundation Master Signing Key"``. If it does
+not, please contact us immediately at support@freedom.press.
+
+Once you've verified the latest release, check it out, then pop your local
+configuration back into place:
+
+.. code:: sh
+
+   git checkout 0.4
+   git stash pop
+
+- Upgrading to Tails 3.x: :doc:`/upgrade_to_tails_3x`

--- a/docs/upgrade_to_tails_3x.rst
+++ b/docs/upgrade_to_tails_3x.rst
@@ -202,32 +202,7 @@ Once complete, you should see a success message:
 .. |Confirm Upgrade| image:: images/upgrade_to_tails_3x/confirm_upgrade.png
 .. |Installation Complete| image:: images/upgrade_to_tails_3x/installation_complete.png
 
-4. Upgrade the Tails Persistence Configuration
-----------------------------------------------
-
-Due to changes in Tails 3.x it is essential you upgrade the custom persistence
-configuration previously set up for your *Admin Workstation* and *Journalist
-Workstation* drives:
-
-  #. Boot into each Tails volume.
-  #. Open a terminal |Terminal| and navigate to the root of the SecureDrop git
-     directory: ``cd ~/Persistent/securedrop``.
-  #. Fetch the latest SecureDrop sources ``git fetch --all``.
-  #. Check out and verify the latest release tag following the instructions in
-     :ref:`Set up the Admin Workstation <Checkout and Verify the Current Release
-     Tag>`. You should already have the **SecureDrop Release Signing Key**
-     stored by Tails persistence, so you won't need to download it again.
-  #. Run the command ``./securedrop-admin tailsconfig``. If you are working on a
-     *Journalist Workstation* and did not previously copy the the
-     ``app-journalist-aths`` and ``app-source-ths`` from the *Admin Workstation*
-     via the *Transfer Device* to
-     ``~/Persistent/securedrop/install_files/ansible-base`` expect to be
-     prompted for this information.
-
-
-.. |Terminal| image:: images/terminal.png
-
-5. Upgrade KeePassX Database
+4. Upgrade KeePassX Database
 ----------------------------
 
 Your password databases will be in KeePass 1 database format (a file that ends
@@ -241,40 +216,15 @@ in ``.kdb``). You should upgrade them to the new format by following these steps
       database in its new format (a file ending in ``.kdbx``) in the same folder
       as the previous database.
 
-6. Verify the Upgrades
-----------------------
+5. Upgrade SecureDrop to 0.4
+----------------------------
 
-Verify the Journalist Workstation and SVS USB Drives Are Successfully Updated
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Now that you've upgraded the Tails workstation to Tails 3, follow the
+:doc:`0.4 Upgrade Guide <upgrade/0.3.x_to_0.4>` to configure the Tails
+environment to access your SecureDrop instance. You will need to perform
+further upgrade steps for the *Admin* and *Journalist Workstations*.
 
-After you upgrade your `Journalist Workstation` and `Secure Viewing Station`,
-do the following to make sure they were upgraded successfully.
-
-  #. Submit a test document to the source interface.
-  #. Log in to the journalist interface.
-  #. Download the test document.
-  #. Transfer the test document over to the SVS.
-  #. Decrypt the test document.
-  #. Delete the submission.
-
-If you are able to successfully download and decrypt your test submission, then
-your upgrade was successful!
-
-Verify the Admin Workstation USB Drive Was Successfully Updated
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-After you upgrade your `Admin Workstation`, ensure that you are able to SSH
-into both servers. Remember you can use the following shortcuts:
-
-.. code:: sh
-
-   ssh mon
-   ssh app
-
-Destroy the Backup or Move It to a Safe Location
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-At this point, you should move your backup drive to a safe location (if you
+After upgrading to 0.4, you should move your backup drive to a safe location (if you
 used a strong passphrase). Else, you should destroy the backup drive following
 the instructions `here <upgrade_to_tails_2x.html#wipe-the-backup-device>`__.
 


### PR DESCRIPTION
## Status

Ready for review. However, review and merge #2000 first, since this documentation covers functionality presented there.

## Description of Changes

Fixes #1997. 

Creates a dedicated upgrade guide for Admins, documenting the manual steps necessary to upgrade from 0.3.x (presumably 0.3.12) to 0.4. These steps are _separate_ from the Tails 2 -> 3 upgrade guide, and include explicit reference to the painful git stash-pull-pop workflow to avoid conflicts in the prod-specific.yml file.

## Testing

1. Confirm #2000 is reviewed and merged.
2. Refer to the new 0.3.x -> 0.4 upgrade guide and confirm the steps work as advertised.

There's explicit documentation of the Tails-based workflow in #2000. Most importantly, you'll need to provision 0.3.12 VMs, then create a **fresh persistence volume** in Tails 3 and use the upgrade guide to migrate the config over to the new format.

## Deployment

Definitely affects deployment, particularly for Admins of existing instances upgrading to the upcoming 0.4 release. Coupled with the functionality changes in #2000, these new docs should clearly delineate the required actions on the part of Admins.

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
