### PR TITLE
journalist: the user to be created uses a YubiKey

### DIFF
--- a/securedrop/journalist_templates/admin_add_user.html
+++ b/securedrop/journalist_templates/admin_add_user.html
@@ -15,7 +15,7 @@
   </p>
   <p>
     <input name="is_hotp" id="is-hotp" type="checkbox">
-    <label for="is_hotp">I'm using a YubiKey [HOTP] </label>
+    <label for="is_hotp">Is using a YubiKey [HOTP] </label>
     <input name="otp_secret" type="text" placeholder="HOTP Secret" size="60"><br>
   </p>
   <button type="submit" class="sd-button"><i class="fa fa-plus"></i> ADD USER</button>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2323

The first person incorrectly suggests that the admin creating the user
is using a YubiKey. It really means that the user to be created is
going to use a YubiKey.

## Testing

* login as an admin in the journalist interface
* click on the **Admin** link
* click on the **Add User** button

## Deployment

Only about user facing strings, no functional change.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
