### PR TITLE
i18n: load the locale depending on user preferences

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -148,6 +148,8 @@
   /var/www/securedrop/rm.pyc rw,
   /var/www/securedrop/secure_tempfile.py r,
   /var/www/securedrop/secure_tempfile.pyc rw,
+  /var/www/securedrop/i18n.py r,
+  /var/www/securedrop/i18n.pyc rw,
   /var/www/securedrop/source.py r,
   /var/www/securedrop/source.pyc rw,
   /var/www/securedrop/source_templates/banner_warning_flashed.html r,

--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -1,0 +1,74 @@
+#
+# SecureDrop whistleblower submission system
+# Copyright (C) 2017 Loic Dachary <loic@dachary.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from flask import request, session
+from flask_babel import Babel
+from babel import core
+
+import config
+import os
+
+LOCALES = set(['en_US'])
+
+
+def setup_app(app):
+    babel = Babel(app)
+    assert len(list(babel.translation_directories)) == 1
+    for dirname in os.listdir(next(babel.translation_directories)):
+        if dirname != 'messages.pot':
+            LOCALES.add(dirname)
+
+    babel.localeselector(get_locale)
+
+
+def get_locale():
+    """
+    Get the locale as follows, by order of precedence:
+    - l request argument or session['locale']
+    - browser suggested locale, from the Accept-Languages header
+    - config.DEFAULT_LOCALE
+    - 'en_US'
+    """
+    locale = None
+    accept_languages = set()
+    for l in request.accept_languages.values():
+        if '-' in l:
+            sep = '-'
+        else:
+            sep = '_'
+        try:
+            accept_languages.add(str(core.Locale.parse(l, sep)))
+        except:
+            pass
+    if 'l' in request.args:
+        if len(request.args['l']) == 0:
+            if 'locale' in session:
+                del session['locale']
+            locale = core.negotiate_locale(accept_languages, LOCALES)
+        else:
+            locale = core.negotiate_locale([request.args['l']], LOCALES)
+            session['locale'] = locale
+    else:
+        if 'locale' in session:
+            locale = session['locale']
+        else:
+            locale = core.negotiate_locale(accept_languages, LOCALES)
+
+    if locale:
+        return locale
+    else:
+        return getattr(config, 'DEFAULT_LOCALE', 'en_US')

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -16,6 +16,7 @@ import config
 import version
 import crypto_util
 from rm import srm
