### PR TITLE
tests: retry if connection to firefox fails

### DIFF
--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from datetime import datetime
+import errno
 import mock
 from multiprocessing import Process
 import os
@@ -50,8 +51,26 @@ class FunctionalTest():
         return port
 
     def _create_webdriver(self, firefox, profile=None):
-        return webdriver.Firefox(firefox_binary=firefox,
-                                 firefox_profile=profile)
+        # see https://review.openstack.org/#/c/375258/ and the
+        # associated issues for background on why this is necessary
+        connrefused_retry_count = 3
+        connrefused_retry_interval = 5
+
+        for i in range(connrefused_retry_count + 1):
+            try:
+                driver = webdriver.Firefox(firefox_binary=firefox,
+                                           firefox_profile=profile)
+                if i > 0:
+                    # i==0 is normal behavior without connection refused.
+                    print('NOTE: Retried {} time(s) due to '
+                          'connection refused.'.format(i))
+                return driver
+            except socket.error as socket_error:
+                if (socket_error.errno == errno.ECONNREFUSED
+                        and i < connrefused_retry_count):
+                    time.sleep(connrefused_retry_interval)
+                    continue
+                raise
 
     def _prepare_webdriver(self):
         log_file = open(join(LOG_DIR, 'firefox.log'), 'a')

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -49,14 +49,17 @@ class FunctionalTest():
         s.close()
         return port
 
-    def _create_webdriver(self):
+    def _create_webdriver(self, firefox, profile=None):
+        return webdriver.Firefox(firefox_binary=firefox,
+                                 firefox_profile=profile)
+
+    def _prepare_webdriver(self):
         log_file = open(join(LOG_DIR, 'firefox.log'), 'a')
         log_file.write(
             '\n\n[%s] Running Functional Tests\n' % str(
                 datetime.now()))
         log_file.flush()
-        firefox = firefox_binary.FirefoxBinary(log_file=log_file)
-        return webdriver.Firefox(firefox_binary=firefox)
+        return firefox_binary.FirefoxBinary(log_file=log_file)
 
     def setup(self):
         # Patch the two-factor verification to avoid intermittent errors
@@ -114,7 +117,7 @@ class FunctionalTest():
                 break
 
         if not hasattr(self, 'override_driver'):
-            self.driver = self._create_webdriver()
+            self.driver = self._create_webdriver(self._prepare_webdriver())
 
             # Poll the DOM briefly to wait for elements. It appears
             # .click() does not always do a good job waiting for the

--- a/securedrop/tests/pages-layout/functional_test.py
+++ b/securedrop/tests/pages-layout/functional_test.py
@@ -47,17 +47,11 @@ class FunctionalTest(functional_test.FunctionalTest):
             os.path.join(dirname(realpath(__file__)),
                          'screenshots', self.accept_languages))
         os.system("mkdir -p " + self.log_dir)
-        log_file = open(os.path.join(self.log_dir, 'firefox.log'), 'a')
-        log_file.write(
-            '\n\n[%s] Running Functional Tests\n' % str(
-                datetime.now()))
-        log_file.flush()
-        firefox = firefox_binary.FirefoxBinary(log_file=log_file)
+        firefox = self._prepare_webdriver()
         profile = webdriver.FirefoxProfile()
         profile.set_preference("intl.accept_languages", self.accept_languages)
         self.override_driver = True
-        self.driver = webdriver.Firefox(firefox_binary=firefox,
-                                        firefox_profile=profile)
+        self.driver = self._create_webdriver(firefox, profile)
         self._javascript_toggle()
 
         yield None


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2214

Retry when selenium fails to connect to firefox. Re-using the solution implemented at https://review.openstack.org/#/c/375258/

## Testing

* pytest tests

Actually verifying it does the right thing when a connection is refused is likely to be difficult.

## Deployment

This is test only.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
