### PR TITLE
Cleans up Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,10 @@ install:
       ansible-playbook -i inventory -vv --connection=local
       install_files/ansible-base/securedrop-development.yml
 script:
-  - DISPLAY=:1 pytest -v securedrop/tests --page-layout
+  # The `cd securedrop` is necessary for coverage support. Swap in the line
+  # below once #2246 is resolved.
+  # - DISPLAY=:1 pytest -v securedrop/tests --page-layout
+  - sh -c "export DISPLAY=:1 ; cd securedrop && pytest -v tests --page-layout"
   - pip freeze -l
   - SECUREDROP_TESTINFRA_TARGET_HOST=travis testinfra -v testinfra/development/
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,10 @@ before_install:
   - sudo mknod -m 0666 /dev/random c 1 9
   - echo HRNGDEVICE=/dev/urandom | sudo tee /etc/default/rng-tools
   - sudo /etc/init.d/rng-tools restart
+  - pip freeze -l
 install:
-  - pip freeze -l
-  # Preinstalled travis pytest is not tracked by us
-  # Preinstalled travis pbr is not tracked by us
-  - pip uninstall pytest pbr -y
-  - pip install -r testinfra/requirements.txt
-  - pip freeze -l
-script:
+  # Installing Python dependencies globally, to match SecureDrop deployment.
+  - sudo -H pip install -r securedrop/requirements/develop-requirements.txt
   # Using YAML folding operator '>' to aid in readability and avoid
   # extremely long lines.
   - >
@@ -55,11 +51,6 @@ script:
   - sudo sh -c "export DISPLAY=:1; cd securedrop/ && pytest -v --page-layout tests/ ; cat tests/log/firefox.log"
   - pip freeze -l
   - SECUREDROP_TESTINFRA_TARGET_HOST=travis testinfra -v testinfra/development/
-  - pip freeze -l
-  # Performing new pip install step *after* build VM tests pass, so as not
-  # to alter the pip requirements, which would cause config tests to fail.
-  # The develop requirements include sphinx tooling for docs linting.
-  - pip install -r securedrop/requirements/develop-requirements.txt
   - make -k lint
 after_success:
   cd securedrop/ && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,15 @@ dist: trusty
 addons:
   firefox: 46.0.1
 
-language: python
-python:
-  - '2.7'
+# Setting language=generic to prevent Travis from setting up a virtualenv.
+# Using a virtualenv conflicts with the global pip installation currently
+# used for configuring SecureDrop, both in development and staging.
+language: generic
 
-virtualenv:
-  system_site_packages: true
 before_install:
   - 'for e in /.packer-env/*; do echo -n "${e}: "; cat "${e}"; done'
+  # Removes Travis-specific PATH customizations that affect Python.
+  - export PATH="$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")"
   - printenv | sort # dump Travis environment for debugging
   - sudo apt-get update -qq
   - sudo apt-get install --yes rng-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ before_install:
 install:
   # Installing Python dependencies globally, to match SecureDrop deployment.
   - sudo -H pip install -r securedrop/requirements/develop-requirements.txt
+  # Run linting early, to fail fast.
+  - make --keep-going lint
   # Using YAML folding operator '>' to aid in readability and avoid
   # extremely long lines.
   - >
@@ -38,6 +40,5 @@ script:
   - DISPLAY=:1 pytest -v securedrop/tests --page-layout
   - pip freeze -l
   - SECUREDROP_TESTINFRA_TARGET_HOST=travis testinfra -v testinfra/development/
-  - make -k lint
 after_success:
   cd securedrop/ && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,8 @@ install:
   - >
       ansible-playbook -i inventory -vv --connection=local
       install_files/ansible-base/securedrop-development.yml
-  # Travis needs the config.py file to be owned by root. In other environments
-  # it's the `securedrop_user` var.
-  - sudo chown root:root securedrop/config.py
-  - sudo sh -c "export DISPLAY=:1; cd securedrop/ && pytest -v --page-layout tests/ ; cat tests/log/firefox.log"
+script:
+  - DISPLAY=:1 pytest -v securedrop/tests --page-layout
   - pip freeze -l
   - SECUREDROP_TESTINFRA_TARGET_HOST=travis testinfra -v testinfra/development/
   - make -k lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,6 @@ before_install:
   # Removes Travis-specific PATH customizations that affect Python.
   - export PATH="$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")"
   - printenv | sort # dump Travis environment for debugging
-  - sudo apt-get update -qq
-  - sudo apt-get install --yes rng-tools
-  - sudo rm -f /dev/random
-  - sudo mknod -m 0666 /dev/random c 1 9
-  - echo HRNGDEVICE=/dev/urandom | sudo tee /etc/default/rng-tools
-  - sudo /etc/init.d/rng-tools restart
   - pip freeze -l
 install:
   # Installing Python dependencies globally, to match SecureDrop deployment.

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,6 @@ install:
   - >
       ansible-playbook -i inventory -vv --connection=local
       install_files/ansible-base/securedrop-development.yml
-
-  # For some reason, redis-server does not start automatically when installed
-  # on Travis. I believe Travis' service machinery may be interfering. See
-  # http://docs.travis-ci.com/user/database-setup/#Redis
-  - sudo service redis-server start
   # Travis needs the config.py file to be owned by root. In other environments
   # it's the `securedrop_user` var.
   - sudo chown root:root securedrop/config.py

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -78,17 +78,7 @@ class FunctionalTest():
             '\n\n[%s] Running Functional Tests\n' % str(
                 datetime.now()))
         log_file.flush()
-        if "TRAVIS" in os.environ:
-            # In Travis, the Firefox path isn't in /usr/bin, and Selenium
-            # doesn't find it automatically.
-            firefox_path = "/home/travis/firefox-46.0.1/firefox/firefox"
-            firefox = firefox_binary.FirefoxBinary(firefox_path,
-                                                   log_file=log_file)
-        else:
-            # Selenium's PATH inference is smart enough outside Travis.
-            firefox = firefox_binary.FirefoxBinary(log_file=log_file)
-
-        return firefox
+        return firefox_binary.FirefoxBinary(log_file=log_file)
 
     def setup(self):
         # Patch the two-factor verification to avoid intermittent errors


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #2216. Fixes #2228.

Changes proposed in this pull request:

* Stop running app test suite as root
* Stop hardcoding Firefix binary path for Travis (running tests as normal user resolves; closes #2228)
* Stop manually configuring /dev/urandom in Travis (it's present in the new Trusty images)
* Stop starting the redis service twice (Ansible logic is sufficient for configuration)
* Lints before building, for faster failures
* **Reduces Travis build time by 50%:** `21 min 42 sec` -> `10 min 1 sec`

## Testing

1. Make sure all CI passes!
2. Run all app tests locally, with `--page-layout` flag, to confirm passing.

## Deployment

No, development and CI only.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
