### PR TITLE
[0.4.1] Fix bug preventing removal of old document interface desktop icon

### DIFF
--- a/docs/upgrade/0.3.x_to_0.4.rst
+++ b/docs/upgrade/0.3.x_to_0.4.rst
@@ -37,8 +37,15 @@ latest release (0.4.1):
    git tag -v 0.4.1
 
 The output of the above commands should include ``Good signature from
-"Freedom of the Press Foundation Master Signing Key"``. If it does
+"SecureDrop Release Signing Key"``. If it does
 not, please contact us immediately at support@freedom.press.
+
+.. note::
+  You may also see output from GPG warning you that the key is not certified
+  with a trusted signature. This means that there is not a trust path to the
+  release signing key. As long as you see the fingerprint ``2224 5C81 E3BA EB41
+  38B3 6061 310F 5612 00F4 AD77`` displayed and the signature verifies as
+  described above then you can proceed safely.
 
 Once you've verified the latest release, check it out, then pop your local
 configuration back into place:

--- a/docs/upgrade/0.3.x_to_0.4.rst
+++ b/docs/upgrade/0.3.x_to_0.4.rst
@@ -1,8 +1,8 @@
-Upgrade from 0.3.x to 0.4
-=========================
+Upgrade from 0.3.x to 0.4.x
+===========================
 
-SecureDrop 0.4 requires the use of Tails 3. It includes substantial
-changes to the Admin tooling used for managing the configuration
+Beginning with SecureDrop 0.4, the use of Tails 3 is required. SecureDrop 0.4
+included substantial changes to the Admin tooling used for managing the configuration
 for the Application and Monitor Servers, and modifies the location
 of the configuration on Admin Workstation to prevent conflicts
 in the future.
@@ -11,7 +11,7 @@ in the future.
 
   .. note::
     All Admin and Journalist Workstations must be upgraded to Tails 3 for use
-    with SecureDrop 0.4. Follow the :doc:`/upgrade_to_tails_3x` guide for
+    with SecureDrop 0.4.x. Follow the :doc:`/upgrade_to_tails_3x` guide for
     detailed instructions on upgrading if you have not already done so.
 
 The steps below should be performed on **both the Admin and all Journalist
@@ -28,13 +28,13 @@ Open a **Terminal** and navigate to your SecureDrop directory.
    cd ~/Persistent/securedrop
 
 Stash your local configuration, fetch the latest code, and verify the tag for the
-latest release (0.4):
+latest release (0.4.1):
 
 .. code:: sh
 
    git stash save "site specific configs"
    git fetch
-   git tag -v 0.4
+   git tag -v 0.4.1
 
 The output of the above commands should include ``Good signature from
 "Freedom of the Press Foundation Master Signing Key"``. If it does
@@ -45,12 +45,12 @@ configuration back into place:
 
 .. code:: sh
 
-   git checkout 0.4
+   git checkout 0.4.1
    git stash pop
 
 Upgrade the Tails Persistence Configuration
 ----------------------------------------------
-SecureDrop 0.4 provides more convenient tooling for configuring the ATHS info
+SecureDrop 0.4.x provides more convenient tooling for configuring the ATHS info
 required to access the Journalist Interface. Run the following commands
 to install the required packages and set up the access to your SecureDrop
 instance.
@@ -65,7 +65,7 @@ Clean up old version-controlled site config
 
 The ``tailsconfig`` task copied the site-specific configuration for your
 SecureDrop instance to a new location: ``install_files/ansible-base/group_vars/all/site-specific``.
-As of 0.4, manual edits to the inventory are no longer required, as the ATHS
+Beginning with 0.4, manual edits to the inventory are no longer required, as the ATHS
 information is read automatically from the ``app-ssh-aths`` and
 ``mon-ssh-aths`` files. Therefore you should permanently store any
 site-specific modifications:

--- a/docs/upgrade_to_tails_3x.rst
+++ b/docs/upgrade_to_tails_3x.rst
@@ -232,15 +232,15 @@ the *Secure Viewing Station* and typing the following commands:
 .. note:: This only needs to be done once on each *Secure Viewing Station*.
           After a reboot it will persist.
 
-6. Upgrade SecureDrop to 0.4
-----------------------------
+6. Upgrade SecureDrop to 0.4.x
+------------------------------
 
 Now that you've upgraded the Tails workstation to Tails 3, follow the
-:doc:`0.4 Upgrade Guide <upgrade/0.3.x_to_0.4>` to configure the Tails
+:doc:`0.4.x Upgrade Guide <upgrade/0.3.x_to_0.4>` to configure the Tails
 environment to access your SecureDrop instance. You will need to perform
 further upgrade steps for the *Admin* and *Journalist Workstations*.
 
