### PR TITLE
Update locations of logs on app server for OSSEC syscheck

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -12,8 +12,9 @@ Both servers
 
 - Apache: ``/var/log/apache2/*``
 
-If an event triggers it's in the SecureDrop application log:
-``/var/www/securedrop/securedrop.log``
+If an error is triggered it's in the SecureDrop application logs:
+``/var/log/apache2/source-error.log`` and
+``/var/log/apache2/journalist-error.log``
 
 *Monitor Server*
 ----------------

--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -112,11 +112,6 @@
   </localfile>
 
   <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/apache2/source-access.log</location>
-  </localfile>
-
-  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/apache2/journalist-error.log</location>
   </localfile>

--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -21,8 +21,6 @@
     <ignore>/var/lib/tor/services/journalist/client_keys</ignore>
     <ignore>/var/lib/tor/services/ssh/client_keys</ignore>
 
-    <ignore>/var/www/securedrop/securedrop.log</ignore>
-
     <ignore>/var/lib/securedrop/keys/pubring.gpg</ignore>
     <ignore>/var/lib/securedrop/keys/secring.gpg</ignore>
     <ignore>/var/lib/securedrop/keys/trustdb.gpg</ignore>
@@ -124,10 +122,5 @@
   <localfile>
     <log_format>syslog</log_format>
     <location>/var/log/tor/log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/www/securedrop/securedrop.log</location>
   </localfile>
 </ossec_config>

--- a/testinfra/app/apache/test_apache_system_config.py
+++ b/testinfra/app/apache/test_apache_system_config.py
@@ -135,3 +135,34 @@ def test_apache_modules_absent(Command, Sudo, apache_module):
         assert "No module matches {} (disabled".format(apache_module) in \
             c.stderr
         assert c.rc == 32
+
+
+@pytest.mark.parametrize("logfile",
+                         securedrop_test_vars.allowed_apache_logfiles)
+def test_apache_logfiles_present(File, Command, Sudo, logfile):
+    """"
+    Ensure that whitelisted Apache log files for the Source and Journalist
+    Interfaces are present. In staging, we permit a "source-error" log,
+    but on prod even that is not allowed. A separate test will confirm
+    absence of unwanted logfiles by comparing the file count in the
+    Apache log directory.
+    """
+    # We need elevated privileges to read files inside /var/log/apache2
+    with Sudo():
+        f = File(logfile)
+        assert f.is_file
+        assert f.user == "root"
+
+
+def test_apache_logfiles_no_extras(Command, Sudo):
+    """
+    Ensure that no unwanted Apache logfiles are present. Complements the
+    `test_apache_logfiles_present` config test. Here, we confirm that the
+    total number of Apache logfiles exactly matches the number permitted
+    on the Application Server, whether staging or prod.
+    """
+    # We need elevated privileges to read files inside /var/log/apache2
+    with Sudo():
+        c = Command("find /var/log/apache2 -mindepth 1 | wc -l")
+        assert int(c.stdout) == \
+            len(securedrop_test_vars.allowed_apache_logfiles)

--- a/testinfra/vars/app-prod.yml
+++ b/testinfra/vars/app-prod.yml
@@ -37,6 +37,14 @@ apparmor_enforce:
 
 apparmor_complain: []
 
+# No source-error.log allowed in prod
+allowed_apache_logfiles:
+  - /var/log/apache2/access.log
+  - /var/log/apache2/error.log
+  - /var/log/apache2/journalist-access.log
+  - /var/log/apache2/journalist-error.log
+  - /var/log/apache2/other_vhosts_access.log
+
 iptables_complete_ruleset: |-
   -P INPUT DROP
   -P FORWARD DROP

--- a/testinfra/vars/app-staging.yml
+++ b/testinfra/vars/app-staging.yml
@@ -75,6 +75,15 @@ tor_services:
     authenticated: yes
     client: journalist
 
+# Staging permits presence of "source-error.log".
+allowed_apache_logfiles:
+  - /var/log/apache2/access.log
+  - /var/log/apache2/error.log
+  - /var/log/apache2/journalist-access.log
+  - /var/log/apache2/journalist-error.log
+  - /var/log/apache2/other_vhosts_access.log
+  - /var/log/apache2/source-error.log
+
 # Hardcoded values, only appropriate for local testing via Vagrant.
 iptables_complete_ruleset: |-
   -P INPUT DROP


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2153

Changes proposed in this pull request:
* Stop `syscheck` monitoring log files that do not exist

## Testing

1. Provision staging locally
2. Verify that `/var/log/apache2/log/source-access.log` does not exist
3. Verify that `/var/www/securedrop/securedrop.log` does not exist.

If you are concerned and want to check that logging is working, you can put an `app.logger.error("TEST <name of interface>")` in the `index()` function of `source.py` and `journalist.py`, visit the interfaces, and verify these events were logged (I did do this).

## Deployment

`/var/ossec/etc/ossec.conf` is distributed through the `securedrop-ossec-agent` deb package, so this should land on the app servers without issue. 

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [x] Doc linting passed locally
