### PR TITLE
Set capability `dac_override` for Apache AppArmor

### DIFF
--- a/install_files/ansible-base/usr.sbin.apache2
+++ b/install_files/ansible-base/usr.sbin.apache2
@@ -5,6 +5,7 @@
   #include <abstractions/base>
   #include <abstractions/tor>
 
+  capability dac_override,
   capability kill,
   capability net_bind_service,
   capability sys_ptrace,

--- a/testinfra/app/test_apparmor.py
+++ b/testinfra/app/test_apparmor.py
@@ -16,6 +16,7 @@ def test_apparmor_enabled(Command, Sudo):
         assert Command("aa-status --enabled").rc == 0
 
 apache2_capabilities = [
+        'dac_override',
         'kill',
         'net_bind_service',
         'sys_ptrace'


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

We were previously relying on the tor apparmor abstractions to provide `capability dac_override`. When the tor package removed the capability in favor of `dac_read_search`, the apache service started
failing due to overconfinement. Editing the AppArmor profile for Apache such that the dac_override capability is now explicitly, rather than implicitly, included.

Fixes #2105.

## Testing
Confirm both clean installs on staging and upgrades from 0.4.1 restore functionality for the web applications (both Source and Journalist Interfaces).

## Deployment
Hotfix release to handle breaking changes from upstream tor package. Discussion of reducing exposure to this form of breakage is in #2106.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
