### PR TITLE
Generic documentation for manually upgrading Tails workstations

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,7 +76,16 @@ anonymous sources.
 
    upgrade/0.3.x_to_0.4.rst
    upgrade_to_tails_2x.rst
-   upgrade_to_tails_3x.rst
+   upgrade_to_tails_3x
+
+.. toctree::
+   :caption: Manually Upgrade Tails
+   :name: manuallyupgradetailstoc
+   :maxdepth: 2
+
+   manually_upgrade_tails/when
+   manually_upgrade_tails/how_often
+   manually_upgrade_tails/how
 
 .. toctree::
    :caption: Developer Documentation

--- a/docs/manually_upgrade_tails/how.rst
+++ b/docs/manually_upgrade_tails/how.rst
@@ -1,0 +1,33 @@
+How to manually upgrade Tails
+=============================
+
+
+Prerequisites
+-------------
+
+You will need:
+
+#. The Tails USB drive to be upgraded (the *Target Drive*).
+#. A blank USB drive to transfer the new version of Tails (the *Install Drive*).
+#. (Optional, but **strongly recommended**): A blank USB drive to store a backup of the *Target Drive*, in case something goes wrong during the upgrade process (the *Backup Drive*).
+
+   - If you will be upgrading multiple *Target Drives*, note that you will need one *Backup Drive* for each *Target Drive*.
+
+.. tip:: As always, we recommend using USB 3 drives and checking that you are using USB 3 compatible ports on your workstations. USB 3 is significantly faster than USB 2, which minimizes your waiting time during many steps of the upgrade process.
+
+
+Overview
+--------
+
+At a high level, the steps to manually upgrade Tails are:
+
+#. (Optional) Backup the *Target Drive* onto the *Backup Drive*.
+#. Download and verify the new version of Tails.
+#. Copy the new version of Tails onto the *Install Drive*.
+#. Boot the new version of Tails from the *Install Drive*.
+#. Insert the *Target Drive* into the computer booted from the *Install Drive*.
+#. Use the *Tails Installer* with the "Upgrade by cloning" option to upgrade the *Target Drive* to the newer version of Tails running on the *Install Drive*.
+#. Once the *Target Drive* is upgraded, reboot into the version of Tails running on the *Target Drive*. Verify that the upgrade was successful and you can still access your persistent data.
+
+To get started, click **Next** for instructions on backing up the *Target Drive*.
+

--- a/docs/manually_upgrade_tails/how_often.rst
+++ b/docs/manually_upgrade_tails/how_often.rst
@@ -1,0 +1,13 @@
+How often do I have to do this?
+===============================
+
+The Tails project releases updates `every 6 weeks`_. Occasionally they release a new version ahead of the normal cycle in order to address a critical security vulnerabilty.
+
+.. tip:: The best way to stay abreast of new versions of Tails is to check their `Security page`_. If you use an RSS/Atom feed reader, they provide RSS/Atom feeds that you may wish to subscribe to.
+
+For the Internet-connected Tails workstations (the *Admin Workstation* and the *Journalist Workstation*), you will be automatically notified via a pop-up dialog box when new versions of Tails are available. We recommend that you install these upgrades as soon as possible. The upgrade process usually takes some time, so keep that in mind when choosing when to upgrade.
+
+The *Secure Viewing Station (SVS)* is airgapped, so it cannot receive automatic updates. One could argue that since the *SVS* is airgapped, it does not need to be updated as often, since it is more difficult to derive a successful chain of exploits that can exfiltrate data over an airgap; however, the *SVS* also runs the greatest risk of being exploited, since it may be used to open a wide variety of file types (increasing the viable attack surface) and it also stores the most sensitive data in the system in plaintext (decrypted submissions and the SecureDrop Application private key). Therefore, we **strongly encourage** end users to manually upgrade their *SVS* as soon as possible after a new version of Tails is released.
+
+.. _every 6 weeks: https://tails.boum.org/support/faq/index.en.html
+.. _Security page: https://tails.boum.org/security/index.en.html

--- a/docs/manually_upgrade_tails/when.rst
+++ b/docs/manually_upgrade_tails/when.rst
@@ -1,0 +1,22 @@
+When do I have to manually upgrade Tails?
+=========================================
+
+Keeping up to date with the latest versions of software is a fundamental part of good digital security hygiene. Freedom of the Press Foundation does not administer SecureDrop administrator's/journalist's Tails-based workstation environments, so it is the responsibility of SecureDrop administrators and journalists to keep these endpoints up to date.
+
+To review: there are 3 components of the SecureDrop architecture that are based on Tails:
+
+#. The *Admin Workstation* (allowed to connect to the Internet)
+#. The *Journalist Workstation* (allowed to connect to the Internet)
+#. The *Secure Viewing Station (SVS)* (airgapped, **never** allowed to connect to a network)
+
+The Internet-connected Tails systems automatically check for available upgrades shortly after booting and successfully connecting to Tor. We encourage users of these systems to apply these upgrades in a timely manner, ideally as soon as they are available.
+
+Unfortunately, there are some scenarios in which automatically upgrading Tails is impossible:
+
+#. The *Secure Viewing Station (SVS)* must **always** be upgraded manually, because it is airgapped. Keeping the *SVS* up-to-date is important because it is used to open arbitrary files submitted by sources, which could be malicious and attempt to exploit a known or unknown vulnerabilty in the software on the *SVS*.
+#. SecureDrop instances upgrading from SecureDrop version 0.3.x to 0.4.x must manually upgrade Tails on **all** of their Tails drives, because there was a corresponding switch from Tails 2.x to Tails 3.x, for which no automatic upgrade path is available. This process is documented in detail in :doc:`Upgrade Tails from 2.x to 3.x </upgrade_to_tails_3x>`.
+#. If you automatically upgraded a Tails 3.0 drive to Tails 3.0.1, you may have encountered a `Tails bug`_ that prevents you from receiving any future automatic upgrades. If you are affected by this bug, the ony available `resolution`_ is to manually upgrade the affected Tails drives.
+
+.. _Tails bug: https://labs.riseup.net/code/issues/13426
+.. _resolution: https://tails.boum.org/news/rescue_3.0.1/index.en.html
+


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #2244.

I ended up investing some time in experimenting with different workflows for backing up and restoring Tails drives w/ persistent volumes, seeking to improve both the ease and the reliablity of the workflow. I have written up my findings and created a new [issue](https://labs.riseup.net/code/issues/14605) on the Tails issue tracker, since I think it might be helpful if they were incorporated into the official Tails documentation.

Ideally, we would be able to link out to the official docs for backing up Tails drives w/ persistent volumes in order to avoid reproducing the same instructions in the SecureDrop docs, but depending on the timing of the next Tails release (which will hopefully include the backported Nautilus security fix, see https://github.com/freedomofpress/securedrop/issues/2238#issuecomment-326763687), we may have to reproduce the backup steps anyway. In any case, I also want to make sure my proposed backup workflow is valid and doesn't have any potential hidden issues that I've failed to address before recommending it to SecureDrop end users.

I have some further WIP saved in a stash locally, but since the specific instructions depend somewhat on the technique used to backup a given Tails drive before upgrading it, I am posting my WIP and will temporarily block on receiving feedback on the Tails issue I've posted. If receiving feedback takes more than a few days, we can unblock and proceed without feedback (but with lots of careful testing required).

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
