### PR TITLE
Specify NTP server to use for ntpdate

### DIFF
--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -377,4 +377,4 @@ System Date
 ~~~~~~~~~~~
 
 The ``ansible`` playbooks you will run later depend on the system clock
-being set accurately, so run ``sudo ntpdate`` on both servers.
+being set accurately, so run ``sudo ntpdate ntp.ubuntu.com`` on both servers.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2094.

Changes proposed in this pull request:
* Ntpdate needs an NTP server to be specified else it will return
"no servers can be used, exiting"

## Testing

* `ntpdate` should return "no servers can be used, exiting"
* `sudo ntpdate ntp.ubuntu.com` should return a time offset

## Deployment

None, docs only.

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
