### PR TITLE
Fix page layout screenshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
   # Travis needs the config.py file to be owned by root. In other environments
   # it's the `securedrop_user` var.
   - sudo chown root:root securedrop/config.py
-  - sudo sh -c "export DISPLAY=:1; cd securedrop/ && pytest -v tests/"
+  - sudo sh -c "export DISPLAY=:1; cd securedrop/ && pytest -v tests/ --page-layout"
   - SECUREDROP_TESTINFRA_TARGET_HOST=travis testinfra -v testinfra/development/
   - pip freeze -l
   # Performing new pip install step *after* build VM tests pass, so as not

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -532,7 +532,6 @@ class JournalistNavigationSteps():
             password='pentagonpapers')
 
         self._add_user(self.new_user['username'],
-                       self.new_user['password'],
                        is_admin=False,
                        hotp=hotp)
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2183.

Changes proposed in this pull request:
 * Adds the page-layout tests / screenshots to CI to prevent breakage
 * Fixes two broken screenshots due to lingering use of `password` between new screenshots / page-layout tests and the diceware passphrase autogeneration (full post mortem in #2183)

## Testing

- [x] Do you see commit `fe5700a` failing?
- [x] Does CI pass on this PR?

## Deployment

Tests/CI only.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
