### PR TITLE
journalist: unify button label caps

### DIFF
--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -7,9 +7,9 @@ function enhance_ui() {
   $('div#filter-container').html('<input id="filter" type="text" placeholder="filter by codename" autofocus >');
 
   // Add the "select {all,none}" buttons
-  $('div#select-container').html('<span id="select_all" class="select"><i class="fa fa-check-square-o"></i> select all</span> <span id="select_unread" class="select"><i class="fa fa-check-square-o"></i> select unread</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> select none</span>');
+  $('div#select-container').html('<span id="select_all" class="select"><i class="fa fa-check-square-o"></i> Select All</span> <span id="select_unread" class="select"><i class="fa fa-check-square-o"></i> Select Unread</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> Select None</span>');
 
-  $('div#index-select-container').replaceWith('<span id="select_all" class="select"><i class="fa fa-check-square-o"></i> select all</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> select none</span>');
+  $('div#index-select-container').replaceWith('<span id="select_all" class="select"><i class="fa fa-check-square-o"></i> Select All</span> <span id="select_none" class="select"><i class="fa fa-square-o"></i> Select None</span>');
 
   // Change the action on the /col pages so we use a Javascript
   // confirmation instead of redirecting to a confirmation page before


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Replace "select all" etc. with "Select All" to match with "Download
Unread" etc.

## Testing

* pytest --page-layout tests/page-layout
* take a look at securedrop/tests/pages-layout/screenshots/en_US/journalist-col_javascript.png and see it looks nicer

![journalist-col_javascript](https://user-images.githubusercontent.com/433594/29968667-0a42481c-8f1d-11e7-84aa-05bb595b42eb.png)


## Deployment

Changing the caps of a label has no impact on deployment.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
