### PR TITLE
Add docs for fully virtualized prod install

### DIFF
--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -1,5 +1,5 @@
-Virtual Environments
-====================
+Virtual Environments: Servers
+=============================
 
 There are three predefined virtual environments in the Vagrantfile:
 

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -3,12 +3,15 @@ Virtual Environments
 
 There are three predefined virtual environments in the Vagrantfile:
 
-1. Development
-2. Staging
-3. Production
+1. :ref:`Development <development_vm>`
+2. :ref:`Staging <staging_vms>`
+3. :ref:`Production <production_vms>`
 
 This document explains the purpose of, and how to get started working with, each
 one.
+
+.. note:: If you plan to alter the configuration of any of these machines, make sure to
+          review the :ref:`config_tests` documentation.
 
 .. note:: If you have errors with mounting shared folders in the Vagrant guest
           machine, you should look at `GitHub #1381`_.
@@ -53,11 +56,13 @@ following ports:
 * Source Interface: `localhost:8080 <http://localhost:8080>`__
 * Journalist Interface: `localhost:8081 <http://localhost:8081>`__
 
+.. _staging_vms:
+
 Staging
 -------
 
 A compromise between the development and production environments. This
-configuration can be thought of as identical to the production enviornment, with
+configuration can be thought of as identical to the production environment, with
 a few exceptions:
 
 * The Debian packages are built from your local copy of the code, instead of
@@ -153,6 +158,8 @@ Direct SSH access is available via Vagrant for staging hosts, so you can use
 ``vagrant ssh app-staging`` and ``vagrant ssh mon-staging`` to start an
 interactive session on either server.
 
+.. _production_vms:
+
 Production
 ----------
 
@@ -162,7 +169,73 @@ virtualized, rather than running on hardware. You will need to
 ``ANSIBLE_ARGS="--skip-tags validate"`` to skip the tasks that prevent the prod
 playbook from running with Vagrant-specific info.
 
-To create only the prod servers, run:
+You can provision production VMs from an Admin Workstation (most realistic),
+or from your host. Instructions for both follow.
+
+.. _prod_install_from_tails:
+
+Install from an Admin Workstation VM
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In SecureDrop, admin tasks are performed from a Tails *Admin Workstation*.
+You should configure a Tails VM in order to install the SecureDrop production VMs
+by following the instructions in the :ref:`Virtualizing Tails <virtualizing_tails>`
+guide.
+
+Once you're prepared the *Admin Workstation*, you can start each VM:
+
+.. code:: sh
+
+  vagrant up --no-provision /prod/
+
+At this point you should be able to SSH into both ``app-prod`` and ``mon-prod``.
+From here you can follow the :ref:`server configuration instructions
+<test_connectivity>` to test connectivity and prepare the servers. These
+instructions will have you generate SSH keys and use ``ssh-copy-id`` to transfer
+the key onto the servers.
+
+.. note:: If you have trouble SSHing to the servers from Ansible, remember
+          to remove any old ATHS files in ``install_files/ansible-base``.
+
+Now from your Admin workstation:
+
+.. code:: sh
+
+  cd ~/Persistent/securedrop
+  ./securedrop-admin setup
+  ./securedrop-admin sdconfig
+  ./securedrop-admin install
+
+.. note:: The sudo password for the ``app-prod`` and ``mon-prod`` servers is by
+          default ``vagrant``.
+
+After install you can configure your Admin Workstation to SSH into each VM via:
+
+.. code:: sh
+
+  ./securedrop-admin tailsconfig
+
+Install from Host OS
+~~~~~~~~~~~~~~~~~~~~
+
+If you are not virtualizing Tails, you can manually modify ``site-specific``,
+and then provision the machines. You should set the following options in
+``site-specific``:
+
+.. code:: sh
+
+  ssh_users: "vagrant"
+  monitor_ip: "10.0.1.5"
+  monitor_hostname: "mon-prod"
+  app_hostname: "app-prod"
+  app_ip: "10.0.1.4"
+
+Note that you will also need to generate Submission and OSSEC PGP public keys,
+and provide email credentials to send emails to. Refer to
+:ref:`this document on configuring prod-like secrets<configure_securedrop>`
+for more details on those steps.
+
+To create the prod servers, run:
 
 .. code:: sh
 
