### PR TITLE
source: hide the delete confirmation prompt

### DIFF
--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -121,6 +121,19 @@ p#codename
     margin: auto
     width: 80%
 
+  .hidden-prompt
+    margin: 0
+    padding: 0
+    height: 0
+    overflow: hidden
+    text-align: center
+
+    &:target
+      margin: auto
+      padding: auto
+      height: auto
+      overflow: visible
+
   .danger
     display: inline-block
     width: 30%


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2269

The CSS hiding the source delete confirmation prompt was removed
by b85bffc8dc4a07a24b975485d9cd3f44d7a1418a but it needs to stay.

## Testing

* Submit some documents as a source and then reply to that source as a journalist
* Navigate to the source interface

![s1](https://user-images.githubusercontent.com/433594/30212306-ac65240c-94a4-11e7-952a-000a8d7af63f.png)

* Click "Delete all replies" under the replies from the journalist see it looks like

![s2](https://user-images.githubusercontent.com/433594/30212358-dfa0a440-94a4-11e7-8ef2-a5bb610fb4f8.png)

* Click "Yes delete all replies"

![s3](https://user-images.githubusercontent.com/433594/30212388-f8fe313c-94a4-11e7-8526-d13858f6193e.png)

* Click "No, Not Yet" and see the same, except the notification on top.

## Deployment

Visual only, no deployment impact.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
