### PR TITLE
Add clarifying note about missing Root Terminal

### DIFF
--- a/docs/backup_workstations.rst
+++ b/docs/backup_workstations.rst
@@ -94,6 +94,11 @@ mounted and ready to access.
 Open a Nautilus window with administrator privileges by going to
 **Applications** ▸ **System Tools** ▸ **Root Terminal**.
 
+.. note::
+  If you cannot see the **Root Terminal** icon in your menu, it might be
+  because an administrator password wasn't set. If that's the case, you'll need
+  to restart and set an administrator password before continuing.
+
 |Root Terminal|
 
 Type ``nautilus`` at the terminal prompt and hit enter:

--- a/docs/upgrade_to_tails_3x.rst
+++ b/docs/upgrade_to_tails_3x.rst
@@ -114,6 +114,11 @@ mounted and ready to access.
 Open a Nautilus window with administrator privileges by going to
 **Applications** ▸ **System Tools** ▸ **Root Terminal**.
 
+.. note::
+  If you cannot see the **Root Terminal** icon in your menu, it might be
+  because an administrator password wasn't set. If that's the case, you'll need
+  to restart and set an administrator password before continuing.
+
 |Root Terminal|
 
 Type ``nautilus`` at the terminal prompt and hit enter:


### PR DESCRIPTION
Adds a clarifying note during Tails backup procedure for the case when someone has a missing "Root Terminal" Launcher in [Tails 3.x Upgrade Docs](https://docs.securedrop.org/en/stable/upgrade_to_tails_3x.html#backup-the-tails-drives) and [Workstation Backups](https://docs.securedrop.org/en/stable/backup_workstations.html)

## Status

Ready for review

## Description of Changes

Resolves #2065.

Changes proposed in this pull request:

Adds a clarifying note during Tails backup procedure for the case when someone has a missing "Root Terminal" Launcher in [Tails 3.x Upgrade Docs](https://docs.securedrop.org/en/stable/upgrade_to_tails_3x.html#backup-the-tails-drives) and [Workstation Backups](https://docs.securedrop.org/en/stable/backup_workstations.html).

## Testing
Any reviewer should check for grammar, spelling, and adherence to the [SecureDrop 
Documentation Style Guide](https://docs.securedrop.org/en/stable/development/documentation_guidelines.html#style-guide). 

Furthermore, they should test if docs build and doc linting passes.

## Deployment

Deployment should happen automatically upon merge (for latest), and release (for stable).

## Checklist
- [x] Doc linting passed locally
