### PR TITLE
[WIP] vagrant: use sshfs instead of nfs for the libvirt provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,7 +40,7 @@ Vagrant.configure("2") do |config|
     end
     development.vm.provider "libvirt" do |lv, override|
       lv.memory = 1024
-      override.vm.synced_folder './', '/vagrant', type: 'nfs', disabled: false
+      override.vm.synced_folder './', '/vagrant', type: 'sshfs', disabled: false
     end
   end
 
@@ -153,7 +153,7 @@ Vagrant.configure("2") do |config|
     end
 
     build.vm.provider "libvirt" do |lv, override|
-      override.vm.synced_folder './', '/vagrant', type: 'nfs', disabled: false
+      override.vm.synced_folder './', '/vagrant', type: 'sshfs', disabled: false
     end
   end
 


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

use sshfs instead of nfs for the libvirt provider

## Testing

* vagrant up --provider libvirt development
* verify it uses sshfs instead of nfs

## Deployment

test only, no deployment side effect
