### PR TITLE
fail unless ansible version 2.2.3 is used

### DIFF
--- a/install_files/ansible-base/callback_plugins/ansible_version_check.py
+++ b/install_files/ansible-base/callback_plugins/ansible_version_check.py
@@ -1,0 +1,28 @@
+# -*- encoding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import sys
+
+import ansible
+
+try:
+    # Version 2.0+
+    from ansible.plugins.callback import CallbackBase
+except ImportError:
+    CallbackBase = object
+
+
+def print_red_bold(text):
+    print('\x1b[31;1m' + text + '\x1b[0m')
+
+
+class CallbackModule(CallbackBase):
+    def __init__(self):
+        # Can't use `on_X` because this isn't forwards compatible with Ansible 2.0+
+        required_version = '2.2'  # Keep synchronized with group_vars/all/main.yml
+        if not ansible.__version__.startswith(required_version):
+            print_red_bold(
+                "SecureDrop restriction: only Ansible {version}.* is supported. "
+                .format(version=required_version)
+            )
+            sys.exit(1)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes: #2165 

fail unless ansible version 2.2.* is used

## Testing

* pip install ansible==2.2.1
* vagrant provision development # succeeds
* pip install ansible==2.3.2
* vagrant provision development # fails with the following
<pre>
SecureDrop restriction: only Ansible 2.2.* is supported. 
</pre>

## Comments

It will not affect developers because using ansible 2.3.* fails anyway and there is zero chance any developer is using this version.

There is a chance someone deploying SecureDrop has ansible 2.3.* installed and did not run into any compatibility problem. The corrective action in this case will be for her/him to **pip install ansible==2.2.3** or re-run the relevant **pip install -r ...requirements.txt** which will do the same.

## Deployment

It will fail a deployment that has ansible 2.3.* installed instead of ansible 2.2.* . The will not affect existing instances because the unattended upgrades do not rely on ansible.

## Checklist

I think all cases are covered by the run of the CI (CircleCI + Travis). Some of the ansible playbooks (at least those using synchronize) will fail with version 2.3+.