### PR TITLE
flake8 compliance for the files in management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  - pushd securedrop; flake8 db.py crypto_util.py journalist.py manage.py store.py secure_tempfile.py source.py template_filters.py tests/functional tests/test_2fa.py tests/conftest.py tests/test_db.py tests/test_manage.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py tests/test_source.py && popd
+  - pushd securedrop; flake8 db.py crypto_util.py journalist.py manage.py store.py secure_tempfile.py source.py template_filters.py management tests/functional tests/test_2fa.py tests/conftest.py tests/test_db.py tests/test_manage.py tests/test_crypto_util.py tests/test_journalist.py tests/test_integration.py tests/test_source.py && popd
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/management/run.py
+++ b/securedrop/management/run.py
@@ -52,10 +52,10 @@ class DevServerProcess(subprocess.Popen):  # pragma: no cover
 
         super(DevServerProcess, self).__init__(
             self.cmd,
-            stdin  = subprocess.PIPE,
-            stdout = subprocess.PIPE,
-            stderr = subprocess.STDOUT,
-            preexec_fn = os.setsid)
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            preexec_fn=os.setsid)
 
     def print_label(self, to):
         label = "\n => {} <= \n\n".format(self.label)
@@ -64,14 +64,14 @@ class DevServerProcess(subprocess.Popen):  # pragma: no cover
         to.write(label)
 
     def fileno(self):
-        """
-        Implement fileno() in order to use DevServerProcesses with select.select
-        directly.
+        """Implement fileno() in order to use DevServerProcesses with
+        select.select directly.
 
         Note this method assumes we only want to select this process'
         stdout. This is a reasonable assumption for a DevServerProcess
         because the __init__ redirects stderr to stdout, so all output is
         available on stdout.
+
         """
         return self.stdout.fileno()
 
@@ -150,7 +150,7 @@ def run():  # pragma: no cover
     Ctrl-C will kill the servers and return you to the terminal.
 
     Useful resources:
-    * https://stackoverflow.com/questions/22565606/python-asynhronously-print-stdout-from-multiple-subprocesses
+    * https://stackoverflow.com/q/22565606/837471
 
     """
     print \
@@ -164,7 +164,7 @@ def run():  # pragma: no cover
     \\/_____/\\/____/\\/____/ \\/___/  \\/_/ \\/____/ \\/___/  \\/_/ \\/___/  \\ \\ \\/ 
                                                                       \\ \\_\\ 
                                                                        \\/_/ 
-"""
+"""  # noqa
 
     procs = [
         lambda: DevServerProcess('Source Interface',


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

makes management compliant

## Testing

* pytest tests

* pip install git+https://github.com/berkerpeksag/astor
* checkout develop and run cd securedrop ; python -m astor.rtrip . ; mv tmp_rtrip tmp_rtrip.orig
* checkout this pull request and run cd securedrop/tests/functional ; python -m astor.rtrip .
* diff -ru tmp_rtrip tmp_rtrip.orig
<pre>
diff -ru tmp_rtrip.orig/run.py tmp_rtrip/run.py
--- tmp_rtrip.orig/run.py	2017-08-01 23:02:34.140142342 +0200
+++ tmp_rtrip/run.py	2017-08-01 23:02:40.684154078 +0200
@@ -42,14 +42,14 @@
         to.write(label)
 
     def fileno(self):
-        """
-        Implement fileno() in order to use DevServerProcesses with select.select
-        directly.
+        """Implement fileno() in order to use DevServerProcesses with
+        select.select directly.
 
         Note this method assumes we only want to select this process'
         stdout. This is a reasonable assumption for a DevServerProcess
         because the __init__ redirects stderr to stdout, so all output is
         available on stdout.
+
         """
         return self.stdout.fileno()
 
@@ -103,7 +103,7 @@
     Ctrl-C will kill the servers and return you to the terminal.
 
     Useful resources:
-    * https://stackoverflow.com/questions/22565606/python-asynhronously-print-stdout-from-multiple-subprocesses
+    * https://stackoverflow.com/q/22565606/837471
 
     """
     print """
</pre>

Comparing the sources normalized with the AST ensures white space changes do not modify the source behavior