### PR TITLE
i18n: add Flask-Babel requirement

### DIFF
--- a/install_files/ansible-base/usr.sbin.apache2
+++ b/install_files/ansible-base/usr.sbin.apache2
@@ -232,6 +232,7 @@
   /etc/apache2/mods-available/socache_shmcb.load r,
   /run/lock/apache2/ssl-cache.* rwk,
   /var/lib/ssl/* r,
+  /etc/timezone r,
 
   ^DEFAULT_URI {
   }

--- a/securedrop/requirements/securedrop-requirements.in
+++ b/securedrop/requirements/securedrop-requirements.in
@@ -1,5 +1,6 @@
 cssmin
 Flask-Assets
+Flask-Babel
 Flask-WTF
 Flask
 gnupg

--- a/securedrop/requirements/securedrop-requirements.txt
+++ b/securedrop/requirements/securedrop-requirements.txt
@@ -4,9 +4,11 @@
 #
 #    pip-compile --output-file securedrop-requirements.txt securedrop-requirements.in
 #
+babel==2.4.0              # via flask-babel
 click==6.7                # via flask, rq
 cssmin==0.2.0
 flask-assets==0.12
+flask-babel==0.11.2
 flask-wtf==0.14.2
 flask==0.12.2             # via flask-assets, flask-wtf
 gnupg==2.3.0
@@ -17,6 +19,7 @@ markupsafe==1.0           # via jinja2
 psutil==5.2.2
 pycrypto==2.6.1
 pyotp==2.2.5
+pytz==2017.2              # via babel
 qrcode==5.3
 redis==2.10.5
 rq==0.8.0


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #2072

babel depends on pytz which reads /etc/timezone implicitly. Allow it
to be read when apache is running under the supervision of apparmor.

## Testing

Run through CircleCI which automatically repeats the steps described at https://github.com/freedomofpress/securedrop/issues/2070

## Deployment

Existing installs will have the apache2 apparmor profile updated as part of the app package upgrade. The app will implicitly load the pytz module because it is added to the dependencies. It will read /etc/timezone which is allowed by the updated apparmor profile.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM