### PR TITLE
Fix AppArmor rule denying access to fontawesome-webfont.svg

### DIFF
--- a/install_files/ansible-base/usr.sbin.apache2
+++ b/install_files/ansible-base/usr.sbin.apache2
@@ -210,6 +210,7 @@
   /var/www/securedrop/static/js/libs/jquery-2.1.4.min.js r,
   /var/www/securedrop/static/js/source.js r,
   /var/www/securedrop/static/fonts/fontawesome-webfont.eot r,
+  /var/www/securedrop/static/fonts/fontawesome-webfont.svg r,
   /var/www/securedrop/static/fonts/fontawesome-webfont.ttf r,
   /var/www/securedrop/static/fonts/fontawesome-webfont.woff r,
   /var/www/securedrop/static/fonts/fontawesome-webfont.woff2 r,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2075.

Apache should have access to fontawesome-webfont.svg. If AppArmor
denies access to this file, a spurious OSSEC alert will be produced.

## Testing

Verify the path to the FontAwesome file is correct

## Deployment

There should be no issues deploying this to new or existing installs 

## Checklist

Relying on manual review and CI here
