### PR TITLE
tests: functional: verify edit user with name only

### DIFF
--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -264,7 +264,7 @@ class JournalistNavigationSteps():
         new_user_edit_links[0].click()
 
         def can_edit_user():
-            assert ('Edit user "{}"'.format(self.new_user['username']) in
+            assert ('"{}"'.format(self.new_user['username']) in
                     self.driver.page_source)
         self.wait_for(can_edit_user)
 
@@ -278,8 +278,7 @@ class JournalistNavigationSteps():
         update_user_btn.click()
 
         def can_edit_user():
-            assert ('Edit user "{}"'.format(new_username) in
-                    self.driver.page_source)
+            assert ('"{}"'.format(new_username) in self.driver.page_source)
         self.wait_for(can_edit_user)
 
         # Update self.new_user with the new username for the future tests


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Instead of including the text of the link which is fragile when used
with l10n, use the user name only.

## Testing

pytest -v tests/functional

## Deployment

This is test only and has no impact on deployment.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
