### PR TITLE
i18n: extract/update/compile gettext from sources/templates

### DIFF
--- a/securedrop/babel.cfg
+++ b/securedrop/babel.cfg
@@ -1,0 +1,6 @@
+[python: *.py]
+silent=False
+
+[jinja2: */*.html]
+silent=False
+extensions=jinja2.ext.autoescape,jinja2.ext.with_,webassets.ext.jinja2.AssetsExtension

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -23,7 +23,7 @@ logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s')
 log = logging.getLogger(__name__)
 
 
-def reset():  # pragma: no cover
+def reset(args):  # pragma: no cover
     """Clears the SecureDrop development applications' state, restoring them to
     the way they were immediately after running `setup_dev.sh`. This command:
     1. Erases the development sqlite database file.
@@ -58,11 +58,11 @@ def reset():  # pragma: no cover
     return 0
 
 
-def add_admin():  # pragma: no cover
+def add_admin(args):  # pragma: no cover
     return _add_user(is_admin=True)
 
 
-def add_journalist():  # pragma: no cover
+def add_journalist(args):  # pragma: no cover
     return _add_user()
 
 
@@ -134,7 +134,7 @@ def _add_user(is_admin=False):  # pragma: no cover
         return 0
 
 
-def delete_user():  # pragma: no cover
+def delete_user(args):  # pragma: no cover
     """Deletes a journalist or administrator from the application."""
     # Select user to delete
     username = raw_input('Username to delete: ')
@@ -172,7 +172,7 @@ def delete_user():  # pragma: no cover
     return 0
 
 
-def clean_tmp():  # pragma: no cover
+def clean_tmp(args):  # pragma: no cover
     """Cleanup the SecureDrop temp directory. This is intended to be run
     as an automated cron job. We skip files that are currently in use to
     avoid deleting files that are currently being downloaded."""
@@ -262,8 +262,8 @@ def setup_verbosity(args):
 def _run_from_commandline():  # pragma: no cover
     try:
         args = get_args().parse_args()
-        rc = args.func()
         setup_verbosity(args)
+        rc = args.func(args)
         sys.exit(rc)
     except KeyboardInterrupt:
         sys.exit(signal.SIGINT)

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -7,6 +7,7 @@ import logging
 import os
 import shutil
 import signal
+import subprocess
 import sys
 import traceback
 
@@ -21,6 +22,42 @@ from management.run import run
 
 logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s')
 log = logging.getLogger(__name__)
+
+
+def sh(command, input=None):
+    """Run the *command* which must be a shell snippet. The stdin is
+    either /dev/null or the *input* argument string.
+
+    The stderr/stdout of the snippet are captured and logged via
+    logging.debug(), one line at a time.
+    """
+    log.debug(":sh: " + command)
+    if input is None:
+        stdin = None
+    else:
+        stdin = subprocess.PIPE
+    proc = subprocess.Popen(
+        args=command,
+        stdin=stdin,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        shell=True,
+        bufsize=1)
+    if stdin is not None:
+        proc.stdin.write(input)
+        proc.stdin.close()
+    lines_of_command_output = []
+    with proc.stdout:
+        for line in iter(proc.stdout.readline, b''):
+            line = line.decode('utf-8')
+            lines_of_command_output.append(line)
+            log.debug(line.strip().encode('ascii', 'ignore'))
+    if proc.wait() != 0:
+        raise subprocess.CalledProcessError(
+            returncode=proc.returncode,
+            cmd=command
+        )
+    return "".join(lines_of_command_output)
 
 
 def reset(args):  # pragma: no cover

--- a/securedrop/management/run.py
+++ b/securedrop/management/run.py
@@ -140,7 +140,7 @@ class DevServerProcessMonitor(object):  # pragma: no cover
                 proc.terminate()
 
 
-def run():  # pragma: no cover
+def run(args):  # pragma: no cover
     """
     Starts development servers for both the Source Interface and the
     Journalist Interface concurrently. Their output is collected,

--- a/securedrop/tests/i18n/babel.cfg
+++ b/securedrop/tests/i18n/babel.cfg
@@ -1,0 +1,4 @@
+[python: tests/i18n/*.py]
+
+[jinja2: tests/i18n/*.html]
+extensions=jinja2.ext.autoescape,jinja2.ext.with_

--- a/securedrop/tests/i18n/code.py
+++ b/securedrop/tests/i18n/code.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+print(gettext('code hello i18n'))

--- a/securedrop/tests/i18n/template.html
+++ b/securedrop/tests/i18n/template.html
@@ -1,0 +1,1 @@
+<button type="submit">{{ gettext('template hello i18n') }}</button>

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -1,12 +1,19 @@
 # -*- coding: utf-8 -*-
 
+import argparse
+import os
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
+import config
+import logging
 import manage
 import mock
 import pytest
 from StringIO import StringIO
 import subprocess
 import sys
+import time
 import unittest
+import version
 
 import utils
 
@@ -54,6 +61,116 @@ class TestManagementCommand(unittest.TestCase):
         self.assertEqual(return_value, 1)
         self.assertIn('ERROR: That username is already taken!',
                       sys.stdout.getvalue())
+
+
+class TestManage(object):
+
+    def setup(self):
+        utils.env.setup()
+
+    def teardown(self):
+        utils.env.teardown()
+
+    def test_translate_compile_code_and_template(self):
+        source = [
+            'tests/i18n/code.py',
+            'tests/i18n/template.html',
+        ]
+        kwargs = {
+            'translations_dir': config.TEMP_DIR,
+            'mapping': 'tests/i18n/babel.cfg',
+            'source': source,
+            'extract_update': True,
+            'compile': True,
+            'verbose': logging.DEBUG,
+            'version': version.__version__,
+        }
+        args = argparse.Namespace(**kwargs)
+        manage.setup_verbosity(args)
+        manage.translate(args)
+        messages_file = os.path.join(config.TEMP_DIR, 'messages.pot')
+        assert os.path.exists(messages_file)
+        pot = open(messages_file).read()
+        assert 'code hello i18n' in pot
+        assert 'template hello i18n' in pot
+
+        locale = 'en_US'
+        locale_dir = os.path.join(config.TEMP_DIR, locale)
+        manage.sh("pybabel init -i {} -d {} -l {}".format(
+            messages_file,
+            config.TEMP_DIR,
+            locale,
+        ))
+        mo_file = os.path.join(locale_dir, 'LC_MESSAGES/messages.mo')
+        assert not os.path.exists(mo_file)
+        manage.translate(args)
+        assert os.path.exists(mo_file)
+        mo = open(mo_file).read()
+        assert 'code hello i18n' in mo
+        assert 'template hello i18n' in mo
+
+    def test_translate_compile_arg(self):
+        source = [
+            'tests/i18n/code.py',
+        ]
+        kwargs = {
+            'translations_dir': config.TEMP_DIR,
+            'mapping': 'tests/i18n/babel.cfg',
+            'source': source,
+            'extract_update': True,
+            'compile': False,
+            'verbose': logging.DEBUG,
+            'version': version.__version__,
+        }
+        args = argparse.Namespace(**kwargs)
+        manage.setup_verbosity(args)
+        manage.translate(args)
+        messages_file = os.path.join(config.TEMP_DIR, 'messages.pot')
+        assert os.path.exists(messages_file)
+        pot = open(messages_file).read()
+        assert 'code hello i18n' in pot
+
+        locale = 'en_US'
+        locale_dir = os.path.join(config.TEMP_DIR, locale)
+        po_file = os.path.join(locale_dir, 'LC_MESSAGES/messages.po')
+        manage.sh("pybabel init -i {} -d {} -l {}".format(
+            messages_file,
+            config.TEMP_DIR,
+            locale,
+        ))
+        assert os.path.exists(po_file)
+        # pretend this happened a few seconds ago
+        few_seconds_ago = time.time() - 60
+        os.utime(po_file, (few_seconds_ago, few_seconds_ago))
+
+        mo_file = os.path.join(locale_dir, 'LC_MESSAGES/messages.mo')
+
+        #
+        # Extract+update but do not compile
+        #
+        old_po_mtime = os.path.getmtime(po_file)
+        assert not os.path.exists(mo_file)
+        manage.translate(args)
+        assert not os.path.exists(mo_file)
+        current_po_mtime = os.path.getmtime(po_file)
+        assert old_po_mtime < current_po_mtime
+
+        #
+        # Compile but do not extract+update
+        #
+        source = [
+            'tests/i18n/code.py',
+            'tests/i18n/template.html',
+        ]
+        kwargs['extract_update'] = False
+        kwargs['compile'] = True
+        args = argparse.Namespace(**kwargs)
+        old_po_mtime = current_po_mtime
+        manage.translate(args)
+        assert old_po_mtime == current_po_mtime
+        mo = open(mo_file).read()
+        assert 'code hello i18n' in mo
+        assert 'template hello i18n' not in mo
 
 
 class TestSh(object):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

manage.py translate --extract-update updates the sources and the result
is meant to be commited to the repository. It is used in development
environments.

manage.py translate --compile creates the .mo files that
are not to be commited to the repository. It is used for packaging
and in development environments.

## Testing

pytest -v tests/test_manage.py

## Deployment

It only adds to the existing manage.py command and is not actually used by any production deployment nor does it add files being deployed.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
