### PR TITLE
Run update_version.sh in development VM

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -26,6 +26,8 @@ development_dependencies:
   - tmux
   - vim
   - libffi-dev # for sphinx
+  - git
+  - devscripts # for dch
 
 # These profiles are referenced by multiple machines, such as Application Server
 # for direct copying at install time, and the build machine for including them

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 ## Usage: ./update_version.sh <version>
 
-# Only run this on the Vagrant build VM, with dch and git available
+# Only run this on the Vagrant development VM, with dch and git available
 set -e
 
-# Only run this on the Vagrant build VM, with dch and git available
-if [[ "$USER" != 'vagrant' || "$(hostname)" != 'build' ]]; then
-  echo 'Only run this on the Vagrant build VM!'
+# Only run this on the Vagrant development VM, with dch and git available
+if [[ "$USER" != 'vagrant' || "$(hostname)" != 'development' ]]; then
+  echo 'Only run this on the Vagrant development VM!'
   exit 1
 fi
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2257.

Changes proposed in this pull request:
 * Install `git` and `devscripts` in the development VM so that we can run `update_version.sh` there
 * Update warnings in `update_version.sh` to direct user to run the script in the development VM

## Testing

Provision development VM on this branch, attempt to run, should encounter no issues.

## Deployment

Release process only

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
