### PR TITLE
Lint YAML files throughout project

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: relaxed
+rules:
+  line-length:
+    max: 200
+    level: warning

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ yamllint: ## Lints YAML files (does not validate syntax!)
 		-o -type f -iname '*.yml' -exec yamllint -d relaxed {} +
 
 .PHONY: lint
-lint: docs-lint flake8 html-lint ## Runs all linting tools (docs, flake8, HTML).
+lint: docs-lint flake8 html-lint yamllint ## Runs all linting tools (docs, flake8, HTML, YAML).
 
 .PHONY: docker-build-ubuntu
 docker-build-ubuntu: ## Builds SD Ubuntu docker container

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ html-lint: ## Validates HTML in web application template files.
 .PHONY: yamllint
 yamllint: ## Lints YAML files (does not validate syntax!)
 # Prune the `.venv/` dir if it exists, since it contains pip-installed files
-# and is not subject to our linting.
-	find "$(PWD)" -path "$(PWD)/.venv" -prune \
-		-o -type f -regextype posix-extended -iregex '^.*\.ya?ml$$' \
-		-exec yamllint -c "$(PWD)/.yamllint" {} +
+# and is not subject to our linting. Using grep to filter filepaths since
+# `-regextype=posix-extended` is not cross-platform.
+	@find "$(PWD)" -path "$(PWD)/.venv" -prune -o -type f \
+		| grep -E '^.*\.ya?ml' | xargs yamllint -c "$(PWD)/.yamllint"
 
 .PHONY: lint
 lint: docs-lint flake8 html-lint yamllint ## Runs all linting tools (docs, flake8, HTML, YAML).

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ yamllint: ## Lints YAML files (does not validate syntax!)
 # Prune the `.venv/` dir if it exists, since it contains pip-installed files
 # and is not subject to our linting.
 	find "$(PWD)" -path "$(PWD)/.venv" -prune \
