### PR TITLE
flake8 compliance for the remaining files in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,9 @@ script:
   - SECUREDROP_TESTINFRA_TARGET_HOST=travis testinfra -v testinfra/development/
   - pip freeze -l
   # Docs linting. Performing this step *after* build VM tests pass, so as not
-  # to alter the pip requirements, which would cause config tests to
-  fail.  - pip install -r
-  securedrop/requirements/develop-requirements.txt - make docs-lint -
-  pushd securedrop; flake8 *.py management tests/*.py && popd
-  after_success: cd securedrop/ && coveralls
+  # to alter the pip requirements, which would cause config tests to fail.
+  - pip install -r securedrop/requirements/develop-requirements.txt
+  - make docs-lint
+  - pushd securedrop; flake8 *.py management tests/functional tests/*.py && popd
+after_success:
+  cd securedrop/ && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,8 @@ script:
   - SECUREDROP_TESTINFRA_TARGET_HOST=travis testinfra -v testinfra/development/
   - pip freeze -l
   # Docs linting. Performing this step *after* build VM tests pass, so as not
-  # to alter the pip requirements, which would cause config tests to fail.
-  - pip install -r securedrop/requirements/develop-requirements.txt
-  - make docs-lint
-  - pushd securedrop; flake8 db.py crypto_util.py journalist.py manage.py store.py secure_tempfile.py source.py template_filters.py tests/functional management tests/utils tests/test_2fa.py tests/conftest.py tests/test_db.py tests/test_manage.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py tests/test_source.py && popd
-after_success:
-  cd securedrop/ && coveralls
+  # to alter the pip requirements, which would cause config tests to
+  fail.  - pip install -r
+  securedrop/requirements/develop-requirements.txt - make docs-lint -
+  pushd securedrop; flake8 *.py management tests/*.py && popd
+  after_success: cd securedrop/ && coveralls

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -19,12 +19,6 @@ class TestSecureTempfile(unittest.TestCase):
     def tearDown(self):
         utils.env.teardown()
 
-    def test_write_then_read_twice(self):
-        self.f.write(self.msg)
-        self.f.read()
-
-        self.assertEqual(self.f.read(), '')
-
     def test_read_before_writing(self):
         with self.assertRaisesRegexp(AssertionError,
                                      'You must write before reading!'):

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -4,7 +4,7 @@ import unittest
 
 from gnupg._util import _is_stream
 
-os.environ['SECUREDROP_ENV'] = 'test'
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 import config
 import secure_tempfile
 import utils
@@ -23,7 +23,7 @@ class TestSecureTempfile(unittest.TestCase):
         with self.assertRaisesRegexp(AssertionError,
                                      'You must write before reading!'):
             self.f.read()
-        
+
     def test_write_then_read_once(self):
         self.f.write(self.msg)
 
@@ -52,7 +52,7 @@ class TestSecureTempfile(unittest.TestCase):
     def test_read_write_unicode(self):
         unicode_msg = u'鬼神 Kill Em All 1989'
         self.f.write(unicode_msg)
-        
+
         self.assertEqual(self.f.read().decode('utf-8'), unicode_msg)
 
     def test_file_seems_encrypted(self):
@@ -74,7 +74,8 @@ class TestSecureTempfile(unittest.TestCase):
         self.assertFalse(os.path.exists(fp))
 
     def test_SecureTemporaryFile_is_a_STREAMLIKE_TYPE(self):
-        self.assertTrue(_is_stream(secure_tempfile.SecureTemporaryFile('/tmp')))
+        self.assertTrue(_is_stream(
+            secure_tempfile.SecureTemporaryFile('/tmp')))
 
     def test_buffered_read(self):
         msg = self.msg * 1000

--- a/securedrop/tests/test_store.py
+++ b/securedrop/tests/test_store.py
@@ -3,10 +3,9 @@ import os
 import unittest
 import zipfile
 
-import crypto_util
-os.environ['SECUREDROP_ENV'] = 'test'
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 import config
-from db import db_session, Source
+from db import db_session
 import mock
 import store
 import utils
@@ -34,8 +33,9 @@ class TestStore(unittest.TestCase):
     def test_verify_store_dir_not_absolute(self):
         STORE_DIR = config.STORE_DIR
         try:
-            with self.assertRaisesRegexp(store.PathException,
-                                         'config.STORE_DIR\(\S*\) is not absolute'):
+            with self.assertRaisesRegexp(
+                    store.PathException,
+                    'config.STORE_DIR\(\S*\) is not absolute'):
                 config.STORE_DIR = '.'
                 store.verify('something')
         finally:
@@ -64,8 +64,9 @@ class TestStore(unittest.TestCase):
         new_journalist_filename = 'nestor_makhno'
         expected_filename = old_filename.replace(old_journalist_filename,
                                                  new_journalist_filename)
-        actual_filename = store.rename_submission(source.filesystem_id, old_filename,
-                                                  new_journalist_filename)
+        actual_filename = store.rename_submission(
+            source.filesystem_id, old_filename,
+            new_journalist_filename)
         self.assertEquals(actual_filename, expected_filename)
 
     @mock.patch('store.subprocess.check_call')

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
-import os
 import unittest
 
 import template_filters
+
 
 class TestTemplateFilters(unittest.TestCase):
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes tests/*.py flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop/tests/functional ; python -m astor.rtrip .
* diff -ru tmp_rtrip tmp_rtrip.orig
<pre>
diff -ru tmp_rtrip.orig/test_secure_tempfile.py tmp_rtrip/test_secure_tempfile.py
--- tmp_rtrip.orig/test_secure_tempfile.py	2017-08-01 22:27:20.504476360 +0200
+++ tmp_rtrip/test_secure_tempfile.py	2017-08-01 22:35:54.685345519 +0200
@@ -17,11 +17,6 @@
     def tearDown(self):
         utils.env.teardown()
 
-    def test_write_then_read_twice(self):
-        self.f.write(self.msg)
-        self.f.read()
-        self.assertEqual(self.f.read(), '')
-
     def test_read_before_writing(self):
         with self.assertRaisesRegexp(AssertionError,
             'You must write before reading!'):
diff -ru tmp_rtrip.orig/test_store.py tmp_rtrip/test_store.py
--- tmp_rtrip.orig/test_store.py	2017-08-01 22:27:20.496476346 +0200
+++ tmp_rtrip/test_store.py	2017-08-01 22:35:54.681345512 +0200
@@ -1,10 +1,9 @@
 import os
 import unittest
 import zipfile
-import crypto_util
 os.environ['SECUREDROP_ENV'] = 'test'
 import config
-from db import db_session, Source
+from db import db_session
 import mock
 import store
 import utils
diff -ru tmp_rtrip.orig/test_template_filters.py tmp_rtrip/test_template_filters.py
--- tmp_rtrip.orig/test_template_filters.py	2017-08-01 22:27:20.500476353 +0200
+++ tmp_rtrip/test_template_filters.py	2017-08-01 22:35:54.681345512 +0200
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-import os
 import unittest
 import template_filters
</pre>

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior