### PR TITLE
i18n: add DEFAULT_LOCALE to config.py.example

### DIFF
--- a/install_files/ansible-base/roles/app/defaults/main.yml
+++ b/install_files/ansible-base/roles/app/defaults/main.yml
@@ -108,3 +108,6 @@ appserver_dependencies:
 
 # Log file location for worker service, used in supervisor template.
 worker_logs_dir: /var/log/securedrop_worker
+
+# The locale used when the browser or the user do not have a preference
+securedrop_default_locale: en_US

--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -180,3 +180,12 @@
   tags:
     - logo
     - securedrop_config
+
+- name: Add DEFAULT_LOCALE to config.py if missing.
+  lineinfile:
+    dest: "{{ securedrop_code }}/config.py"
+    line: "DEFAULT_LOCALE = '{{ securedrop_default_locale }}'"
+    regexp: "^DEFAULT_LOCALE"
+  when: db.stat.exists
+  tags:
+    - securedrop_config

--- a/securedrop/config.py.example
+++ b/securedrop/config.py.example
@@ -83,3 +83,6 @@ TEMP_DIR = os.path.join(SECUREDROP_DATA_ROOT, "tmp")
 # depending on the environment
 DATABASE_ENGINE = 'sqlite'
 DATABASE_FILE = os.path.join(SECUREDROP_DATA_ROOT, 'db.sqlite')
+
+# Which of the available locales should be displayed by default ?
+DEFAULT_LOCALE = 'en_US'

--- a/testinfra/app-code/test_securedrop_app_code.py
+++ b/testinfra/app-code/test_securedrop_app_code.py
@@ -35,6 +35,18 @@ def test_securedrop_application_apt_dependencies(Package, package):
     assert Package(package).is_installed
 
 
+def test_securedrop_application_test_locale(File, Sudo):
+    """
+    Ensure SecureDrop DEFAULT_LOCALE is present.
+    """
+    securedrop_config = File("{}/config.py".format(
+        securedrop_test_vars.securedrop_code))
+    with Sudo():
+        assert securedrop_config.is_file
+        assert securedrop_config.contains("^DEFAULT_LOCALE")
+        assert securedrop_config.content.count("DEFAULT_LOCALE") == 1
+
+
 def test_securedrop_application_test_journalist_key(File, Sudo):
     """
     Ensure the SecureDrop Application GPG public key file is present.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

And upgrade an existing config.py if no DEFAULT_LOCALE is found

## Testing

* vagrant up development
* testinfra/test.py development
* verify the output has:
<pre>
[gw0] PASSED testinfra/app-code/test_securedrop_app_code.py::test_securedrop_application_test_locale[ansible://development] 
</pre>


## Deployment

The existing config.py will be updated to add a new variable. It is not currently in use and should have no impact on existing systems.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
