### PR TITLE
Add Flake8 of testinfra to CI, fix all failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,9 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
-  # Application code flake8 linting
+  # flake8 linting
   - pushd securedrop; flake8 *.py management tests/functional tests/*.py && popd
+  - flake8 testinfra
   # HTML linting
   - >
       html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation

--- a/testinfra/app-code/test_redis_worker.py
+++ b/testinfra/app-code/test_redis_worker.py
@@ -18,27 +18,27 @@ securedrop_test_vars = pytest.securedrop_test_vars
   'environment=HOME="/tmp/python-gnupg"',
 ])
 def test_redis_worker_configuration(File, config_line):
-  """
-  Ensure SecureDrop Redis worker config for supervisor service
-  management is configured correctly.
-  """
-  f = File('/etc/supervisor/conf.d/securedrop_worker.conf')
-  # Config lines may have special characters such as [] which will
-  # throw off the regex matching, so let's escape those chars.
-  regex = re.escape(config_line)
-  assert f.contains('^{}$'.format(regex))
+    """
+    Ensure SecureDrop Redis worker config for supervisor service
+    management is configured correctly.
+    """
+    f = File('/etc/supervisor/conf.d/securedrop_worker.conf')
+    # Config lines may have special characters such as [] which will
+    # throw off the regex matching, so let's escape those chars.
+    regex = re.escape(config_line)
+    assert f.contains('^{}$'.format(regex))
 
 
 def test_redis_worker_config_file(File):
-  """
-  Ensure SecureDrop Redis worker config for supervisor service
-  management has proper ownership and mode.
+    """
+    Ensure SecureDrop Redis worker config for supervisor service
+    management has proper ownership and mode.
 
-  Using separate test so that the parametrization doesn't rerun
-  the file mode checks, which would be useless.
-  """
-  f = File('/etc/supervisor/conf.d/securedrop_worker.conf')
-  assert f.is_file
-  assert oct(f.mode) == '0644'
-  assert f.user == "root"
-  assert f.group == "root"
+    Using separate test so that the parametrization doesn't rerun
+    the file mode checks, which would be useless.
+    """
+    f = File('/etc/supervisor/conf.d/securedrop_worker.conf')
+    assert f.is_file
+    assert oct(f.mode) == '0644'
+    assert f.user == "root"
+    assert f.group == "root"

--- a/testinfra/app-code/test_securedrop_app_code.py
+++ b/testinfra/app-code/test_securedrop_app_code.py
@@ -63,11 +63,13 @@ def test_securedrop_application_test_journalist_key(File, Sudo):
             assert securedrop_config.user == "root"
             assert securedrop_config.group == "root"
         else:
-            assert securedrop_config.user == securedrop_test_vars.securedrop_user
-            assert securedrop_config.group == securedrop_test_vars.securedrop_user
+            assert securedrop_config.user == \
+                securedrop_test_vars.securedrop_user
+            assert securedrop_config.group == \
+                securedrop_test_vars.securedrop_user
         assert oct(securedrop_config.mode) == "0600"
         assert securedrop_config.contains(
-                "^JOURNALIST_KEY = '65A1B5FF195B56353CC63DFFCC40EF1228271441'$")
+            "^JOURNALIST_KEY = '65A1B5FF195B56353CC63DFFCC40EF1228271441'$")
 
 
 def test_securedrop_application_sqlite_db(File, Sudo):

--- a/testinfra/app/apache/test_apache_journalist_interface.py
+++ b/testinfra/app/apache/test_apache_journalist_interface.py
@@ -16,6 +16,7 @@ wanted_apache_headers = [
   'Header unset Etag',
 ]
 
+
 # Test is not DRY; haven't figured out how to parametrize on
 # multiple inputs, so explicitly redeclaring test logic.
 @pytest.mark.parametrize("header", wanted_apache_headers)
@@ -30,6 +31,7 @@ def test_apache_headers_journalist_interface(File, header):
     assert oct(f.mode) == "0644"
     header_regex = "^{}$".format(re.escape(header))
     assert re.search(header_regex, f.content, re.M)
+
 
 # Block of directory declarations for Apache vhost is common
 # to both Source and Journalist interfaces. Hardcoding these values
@@ -75,8 +77,10 @@ common_apache2_directory_declarations = """
 
 # declare journalist-specific apache configs
 @pytest.mark.parametrize("apache_opt", [
-  "<VirtualHost {}:8080>".format(securedrop_test_vars.apache_listening_address),
-  "WSGIDaemonProcess journalist processes=2 threads=30 display-name=%{{GROUP}} python-path={}".format(securedrop_test_vars.securedrop_code),
+  "<VirtualHost {}:8080>".format(
+      securedrop_test_vars.apache_listening_address),
+  "WSGIDaemonProcess journalist processes=2 threads=30 display-name=%{{GROUP}} python-path={}".format(  # noqa
+      securedrop_test_vars.securedrop_code),
   'WSGIProcessGroup journalist',
   'WSGIScriptAlias / /var/www/journalist.wsgi',
   'Header set Cache-Control "no-store"',
@@ -129,8 +133,8 @@ def test_apache_logging_journalist_interface(File, Command, Sudo):
     The actions of Journalists are logged by the system, so that an Admin can
     investigate incidents and track access.
 
-    Logs were broken for some period of time, logging only "combined" to the logfile,
-    rather than the combined LogFormat intended.
+    Logs were broken for some period of time, logging only "combined" to
+    the logfile, rather than the combined LogFormat intended.
     """
     # Sudo is necessary because /var/log/apache2 is mode 0750.
     with Sudo():
@@ -142,7 +146,7 @@ def test_apache_logging_journalist_interface(File, Command, Sudo):
             # validate the log entry.
             Command.check_output("curl http://127.0.0.1:8080")
 
-        assert f.size > 0 # Make sure something was logged.
+        assert f.size > 0  # Make sure something was logged.
         # LogFormat declaration was missing, so track regressions that log
         # just the string "combined" and nothing else.
         assert not f.contains("^combined$")

--- a/testinfra/app/apache/test_apache_service.py
+++ b/testinfra/app/apache/test_apache_service.py
@@ -1,5 +1,4 @@
 import pytest
-import re
 
 
 securedrop_test_vars = pytest.securedrop_test_vars
@@ -65,5 +64,6 @@ def test_apache_listening(Socket, Sudo, port):
     """
     # Sudo is necessary to read from /proc/net/tcp.
     with Sudo():
-        s = Socket("tcp://{}:{}".format(securedrop_test_vars.apache_listening_address, port))
+        s = Socket("tcp://{}:{}".format(
+            securedrop_test_vars.apache_listening_address, port))
         assert s.is_listening

--- a/testinfra/app/apache/test_apache_source_interface.py
+++ b/testinfra/app/apache/test_apache_source_interface.py
@@ -20,8 +20,10 @@ def test_apache_headers_source_interface(File, header):
 
 
 @pytest.mark.parametrize("apache_opt", [
-    "<VirtualHost {}:80>".format(securedrop_test_vars.apache_listening_address),
-    "WSGIDaemonProcess source  processes=2 threads=30 display-name=%{{GROUP}} python-path={}".format(securedrop_test_vars.securedrop_code),
+    "<VirtualHost {}:80>".format(
+        securedrop_test_vars.apache_listening_address),
+    "WSGIDaemonProcess source  processes=2 threads=30 display-name=%{{GROUP}} python-path={}".format(  # noqa
+        securedrop_test_vars.securedrop_code),
     'WSGIProcessGroup source',
     'WSGIScriptAlias / /var/www/source.wsgi',
     'Header set Cache-Control "no-store"',

--- a/testinfra/app/apache/test_apache_system_config.py
+++ b/testinfra/app/apache/test_apache_system_config.py
@@ -4,6 +4,7 @@ import re
 
 securedrop_test_vars = pytest.securedrop_test_vars
 
+
 @pytest.mark.parametrize("package", [
     "apache2-mpm-worker",
     "libapache2-mod-wsgi",
@@ -131,5 +132,6 @@ def test_apache_modules_absent(Command, Sudo, apache_module):
     """
     with Sudo():
         c = Command("/usr/sbin/a2query -m {}".format(apache_module))
-        assert "No module matches {} (disabled".format(apache_module) in c.stderr
+        assert "No module matches {} (disabled".format(apache_module) in \
+            c.stderr
         assert c.rc == 32

--- a/testinfra/app/test_apparmor.py
+++ b/testinfra/app/test_apparmor.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 
 
@@ -10,49 +9,66 @@ def test_apparmor_pkg(Package, pkg):
     """ Apparmor package dependencies """
     assert Package(pkg).is_installed
 
+
 def test_apparmor_enabled(Command, Sudo):
     """ Check that apparmor is enabled """
     with Sudo():
         assert Command("aa-status --enabled").rc == 0
+
 
 apache2_capabilities = [
         'kill',
         'net_bind_service',
         'sys_ptrace'
         ]
+
+
 @pytest.mark.parametrize('cap', apache2_capabilities)
 def test_apparmor_apache_capabilities(Command, cap):
     """ check for exact list of expected app-armor capabilities for apache2 """
-    c = Command("perl -nE \'/^\s+capability\s+(\w+),$/ && say $1\' /etc/apparmor.d/usr.sbin.apache2")
+    c = Command("perl -nE \'/^\s+capability\s+(\w+),$/ && say $1\' "
+                "/etc/apparmor.d/usr.sbin.apache2")
     assert cap in c.stdout
+
 
 def test_apparmor_apache_exact_capabilities(Command):
     """ ensure no extra capabilities are defined for apache2 """
-    c = Command.check_output("grep -ic capability /etc/apparmor.d/usr.sbin.apache2")
+    c = Command.check_output("grep -ic capability "
+                             "/etc/apparmor.d/usr.sbin.apache2")
     assert str(len(apache2_capabilities)) == c
 
+
 tor_capabilities = ['setgid']
+
+
 @pytest.mark.parametrize('cap', tor_capabilities)
 def test_apparmor_tor_capabilities(Command, cap):
     """ check for exact list of expected app-armor capabilities for tor """
-    c = Command("perl -nE \'/^\s+capability\s+(\w+),$/ && say $1\' /etc/apparmor.d/usr.sbin.tor")
+    c = Command("perl -nE \'/^\s+capability\s+(\w+),$/ && "
+                "say $1\' /etc/apparmor.d/usr.sbin.tor")
     assert cap in c.stdout
 
-def test_apparmor_apache_exact_capabilities(Command):
+
+def test_apparmor_tor_exact_capabilities(Command):
     """ ensure no extra capabilities are defined for tor """
-    c = Command.check_output("grep -ic capability /etc/apparmor.d/usr.sbin.tor")
+    c = Command.check_output("grep -ic capability "
+                             "/etc/apparmor.d/usr.sbin.tor")
     assert str(len(tor_capabilities)) == c
+
 
 enforced_profiles = [
         'ntpd',
         'apache2',
         'tcpdump',
         'tor']
+
+
 @pytest.mark.parametrize('profile', enforced_profiles)
 def test_apparmor_ensure_not_disabled(File, Sudo, profile):
-    """ Explicitly check that enforced profiles are NOT in /etc/apparmor.d/disable 
-        Polling aa-status only checks the last config that was loaded, this ensures
-        it wont be disabled on reboot.
+    """ Explicitly check that enforced profiles are NOT in
+        /etc/apparmor.d/disable
+        Polling aa-status only checks the last config that was loaded,
+        this ensures it wont be disabled on reboot.
     """
     f = File("/etc/apparmor.d/disabled/usr.sbin.{}".format(profile))
     with Sudo():
@@ -63,7 +79,8 @@ def test_apparmor_ensure_not_disabled(File, Sudo, profile):
 def test_app_apparmor_complain(Command, Sudo, complain_pkg):
     """ Ensure app-armor profiles are in complain mode for staging """
     with Sudo():
-        awk = "awk '/[0-9]+ profiles.*complain./{flag=1;next}/^[0-9]+.*/{flag=0}flag'"
+        awk = ("awk '/[0-9]+ profiles.*complain."
+               "/{flag=1;next}/^[0-9]+.*/{flag=0}flag'")
         c = Command.check_output("aa-status | {}".format(awk))
         assert complain_pkg in c
 
