### PR TITLE
Revert "silently strip whitespace from fingerprint"

### DIFF
--- a/install_files/ansible-base/securedrop-configure.yml
+++ b/install_files/ansible-base/securedrop-configure.yml
@@ -156,11 +156,11 @@
         - var_name: securedrop_app_gpg_public_key
           var_value: "{{ securedrop_app_gpg_public_key }}"
         - var_name: securedrop_app_gpg_fingerprint
-          var_value: "{{ securedrop_app_gpg_fingerprint|replace(" ","") }}"
+          var_value: "{{ securedrop_app_gpg_fingerprint }}"
         - var_name: ossec_alert_gpg_public_key
           var_value: "{{ ossec_alert_gpg_public_key }}"
         - var_name: ossec_gpg_fpr
-          var_value: "{{ ossec_gpg_fpr|replace(" ","") }}"
+          var_value: "{{ ossec_gpg_fpr }}"
         - var_name: ossec_alert_email
           var_value: "{{ ossec_alert_email }}"
         - var_name: smtp_relay


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Related #2266 

This reverts commit 2227b0f3f59672890b02063910d6f39a131f8052 because it does not work. See https://github.com/freedomofpress/securedrop/issues/2266#issuecomment-329032505 for more.

## Testing

This goes back to a state where tests were conducted already and should not require more.

## Deployment

The change breaks deployment scenarios and it is important to revert it.
