### PR TITLE
tests: PAGE_LAYOUT_LOCALES controls --page-layout scope

### DIFF
--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -54,14 +54,17 @@ the following::
 
      ./manage.py run
 
-An easier way is to generate screenshots for each state in each known
-language with::
+An easier way is to generate screenshots for each desired language
+with::
 
-     $ pytest -v tests/pages-layout --page-layout
+     $ export PAGE_LAYOUT_LOCALES=en_US,fr_FR
+     $ pytest -v --page-layout tests/pages-layout
      ...
      ...TestJournalistLayout::test_col_no_documents[en_US] PASSED
      ...TestJournalistLayout::test_col_no_documents[fr_FR] PASSED
      ...
+
+.. note:: if unset, PAGE_LAYOUT_LOCALES defaults to en_US
 
 The screenshots for ``fr_FR`` are available in
 ``securedrop/tests/pages-layout/screenshots/fr_FR`` and the name of

--- a/securedrop/tests/pages-layout/functional_test.py
+++ b/securedrop/tests/pages-layout/functional_test.py
@@ -30,11 +30,10 @@ from tests.functional import functional_test
 
 
 def list_locales():
-    d = os.path.join(dirname(__file__), '..', '..', 'translations')
-    locales = ['en_US']
-    if os.path.isdir(d):
-        files = os.listdir(d)
-        locales.extend([f for f in files if f != 'messages.pot'])
+    if 'PAGE_LAYOUT_LOCALES' in os.environ:
+        locales = os.environ['PAGE_LAYOUT_LOCALES'].split(',')
+    else:
+        locales = ['en_US']
     return locales
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

By default the current implementation makes screenshots for every
locale found in the securedrop/translation directory. This is
impractical and never actually used because it takes too long. Instead
create screenshots for all locales listed in the coma separated string
from the PAGE_LAYOUT_LOCALES which defaults to en_US.

## Testing

* in the development vm run
<pre>
$ PAGE_LAYOUT_LOCALES='en_US,fr_FR' time pytest -v --page-layout tests/pages-layout
========================================================== test session starts ==========================================================
platform linux2 -- Python 2.7.6, pytest-3.1.1, py-1.4.34, pluggy-0.4.0 -- /usr/bin/python
cachedir: tests/.cache
rootdir: /vagrant/securedrop/tests, inifile: pytest.ini
plugins: cov-2.5.1, xdist-1.18.2, testinfra-1.6.5, capturelog-0.7
collected 82 items 

tests/pages-layout/test_journalist.py::TestJournalistLayout::test_account_edit_hotp_secret[en_US] PASSED
tests/pages-layout/test_journalist.py::TestJournalistLayout::test_account_edit_hotp_secret[fr_FR] PASSED
...
</pre>

Note that the fr_FR screenshots won't actually be translated but they will be generated.

## Deployment

Only tests.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
