### PR TITLE
Provides Makefile targets for running linters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,13 +54,10 @@ script:
   - sudo sh -c "export DISPLAY=:1; cd securedrop/ && pytest -v tests/"
   - SECUREDROP_TESTINFRA_TARGET_HOST=travis testinfra -v testinfra/development/
   - pip freeze -l
-  # Docs linting. Performing this step *after* build VM tests pass, so as not
+  # Performing new pip install step *after* build VM tests pass, so as not
   # to alter the pip requirements, which would cause config tests to fail.
+  # The develop requirements include sphinx tooling for docs linting.
   - pip install -r securedrop/requirements/develop-requirements.txt
-  - make docs-lint
-  # flake8 linting
-  - make flake8
-  # HTML linting
-  - make html-lint
+  - make lint
 after_success:
   cd securedrop/ && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,10 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   # The develop requirements include sphinx tooling for docs linting.
   - pip install -r securedrop/requirements/develop-requirements.txt
-  - make lint
+  # Intentionally *not* using `make lint` wrapper so as not to skip linting
+  # steps if one fails. Continue linting in CI, and report full status.
+  - make docs-lint
+  - make flake8
+  - make html-lint
 after_success:
   cd securedrop/ && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,6 @@ script:
   # flake8 linting
   - make flake8
   # HTML linting
-  - >
-      html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation
-      securedrop/source_templates/*.html securedrop/journalist_templates/*.html
+  - make html-lint
 after_success:
   cd securedrop/ && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,7 @@ script:
   - pip install -r securedrop/requirements/develop-requirements.txt
   - make docs-lint
   # flake8 linting
-  - >
-      flake8 testinfra securedrop-admin securedrop/*.py securedrop/management
-      securedrop/tests/functional securedrop/tests/*.py
+  - make flake8
   # HTML linting
   - >
       html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,19 @@ docs:
 # Spins up livereload environment for editing; blocks.
 	make -C docs/ clean && sphinx-autobuild docs/ docs/_build/html
 
+.PHONY: flake8
+flake8:
+# Validates PEP8 compliance for Python source files.
+	flake8 --exclude='config.py' testinfra securedrop-admin \
+		securedrop/*.py securedrop/management \
+		securedrop/tests/functional securedrop/tests/*.py
+
 help:
 	@echo Makefile for developing and testing SecureDrop.
 	@echo Subcommands:
 	@echo "\t docs: Build project documentation in live reload for editing."
 	@echo "\t docs-lint: Check documentation for common syntax errors."
+	@echo "\t flake8: Validates PEP8 compliance for Python source files."
 	@echo "\t ci-spinup: Creates AWS EC2 hosts for testing staging environment."
 	@echo "\t ci-teardown: Destroy AWS EC2 hosts for testing staging environment."
 	@echo "\t ci-run: Provisions AWS EC2 hosts for testing staging environment."

--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,19 @@ flake8:
 		securedrop/*.py securedrop/management \
 		securedrop/tests/functional securedrop/tests/*.py
 
+.PHONY: html-lint
+html-lint:
+# Validates HTML to the best of our ability.
+	html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation \
+		securedrop/source_templates/*.html securedrop/journalist_templates/*.html
+
 help:
 	@echo Makefile for developing and testing SecureDrop.
 	@echo Subcommands:
 	@echo "\t docs: Build project documentation in live reload for editing."
 	@echo "\t docs-lint: Check documentation for common syntax errors."
 	@echo "\t flake8: Validates PEP8 compliance for Python source files."
+	@echo "\t html-lint: Validates HTML in web application template files."
 	@echo "\t ci-spinup: Creates AWS EC2 hosts for testing staging environment."
 	@echo "\t ci-teardown: Destroy AWS EC2 hosts for testing staging environment."
 	@echo "\t ci-run: Provisions AWS EC2 hosts for testing staging environment."

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ html-lint:
 	html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation \
 		securedrop/source_templates/*.html securedrop/journalist_templates/*.html
 
+.PHONY: lint
+# Runs all linting tools (docs, flake8, HTML)
+lint: docs-lint flake8 html-lint
+
 help:
 	@echo Makefile for developing and testing SecureDrop.
 	@echo Subcommands:
@@ -58,6 +62,7 @@ help:
 	@echo "\t docs-lint: Check documentation for common syntax errors."
 	@echo "\t flake8: Validates PEP8 compliance for Python source files."
 	@echo "\t html-lint: Validates HTML in web application template files."
+	@echo "\t lint: Runs all linting tools (docs, flake8, HTML)."
 	@echo "\t ci-spinup: Creates AWS EC2 hosts for testing staging environment."
 	@echo "\t ci-teardown: Destroy AWS EC2 hosts for testing staging environment."
 	@echo "\t ci-run: Provisions AWS EC2 hosts for testing staging environment."

--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -66,7 +66,7 @@ our HTML templates in ``securedrop/source_templates`` and
 
   .. code:: sh
 
-      html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation example.html
+      make html-lint
 
 Git History
 -----------

--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -53,7 +53,7 @@ compliant. You can run ``flake8`` locally via:
 
   .. code:: sh
 
-      flake8 example.py
+      make flake8
 
 HTML
 ~~~~


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Closes #1920.

Changes proposed in this pull request:

* Created new linting-related new Makefile targets:
  * `make flake8`
  * `make html-lint`
  * `make lint` (which runs docs-lint, flake8, _and_ html-lint)
* Updates Travis CI config to use new catch-all `make lint`
* Updates developer docs where appropriate to mention the new targets.

## Testing

* [x] Make sure CI passes (both Travis and CircleCI)
* [x] Run the new targets locally and confirm everything passes

## Deployment
None, dev-env only.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [x] Doc linting passed locally
