### PR TITLE
i18n:  enable fuzzy translations

### DIFF
--- a/install_files/ansible-base/roles/app/tasks/install_gettext.yml
+++ b/install_files/ansible-base/roles/app/tasks/install_gettext.yml
@@ -1,0 +1,26 @@
+- name: Add gettext zesty apt repository
+  apt_repository:
+    repo: deb http://archive.ubuntu.com/ubuntu/ zesty main
+    state: present
+    update_cache: yes
+  tags:
+    - apt
+    - development
+
+- name: Install modern gettext
+  apt:
+    name: gettext
+    state: latest
+  tags:
+    - apt
+    - development
+
+- name: Remove gettext zesty apt repository
+  apt_repository:
+    repo: deb http://archive.ubuntu.com/ubuntu/ zesty main
+    state: absent
+    update_cache: yes
+  tags:
+    - apt
+    - development
+

--- a/install_files/ansible-base/roles/app/tasks/main.yml
+++ b/install_files/ansible-base/roles/app/tasks/main.yml
@@ -22,3 +22,5 @@
 - include: setup_cron.yml
 
 - include: configure_haveged.yml
+
+- include: install_gettext.yml

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -286,9 +286,6 @@ def translate(args):
         --msgid-bugs-address='securedrop@freedom.press' \
         --copyright-holder='Freedom of the Press Foundation' \
         {sources}
-
-        # we do not handle fuzzy translations yet
-        sed -i '/^#, fuzzy$/d' {messages_file}
         """.format(translations_dir=args.translations_dir,
                    mapping=args.mapping,
                    messages_file=messages_file,
@@ -301,7 +298,7 @@ def translate(args):
             pybabel update \
             --input-file {messages_file} \
             --output-dir {translations_dir} \
-            --no-fuzzy-matching --ignore-obsolete
+            --ignore-obsolete
             """.format(translations_dir=args.translations_dir,
                        messages_file=messages_file))
         else:

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -295,10 +295,9 @@ def translate(args):
         if len(os.listdir(args.translations_dir)) > 1:
             sh("""
             set -xe
-            pybabel update \
-            --input-file {messages_file} \
-            --output-dir {translations_dir} \
-            --ignore-obsolete
+            for translation in {translations_dir}/*/LC_MESSAGES/*.po ; do
+              msgmerge --previous --update $translation {messages_file}
+            done
             """.format(translations_dir=args.translations_dir,
                        messages_file=messages_file))
         else:

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -3,6 +3,7 @@
 # This file is distributed under the same license as the SecureDrop project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: SecureDrop 0.3.12\n"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fuzzy translations will find that a comma changed into a period does not mean the entire string has to be translated again. It greatly reduces the amount of work required from translators. The pybabel update algorithm is not as good as the one from msmerge we need to switch to it for better results.

## Testing

* change ! to a period in the **High in 4 easy steps!** string of source_templates/index.html
* vagrant ssh development
* cd /vagrant/securedrop
* mkdir -p translations/fr_FR/LC_MESSAGES
* wget http://lab.securedrop.club/bot/securedrop/raw/i18n/securedrop/translations/fr_FR/LC_MESSAGES/messages.po 
* cp messages.po translations/fr_FR/LC_MESSAGES
* ./manage.py --verbose translate --extract-update
<pre>
...
2017-09-21 07:59:51,769 DEBUG + msgmerge --previous --update translations/fr_FR/LC_MESSAGES/messages.po translations/messages.pot
2017-09-21 07:59:51,782 DEBUG ........................ done.
...
</pre>
* diff -ru translations/fr_FR/LC_MESSAGES/messages.po messages.po
<pre>
-#: source_templates/index.html:89
-#, fuzzy
-#| msgid ""
-#| "You appear to be using the Tor Browser. You can turn the Security Slider "
-#| "to High in 4 easy steps!"
+#: source_templates/index.html:90
 msgid ""
 "You appear to be using the Tor Browser. You can turn the Security Slider to "
-"High in 4 easy steps."
+"High in 4 easy steps!"
 msgstr ""
 "Il semble que vous utilisiez le navigateur Tor. Vous pouvez régler le niveau "
 "de sécurité sur « Élevé » en quatre étapes simples !"
</pre>

## Deployment

No deployment impact, it only is used during development.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