@@ -74,22 +91,28 @@ def test_app_apparmor_complain_count(Command, Sudo):
         c = Command.check_output("aa-status --complaining")
         assert c == str(len(sdvars.apparmor_complain))
 
+
 @pytest.mark.parametrize('aa_enforced', sdvars.apparmor_enforce)
 def test_apparmor_enforced(Command, Sudo, aa_enforced):
-    awk = "awk '/[0-9]+ profiles.*enforce./{flag=1;next}/^[0-9]+.*/{flag=0}flag'"
+    awk = ("awk '/[0-9]+ profiles.*enforce./"
+           "{flag=1;next}/^[0-9]+.*/{flag=0}flag'")
     with Sudo():
         c = Command.check_output("aa-status | {}".format(awk))
         assert aa_enforced in c
 
+
 def test_apparmor_total_profiles(Command, Sudo):
-    """ ensure number of total profiles is sum of enforced and complaining profiles """
+    """ Ensure number of total profiles is sum of enforced and
+        complaining profiles """
     with Sudo():
-        total_expected = str((len(sdvars.apparmor_enforce) 
-                        + len(sdvars.apparmor_complain)))
+        total_expected = str((len(sdvars.apparmor_enforce)
+                             + len(sdvars.apparmor_complain)))
         assert Command.check_output("aa-status --profiled") == total_expected
 
+
 def test_aastatus_unconfined(Command, Sudo):
