### PR TITLE
[0.4] typos and leftovers cleanup in the servers.rst documentation page

### DIFF
--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -267,9 +267,6 @@ When the packages are finished installing, Ubuntu will automatically
 install the bootloader (GRUB). If it asks to install the bootloader to
 the Master Boot Record, choose **Yes**. When everything is done, reboot.
 
-You can now return to where you left off in the main SecureDrop install
-guide :doc:`by clicking here <servers>`.
-
 .. |Ubuntu Server| image:: images/install/ubuntu_server.png
 
 Save the Configurations

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -318,7 +318,7 @@ First, generate the new SSH keypair:
 
     ssh-keygen -t rsa -b 4096
 
-You'll be asked to "enter file in which to save the key." Type
+You'll be asked to "Enter file in which to save the key" Type
 **Enter** to use the default location.
 
 If you choose to passphrase-protect this key, you must use a strong,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

typos and leftovers cleanup in the servers.rst documentation page

## Testing

make docs-lint

## Deployment

Docs only, not deployment issues.

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
