### PR TITLE
tests: ignore config.py SUPPORTED_LOCALES during tests

### DIFF
--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -195,10 +195,17 @@ class TestI18N(object):
 
         manage.translate(args)
 
-        for app in (journalist.app, source.app):
-            app.config['BABEL_TRANSLATION_DIRECTORIES'] = config.TEMP_DIR
-            i18n.setup_app(app)
-            self.verify_i18n(app)
+        supported = getattr(config, 'SUPPORTED_LOCALES', None)
+        try:
+            if supported:
+                del config.SUPPORTED_LOCALES
+            for app in (journalist.app, source.app):
+                app.config['BABEL_TRANSLATION_DIRECTORIES'] = config.TEMP_DIR
+                i18n.setup_app(app)
+                self.verify_i18n(app)
+        finally:
+            if supported:
+                config.SUPPORTED_LOCALES = supported
 
     def test_verify_default_locale_en_us_if_not_defined_in_config(self):
         DEFAULT_LOCALE = config.DEFAULT_LOCALE


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The test_i18n.py tests must ignore the content of the
SUPPORTED_LOCALES config.py variable when they run, otherwise the
result depends on it and it is unstable.

## Testing

* set SUPPORTED_LOCALES = ['en_US'] in config.py
* pytest -v tests/test_i18n.py fails with
<pre>
>           assert 'fr_FR' in locales
E           AssertionError: assert 'fr_FR' in ''
</pre>
* use this pull request and see it passes regardless of the content of SUPPORTED_LOCALES 

## Deployment

Test only.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