-    """ Ensure that there are no processes that are unconfined but have a profile """
+    """ Ensure that there are no processes that are unconfined but have
+        a profile """
     unconfined_chk = "0 processes are unconfined but have a profile defined"
     with Sudo():
         assert unconfined_chk in Command("aa-status").stdout

--- a/testinfra/app/test_appenv.py
+++ b/testinfra/app/test_appenv.py
@@ -1,7 +1,7 @@
 import pytest
-import os
 
 sdvars = pytest.securedrop_test_vars
+
 
 @pytest.mark.parametrize('exp_pip_pkg', sdvars.pip_deps)
 def test_app_pip_deps(PipPackage, exp_pip_pkg):
@@ -21,10 +21,12 @@ def test_app_wsgi(File, Sudo):
         assert f.contains("^import logging$")
         assert f.contains("^logging\.basicConfig(stream=sys\.stderr)$")
 
+
 def test_pidfile(File):
     """ ensure there are no pid files """
     assert not File('/tmp/journalist.pid').exists
     assert not File('/tmp/source.pid').exists
+
 
 @pytest.mark.parametrize('app_dir', sdvars.app_directories)
 def test_app_directories(File, Sudo, app_dir):
@@ -36,15 +38,19 @@ def test_app_directories(File, Sudo, app_dir):
         assert f.group == sdvars.securedrop_user
         assert oct(f.mode) == "0700"
 
+
 def test_app_code_pkg(Package):
     """ ensure securedrop-app-code package is installed """
     assert Package("securedrop-app-code").is_installed
 
+
 def test_gpg_key_in_keyring(Command, Sudo):
     """ ensure test gpg key is present in app keyring """
     with Sudo(sdvars.securedrop_user):
-        c = Command("gpg --homedir /var/lib/securedrop/keys --list-keys 28271441")
-        assert "pub   4096R/28271441 2013-10-12" in c.stdout 
+        c = Command("gpg --homedir /var/lib/securedrop/keys "
+                    "--list-keys 28271441")
+        assert "pub   4096R/28271441 2013-10-12" in c.stdout
+
 
 def test_ensure_logo(File, Sudo):
     """ ensure default logo header file exists """
@@ -54,12 +60,15 @@ def test_ensure_logo(File, Sudo):
         assert f.user == sdvars.securedrop_user
         assert f.group == sdvars.securedrop_user
 
+
 def test_securedrop_tmp_clean_cron(Command, Sudo):
     """ Ensure securedrop tmp clean cron job in place """
     with Sudo():
         cronlist = Command("crontab -l").stdout
-        cronjob = "@daily {}/manage.py clean-tmp".format(sdvars.securedrop_code)
+        cronjob = "@daily {}/manage.py clean-tmp".format(
+            sdvars.securedrop_code)
         assert cronjob in cronlist
+
 
 def test_app_workerlog_dir(File, Sudo):
     """ ensure directory for worker logs is present """

--- a/testinfra/app/test_network.py
+++ b/testinfra/app/test_network.py
@@ -12,21 +12,22 @@ def test_app_iptables_rules(SystemInfo, Command, Sudo):
     # Build a dict of variables to pass to jinja for iptables comparison
     kwargs = dict(
         mon_ip=securedrop_test_vars.mon_ip,
-        default_interface = Command.check_output("ip r | head -n 1 | awk '{ print $5 }'"),
-        tor_user_id = Command.check_output("id -u debian-tor"),
-        securedrop_user_id = Command.check_output("id -u www-data"),
-        ssh_group_gid = Command.check_output("getent group ssh | cut -d: -f3"),
-        dns_server = securedrop_test_vars.dns_server)
+        default_interface=Command.check_output("ip r | head -n 1 | "
+                                               "awk '{ print $5 }'"),
+        tor_user_id=Command.check_output("id -u debian-tor"),
+        securedrop_user_id=Command.check_output("id -u www-data"),
+        ssh_group_gid=Command.check_output("getent group ssh | cut -d: -f3"),
+        dns_server=securedrop_test_vars.dns_server)
 
     # Build iptables scrape cmd, purge comments + counters
     iptables = "iptables-save | sed 's/ \[[0-9]*\:[0-9]*\]//g' | egrep -v '^#'"
     environment = os.environ.get("CI_SD_ENV", "staging")
     iptables_file = "{}/iptables-app-{}.j2".format(
-                                      os.path.dirname(os.path.abspath(__file__)),
-                                      environment)
+                          os.path.dirname(os.path.abspath(__file__)),
+                          environment)
 
     # template out a local iptables jinja file
-    jinja_iptables = Template(open(iptables_file,'r').read())
+    jinja_iptables = Template(open(iptables_file, 'r').read())
     iptables_expected = jinja_iptables.render(**kwargs)
 
     with Sudo():
@@ -35,7 +36,7 @@ def test_app_iptables_rules(SystemInfo, Command, Sudo):
         # print diff comparison (only shows up in pytests if test fails or
         # verbosity turned way up)
         for iptablesdiff in difflib.context_diff(iptables_expected.split('\n'),
-                                             iptables.split('\n')):
+                                                 iptables.split('\n')):
             print(iptablesdiff)
         # Conduct the string comparison of the expected and actual iptables
         # ruleset

--- a/testinfra/app/test_ossec.py
+++ b/testinfra/app/test_ossec.py
@@ -3,19 +3,11 @@ import pytest
 
 sdvars = pytest.securedrop_test_vars
 
-# Currently failing in CI under remote hosts
-# Looks like vagrant is currently appending hostname to local IP
-@pytest.mark.xfail
-def test_hosts_files(File, SystemInfo):
-    """ Ensure host localhost is mapping to servername """
-    f = File('/etc/hosts')
-    assert f.contains('^127.0.0.1\.*mon-{0}$'.format(env))
 
 def test_hosts_files(File, SystemInfo):
     """ Ensure host files mapping are in place """
     f = File('/etc/hosts')
 
-    hostname = SystemInfo.hostname
     mon_ip = sdvars.mon_ip
     mon_host = sdvars.monitor_hostname
 
@@ -24,9 +16,11 @@ def test_hosts_files(File, SystemInfo):
                                                                     mon_ip,
                                                                     mon_host))
 
+
 def test_hosts_duplicate(Command):
     """ Regression test for duplicate entries """
     assert Command.check_output("uniq --repeated /etc/hosts") == ""
+
 
 def test_ossec_agent_installed(Package):
     """ Check that ossec-agent package is present """

--- a/testinfra/build/test_build_dependencies.py
+++ b/testinfra/build/test_build_dependencies.py
@@ -17,7 +17,8 @@ def get_build_directories():
             ossec_version=securedrop_test_vars.ossec_version,
             keyring_version=securedrop_test_vars.keyring_version,
             )
-    build_directories = [d.format(**substitutions) for d in securedrop_test_vars.build_directories]
+    build_directories = [d.format(**substitutions) for d
+                         in securedrop_test_vars.build_directories]
     return build_directories
 
 

--- a/testinfra/build/test_securedrop_deb_package.py
+++ b/testinfra/build/test_securedrop_deb_package.py
@@ -39,11 +39,13 @@ def get_deb_packages():
             keyring_version=securedrop_test_vars.keyring_version,
             )
 
-    deb_packages = [d.format(**substitutions) for d in securedrop_test_vars.build_deb_packages]
+    deb_packages = [d.format(**substitutions) for d
+                    in securedrop_test_vars.build_deb_packages]
     return deb_packages
 
 
 deb_packages = get_deb_packages()
+
 
 @pytest.mark.parametrize("deb", deb_packages)
 def test_build_deb_packages(File, deb):
@@ -78,8 +80,10 @@ def test_deb_packages_appear_installable(File, Command, Sudo, deb):
     # Sudo is required to call `dpkg --install`, even as dry-run.
     with Sudo():
         c = Command("dpkg --install --dry-run {}".format(deb_package.path))
-        assert "Selecting previously unselected package {}".format(package_name) in c.stdout
-        regex = "Preparing to unpack [./]+{} ...".format(re.escape(deb_basename))
+        assert "Selecting previously unselected package {}".format(
+            package_name) in c.stdout
+        regex = "Preparing to unpack [./]+{} ...".format(
+            re.escape(deb_basename))
         assert re.search(regex, c.stdout, re.M)
         assert c.rc == 0
 
@@ -176,17 +180,22 @@ def test_deb_package_contains_no_generated_assets(File, Command, deb):
     if "securedrop-app-code" in deb_package.path:
         c = Command("dpkg-deb --contents {}".format(deb_package.path))
         # static/gen/ directory should exist
-        assert re.search("^.*\./var/www/securedrop/static/gen/$", c.stdout, re.M)
+        assert re.search("^.*\./var/www/securedrop"
+                         "/static/gen/$", c.stdout, re.M)
         # static/gen/ directory should be empty
-        assert not re.search("^.*\./var/www/securedrop/static/gen/.+$", c.stdout, re.M)
+        assert not re.search("^.*\./var/www/securedrop"
+                             "/static/gen/.+$", c.stdout, re.M)
 
         # static/.webassets-cache/ directory should exist
-        assert re.search("^.*\./var/www/securedrop/static/.webassets-cache/$", c.stdout, re.M)
+        assert re.search("^.*\./var/www/securedrop"
+                         "/static/.webassets-cache/$", c.stdout, re.M)
         # static/.webassets-cache/ directory should be empty
-        assert not re.search("^.*\./var/www/securedrop/static/.webassets-cache/.+$", c.stdout, re.M)
+        assert not re.search("^.*\./var/www/securedrop"
+                             "/static/.webassets-cache/.+$", c.stdout, re.M)
 
         # no SASS files should exist; only the generated CSS files.
         assert not re.search("^.*sass.*$", c.stdout, re.M)
+
 
 @pytest.mark.parametrize("deb", deb_packages)
 def test_deb_package_contains_css(File, Command, deb):
@@ -202,5 +211,8 @@ def test_deb_package_contains_css(File, Command, deb):
         c = Command("dpkg-deb --contents {}".format(deb_package.path))
 
         for css_type in ['journalist', 'source']:
-            assert re.search("^.*\./var/www/securedrop/static/css/{}.css$".format(css_type), c.stdout, re.M)
-            assert re.search("^.*\./var/www/securedrop/static/css/{}.css.map$".format(css_type), c.stdout, re.M)
+            assert re.search("^.*\./var/www/securedrop/static/"
+                             "css/{}.css$".format(css_type), c.stdout, re.M)
+            assert re.search("^.*\./var/www/securedrop/static/"
+                             "css/{}.css.map$".format(css_type), c.stdout,
+                             re.M)

--- a/testinfra/common/test_cron_apt.py
+++ b/testinfra/common/test_cron_apt.py
@@ -32,7 +32,6 @@ def test_cron_apt_config(File):
     assert f.contains('^EXITON=error$')
 
 
-
 @pytest.mark.parametrize('repo', [
   'deb http://security.ubuntu.com/ubuntu trusty-security main',
   'deb-src http://security.ubuntu.com/ubuntu trusty-security main',
@@ -54,7 +53,6 @@ def test_cron_apt_repo_list(File, repo):
     assert f.contains(repo_regex)
 
 
-
 def test_cron_apt_repo_config_update(File):
     """
     Ensure cron-apt updates repos from the security.list config.
@@ -65,8 +63,8 @@ def test_cron_apt_repo_config_update(File):
     assert f.user == "root"
     assert oct(f.mode) == "0644"
     repo_config = str('update -o quiet=2'
-                     ' -o Dir::Etc::SourceList=/etc/apt/security.list'
-                     ' -o Dir::Etc::SourceParts=""')
+                      ' -o Dir::Etc::SourceList=/etc/apt/security.list'
+                      ' -o Dir::Etc::SourceParts=""')
     assert f.contains('^{}$'.format(repo_config))
 
 
@@ -80,9 +78,9 @@ def test_cron_apt_repo_config_upgrade(File):
     assert oct(f.mode) == "0644"
     assert f.contains('^autoclean -y$')
     repo_config = str('dist-upgrade -y -o APT::Get::Show-Upgraded=true'
-                       ' -o Dir::Etc::SourceList=/etc/apt/security.list'
-                       ' -o Dpkg::Options::=--force-confdef'
-                       ' -o Dpkg::Options::=--force-confold')
+                      ' -o Dir::Etc::SourceList=/etc/apt/security.list'
+                      ' -o Dpkg::Options::=--force-confdef'
+                      ' -o Dpkg::Options::=--force-confold')
     assert f.contains(re.escape(repo_config))
 
 
@@ -95,15 +93,12 @@ def test_cron_apt_config_deprecated(File):
 
 
 @pytest.mark.parametrize('cron_job', [
-    { 'job': '0 4 * * * root    /usr/bin/test -x /usr/sbin/cron-apt && /usr/sbin/cron-apt && /sbin/reboot',
-      'state': 'present',
-    },
-    { 'job': '0 4 * * * root    /usr/bin/test -x /usr/sbin/cron-apt && /usr/sbin/cron-apt',
-      'state': 'absent',
-    },
-    { 'job': '0 5 * * * root    /sbin/reboot',
-      'state': 'absent',
-    },
+    {'job': '0 4 * * * root    /usr/bin/test -x /usr/sbin/cron-apt && /usr/sbin/cron-apt && /sbin/reboot', # noqa
+     'state': 'present'},
+    {'job': '0 4 * * * root    /usr/bin/test -x /usr/sbin/cron-apt && /usr/sbin/cron-apt', # noqa
+     'state': 'absent'},
+    {'job': '0 5 * * * root    /sbin/reboot',
+     'state': 'absent'},
 ])
 def test_cron_apt_cron_jobs(File, cron_job):
     """
@@ -136,5 +131,6 @@ def test_cron_apt_all_packages_updated(Command):
     assert c.rc == 0
     # Staging hosts will have locally built deb packages, marked as held.
     # Staging and development will have a version-locked Firefox pinned for
-    # Selenium compatibility; if the holds are working, they shouldn't be upgraded.
+    # Selenium compatibility; if the holds are working, they shouldn't be
+    # upgraded.
     assert "No packages will be installed, upgraded, or removed." in c.stdout

--- a/testinfra/common/test_fpf_apt_repo.py
+++ b/testinfra/common/test_fpf_apt_repo.py
@@ -13,17 +13,17 @@ def test_fpf_apt_repo_present(File):
     is tested separately.
     """
     f = File('/etc/apt/sources.list.d/apt_freedom_press.list')
-    assert f.contains('^deb \[arch=amd64\] https:\/\/apt\.freedom\.press trusty main$')
+    assert f.contains('^deb \[arch=amd64\] https:\/\/apt\.freedom\.press '
+                      'trusty main$')
 
 
 def test_fpf_apt_repo_fingerprint(Command):
     """
     Ensure the FPF apt repo has the correct fingerprint on the associated
-    signing pubkey. The key changed in October 2016, so test for the 
-    newest fingerprint, which is installed on systems via the 
+    signing pubkey. The key changed in October 2016, so test for the
+    newest fingerprint, which is installed on systems via the
     `securedrop-keyring` package.
     """
-
 
     c = Command('apt-key finger')
 
@@ -36,7 +36,8 @@ uid                  SecureDrop Release Signing Key"""
     assert c.rc == 0
     assert fpf_gpg_pub_key_info in c.stdout
 
-    fpf_gpg_pub_key_fingerprint_expired = 'B89A 29DB 2128 160B 8E4B  1B4C BADD E0C7 FC9F 6818'
+    fpf_gpg_pub_key_fingerprint_expired = ('B89A 29DB 2128 160B 8E4B  '
+                                           '1B4C BADD E0C7 FC9F 6818')
     fpf_gpg_pub_key_info_expired = """pub   4096R/FC9F6818 2014-10-26 [expired: 2016-10-27]
       Key fingerprint = #{fpf_gpg_pub_key_fingerprint_expired}
 uid                  Freedom of the Press Foundation Master Signing Key"""

--- a/testinfra/common/test_grsecurity.py
+++ b/testinfra/common/test_grsecurity.py
@@ -13,7 +13,7 @@ def test_ssh_motd_disabled(File):
     assert not f.contains("pam\.motd")
 
 
-@pytest.mark.skipif(os.environ.get('FPF_GRSEC','true') == "false",
+@pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",
                     reason="Need to skip in environment w/o grsec")
 @pytest.mark.parametrize("package", [
     'paxctl',
@@ -28,7 +28,7 @@ def test_grsecurity_apt_packages(Package, package):
     assert Package(package).is_installed
 
 
-@pytest.mark.skipif(os.environ.get('FPF_GRSEC','true') == "false",
+@pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",
                     reason="Need to skip in environment w/o grsec")
 @pytest.mark.parametrize("package", [
     'linux-signed-image-generic-lts-utopic',
@@ -42,7 +42,7 @@ def test_generic_kernels_absent(Command, package):
     """
     Ensure the default Ubuntu-provided kernel packages are absent.
     In the past, conflicting version numbers have caused machines
-    to reboot into a non-grsec kernel due to poor handling of 
+    to reboot into a non-grsec kernel due to poor handling of
     GRUB_DEFAULT logic. Removing the vendor-provided kernel packages
     prevents accidental boots into non-grsec kernels.
     """
@@ -55,7 +55,7 @@ def test_generic_kernels_absent(Command, package):
     assert c.stderr == error_text
 
 
-@pytest.mark.skipif(os.environ.get('FPF_GRSEC','true') == "false",
+@pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",
                     reason="Need to skip in environment w/o grsec")
 def test_grsecurity_lock_file(File):
     """
@@ -68,7 +68,7 @@ def test_grsecurity_lock_file(File):
     assert f.size == 0
 
 
-@pytest.mark.skipif(os.environ.get('FPF_GRSEC','true') == "false",
+@pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",
                     reason="Need to skip in environment w/o grsec")
 def test_grsecurity_kernel_is_running(Command):
     """
@@ -79,7 +79,7 @@ def test_grsecurity_kernel_is_running(Command):
     assert c.stdout == '3.14.79-grsec'
 
 
-@pytest.mark.skipif(os.environ.get('FPF_GRSEC','true') == "false",
+@pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",
                     reason="Need to skip in environment w/o grsec")
 @pytest.mark.parametrize('sysctl_opt', [
   ('kernel.grsecurity.grsec_lock', 1),
@@ -94,7 +94,8 @@ def test_grsecurity_sysctl_options(Sysctl, Sudo, sysctl_opt):
     with Sudo():
         assert Sysctl(sysctl_opt[0]) == sysctl_opt[1]
 
-@pytest.mark.skipif(os.environ.get('FPF_GRSEC','true') == "false",
+
+@pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",
                     reason="Need to skip in environment w/o grsec")
 @pytest.mark.parametrize('paxtest_check', [
   "Executable anonymous mapping",
@@ -127,10 +128,10 @@ def test_grsecurity_paxtest(Command, Sudo, paxtest_check):
             assert c.rc == 0
             assert "Vulnerable" not in c.stdout
             regex = "^{}\s*:\sKilled$".format(re.escape(paxtest_check))
+            assert re.search(regex, c.stdout)
 
 
-
-@pytest.mark.skipif(os.environ.get('FPF_CI','false') == "true",
+@pytest.mark.skipif(os.environ.get('FPF_CI', 'false') == "true",
                     reason="Not needed in CI environment")
 def test_grub_pc_marked_manual(Command):
     """
@@ -151,7 +152,7 @@ def test_apt_autoremove(Command):
     assert "The following packages will be REMOVED" not in c.stdout
 
 
-@pytest.mark.skipif(os.environ.get('FPF_GRSEC','true') == "false",
+@pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",
                     reason="Need to skip in environment w/o grsec")
 @pytest.mark.parametrize("binary", [
     "/usr/sbin/grub-probe",

--- a/testinfra/common/test_platform.py
+++ b/testinfra/common/test_platform.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_ansible_version(host):
     """
     Check that a supported version of Ansible is being used.
@@ -12,6 +9,7 @@ def test_ansible_version(host):
     localhost = host.get_host("local://")
     c = localhost.check_output("ansible --version")
     assert c.startswith("ansible 2.")
+
 
 def test_platform(SystemInfo):
     """

--- a/testinfra/common/test_system_hardening.py
+++ b/testinfra/common/test_system_hardening.py
@@ -64,7 +64,7 @@ def test_blacklisted_kernel_modules(Command, File, Sudo, kernel_module):
 
 
 @pytest.mark.skipif(hostenv.startswith('mon'),
-        reason="Monitor Server does not have swap disabled yet.")
+                    reason="Monitor Server does not have swap disabled yet.")
 def test_swap_disabled(Command):
     """
     Ensure swap space is disabled. Prohibit writing memory to swapfiles

--- a/testinfra/common/test_tor_config.py
+++ b/testinfra/common/test_tor_config.py
@@ -3,13 +3,15 @@ import re
 
 sdvars = pytest.securedrop_test_vars
 
+
 def test_tor_apt_repo(File):
     """
     Ensure the Tor Project apt repository is configured.
     The version of Tor in the Trusty repos is not up to date.
     """
     f = File('/etc/apt/sources.list.d/deb_torproject_org_torproject_org.list')
-    repo_regex = re.escape('deb http://deb.torproject.org/torproject.org trusty main')
+    repo_regex = re.escape('deb http://deb.torproject.org/torproject.org '
+                           'trusty main')
     assert f.contains(repo_regex)
 
 
@@ -36,7 +38,8 @@ def test_tor_service_running(Command, File, Sudo):
     # script, so let's just shell out and verify the running and enabled
     # states explicitly.
     with Sudo():
-        assert Command.check_output("service tor status") == " * tor is running"
+        assert Command.check_output("service tor status") == \
+               " * tor is running"
         tor_enabled = Command.check_output("find /etc/rc?.d -name S??tor")
 
     assert tor_enabled != ""

--- a/testinfra/common/test_tor_hidden_services.py
+++ b/testinfra/common/test_tor_hidden_services.py
@@ -32,7 +32,8 @@ def test_tor_service_hostnames(File, Sudo, tor_service):
     ths_hostname_regex = "[a-z0-9]{16}\.onion"
 
     with Sudo():
-        f = File("/var/lib/tor/services/{}/hostname".format(tor_service['name']))
+        f = File("/var/lib/tor/services/{}/hostname".format(
+            tor_service['name']))
         assert f.is_file
         assert oct(f.mode) == "0600"
         assert f.user == "debian-tor"
@@ -43,8 +44,10 @@ def test_tor_service_hostnames(File, Sudo, tor_service):
 
         if tor_service['authenticated']:
             # HidServAuth regex is approximately [a-zA-Z0-9/+], but validating
-            # the entire entry is sane, and we don't need to nitpick the charset.
-            aths_hostname_regex = ths_hostname_regex+" .{22} # client: "+tor_service['client']
+            # the entire entry is sane, and we don't need to nitpick the
+            # charset.
+            aths_hostname_regex = ths_hostname_regex + " .{22} # client: " + \
+                                  tor_service['client']
             assert re.search("^{}$".format(aths_hostname_regex), f.content)
         else:
             assert re.search("^{}$".format(ths_hostname_regex), f.content)
@@ -67,7 +70,7 @@ def test_tor_services_config(File, tor_service):
     """
     f = File("/etc/tor/torrc")
     dir_regex = "HiddenServiceDir /var/lib/tor/services/{}".format(
-                                                            tor_service['name'])
+        tor_service['name'])
     # We need at least one port, but it may be used for both config values.
     # On the Journalist Interface, we reuse the "80" remote port but map it to
     # a different local port, so Apache can listen on several sockets.

--- a/testinfra/common/test_user_config.py
+++ b/testinfra/common/test_user_config.py
@@ -27,8 +27,11 @@ def test_sudoers_config(File, Sudo):
     assert re.search('^Defaults\s+env_reset$', sudoers_config, re.M)
     assert re.search('^Defaults\s+env_reset$', sudoers_config, re.M)
     assert re.search('^Defaults\s+mail_badpass$', sudoers_config, re.M)
-    assert re.search('Defaults\s+secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"', sudoers_config, re.M)
-    assert re.search('^%sudo\s+ALL=\(ALL\)\s+NOPASSWD:\s+ALL$', sudoers_config, re.M)
+    assert re.search('Defaults\s+secure_path="/usr/local/sbin:'
+                     '/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"',
+                     sudoers_config, re.M)
+    assert re.search('^%sudo\s+ALL=\(ALL\)\s+NOPASSWD:\s+ALL$',
+                     sudoers_config, re.M)
     assert re.search('Defaults:%sudo\s+!requiretty', sudoers_config, re.M)
 
 
@@ -42,7 +45,8 @@ def test_sudoers_tmux_env(File):
 
     f = File('/etc/profile.d/securedrop_additions.sh')
     non_interactive_str = re.escape('[[ $- != *i* ]] && return')
-    tmux_check = re.escape('test -z "$TMUX" && (tmux attach || tmux new-session)')
+    tmux_check = re.escape('test -z "$TMUX" && (tmux attach ||'
+                           ' tmux new-session)')
 
     assert f.contains("^{}$".format(non_interactive_str))
     assert f.contains("^if which tmux >\/dev\/null 2>&1; then$")
@@ -55,15 +59,15 @@ def test_tmux_installed(Package):
     """
     Ensure the `tmux` package is present, since it's required for the user env.
     When running an interactive SSH session over Tor, tmux should be started
-    automatically, to prevent problems if the connection is broken unexpectedly,
-    as sometimes happens over Tor. The Admin will be able to reconnect to the
-    running tmux session and review command output.
+    automatically, to prevent problems if the connection is broken
+    unexpectedly, as sometimes happens over Tor. The Admin will be able to
+    reconnect to the running tmux session and review command output.
     """
     assert Package("tmux").is_installed
 
 
 @pytest.mark.skipif(hostenv == 'travis',
-            reason="Bashrc tests dont make sense on Travis")
+                    reason="Bashrc tests dont make sense on Travis")
 def test_sudoers_tmux_env_deprecated(File):
     """
     Previous version of the Ansible config set the tmux config

--- a/testinfra/conftest.py
+++ b/testinfra/conftest.py
@@ -7,9 +7,7 @@ Vars should be placed in `testinfra/vars/<hostname>.yml`.
 """
 
 import os
-import sys
 import yaml
-import pytest
 
 
 target_host = os.environ['SECUREDROP_TESTINFRA_TARGET_HOST']

--- a/testinfra/development/test_development_application_settings.py
+++ b/testinfra/development/test_development_application_settings.py
@@ -5,6 +5,7 @@ hostenv = os.environ['SECUREDROP_TESTINFRA_TARGET_HOST']
 
 sd_test_vars = pytest.securedrop_test_vars
 
+
 @pytest.mark.parametrize('package', [
     "securedrop-app-code",
     "apache2-mpm-worker",
@@ -23,7 +24,8 @@ def test_development_lacks_deb_packages(Command, package):
     assert c.rc == 1
     assert c.stdout == ""
     stderr = c.stderr.rstrip()
-    assert stderr == "dpkg-query: no packages found matching {}".format(package)
+    assert stderr == "dpkg-query: no packages found matching {}".format(
+        package)
 
 
 def test_development_apparmor_no_complain_mode(Command, Sudo):
@@ -106,8 +108,10 @@ def test_development_clean_tmp_cron_job(Command, Sudo):
 
     with Sudo():
         c = Command.check_output('crontab -l')
-    assert "@daily {}/manage.py clean-tmp".format(sd_test_vars.securedrop_code) in c
-    assert "@daily {}/manage.py clean_tmp".format(sd_test_vars.securedrop_code) not in c
+    assert "@daily {}/manage.py clean-tmp".format(
+        sd_test_vars.securedrop_code) in c
+    assert "@daily {}/manage.py clean_tmp".format(
+        sd_test_vars.securedrop_code) not in c
     assert "clean_tmp".format(sd_test_vars.securedrop_code) not in c
     # Make sure that the only cron lines are a comment and the actual job.
     # We don't want any duplicates.

--- a/testinfra/development/test_development_environment.py
+++ b/testinfra/development/test_development_environment.py
@@ -1,6 +1,6 @@
 import pytest
-import os
 import getpass
+
 
 def test_development_app_dependencies(Package):
     """
@@ -50,7 +50,7 @@ def test_development_pip_dependencies(Command, pip_package, version):
 
 
 @pytest.mark.skipif(getpass.getuser() != 'vagrant',
-            reason="vagrant bashrc checks dont make sense in CI")
+                    reason="vagrant bashrc checks dont make sense in CI")
 def test_development_securedrop_env_var(File):
     """
     Ensure that the SECUREDROP_ENV var is set to "dev".

--- a/testinfra/development/test_development_networking.py
+++ b/testinfra/development/test_development_networking.py
@@ -3,6 +3,7 @@ import os
 
 hostenv = os.environ['SECUREDROP_TESTINFRA_TARGET_HOST']
 
+
 @pytest.mark.skipif(hostenv == 'travis',
                     reason="Custom networking in Travis")
 def test_development_iptables_rules(Command, Sudo):
@@ -50,12 +51,12 @@ def test_development_redis_worker(Socket):
 # aren't configured to run by default, e.g. on boot. Nor
 # do the app tests cause them to be run. So, we shouldn't
 # really expected them to be running.
-## check for source interface flask port listening
-#describe port(8080) do
+# check for source interface flask port listening
+# describe port(8080) do
 #  it { should be_listening.on('0.0.0.0').with('tcp') }
-#end
+# end
 #
-## check for journalist interface flask port listening
-#describe port(8081) do
+# check for journalist interface flask port listening
+# describe port(8081) do
 #  it { should be_listening.on('0.0.0.0').with('tcp') }
-#end
+# end

--- a/testinfra/development/test_xvfb.py
+++ b/testinfra/development/test_xvfb.py
@@ -55,7 +55,7 @@ case "$1" in
 esac
 
 exit 0
-""".lstrip().rstrip()
+""".lstrip().rstrip()  # noqa
     with Sudo():
         assert f.contains('^XVFB=/usr/bin/Xvfb$')
         assert f.contains('^XVFBARGS=":1 -screen 0 1024x768x24 '
@@ -106,7 +106,7 @@ def test_xvfb_service_running(Process, Sudo):
     with Sudo():
         p = Process.get(user="root", comm="Xvfb")
         wanted_args = str('/usr/bin/Xvfb :1 -screen 0 1024x768x24 '
-                      '-ac +extension GLX +render -noreset')
+                          '-ac +extension GLX +render -noreset')
         assert p.args == wanted_args
         # We only expect a single process, no children.
         workers = Process.filter(ppid=p.pid)

--- a/testinfra/functional/test_tor_interfaces.py
+++ b/testinfra/functional/test_tor_interfaces.py
@@ -4,6 +4,7 @@ import pytest
 
 sdvars = pytest.securedrop_test_vars
 
+
 @pytest.mark.parametrize('site', sdvars.tor_url_files)
 @pytest.mark.skipif(os.environ.get('FPF_CI', 'false') == "false",
                     reason="Can only assure Tor is configured in CI atm")
@@ -13,13 +14,16 @@ def test_www(Command, site):
     """
 
     # Extract Onion URL from saved onion file, fetched back from app-staging.
-    onion_url_filepath = os.path.join(os.path.dirname(__file__),
-                                      "../../install_files/ansible-base/{}".format(site['file']))
-    onion_url_raw = open(onion_url_filepath,'ro').read()
+    onion_url_filepath = os.path.join(
+        os.path.dirname(__file__),
+        "../../install_files/ansible-base/{}".format(site['file'])
+    )
+    onion_url_raw = open(onion_url_filepath, 'ro').read()
     onion_url = re.search("\w+\.onion", onion_url_raw).group()
 
     # Fetch Onion URL via curl to confirm interface is rendered correctly.
-    curl_tor = 'curl -s --socks5-hostname "${{TOR_PROXY}}":9050 {}'.format(onion_url)
+    curl_tor = 'curl -s --socks5-hostname "${{TOR_PROXY}}":9050 {}'.format(
+        onion_url)
     curl_tor_status = '{} -o /dev/null -w "%{{http_code}}"'.format(curl_tor)
 
     site_scrape = Command.check_output(curl_tor)

--- a/testinfra/mon/test_network.py
+++ b/testinfra/mon/test_network.py
@@ -13,21 +13,22 @@ def test_mon_iptables_rules(SystemInfo, Command, Sudo):
     # Build a dict of variables to pass to jinja for iptables comparison
     kwargs = dict(
         app_ip=app_ip,
-        default_interface = Command.check_output("ip r | head -n 1 | awk '{ print $5 }'"),
-        tor_user_id = Command.check_output("id -u debian-tor"),
-        ssh_group_gid = Command.check_output("getent group ssh | cut -d: -f3"),
-        postfix_user_id = Command.check_output("id -u postfix"),
-        dns_server = securedrop_test_vars.dns_server)
+        default_interface=Command.check_output(
+            "ip r | head -n 1 | awk '{ print $5 }'"),
+        tor_user_id=Command.check_output("id -u debian-tor"),
+        ssh_group_gid=Command.check_output("getent group ssh | cut -d: -f3"),
+        postfix_user_id=Command.check_output("id -u postfix"),
+        dns_server=securedrop_test_vars.dns_server)
 
     # Build iptables scrape cmd, purge comments + counters
     iptables = "iptables-save | sed 's/ \[[0-9]*\:[0-9]*\]//g' | egrep -v '^#'"
     environment = os.environ.get("CI_SD_ENV", "staging")
     iptables_file = "{}/iptables-mon-{}.j2".format(
-                                      os.path.dirname(os.path.abspath(__file__)),
-                                      environment)
+        os.path.dirname(os.path.abspath(__file__)),
+        environment)
 
     # template out a local iptables jinja file
-    jinja_iptables = Template(open(iptables_file,'r').read())
+    jinja_iptables = Template(open(iptables_file, 'r').read())
     iptables_expected = jinja_iptables.render(**kwargs)
 
     with Sudo():
@@ -36,7 +37,7 @@ def test_mon_iptables_rules(SystemInfo, Command, Sudo):
         # print diff comparison (only shows up in pytests if test fails or
         # verbosity turned way up)
         for iptablesdiff in difflib.context_diff(iptables_expected.split('\n'),
-                                             iptables.split('\n')):
+                                                 iptables.split('\n')):
             print(iptablesdiff)
         # Conduct the string comparison of the expected and actual iptables
         # ruleset

--- a/testinfra/mon/test_ossec.py
+++ b/testinfra/mon/test_ossec.py
@@ -4,6 +4,7 @@ import pytest
 
 securedrop_test_vars = pytest.securedrop_test_vars
 
+
 @pytest.mark.parametrize('package', [
     'mailutils',
     'ossec-server',
@@ -87,16 +88,18 @@ def test_ossec_connectivity(Command, Sudo):
     The ossec service will report all available agents, and we can inspect
     that list to make sure it's the host we expect.
     """
-    desired_output = "{}-{} is available.".format(securedrop_test_vars.app_hostname,
-            securedrop_test_vars.app_ip)
+    desired_output = "{}-{} is available.".format(
+        securedrop_test_vars.app_hostname,
+        securedrop_test_vars.app_ip)
     with Sudo():
         c = Command.check_output("/var/ossec/bin/list_agents -a")
         assert c == desired_output
 
-def test_ossec_gnupg(File, Sudo):
+
+def test_ossec_gnupg_homedir(File, Sudo):
     """ ensure ossec gpg homedir exists """
     with Sudo():
-        f = File(OSSEC_GNUPG)
+        f = File("/var/ossec/.gnupg")
         assert f.is_directory
         assert f.user == "ossec"
         assert oct(f.mode) == "0700"
@@ -123,10 +126,11 @@ def test_ossec_pubkey_in_keyring(Command, Sudo):
     """
     ossec_gpg_pubkey_info = """pub   4096R/EDDDC102 2014-10-15
 uid                  Test/Development (DO NOT USE IN PRODUCTION) (Admin's OSSEC Alert GPG key) <securedrop@freedom.press>
-sub   4096R/97D2EB39 2014-10-15"""
+sub   4096R/97D2EB39 2014-10-15"""  # noqa
     with Sudo("ossec"):
-        c = Command.check_output("gpg --homedir /var/ossec/.gnupg --list-keys EDDDC102")
-        assert c ==  ossec_gpg_pubkey_info
+        c = Command.check_output("gpg --homedir /var/ossec/.gnupg "
+                                 "--list-keys EDDDC102")
+        assert c == ossec_gpg_pubkey_info
 
 
 # Permissions don't match between Ansible and OSSEC deb packages postinst.
@@ -146,8 +150,8 @@ def test_ossec_keyfiles(File, Sudo, keyfile):
     with Sudo():
         f = File(keyfile)
         assert f.is_file
-        # The postinst scripts in the OSSEC deb packages set 440 on the keyfiles;
-        # the Ansible config should be updated to do the same.
+        # The postinst scripts in the OSSEC deb packages set 440 on the
+        # keyfiles; the Ansible config should be updated to do the same.
         assert oct(f.mode) == "0440"
         assert f.user == "root"
         assert f.group == "ossec"
@@ -209,20 +213,11 @@ def test_ossec_authd(Command, Sudo):
         assert c.stdout == ""
         assert c.rc != 0
 
-# Currently failing in CI under remote hosts
-# Looks like vagrant is currently appending hostname to local IP
-@pytest.mark.xfail
-def test_hosts_files(File, SystemInfo):
-    """ Ensure host localhost is mapping to servername """
-    f = File('/etc/hosts')
-    mon_host = securedrop_test_vars.monitor_hostname
-    assert f.contains('^127.0.0.1.*{0}$'.format(mon_host))
 
 def test_hosts_files(File, SystemInfo):
     """ Ensure host files mapping are in place """
     f = File('/etc/hosts')
 
-    hostname = SystemInfo.hostname
     app_ip = securedrop_test_vars.app_ip
     app_host = securedrop_test_vars.app_hostname
 

--- a/testinfra/test.py
+++ b/testinfra/test.py
@@ -64,10 +64,12 @@ def run_testinfra(target_host, verbose=True):
     if target_host.endswith("-prod"):
         os.environ['SECUREDROP_SSH_OVER_TOR'] = '1'
         # Dump SSH config to tempfile so it can be passed as arg to testinfra.
-        ssh_config_output = subprocess.check_output(["vagrant", "ssh-config", target_host])
-        # Create temporary file to store ssh-config. Not deleting it automatically
-        # because there's no sensitive info (HidServAuth is required to connect),
-        # and we'll need it outside of the context-manager block that writes to it.
+        ssh_config_output = subprocess.check_output(["vagrant", "ssh-config",
+                                                     target_host])
+        # Create temporary file to store ssh-config. Not deleting it
+        # automatically because there's no sensitive info (HidServAuth is
+        # required to connect), and we'll need it outside of the
+        # context-manager block that writes to it.
         ssh_config_tmpfile = tempfile.NamedTemporaryFile(delete=False)
         with ssh_config_tmpfile.file as f:
             f.write(ssh_config_output)
@@ -84,7 +86,7 @@ testinfra \
 """.lstrip().rstrip()
 
     elif os.environ.get("FPF_CI", 'false') == 'true':
-        if os.environ.get("CI_SD_ENV","development") == "development":
+        if os.environ.get("CI_SD_ENV", "development") == "development":
             os.environ['SECUREDROP_TESTINFRA_TARGET_HOST'] = "travis"
             ssh_config_path = ""
             testinfra_command_template = "testinfra -vv {target_roles}"
@@ -129,6 +131,7 @@ testinfra \
 
     # Execute config tests.
     subprocess.check_call(testinfra_command)
+
 
 if __name__ == "__main__":
     run_testinfra(target_host)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
* These are the minimal changes to `flake8` the `testinfra` system configuration tests
* Add `flake8 testinfra` to Travis CI

## Testing

Where the changes were not obvious, I added an explanation in the commit message, so check out in particular any commit with a message longer than one line. 

Travis CI will sufficiently test these changes in the development VM - however - to review the changes in the staging environment you _will_ need to provision staging locally. CI is not sufficient here because I made changes to the grsecurity tests here that _don't_ run on Circle CI (e.g. there is an additional assert for each paxtest check)

## Deployment

This PR makes changes to tests only, so no deployment concerns.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass in the development VM
- [x] Configuration tests pass in the local staging VM
