### PR TITLE
Add short pre-install hardware checklist

### DIFF
--- a/docs/checklists/pre_install_hardware.rst
+++ b/docs/checklists/pre_install_hardware.rst
@@ -1,0 +1,9 @@
+Pre-Install Hardware Checklist
+==============================
+
+This is the *minimum* hardware that must be acquired to install SecureDrop:
+
+.. include:: ../includes/pre-install-hardware.txt
+
+.. note:: For additional details, please read the full document on
+       :ref:`Hardware Recommendations` for SecureDrop.

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -82,13 +82,13 @@ our support or consent.
 Workstations
 ^^^^^^^^^^^^
 .. note:: SecureDrop depends on the Tails operating system for its bootable USB
-  drives.  The current stable version of Tails, Tails 3.0, no longer supports
-  32-bit computers.
+  drives.  Since the release of Tails 3.0, 32-bit computers are no longer
+  supported.
 
   To see if you have a 64-bit machine, run ``uname -m`` from a terminal.  If you
   see ``x86_64``, then Tails should work on your current machine.  If, on the
   other hand, you see ``i686``, your current machine will not work with Tails
-  3.0.  For more details, see `the Tails website
+  3.0 or greater.  For more details, see `the Tails website
   <https://tails.boum.org/news/version_3.0/index.en.html#index3h3>`_.
 
 These components are necessary to do the initial installation of
@@ -357,7 +357,7 @@ as advertised by the `NUC5i5MYHE` that we recommend.
 Tails USBs
 ^^^^^^^^^^
 
-.. note:: The upcoming version of Tails, Tails 3.0, will no longer support 32-bit computers.
+.. note:: Tails no longer supports 32-bit computers.
 	Please see the note in the `Workstations`_ section for more details.
 
 We *strongly recommend* getting USB 3.0-compatible drives to run Tails

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -6,6 +6,17 @@ successfully install and operate a SecureDrop instance, and recommends
 some specific components that we have found to work well. If you have
 any questions, please email securedrop@freedom.press.
 
+Hardware Overview
+-----------------
+
+For an installation of SecureDrop, you must acquire:
+
+.. include:: includes/pre-install-hardware.txt
+
+In the sections that follow, we provide additional details on each item.
+
+.. _Hardware Recommendations:
+
 Required Hardware
 -----------------
 

--- a/docs/includes/pre-install-hardware.txt
+++ b/docs/includes/pre-install-hardware.txt
@@ -1,0 +1,12 @@
+* 2 computers with memory and hard drives to use as the SecureDrop servers.
+* Mouse, keyboard, monitor (and necessary dongle or adapter) for
+  installing the servers.
+* Dedicated physical computers for the Admin, Journalist, and Secure Viewing
+  Station that can boot to Tails. At *minimum* this is 2 computers.
+* Dedicated airgapped hardware for the mouse, keyboard, and monitor (only if you
+  are using a desktop for the Secure Viewing Station).
+* Network firewall.
+* At least 3 ethernet cables.
+* Plenty of USB sticks: 1 drive for the master Tails stick, 1 drive for each
+  Secure Viewing Station, 1 drive for each Transfer drive, and 1 drive for each
+  admin and journalist.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,13 @@ anonymous sources.
    onboarding
 
 .. toctree::
+   :caption: Checklists
+   :name: checklists
+   :maxdepth: 2
+
+   checklists/pre_install_hardware
+
+.. toctree::
    :caption: Topic Guides
    :name: topictoc
    :maxdepth: 2


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
 * Adds reusable text snippet for a very short pre-install checklist. The goal of this checklist is to provide the "tl;dr" for people that do not want to read the long hardware document under "Install SecureDrop"
 * Adds "checklists" section to sidebar:

![screen shot 2017-08-16 at 6 09 27 pm](https://user-images.githubusercontent.com/7832803/29391811-93e8ed62-82ae-11e7-92a2-2c53ee641019.png)
  * Adds the hardware checklist to the checklists section and to the top of the long hardware document under "Install SecureDrop"

This complements the pre-onsite checklist that @justintroutman is working on. 

## Testing

* Build docs locally and make sure everything renders well
* See if there's anything _critical_ I've left off the pre-install checklist. Note that the checklist is intentionally terse and only what is _necessary_ for a SecureDrop install to be successful should be on it. 

## Deployment

None, documentation only. 

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
