### PR TITLE
Add --page-layout option to toggle page-layout tests

### DIFF
--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -17,6 +17,22 @@ import config
 TEST_WORKER_PIDFILE = '/tmp/securedrop_test_worker.pid'
 
 
+def pytest_addoption(parser):
+    parser.addoption("--page-layout", action="store_true",
+                     default=False, help="run page layout tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--page-layout"):
+        return
+    skip_page_layout = pytest.mark.skip(
+        reason="need --page-layout option to run page layout tests"
+    )
+    for item in items:
+        if "pagelayout" in item.keywords:
+            item.add_marker(skip_page_layout)
+
+
 @pytest.fixture(scope='session')
 def setUptearDown():
     _start_test_rqworker(config)

--- a/securedrop/tests/pages-layout/test_journalist.py
+++ b/securedrop/tests/pages-layout/test_journalist.py
@@ -33,7 +33,7 @@ def hardening(request):
     db.LOGIN_HARDENING = True
     return None
 
-
+@pytest.mark.pagelayout
 class TestJournalistLayout(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationSteps,

--- a/securedrop/tests/pages-layout/test_source.py
+++ b/securedrop/tests/pages-layout/test_source.py
@@ -18,8 +18,10 @@
 from tests.functional import journalist_navigation_steps
 from tests.functional import source_navigation_steps
 import functional_test
+import pytest
 
 
+@pytest.mark.pagelayout
 class TestSourceLayout(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationSteps,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Note: This is a PR into #2141

The page layout tests added in #2141 are useful for developers
but they can add significant time to the
running of the full test suite. We want to provide an easy
way for the developer to run them when checking the rendering
of i10n strings or when generating new screenshots for user guides.

This commit adds a `--page-layout` option in `conftest.py` and marks
each page-layout test with `pytest.mark`. By default, the page-layout
tests will not run. However if the `--page-layout` option is run, all
tests will execute.

## Testing

In the development VM:

1. `cd /vagrant/develop`
2. `pytest tests/` (all tests except page-layout should run. They will show as skipped.)
3. `pytest tests/ --page-layout` (all tests should run)

## Deployment

Tests only

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
