### PR TITLE
Disable Postfix service in staging environment

### DIFF
--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -63,6 +63,7 @@ a few exceptions:
 * The production environment only allows SSH over an Authenticated Tor Hidden
   Service (ATHS), but the staging environment allows direct SSH access so it's
   more ergonomic for developers to interact with the system during debugging.
+* The Postfix service is disabled, so OSSEC alerts will not be sent via email.
 
 This is a convenient environment to test how changes work across the full stack.
 

--- a/install_files/ansible-base/group_vars/staging.yml
+++ b/install_files/ansible-base/group_vars/staging.yml
@@ -40,6 +40,10 @@ sasl_username: "test"
 sasl_domain: "ossec.test"
 sasl_password: "password123"
 
+# Disable Postfix in staging, so we don't hammer Google mail relays
+# with known-bad credentials.
+ossec_server_enable_postfix: no
+
 # Permit direct access for SSH in the staging environment.
 # Otherwise, all SSH connections would be forced over Tor.
 ssh_listening_address: 0.0.0.0

--- a/install_files/ansible-base/roles/ossec-server/defaults/main.yml
+++ b/install_files/ansible-base/roles/ossec-server/defaults/main.yml
@@ -22,3 +22,8 @@ ossec_postfix_dependencies:
 
 # Configuration info for procmail and postfix
 postfix_hostname: ossec.server
+
+# Whether to enable Postfix for sending mail. Required in prod,
+# but unnecessary in staging contexts, where SASL authentication
+# will always fail, due to lack of site-specific credentials.
+ossec_server_enable_postfix: True

--- a/install_files/ansible-base/roles/ossec-server/handlers/main.yml
+++ b/install_files/ansible-base/roles/ossec-server/handlers/main.yml
@@ -28,6 +28,8 @@
   service:
     name: postfix
     state: restarted
+  # Don't bounce the service if set to disabled, e.g. in staging
+  when: ossec_server_enable_postfix
 
 - name: restart ossec-server
   service:

--- a/install_files/ansible-base/roles/ossec-server/tasks/mon_install_postfix.yml
+++ b/install_files/ansible-base/roles/ossec-server/tasks/mon_install_postfix.yml
@@ -52,4 +52,10 @@
   tags:
     - postfix
 
+- name: Configure Postfix service.
+  service:
+    name: postfix
+    state: "{{ 'started' if ossec_server_enable_postfix else 'stopped' }}"
+    enabled: "{{ ossec_server_enable_postfix }}"
+
 # TODO - name: configure postfix proxy

--- a/testinfra/mon/test_network.py
+++ b/testinfra/mon/test_network.py
@@ -45,15 +45,21 @@ def test_mon_iptables_rules(SystemInfo, Command, Sudo):
 
 
 @pytest.mark.parametrize('ossec_service', [
-    dict(host="0.0.0.0", proto="tcp", port=22),
-    dict(host="127.0.0.1", proto="tcp", port=25),
-    dict(host="0.0.0.0", proto="udp", port=1514),
+    dict(host="0.0.0.0", proto="tcp", port=22, listening=True),
+    dict(host="0.0.0.0", proto="udp", port=1514, listening=True),
+    dict(host="0.0.0.0", proto="tcp", port=1515, listening=False),
 ])
 def test_listening_ports(Socket, Sudo, ossec_service):
     """
     Ensure the OSSEC-related services are listening on the
-    expected sockets. Services to check include ossec, mail, and ssh.
+    expected sockets. Services to check include ossec-remoted
+    and ossec-authd. Helper services such as postfix are checked
+    separately.
+
+    Note that the SSH check will fail if run against a prod host, due
+    to the SSH-over-Tor strategy. We can port the parametrized values
+    to config test YAML vars at that point.
     """
     socket = "{proto}://{host}:{port}".format(**ossec_service)
     with Sudo():
-        assert Socket(socket).is_listening
+        assert Socket(socket).is_listening == ossec_service['listening']

--- a/testinfra/mon/test_ossec.py
+++ b/testinfra/mon/test_ossec.py
@@ -1,4 +1,3 @@
-import re
 import pytest
 
 
