### PR TITLE
Removes outdated comment about connect-proxy support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -187,8 +187,6 @@ def find_ssh_aths(filename)
 end
 
 # Build proxy command for connecting to prod instances over Tor.
-# connect-proxy is recommended, but netcat is also supported
-# for CentOS Snap CI boxes, where connect-proxy isn't available.
 def tor_ssh_proxy_command
    def command?(command)
      system("which #{command} > /dev/null 2>&1")


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #1087.

We dropped support for `connect-proxy` in favor of `netcat-openbsd`
in #1441, but there was still a comment in place that referred to it.
Removing the comment allows use to close #1087.

## Testing
There's really not much here to test! Just removing a comment in the Vagrantfile. I was tempted to use the `[skip ci]` line in the commit message, but didn't want to start a bad habit.

## Deployment

None whatsoever, the Vagrantfile is only used in the dev env, and this change is a no-op, essentially docs-only.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
