### PR TITLE
[0.4] Ensure sudo passwords with spaces are not terminated early

### DIFF
--- a/securedrop-admin
+++ b/securedrop-admin
@@ -211,7 +211,7 @@ def install_securedrop(args):
         sudo_prompt = "Sudo password for servers [blank if not needed]: "
         ansible_password = getpass.getpass(prompt=sudo_prompt)
         subprocess.check_call([os.path.join(ANSIBLE_PATH, 'securedrop-prod.yml'),
-                         "-e ansible_become_pass={}".format(ansible_password),
+                         "-e ansible_become_pass='{}'".format(ansible_password),
                          ],
                         cwd=ANSIBLE_PATH)
 

--- a/securedrop-admin
+++ b/securedrop-admin
@@ -208,10 +208,10 @@ def install_securedrop(args):
 
     else:
         sdlog.info("Now installing SecureDrop on remote servers.")
-        sudo_prompt = "Sudo password for servers [blank if not needed]: "
-        ansible_password = getpass.getpass(prompt=sudo_prompt)
+        sdlog.info("You will be prompted for the sudo password on the servers.")
+        sdlog.info("The sudo password is only necessary during initial installation.")
         subprocess.check_call([os.path.join(ANSIBLE_PATH, 'securedrop-prod.yml'),
-                         "-e ansible_become_pass='{}'".format(ansible_password),
+                         '--ask-become-pass',
                          ],
                         cwd=ANSIBLE_PATH)
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2013.

In order to prevent early termination of the password string,
wrap the sudo password in quotes. Without quotes, the password
terminates early and an authentication error will occur if the
sudo password has spaces.

## Testing

1. Set up sudo password with spaces on app, mon
2. `./securedrop-admin install`
3. It should complete without errors

## Deployment

None

## Testing

Manual testing needed on Tails workstations :cry: