### PR TITLE
OSSEC Rules: Remove syscheck alert when bulk tmp file deleted

### DIFF
--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -28,6 +28,8 @@
     <ignore>/var/lib/securedrop/keys/trustdb.gpg</ignore>
     <ignore>/var/lib/securedrop/keys/trustdb.gpg</ignore>
 
+    <ignore type="sregex">/var/lib/securedrop/tmp/tmp_securedrop_bulk_\.+</ignore>
+
     <ignore>/var/lib/securedrop/store</ignore>
 
     <ignore>/var/lib/securedrop/db.sqlite</ignore>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1691.

Changes proposed in this pull request:
* When bulk downloads occur on the SecureDrop journalist interface,
a temporary file is created in `/var/lib/securedrop/tmp`. When
this file is cleaned up, an integrity checking alert fires.
If SecureDrop is getting heavy use, this alert can fire many times per
day.

* This commit modifies the `syscheck` options on the app server
to exclude any files named `tmp_securedrop_bulk_*` in
`/var/lib/securedrop/tmp` from the integrity checking.

## Testing

*Note:* In the testing instructions that follow, I'm indicating the hostname via the string prior to the shell prompt. 

### A. Reproduce the alert

1. Provision staging locally. 
2. Create test file:

   `app-staging# echo "test" > /var/lib/securedrop/tmp/tmp_securedrop_bulk_dl_FDkPe4`

3. Establish `syscheck` baseline:

   `mon-staging# /var/ossec/bin/agent_control -r -a`

4. Remove test file:

   `app-staging# rm /var/lib/securedrop/tmp/tmp_securedrop_bulk_dl_FDkPe4`

5. Watch the OSSEC alerts log (or watch your email if you have prod-like secrets configured in `site-specific`):

   `mon-staging# tail -f /var/ossec/logs/alerts/alerts.log`

5. And now `syscheck` again to rerun integrity checking:

   `mon-staging# /var/ossec/bin/agent_control -r -a`

6. An alert will appear in `/var/ossec/logs/alerts/alerts.log`:

```
** Alert 1503096612.240301: mail  - ossec,syscheck,
2017 Aug 18 22:50:12 (app-staging) 10.0.1.2->syscheck
Rule: 553 (level 7) -> 'File deleted. Unable to retrieve checksum.'
File '/var/lib/securedrop/tmp/tmp_securedrop_bulk_dl_FDkPe4' was deleted. Unable to retrieve checksum.
```

### B. Verify the fix in this PR

1. The patch is in `ossec.conf` on the agent (the Application server), so you can either:

   a. reprovision staging with the patch applied, or
   
   b. you can just manually apply the patch to `/var/ossec/etc/ossec.conf` on `mon-staging`. Note that you will then need to bounce the service (i.e. `mon-staging# service ossec restart`).

2. Follow steps 2-5 from section A above, except now no alert will fire.

## Deployment

As `ossec.conf` is delivered via the `securedrop-ossec-agent` deb package,  the change should be deployed without issue.

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
