### PR TITLE
tests: @screenshot must accept **kwargs

### DIFF
--- a/securedrop/tests/functional/step_helpers.py
+++ b/securedrop/tests/functional/step_helpers.py
@@ -10,7 +10,7 @@ screenshots_enabled = os.environ.get('SCREENSHOTS_ENABLED')
 # screenshots is a decorator that records an image before and after
 # the steps described in this file
 def screenshots(f):
-    def wrapper(*args):
+    def wrapper(*args, **kwargs):
         curframe = inspect.currentframe()
         calframe = inspect.getouterframes(curframe, 2)
 
@@ -28,7 +28,7 @@ def screenshots(f):
         if screenshots_enabled:
             image_path = join(LOG_DIR, '%s-before.png' % path)
             args[0].driver.save_screenshot(image_path)
-        result = f(*args)
+        result = f(*args, **kwargs)
         if screenshots_enabled:
             image_path = join(LOG_DIR, '%s-after.png' % path)
             args[0].driver.save_screenshot(image_path)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

If the decorated function has keywords arguments, @screenshot will
fail because it does not have a **kwargs argument. It must be accepted
and passed to the wrapped function unmodified.

The decorator is always used (even if the SCREENSHOTS_ENABLED environment variable is not set). The **is_admin** argument from **_add_user** is not currently used, reason why the bug did not show.

## Testing

pytest -v tests/functional

## Deployment

This is for test only, deployment is not an issue.
