### PR TITLE
Retry network calls in Tails during validation checks

### DIFF
--- a/install_files/ansible-base/roles/validate/tasks/validate_ossec_info.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_ossec_info.yml
@@ -40,29 +40,32 @@
       - smtp_relay is defined
       - sasl_domain is defined
 
-# We can't simply call `host <domain>` under Tails, we need to support
-# the tor-only config and specify a nameserver to use for the call
-# (since Tails defaults to localhost as nameserver).
+# In Tails, we must explicitly pass a number of arguments, such as forcing
+# TCP via the "virtual circuit" option. Due to networking variability within
+# Tails due to Tor, we'll also retry the command several times to make sure
+# flaky connections don't result in early failures. In Tails, we must also
+# pass the entire command through `torify`, otherwise it will fail immediately.
 - name: Determine query strategy for mail config checks.
   set_fact:
     _smtp_hostname_query_command: >-
-      {% if ansible_lsb.id == "Tails" %}
-      torify host -T -4 {{ smtp_relay }} 8.8.8.8
-      {% else %}
-      host {{ smtp_relay }}
-      {% endif %}
+      {% if ansible_lsb.id == "Tails" -%}torify {% endif %}
+      nslookup -vc -retry=3 -timeout=10 -fail {{ smtp_relay }} 8.8.8.8
     _sasl_hostname_query_command: >-
-      {% if ansible_lsb.id == "Tails" %}
-      torify host -T -4 {{ sasl_domain }} 8.8.8.8
-      {% else %}
-      host {{ smtp_relay }}
-      {% endif %}
+      {% if ansible_lsb.id == "Tails" %}torify {% endif %}
+      nslookup -vc -retry=3 -timeout=10 -fail {{ sasl_domain }} 8.8.8.8
 
-- name: Validate SMTP relay.
+- name: Perform SMTP lookup check.
+  command: "{{ _smtp_hostname_query_command }}"
+  changed_when: false
+  register: smtp_validate_result
+  # We'll inspect return code in subsequent task to provide an informative
+  # failure message.
+  ignore_errors: yes
+
+- name: Validate SMTP relay connection.
   assert:
     that:
-      # The pipe lookup will fail if command returns non-zero.
-      - lookup('pipe', _smtp_hostname_query_command)
+      - "{{ smtp_validate_result.rc == 0 }}"
     msg: >-
       The SMTP relay domain failed during lookup. This domain
       is the server contacted for authentication in order to send
@@ -70,11 +73,18 @@
       {{ securedrop_validate_error_msg_start }} the `smtp_relay` var
       is set correctly.
 
+- name: Perform SASL lookup check.
+  command: "{{ _sasl_hostname_query_command }}"
+  register: sasl_validate_result
+  changed_when: false
+  # We'll inspect return code in subsequent task to provide an informative
+  # failure message.
+  ignore_errors: yes
+
 - name: Validate SASL domain.
   assert:
     that:
-      # The pipe lookup will fail if command returns non-zero.
-      - lookup('pipe', _sasl_hostname_query_command)
+      - "{{ sasl_validate_result.rc == 0 }}"
     msg: >-
       The SASL domain failed during lookup. This is typically the
       portion of the email address after the '@' symbol, although

--- a/install_files/ansible-base/roles/validate/tasks/validate_ossec_info.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_ossec_info.yml
@@ -32,10 +32,18 @@
       {{ securedrop_validate_error_msg_start }} the `sasl_password` var
       is set correctly.
 
+# Validating that vars are defined before using them to build
+# service-checking commands.
+- name: Ensure mail config vars are defined.
+  assert:
+    that:
+      - smtp_relay is defined
+      - sasl_domain is defined
+
 # We can't simply call `host <domain>` under Tails, we need to support
 # the tor-only config and specify a nameserver to use for the call
 # (since Tails defaults to localhost as nameserver).
-- name: Determine SMTP relay query strategy.
+- name: Determine query strategy for mail config checks.
   set_fact:
     _smtp_hostname_query_command: >-
       {% if ansible_lsb.id == "Tails" %}
@@ -43,9 +51,6 @@
       {% else %}
       host {{ smtp_relay }}
       {% endif %}
-
-- name: Determine SASL domain query strategy.
-  set_fact:
     _sasl_hostname_query_command: >-
       {% if ansible_lsb.id == "Tails" %}
       torify host -T -4 {{ sasl_domain }} 8.8.8.8
@@ -56,7 +61,6 @@
 - name: Validate SMTP relay.
   assert:
     that:
-      - smtp_relay is defined
       # The pipe lookup will fail if command returns non-zero.
       - lookup('pipe', _smtp_hostname_query_command)
     msg: >-
@@ -69,7 +73,6 @@
 - name: Validate SASL domain.
   assert:
     that:
-      - sasl_domain is defined
       # The pipe lookup will fail if command returns non-zero.
       - lookup('pipe', _sasl_hostname_query_command)
     msg: >-


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #2099.

Changes proposed in this pull request:

* Uses `nslookup` rather than `host` to perform DNS lookups in Tails validation tasks.
* Passes `retry=3` and `timeout=10` to `nslookup` to force retries.

The timeout logic is not perfect: the command will still hang for several minutes, due to use of `torify` (required under Tails), in the event a connection connect be established. It will still report the failure with a custom informative error message.

## Testing
### With a working connection
1. Configure prod-like secrets for testing in Tails.
2. Fire up Tails workstation.
3. Run `./securedrop-admin sdconfig`. If you've already provided prod-like secrets, you won't be prompted for any information, and the validation checks will run.
4. Confirm validation checks pass quickly:

```
TASK: validate : Perform SMTP lookup check. ----------------------------- 3.14s
TASK: validate : Perform SASL lookup check. ----------------------------- 2.78s
```

### With no network connection
1. Disable networking in Tails.
2. Run through 1-3 above with no network.
3. Observe failure on SMTP lookup check:

```
TASK [validate : Validate SMTP relay connection.] ******************************
fatal: [localhost]: FAILED! => {
    "assertion": false, 
    "changed": false, 
    "evaluated_to": false, 
    "failed": true, 
    "msg": "The SMTP relay domain failed during lookup. This domain is the server contacted for authentication in order to send OSSEC email notifications. You should manually edit the file `group_vars/all/site-specific` and confirm that the `smtp_relay` var is set correctly."
}
	to retry, use: --limit @/home/amnesia/Persistent/securedrop/install_files/ansible-base/securedrop-configure.retry

PLAY RECAP *********************************************************************
localhost                  : ok=18   changed=0    unreachable=0    failed=1   

TASK: validate : Perform SMTP lookup check. --------------------------- 248.69s
```

The no-network scenario takes a long time for the timeout, due to use of `torify`. I'm comfortable with the increased delay here: the failure mode essentially informs the Admin that the network connection in Tails is not working. 

## Deployment

Minor modifications to the Admin around validating the site-specific vars, trying to make the script more resilient and report failures less eagerly.

## Checklist

Requiring manual testing via Tails.