### PR TITLE
Instructs Admins to stash changes permanently

### DIFF
--- a/docs/upgrade/0.3.x_to_0.4.rst
+++ b/docs/upgrade/0.3.x_to_0.4.rst
@@ -65,21 +65,17 @@ Clean up old version-controlled site config
 
 The ``tailsconfig`` task copied the site-specific configuration for your
 SecureDrop instance to a new location: ``install_files/ansible-base/group_vars/all/site-specific``.
-You should open this file and confirm that the information there matches the
-contents of ``install_files/ansible-base/prod-specific.yml``.
+As of 0.4, manual edits to the inventory are no longer required, as the ATHS
+information is read automatically from the ``app-ssh-aths`` and
+``mon-ssh-aths`` files. Therefore you should permanently store any
+site-specific modifications:
 
-.. warning::
-   The ``git checkout prod-specific.yml`` command will effectively delete the
-   old configuration file. Make sure the contents of that file were copied
-   to the new location before proceeding.
+.. code:: sh
 
-Once you have confirmed the config exists in the new location, run: ::
+   git stash save "old site-specific configs"
 
-   git checkout prod-specific.yml
-
-During subsequent upgrades to the SecureDrop Admin configuration, you will no longer need to perform
-``git stash`` and ``git pop`` as described above. The site-specific configuration for your instance
-will continue to persist in the new file location.
+During subsequent upgrades to the SecureDrop Admin configuration, you will no
+longer need to perform ``git stash`` and ``git pop`` as described above.
 
 Verify the Upgrades
 ----------------------


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #2022. During the 0.3.12 -> 0.4 migration, the Admin tooling got a lot smarter, and we no longer need Admins to maintain modifications to version-controlled files such as:

  * install_files/ansible-base/prod-specific.yml
  * install_files/ansible-base/inventory

Rather than instruct Admins to wipe out those modifications destructively via `git checkout <filename>`, we can recommend a more cautious stash save. That way, in case problems arise, the changes are
not lost permanently, and can be recovered at a later date. The old configs will even persist in Tails across reboots, since they'll be stored in the .git directory.

## Testing

Render the docs locally and read through the "Upgrade the Tails Persistence Configuration" section. Put yourself in the shoes of an Admin and try to identify and shortcomings on clarity, or any problems with the recommended approach.

## Deployment

Most Admins will be reading these docs in order to perform the 0.4 upgrade, so trying to make them as readable and as future-proof as possible.

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
