### PR TITLE
jinja: implement localized filesizeformat() and datetimeformat() filters

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -42,6 +42,7 @@ else:
     app.jinja_env.globals['use_custom_header_image'] = False
 
 app.jinja_env.filters['datetimeformat'] = template_filters.datetimeformat
+app.jinja_env.filters['filesizeformat'] = template_filters.filesizeformat
 
 
 @app.teardown_appcontext

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -44,10 +44,10 @@
             {% endif %}
             {% if doc.filename.endswith('reply.gpg') %}
               <span class="file reply"><span class="filename">{{ doc.filename }}</span></span>
-              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat(binary=True) }}</span></span>
+              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat() }}</span></span>
             {% else %}
               <span class="file"><a class="btn small" href="/col/{{ filesystem_id }}/{{ doc.filename }}"><i class="fa fa-download"></i> <span class="filename">{{ doc.filename }}</span></a></span>
-              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat(binary=True) }}</span></span>
+              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat() }}</span></span>
             {% endif %}
             {% if doc.filename.endswith('-doc.gz.gpg') %}
               <i title="{{ gettext('Uploaded Document') }}" class="fa fa-file-archive-o pull-right"></i>

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -55,6 +55,7 @@ else:
 
 app.jinja_env.filters['datetimeformat'] = template_filters.datetimeformat
 app.jinja_env.filters['nl2br'] = evalcontextfilter(template_filters.nl2br)
+app.jinja_env.filters['filesizeformat'] = template_filters.filesizeformat
 
 
 @app.teardown_appcontext

--- a/securedrop/template_filters.py
+++ b/securedrop/template_filters.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
-from flask_babel import gettext, ngettext
+from flask_babel import gettext, ngettext, get_locale
+from babel import units
 from datetime import datetime
 from jinja2 import Markup, escape
+import math
 
 
 def datetimeformat(dt, fmt=None, relative=False):
@@ -46,3 +48,26 @@ def nl2br(context, value):
     if context.autoescape:
         formatted = Markup(formatted)
     return formatted
+
+
+def filesizeformat(value):
+    prefixes = [
+        'digital-kilobyte',
+        'digital-megabyte',
+        'digital-gigabyte',
+        'digital-terabyte',
+    ]
+    locale = get_locale()
+    base = 1024
+    #
+    # we are using the long length because the short length has no
+    # plural variant and it reads like a bug instead of something
+    # on purpose
+    #
+    if value < base:
+        return units.format_unit(value, "byte", locale=locale, length="long")
+    else:
+        i = min(int(math.log(value, base)), len(prefixes)) - 1
+        prefix = prefixes[i]
+        bytes = float(value) / base ** (i + 1)
+        return units.format_unit(bytes, prefix, locale=locale, length="short")

--- a/securedrop/template_filters.py
+++ b/securedrop/template_filters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from flask_babel import gettext, ngettext, get_locale
-from babel import units
+from flask_babel import get_locale
+from babel import units, dates
 from datetime import datetime
 from jinja2 import Markup, escape
 import math
@@ -8,39 +8,12 @@ import math
 
 def datetimeformat(dt, fmt=None, relative=False):
     """Template filter for readable formatting of datetime.datetime"""
-    fmt = fmt or '%b %d, %Y %I:%M %p'
     if relative:
-        time_difference = _relative_timestamp(dt)
-        if time_difference:
-            return gettext('{time} ago').format(time=time_difference)
-    return dt.strftime(fmt)
-
-
-def _relative_timestamp(dt):
-    """"
-    Format a human readable relative time for timestamps up to 30 days old
-    """
-    delta = datetime.utcnow() - dt
-    diff = (
-        delta.microseconds + (delta.seconds +
-                              delta.days * 24 * 3600) * 1e6) / 1e6
-    if diff < 45:
-        return ngettext('{n} second', '{n} seconds', int(diff)).format(
-            n=int(diff))
-    elif diff < 90:
-        return gettext('a minute')
-    elif diff < 2700:
-        return gettext('{n} minutes').format(n=int(max(diff / 60, 2)))
-    elif diff < 5400:
-        return gettext('an hour')
-    elif diff < 79200:
-        return gettext('{n} hours').format(n=int(max(diff / 3600, 2)))
-    elif diff < 129600:
-        return gettext('a day')
-    elif diff < 2592000:
-        return gettext('{n} days').format(n=int(max(diff / 86400, 2)))
+        return dates.format_timedelta(datetime.utcnow() - dt,
+                                      locale=get_locale())
     else:
