### PR TITLE
Automatically generate the screenshot of an admin adding a journalist with a Yubikey

### DIFF
--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -581,3 +581,17 @@ class JournalistNavigationSteps():
         self.user, self.user_pw = db_helper.init_journalist()
         for _ in range(Journalist._MAX_LOGIN_ATTEMPTS_PER_PERIOD + 1):
             self._try_login_user(self.user.username, 'worse', 'mocked')
+
+    def _admin_enters_journalist_account_details_hotp(self, username,
+                                                      hotp_secret):
+        username_field = self.driver.find_element_by_css_selector(
+            'input[name="username"]')
+        username_field.send_keys(username)
+
+        hotp_secret_field = self.driver.find_element_by_css_selector(
+            'input[name="otp_secret"]')
+        hotp_secret_field.send_keys(hotp_secret)
+
+        hotp_checkbox = self.driver.find_element_by_css_selector(
+            'input[name="is_hotp"]')
+        hotp_checkbox.click()

--- a/securedrop/tests/pages-layout/test_journalist.py
+++ b/securedrop/tests/pages-layout/test_journalist.py
@@ -58,11 +58,21 @@ class TestJournalistLayout(
         self._visit_edit_totp_secret()
         self._screenshot('journalist-account_new_two_factor_totp.png')
 
-    def test_admin_add_user(self):
+    def test_admin_add_user_hotp(self):
         self._admin_logs_in()
         self._admin_visits_admin_interface()
         self._admin_visits_add_user()
-        self._screenshot('journalist-admin_add_user.png')
+        self._admin_enters_journalist_account_details_hotp(
+            'journalist2',
+            'c4 26 43 52 69 13 02 49 9f 6a a5 33 96 46 d9 05 42 a3 4f ae'
+        )
+        self._screenshot('journalist-admin_add_user_hotp.png')
+
+    def test_admin_add_user_totp(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_visits_add_user()
+        self._screenshot('journalist-admin_add_user_totp.png')
 
     def test_admin_edit_hotp_secret(self):
         self._admin_logs_in()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2186. Adds test to generate the screenshot needed for completing #2167. Check it out:

![journalist-admin_add_user_hotp](https://user-images.githubusercontent.com/7832803/29645589-68e78c1a-8833-11e7-8e77-d252291cbb94.png)

Changes proposed in this pull request:
 * Adds new `page-layout` test to create a screenshot needed in the Admin Guide

## Testing

1. Provision dev VM
2. `cd /vagrant/securedrop`
3. `pytest -v tests/pages-layout/test_journalist.py::TestJournalistLayout::test_admin_add_user_hotp --page-layout`
4. Check out the image called `journalist-admin_add_user_hotp.png` 😇 

## Deployment

None, just continuing to automate ourselves out of yawn-inducing "take screenshots of the UI before the upcoming release to update the user guides" work

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM (_except_ those described in #2183 and fixed in #2184)