@@ -18,68 +17,6 @@ def test_ossec_package(Package, package):
     Includes mail utilities and the FPF-maintained metapackage.
     """
     assert Package(package).is_installed
-
-
-@pytest.mark.parametrize('header', [
-    '/^X-Originating-IP:/    IGNORE',
-    '/^X-Mailer:/    IGNORE',
-    '/^Mime-Version:/        IGNORE',
-    '/^User-Agent:/  IGNORE',
-    '/^Received:/    IGNORE',
-])
-def test_postfix_headers(File, header):
-    """
-    Ensure postfix header filters are set correctly. Common mail headers
-    are stripped by default to avoid leaking metadata about the instance.
-    Message body is always encrypted prior to sending.
-    """
-    f = File("/etc/postfix/header_checks")
-    assert f.is_file
-    assert oct(f.mode) == "0644"
-    regex = '^{}$'.format(re.escape(header))
-    assert re.search(regex, f.content, re.M)
-
-
-@pytest.mark.parametrize('setting', [
-    'relayhost = [smtp.gmail.com]:587',
-    'smtp_sasl_auth_enable = yes',
-    'smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd',
-    'smtp_sasl_security_options = noanonymous',
-    'smtp_use_tls = yes',
-    'smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache',
-    'smtp_tls_security_level = secure',
-    'smtp_tls_CApath = /etc/ssl/certs',
-    'smtp_tls_ciphers = high',
-    'smtp_tls_protocols = TLSv1.2 TLSv1.1 TLSv1 !SSLv3 !SSLv2',
-    'myhostname = ossec.server',
-    'myorigin = $myhostname',
-    'smtpd_banner = $myhostname ESMTP $mail_name (Ubuntu)',
-    'biff = no',
-    'append_dot_mydomain = no',
-    'readme_directory = no',
-    'smtp_header_checks = regexp:/etc/postfix/header_checks',
-    'mailbox_command = /usr/bin/procmail',
-    'inet_interfaces = loopback-only',
-    'alias_maps = hash:/etc/aliases',
-    'alias_database = hash:/etc/aliases',
-    'mydestination = $myhostname, localhost.localdomain , localhost',
-    'mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128',
-    'mailbox_size_limit = 0',
-    'recipient_delimiter = +',
-])
-def test_postfix_settings(File, setting):
-    """
-    Check all postfix configuration lines. There are technically multiple
-    configuration paths regarding the TLS settings, particularly the
-    fingerprint verification logic, but only the base default config is tested
-    currently.
-    """
-    f = File("/etc/postfix/main.cf")
-    assert f.is_file
-    assert f.user == 'root'
-    assert oct(f.mode) == "0644"
-    regex = '^{}$'.format(re.escape(setting))
-    assert re.search(regex, f.content, re.M)
 
 
 def test_ossec_connectivity(Command, Sudo):
@@ -243,15 +180,3 @@ def test_ossec_log_contains_no_malformed_events(File, Sudo):
 def test_regression_hosts(Command):
     """ Regression test to check for duplicate entries. """
     assert Command.check_output("uniq --repeated /etc/hosts") == ""
-
-
-def test_postfix_generic_maps(File):
-    """
-    Regression test to check that generic Postfix maps are not configured
-    by default. As of #1565 Admins can opt-in to overriding the FROM address
-    used for sending OSSEC alerts, but by default we're preserving the old
-    `ossec@ossec.server` behavior, to avoid breaking email for previously
-    existing instances.
-    """
-    assert not File("/etc/postfix/generic").exists
-    assert not File("/etc/postfix/main.cf").contains("^smtp_generic_maps")

--- a/testinfra/mon/test_postfix.py
+++ b/testinfra/mon/test_postfix.py
@@ -1,0 +1,79 @@
+import re
+import pytest
+
+
+securedrop_test_vars = pytest.securedrop_test_vars
+
+
+@pytest.mark.parametrize('header', [
+    '/^X-Originating-IP:/    IGNORE',
+    '/^X-Mailer:/    IGNORE',
+    '/^Mime-Version:/        IGNORE',
+    '/^User-Agent:/  IGNORE',
+    '/^Received:/    IGNORE',
+])
+def test_postfix_headers(File, header):
+    """
+    Ensure postfix header filters are set correctly. Common mail headers
+    are stripped by default to avoid leaking metadata about the instance.
+    Message body is always encrypted prior to sending.
+    """
+    f = File("/etc/postfix/header_checks")
+    assert f.is_file
+    assert oct(f.mode) == "0644"
+    regex = '^{}$'.format(re.escape(header))
+    assert re.search(regex, f.content, re.M)
+
+
+@pytest.mark.parametrize('setting', [
+    'relayhost = [smtp.gmail.com]:587',
+    'smtp_sasl_auth_enable = yes',
+    'smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd',
+    'smtp_sasl_security_options = noanonymous',
+    'smtp_use_tls = yes',
+    'smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache',
+    'smtp_tls_security_level = secure',
+    'smtp_tls_CApath = /etc/ssl/certs',
+    'smtp_tls_ciphers = high',
+    'smtp_tls_protocols = TLSv1.2 TLSv1.1 TLSv1 !SSLv3 !SSLv2',
+    'myhostname = ossec.server',
+    'myorigin = $myhostname',
+    'smtpd_banner = $myhostname ESMTP $mail_name (Ubuntu)',
+    'biff = no',
+    'append_dot_mydomain = no',
+    'readme_directory = no',
+    'smtp_header_checks = regexp:/etc/postfix/header_checks',
+    'mailbox_command = /usr/bin/procmail',
+    'inet_interfaces = loopback-only',
+    'alias_maps = hash:/etc/aliases',
+    'alias_database = hash:/etc/aliases',
+    'mydestination = $myhostname, localhost.localdomain , localhost',
+    'mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128',
+    'mailbox_size_limit = 0',
+    'recipient_delimiter = +',
+])
+def test_postfix_settings(File, setting):
+    """
+    Check all postfix configuration lines. There are technically multiple
+    configuration paths regarding the TLS settings, particularly the
+    fingerprint verification logic, but only the base default config is tested
+    currently.
+    """
+    f = File("/etc/postfix/main.cf")
+    assert f.is_file
+    assert f.user == 'root'
+    assert oct(f.mode) == "0644"
+    regex = '^{}$'.format(re.escape(setting))
+    assert re.search(regex, f.content, re.M)
+
+
+def test_postfix_generic_maps(File):
+    """
+    Regression test to check that generic Postfix maps are not configured
+    by default. As of #1565 Admins can opt-in to overriding the FROM address
+    used for sending OSSEC alerts, but by default we're preserving the old
+    `ossec@ossec.server` behavior, to avoid breaking email for previously
+    existing instances.
+    """
+    assert not File("/etc/postfix/generic").exists
+    assert not File("/etc/postfix/main.cf").contains("^smtp_generic_maps")

--- a/testinfra/vars/mon-prod.yml
+++ b/testinfra/vars/mon-prod.yml
@@ -48,3 +48,7 @@ iptables_complete_ruleset: |-
   -A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-ip-options --log-uid
   -A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-ip-options --log-uid
   -A LOGNDROP -j DROP
+
+# Postfix should indeed be running on prod hosts, otherwise
+# OSSEC alerts cannot be delivered. It's disabled in staging.
+postfix_enabled: True

--- a/testinfra/vars/mon-staging.yml
+++ b/testinfra/vars/mon-staging.yml
@@ -10,3 +10,6 @@ tor_services:
       - "22" # assumes remote and local ports are identical
     authenticated: yes # value will automatically be coerced to boolean
     client: admin
+
+# Disable Postfix in staging, since we don't have valid credentials.
+postfix_enabled: False


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #1164.

Changes proposed in this pull request:

* Ensures that the `postfix` service is both "stopped" and "disabled" (meaning it isn't running, and won't run on the next boot, either) only in the staging environment
* Updates testinfra config tests to confirm the above statements
* Modifies the testinfra tests a bit to make them more flexible, since prod environments don't change as a result of the new conditional logic

We don't have great support for the prod testinfra tests, and we're not running them in CI, so manual testing will be required to confirm we don't have regressions. 

Also, the diff is larger than strictly necessary, simply because I moved the postfix-related config tests from `testinfra/mon/test_ossec.py` to `testinfra/mon/test_postfix.py`. 

## Testing

1. Make sure CI passes!
2. Provision a staging environment locally; confirm that tests pass, and that `sudo service postfix status` shows ` * postfix is not running`.
3. Provision a prod environment and confirm that `sudo service postfix status` shows ` * postfix is running`.



## Deployment

Yes: we must be certain that the new conditional logic preserves the existing functionality of "postfix is started and enabled" on prod-like hosts. 

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
