### PR TITLE
Restore the original filename when uncompressing a file in the SVS

### DIFF
--- a/docs/generate_securedrop_application_key.rst
+++ b/docs/generate_securedrop_application_key.rst
@@ -7,8 +7,23 @@ of this key is only stored on the *Secure Viewing Station* which is never
 connected to the Internet. SecureDrop submissions can only be decrypted and
 read on the *Secure Viewing Station*.
 
-We will now generate the *SecureDrop Submission Key* on the *Secure Viewing
-Station*.
+We will now prepare the *Secure Viewing Station* and generate the *SecureDrop
+Submission Key*.
+
+Ensure Filenames are Preserved
+------------------------------
+
+In order to preserve filenames when you decrypt submissions, on each *Secure
+Viewing Station*, you should open a **Terminal** and type the following commands:
+
+.. code:: sh
+
+  cd /live/persistence/TailsData_unlocked/dotfiles
+  cp ~/.bashrc .
+  echo "/usr/bin/dconf write /org/gnome/nautilus/preferences/automatic-decompression false" >> .bashrc
+
+.. note:: This only needs to be done once on each *Secure Viewing Station*.
+          After a reboot it will persist.
 
 Correct the system time
 -----------------------

--- a/docs/set_up_tails.rst
+++ b/docs/set_up_tails.rst
@@ -74,8 +74,8 @@ Please use the instructions on the `Tails website
 <https://tails.boum.org/doc/first_steps/persistence/index.en.html>`__
 to make the persistent volume on each Tails drive you create. When
 creating the persistence volume, you will be asked to select from a
-list of features, such as 'Personal Data'. We recommend that you
-enable **all** features.
+list of features, such as 'Personal Data'. You should enable **all** features by
+selecting each item in the list.
 
 Some other things to keep in mind:
 

--- a/docs/upgrade_to_tails_3x.rst
+++ b/docs/upgrade_to_tails_3x.rst
@@ -216,7 +216,23 @@ in ``.kdb``). You should upgrade them to the new format by following these steps
       database in its new format (a file ending in ``.kdbx``) in the same folder
       as the previous database.
 
-5. Upgrade SecureDrop to 0.4
+5. Upgrade Secure Viewing Stations
+----------------------------------
+
+Due to a change in Tails 3, if you wish to preserve the names of files when
+decrypting, you'll need to apply the following fix by opening a **Terminal** on
+the *Secure Viewing Station* and typing the following commands:
+
+.. code:: sh
+
+  cd /live/persistence/TailsData_unlocked/dotfiles
+  cp ~/.bashrc .
+  echo "/usr/bin/dconf write /org/gnome/nautilus/preferences/automatic-decompression false" >> .bashrc
+
+.. note:: This only needs to be done once on each *Secure Viewing Station*.
+          After a reboot it will persist.
+
+6. Upgrade SecureDrop to 0.4
 ----------------------------
 
 Now that you've upgraded the Tails workstation to Tails 3, follow the


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #1862.

Changes proposed in this pull request:
   * Add instructions for admins to restore SVS behavior that preserves the filename when a submission is decrypted

## Testing

How should the reviewer test this PR?

1. Submit a PDF file to the source interface.
2. Download and transfer to your SVS.
3. Decrypt it, the file should be called "data". This reproduces the bug.
4. Follow the instructions in the documentation provided here.
5. Reboot.
6. `/usr/bin/dconf read /org/gnome/nautilus/preferences/automatic-decompression` should return `false`
7. Decrypt your file again, its filename should be preserved.

## Deployment

So, in my defense of asking SecureDrop admins type a bunch of commands, which I obviously realize is not ideal, the choices here to fix the bug were:

1. Add scripting which requires admin to shuttle a transfer device back and forth through the airgap.
2. Have them type three simple commands.

I chose option 2 because in my opinion option 1 is not justified given the small customization we are doing here. If at some later point we want to add even more customization to the SVS, then yes we should have some tooling in the SVS, but until then I suggest we leave this as is. 

## Checklist

Fix needs to be manually tested in Tails

### If you made changes to documentation:

- [x] Doc linting passed locally
