### PR TITLE
Fixes #2262 Removes extra folder level in zip

### DIFF
--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -78,6 +78,7 @@ def get_bulk_archive(selected_submissions, zip_directory=''):
     # folder structure per #383
     with zipfile.ZipFile(zip_file, 'w') as zip:
         for source in sources:
+            fname = ""
             submissions = [s for s in selected_submissions
                            if s.source.journalist_designation == source]
             for submission in submissions:
@@ -85,9 +86,12 @@ def get_bulk_archive(selected_submissions, zip_directory=''):
                                 submission.filename)
                 verify(filename)
                 document_number = submission.filename.split('-')[0]
+                if zip_directory == submission.source.journalist_filename:
+                    fname = zip_directory
+                else:
+                    fname = os.path.join(zip_directory, source)
                 zip.write(filename, arcname=os.path.join(
-                    zip_directory,
-                    source,
+                    fname,
                     "%s_%s" % (document_number,
                                submission.source.last_updated.date()),
                     os.path.basename(filename)

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -774,7 +774,6 @@ class TestJournalistApp(TestCase):
                 zipfile.ZipFile(StringIO(resp.data)).getinfo(
                     os.path.join(
                         source.journalist_filename,
-                        source.journalist_designation,
                         "%s_%s" % (filename.split('-')[0],
                                    source.last_updated.date()),
                         filename


### PR DESCRIPTION
Downloading submissions from any source, will now
have only one level directory based on source name.

## Status

Ready for review

## Description of Changes

Fixes #2262 

Changes proposed in this pull request:

If someone downloads submissions from a source (after clicking on the source name) in the journalist view, it will not have any extra level of directory.

## Testing

I have updated the corresponding test in this PR.

```
$ pytest tests/test_journalist.py::TestJournalistApp::test_download_selected_submissions_from_source
```

## Deployment

None

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
