### PR TITLE
tests: join threads before teardown

### DIFF
--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -5,6 +5,7 @@ import os
 from os.path import abspath, dirname, exists, isdir, join, realpath
 import shutil
 import subprocess
+import threading
 
 import gnupg
 
@@ -59,6 +60,12 @@ def setup():
 
 
 def teardown():
+    # make sure threads launched by tests complete before
+    # teardown, otherwise they may fail because resources
+    # they need disappear
+    for t in threading.enumerate():
+        if t.is_alive() and not isinstance(t, threading._MainThread):
+            t.join()
     db_session.remove()
     try:
         shutil.rmtree(config.SECUREDROP_DATA_ROOT)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2122 

If the tests left live threads, join them before proceeding with
teardown. The most common live thread is from the
source.py::async_keygen function. If not joined, the thread will
terminate after the teardown and is likely to fail because files have
been removed.

## Testing

while : ; do pytest -v tests/test_source.py || break ; done

## Deployment

This is test only, no deployment impact
