### PR TITLE
i18n: datetimeformat regression: add {time} ago

### DIFF
--- a/securedrop/template_filters.py
+++ b/securedrop/template_filters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from flask_babel import get_locale
+from flask_babel import gettext, get_locale
 from babel import units, dates
 from datetime import datetime
 from jinja2 import Markup, escape
@@ -9,8 +9,9 @@ import math
 def datetimeformat(dt, fmt=None, relative=False):
     """Template filter for readable formatting of datetime.datetime"""
     if relative:
-        return dates.format_timedelta(datetime.utcnow() - dt,
+        time = dates.format_timedelta(datetime.utcnow() - dt,
                                       locale=get_locale())
+        return gettext('{time} ago').format(time=time)
     else:
         fmt = fmt or 'MMM dd, yyyy hh:mm a'
         return dates.format_datetime(dt, fmt, locale=get_locale())

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -32,7 +32,7 @@ class TestTemplateFilters(object):
 
             test_time = datetime.utcnow() - timedelta(hours=2)
             result = template_filters.datetimeformat(test_time, relative=True)
-            assert "2 hours" == result
+            assert "2 hours ago" == result
 
             c.get('/?l=fr_FR')
             assert session.get('locale') == 'fr_FR'
@@ -46,7 +46,7 @@ class TestTemplateFilters(object):
 
             test_time = datetime.utcnow() - timedelta(hours=2)
             result = template_filters.datetimeformat(test_time, relative=True)
-            assert "2 heures" == result
+            assert "2 heures ago" == result
 
     def verify_filesizeformat(self, app):
         with app.test_client() as c:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The refactor of datetimeformat in 56c338f60568518dd1c132e7933f2df7f878522f had a gression. It removed the "ago" part of the relative date time display.

## Testing

* pytest -v tests/test_template_filters.py

## Deployment

Ui only.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
