### PR TITLE
Permanently removes Document Interface desktop icon in Tails

### DIFF
--- a/install_files/ansible-base/roles/tails-config/tasks/cleanup_legacy_artifacts.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/cleanup_legacy_artifacts.yml
@@ -23,3 +23,8 @@
   with_items:
     - "{{ tails_config_amnesia_home }}/Desktop/document.desktop"
     - "{{ tails_config_amnesia_home }}/.local/share/applications/document.desktop"
+    - "{{ tails_config_amnesia_home }}/.securedrop/document.desktop"
+    - "{{ tails_config_live_persistence }}/Desktop/document.desktop"
+    - "{{ tails_config_live_persistence }}/dotfiles/Desktop/document.desktop"
+    - "{{ tails_config_live_persistence }}/dotfiles/.local/share/applications/document.desktop"
+    - "{{ tails_config_live_persistence }}/Persistent/.securedrop/document.desktop"


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #2020.

The previous implementation that attempted to remove the Document Interface desktop icon from Tails workstations (in favor of the renamed version "Journalist Interface" desktop icons) wasn't persisting between reboots. The new icons were indeed added, but the old ones kept coming back, making for a confusing UX. (Both icons worked and referenced the same URL.)

Ran `locate /document.desktop` and added those filepaths to the list of paths to remove. After reboot, the file removal now sticks, so only the Source and Journalist Interface desktop icons are present, and the Document Interface desktop icon is absent.

## Testing

If you have an old 0.3.12 Tails 3 drive lying around, try to reproduce the "3 screenshots instead of 2" state described in #2020. Otherwise, use a Tails 3 0.4-rc1 Tails drive and rerun `./securedrop-admin tailsconfig`. Reboot, and make sure that you're still able to access the interfaces via the desktop icons, and that there are only two desktop icons.

## Deployment

Specific to the Tails workstation, and related to the upgrade tooling designed to port over the config from SecureDrop 0.3.12 to 0.4 on the Tails workstations.

## Checklist
Relying on manual testing via Tails.