### PR TITLE
i18n: set html dir attribute from locale

### DIFF
--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -72,3 +72,7 @@ def get_locale():
         return locale
     else:
         return getattr(config, 'DEFAULT_LOCALE', 'en_US')
+
+
+def get_text_direction(locale):
+    return core.Locale.parse(locale).text_direction

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -69,6 +69,7 @@ def setup_g():
         g.user = Journalist.query.get(uid)
 
     g.locale = i18n.get_locale()
+    g.text_direction = i18n.get_text_direction(g.locale)
 
     if request.method == 'POST':
         filesystem_id = request.form.get('filesystem_id')

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html dir="{{ g.text_direction }}">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -93,6 +93,7 @@ def ignore_static(f):
 def setup_g():
     """Store commonly used values in Flask's special g object"""
     g.locale = i18n.get_locale()
+    g.text_direction = i18n.get_text_direction(g.locale)
     # ignore_static here because `crypto_util.hash_codename` is scrypt (very
     # time consuming), and we don't need to waste time running if we're just
     # serving a static resource that won't need to access these common values.

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html dir="{{ g.text_direction }}">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html dir="{{ g.text_direction }}">
   <head>
     <title>SecureDrop | {{ gettext('Protecting Journalists and Sources') }}</title>
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes: #1168

If the text direction of the locale is RTL (Arabic), the html element
dir attribute must be set to dir="rtl". The text direction is found in
the text_direction attribute of the babel locale object.

## Testing

* pytest --page-layout tests/pages-layout
* vagrant ssh development
* cd /vagrant/securedrop
* mkdir -p translations/ar/LC_MESSAGES
* ( cd translations/ar/LC_MESSAGES ; wget http://lab.securedrop.club/bot/securedrop/raw/i18n/securedrop/translations/ar/LC_MESSAGES/messages.po )
* ./manage.py --verbose translate --compile
* ./manage.py run
<pre>
$ curl localhost:8080 -H 'Accept-Language: ar' -s | head -2
&lt;!DOCTYPE html>
&lt;html dir="rtl">
</pre>

<pre>
$ curl -s localhost:8080 | head -2
&lt;!DOCTYPE html>
&lt;html dir="ltr">
</pre>



## Deployment

This only has an impact on the visual interface, not the deployments.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
