### PR TITLE
Moves linting checks Travis -> CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,21 @@ jobs:
           name: Installation pre-reqs
           command: pip install -U -r securedrop/requirements/develop-requirements.txt
 
+      # Circle CI automatically dumps its env vars (`CIRCLE_*`), but let's
+      # inspect everything.
+      - run:
+          name: Dump environment variables.
+          command: printenv | sort
+
+      - run:
+          name: Check python version
+          command: python --version || true
+
+      - run:
+          name: Check user
+          command: whoami ; id -u || true
+
+
       # Intentionally *not* using `make lint` wrapper so as not to skip linting
       # steps if one fails. Continue linting in CI, and report full status.
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 version: 2
 jobs:
-  docs-lint:
+  lint:
     docker:
       - image: msheiny/pressfreedomci:latest
 
@@ -12,9 +12,17 @@ jobs:
           name: Installation pre-reqs
           command: pip install -U -r securedrop/requirements/develop-requirements.txt
 
+      # Intentionally *not* using `make lint` wrapper so as not to skip linting
+      # steps if one fails. Continue linting in CI, and report full status.
       - run:
           name: Run docs lint
           command: make docs-lint
+      - run:
+          name: Run flake8 linting checks
+          command: make flake8
+      - run:
+          name: Run HTML linting checks
+          command: make html-lint
 
   staging-test:
     docker:
@@ -55,7 +63,7 @@ workflows:
   version: 2
   securedrop_ci:
     jobs:
-      - docs-lint
+      - lint
       - staging-test:
           requires:
-            - docs-lint
+            - lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,14 +54,5 @@ script:
   - sudo sh -c "export DISPLAY=:1; cd securedrop/ && pytest -v tests/ --page-layout"
   - SECUREDROP_TESTINFRA_TARGET_HOST=travis testinfra -v testinfra/development/
   - pip freeze -l
-  # Performing new pip install step *after* build VM tests pass, so as not
-  # to alter the pip requirements, which would cause config tests to fail.
-  # The develop requirements include sphinx tooling for docs linting.
-  - pip install -r securedrop/requirements/develop-requirements.txt
-  # Intentionally *not* using `make lint` wrapper so as not to skip linting
-  # steps if one fails. Continue linting in CI, and report full status.
-  - make docs-lint
-  - make flake8
-  - make html-lint
 after_success:
   cd securedrop/ && coveralls


### PR DESCRIPTION
## Status

~Ready for review.~ Work in progress.

## Description of Changes

The Travis environment has far too many machine roles shoehorned into
it, which causes conflicts when checking for explicit dependencies in
pip output. We have a linting-only workflow for Circle CI now, so let's
use it. We're ramping down our usage of Travis in favor of Circle CI.

Also renames the workflow step docs-lint -> lint since we're checking
multiple linting targets now.

Closes #2217.

## Testing

1. Confirm all CI checks pass.
2. If you want, you can run `make lint` locally, because you can do that now.

## Deployment

None, only affects CI, and linting, at that.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
