### PR TITLE
Skip CircleCI if branch prefixed with `docs-`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,11 @@
 version: 2
 jobs:
   build:
+    branches:
+      ignore:
+        # Skip staging CI if branch name starts with `docs-`.
+        - /docs-.*/
+
     docker:
       - image: msheiny/pressfreedomci:latest
         environment:

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -33,7 +33,10 @@ You can then can browse the documentation at http://127.0.0.1:8000/.
 As you make changes, the docs will automatically rebuild in the browser
 window, so you don't need to refresh the page manually.
 
-You can also check the docs for formatting violations by running the linting
+Testing documentation changes
+-----------------------------
+
+You can check the docs for formatting violations by running the linting
 option:
 
    .. code:: sh
@@ -43,7 +46,14 @@ option:
 The ``make docs`` command will display warnings, but will still build the
 documentation if formatting mistakes are found. Using ``make docs-lint``
 will convert any warnings to errors, causing the build to fail.
-The CI tests will automatically perform linting via the same command.
+The :ref:`CI tests<ci_tests>` will automatically perform linting via the same
+command.
+
+The :ref:`CI tests<ci_tests>` by default create staging servers to test the
+application code. If your PR only makes documentation changes, you should
+prefix the branch name with ``docs-`` to skip the staging run. Project
+maintainers will still need to approve the PR prior to merge, and the linting
+checks will also still run.
 
 Integration with Read the Docs
 ------------------------------


### PR DESCRIPTION
## Status

~Ready for review.~ Work in progress.

## Description of Changes

Using the CircleCI branch filter settings [0] to skip running the
staging build environment if-and-only-if the PR branch name is prefixed
with `docs-`. Utilization of this feature is opt-in, so it will require
training regular contributors to make use of it, but should save 30-45
minutes for CI runs for those who do.

Updated the developer docs to make mention of the special branch prefix,
so that first-time contributors have a shot at discovering it
themselves.

Closes #2132.

[0] https://circleci.com/docs/2.0/configuration-reference/#full-example

## Testing

In order to test these CI changes, I configured a fork of this repo and bootstrapped it with fresh AWS creds (which I will revoke after this is merged). To verify these changes work as expected:

* [x] Confirm CircleCI ran on: https://github.com/conorsch/securedrop/pull/5
* [x] Confirm CircleCI did **not** run on: https://github.com/conorsch/securedrop/pull/6

## Deployment

None, only affects developers and the CI flow.

## Checklist

### If you made changes to CI:

Relying on manual confirmation of the changes linked to in the forked repo above.

### If you made changes to documentation:

- [x] Doc linting passed locally
