### PR TITLE
Tests for manage.py

### DIFF
--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -62,7 +62,7 @@ def sh(command, input=None):
     return "".join(lines_of_command_output)
 
 
-def reset(args):  # pragma: no cover
+def reset(args):
     """Clears the SecureDrop development applications' state, restoring them to
     the way they were immediately after running `setup_dev.sh`. This command:
     1. Erases the development sqlite database file.

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -192,10 +192,23 @@ def _add_user(is_admin=False):
         return 0
 
 
-def delete_user(args):  # pragma: no cover
+def _get_username_to_delete():
+    return raw_input('Username to delete: ')
+
+
+def _get_delete_confirmation(user):
+    confirmation = raw_input('Are you sure you want to delete user '
+                             '"{}" (y/n)?'.format(user))
+    if confirmation.lower() != 'y':
+        print('Confirmation not received: user "{}" was NOT '
+              'deleted'.format(user))
+        return False
+    return True
+
+
+def delete_user(args):
     """Deletes a journalist or administrator from the application."""
-    # Select user to delete
-    username = raw_input('Username to delete: ')
+    username = _get_username_to_delete()
     try:
         selected_user = Journalist.query.filter_by(username=username).one()
     except NoResultFound:
@@ -203,28 +216,24 @@ def delete_user(args):  # pragma: no cover
         return 0
 
     # Confirm deletion if user is found
-    confirmation = raw_input('Are you sure you want to delete user '
-                             '{} (y/n)?'.format(selected_user))
-    if confirmation.lower() != 'y':
-        print('Confirmation not received: user "{}" was NOT '
-              'deleted'.format(username))
+    if not _get_delete_confirmation(selected_user.username):
         return 0
 
     # Try to delete user from the database
     try:
         db_session.delete(selected_user)
         db_session.commit()
-    except:
+    except Exception as e:
         # If the user was deleted between the user selection and confirmation,
         # (e.g., through the web app), we don't report any errors. If the user
         # is still there, but there was a error deleting them from the
         # database, we do report it.
         try:
-            selected_user = Journalist.query.filter_by(username=username).one()
+            Journalist.query.filter_by(username=username).one()
         except NoResultFound:
             pass
         else:
-            raise
+            raise e
 
     print('User "{}" successfully deleted'.format(username))
     return 0

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -82,6 +82,40 @@ class TestManagementCommand(unittest.TestCase):
         self.assertIn('ERROR: That username is already taken!',
                       sys.stdout.getvalue())
 
+    @mock.patch("manage._get_username", return_value='test-user-56789')
+    @mock.patch("manage._get_yubikey_usage", return_value=False)
+    @mock.patch("manage._get_username_to_delete",
+                return_value='test-user-56789')
+    @mock.patch('manage._get_delete_confirmation', return_value=True)
+    def test_delete_user(self,
+                         mock_username,
+                         mock_yubikey,
+                         mock_user_to_delete,
+                         mock_user_del_confirm):
+        return_value = manage._add_user()
+        self.assertEqual(return_value, 0)
+
+        return_value = manage.delete_user(args=None)
+        self.assertEqual(return_value, 0)
+
+    @mock.patch("manage._get_username_to_delete",
+                return_value='does-not-exist')
+    @mock.patch('manage._get_delete_confirmation', return_value=True)
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_delete_non_existent_user(self,
+                                      mock_user_to_delete,
+                                      mock_user_del_confirm,
+                                      mock_stdout):
+        return_value = manage.delete_user(args=None)
+        self.assertEqual(return_value, 0)
+        self.assertIn('ERROR: That user was not found!',
+                      sys.stdout.getvalue())
+
+    @mock.patch("__builtin__.raw_input", return_value='test-user-12345')
+    def test_get_username_to_delete(self, mock_username):
+        return_value = manage._get_username_to_delete()
+        self.assertEqual(return_value, 'test-user-12345')
+
 
 class TestManage(object):
 

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -116,6 +116,12 @@ class TestManagementCommand(unittest.TestCase):
         return_value = manage._get_username_to_delete()
         self.assertEqual(return_value, 'test-user-12345')
 
+    def test_reset(self):
+        return_value = manage.reset(args=None)
+        self.assertEqual(return_value, 0)
+        assert os.path.exists(config.DATABASE_FILE)
+        assert os.path.exists(config.STORE_DIR)
+
 
 class TestManage(object):
 


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Mostly addresses #1982. This doesn't fully close it due to some issues listed below. Fully closing this issue would require a major change to how we do tests.

Changes proposed in this pull request:

Adds unit tests to some of the `manage.py` subcommands.

## Deficiencies

### `manage.py clean-temp` requires `sudo`

Otherwise it can't list all the processes' open files and errors out. Running it with `sudo` breaks because we change the `config.TEMP_DIR` value at the start of the tests. Because we have to shell out, we'd have to make `manage.py` accept a path value that allows us to dynamically load modules so we can write our own `config.py` from the original, change the values, write it to `/tmp` and then pass it back to `manage.py`.

### `db_session` has odd caching

There are errors when attempting to verify that `manage.py reset` purges the database errors with the following steps:

1. Insert `Journalist`
2. Run `manage.reset(args=None)`
3. Expect inserted Journalist to not be present under a new `Journalist.query`

However, the journalist is present. If instead I do:

```python
j = Journalist(**kwargs)
db_session.add(j)
db_session.commit()
manage.reset(args=None)
Jornalist.query.filter(username=j.username).one()
```

It raises an exception saying that row was deleted when I attempt to access the `j.username` field.

Thus, it both caches the result and acknowledges that the DB was deleted at the same time. This has been... frustrating.

## Testing

```bash
vagrant ssh
cd /vagrant/securedrop/
pytest -v tests/
```