### PR TITLE
Rebase to latest develop conditionally in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,11 @@ jobs:
       - checkout
 
       - run:
+          name: Rebase on-top of latest develop
+          command: |
+            if [[ "$CIRCLE_BRANCH" != "master"  && "$CIRCLE_BRANCH" != release*  ]]; then git fetch origin develop && git rebase origin/develop; git rev-parse HEAD; fi
+
+      - run:
           name: Installation pre-reqs
           command: pip install -U -r securedrop/requirements/develop-requirements.txt
 
@@ -29,6 +34,11 @@ jobs:
 
     steps:
       - checkout
+
+      - run:
+          name: Rebase on-top of latest develop
+          command: |
+            if [[ "$CIRCLE_BRANCH" != "master"  && "$CIRCLE_BRANCH" != release*  ]]; then git fetch origin develop && git rebase origin/develop; git rev-parse HEAD; fi
 
       - run:
           name: Installation pre-reqs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,7 @@ jobs:
 
       - run:
           name: Rebase on-top of latest develop
-          command: |
-            if [[ "$CIRCLE_BRANCH" != "master"  && "$CIRCLE_BRANCH" != release*  ]]; then git fetch origin develop && git rebase origin/develop; git rev-parse HEAD; fi
+          command: ./devops/scripts/rebase-develop.sh
 
       - run:
           name: Installation pre-reqs
@@ -37,8 +36,7 @@ jobs:
 
       - run:
           name: Rebase on-top of latest develop
-          command: |
-            if [[ "$CIRCLE_BRANCH" != "master"  && "$CIRCLE_BRANCH" != release*  ]]; then git fetch origin develop && git rebase origin/develop; git rev-parse HEAD; fi
+          command: ./devops/scripts/rebase-develop.sh
 
       - run:
           name: Installation pre-reqs

--- a/devops/scripts/rebase-develop.sh
+++ b/devops/scripts/rebase-develop.sh
@@ -4,9 +4,15 @@ set -e
 
 # If current branch is not master or doesnt start with release...
 if [[ "$CIRCLE_BRANCH" != "master"  && "$CIRCLE_BRANCH" != release*  ]]; then
+
+  # Git will yell at you when trying to rebase without author/email configured
+  git config --global user.email "ci@freedom.press"
+  git config --global user.name "CI User"
+
   # Fetch and rebase onto the latest in develop
   git fetch origin develop
   git rebase origin/develop
+
   # Print out the current head for debugging potential CI issues
   git rev-parse HEAD
 fi

--- a/devops/scripts/rebase-develop.sh
+++ b/devops/scripts/rebase-develop.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# If current branch is not master or doesnt start with release...
+if [[ "$CIRCLE_BRANCH" != "master"  && "$CIRCLE_BRANCH" != release*  ]]; then
+  # Fetch and rebase onto the latest in develop
+  git fetch origin develop
+  git rebase origin/develop
+  # Print out the current head for debugging potential CI issues
+  git rev-parse HEAD
+fi


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2080 

Changes proposed in this pull request:

Provides scripting to perform a git rebase on top of develop during the `CircleCI` build process (this is already present in `Travis`).

There is a potential issue with a race conditions here that I'm not sure how best to resolve due to outstanding issues with passing context between workflow jobs in CircleCI (it breaks the ability to SSH debug). The gist of the problem is this -- there is potential for two jobs we have in CircleCI to be tested against different rebasing of develop if someone were to merge into develop at a particular moment in time during the test run. I dont see this as a hugee issue -- but it is something that I thought should be brought up and discussed.

## Testing

Really only applicable to CircleCI. So get out that CI magnifying glass!

## Deployment

Any special considerations for deployment?  Nope - only affects CI