### PR TITLE
HTTPS docs: Explicitly state starting point in instructions

### DIFF
--- a/docs/https_source_interface.rst
+++ b/docs/https_source_interface.rst
@@ -87,6 +87,12 @@ Activating HTTPS in SecureDrop
 
 Make sure you have :doc:`installed SecureDrop already <install>`.
 
+First, on the *Admin Workstation*:
+
+.. code:: sh
+
+  cd ~/Persistent/securedrop
+
 Make note of the Source Interface Onion URL. Edit the site-specific variables
 for your organization in
 ``install_files/ansible-base/group_vars/all/site-specific`` to include the


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Following these docs worked perfectly to set up HTTPS on the source interface on a 0.4 hardware install :sparkles:. One point of possible confusion for admins is that there are only relative paths in these docs, so this is a small docs addition just to remind admins where they should be starting from.

## Testing

Read through, check this renders fine

## Deployment

Docs only

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
