### PR TITLE
Removes usage of `safe` filter in jinja templates

### DIFF
--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import scoped_session, sessionmaker, relationship, backref
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, Boolean, DateTime, Binary
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from jinja2 import Markup
 
 import scrypt
 import pyotp
@@ -369,7 +370,7 @@ class Journalist(Base):
 
         svg_out = StringIO()
         img.save(svg_out)
-        return svg_out.getvalue()
+        return Markup(svg_out.getvalue())
 
     @property
     def formatted_otp_secret(self):

--- a/securedrop/journalist_templates/account_new_two_factor.html
+++ b/securedrop/journalist_templates/account_new_two_factor.html
@@ -10,7 +10,7 @@
   <li>Tap menu, then tap "Set up account", then tap "Scan a barcode"</li>
   <li>Your phone will now be in "scanning" mode. When you are in this mode, scan the barcode below:</li>
 </ol>
-<div id="qrcode-container">{{ user.shared_secret_qrcode|safe }}</div>
+<div id="qrcode-container">{{ user.shared_secret_qrcode }}</div>
 <p>Can't scan the barcode? Enter the following code manually: <span id="shared-secret">{{ user.formatted_otp_secret }}</span></p>
 <p>Once you have scanned the barcode, enter the 6-digit code below:</p>
 {% else %}

--- a/securedrop/journalist_templates/admin_new_user_two_factor.html
+++ b/securedrop/journalist_templates/admin_new_user_two_factor.html
@@ -11,7 +11,7 @@
   <li>Tap menu, then tap "Set up account", then tap "Scan a barcode"</li>
   <li>Your phone will now be in "scanning" mode. When you are in this mode, scan the barcode below:</li>
 </ol>
-<div id="qrcode-container">{{ user.shared_secret_qrcode|safe }}</div>
+<div id="qrcode-container">{{ user.shared_secret_qrcode }}</div>
 <p>Can't scan the barcode? Enter the following code manually: <span id="shared-secret">{{ user.formatted_otp_secret }}</span></p>
 <p>Once you have scanned the barcode, enter the 6-digit code below:</p>
 {% else %}

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -118,9 +118,10 @@ def check_tor2web():
     # ignore_static here so we only flash a single message warning
     # about Tor2Web, corresponding to the initial page load.
     if 'X-tor2web' in request.headers:
-        flash('<strong>WARNING:</strong> You appear to be using Tor2Web. '
-              'This <strong>does not</strong> provide anonymity. '
-              '<a href="/tor2web-warning">Why is this dangerous?</a>',
+        flash(Markup('<strong>WARNING:</strong> You appear to be using '
+                     'Tor2Web. This <strong>does not</strong> provide '
+                     'anonymity. <a href="/tor2web-warning">Why is this '
+                     'dangerous?</a>'),
               "banner-warning")
 
 

--- a/securedrop/source_templates/banner_warning_flashed.html
+++ b/securedrop/source_templates/banner_warning_flashed.html
@@ -2,6 +2,6 @@
 {% with messages = get_flashed_messages(with_categories=True, category_filter=["banner-warning"]) %}
   {% for category, message in messages %}
   <p class="flash {{ category }}"><img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/exclamation-triangle-black.png') }}" width="20px" height="17px">
- {{ message|safe }}</p>
+ {{ message }}</p>
   {% endfor %}
 {% endwith %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2226.

Changes:
- QR codes are now `Markup` and not `str`
- Tor2Web banner warning is now `Markup` and not `str`
- All instance of `foo | safe` were removed from the templates

## Testing

In the source interface, set Tor2Web header and ensure warning hasn't escaped its tags. In the Journalist interface, try to create a user and ensure QR code still works.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM