### PR TITLE
run srm with minimal dependencies

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -144,6 +144,8 @@
   /var/www/securedrop/journalist_templates/login.html r,
   /var/www/securedrop/request_that_secures_file_uploads.py r,
   /var/www/securedrop/request_that_secures_file_uploads.pyc rw,
+  /var/www/securedrop/rm.py r,
+  /var/www/securedrop/rm.pyc rw,
   /var/www/securedrop/secure_tempfile.py r,
   /var/www/securedrop/secure_tempfile.pyc rw,
   /var/www/securedrop/source.py r,

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -15,6 +15,7 @@ from sqlalchemy.sql.expression import false
 import config
 import version
 import crypto_util
+from rm import srm
 import store
 import template_filters
 from db import (db_session, Source, Journalist, Submission, Reply,
@@ -526,7 +527,7 @@ def col(filesystem_id):
 
 def delete_collection(filesystem_id):
     # Delete the source's collection of submissions
-    job = worker.enqueue(store.delete_source_directory, filesystem_id)
+    job = worker.enqueue(srm, store.path(filesystem_id))
 
     # Delete the source's reply keypair
     crypto_util.delete_reply_keypair(filesystem_id)
@@ -767,7 +768,7 @@ def confirm_bulk_delete(filesystem_id, items_selected):
 def bulk_delete(filesystem_id, items_selected):
     for item in items_selected:
         item_path = store.path(filesystem_id, item.filename)
-        worker.enqueue(store.secure_unlink, item_path)
+        worker.enqueue(srm, item_path)
         db_session.delete(item)
     db_session.commit()
 

--- a/securedrop/rm.py
+++ b/securedrop/rm.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# SecureDrop whistleblower submission system
+# Copyright (C) 2017 Loic Dachary <loic@dachary.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import subprocess
+
+
+def srm(fn):
+    subprocess.check_call(['srm', '-r', fn])
+    return "success"

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -18,6 +18,7 @@ import config
 import json
 import version
 import crypto_util
+from rm import srm
 import store
 import template_filters
 from db import db_session, Source, Submission, Reply, get_one_or_else
@@ -340,7 +341,7 @@ def delete():
     query = Reply.query.filter(
         Reply.filename == request.form['reply_filename'])
     reply = get_one_or_else(query, app.logger, abort)
-    store.secure_unlink(store.path(g.filesystem_id, reply.filename))
+    srm(store.path(g.filesystem_id, reply.filename))
     db_session.delete(reply)
     db_session.commit()
 
@@ -356,7 +357,7 @@ def batch_delete():
         app.logger.error("Found no replies when at least one was expected")
         return redirect(url_for('lookup'))
     for reply in replies:
-        store.secure_unlink(store.path(g.filesystem_id, reply.filename))
+        srm(store.path(g.filesystem_id, reply.filename))
         db_session.delete(reply)
     db_session.commit()
 

--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -5,7 +5,6 @@ import config
 import zipfile
 import crypto_util
 import tempfile
-import subprocess
 import gzip
 from werkzeug import secure_filename
 
@@ -156,18 +155,3 @@ def rename_submission(filesystem_id, orig_filename, journalist_filename):
             else:
                 return new_filename  # Only return new filename if successful
     return orig_filename
-
-
-def secure_unlink(fn, recursive=False):
-    verify(fn)
-    command = ['srm']
-    if recursive:
-        command.append('-r')
-    command.append(fn)
-    subprocess.check_call(command)
-    return "success"
-
-
-def delete_source_directory(filesystem_id):
-    secure_unlink(path(filesystem_id), recursive=True)
-    return "success"

--- a/securedrop/tests/test_store.py
+++ b/securedrop/tests/test_store.py
@@ -6,7 +6,6 @@ import zipfile
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 import config
 from db import db_session
-import mock
 import store
 import utils
 
@@ -68,15 +67,3 @@ class TestStore(unittest.TestCase):
             source.filesystem_id, old_filename,
             new_journalist_filename)
         self.assertEquals(actual_filename, expected_filename)
-
-    @mock.patch('store.subprocess.check_call')
-    def test_secure_unlink(self, mock_check_call):
-        path = os.path.join(config.STORE_DIR, 'FILENAME')
-        self.assertEqual(store.secure_unlink(path), "success")
-        mock_check_call.assert_called_with(['srm', path])
-
-    @mock.patch('store.subprocess.check_call')
-    def test_delete_source_directory(self, mock_check_call):
-        path = os.path.join(config.STORE_DIR, 'DIRNAME')
-        self.assertEqual(store.delete_source_directory('DIRNAME'), "success")
-        mock_check_call.assert_called_with(['srm', '-r', path])

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -70,9 +70,5 @@ def teardown():
     try:
         shutil.rmtree(config.SECUREDROP_DATA_ROOT)
     except OSError as exc:
-        os.system("find " + config.SECUREDROP_DATA_ROOT)  # REMOVE ME, see #844
         if 'No such file or directory' not in exc:
             raise
-    except:
-        os.system("find " + config.SECUREDROP_DATA_ROOT)  # REMOVE ME, see #844
-        raise

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -69,6 +69,9 @@ def teardown():
     db_session.remove()
     try:
         shutil.rmtree(config.SECUREDROP_DATA_ROOT)
+        import time
+        time.sleep(0.1)
+        assert not os.path.exists(config.SECUREDROP_DATA_ROOT)  # safeguard for #844
     except OSError as exc:
         if 'No such file or directory' not in exc:
             raise

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -69,8 +69,6 @@ def teardown():
     db_session.remove()
     try:
         shutil.rmtree(config.SECUREDROP_DATA_ROOT)
-        import time
-        time.sleep(0.1)
         assert not os.path.exists(config.SECUREDROP_DATA_ROOT)  # safeguard for #844
     except OSError as exc:
         if 'No such file or directory' not in exc:


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #844

When srm is delegated to a redis worker via rq, the modules it needs
will be imported in another python interpreter. To keep this to a
minimum, the srm function is isolated in a single file which only
depends on subprocess.

The former implementation was included in the store file which imports
gnupg. But gnupg runs processes and create directories when it is
imported. It will race with the journalist wsgi threads (each thread
has its own python interpreter) on a production server. And it will
also race with the journalist application run in a test environment,
inadvertendly re-creating the key directory after the teardown
function of the test removed the temporary directory in which it ran.

The redis server cannot be replaced by a thread run from the
journalist application because the production server has dozens of
them ran in each wsgi thread.

## Testing

* cherry-pick **reproducer for #844** to develop
* run  `while : ; do pytest -v tests/test_journalist.py || break ; done` in the development VM
* verify that it quickly (less than 5 runs) fails with
<pre>
>           assert not os.path.exists(config.SECUREDROP_DATA_ROOT)  # reproducer for #844
E           AssertionError
</pre>
* cherry-pick **isolate the srm function** on top of **reproducer for #844**
* run  `while : ; do pytest -v tests/test_journalist.py || break ; done` in the development VM
* verify that it loops with no failure during an hour

## Deployment

* The new rm.py file was added to apparmor for usr.sbin.apache2
* The code delegating the removal of files is not changed, it is just moved into a separate file which has 100% coverage.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
