### PR TITLE
silently strip whitespace from fingerprint

### DIFF
--- a/install_files/ansible-base/securedrop-configure.yml
+++ b/install_files/ansible-base/securedrop-configure.yml
@@ -156,11 +156,11 @@
         - var_name: securedrop_app_gpg_public_key
           var_value: "{{ securedrop_app_gpg_public_key }}"
         - var_name: securedrop_app_gpg_fingerprint
-          var_value: "{{ securedrop_app_gpg_fingerprint }}"
+          var_value: "{{ securedrop_app_gpg_fingerprint|replace(" ","") }}"
         - var_name: ossec_alert_gpg_public_key
           var_value: "{{ ossec_alert_gpg_public_key }}"
         - var_name: ossec_gpg_fpr
-          var_value: "{{ ossec_gpg_fpr }}"
+          var_value: "{{ ossec_gpg_fpr|replace(" ","") }}"
         - var_name: ossec_alert_email
           var_value: "{{ ossec_alert_email }}"
         - var_name: smtp_relay


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2266

silently strip whitespace from fingerprint

## Testing

* On the admin workstation run `securedrop-admin sdconfig`
* When asked for the application / ossec fingerprint, use a whitespace separate form
* Verify the site-specific file has the non-whitespace separated version of the key

## Deployment

It won't change the deployment. It will only be more accepting when the admin fails to realize the non-whitespace separated form of the fingerprints are preferred.
