### PR TITLE
Revert "i18n: add Flask-Babel requirement"

### DIFF
--- a/securedrop/requirements/securedrop-requirements.in
+++ b/securedrop/requirements/securedrop-requirements.in
@@ -1,6 +1,5 @@
 cssmin
 Flask-Assets
-Flask-Babel
 Flask-WTF
 Flask
 gnupg

--- a/securedrop/requirements/securedrop-requirements.txt
+++ b/securedrop/requirements/securedrop-requirements.txt
@@ -4,11 +4,9 @@
 #
 #    pip-compile --output-file securedrop-requirements.txt securedrop-requirements.in
 #
-babel==2.4.0              # via flask-babel
 click==6.7                # via flask, rq
 cssmin==0.2.0
 flask-assets==0.12
-flask-babel==0.11.2
 flask-wtf==0.14.2
 flask==0.12.2             # via flask-assets, flask-wtf
 gnupg==2.3.0
@@ -19,7 +17,6 @@ markupsafe==1.0           # via jinja2
 psutil==5.2.2
 pycrypto==2.6.1
 pyotp==2.2.5
-pytz==2017.2              # via babel
 qrcode==5.3
 redis==2.10.5
 rq==0.8.0


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Change came in via #1924 but tests were not run (see #1826), so a
breaking regression due to the AppArmor profiles has been wrecking
builds in CI. We need to reland the requirements updates as part of the
i18n effort, but as a short-term fix, we're backing out the breaking
change from develop, pending a more durable and fully-tested
implementation.

Fixes #2070.

This reverts commit 10b41800d5524aef6c483c5c77d37f279e4fcecd.

## Testing

Confirm CircleCI passes. Bonus points if you spin up a staging environment and confirm a 200 GET on both Source and Journalist Interfaces.

## Deployment

No concerns for deployment, this bug only landed in develop and has never shipped.

## Checklist

Trust nothing but CircleCI. 
