### PR TITLE
journalist: templates: add id to flag continuation

### DIFF
--- a/securedrop/journalist_templates/flag.html
+++ b/securedrop/journalist_templates/flag.html
@@ -7,5 +7,5 @@ Thanks!
 
 <p>SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them.</p>
 
-<p><a href="/col/{{ sid }}">Continue to the list of documents for {{ codename }}...</a></p>
+<p><a href="/col/{{ sid }}" id="continue-to-list">Continue to the list of documents for {{ codename }}...</a></p>
 {% endblock %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Add an id to the continuation link of the flag information page of the
journalist interface. This allows test to verify the link is present or
click it without relying on the textual content of the link or its
position in the DOM, both of which are fragile and will break if l10n is
active or the DOM changes.

## Testing

pytest -v tests

## Deployment

This adds an id which is not used and has no impact on deployment.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