-		-o -type f -iname '*.yml' \
+		-o -type f -regextype posix-extended -iregex '^.*\.ya?ml$$' \
 		-exec yamllint -c "$(PWD)/.yamllint" {} +
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,13 @@ html-lint: ## Validates HTML in web application template files.
 	html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation \
 		securedrop/source_templates/*.html securedrop/journalist_templates/*.html
 
+.PHONY: yamllint
+yamllint: ## Lints YAML files (does not validate syntax!)
+# Prune the `.venv/` dir if it exists, since it contains pip-installed files
+# and is not subject to our linting.
+	find "$(PWD)" -path "$(PWD)/.venv" -prune \
+		-o -type f -iname '*.yml' -exec yamllint -d relaxed {} +
+
 .PHONY: lint
 lint: docs-lint flake8 html-lint ## Runs all linting tools (docs, flake8, HTML).
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,8 @@ yamllint: ## Lints YAML files (does not validate syntax!)
 # Prune the `.venv/` dir if it exists, since it contains pip-installed files
 # and is not subject to our linting.
 	find "$(PWD)" -path "$(PWD)/.venv" -prune \
-		-o -type f -iname '*.yml' -exec yamllint -d relaxed {} +
+		-o -type f -iname '*.yml' \
+		-exec yamllint -c "$(PWD)/.yamllint" {} +
 
 .PHONY: lint
 lint: docs-lint flake8 html-lint yamllint ## Runs all linting tools (docs, flake8, HTML, YAML).

--- a/devops/playbooks/ci-app-tests.yml
+++ b/devops/playbooks/ci-app-tests.yml
@@ -15,7 +15,7 @@
         dest: ../../apptest-results.xml
         flat: yes
   vars:
-    ci_env: "{{ lookup('env', 'CI_SD_ENV') }}" 
+    ci_env: "{{ lookup('env', 'CI_SD_ENV') }}"
     # We must define this var at the play-level since the group/host vars
     # won't automatically be included, since they're relative to the
     # provisioning playbooks (rather than the CI bootstrapping playbooks).

--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -52,8 +52,6 @@ root of the repository:
 
      pip install -r securedrop/requirements/develop-requirements.txt
 
-
-
 Python
 ~~~~~~
 
@@ -76,6 +74,19 @@ our HTML templates in ``securedrop/source_templates`` and
   .. code:: sh
 
       make html-lint
+
+YAML
+~~~~
+
+The Ansible configuration is specified in YAML files, including variables,
+tasks, and playbooks. All YAML files in the project should pass the
+`yamllint <https://github.com/adrienverge/yamllint>`__ standards declared
+in the ``.yamllint`` file at the root of the repository.
+Run the checks locally via:
+
+  .. code:: sh
+
+      make yamllint
 
 Git History
 -----------

--- a/install_files/ansible-base/roles/app-test/tasks/setup_firefox_for_selenium.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/setup_firefox_for_selenium.yml
@@ -63,4 +63,3 @@
   # `aptitude hold <package>` doesn't report meaningful changed status,
   # so mark the task as not changed.
   changed_when: false
-

--- a/install_files/ansible-base/roles/common/tasks/setup_etc_hosts.yml
+++ b/install_files/ansible-base/roles/common/tasks/setup_etc_hosts.yml
@@ -36,4 +36,3 @@
   tags:
     - host_aliases
     - static-hosts
-

--- a/install_files/ansible-base/roles/install-local-packages/tasks/install_debs.yml
+++ b/install_files/ansible-base/roles/install-local-packages/tasks/install_debs.yml
@@ -19,9 +19,9 @@
   with_indexed_items: "{{ local_deb_packages }}"
 
 # Using `dpkg` via `command` to ensure installation ensure installation
-# every time, regardless of whether packages changed. SecureDrop deb package 
-# builds are not deterministic, so the `copy` task above will always report 
-# changed. Once the `apt` task above has installed the packages, only the 
+# every time, regardless of whether packages changed. SecureDrop deb package
+# builds are not deterministic, so the `copy` task above will always report
+# changed. Once the `apt` task above has installed the packages, only the
 # `dpkg -i` calls will reinstall, ensuring the latest local code changes are used.
 - name: Install locally built deb packages (via dpkg).
   command: dpkg -i /root/{{ item }}

--- a/install_files/ansible-base/roles/ossec-agent/handlers/main.yml
+++ b/install_files/ansible-base/roles/ossec-agent/handlers/main.yml
@@ -6,4 +6,3 @@
   service:
     name: ossec
     state: restarted
-

--- a/install_files/ansible-base/roles/ossec-agent/tasks/agent_config.yml
+++ b/install_files/ansible-base/roles/ossec-agent/tasks/agent_config.yml
@@ -56,4 +56,3 @@
   tags:
     - iptables
     - ossec_auth
-

--- a/install_files/ansible-base/roles/ossec-server/tasks/mon_configure_custom_cert.yml
+++ b/install_files/ansible-base/roles/ossec-server/tasks/mon_configure_custom_cert.yml
@@ -36,4 +36,3 @@
         smtp_relay_cert_override_file != ''
   tags:
     - postfix_custom_cert
-

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/dh_moduli.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/dh_moduli.yml
@@ -1,21 +1,21 @@
----                                                                             
-- name: Check whether Diffie-Hellman groups have been updated                   
-  stat:                                                                         
-    path: /etc/ssh/moduli                                                       
-  register: dh_moduli                                                           
+---
+- name: Check whether Diffie-Hellman groups have been updated
+  stat:
+    path: /etc/ssh/moduli
+  register: dh_moduli
 
 # SHA1 checksum represents the latest default primes/moduli shipped with OpenSSH
-                                                                                
-- name: Remove weak DH moduli                                                   
-  command: awk '$5 > 2000' /etc/ssh/moduli                                      
-  register: new_dh_moduli                                                       
-  when: dh_moduli.stat.checksum == '2dc7b3b18a2d3884ca4604466b75cf7903e96a97'   
-                                                                                
-- name: Install updated DH moduli                                               
-  copy:                                                                         
-    dest: /etc/ssh/moduli                                                       
-    content: "{{ new_dh_moduli.stdout }}"                                       
-    owner: root                                                                 
-    group: root                                                                 
-    mode: "0644"                                                                
-  when: dh_moduli.stat.checksum == '2dc7b3b18a2d3884ca4604466b75cf7903e96a97' 
+
+- name: Remove weak DH moduli
+  command: awk '$5 > 2000' /etc/ssh/moduli
+  register: new_dh_moduli
+  when: dh_moduli.stat.checksum == '2dc7b3b18a2d3884ca4604466b75cf7903e96a97'
+
+- name: Install updated DH moduli
+  copy:
+    dest: /etc/ssh/moduli
+    content: "{{ new_dh_moduli.stdout }}"
+    owner: root
+    group: root
+    mode: "0644"
+  when: dh_moduli.stat.checksum == '2dc7b3b18a2d3884ca4604466b75cf7903e96a97'

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
@@ -29,4 +29,3 @@
   tags:
     - tor
     - admin
-

--- a/install_files/ansible-base/roles/tails-config/tasks/configure_network_hook.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/configure_network_hook.yml
@@ -19,4 +19,3 @@
     - "{{ tails_config_live_persistence }}/custom-nm-hooks"
     - "{{ tails_config_network_manager_dispatcher }}"
   notify: run securedrop network hook
-

--- a/securedrop/requirements/develop-requirements.in
+++ b/securedrop/requirements/develop-requirements.in
@@ -1,11 +1,12 @@
 # Temporary peg until issue #1146 is resolved
 ansible==2.2.1
 boto
-html-linter
 flake8
+html-linter
 pip-tools
 pytest-xdist
-testinfra
 sphinx
 sphinx-autobuild
 sphinx_rtd_theme
+testinfra
+yamllint

--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -34,6 +34,7 @@ livereload==2.5.1         # via sphinx-autobuild
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8
 paramiko==2.2.1           # via ansible
+pathspec==0.5.5           # via yamllint
 pathtools==0.1.2          # via sphinx-autobuild, watchdog
 pip-tools==1.9.0
 port-for==0.3.1           # via sphinx-autobuild
@@ -48,7 +49,7 @@ pynacl==1.1.2             # via paramiko
 pytest-xdist==1.18.2
 pytest==3.2.0             # via pytest-xdist, testinfra
 pytz==2017.2              # via babel
-pyyaml==3.12              # via ansible, sphinx-autobuild, watchdog
+pyyaml==3.12              # via ansible, sphinx-autobuild, watchdog, yamllint
 requests==2.18.3          # via sphinx
 singledispatch==3.4.0.3   # via tornado
 six==1.10.0               # via bcrypt, cryptography, livereload, pip-tools, pynacl, singledispatch, sphinx, testinfra
@@ -63,3 +64,4 @@ tornado==4.5.1            # via livereload, sphinx-autobuild
 typing==3.6.1             # via sphinx
 urllib3==1.22             # via requests
 watchdog==0.8.3           # via sphinx-autobuild
+yamllint==1.8.1

--- a/testinfra/vars/app-prod.yml
+++ b/testinfra/vars/app-prod.yml
@@ -19,10 +19,6 @@ app_directories:
   - /var/lib/securedrop/keys
   - /var/lib/securedrop/tmp
 
-tor_services:
-  - ssh
-  - source
-
 apparmor_enforce:
   - "/sbin/dhclient"
   - "/usr/lib/NetworkManager/nm-dhcp-client.action"

--- a/testinfra/vars/app-prod.yml
+++ b/testinfra/vars/app-prod.yml
@@ -1,4 +1,4 @@
-
+---
 mon_ip: 10.0.1.5
 
 tor_services:


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #2255.

Changes proposed in this pull request:

* Adds Makefile target `yamllint`
* Updates YAML files to adhere to "relaxed" linting standards.
* Adds a custom yamllint config file to silence most line-length warnings.

Since I've added the target to the general `make lint`, this will run as part of the new pre-commit hook (#2237). It doesn't take long, however the `yamllint` dependency technically comes in via the molecule dependency in `testinfra/requirements.txt`, and _not_ via `securedrop/requirements/develop-requirements.txt` (where Molecule is not listed). I'm fine with this for now, since the underlying issue of disorganized pip requirements files is tracked in #2175.

However, if reviewers have trouble running the linter because `testinfra/requirements.txt` is not installed locally, I'm happy to remove the inclusion from `make lint` and just run YAML linting in CI for now.

## Testing

Run `make lint` locally and confirm everything passes for you. If you get an error about `yamllint` not being installed, let me know. 

## Deployment

CI and dev only, no implications for depoyment.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
