### PR TITLE
Convert CircleCI to workflow + skip staging tests on `docs-`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,11 @@
 version: 2
 jobs:
   build:
+    branches:
+      ignore:
+        # Skip staging CI if branch name starts with `docs-`.
+        - /docs-.*/
+
     docker:
       - image: msheiny/pressfreedomci:latest
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,5 @@ workflows:
     jobs:
       - docs-lint
       - staging-test:
-          filters:
-            branches:
-              ignore: /^docs-.*/
           requires:
             - docs-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,22 @@
+---
 version: 2
 jobs:
-  build:
-    branches:
-      ignore:
-        # Skip staging CI if branch name starts with `docs-`.
-        - /docs-.*/
+  docs-lint:
+    docker:
+      - image: msheiny/pressfreedomci:latest
 
+    steps:
+      - checkout
+
+      - run:
+          name: Installation pre-reqs
+          command: pip install -U -r securedrop/requirements/develop-requirements.txt
+
+      - run:
+          name: Run docs lint
+          command: make docs-lint
+
+  staging-test:
     docker:
       - image: msheiny/pressfreedomci:latest
         environment:
@@ -39,3 +50,15 @@ jobs:
 
       - store_artifacts:
           path: /root/sd/junit
+
+workflows:
+  version: 2
+  securedrop_ci:
+    jobs:
+      - docs-lint
+      - staging-test:
+          filters:
+            branches:
+              ignore: /^docs-.*/
+          requires:
+            - docs-lint

--- a/devops/scripts/ci-teardown.sh
+++ b/devops/scripts/ci-teardown.sh
@@ -3,6 +3,7 @@
 #
 #
 . devops/ansible_env
+devops/scripts/docs-detection || exit 0
 
 export ANSIBLE_INVENTORY="localhost"
 export RETRY_FILES_ENABLED=False

--- a/devops/scripts/docs-detection
+++ b/devops/scripts/docs-detection
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+if [[ "$CIRCLE_BRANCH" == docs-* ]]; then echo "Docs branch detected. Exiting..."; exit 1; fi

--- a/devops/scripts/spin-run-test.sh
+++ b/devops/scripts/spin-run-test.sh
@@ -3,6 +3,7 @@
 #
 #
 . devops/ansible_env
+devops/scripts/docs-detection || exit 0
 
 # When this script completes, teardown the environment
 # To get around this and debug, enter `make ci-debug` before

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -33,7 +33,10 @@ You can then can browse the documentation at http://127.0.0.1:8000/.
 As you make changes, the docs will automatically rebuild in the browser
 window, so you don't need to refresh the page manually.
 
-You can also check the docs for formatting violations by running the linting
+Testing documentation changes
+-----------------------------
+
+You can check the docs for formatting violations by running the linting
 option:
 
    .. code:: sh
@@ -43,7 +46,14 @@ option:
 The ``make docs`` command will display warnings, but will still build the
 documentation if formatting mistakes are found. Using ``make docs-lint``
 will convert any warnings to errors, causing the build to fail.
-The CI tests will automatically perform linting via the same command.
+The :ref:`CI tests<ci_tests>` will automatically perform linting via the same
+command.
+
+The :ref:`CI tests<ci_tests>` by default create staging servers to test the
+application code. If your PR only makes documentation changes, you should
+prefix the branch name with ``docs-`` to skip the staging run. Project
+maintainers will still need to approve the PR prior to merge, and the linting
+checks will also still run.
 
 Integration with Read the Docs
 ------------------------------


### PR DESCRIPTION
## Status

✔️ Ready for review

## Description of Changes

Fixes #2132.

Changes proposed in this pull request:

Switch the CircleCI test to utilize [workflows](https://circleci.com/docs/2.0/workflows/) and to filter out the staging tests when a PR branch starts with `docs-*`

## Testing

You can try pulling a PR (branched from this branch) yourself to a branch that starts with `docs-`. Also observe the following results:

* ✔️ Successful test of a docs branch - `https://github.com/freedomofpress/securedrop/pull/2150`
* ✔️ Successful test of a non-docs branch (HERE). 

## Deployment

Nope - Only affects CI.

## Checklist

### If you made changes to the app code:

N/A

### If you made changes to the system configuration:

N/A

### If you made changes to documentation:

N/A - yet
