### PR TITLE
journalist: unify case of relative datetime

### DIFF
--- a/securedrop/journalist_templates/admin.html
+++ b/securedrop/journalist_templates/admin.html
@@ -28,7 +28,7 @@
         {% if user.last_access %}
           <td><time class="date" title="{{ user.last_access }}">{{ user.last_access|datetimeformat(relative=True) }}</time></td>
         {% else %}
-          <td><time class="date">Never</time></td>
+          <td><time class="date">never</time></td>
         {% endif %}
       </tr>
     {% endfor %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The relative datetime displayed on the journalist administration page
is all in lowercase except the string Never.

## Testing

* login as a journalist with admin rights
* click on **Admin**
* create a new user
* verify it shows **never** instead of **Never**

## Deployment

No code change, no deployment troubles ahead.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