@@ -181,8 +254,8 @@ directory, named:
 * ``app-ssh-aths``
 * ``mon-ssh-aths``
 
+SSH Access
+~~~~~~~~~~
+
 Direct SSH access is not available in the prod environment. You will need to log
 in over Tor after initial provisioning. See :ref:`ssh_over_tor` for more info.
-
-If you plan to alter the configuration of any of these machines, make sure to
-review the :ref:`config_tests` documentation.

--- a/docs/development/virtualizing_tails.rst
+++ b/docs/development/virtualizing_tails.rst
@@ -1,0 +1,251 @@
+.. _virtualizing_tails:
+
+Virtualizing Tails
+==================
+
+SecureDrop uses Tails for the *Admin Workstation* environment. In order to
+perform a fully virtualized production install, you will need to first set up
+Tails in a virtual machine.
+
+.. note:: For the instructions that follow, you need to download the most
+          recent Tails ISO from the `Tails`_ website.
+
+.. _`Tails`: https://tails.boum.org
+
+macOS
+-----
+
+For the macOS instructions, you will use VirtualBox to create a Tails VM that
+you can use to install SecureDrop on ``app-prod`` and ``mon-prod``.
+
+Create a VirtualBox VM
+~~~~~~~~~~~~~~~~~~~~~~
+
+1. Open VirtualBox
+2. Click **New** to create a new VM with the following options:
+
+   * **Name**: "Admin Workstation"
+   * **Type**: "Linux"
+   * **Version**: "Debian (64-bit)"
+
+.. note:: You may call the VM a different name, but you must replace
+    "Admin Workstation" later on in these instructions with the name you select.
+
+3. Click **Continue**.
+4. At the prompt, configure at least 2048 MB of RAM. Click **Continue**.
+5. Leave the default **Create a virtual hard disk now** selected and click
+   **Create**. All the default options (**Hard disk file type: VDI (VirtualBox
+   Disk Image)** and **Dynamically allocated**) are fine. Click **Create**.
+
+Booting Tails
+~~~~~~~~~~~~~
+
+Now that the VM is set up, you are ready to boot to Tails. Select the new VM
+in the VirtualBox sidebar, and click **Settings**.
+
+1. Click **Storage**.
+2. Click **Empty** under **Controller: IDE**.
+3. Click the CD icon next to **Optical Drive:** and click **Choose Virtual
+   Optical Disk File**.
+4. Navigate to the Tails ISO to boot from.
+5. Click **General** then **Advanced**.
+6. Under **Shared Clipboard** select **Bidirectional** instead of **Disabled**.
+   This option will enable you to transfer text from your host to the Tails VM,
+   which we will use later on in these steps.
+
+   .. note:: Alternatively you can open these docs in Tor Browser in Tails.
+             This will obviate the need to copy and paste between the guest
+             and host OS.
+
+Install Tails
+~~~~~~~~~~~~~
+
+Next you will install Tails onto the Virtual Hard Disk Image. Start the VM, boot
+to Tails, and enter an administration password and start Tails.
+
+.. note:: For all the instructions that follow, you will need to configure an
+          administrator password each time you boot Tails.
+
+1. Copy the following patch and save it as ``installer.patch`` in a folder in
+   your Tails VM:
+
+.. code:: python
+
+  --- /usr/lib/python2.7/dist-packages/tails_installer/creator.py	2017-06-30 11:14:11.000000000 +0000
+  +++ /usr/lib/python2.7/dist-packages/tails_installer/creator.py.mod	2017-07-20 06:53:31.152000000 +0000
+  @@ -615,15 +615,6 @@
+               if not data['removable']:
+                   self.log.debug('Skipping non-removable device: %s' % data['device'])
+
+  -            # Only pay attention to USB and SDIO devices, unless --force'd
+  -            iface = drive.props.connection_bus
+  -            if iface != 'usb' and iface != 'sdio' and self.opts.force != data['device']:
+  -                self.log.warning(
+  -                    "Skipping device '%(device)s' connected to '%(interface)s' interface"
+  -                    % {'device': data['udi'], 'interface': iface}
+  -                )
+  -                continue
+  -
+               # Skip optical drives
+               if data['is_optical'] and self.opts.force != data['device']:
+                   self.log.debug('Skipping optical device: %s' % data['device'])
+  --- /usr/lib/python2.7/dist-packages/tails_installer/gui.py	2017-06-30 11:14:11.000000000 +0000
+  +++ /usr/lib/python2.7/dist-packages/tails_installer/gui.py.mod	2017-07-20 06:53:44.040000000 +0000
+  @@ -483,16 +483,6 @@
+                       'model':   info['model'],
+                       'details': details
+                   }
+  -                # Skip devices with non-removable bit enabled
+  -                if not info['removable']:
+  -                    message =_('The USB stick "%(pretty_name)s"'
+  -                               ' is configured as non-removable by its'
+  -                               ' manufacturer and Tails will fail to start on it.'
+  -                               ' Please try installing on a different model.') % {
+  -                               'pretty_name':  pretty_name
+  -                               }
+  -                    self.status(message)
+  -                    continue
+                   # Skip too small devices, but inform the user
+                   if not info['is_device_big_enough']:
+                       message =_('The device "%(pretty_name)s"'
+
+2. Now run the following two commands in a Terminal in your Tails VM:
+
+.. code:: sh
+
+  sudo patch -p0 -d/ < installer.patch
+  sudo /usr/bin/python -tt /usr/lib/tails_installer/tails-installer -u -n --clone -P -m -x
+
+3. The **Tails Installer** will appear. Click **Install Tails**.
+4. Once complete, navigate to **Applications**, **Utilities** and open **Disks**.
+5. Click on the disk named "Tails" and click the Play icon to mount the disk.
+6. Next open ``/media/amnesia/Tails/syslinux/live*.cfg`` and delete all instances
+   of ``live-media=removable``.
+7. Shut down the VM.
+
+Boot to Tails Hard Drive Install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Now we will remove the CD and boot to the Tails we just installed on our
+virtual hard drive. From macOS you should:
+
+1. Click the VM in the sidebar of VirtualBox and click **Settings**.
+2. Click **Storage** and select the Tails .iso under **Controller: IDE**.
+3. Click the CD icon, then **Remove Disk from Virtual Drive**.
+4. Click **Ok**.
+5. Start the VM.
+
+Configure Persistence
+~~~~~~~~~~~~~~~~~~~~~
+
+Now in your booted Tails VM you should:
+
+1. Configure an admin password when prompted.
+2. Copy the following patch to the Tails VM and save it as ``persistence.patch``:
+
+.. code:: python
+
+   --- /usr/share/perl5/Tails/Persistence/Setup.pm	2017-06-30 09:56:25.000000000 +0000
+   +++ /usr/share/perl5/Tails/Persistence/Setup.pm.mod	2017-07-20 07:17:48.472000000 +0000
+   @@ -404,19 +404,6 @@
+
+        my @checks = (
+            {
+   -            method  => 'drive_is_connected_via_a_supported_interface',
+   -            message => $self->encoding->decode(gettext(
+   -                "Tails is running from non-USB / non-SDIO device %s.")),
+   -            needs_drive_arg => 1,
+   -        },
+   -        {
+   -            method  => 'drive_is_optical',
+   -            message => $self->encoding->decode(gettext(
+   -                "Device %s is optical.")),
+   -            must_be_false    => 1,
+   -            needs_drive_arg => 1,
+   -        },
+   -        {
+                method  => 'started_from_device_installed_with_tails_installer',
+                message => $self->encoding->decode(gettext(
+                    "Device %s was not created using Tails Installer.")),
+
+3. To apply the patch, from the Terminal run:
+
+.. code:: sh
+
+  sudo patch -p0 -d/ < persistence.patch
+
+4. Navigate to **Applications** then **Tails** and click **Configure
+   persistent volume**. Configure a persistent volume enabling all persistence
+   options.
+
+Shared Folders
+~~~~~~~~~~~~~~
+
+1. In macOS, click on the Tails VM in VirtualBox and then go to
+   **Settings**.
+2. Click on **Shared Folders** and click the button on the right hand side to
+   add the folder. Navigate to the location of the SecureDrop repository on
+   your local machine. Check **Auto-mount**. Do not check
+   **Read-only**.
+
+3. Now reboot your Tails VM, decrypt the Persistent volume, and run the following
+   commands in a **Terminal** in Tails:
+
+.. code:: sh
+
+  mkdir ~/Persistent/securedrop
+  echo 'if [ ! -d ~/Persistent/securedrop/install_files ]; then sudo mount -t vboxsf -o uid=$UID,gid=$(id -g) securedrop ~/Persistent/securedrop; fi' >> /live/persistence/TailsData_unlocked/dotfiles/.bashrc
+
+The first time you open a Terminal in that session you will be prompted for your
+sudo password and the shared folder will be mounted. Each time you open a
+Terminal thereafter in the Tails session, your sudo password will not be needed.
+
+Allow the Guest to Create Symlinks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Finally, you'll need to allow the guest to create symlinks, which are
+`disabled by default in VirtualBox`_.
+
+.. _`disabled by default in VirtualBox`: https://www.virtualbox.org/ticket/10085#comment:12
+
+Shut down the Tails VM, and in your host run:
+
+.. code:: sh
+
+  VBoxManage setextradata "Admin Workstation" VBoxInternal2/SharedFoldersEnableSymlinksCreate/securedrop 1
+
+.. note:: If you named your Tails VM something other than "Admin Workstation",
+    you can run ``VBoxManage list vms`` to get the name of the Virtual Machine.
+
+Finally, restart VirtualBox.
+
+Configure Networking
+~~~~~~~~~~~~~~~~~~~~
+
+In order to communicate with the server VMs, you'll need to attach this
+virtualized *Admin Workstation* to the ``securedrop`` network.
+
+.. warning:: If you named the SecureDrop repository something other than
+    ``securedrop``, you should connect your VM to the network of the same name.
+
+With the *Admin Workstation* VM turned off, you should:
+
+1. Click on the VM in VirtualBox.
+2. Click **Settings**.
+3. Click **Network** and then **Adapter 2**.
+4. Enable this network adapter and attach it to the **Internal Network** called
+   ``securedrop``.
+5. Click OK and start the VM.
+
+Now you should be able to boot to Tails, decrypt the Persistent volume,
+navigate to ``~/Persistent/securedrop`` and proceed with the :ref:`production
+install <prod_install_from_tails>`.
+
+Disable Shared Clipboard (Optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Click on the VM in VirtualBox.
+2. Click **Settings**.
+3. Click **General** and then **Advanced**.
+4. Now that you are finished with copy pasting the patches above you can change
+   the **Shared Clipboard** from **Bidirectional** back to **Disabled**.

--- a/docs/development/virtualizing_tails.rst
+++ b/docs/development/virtualizing_tails.rst
@@ -1,7 +1,7 @@
 .. _virtualizing_tails:
 
-Virtualizing Tails
-==================
+Virtual Environments: Admin Workstation
+=======================================
 
 SecureDrop uses Tails for the *Admin Workstation* environment. In order to
 perform a fully virtualized production install, you will need to first set up

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,6 +94,7 @@ anonymous sources.
 
    development/getting_started
    development/virtual_environments
+   development/virtualizing_tails
    development/contributor_guidelines
    development/tips_and_tricks
    development/i18n

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -283,6 +283,8 @@ When you are done, make sure you save the following information:
 -  The IP address of the *Monitor Server*
 -  The non-root user's name and password for the servers.
 
+.. _test_connectivity:
+
 Test Connectivity
 -----------------
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #2203. Completes the macOS side of #2204. 

Changes proposed in this pull request:
 * Adds more detailed description of prod VM testing from both a virtualized Admin Workstation and the host. 
 * Adds instructions for setting up an Admin Workstation VM in macOS (kudos to @garrettr for his notes on virtualizing Tails on macOS :1st_place_medal:).

## Testing

In addition to checking things render well, one should at least read through the instructions to check that I'm not missing any critical pieces of information for developers.

## Deployment

Docs only

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
