### PR TITLE
Readme should link to stable docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ If you're here because you want to report an issue in SecureDrop, please observe
 
 ## How to Install SecureDrop
 
-See the [Installation Guide](https://docs.securedrop.org/en/latest/#installtoc).
+See the [Installation Guide](https://docs.securedrop.org/en/stable/#installtoc).
 
 ## How to Use SecureDrop
 
-* [As a source](https://docs.securedrop.org/en/latest/source.html)
-* [As a journalist](https://docs.securedrop.org/en/latest/journalist.html)
+* [As a source](https://docs.securedrop.org/en/stable/source.html)
+* [As a journalist](https://docs.securedrop.org/en/stable/journalist.html)
 
 ## How to Contribute to SecureDrop
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ SecureDrop is an open-source whistleblower submission system that media organiza
 
 The SecureDrop documentation is now built and hosted by [Read the Docs](https://readthedocs.org): https://docs.securedrop.org. If you are still trying to use links to Markdown files on our GitHub to read documentation, please update your bookmarks.
 
+There are two *versions* of the [SecureDrop documentation](https://docs.securedrop.org): **stable** and **latest**. The **stable** documentation is the default, and corresponds to the latest stable release of SecureDrop; therefore, it is the best version of the documentation for end users (Sources, Journalists, or Administrators). The **latest** documentation is automatically built from the latest commit on the SecureDrop development branch; therefore, it is most useful for developers and contributors to the project. You can choose to view a different version of the documentation by using the version picker shown at the bottom left of the screen.
+
 ## Found an issue?
 
 If you're here because you want to report an issue in SecureDrop, please observe the following protocol to do so responsibly:


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Follow-up for https://github.com/freedomofpress/securedrop/pull/2040#pullrequestreview-52217054.

* Explains the different "versions" of the SecureDrop documentation in the README, since both developers/external contributors and end users might encounter our README on GitHub before they encounter our [documentation](https://docs.securedrop.org).
* When linking to documentation that is primarily for end users, point to the "stable" version of the documentation since that is the correct version of the documentation for them.