### PR TITLE
Document --page-layout pytest option

### DIFF
--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -57,7 +57,7 @@ the following::
 An easier way is to generate screenshots for each state in each known
 language with::
 
-     $ pytest -v tests/pages-layout
+     $ pytest -v tests/pages-layout --page-layout
      ...
      ...TestJournalistLayout::test_col_no_documents[en_US] PASSED
      ...TestJournalistLayout::test_col_no_documents[fr_FR] PASSED

--- a/docs/development/testing_application_tests.rst
+++ b/docs/development/testing_application_tests.rst
@@ -78,6 +78,21 @@ variable. Output PNG files will be placed in the ``tests/log/`` directory.
 
     SCREENSHOTS_ENABLED=1 pytest tests/functional/
 
+Page Layout Tests
+~~~~~~~~~~~~~~~~~
+
+You can check the rendering of the layout of each page in each translated
+language using the page layout tests. These will generate screenshots of
+each page and can be used for example to update the SecureDrop user guides
+when modifications are made to the UI.
+
+You can run all tests, including the page layout tests with the `--page-layout`
+option:
+
+.. code:: sh
+
+    pytest tests/ --page-layout
+
 
 Updating the application tests
 ------------------------------


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2179

Changes proposed in this pull request:
 * Documents `--page-layout` pytest option

## Testing

Run the instructions as described
Check the docs render fine

## Deployment

Docs only

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
