### PR TITLE
manage: verbosity control

### DIFF
--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -3,6 +3,7 @@
 
 import argparse
 from getpass import getpass
+import logging
 import os
 import shutil
 import signal
@@ -17,6 +18,9 @@ os.environ['SECUREDROP_ENV'] = 'dev'  # noqa
 import config
 from db import db_session, init_db, Journalist
 from management.run import run
+
+logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s')
+log = logging.getLogger(__name__)
 
 
 def reset():  # pragma: no cover
@@ -209,6 +213,7 @@ def clean_tmp():  # pragma: no cover
 def get_args():
     parser = argparse.ArgumentParser(prog=__file__, description='Management '
                                      'and testing utility for SecureDrop.')
+    parser.add_argument('-v', '--verbose', action='store_true')
     subps = parser.add_subparsers()
     # Run WSGI app
     run_subp = subps.add_parser('run', help='Run the Werkzeug source & '
@@ -247,10 +252,18 @@ def get_args():
     return parser
 
 
+def setup_verbosity(args):
+    if args.verbose:
+        logging.getLogger(__name__).setLevel(logging.DEBUG)
+    else:
+        logging.getLogger(__name__).setLevel(logging.INFO)
+
+
 def _run_from_commandline():  # pragma: no cover
     try:
         args = get_args().parse_args()
         rc = args.func()
+        setup_verbosity(args)
         sys.exit(rc)
     except KeyboardInterrupt:
         sys.exit(signal.SIGINT)

--- a/securedrop/requirements/test-requirements.in
+++ b/securedrop/requirements/test-requirements.in
@@ -7,4 +7,5 @@ pip-tools
 py
 pytest
 pytest-cov
+pytest-capturelog
 selenium < 3

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -24,6 +24,7 @@ mock==2.0.0
 pbr==3.0.1                # via mock
 pip-tools==1.9.0
 py==1.4.34
+pytest-capturelog==0.7
 pytest-cov==2.5.1
 pytest==3.1.1
 requests==2.17.3          # via coveralls

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -9,10 +9,22 @@ import unittest
 import utils
 
 
-class TestManagePy(unittest.TestCase):
+class TestManagePy(object):
     def test_parse_args(self):
         # just test that the arg parser is stable
         manage.get_args()
+
+    def test_not_verbose(self, caplog):
+        args = manage.get_args().parse_args(['run'])
+        manage.setup_verbosity(args)
+        manage.log.debug('INVISIBLE')
+        assert 'INVISIBLE' not in caplog.text()
+
+    def test_verbose(self, caplog):
+        args = manage.get_args().parse_args(['--verbose', 'run'])
+        manage.setup_verbosity(args)
+        manage.log.debug('VISIBLE')
+        assert 'VISIBLE' in caplog.text()
 
 
 class TestManagementCommand(unittest.TestCase):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Add logging and verbosity control (via the --verbose flag) to the manage.py subcommand. Also add pytest capture log which defines a convenient fixture for pytest to inspect logged messages.

## Testing

pytest -v pytest

## Deployment

The --verbose option is not used during deployment and has no side effects.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
