### PR TITLE
flake8 compliance for the files in tests/utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py crypto_util.py journalist.py manage.py store.py secure_tempfile.py source.py template_filters.py management tests/functional tests/test_2fa.py tests/conftest.py tests/test_db.py tests/test_manage.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py tests/test_source.py && popd
+  - pushd securedrop; flake8 db.py crypto_util.py journalist.py manage.py store.py secure_tempfile.py source.py template_filters.py tests/functional management tests/utils tests/test_2fa.py tests/conftest.py tests/test_db.py tests/test_manage.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py tests/test_source.py && popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/tests/utils/__init__.py
+++ b/securedrop/tests/utils/__init__.py
@@ -1,3 +1,3 @@
-import async
-import db_helper
-import env
+import async  # noqa
+import db_helper  # noqa
+import env  # noqa

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -5,13 +5,14 @@ filesystem) interaction.
 import mock
 import os
 
-os.environ['SECUREDROP_ENV'] = 'test'
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 import config
 import crypto_util
 import db
 import store
 
-## db.{Journalist, Reply}
+# db.{Journalist, Reply}
+
 
 def init_journalist(is_admin=False):
     """Initialize a journalist into the database. Return their
@@ -88,7 +89,7 @@ def mark_downloaded(*submissions):
     db.db_session.commit()
 
 
-## db.{Source,Submission}
+# db.{Source,Submission}
 
 def init_source():
     """Initialize a source: create their database record, the

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -8,7 +8,7 @@ import subprocess
 
 import gnupg
 
-os.environ['SECUREDROP_ENV'] = 'test'
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 import config
 import crypto_util
 from db import init_db, db_session


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes tests/utils flake8 compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop/tests/functional ; python -m astor.rtrip .
* diff -ru tmp_rtrip tmp_rtrip.orig (no difference)

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior