### PR TITLE
source: reword to avoid repetition

### DIFF
--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -59,7 +59,7 @@
   {% if replies %}
     <aside>
       <p>You have received a reply. To protect your identity in the unlikely event someone learns your codename,
-        please delete all replies when you're done with them. This also lets us know that you have received our reply.
+        please delete all replies when you're done with them. This also lets us know that you are aware of our reply.
         You can respond by submitting a new message above.</p>
     </aside>
     <hr class="no-line">


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This is a change suggested by Alain-Olivier, french coordinator for LocalizationLab.

We have « You have received a reply... » and « This also lets us
know that you have received our reply. » Two almost identical phrases
for two different meanings.

"This also lets us know that you are aware of our reply" would be better.

## Testing

* pytest tests

## Deployment

Just rewording, no impact on deployment.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
