### PR TITLE
Add HTML linting to CI and fix linting errors on all HTML templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,8 @@ script:
   # Application code flake8 linting
   - pushd securedrop; flake8 *.py management tests/functional tests/*.py && popd
   # HTML linting
-  - html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation securedrop/source_templates/*.html
+  - >
+      html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation
+      securedrop/source_templates/*.html securedrop/journalist_templates/*.html
 after_success:
   cd securedrop/ && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,9 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
+  # Application code flake8 linting
   - pushd securedrop; flake8 *.py management tests/functional tests/*.py && popd
+  # HTML linting
+  - html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation securedrop/source_templates/*.html
 after_success:
   cd securedrop/ && coveralls

--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -5,11 +5,11 @@
   <div class="designation">
     {% if source.star.starred %}
       <button class="button-star starred" type="submit" formaction="/col/remove_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
-      <input id="checkbox" type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
+      <input id="checkbox" type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}">
       <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="starred-source-link-{{ loop_index }}">{{ source.journalist_designation }}</a></span>
     {% else %}
       <button class="button-star un-starred" type="submit" formaction="/col/add_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>
-      <input id="checkbox" type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" />
+      <input id="checkbox" type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}">
       <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="un-starred-source-link-{{ loop_index }}">{{ source.journalist_designation }}</a></span>
     {% endif %}
   </div>
@@ -18,7 +18,7 @@
     <span><i class="fa fa-file-text-o"></i> {{ msgs }} messages</span>
     {% if source.num_unread > 0 %}
       <span class="unread">
-        <a class="btn small" href='/download_unread/{{ source.filesystem_id }}' ><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
+        <a class="btn small" href="/download_unread/{{ source.filesystem_id }}"><i class="fa fa-download"></i> {{ source.num_unread }} unread</a>
       </span>
     {% endif %}
   </div>

--- a/securedrop/journalist_templates/account_edit_hotp_secret.html
+++ b/securedrop/journalist_templates/account_edit_hotp_secret.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 {% block body %}
 <form method="post">
-  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   <p>
     <label for="otp_secret">Change Secret</label>
-    <input name="otp_secret" type="text" placeholder="HOTP Secret"><br />
+    <input name="otp_secret" type="text" placeholder="HOTP Secret"><br>
   </p>
   <button class="sd-button" type="submit">CONTINUE</button>
 </form>

--- a/securedrop/journalist_templates/account_new_two_factor.html
+++ b/securedrop/journalist_templates/account_new_two_factor.html
@@ -10,17 +10,17 @@
   <li>Tap menu, then tap "Set up account", then tap "Scan a barcode"</li>
   <li>Your phone will now be in "scanning" mode. When you are in this mode, scan the barcode below:</li>
 </ol>
-<div id="qrcode_container">{{ user.shared_secret_qrcode|safe }}</div>
-<p>Can't scan the barcode? Enter the following code manually: <span id="shared_secret">{{ user.formatted_otp_secret }}</span></p>
+<div id="qrcode-container">{{ user.shared_secret_qrcode|safe }}</div>
+<p>Can't scan the barcode? Enter the following code manually: <span id="shared-secret">{{ user.formatted_otp_secret }}</span></p>
 <p>Once you have scanned the barcode, enter the 6-digit code below:</p>
 {% else %}
 <h1>Enable Yubikey (OATH-HOTP)</h1>
 <p>Once you have configured your Yubikey, enter the 6-digit code below:</p>
 {% endif %}
-<form id="check_token" method="post">
-  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+<form id="check-token" method="post">
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   <label for="token">Verification code</label>
-  <input name="token" id="token" type="text" placeholder="123456" />
+  <input name="token" id="token" type="text" placeholder="123456">
   <button type="submit" class="sd-button">SUBMIT</button>
 </form>
 {% endblock %}

--- a/securedrop/journalist_templates/admin.html
+++ b/securedrop/journalist_templates/admin.html
@@ -6,11 +6,11 @@
   <button class="sd-button" type="submit" class="btn" id="add-user"><i class="fa fa-plus"></i> ADD USER</button>
 </form>
 
-<hr class="no-line" />
+<hr class="no-line">
 
 {% if users %}
-<form id="user_actions" method="post">
-  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+<form id="user-actions" method="post">
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   <table id="users">
     <tr>
       <th>Username</th>

--- a/securedrop/journalist_templates/admin_add_user.html
+++ b/securedrop/journalist_templates/admin_add_user.html
@@ -1,22 +1,22 @@
 {% extends "base.html" %}
 {% block body %}
 <p>
-  <a href="/admin">&laquo; Back to admin interface</a>
+  <a href="/admin">« Back to admin interface</a>
 </p>
 
 <form method="post">
-  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
-  <p><input name="username" type="text" placeholder="Username" /></p>
-  <p><input name="password" type="password" placeholder="Password" /></p>
-  <p><input name="password_again" type="password" placeholder="Password (again)" /></p>
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+  <p><input name="username" type="text" placeholder="Username"></p>
+  <p><input name="password" type="password" placeholder="Password"></p>
+  <p><input name="password_again" type="password" placeholder="Password (again)"></p>
   <p>
-    <input name="is_admin" id="is_admin" type="checkbox" />
+    <input name="is_admin" id="is-admin" type="checkbox">
     <label for="is_admin">Is Administrator</label>
   </p>
   <p>
-    <input name="is_hotp" id="is_hotp" type="checkbox" />
+    <input name="is_hotp" id="is-hotp" type="checkbox">
     <label for="is_hotp">I'm using a Yubikey </label>
-    <input name="otp_secret" type="text" placeholder="HOTP Secret" size="60"><br />
+    <input name="otp_secret" type="text" placeholder="HOTP Secret" size="60"><br>
   </p>
   <button type="submit" class="sd-button"><i class="fa fa-plus"></i> ADD USER</button>
 </form>

--- a/securedrop/journalist_templates/admin_edit_hotp_secret.html
+++ b/securedrop/journalist_templates/admin_edit_hotp_secret.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% block body %}
 <form method="post">
-  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
-  <input type="hidden" name="uid" value="{{ uid }}" />
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+  <input type="hidden" name="uid" value="{{ uid }}">
   <p>
     <label for="otp_secret">Change Secret</label>
-    <input name="otp_secret" type="text" placeholder="HOTP Secret"><br />
+    <input name="otp_secret" type="text" placeholder="HOTP Secret"><br>
   </p>
   <button class="sd-button" type="submit">CONTINUE</button>
 </form>

--- a/securedrop/journalist_templates/admin_new_user_two_factor.html
+++ b/securedrop/journalist_templates/admin_new_user_two_factor.html
@@ -3,23 +3,24 @@
 {% if user.is_totp %}
 <h1>Enable Google Authenticator</h1>
 <p>You're almost done! To finish adding this new user, have them follow the instructions below to set up two-factor authentication with Google Authenticator. Once they've added an entry for this account in the app, have them enter one of the 6-digit codes from the app to confirm that two factor authentication is set up correctly.</p>
+
 <ol>
   <li>Install Google Authenticator on your phone</li>
   <li>Open the Google Authenticator app</li>
   <li>Tap menu, then tap "Set up account", then tap "Scan a barcode"</li>
   <li>Your phone will now be in "scanning" mode. When you are in this mode, scan the barcode below:</li>
 </ol>
-<div id="qrcode_container">{{ user.shared_secret_qrcode|safe }}</div>
-<p>Can't scan the barcode? Enter the following code manually: <span id="shared_secret">{{ user.formatted_otp_secret }}</span></p>
+<div id="qrcode-container">{{ user.shared_secret_qrcode|safe }}</div>
+<p>Can't scan the barcode? Enter the following code manually: <span id="shared-secret">{{ user.formatted_otp_secret }}</span></p>
 <p>Once you have scanned the barcode, enter the 6-digit code below:</p>
 {% else %}
 <h1>Enable Yubikey (OATH-HOTP)</h1>
 <p>Once you have configured your Yubikey, enter the 6-digit code below:</p>
 {% endif %}
-<form id="check_token" method="post">
-  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+<form id="check-token" method="post">
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   <label for="token">Verification code</label>
-  <input name="token" id="token" type="text" placeholder="123456" />
-  <button class "sd-button" type="submit">SUBMIT</button>
+  <input name="token" id="token" type="text" placeholder="123456">
+  <button type="submit" class="sd-button">SUBMIT</button>
 </form>
 {% endblock %}

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>SecureDrop</title>
 
-    <link rel="stylesheet" href="/static/css/journalist.css" />
+    <link rel="stylesheet" href="/static/css/journalist.css">
 
     <link rel="icon" type="image/png" href="/static/i/favicon.png">
 
@@ -12,18 +12,17 @@
       "js/libs/jquery-2.1.4.min.js", "js/journalist.js" %}
       <script src="{{ ASSET_URL }}"></script>
     {% endassets %}
-
     {% block extrahead %}{% endblock %}
   </head>
   <body>
 
     {% if g.user %}
     <div id="logout">
-      <a href="{{ url_for('edit_account') }}" id="link_edit_account">Edit Account</a> |
+      <a href="{{ url_for('edit_account') }}" id="link-edit-account">Edit Account</a> |
       {% if g.user and g.user.is_admin %}
-      <a href="{{ url_for('admin_index') }}" id="link_admin_index">Admin</a> |
+      <a href="{{ url_for('admin_index') }}" id="link-admin-index">Admin</a> |
       {% endif %}
-      <a href="{{ url_for('logout') }}" id="link_logout">Logout</a>
+      <a href="{{ url_for('logout') }}" id="link-logout">Logout</a>
     </div>
     <div class="clearfix"></div>
     {% endif %}
@@ -34,7 +33,7 @@
         <a href="{{ url_for('index') }}"><img src="/static/i/{{ header_image }}" class="logo small" alt="SecureDrop" width="250px"></a>
         {% if use_custom_header_image %}
         <div class="powered">
-          Powered by<br/>
+          Powered by<br>
           <img src="/static/i/securedrop_small.png" alt="SecureDrop">
         </div>
         {% endif %}

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -2,8 +2,8 @@
 {% block body %}
 <div id="content" class="journalist-view-single">
 
-  <form action='/regenerate-code' method='post' id="regenerate-code">
-    <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+  <form action="/regenerate-code" method="post" id="regenerate-code">
+    <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
     <input type="hidden" name="sid" value="{{ sid }}">
 
     <p class="breadcrumbs">
@@ -22,9 +22,9 @@
     <p>The documents are stored encrypted for security. To read them, you will need to decrypt them using GPG.</p>
     <form action="/bulk" method="post">
       <p>
-        <div id='select-container'></div>
+        <div id="select-container"></div>
         <button type="submit" name="action" value="download" class="small"><i class="fa fa-download"></i> Download Selected</button>
-        <button type="submit" name="action" value="confirm_delete" id="delete_selected" class="small danger"><i class="fa fa-trash-o"></i> Delete Selected</button>
+        <button type="submit" name="action" value="confirm_delete" id="delete-selected" class="small danger"><i class="fa fa-trash-o"></i> Delete Selected</button>
       </p>
 
       <ul id="submissions" class="plain submissions">
@@ -32,14 +32,14 @@
           <li class="submission">
             {% if not doc.filename.endswith('reply.gpg') %}
               {% if not doc.downloaded %}
-                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb"/>
+                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
                 <span title="Unread" class="icon"><i class="fa fa-envelope"></i></span>
               {% else %}
-                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check"/>
+                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
                 <span class="icon"><i class="fa fa-envelope-open"></i></span>
               {% endif %}
             {% elif doc.filename.endswith('reply.gpg') %}
-                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check"/>
+                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
                 <span class="icon"></span>
             {% endif %}
             {% if doc.filename.endswith('reply.gpg') %}
@@ -60,23 +60,23 @@
         {% endfor %}
       </ul>
 
-      <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
-      <input type="hidden" name="sid" value="{{ sid }}"/>
+      <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+      <input type="hidden" name="sid" value="{{ sid }}">
     </form>
   {% else %}
-    <p><br />No documents to display.</p>
+    <p><br>No documents to display.</p>
   {% endif %}
 
-  <hr class="cut-out" />
-  <hr class="no-line" />
+  <hr class="cut-out">
+  <hr class="no-line">
   <h3><i class="fa fa-reply"></i> Reply</h3>
   {% if source.has_key %}
     <p>You can write a secure reply to the person who submitted these documents:</p>
     <form action="/reply" method="post" autocomplete="off">
-      <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
-      <input type="hidden" name="sid" value="{{ sid }}"/>
+      <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+      <input type="hidden" name="sid" value="{{ sid }}">
       <textarea id="reply-text-field" name="msg" cols="72" rows="10"></textarea>
-      <hr class="no-line" />
+      <hr class="no-line">
       <button id="reply-button" class="sd-button" type="submit">SUBMIT</button>
     </form>
   {% elif source.flagged %}
@@ -85,19 +85,19 @@
   {% else %}
     <p>Click below if you would like to write a reply to this source.</p>
     <form action="/flag" method="post">
-      <input type="hidden" name="sid" value="{{ sid }}"/>
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      <input type="hidden" name="sid" value="{{ sid }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <button id="flag-button" class="sd-button" type="submit">FLAG THIS SOURCE FOR REPLY</button>
     </form>
   {% endif %}
-  <hr class="no-line" />
-  <hr class="cut-out" />
+  <hr class="no-line">
+  <hr class="cut-out">
   <p>Click below to delete this source's collection. <em>Warning: If you do this, the files seen here will be unrecoverable and the source will no longer be able to login using their previous codename.</em></p>
 
-  <form id="delete_collection" action="/col/delete/{{sid}}" method="post">
-    <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
-    <input type="hidden" name="sid" value="{{ sid }}"/>
-    <input type="hidden" name="col_name" value="{{ source.journalist_designation }}"/>
+  <form id="delete-collection" action="/col/delete/{{sid}}" method="post">
+    <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+    <input type="hidden" name="sid" value="{{ sid }}">
+    <input type="hidden" name="col_name" value="{{ source.journalist_designation }}">
     <button type="submit" class="sd-button danger"><i class="fa fa-trash-o"></i> DELETE COLLECTION</button>
   </form>
 

--- a/securedrop/journalist_templates/delete.html
+++ b/securedrop/journalist_templates/delete.html
@@ -10,13 +10,13 @@
   {% for item in items_selected %}
     <li>
       {{ item.filename }}
-      <input type="hidden" name="doc_names_selected" value="{{ item.filename }}" />
+      <input type="hidden" name="doc_names_selected" value="{{ item.filename }}">
     </li>
   {% endfor %}
   </ul>
-  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
-  <input type="hidden" name="sid" value="{{ sid }}" autocomplete="off"/>
-  <input type="hidden" name="confirm_delete" value="true" />
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+  <input type="hidden" name="sid" value="{{ sid }}" autocomplete="off">
+  <input type="hidden" name="confirm_delete" value="true">
   <p><button class="sd-button" type="submit" name="action" value="delete">PERMANENTLY DELETE FILES</button></p>
 </form>
 

--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -3,28 +3,27 @@
 
 {% if user %}
 <h1>Edit user "{{ user.username }}"</h1>
-<p><a href="/admin">&laquo; Back to admin interface</a></p>
+<p><a href="/admin">« Back to admin interface</a></p>
 {% else %}
 <h1>Edit your account</h1>
 {% endif %}
 
 <form method="post">
-  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
 
   {# Non-admin users are not able to change their own usernames. #}
   {% if user %}
   <p>
     <label for="username">Change username</label>
-    <input name="username" id="username" type="text" placeholder="{{ user.username }}" />
+    <input name="username" id="username" type="text" placeholder="{{ user.username }}">
   </p>
   {% endif %}
 
   <p>
     <label for="password">Change password</label>
-    <input name="password" id="password" type="password" />
+    <input name="password" id="password" type="password">
 
-    {# While non-admin users can only change their own passwords, admin users
-    can make many other changes, which may exclude password changes. #}
+    {# While non-admin users can only change their own passwords, admin users can make many other changes, which may exclude password changes. #}
     {% if user %}
     <em class="light">Leave blank for no change</em>
     {% endif %}
@@ -32,13 +31,13 @@
   </p>
   <p>
     <label for="password_again">Change password (confirm)</label>
-    <input name="password_again" id="password_again" type="password" />
+    <input name="password_again" id="password-again" type="password">
   </p>
 
   {# Only admin users may modify the admin status of other users. #}
   {% if user %}
   <p>
-    <input name="is_admin" id="is_admin" type="checkbox" {% if user.is_admin %}checked{% endif %} />
+    <input name="is_admin" id="is-admin" type="checkbox" {% if user.is_admin %}checked{% endif %}>
     <label for="is_admin">Is Administrator</label>
   </p>
   {% endif %}
@@ -76,17 +75,15 @@ Yubikey, choose the second.</p>
 {% macro twofa_reset(user, reset_url, type, button_text) %}
 <form method="post" action="{{ reset_url }}" id="reset-two-factor-{{ type }}">
   {% if user %}
-  <input name="uid" type="hidden" value="{{ user.id }}"/>
+  <input name="uid" type="hidden" value="{{ user.id }}">
   {% endif %}
-  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   <button class="sd-button" type="submit" class="pull-right"><i class="fa fa-refresh"></i> {{ button_text }}</button>
 </form>
 {%- endmacro %}
 
-{{ twofa_reset(user, totp_reset_url, "totp", "RESET TWO-FACTOR AUTHENTICATION
-(APP)")}}
-<br />
-{{ twofa_reset(user, hotp_reset_url, "hotp", "RESET TWO-FACTOR AUTHENTICATION
-(HARDWARE TOKEN)")}}
+{{ twofa_reset(user, totp_reset_url, "totp", "RESET TWO-FACTOR AUTHENTICATION (APP)")}}
+<br>
+{{ twofa_reset(user, hotp_reset_url, "hotp", "RESET TWO-FACTOR AUTHENTICATION (HARDWARE TOKEN)")}}
 
 {% endblock %}

--- a/securedrop/journalist_templates/flashed.html
+++ b/securedrop/journalist_templates/flashed.html
@@ -1,19 +1,14 @@
 {% with messages = get_flashed_messages(with_categories=true) %}
 {% if messages %}
   {% for category, message in messages %}
-    {% if category != 'banner-warning' %}
+    {% if category != "banner-warning" %}
       <div class="flash {{ category }}">
-        {% if category == 'notification' %}
-        <img src="{{ url_for('static',
-        filename='i/font-awesome/info-circle-black.png') }}" height=16
-        width=20>
-        {% elif category == 'success' %}
-        <img src="{{ url_for('static', filename='i/success_checkmark.png') }}"
-        height=17 width=20>
-        {% elif category == 'error' %}
-        <img src="{{ url_for('static',
-        filename='i/font-awesome/exclamation-triangle-black.png') }}" height=17
-        width=20>
+        {% if category == "notification" %}
+        <img src="{{ url_for('static', filename='i/font-awesome/info-circle-black.png') }}" height="16" width="20">
+        {% elif category == "success" %}
+        <img src="{{ url_for('static', filename='i/success_checkmark.png') }}" height="17" width="20">
+        {% elif category == "error" %}
+        <img src="{{ url_for('static', filename='i/font-awesome/exclamation-triangle-black.png') }}" height="17" width="20">
         {% endif %}
         {{ message }}
       </div>
@@ -21,4 +16,3 @@
   {% endfor %}
 {% endif %}
 {% endwith %}
-

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -3,16 +3,16 @@
 <div id="content" class="journalist-view-all">
   <h1><span class="headline">Sources</span></h1>
   {% if unstarred or starred %}
-    <div id='filter-container'></div>
-    <form id="process_collections" action="/col/process" method="post">
-      <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+    <div id="filter-container"></div>
+    <form id="process-collections" action="/col/process" method="post">
+      <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
       <p>
-        <div id='index-select-container'></div>
+        <div id="index-select-container"></div>
         <button type="submit" name="action" value="download-unread" class="small"><i class="fa fa-download"></i> Download Unread</button>
         <button type="submit" name="action" value="download-all" class="small"><i class="fa fa-download"></i> Download</button>
         <button type="submit" name="action" value="star" class="small"><i class="fa fa-star"></i> Star</button>
         <button type="submit" name="action" value="un-star" class="small"><i class="fa fa-star-half-full"></i> Un-star</button>
-        <button type="submit" id="delete_collections" name="action" value="delete" class="small-danger"><i class="fa fa-trash-o"></i> Delete</button>
+        <button type="submit" id="delete-collections" name="action" value="delete" class="small-danger"><i class="fa fa-trash-o"></i> Delete</button>
       </p>
 
       {% if starred %}

--- a/securedrop/requirements/develop-requirements.in
+++ b/securedrop/requirements/develop-requirements.in
@@ -1,6 +1,7 @@
 # Temporary peg until issue #1146 is resolved
 ansible==2.2.1
 boto
+html-linter
 flake8
 pip-tools
 pytest-xdist

--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -11,18 +11,21 @@ argh==0.26.2              # via sphinx-autobuild, watchdog
 asn1crypto==0.22.0        # via cryptography
 babel==2.4.0              # via sphinx
 backports-abc==0.5        # via tornado
-boto==2.47.0
-certifi==2017.4.17        # via requests, tornado
-cffi==1.10.0              # via cryptography
+bcrypt==3.1.3             # via paramiko
+boto==2.48.0
+certifi==2017.7.27.1      # via requests, tornado
+cffi==1.10.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
 configparser==3.5.0       # via flake8
-cryptography==1.9         # via paramiko
-docutils==0.13.1          # via sphinx
+cryptography==2.0.3       # via paramiko
+docopt==0.6.2             # via html-linter, template-remover
+docutils==0.14            # via sphinx
 enum34==1.1.6             # via cryptography, flake8
 execnet==1.4.1            # via pytest-xdist
 first==2.0.1              # via pip-tools
-flake8==3.3.0
+flake8==3.4.1
+html-linter==0.4.0
 idna==2.5                 # via cryptography, requests
 imagesize==0.7.1          # via sphinx
 ipaddress==1.0.18         # via cryptography
@@ -30,31 +33,33 @@ jinja2==2.8.1             # via ansible, sphinx
 livereload==2.5.1         # via sphinx-autobuild
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8
-paramiko==2.1.2           # via ansible
+paramiko==2.2.1           # via ansible
 pathtools==0.1.2          # via sphinx-autobuild, watchdog
 pip-tools==1.9.0
 port-for==0.3.1           # via sphinx-autobuild
-py==1.4.34                # via pytest, pytest-xdist
-pyasn1==0.2.3             # via paramiko
+py==1.4.34                # via pytest
+pyasn1==0.3.1             # via paramiko
 pycodestyle==2.3.1        # via flake8
-pycparser==2.17           # via cffi
+pycparser==2.18           # via cffi
 pycrypto==2.6.1           # via ansible
 pyflakes==1.5.0           # via flake8
 pygments==2.2.0           # via sphinx
-pytest-xdist==1.16.0
-pytest==3.1.1             # via pytest-xdist, testinfra
+pynacl==1.1.2             # via paramiko
+pytest-xdist==1.18.2
+pytest==3.2.0             # via pytest-xdist, testinfra
 pytz==2017.2              # via babel
 pyyaml==3.12              # via ansible, sphinx-autobuild, watchdog
-requests==2.17.3          # via sphinx
+requests==2.18.3          # via sphinx
 singledispatch==3.4.0.3   # via tornado
-six==1.10.0               # via cryptography, livereload, pip-tools, singledispatch, sphinx, testinfra
+six==1.10.0               # via bcrypt, cryptography, livereload, pip-tools, pynacl, singledispatch, sphinx, testinfra
 snowballstemmer==1.2.1    # via sphinx
-sphinx-autobuild==0.6.0
+sphinx-autobuild==0.7.1
 sphinx-rtd-theme==0.2.4
-sphinx==1.6.2
+sphinx==1.6.3
 sphinxcontrib-websupport==1.0.1  # via sphinx
-testinfra==1.6.3
+template-remover==0.1.9   # via html-linter
+testinfra==1.6.5
 tornado==4.5.1            # via livereload, sphinx-autobuild
 typing==3.6.1             # via sphinx
-urllib3==1.21.1           # via requests
+urllib3==1.22             # via requests
 watchdog==0.8.3           # via sphinx-autobuild

--- a/securedrop/sass/_base.sass
+++ b/securedrop/sass/_base.sass
@@ -397,10 +397,10 @@
   em.light
     color: gray
 
-  div#qrcode_container
+  div#qrcode-container
     text-align: center
 
-  span#shared_secret
+  span#shared-secret
     background-color: #FFFD9E
     color: #555
     padding: 4px

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <title>SecureDrop | Protecting Journalists and Sources</title>
 
-    <link rel="stylesheet" href="/static/css/source.css" />
-    <link rel="icon" type="image/png" href="/static/i/favicon.png" >
+    <link rel="stylesheet" href="/static/css/source.css">
+    <link rel="icon" type="image/png" href="/static/i/favicon.png">
     {% block extrahead %}{% endblock %}
   </head>
   <body>
@@ -14,10 +14,12 @@
     <div class="content">
       {% block header %}
       <div id="header">
-        <a href="{% if 'logged_in' in session %}{{ url_for('lookup') }}{% else %}{{ url_for('index') }}{% endif %}"><img src="/static/i/{{ header_image }}" class="logo small" alt="SecureDrop" width="250px"></a>
+        <a href="{% if 'logged_in' in session %}{{ url_for('lookup') }}{% else %}{{ url_for('index') }}{% endif %}">
+          <img src="/static/i/{{ header_image }}" class="logo small" alt="SecureDrop" width="250px">
+        </a>
         {% if use_custom_header_image %}
         <div class="powered">
-          Powered by<br/>
+          Powered by<br>
           <img src="/static/i/securedrop_small.png" alt="SecureDrop">
         </div>
         {% endif %}
@@ -28,7 +30,7 @@
       {% if 'logged_in' in session %}
         <a href="{{ url_for('logout') }}" class="sd-button btn pull-right" id="logout">EXIT</a>
       {% endif %}
-        <hr class="no-line" />
+        <hr class="no-line">
 
         {% block body %}{% endblock %}
 

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -4,7 +4,7 @@
 <h1>Welcome</h1>
 <p class="explanation">This codename is what you will use in future visits to receive messages from our journalists in response to what you submit on the next screen.</p>
 
-<hr class="no-line" />
+<hr class="no-line">
 
 <div class="code">
   <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/lock-black.png') }}" width="20px" height="23px">
@@ -14,8 +14,8 @@
     <form id="regenerate-form" method="post">
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
       <button type="submit" id="regenerate-submit" class="small">
-        <img class="icon pull-left off-hover" src="{{ url_for('static', filename='i/font-awesome/refresh-white.png') }}" width="20px" height="20px" />
-        <img class="icon pull-left on-hover" src="{{ url_for('static', filename='i/font-awesome/refresh-blue.png') }}"  width="20px" height="20px" />
+        <img class="icon pull-left off-hover" src="{{ url_for('static', filename='i/font-awesome/refresh-white.png') }}" width="20px" height="20px">
+        <img class="icon pull-left on-hover" src="{{ url_for('static', filename='i/font-awesome/refresh-blue.png') }}"  width="20px" height="20px">
       </button>
     </form>
   </div>
@@ -31,7 +31,7 @@
  questions or are interested in additional documents. Unlike passwords, there is no way to retrieve a lost codename.
 </p>
 
-<hr class="no-line"/>
+<hr class="no-line">
 <aside class="center">
   <p>Please either write this codename down and keep it in a safe place, or memorize it.</p>
 </aside>
@@ -41,8 +41,8 @@
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   <a id="already-have-codename" href="/login" class="sd-button btn secondary">ALREADY HAVE A CODENAME?</a>
   <button type="submit" class="sd-button btn primary" id="continue-button">
-    <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-white.png') }}" width="17px" height="17px" />
-    <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-blue.png') }}" width="17px" height="17px" />
+    <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-white.png') }}" width="17px" height="17px">
+    <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-blue.png') }}" width="17px" height="17px">
      CONTINUE
   </button>
 </form>

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -3,8 +3,9 @@
   <head>
     <title>SecureDrop | Protecting Journalists and Sources</title>
 
-    <link rel="stylesheet" href="/static/css/source.css" />
-    <link rel="icon" type="image/png" href="/static/i/favicon.png" >
+    <link rel="stylesheet" href="/static/css/source.css">
+    <link rel="icon" type="image/png" href="/static/i/favicon.png">
+    <meta charset="utf-8">
 
     {% assets filters="jsmin", output="gen/source.js",
       "js/libs/jquery-2.1.4.min.js", "js/source.js" %}
@@ -24,7 +25,7 @@
           <img src="/static/i/{{ header_image }}" class="logo grid-item" alt="SecureDrop" width="250px">
           {% if use_custom_header_image %}
           <div class="powered">
-            Powered by<br/>
+            Powered by<br>
             <img src="/static/i/securedrop_small.png" alt="SecureDrop">
           </div>
           {% endif %}
@@ -34,11 +35,11 @@
           <h2 class="welcome-text">
             Submit documents for the first time
           </h2>
-          <hr class="cut-out" />
+          <hr class="cut-out">
           <p>If this is your first time submitting documents to journalists, start here.</p>
           <a href="/generate" class="sd-button btn alt index" id="submit-documents-button">
-            <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-white.png') }}" width="20px" height="14px" />
-            <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-blue.png') }}" width="20px" height="14px" />
+            <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-white.png') }}" width="20px" height="14px">
+            <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-blue.png') }}" width="20px" height="14px">
             SUBMIT DOCUMENTS
           </a>
         </div>
@@ -46,11 +47,11 @@
           <h2 class="welcome-text">
             Already submitted something?
           </h2>
-          <hr class="cut-out" />
+          <hr class="cut-out">
           <p>If you have already submitted documents in the past, log in here to check for responses.</p>
           <a href="/login" id="login-button" class="sd-button btn primary index">
-            <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/comments-white.png') }}" width="20px" height="16px" />
-            <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/comments-blue.png') }}" width="20px" height="16px" />
+            <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/comments-white.png') }}" width="20px" height="16px">
+            <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/comments-blue.png') }}" width="20px" height="16px">
             CHECK FOR A RESPONSE
           </a>
         </div>
@@ -67,7 +68,7 @@
     <div class="bubble" id="security-slider-info-bubble">
       <p>You appear to be using the Tor Browser. You can turn the Security Slider to High in 4 easy steps!</p>
       <ol>
-        <li>Click the <img src="{{ url_for('static', filename='i/toronion.png') }}" alt="Tor icon" />Tor icon in the toolbar above</li>
+        <li>Click the <img src="{{ url_for('static', filename='i/toronion.png') }}" alt="Tor icon">Tor icon in the toolbar above</li>
         <li>Click <strong>Security Settings...</strong></li>
         <li>Turn the Slider to <strong>High</strong>, then click <strong>Ok</strong></li>
         <li><a href="/">Click here</a> to refresh the page</li>

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -8,12 +8,12 @@
 <form method="post" action="/login" autocomplete="off">
 <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
 
-<p class="center"><input id="login-with-existing-codename" type="password" name="codename" class="codename-box" autocomplete="off" placeholder="Enter your codename" autofocus /></p>
+<p class="center"><input id="login-with-existing-codename" type="password" name="codename" class="codename-box" autocomplete="off" placeholder="Enter your codename" autofocus></p>
 <div class="pull-right">
   <a href="{{ url_for('index') }}" class="sd-button btn secondary" id="cancel">CANCEL</a>
   <button type="submit" class="sd-button btn primary" id="login">
-    <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-white.png') }}" width="18px" height="18px" />
-    <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-blue.png') }}" width="18px" height="18px" />
+    <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-white.png') }}" width="18px" height="18px">
+    <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-blue.png') }}" width="18px" height="18px">
     CONTINUE
   </button>
 </div>

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -8,7 +8,7 @@
     <div class="flash notification">
       <img src="{{ url_for('static', filename='i/relieved_face.png')  }}" alt="relieved-face" class="icon">
       <div class="message">
-        <strong>Whew, it’s you! Now, the embarrassing part...</strong></br>
+        <strong>Whew, it’s you! Now, the embarrassing part...</strong>
         <p>Our servers experienced an unusual surge of new activity, when you last visited. This could
           have been human activity, an automated attack, or just some random blip. To err on the side
           of caution, we put a hold on sending all documents from that day through to our journalists.</p>
@@ -28,7 +28,7 @@
 <hr class="no-line">
 
 <form id="upload" method="post" action="/submit" enctype="multipart/form-data" autocomplete="off">
-  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   <div class="snippet">
     <div class="attachment grid-item center">
       <img class="center" src="{{ url_for('static', filename='i/server_upload.png') }}" width="73px" height="62px">
@@ -44,14 +44,14 @@
   <div class="pull-right">
     <a href="{{ url_for('lookup') }}" class="btn secondary" id="cancel">CANCEL</a>
     <button type="submit" class="sd-button btn primary" id="submit-doc-button">
-      <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-white.png') }}" width="20px" height="14px" />
-      <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-blue.png') }}" width="20px" height="14px" />
+      <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-white.png') }}" width="20px" height="14px">
+      <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-blue.png') }}" width="20px" height="14px">
       SUBMIT
     </button>
   </div>
 </form>
 
-<hr class="no-line"/>
+<hr class="no-line">
 
 <h2 class="headline">Get Replies</h2>
 
@@ -85,7 +85,7 @@
     {% endfor %}
     <form id="delete-all" method="post" action="/delete-all">
       <a class="sd-button btn" href="#delete-all-confirm">DELETE ALL REPLIES</a>
-      <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+      <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
       <div id="delete-all-confirm" class="hidden-prompt">
         <p><strong>Are you finished with the replies?</strong></p>
         <button class="sd-button danger" type="submit">YES, DELETE ALL REPLIES</button>
@@ -102,7 +102,9 @@
 <div class="code-reminder" id="codename-hint">
   <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/lock-black.png') }}" width="17px" height="20px"> Remember your codename is:
   <div id="show" class="show pull-right"></div>
-  <span id="content" class="codename"><p class="alert">{{ codename }}</p></span>
+  <span id="content" class="codename">
+    <p class="alert">{{ codename }}</p>
+  </span>
 </div>
 
 {% endblock %}

--- a/securedrop/source_templates/next_submission_flashed_message.html
+++ b/securedrop/source_templates/next_submission_flashed_message.html
@@ -1,2 +1,4 @@
 <img src="{{ url_for('static', filename='i/success_checkmark.png') }}">
-<div class="message"><p>Thanks! We received your {{ things }}.</p></div>
+<div class="message">
+  <p>Thanks! We received your {{ things }}.</p>
+</div>

--- a/securedrop/source_templates/notfound.html
+++ b/securedrop/source_templates/notfound.html
@@ -2,7 +2,7 @@
 {% block body %}
 <h1>Page not found</h1>
 
-<p id="page_not_found">Sorry, we couldn't locate what you requested.</p>
+<p id="page-not-found">Sorry, we couldn't locate what you requested.</p>
 
 <p><a href="/login">Look up a codename...</a></p>
 {% endblock %}

--- a/securedrop/source_templates/tor2web-warning.html
+++ b/securedrop/source_templates/tor2web-warning.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block body %}
 <h1>Why is there a warning about Tor2Web?</h1>
-<p><a href='https://tor2web.org'>Tor2Web</a> is a proxy service that lets you browse Tor Hidden Services (.onion sites) without installing Tor. It was designed to facilitate anonymous publishing.</p>
+<p><a href="tor2web.org">Tor2Web</a> is a proxy service that lets you browse Tor Hidden Services (.onion sites) without installing Tor. It was designed to facilitate anonymous publishing.</p>
 <p>Tor2Web only protects publishers, not readers. If you upload documents to us using Tor2Web, you are <strong>not anonymous</strong> and could be identified by your ISP or the Tor2Web proxy operators. Additionally, since Tor2Web sites typically use HTTPS, it is possible that your connection could be MITM'ed by a capable adversary.</p>
-<p>If you want to submit information, we <strong>strongly advise you</strong> to install <a href='https://www.torproject.org/download.html.en'>Tor</a> and use it to access our site safely and anonymously.</p>
+<p>If you want to submit information, we <strong>strongly advise you</strong> to install <a href="torproject.org/download.html.en">Tor</a> and use it to access our site safely and anonymously.</p>
 {% endblock %}

--- a/securedrop/source_templates/use-tor-browser.html
+++ b/securedrop/source_templates/use-tor-browser.html
@@ -3,5 +3,7 @@
 <h1>You Should Use Tor Browser</h1>
 <p>If you are not using Tor Browser, you <strong>may not be anonymous</strong>.</p>
 <p>If you want to submit information to SecureDrop, we <strong>strongly advise you</strong> to install Tor Browser and use it to access our site safely and anonymously.</p>
-<p>Copy and paste the following address into your browser and follow the instructions to download and install Tor Browser: <pre>https://www.torproject.org/projects/torbrowser.html.en</pre></p>
+<p>Copy and paste the following address into your browser and follow the instructions to download and install Tor Browser:
+  <pre>https://www.torproject.org/projects/torbrowser.html.en</pre>
+</p>
 {% endblock %}

--- a/securedrop/source_templates/why-journalist-key.html
+++ b/securedrop/source_templates/why-journalist-key.html
@@ -7,7 +7,7 @@
 <li><a href="/journalist-key">Download</a> the public key. The public key is a text file with the extension <code>.asc</code></li>
 <li>Import it into your GPG keyring.
 <ul>
-<li>If you are using <a href='https://tails.boum.org/'>Tails</a>, you can double-click the <code>.asc</code> file you just downloaded and it will be automatically imported to your keyring.</li>
+<li>If you are using <a href="tails.boum.org">Tails</a>, you can double-click the <code>.asc</code> file you just downloaded and it will be automatically imported to your keyring.</li>
 <li>If you are using Mac/Linux, open the Terminal. You can import the key with <code>gpg --import /path/to/key.asc</code>.</li>
 </ul>
 </li>
@@ -22,5 +22,5 @@
 
 <p><strong>Tip:</strong> If you wish to remain anonymous, <strong>do not</strong> use GPG to sign the encrypted file (with the <code>--sign</code> or <code>-s</code> flag) as this will reveal your GPG identity to us.</p>
 
-<p><a href="/lookup">&laquo; Back to submission page</a></p>
+<p><a href="/lookup">« Back to submission page</a></p>
 {% endblock %}

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -14,7 +14,7 @@ function enhance_ui() {
   // Change the action on the /col pages so we use a Javascript
   // confirmation instead of redirecting to a confirmation page before
   // deleting submissions
-  $('button#delete_selected').attr('value', 'delete');
+  $('button#delete-selected').attr('value', 'delete');
 }
 
 $(function () {
@@ -46,11 +46,11 @@ $(function () {
       }
     });
 
-  $("#delete_collection").submit(function () {
+  $("#delete-collection").submit(function () {
     return confirm("Are you sure you want to delete this collection?");
   });
 
-  $("#delete_collections").click(function () {
+  $("#delete-collections").click(function () {
     var checked = $("ul#cols li :checkbox").filter(":visible").filter(function(index) {
         return $(this).prop('checked');
     });
@@ -61,7 +61,7 @@ $(function () {
     return false;
   });
 
-  $("#delete_selected").click(function () {
+  $("#delete-selected").click(function () {
       var checked = $("ul#submissions li :checkbox").filter(function() {
           return $(this).prop('checked')
       });

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -64,7 +64,7 @@ class JournalistNavigationSteps():
         self.driver.find_elements_by_name('doc_names_selected')[0].click()
 
     def _journalist_clicks_delete_selected_javascript(self):
-        self.driver.find_element_by_id('delete_selected').click()
+        self.driver.find_element_by_id('delete-selected').click()
         self._alert_wait()
 
     def _journalist_verifies_deletion_of_one_submission_javascript(self):
@@ -94,7 +94,7 @@ class JournalistNavigationSteps():
 
     def _admin_visits_admin_interface(self):
         admin_interface_link = self.driver.find_element_by_id(
-            'link_admin_index')
+            'link-admin-index')
         admin_interface_link.click()
 
         h1s = self.driver.find_elements_by_tag_name('h1')
@@ -163,7 +163,7 @@ class JournalistNavigationSteps():
 
     def _logout(self):
         # Click the logout link
-        logout_link = self.driver.find_element_by_id('link_logout')
+        logout_link = self.driver.find_element_by_id('link-logout')
         logout_link.click()
 
         # Logging out should redirect back to the login page
@@ -194,11 +194,11 @@ class JournalistNavigationSteps():
         # The new user was not an admin, so they should not have the admin
         # interface link available
         with pytest.raises(NoSuchElementException):
-            self.driver.find_element_by_id('link_admin_index')
+            self.driver.find_element_by_id('link-admin-index')
 
     def _edit_account(self):
         edit_account_link = self.driver.find_element_by_id(
-            'link_edit_account')
+            'link-edit-account')
         edit_account_link.click()
 
         # The header says "Edit your account"
@@ -214,7 +214,7 @@ class JournalistNavigationSteps():
         # There's no checkbox to change the administrator status of your
         # account.
         with pytest.raises(NoSuchElementException):
-            self.driver.find_element_by_css_selector('#is_admin')
+            self.driver.find_element_by_css_selector('#is-admin')
         # 2FA reset buttons at the bottom point to the user URLs for reset.
         totp_reset_button = self.driver.find_elements_by_css_selector(
             '#reset-two-factor-totp')[0]
@@ -247,7 +247,7 @@ class JournalistNavigationSteps():
         # There's a checkbox to change the administrator status of the user and
         # it's already checked appropriately to reflect the current status of
         # our user.
-        username_field = self.driver.find_element_by_css_selector('#is_admin')
+        username_field = self.driver.find_element_by_css_selector('#is-admin')
         assert (bool(username_field.get_attribute('checked')) ==
                 user.is_admin)
         # 2FA reset buttons at the bottom point to the admin URLs for
@@ -276,7 +276,7 @@ class JournalistNavigationSteps():
 
         # Go to the admin interface
         admin_interface_link = self.driver.find_element_by_id(
-            'link_admin_index')
+            'link-admin-index')
         admin_interface_link.click()
 
         # Click the "edit user" link for the new user
@@ -325,7 +325,7 @@ class JournalistNavigationSteps():
 
         # Go to the admin interface
         admin_interface_link = self.driver.find_element_by_id(
-            'link_admin_index')
+            'link-admin-index')
         admin_interface_link.click()
         # Edit the new user's password
         self._edit_user(self.new_user['username'])

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -165,5 +165,5 @@ class SourceNavigationSteps():
 
     def _source_not_found(self):
         self.driver.get(self.source_location + "/unlikely")
-        message = self.driver.find_element_by_id('page_not_found')
+        message = self.driver.find_element_by_id('page-not-found')
         assert message.is_displayed()

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -426,7 +426,7 @@ class TestIntegration(unittest.TestCase):
 
         # find the delete form and extract the post parameters
         soup = BeautifulSoup(resp.data, 'html.parser')
-        delete_form_inputs = soup.select('form#delete_collection')[0]('input')
+        delete_form_inputs = soup.select('form#delete-collection')[0]('input')
         sid = delete_form_inputs[1]['value']
         col_name = delete_form_inputs[2]['value']
         resp = self.journalist_app.post('/col/delete/' + sid,

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -163,7 +163,7 @@ class TestJournalistApp(TestCase):
                                           password=self.admin_pw,
                                           token='mocked'),
                                 follow_redirects=True)
-        edit_account_link = '<a href="{}" id="link_edit_account">'.format(
+        edit_account_link = '<a href="{}" id="link-edit-account">'.format(
             url_for('edit_account'))
         self.assertIn(edit_account_link, resp.data)
 
@@ -173,7 +173,7 @@ class TestJournalistApp(TestCase):
                                           password=self.user_pw,
                                           token='mocked'),
                                 follow_redirects=True)
-        edit_account_link = '<a href="{}" id="link_edit_account">'.format(
+        edit_account_link = '<a href="{}" id="link-edit-account">'.format(
             url_for('edit_account'))
         self.assertIn(edit_account_link, resp.data)
 
@@ -183,7 +183,7 @@ class TestJournalistApp(TestCase):
                                           password=self.admin_pw,
                                           token='mocked'),
                                 follow_redirects=True)
-        admin_link = '<a href="{}" id="link_admin_index">'.format(
+        admin_link = '<a href="{}" id="link-admin-index">'.format(
             url_for('admin_index'))
         self.assertIn(admin_link, resp.data)
 
@@ -193,7 +193,7 @@ class TestJournalistApp(TestCase):
                                           password=self.user_pw,
                                           token='mocked'),
                                 follow_redirects=True)
-        admin_link = '<a href="{}" id="link_admin_index">'.format(
+        admin_link = '<a href="{}" id="link-admin-index">'.format(
             url_for('admin_index'))
         self.assertNotIn(admin_link, resp.data)
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR closes #1897

Changes proposed in this pull request:
* Adds [html-linter](https://pypi.python.org/pypi/html-linter/) to Travis CI
* Cleans up all our HTML templates so now we pass all linting checks (and thus follow the [Google HTML style guide](https://google.github.io/styleguide/htmlcssguide.html))

Linting errors will result in failed CI builds (019724b) and no linting errors result in passing builds (e5a2762).

### Disabled checks

Note that I disabled three checks. Here I'm going to briefly describe why for posterity. 

####  `optional_tag` 

This is an informational only linting warning about removing unnecessary closing tags. See [here](https://google.github.io/styleguide/htmlcssguide.html#Optional_Tags) for more explanation. I turned this off as it is optional and I personally prefer the more explicit style (for example, this linting check recommends the removal of `</p>` tags). If consensus is that this should be turned on, we can do so, but I recommend in a followup PR, as it would add _significantly_ to the diff.

####  `extra_whitespace`

This check gets confused by the fact we are linting Jinja2 templates, e.g. it reports an error on this line in `securedrop/source_templates/base.html`: 

```
<a href="{% if 'logged_in' in session %}{{ url_for('lookup') }}{% else %}{{ url_for('index') }}{% endif %}">
```

#### `indentation`

This would make some of our Jinja2 templates _less_ readable, e.g. when we have a code block like this:

```
{% if messages %}
  {% for category, message in messages %}
    {% if category != "banner-warning" %}
      <div class="flash {{ category }}">
        {% if category == "notification" %}
        <img src="{{ url_for('static', filename='i/font-awesome/info-circle-black.png') }}" height="16" width="20">
        {% elif category == "success" %}
        <img src="{{ url_for('static', filename='i/success_checkmark.png') }}" height="17" width="20">
        {% elif category == "error" %}
        <img src="{{ url_for('static', filename='i/font-awesome/exclamation-triangle-black.png') }}" height="17" width="20">
        {% endif %}
        {{ message }}
      </div>
    {% endif %}
  {% endfor %}
{% endif %}
```

it will complain about the nesting here. 

Most of the changes in this PR were pretty straightforward, but I know this is a big diff, so let me know if it needs to get split up into multiple PRs. Happy to do so to aid review :smile:

## Testing

Verify that all tests pass and inspect the diff. 

## Deployment

Just changes some of the HTML and functional tests, should introduce no problems in deployment.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
