### PR TITLE
tests: verbose teardown to debug #844 (take 2)

### DIFF
--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -67,9 +67,12 @@ def teardown():
         if t.is_alive() and not isinstance(t, threading._MainThread):
             t.join()
     db_session.remove()
-    os.system("find " + config.SECUREDROP_DATA_ROOT)  # REMOVE ME, see #844
     try:
         shutil.rmtree(config.SECUREDROP_DATA_ROOT)
     except OSError as exc:
+        os.system("find " + config.SECUREDROP_DATA_ROOT)  # REMOVE ME, see #844
         if 'No such file or directory' not in exc:
             raise
+    except:
+        os.system("find " + config.SECUREDROP_DATA_ROOT)  # REMOVE ME, see #844
+        raise


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Related to  #844

The previous find is misplaced: it will just show the temporary dir is
populated. What we really need to know is what it contains *after*
rmtree failed and not before.

## Testing

* pytest tests

## Deployment

Test only

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
