### PR TITLE
Docs: Remove 3NIC firewall network configuration in install

### DIFF
--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -137,31 +137,9 @@ the settings you choose are unique on the firewall's network and
 remember to propagate your choices through the rest of the installation
 process.
 
-Below are two configurations you should enter, assuming you used the
-network settings from the network firewall guide. If you did not, adjust
-these settings accordingly.
-
-**3 NIC Firewall**
-
--  *Application Server*:
-
-   -  Server IP address: 10.20.1.2
-   -  Netmask (default is fine): 255.255.255.0
-   -  Gateway: 10.20.1.1
-   -  For DNS, use Google's name servers: 8.8.8.8 and 8.8.4.4
-   -  Hostname: app
-   -  Domain name should be left blank
-
--  *Monitor Server*:
-
-   -  Server IP address: 10.20.2.2
-   -  Netmask (default is fine): 255.255.255.0
-   -  Gateway: 10.20.2.1
-   -  For DNS, use Google's name servers: 8.8.8.8 and 8.8.4.4
-   -  Hostname: mon
-   -  Domain name should be left blank
-
-**4 NIC Firewall**
+Below are the configurations you should enter, assuming you used the
+network settings from the network firewall guide for the recommended 4 NIC
+firewall. If you did not, adjust these settings accordingly.
 
 -  *Application Server*:
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Note: this does not _need_ to go into `release/0.4`, but am making this PR against it because it's likely a quick review. Happy to let this go into 0.4.1 if it doesn't make it into 0.4. 

We no longer include documentation of the 3NIC firewall config, and the presence of two blocks - one corresponding to the 3NIC, one corresponding to the 4 NIC - will be confusing. Admins who are using an alternative firewall can modify this as needed.

## Testing

Check you agree with my rationale above ^

## Deployment

Docs only

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
