### PR TITLE
Added pre-commit hook

### DIFF
--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -33,17 +33,26 @@ Code Style
 ----------
 
 We use code linters to keep a consistent code quality and style. These linters
-also run in CI and will produce build failures. To avoid this, we suggest running
-the linters locally as you work.
+also run in CI and will produce build failures. To avoid this, we have included
+a git pre-commit hook. You can install it with the following command run at the
+root of the repository:
+
+.. code:: sh
+
+    ln -sf ../../git/pre-commit .git/hooks/pre-commit
+
 
 .. note::
-  The code linters are installed automatically on the Development VM.
-  To install the linting tools locally on your host machine, from the root
-  of the repo you can run the following:
+  The code linters are installed automatically on the Development VM, but for
+  the pre-commit hook to work, you will need to install the linting tools
+  locally on your host machine. From the root of the repo you can run the
+  following:
 
   .. code:: sh
 
      pip install -r securedrop/requirements/develop-requirements.txt
+
+
 
 Python
 ~~~~~~

--- a/git/pre-commit
+++ b/git/pre-commit
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# This file will exist in $project_root/.git/hooks/, so we need to move back up
+# to $project_root. This apparent mess needs to happen because macOS doesn't
+# have `readlink -f`.
+declare src="$0"
+declare dir=''
+
+while [ -h "$src" ]; do
+  dir="$(cd -P "$( dirname "$src")" && pwd)"
+  src="$(readlink "$src")"
+  [[ "$src" != /* ]] && src="$dir/$src"
+done
+
+cd -P "$(dirname "$src")/../"
+
+##### This is the actual pre-commit hook. #####
+
+if [ -z "$VIRTUAL_ENV" ]; then
+    # If the developer has a virtual environment in the canonical location, then
+    # this will attempt to use that. Otherwise, assume the necessary things are
+    # installed globally.
+    declare -r venv='./venv/bin/activate'
+    if [ -f "$venv" ]; then
+      source "$venv"
+    fi
+fi
+
+make lint


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2234. Supersedes #1471

Creates a simple pre-commit hook, adds docs about it.

## Testing

`cp git/pre-comit .git/hooks/` and then try to commit. The linters should run.

- [x] Doc linting passed locally
