### PR TITLE
i18n: package securedrop-app translation files

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -38,3 +38,16 @@ apparmor_profiles:
 
 # Installing the securedrop-app-code.deb package
 securedrop_app_code_deb: "securedrop-app-code-{{ securedrop_app_code_version }}-amd64" # do not enter .deb extension
+
+# Apt package dependencies for running the SecureDrop application.
+appserver_dependencies:
+  - gnupg2
+  - haveged
+  - python
+  - python-pip
+  - secure-delete
+  - sqlite
+  - apparmor-utils
+  - redis-server
+  - supervisor
+

--- a/install_files/ansible-base/roles/app/defaults/main.yml
+++ b/install_files/ansible-base/roles/app/defaults/main.yml
@@ -94,18 +94,6 @@ apache_disabled_modules:
   - env
   - status
 
-# Apt package dependencies for running the SecureDrop application.
-appserver_dependencies:
-  - gnupg2
-  - haveged
-  - python
-  - python-pip
-  - secure-delete
-  - sqlite
-  - apparmor-utils
-  - redis-server
-  - supervisor
-
 # Log file location for worker service, used in supervisor template.
 worker_logs_dir: /var/log/securedrop_worker
 

--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -225,6 +225,8 @@
   /var/www/securedrop/wordlist r,
   /var/www/securedrop/worker.py r,
   /var/www/securedrop/worker.pyc rw,
+  /var/www/securedrop/translations/ r,
+  /var/www/securedrop/translations/** r,
   /var/www/source.wsgi r,
   /var/www/.gnupg/ rw,
   /var/www/.gnupg/** rw,

--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/build_securedrop_app_code_deb.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/build_securedrop_app_code_deb.yml
@@ -39,6 +39,8 @@
     -w {{ securedrop_app_code_deb_dir }}/var/securedrop/wheelhouse
   tags: pip
 
+- include: translations.yml
+
 - name: Create apparmor.d directory in build path.
   file:
     state: directory

--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/translations.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/translations.yml
@@ -1,0 +1,23 @@
+---
+- name: Install dependencies for building translations
+  apt:
+    pkg: "{{ item }}"
+    state: present
+  with_items: "{{ appserver_dependencies }}"
+  tags: apt
+
+- name: Install pip dependencies for SecureDrop.
+  pip:
+    requirements: "{{ securedrop_code_filtered }}/requirements/securedrop-requirements.txt"
+  tags:
+    - pip
+
+- name: Compile PO to MO.
+  shell: >-
+    cp config.py.example config.py ;
+    trap 'rm config.py' EXIT ;
+    ./manage.py --verbose translate --compile
+  args:
+    chdir: "{{ securedrop_code_filtered }}"
+  environment:
+    PYTHONDONTWRITEBYTECODE: "true"

--- a/molecule/builder/tests/test_build_dependencies.py
+++ b/molecule/builder/tests/test_build_dependencies.py
@@ -31,6 +31,7 @@ build_directories = get_build_directories()
     "libssl-dev",
     "python-dev",
     "python-pip",
+    "secure-delete",
 ])
 def test_build_dependencies(Package, package):
     """
@@ -58,6 +59,15 @@ def test_sass_gem_installed(Command):
     """
     c = Command("gem list")
     assert "sass (3.4.23)" in c.stdout
+    assert c.rc == 0
+
+
+def test_pip_dependencies_installed(Command):
+    """
+    Ensure the development pip dependencies are installed
+    """
+    c = Command("pip list installed")
+    assert "Flask-Babel" in c.stdout
     assert c.rc == 0
 
 

--- a/molecule/builder/tests/test_securedrop_deb_package.py
+++ b/molecule/builder/tests/test_securedrop_deb_package.py
@@ -167,6 +167,35 @@ def test_deb_package_contains_no_config_file(File, Command, deb):
 
 
 @pytest.mark.parametrize("deb", deb_packages)
+def test_deb_package_contains_pot_file(File, Command, deb):
+    """
+    Ensures the `securedrop-app-code` package has the
+    messages.pot file
+    """
+    deb_package = File(deb.format(
+        securedrop_test_vars.securedrop_version))
+    c = Command("dpkg-deb --contents {}".format(deb_package.path))
+    # Only relevant for the securedrop-app-code package:
+    if "securedrop-app-code" in deb_package.path:
+        assert re.search("^.*messages.pot$", c.stdout, re.M)
+
+
+@pytest.mark.xfail  # remove after merging the first translation
+@pytest.mark.parametrize("deb", deb_packages)
+def test_deb_package_contains_mo_file(File, Command, deb):
+    """
+    Ensures the `securedrop-app-code` package has at least one
+    compiled mo file.
+    """
+    deb_package = File(deb.format(
+        securedrop_test_vars.securedrop_version))
+    c = Command("dpkg-deb --contents {}".format(deb_package.path))
+    # Only relevant for the securedrop-app-code package:
+    if "securedrop-app-code" in deb_package.path:
+        assert re.search("^.*messages\.mo$", c.stdout, re.M)
+
+
+@pytest.mark.parametrize("deb", deb_packages)
 def test_deb_package_contains_no_generated_assets(File, Command, deb):
     """
     Ensures the `securedrop-app-code` package does not ship a minified

--- a/securedrop/.rsync-filter
+++ b/securedrop/.rsync-filter
@@ -44,4 +44,10 @@ include tests/utils/**.py
 include wordlist
 include sass/
 include sass/**.sass
+include babel.cfg
+include translations/
+include translations/*.pot
+include translations/*/
+include translations/*/*/
+include translations/*/*/*.po
 exclude *

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -1,0 +1,18 @@
+# Translations template for SecureDrop.
+# Copyright (C) 2017 Freedom of the Press Foundation
+# This file is distributed under the same license as the SecureDrop project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: SecureDrop 0.3.12\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"POT-Creation-Date: 2017-07-03 15:42+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.4.0\n"
+


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Add the i18n files to the app package so they are installed and useable.

## Testing

* make build-debs

Note that the build process will use ./manage.py --verbose translate to build the .mo file. This must be verified to run successfully. There are no translations yet so it will not produce any file. But it should not fail either.

## Deployment

Although the app package now contains more files, they are not used and are not concern for existing deployments.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

