### PR TITLE
manage: clean-tmp removes old files to avoid races

### DIFF
--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -8,6 +8,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import time
 import traceback
 import version
 
@@ -231,14 +232,21 @@ def delete_user(args):  # pragma: no cover
 
 def clean_tmp(args):  # pragma: no cover
     """Cleanup the SecureDrop temp directory. """
-    try:
-        os.stat(config.TEMP_DIR)
-    except OSError:
-        pass
-    else:
-        for path in listdir_fullpath(config.TEMP_DIR):
-            if not file_in_use(path):
-                os.remove(path)
+    if not os.path.exists(args.directory):
+        log.debug('{} does not exist, do nothing'.format(args.directory))
+        return 0
+
+    def listdir_fullpath(d):
+        return [os.path.join(d, f) for f in os.listdir(d)]
+
+    too_old = args.days * 24 * 60 * 60
+    for path in listdir_fullpath(args.directory):
+        if time.time() - os.stat(path).st_mtime > too_old:
+            os.remove(path)
+            log.debug('{} removed'.format(path))
+        else:
+            log.debug('{} modified less than {} days ago'.format(
+                path, args.days))
 
     return 0
 
@@ -322,11 +330,8 @@ def get_args():
                                   "SecureDrop application's state.")
     reset_subp.set_defaults(func=reset)
     # Cleanup the SD temp dir
-    clean_tmp_subp = subps.add_parser('clean-tmp', help='Cleanup the '
-                                      'SecureDrop temp directory.')
-    clean_tmp_subp.set_defaults(func=clean_tmp)
-    clean_tmp_subp_a = subps.add_parser('clean_tmp', help='^')
-    clean_tmp_subp_a.set_defaults(func=clean_tmp)
+    set_clean_tmp_parser(subps, 'clean-tmp')
+    set_clean_tmp_parser(subps, 'clean_tmp')
 
     set_translate_parser(subps)
 
@@ -369,6 +374,24 @@ def set_translate_parser(subps):
         help='Source file or directory to extract (default {})'.format(
             sources))
     parser.set_defaults(func=translate)
+
+
+def set_clean_tmp_parser(subps, name):
+    parser = subps.add_parser(name, help='Cleanup the '
+                              'SecureDrop temp directory.')
+    default_days = 7
+    parser.add_argument(
+        '--days',
+        default=default_days,
+        type=int,
+        help=('remove files not modified in a given number of DAYS '
+              '(default {} days)'.format(default_days)))
+    parser.add_argument(
+        '--directory',
+        default=config.TEMP_DIR,
+        help=('remove old files from DIRECTORY '
+              '(default {})'.format(config.TEMP_DIR)))
+    parser.set_defaults(func=clean_tmp)
 
 
 def setup_verbosity(args):

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -11,7 +11,6 @@ import sys
 import traceback
 import version
 
-import psutil
 import qrcode
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -231,31 +230,7 @@ def delete_user(args):  # pragma: no cover
 
 
 def clean_tmp(args):  # pragma: no cover
-    """Cleanup the SecureDrop temp directory. This is intended to be run
-    as an automated cron job. We skip files that are currently in use to
-    avoid deleting files that are currently being downloaded."""
-    # Inspired by http://stackoverflow.com/a/11115521/1093000
-    def file_in_use(fname):
-        for proc in psutil.process_iter():
-            try:
-                open_files = proc.open_files()
-                in_use = False or any([open_file.path == fname
-                                       for open_file in open_files])
-                # Early return for perf
-                if in_use:
-                    break
-            except psutil.NoSuchProcess:
-                # This catches a race condition where a process ends before we
-                # can examine its files. Ignore this - if the process ended, it
-                # can't be using fname, so this won't cause an error.
-                pass
-
-        return in_use
-
-    def listdir_fullpath(d):
-        # Thanks to http://stackoverflow.com/a/120948/1093000
-        return [os.path.join(d, f) for f in os.listdir(d)]
-
+    """Cleanup the SecureDrop temp directory. """
     try:
         os.stat(config.TEMP_DIR)
     except OSError:

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -197,6 +197,35 @@ class TestManage(object):
         assert 'code hello i18n' in mo
         assert 'template hello i18n' not in mo
 
+    def test_clean_tmp_do_nothing(self, caplog):
+        args = argparse.Namespace(days=0,
+                                  directory=' UNLIKELY ',
+                                  verbose=logging.DEBUG)
+        manage.setup_verbosity(args)
+        manage.clean_tmp(args)
+        assert 'does not exist, do nothing' in caplog.text()
+
+    def test_clean_tmp_too_young(self, caplog):
+        args = argparse.Namespace(days=24*60*60,
+                                  directory=config.TEMP_DIR,
+                                  verbose=logging.DEBUG)
+        open(os.path.join(config.TEMP_DIR, 'FILE'), 'a').close()
+        manage.setup_verbosity(args)
+        manage.clean_tmp(args)
+        assert 'modified less than' in caplog.text()
+
+    def test_clean_tmp_removed(self, caplog):
+        args = argparse.Namespace(days=0,
+                                  directory=config.TEMP_DIR,
+                                  verbose=logging.DEBUG)
+        fname = os.path.join(config.TEMP_DIR, 'FILE')
+        with open(fname, 'a'):
+            old = time.time() - 24*60*60
+            os.utime(fname, (old, old))
+        manage.setup_verbosity(args)
+        manage.clean_tmp(args)
+        assert 'FILE removed' in caplog.text()
+
 
 class TestSh(object):
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1849

A file is considered old if it has not been modified in seven days (or
--days) and is removed from config.TEMP_DIR (or --directory).

The files in config.TEMP_DIR are for preparing downloads and they must
not be deleted before the user gets a chance to start the download. The
preparation of the file may be long for large collections but it will
always take less than a week.

It is not impossible for a the download to take more than a week if the
network is slow. However, once the download has begun it does not matter
if the file is removed: the server still has an open file descriptor and
keeps serving its content.

## Testing

The test_manage.py has been modified to test the new implementation.

## Deployment

1. Upgrading existing production instances.

The new implementation will leave temporary files for a week longer than the previous one.

2. New installs.

Nothing special.
