### PR TITLE
tests: avoid flake8 breaking the test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,9 @@ script:
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
   # flake8 linting
-  - pushd securedrop; flake8 *.py management tests/functional tests/*.py && popd
-  - flake8 testinfra securedrop-admin
+  - >
+      flake8 testinfra securedrop-admin securedrop/*.py securedrop/management
+      securedrop/tests/functional securedrop/tests/*.py
   # HTML linting
   - >
       html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

If the first flake8 fails, the popd is not done and the next lines
do not run where they are supposed to run. Group all flake8 into a
single call instead. And it looks nicer.

## Testing

* Introduce a flake8 error
* Push a PR
* See that it fails and that the HTML linter runs

## Deployment

test only, no deployment issue

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