-After upgrading to 0.4, you should move your backup drive to a safe location (if you
+After upgrading to 0.4.x, you should move your backup drive to a safe location (if you
 used a strong passphrase). Else, you should destroy the backup drive following
 the instructions `here <upgrade_to_tails_2x.html#wipe-the-backup-device>`__.
 

--- a/install_files/ansible-base/roles/tails-config/tasks/cleanup_legacy_artifacts.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/cleanup_legacy_artifacts.yml
@@ -4,6 +4,7 @@
 # items will be handled and updated accordingly.
 
 - name: Remove deprecated network hook config files.
+  become: yes
   file:
     path: "{{ item.0 }}/{{ item.1 }}"
     state: absent
@@ -12,6 +13,7 @@
     - "{{ tails_config_deprecated_config_files }}"
 
 - name: Remove deprecated xsessionrc file.
+  become: yes
   file:
     path: "{{ tails_config_live_persistence }}/dotfiles/.xsessionrc"
     state: absent

--- a/install_files/ansible-base/roles/tails-config/tasks/cleanup_legacy_artifacts.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/cleanup_legacy_artifacts.yml
@@ -17,6 +17,7 @@
     state: absent
 
 - name: Remove deprecated Document Interface desktop icons.
+  become: yes
   file:
     state: absent
     path: "{{ item }}"

--- a/install_files/ansible-base/roles/tails-config/tasks/copy_dotfiles.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/copy_dotfiles.yml
@@ -1,14 +1,20 @@
 ---
 - name: Create SecureDrop-specific dotfiles directory for Tails persistence.
+  become: yes
   file:
     path: "{{ tails_config_securedrop_dotfiles }}"
     state: directory
     mode: "0755"
+    owner: amnesia
+    group: amnesia
 
 - name: Copy SecureDrop logo for desktop icons to dotfiles directory.
+  become: yes
   copy:
     src: securedrop_icon.png
     dest: "{{ tails_config_securedrop_dotfiles }}/"
+    owner: amnesia
+    group: amnesia
 
 # Script used to append torrc additions. Triggered by NetworkManager hook.
 # Resides in dotfiles in order to achieve persistence.

--- a/install_files/ansible-base/roles/tails-config/tasks/create_desktop_shortcuts.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/create_desktop_shortcuts.yml
@@ -46,6 +46,8 @@
   template:
     src: desktop-icon.j2
     dest: "{{ item.1 }}/{{ item.0.filename }}"
+    owner: amnesia
+    group: amnesia
     mode: "0700"
   with_nested:
     - "{{ _securedrop_desktop_icon_info }}"

--- a/install_files/ansible-base/roles/tails-config/tasks/create_desktop_shortcuts.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/create_desktop_shortcuts.yml
@@ -42,6 +42,7 @@
         onion_url: "{{ journalist_interface_lookup_result.stdout }}"
 
 - name: Create SecureDrop interface desktop icons.
+  become: yes
   template:
     src: desktop-icon.j2
     dest: "{{ item.1 }}/{{ item.0.filename }}"

--- a/install_files/ansible-base/roles/tails-config/tasks/create_ssh_aliases.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/create_ssh_aliases.yml
@@ -15,16 +15,22 @@
   register: mon_ssh_lookup_result
 
 - name: Create SSH config directory.
+  become: yes
   file:
     state: directory
     path: "{{ tails_config_amnesia_home }}/.ssh"
     mode: "0700"
+    owner: amnesia
+    group: amnesia
 
 - name: Create SSH alias
+  become: yes
   template:
     src: ssh_config.j2
     dest: "{{ item }}"
     mode: "0600"
+    owner: amnesia
+    group: amnesia
   with_items:
     - "{{ tails_config_securedrop_dotfiles }}/ssh_config"
     - "{{ tails_config_amnesia_home }}/.ssh/config"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2049. 

Changes proposed in this pull request:
 * Pulls in the patch from @conorsch [here](https://github.com/freedomofpress/securedrop/issues/2049#issuecomment-318251010) 
 * Updates documentation and upgrade guides for 0.4.1 so as admins don't hit this bug as they are updating their workstations

## Testing

I tested this using an old Tails 2 drive and reproduced the bug in #2049:

1. Using a Tails 2 drive
2. Follow the instructions in the existing upgrade guide: `./securedrop-admin setup` and `./securedrop-admin tailsconfig`
3. You should reproduce the bug in #2049 
4. Apply the patch here
5. Run `./securedrop-admin tailsconfig` again
6. The "SecureDrop Document Interface" icon should be replaced with "SecureDrop Journalist Icon"

## Deployment

No issues for new installs. 

For existing installs we will just need to indicate to admins they will need to check out the 0.4.1 tag (as we do in the changes in the upgrade guide shown here). 

## Checklist

Modifications to the Tails config must be verified manually.

### If you made changes to documentation:

- [x] Doc linting passed locally
