### PR TITLE
Add missing AppArmor rule for fontawesome-webfont.woff2

### DIFF
--- a/install_files/ansible-base/usr.sbin.apache2
+++ b/install_files/ansible-base/usr.sbin.apache2
@@ -212,6 +212,7 @@
   /var/www/securedrop/static/fonts/fontawesome-webfont.eot r,
   /var/www/securedrop/static/fonts/fontawesome-webfont.ttf r,
   /var/www/securedrop/static/fonts/fontawesome-webfont.woff r,
+  /var/www/securedrop/static/fonts/fontawesome-webfont.woff2 r,
   /var/www/securedrop/store.py r,
   /var/www/securedrop/store.pyc rw,
   /var/www/securedrop/store/** rw,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2024.

Changes proposed in this pull request:
  * Add missing AppArmor rule on a font used on the journalist interface
 
## Testing

1. Apply this patch on your Admin workstation
2. Install
3. `sudo tail -f /var/log/apache2/journalist-error.log`
4. Click around on the journalist interface
5. If no errors, good to merge

## Deployment

Should be fine

## Checklist

Manual testing required