### PR TITLE
Adds offer for source for custom kernels

### DIFF
--- a/SOURCE_OFFER
+++ b/SOURCE_OFFER
@@ -1,0 +1,19 @@
+Freedom of the Press Foundation (FPF) maintains custom-compiled Linux
+kernel images for use in SecureDrop. The kernel source has been patched
+with the grsecurity modifications, and only binaries are available in the
+FPF apt repository.
+
+Under the terms of the GPL, any user with access to the binaries has a right
+to request the source code used to compile those binaries.
+You may submit a written request to:
+
+    Freedom of the Press Foundation
+    601 Van Ness Ave., Suite E371
+    San Francisco, CA 94102
+
+Or via email to:
+
+    source-offer@freedom.press
+
+A full copy of this message can be found online at
+https://github.com/freedomofpress/securedrop/blob/develop/SOURCE_OFFER

--- a/SOURCE_OFFER
+++ b/SOURCE_OFFER
@@ -3,7 +3,7 @@ kernel images for use in SecureDrop. The kernel source has been patched
 with the grsecurity modifications, and only binaries are available in the
 FPF apt repository.
 
-Under the terms of the GPL, any user with access to the binaries has a right
+Under the terms of the GPL, any user in possession of this offer has a right
 to request the source code used to compile those binaries.
 You may submit a written request to:
 

--- a/docs/development/apt_repo.rst
+++ b/docs/development/apt_repo.rst
@@ -39,5 +39,11 @@ securedrop-keyring
     Allows for managed key rotation via automatic updates, as implemented in
     `SecureDrop 0.3.10`_.
 
+.. note::
+   The SecureDrop install process configures a custom Linux kernel hardened
+   with the grsecurity patch set. Only binary images are hosted in the apt
+   repo. For source packages, see the `Source Offer`_.
+
 .. _SecureDrop 0.3.10: https://github.com/freedomofpress/securedrop/blob/c5b4220e04e3c81ad6f92d5e8a92798f07f0aca2/changelog.md#0310
 .. _apt.freedom.press: https://apt.freedom.press
+.. _`Source Offer`: https://github.com/freedomofpress/securedrop/blob/develop/SOURCE_OFFER

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -94,6 +94,13 @@ running the install, please submit a detailed `GitHub
 issue <https://github.com/freedomofpress/securedrop/issues/new>`__ or
 send an email to securedrop@freedom.press.
 
+.. note::
+   The SecureDrop install process configures a custom Linux kernel hardened
+   with the grsecurity patch set. Only binary images are hosted in the apt
+   repo. For source packages, see the `Source Offer`_.
+
+.. _`Source Offer`: https://github.com/freedomofpress/securedrop/blob/develop/SOURCE_OFFER
+
 Once the installation is complete, the addresses for each Tor Hidden
 Service will be available in the following files under
 ``install_files/ansible-base``:

--- a/install_files/ansible-base/roles/grsecurity/tasks/from_fpf_repo_install_grsec.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/from_fpf_repo_install_grsec.yml
@@ -20,6 +20,11 @@
     - motd
     - grsecurity
 
+# The `securedrop-grsec` package named below is a metapackage that depends
+# on a custom-compiled linux-image binary package hosted in the FPF repo.
+# To request the source package for the grsecurity-patched kernel, see:
+#
+#   https://github.com/freedomofpress/securedrop/blob/develop/SOURCE_OFFER
 - name: Install the grsecurity-patched kernel from the FPF repo.
   apt:
     pkg: securedrop-grsec

--- a/install_files/ansible-base/roles/install-fpf-repo/defaults/main.yml
+++ b/install_files/ansible-base/roles/install-fpf-repo/defaults/main.yml
@@ -1,4 +1,15 @@
 ---
+# The FPF apt repository hosts Debian packages for use with SecureDrop.
+# For a full list of the packages, see:
+#
+#   https://docs.securedrop.org/en/stable/development/apt_repo.html
+#
+# To request source packages for the grsecurity-patched kernels, see:
+#
+#   https://github.com/freedomofpress/securedrop/blob/develop/SOURCE_OFFER
+#
+# For testing/QA, set this URL to another apt server. You must also update
+# the associated public key for the apt repo for testing/QA.
 apt_repo_url: https://apt.freedom.press
 
 # By default, install packages from the apt-repo, but under


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes
Accomplishes most of the plan laid out in #2031. (Does not implement the `apt-get source <package>` option discussed there.)

Created a top-level file in the repo called `SOURCE_OFFER`, which includes a concise statement of offering source for the kernel packages, and links to itself via a public URL (in case someone is reading it offline). We can reuse the copy here in various places, and more importantly, we can link directly to this document from anywhere, giving us a single  point of update, and a single URL to sprinkle around in the  documentation. 

Updated the project documentation (both the install guide and the apt repo docs) with explicit mention of the source offer, and a link  directly to the SOURCE_OFFER file. Also added some comments to the Ansible YAML files in locations relevant to the apt repo and kernel install tasks.

## Testing

1. Render the docs locally and read through the changes.
2. Double-check the contact information is correct.
3. Observe the final "stable" URL https://github.com/freedomofpress/securedrop/blob/develop/SOURCE_OFFER and make sure it's appropriate, because I'd like to maintain it for a long time.
4. Observe the final "stable" URL and confirm it will be accurate when this PR is merged.

Note that the URL won't be live until we merge this PR, so don't be surprised at a 404.

## Deployment
None at all, this is documentation-only.

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