+import i18n
 import store
 import template_filters
 from db import (db_session, Source, Journalist, Submission, Reply,
@@ -26,6 +27,8 @@ import worker
 app = Flask(__name__, template_folder=config.JOURNALIST_TEMPLATES_DIR)
 app.config.from_object(config.JournalistInterfaceFlaskConfig)
 CSRFProtect(app)
+
+i18n.setup_app(app)
 
 assets = Environment(app)
 
@@ -63,6 +66,8 @@ def setup_g():
     uid = session.get('uid', None)
     if uid:
         g.user = Journalist.query.get(uid)
+
+    g.locale = i18n.get_locale()
 
     if request.method == 'POST':
         filesystem_id = request.form.get('filesystem_id')

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -19,6 +19,7 @@ import json
 import version
 import crypto_util
 from rm import srm
+import i18n
 import store
 import template_filters
 from db import db_session, Source, Submission, Reply, get_one_or_else
@@ -33,6 +34,8 @@ log = logging.getLogger('source')
 app = Flask(__name__, template_folder=config.SOURCE_TEMPLATES_DIR)
 app.request_class = RequestThatSecuresFileUploads
 app.config.from_object(config.SourceInterfaceFlaskConfig)
+
+i18n.setup_app(app)
 
 assets = Environment(app)
 
@@ -88,6 +91,7 @@ def ignore_static(f):
 @ignore_static
 def setup_g():
     """Store commonly used values in Flask's special g object"""
+    g.locale = i18n.get_locale()
     # ignore_static here because `crypto_util.hash_codename` is scrypt (very
     # time consuming), and we don't need to waste time running if we're just
     # serving a static resource that won't need to access these common values.

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -1,0 +1,159 @@
+#
+# SecureDrop whistleblower submission system
+# Copyright (C) 2017 Loic Dachary <loic@dachary.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import argparse
+import logging
+import os
+
+from flask import request, session, render_template_string
+from flask_babel import gettext
+from werkzeug.datastructures import Headers
+
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
+import config
+import i18n
+import journalist
+import manage
+import source
+import version
+
+
+class TestI18N(object):
+
+    def verify_i18n(self, app):
+        not_translated = 'code hello i18n'
+        translated_fr = 'code bonjour'
+
+        for accepted in ('unknown', 'en_US'):
+            headers = Headers([('Accept-Language', accepted)])
+            with app.test_request_context(headers=headers):
+                assert not hasattr(request, 'babel_locale')
+                assert not_translated == gettext(not_translated)
+                assert hasattr(request, 'babel_locale')
+                assert render_template_string('''
+                {{ gettext('code hello i18n') }}
+                ''').strip() == not_translated
+
+        for lang in ('fr_FR', 'fr', 'fr-FR'):
+            headers = Headers([('Accept-Language', lang)])
+            with app.test_request_context(headers=headers):
+                assert not hasattr(request, 'babel_locale')
+                assert translated_fr == gettext(not_translated)
+                assert hasattr(request, 'babel_locale')
+                assert render_template_string('''
+                {{ gettext('code hello i18n') }}
+                ''').strip() == translated_fr
+
+        translated_cn = 'code chinese'
+
+        for lang in ('zh-CN', 'zh-Hans-CN'):
+            headers = Headers([('Accept-Language', lang)])
+            with app.test_request_context(headers=headers):
+                assert not hasattr(request, 'babel_locale')
+                assert translated_cn == gettext(not_translated)
+                assert hasattr(request, 'babel_locale')
+                assert render_template_string('''
+                {{ gettext('code hello i18n') }}
+                ''').strip() == translated_cn
+
+        with app.test_client() as c:
+            c.get('/')
+            assert session.get('locale') is None
+            assert not_translated == gettext(not_translated)
+
+            c.get('/?l=fr_FR', headers=Headers([('Accept-Language', 'en_US')]))
+            assert session.get('locale') == 'fr_FR'
+            assert translated_fr == gettext(not_translated)
+
+            c.get('/', headers=Headers([('Accept-Language', 'en_US')]))
+            assert session.get('locale') == 'fr_FR'
+            assert translated_fr == gettext(not_translated)
+
+            c.get('/?l=')
+            assert session.get('locale') is None
+            assert not_translated == gettext(not_translated)
+
+            c.get('/?l=en_US', headers=Headers([('Accept-Language', 'fr_FR')]))
+            assert session.get('locale') == 'en_US'
+            assert not_translated == gettext(not_translated)
+
+            c.get('/', headers=Headers([('Accept-Language', 'fr_FR')]))
+            assert session.get('locale') == 'en_US'
+            assert not_translated == gettext(not_translated)
+
+            c.get('/?l=', headers=Headers([('Accept-Language', 'fr_FR')]))
+            assert session.get('locale') is None
+            assert translated_fr == gettext(not_translated)
+
+            c.get('/')
+            assert session.get('locale') is None
+            assert not_translated == gettext(not_translated)
+
+            c.get('/?l=YY_ZZ')
+            assert session.get('locale') is None
+            assert not_translated == gettext(not_translated)
+
+    def test_i18n(self):
+        sources = [
+            'tests/i18n/code.py',
+            'tests/i18n/template.html',
+        ]
+        kwargs = {
+            'translations_dir': config.TEMP_DIR,
+            'mapping': 'tests/i18n/babel.cfg',
+            'source': sources,
+            'extract_update': True,
+            'compile': True,
+            'verbose': logging.DEBUG,
+            'version': version.__version__,
+        }
+        args = argparse.Namespace(**kwargs)
+        manage.setup_verbosity(args)
+        manage.translate(args)
+
+        manage.sh("""
+        pybabel init -i {d}/messages.pot -d {d} -l en_US
+        pybabel init -i {d}/messages.pot -d {d} -l fr_FR
+        sed -i -e '/code hello i18n/,+1s/msgstr ""/msgstr "code bonjour"/' \
+              {d}/fr_FR/LC_MESSAGES/messages.po
+        pybabel init -i {d}/messages.pot -d {d} -l zh_Hans_CN
+        sed -i -e '/code hello i18n/,+1s/msgstr ""/msgstr "code chinese"/' \
+              {d}/zh_Hans_CN/LC_MESSAGES/messages.po
+        """.format(d=config.TEMP_DIR))
+
+        manage.translate(args)
+
+        for app in (journalist.app, source.app):
+            app.config['BABEL_TRANSLATION_DIRECTORIES'] = config.TEMP_DIR
+            i18n.setup_app(app)
+            self.verify_i18n(app)
+
+    def test_verify_default_locale_en_us_if_not_defined_in_config(self):
+        DEFAULT_LOCALE = config.DEFAULT_LOCALE
+        try:
+            del config.DEFAULT_LOCALE
+            not_translated = 'code hello i18n'
+            with source.app.test_client() as c:
+                c.get('/')
+                assert not_translated == gettext(not_translated)
+        finally:
+            config.DEFAULT_LOCALE = DEFAULT_LOCALE
+
+    @classmethod
+    def teardown_class(cls):
+        reload(journalist)
+        reload(source)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Set the locale of the source or journalist interface as follows, by
order of precedence:

  - l request argument or session['locale']
  - browser suggested locale via Accept-Languages
  - config.DEFAULT_LOCALE
  - 'en_US'

When the l request argument is specified, the locale is saved in the
session. If the l request argument is empty, the locale from the session
is cleared and the Accept-Languages header takes precedence again.

The locale requested with the l argument or via the Accept-Languages
header is matched against the available locales, as found in the
translations directory. The babel.core.negotiate_locale function is used
to find a match and it will, for instance, match:

   fr to fr_FR
   fr-FR to fr_FR
   zh-CN to zh_Hans_CN (script part)
   zh_Hans to zh_Hans

In order to improve the chances to find a match, the Accept-Languages
values are normalized via the core.Locale.parse function which knowns
about aliases, default script for Chinese etc.


## Testing

* pytest --page-layout tests/pages-layout and visually verify all pages look as they should
* pytest tests will run the additional tests that should could all modified lines
<pre>
modified   securedrop/tests/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 testpaths = . functional
 usefixtures = setUptearDown
-addopts = --cov=../securedrop/
+addopts = --cov-report term-missing --cov=../securedrop/
</pre>
will help verify this is the case.

## Deployment

The code makes use of new config variables. It will do nothing and behave in a backward compatible way if they are not present. This should be verified by upgrading from a 0.4.3 fresh install.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
