### PR TITLE
source: allow testing of tor2web

### DIFF
--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -110,12 +110,15 @@ def setup_g():
         g.loc = store.path(g.sid)
 
 
+TEST_X_TOR2WEB = False
+
+
 @app.before_request
 @ignore_static
 def check_tor2web():
     # ignore_static here so we only flash a single message warning
     # about Tor2Web, corresponding to the initial page load.
-    if 'X-tor2web' in request.headers:
+    if 'X-tor2web' in request.headers or TEST_X_TOR2WEB:
         flash('<strong>WARNING:</strong> You appear to be using Tor2Web. '
               'This <strong>does not</strong> provide anonymity. '
               '<a href="/tor2web-warning">Why is this dangerous?</a>',


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Although it is possible to manually install an extension to the tor
browser to add a custom header and set X-tor2web in this way, it makes
the development environment more complicated. Besides, no other
source/journalist feature needs that kind of fixture and the effort does
not seem worth the reward.

Add a global variable TEST_X_TOR2WEB that allows tests to simulate the
presence of tor2web.

## Testing

pytest tests

## Deployment

This is only for tests, there are not deployment side effects.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
