### PR TITLE
source: toggle show/hide via target CSS selector

### DIFF
--- a/securedrop/sass/_base.sass
+++ b/securedrop/sass/_base.sass
@@ -191,13 +191,6 @@
     font-size: large
     text-align: center
 
-  .code-reminder
-    background: rgba(0, 0, 0, 0.05)
-    box-sizing: border-box
-    -moz-box-sizing: border-box
-    padding: 5px 10px
-    text-align: center
-
   .snippet
     border: 1px solid #c3c3c3
     background: $color_grey_xlight

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -63,17 +63,6 @@ html
     width: 100%
     display: block
 
-input#show
-  display: none
-
-#content
-  display: block
-  transition: opacity 1s ease-out
-  opacity: 0
-  height: 0
-  font-size: 0
-  overflow: hidden
-
 #codename-hint
   background: rgba(0, 0, 0, 0.05)
   box-sizing: border-box
@@ -81,21 +70,6 @@ input#show
   padding: 5px 10px
   text-align: center
 
-
-#show
-  &:before
-    color: $color_purple_medium
-    content: "Show"
-
-  &:hover
-    &.show:before
-      color: $color_grey_medium
-      content: "Hide"
-
-    ~ span#content
-      opacity: 1
-      font-size: 100%
-      height: auto
 
 input.codename-box
   width: 400px

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -74,6 +74,14 @@ input#show
   font-size: 0
   overflow: hidden
 
+#codename-hint
+  background: rgba(0, 0, 0, 0.05)
+  box-sizing: border-box
+  -moz-box-sizing: border-box
+  padding: 5px 10px
+  text-align: center
+
+
 #show
   &:before
     color: $color_purple_medium

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -70,6 +70,32 @@ html
   padding: 5px 10px
   text-align: center
 
+#codename-hint-visible
+  .visible-codename
+    margin: auto
+    padding: auto
+    height: auto
+    overflow: visible
+
+  .hidden-codename
+    margin: 0
+    padding: 0
+    height: 0
+    overflow: hidden
+
+  &:target
+
+    .visible-codename
+      margin: 0
+      padding: 0
+      height: 0
+      overflow: hidden
+
+    .hidden-codename
+      margin: auto
+      padding: auto
+      height: auto
+      overflow: visible
 
 input.codename-box
   width: 400px

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -100,11 +100,13 @@
 <hr class="no-line">
 
 <div class="code-reminder" id="codename-hint">
-  <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/lock-black.png') }}" width="17px" height="20px"> Remember your codename is:
-  <div id="show" class="show pull-right"></div>
-  <span id="content" class="codename">
-    <p class="alert">{{ codename }}</p>
-  </span>
+  <div id="codename-hint-visible">
+    <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/lock-black.png') }}" width="17px" height="20px"> Remember your codename is:
+    <a id="codename-hint-show" class="show pull-right visible-codename" href="#codename-hint-visible">Show</a>
+    <div id="codename-hint-content" class="hidden-codename codename">
+      <p>{{ codename }} <a id="codename-hint-hide" class="pull-right" href="#codename-hint">Hide</a></p>
+    </div>
+  </div>
 </div>
 
 {% endblock %}

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -49,6 +49,18 @@ class SourceNavigationSteps():
         assert len(codename.text) > 0
         self.source_name = codename.text
 
+    def _source_shows_codename(self):
+        content = self.driver.find_element_by_id('codename-hint-content')
+        assert not content.is_displayed()
+        self.driver.find_element_by_id('codename-hint-show').click()
+        assert content.is_displayed()
+
+    def _source_hides_codename(self):
+        content = self.driver.find_element_by_id('codename-hint-content')
+        assert content.is_displayed()
+        self.driver.find_element_by_id('codename-hint-hide').click()
+        assert not content.is_displayed()
+
     @screenshots
     def _source_chooses_to_login(self):
         self.driver.find_element_by_id('login-button').click()

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -1,0 +1,14 @@
+import source_navigation_steps
+import functional_test
+
+
+class TestSourceInterfaceBannerWarnings(
+        functional_test.FunctionalTest,
+        source_navigation_steps.SourceNavigationSteps):
+
+    def test_lookup_codename_hint(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_shows_codename()
+        self._source_hides_codename()

--- a/securedrop/tests/pages-layout/test_source.py
+++ b/securedrop/tests/pages-layout/test_source.py
@@ -43,6 +43,13 @@ class TestSourceLayout(
         self._source_submits_a_file()
         self._screenshot('source-lookup.png')
 
+    def test_lookup_shows_codename(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_shows_codename()
+        self._screenshot('source-lookup-shows-codename.png')
+
     def test_login(self):
         self._source_visits_source_homepage()
         self._source_chooses_to_login()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2276

toggle show/hide via target CSS selector

## Testing

Functional tests should cover the logic but needs to be reviewed to verify they actually check the right thing. In addition a new screenshot (source-lookup-shows-codename.png) was added when --page-layout is set for visual verification:

![source-lookup-shows-codename](https://user-images.githubusercontent.com/433594/30565233-d1bde6c8-9cc7-11e7-9fae-b9e26ce3a52a.png)

* go to the source interface and click **SUBMIT DOCUMENTS**
* go to the bottom of the page and verify the codename is not displayed
* click **show** and verify the codename is displayed and the **show** button is not displayed
* click **hide** and verify codename is hidden and the **show** button is displayed

## Deployment

User interface only.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
