### PR TITLE
tests: use make -k instead of listing targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,6 @@ script:
   # to alter the pip requirements, which would cause config tests to fail.
   # The develop requirements include sphinx tooling for docs linting.
   - pip install -r securedrop/requirements/develop-requirements.txt
-  # Intentionally *not* using `make lint` wrapper so as not to skip linting
-  # steps if one fails. Continue linting in CI, and report full status.
-  - make docs-lint
-  - make flake8
-  - make html-lint
+  - make -k lint
 after_success:
   cd securedrop/ && coveralls


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Using **make -k** ensures all targets run even if one fails and we don't need to explicitly duplicate the list of lint targets in the travis file

## Testing

* push a flake8 error
* look at the travis output and verify the html-lint checks run although the target is *after* flake8 in the Makefile

## Deployment

test only