-        return None
+        fmt = fmt or 'MMM dd, yyyy hh:mm a'
+        return dates.format_datetime(dt, fmt, locale=get_locale())
 
 
 def nl2br(context, value):

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -1,8 +1,20 @@
 # -*- coding: utf-8 -*-
+import argparse
+import logging
 from datetime import datetime, timedelta
+import os
 import unittest
 
+from flask import session
+
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
+import config
+import i18n
+import journalist
+import manage
+import source
 import template_filters
+import version
 
 
 class TestTemplateFilters(unittest.TestCase):
@@ -55,3 +67,67 @@ class TestTemplateFilters(unittest.TestCase):
         test_time = datetime.utcnow() - timedelta(days=999)
         result = template_filters._relative_timestamp(test_time)
         self.assertEquals(None, result)
+
+    def verify_filesizeformat(self, app):
+        with app.test_client() as c:
+            c.get('/')
+            assert session.get('locale') is None
+            assert "1 byte" == template_filters.filesizeformat(1)
+            assert "2 bytes" == template_filters.filesizeformat(2)
+            value = 1024 * 3
+            assert "3 kB" == template_filters.filesizeformat(value)
+            value *= 1024
+            assert "3 MB" == template_filters.filesizeformat(value)
+            value *= 1024
+            assert "3 GB" == template_filters.filesizeformat(value)
+            value *= 1024
+            assert "3 TB" == template_filters.filesizeformat(value)
+            value *= 1024
+            assert "3,072 TB" == template_filters.filesizeformat(value)
+
+            c.get('/?l=fr_FR')
+            assert session.get('locale') == 'fr_FR'
+            assert "1 octet" == template_filters.filesizeformat(1)
+            assert "2 octets" == template_filters.filesizeformat(2)
+            value = 1024 * 3
+            assert "3 ko" == template_filters.filesizeformat(value)
+            value *= 1024
+            assert "3 Mo" == template_filters.filesizeformat(value)
+            value *= 1024
+            assert "3 Go" == template_filters.filesizeformat(value)
+            value *= 1024
+            assert "3 To" == template_filters.filesizeformat(value)
+            value *= 1024
+            assert "072 To" in template_filters.filesizeformat(value)
+
+    def test_filesizeformat(self):
+        sources = [
+            'tests/i18n/code.py',
+        ]
+        kwargs = {
+            'translations_dir': config.TEMP_DIR,
+            'mapping': 'tests/i18n/babel.cfg',
+            'source': sources,
+            'extract_update': True,
+            'compile': True,
+            'verbose': logging.DEBUG,
+            'version': version.__version__,
+        }
+        args = argparse.Namespace(**kwargs)
+        manage.setup_verbosity(args)
+        manage.translate_messages(args)
+
+        manage.sh("""
+        pybabel init -i {d}/messages.pot -d {d} -l en_US
+        pybabel init -i {d}/messages.pot -d {d} -l fr_FR
+        """.format(d=config.TEMP_DIR))
+
+        for app in (journalist.app, source.app):
+            app.config['BABEL_TRANSLATION_DIRECTORIES'] = config.TEMP_DIR
+            i18n.setup_app(app)
+            self.verify_filesizeformat(app)
+
+    @classmethod
+    def teardown_class(cls):
+        reload(journalist)
+        reload(source)

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -3,7 +3,6 @@ import argparse
 import logging
 from datetime import datetime, timedelta
 import os
-import unittest
 
 from flask import session
 
@@ -17,56 +16,37 @@ import template_filters
 import version
 
 
-class TestTemplateFilters(unittest.TestCase):
+class TestTemplateFilters(object):
 
-    def test_datetimeformat_default_fmt(self):
-        result = template_filters.datetimeformat(datetime(2016, 1, 1, 1, 1, 1))
-        self.assertEquals("Jan 01, 2016 01:01 AM", result)
+    def verify_datetimeformat(self, app):
+        with app.test_client() as c:
+            c.get('/')
+            assert session.get('locale') is None
+            result = template_filters.datetimeformat(
+                datetime(2016, 1, 1, 1, 1, 1))
+            assert "Jan 01, 2016 01:01 AM" == result
 
