### PR TITLE
Store Tails decompression option in xsessionrc instead of bashrc

### DIFF
--- a/docs/generate_securedrop_application_key.rst
+++ b/docs/generate_securedrop_application_key.rst
@@ -16,14 +16,7 @@ Ensure Filenames are Preserved
 In order to preserve filenames when you decrypt submissions, on each *Secure
 Viewing Station*, you should open a **Terminal** and type the following commands:
 
-.. code:: sh
-
-  cd /live/persistence/TailsData_unlocked/dotfiles
-  cp ~/.bashrc .
-  echo "/usr/bin/dconf write /org/gnome/nautilus/preferences/automatic-decompression false" >> .bashrc
-
-.. note:: This only needs to be done once on each *Secure Viewing Station*.
-          After a reboot it will persist.
+.. include:: includes/tails-svs-nautilus.txt
 
 Correct the system time
 -----------------------

--- a/docs/includes/tails-svs-nautilus.txt
+++ b/docs/includes/tails-svs-nautilus.txt
@@ -1,0 +1,7 @@
+.. code:: sh
+
+  cd /live/persistence/TailsData_unlocked/dotfiles
+  echo "/usr/bin/dconf write /org/gnome/nautilus/preferences/automatic-decompression false" > .xsessionrc
+
+.. note:: This only needs to be done once on each *Secure Viewing Station*.
+          After a reboot it will persist.

--- a/docs/upgrade_to_tails_3x.rst
+++ b/docs/upgrade_to_tails_3x.rst
@@ -232,14 +232,7 @@ Due to a change in Tails 3, if you wish to preserve the names of files when
 decrypting, you'll need to apply the following fix by opening a **Terminal** on
 the *Secure Viewing Station* and typing the following commands:
 
-.. code:: sh
-
-  cd /live/persistence/TailsData_unlocked/dotfiles
-  cp ~/.bashrc .
-  echo "/usr/bin/dconf write /org/gnome/nautilus/preferences/automatic-decompression false" >> .bashrc
-
-.. note:: This only needs to be done once on each *Secure Viewing Station*.
-          After a reboot it will persist.
+.. include:: includes/tails-svs-nautilus.txt
 
 6. Upgrade SecureDrop to 0.4.x
 ------------------------------


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2188.

Changes proposed in this pull request:
* To preserve filenames and the file structure of office files (.docx, .odt, .xlsx,
etc.), we must store custom config in xsessionrc so that it starts when users log in
to their Tails session. 

## Testing

1. Apply option in this PR. 
2. Reboot.
3. DO NOT open a Terminal.
4. Open files submitted through SecureDrop (I tested with .ods, .xlsx, .docx, .odt but you should just test one office format since they all have the same behavior).
5. Verify that the office formats are not unpacked and appear as you would expect an office file to.  

## Deployment

Anyone who has ran through the upgrade to Tails 3 instructions will need to set this option. We can inform organizations through the support portal or in the upgrade guide to do so. If a lot of people are reporting trouble, we can write a blog. 

Anyone that has not upgraded to Tails 3 or anyone that is doing a new install will encounter the updated instructions from this PR and should not encounter the bug in #2188.

## Checklist

Unfortunately in the Tails environment we rely on manual testing.

### If you made changes to documentation:

- [x] Doc linting passed locally
