### PR TITLE
Enforce ownership on SecureDrop dotfiles in Talis

### DIFF
--- a/install_files/ansible-base/roles/tails-config/tasks/create_desktop_shortcuts.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/create_desktop_shortcuts.yml
@@ -19,6 +19,17 @@
     path: "{{ item }}"
   with_items: "{{ tails_config_desktop_icon_directories }}"
 
+- name: Set normal user ownership on subset of directories.
+  become: yes
+  file:
+    state: directory
+    path: "{{ item }}"
+    owner: amnesia
+    group: amnesia
+  # Only set normal user ownership for files in ~amnesia.
+  when: item.startswith(tails_config_amnesia_home)
+  with_items: "{{ tails_config_desktop_icon_directories }}"
+
 # Storing as host fact so we can loop over the data in one task.
 - name: Assemble desktop icon info.
   set_fact:


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #2017. 

## Testing

1. Inspect this terminal session: https://gist.github.com/conorsch/e2348edeb32feb94d4905fa9009d36fb (particularly the `stat` output at the end).
2. Boot into Tails Admin Workstation.
3. Run `sudo chown root:root /home/amnesia/Persistent/.securedrop`, to recreate the from-0.3.12 upgrade scenario.
4. Run the `./securedrop-admin tailsconfig` from this feature branch.
5. Confirm on failures.
6. Confirm the `~/Persistent/.securedrop` dotfiles directory is now owned and grouped into amnesia.
7. Reboot and make sure you can still access the interfaces.

## Deployment

Yes, this is an update to the Admin upgrade flow that was explicitly documented in #2003. Discovered during QA on hardware.

## Checklist

Relying on manual testing via Tails.