-    def test_datetimeformat_unusual_fmt(self):
-        result = template_filters.datetimeformat(datetime(2016, 1, 1, 1, 1, 1),
-                                                 fmt="%b %d %Y")
-        self.assertEquals("Jan 01 2016", result)
+            result = template_filters.datetimeformat(
+                datetime(2016, 1, 1, 1, 1, 1), fmt="yyyy")
+            assert "2016" == result
 
-    def test_relative_timestamp_seconds(self):
-        test_time = datetime.utcnow() - timedelta(seconds=5)
-        result = template_filters._relative_timestamp(test_time)
-        self.assertIn("seconds", result)
+            test_time = datetime.utcnow() - timedelta(hours=2)
+            result = template_filters.datetimeformat(test_time, relative=True)
+            assert "2 hours" == result
 
-    def test_relative_timestamp_one_minute(self):
-        test_time = datetime.utcnow() - timedelta(minutes=1)
-        result = template_filters._relative_timestamp(test_time)
-        self.assertEquals("a minute", result)
+            c.get('/?l=fr_FR')
+            assert session.get('locale') == 'fr_FR'
+            result = template_filters.datetimeformat(
+                datetime(2016, 1, 1, 1, 1, 1))
+            assert "janv. 01, 2016 01:01 AM" == result
 
-    def test_relative_timestamp_minutes(self):
-        test_time = datetime.utcnow() - timedelta(minutes=10)
-        result = template_filters._relative_timestamp(test_time)
-        self.assertEquals("10 minutes", result)
+            result = template_filters.datetimeformat(
+                datetime(2016, 1, 1, 1, 1, 1), fmt="yyyy")
+            assert "2016" == result
 
-    def test_relative_timestamp_one_hour(self):
-        test_time = datetime.utcnow() - timedelta(hours=1)
-        result = template_filters._relative_timestamp(test_time)
-        self.assertEquals("an hour", result)
-
-    def test_relative_timestamp_hours(self):
-        test_time = datetime.utcnow() - timedelta(hours=10)
-        result = template_filters._relative_timestamp(test_time)
-        self.assertEquals("10 hours", result)
-
-    def test_relative_timestamp_one_day(self):
-        test_time = datetime.utcnow() - timedelta(days=1)
-        result = template_filters._relative_timestamp(test_time)
-        self.assertEquals("a day", result)
-
-    def test_relative_timestamp_days(self):
-        test_time = datetime.utcnow() - timedelta(days=4)
-        result = template_filters._relative_timestamp(test_time)
-        self.assertEquals("4 days", result)
-
-    def test_relative_timestamp_none(self):
-        test_time = datetime.utcnow() - timedelta(days=999)
-        result = template_filters._relative_timestamp(test_time)
-        self.assertEquals(None, result)
+            test_time = datetime.utcnow() - timedelta(hours=2)
+            result = template_filters.datetimeformat(test_time, relative=True)
+            assert "2 heures" == result
 
     def verify_filesizeformat(self, app):
         with app.test_client() as c:
@@ -100,7 +80,7 @@ class TestTemplateFilters(unittest.TestCase):
             value *= 1024
             assert "072 To" in template_filters.filesizeformat(value)
 
-    def test_filesizeformat(self):
+    def test_filters(self):
         sources = [
             'tests/i18n/code.py',
         ]
@@ -115,7 +95,7 @@ class TestTemplateFilters(unittest.TestCase):
         }
         args = argparse.Namespace(**kwargs)
         manage.setup_verbosity(args)
-        manage.translate_messages(args)
+        manage.translate(args)
 
         manage.sh("""
         pybabel init -i {d}/messages.pot -d {d} -l en_US
@@ -126,6 +106,7 @@ class TestTemplateFilters(unittest.TestCase):
             app.config['BABEL_TRANSLATION_DIRECTORIES'] = config.TEMP_DIR
             i18n.setup_app(app)
             self.verify_filesizeformat(app)
+            self.verify_datetimeformat(app)
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The babel.units module provides support for localized digital units
display. It is not identical to the filesizeformat() filter natively
provided by jinja because:

* it only supports powers of 1024 (i.e. decimal prefixes like kB, MB
  etc. and not binary prefixes like KiB, MiB etc.)
* it only supports units up to the terabyte and not yoctobyte

The advantage of having translations of the prefixes in dozens of
languages outweight the incompatibility.

The babel.dates implements localized display of relative and regular date functions.

## Testing

* pytest -v tests

## Deployment

This is only a user facing change.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
