### PR TITLE
i18n: support for <html lang="$lang">

### DIFF
--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -22,7 +22,9 @@ from babel import core
 import collections
 import config
 import os
+import re
 
+LOCALE_SPLIT = re.compile('(-|_)')
 LOCALES = set(['en_US'])
 babel = None
 
@@ -129,3 +131,13 @@ def get_locale2name():
             locale = core.Locale.parse(l)
             locale2name[l] = locale.languages[locale.language]
     return locale2name
+
+
+def locale_to_rfc_5646(locale):
+    lower = locale.lower()
+    if 'hant' in lower:
+        return 'zh-Hant'
+    elif 'hans' in lower:
+        return 'zh-Hans'
+    else:
+        return LOCALE_SPLIT.split(locale)[0]

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -71,6 +71,7 @@ def setup_g():
 
     g.locale = i18n.get_locale()
     g.text_direction = i18n.get_text_direction(g.locale)
+    g.html_lang = i18n.locale_to_rfc_5646(g.locale)
     g.locales = i18n.get_locale2name()
 
     if request.method == 'POST':

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html dir="{{ g.text_direction }}">
+<html lang="{{ g.html_lang }}" dir="{{ g.text_direction }}">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -95,7 +95,9 @@ def setup_g():
     """Store commonly used values in Flask's special g object"""
     g.locale = i18n.get_locale()
     g.text_direction = i18n.get_text_direction(g.locale)
+    g.html_lang = i18n.locale_to_rfc_5646(g.locale)
     g.locales = i18n.get_locale2name()
+
     # ignore_static here because `crypto_util.hash_codename` is scrypt (very
     # time consuming), and we don't need to waste time running if we're just
     # serving a static resource that won't need to access these common values.

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html dir="{{ g.text_direction }}">
+<html lang="{{ g.html_lang }}" dir="{{ g.text_direction }}">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html dir="{{ g.text_direction }}">
+<html lang="{{ g.html_lang }}" dir="{{ g.text_direction }}">
   <head>
     <title>SecureDrop | {{ gettext('Protecting Journalists and Sources') }}</title>
 

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -19,6 +19,7 @@
 import argparse
 import logging
 import os
+import re
 
 from flask import request, session, render_template_string, render_template
 from flask_babel import gettext
@@ -32,9 +33,14 @@ import manage
 import pytest
 import source
 import version
+import utils
 
 
 class TestI18N(object):
+
+    @classmethod
+    def setup_class(cls):
+        utils.env.setup()
 
     def test_get_supported_locales(self):
         locales = ['en_US', 'fr_FR']
@@ -217,6 +223,29 @@ class TestI18N(object):
                 assert not_translated == gettext(not_translated)
         finally:
             config.DEFAULT_LOCALE = DEFAULT_LOCALE
+
+    def test_locale_to_rfc_5646(self):
+        assert i18n.locale_to_rfc_5646('en') == 'en'
+        assert i18n.locale_to_rfc_5646('en-US') == 'en'
+        assert i18n.locale_to_rfc_5646('en_US') == 'en'
+        assert i18n.locale_to_rfc_5646('en-us') == 'en'
+        assert i18n.locale_to_rfc_5646('zh-hant') == 'zh-Hant'
+
+    def test_html_lang_correct(self):
+        app = journalist.app.test_client()
+        resp = app.get('/', follow_redirects=True)
+        html = resp.data.decode('utf-8')
+        assert re.compile('<html .*lang="en".*>').search(html), html
+
+        app = source.app.test_client()
+        resp = app.get('/', follow_redirects=True)
+        html = resp.data.decode('utf-8')
+        assert re.compile('<html .*lang="en".*>').search(html), html
+
+        # check '/generate' too because '/' uses a different template
+        resp = app.get('/generate', follow_redirects=True)
+        html = resp.data.decode('utf-8')
+        assert re.compile('<html .*lang="en".*>').search(html), html
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2354.

Adds the RFC 5646 language tag to the HTML.

## Testing

`pytest tests`.

More complete testing depends on merging in some translations.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM