### PR TITLE
Add initial automated tests for OSSEC and whitelist overloaded Tor guard log event

### DIFF
--- a/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
+++ b/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
@@ -128,3 +128,16 @@
     <options>no_email_alert</options>
   </rule>
 </group>
+
+<!--
+  Do not send an email alert on overloaded Tor guard events.
+  These are purely informational notifications, but would be
+  a candidate for sending up to FPF for analysis in aggregate.
+-->
+<group name="tor guard overloaded">
+  <rule id="200002" level="0">
+    <if_sid>1002</if_sid>
+    <match>this means the Tor network is overloaded</match>
+    <options>no_email_alert</options>
+  </rule>
+</group>

--- a/testinfra/mon/test_ossec_ruleset.py
+++ b/testinfra/mon/test_ossec_ruleset.py
@@ -1,0 +1,21 @@
+import re
+
+
+alert_level_regex = re.compile(r"Level: '(\d+)'")
+
+
+def test_grsec_denied_rwx_mapping_produces_alert(Command, Sudo):
+    """Check that a denied RWX mmaping produces an OSSEC alert"""
+    test_alert = ("Feb 10 23:34:40 app kernel: [  124.188641] grsec: denied "
+                  "RWX mmap of <anonymous mapping> by /usr/sbin/apache2"
+                  "[apache2:1328] uid/euid:33/33 gid/egid:33/33, parent "
+                  "/usr/sbin/apache2[apache2:1309] uid/euid:0/0 gid/egid:0/0")
+
+    with Sudo():
+        c = Command('echo "{}" | /var/ossec/bin/ossec-logtest'.format(
+                test_alert))
+
+        # Level 7 alert should be triggered by rule 100101
+        assert "Alert to be generated" in c.stderr
+        alert_level = alert_level_regex.findall(c.stderr)[0]
+        assert alert_level == "7"

--- a/testinfra/mon/test_ossec_ruleset.py
+++ b/testinfra/mon/test_ossec_ruleset.py
@@ -19,3 +19,18 @@ def test_grsec_denied_rwx_mapping_produces_alert(Command, Sudo):
         assert "Alert to be generated" in c.stderr
         alert_level = alert_level_regex.findall(c.stderr)[0]
         assert alert_level == "7"
+
+
+def test_overloaded_tor_guard_does_not_produce_alert(Command, Sudo):
+    """Check that using an overloaded guard does not produce an OSSEC alert"""
+    test_alert = ("Aug 16 21:54:44 app-staging Tor[26695]: [warn] Your Guard "
+                  "<name> (<fingerprint>) is failing a very large amount of "
+                  "circuits. Most likely this means the Tor network is "
+                  "overloaded, but it could also mean an attack against you "
+                  "or potentially the guard itself.")
+
+    with Sudo():
+        c = Command('echo "{}" | /var/ossec/bin/ossec-logtest'.format(
+                test_alert))
+
+        assert "Alert to be generated" not in c.stderr


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1670 and begins work towards #2134

Changes proposed in this pull request:
  * 523447e - Adds initial example of automated testing for OSSEC rules based on log event in PR #871
  * dd40158 - Adds a failing test to reproduce spurious OSSEC alert described in ticket #1670
  * 32b18ad - Adds an OSSEC rule to suppress the spurious email notification for the log event in ticket #1670 and thus makes the failing test added in dd40158 pass

(Happy to break this up into separate PRs to aid in review)

## Testing

At minimum, verify the new tests run and pass in the CI staging environment.

If you want to be super thorough:

1. Provision staging on dd40158 and see that `test_overloaded_tor_guard_does_not_produce_alert` fails ("Alert to be generated" appears in the output of `ossec-logtest`)
3. Provision staging on 32b18ad and see that `test_overloaded_tor_guard_does_not_produce_alert` now passes ("Alert to be generated" does not appear in the output of `ossec-logtest`)

## Deployment

This just updates the OSSEC rules, so there should be no issues in deployment.  

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass on app and mon

