### PR TITLE
i18n: the order of the accepted languages matters

### DIFF
--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -66,14 +66,14 @@ def get_locale():
     - 'en_US'
     """
     locale = None
-    accept_languages = set()
+    accept_languages = []
     for l in request.accept_languages.values():
         if '-' in l:
             sep = '-'
         else:
             sep = '_'
         try:
-            accept_languages.add(str(core.Locale.parse(l, sep)))
+            accept_languages.append(str(core.Locale.parse(l, sep)))
         except:
             pass
     if 'l' in request.args:

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -80,6 +80,13 @@ class TestI18N(object):
                 {{ gettext('code hello i18n') }}
                 ''').strip() == translated_fr
 
+        # https://github.com/freedomofpress/securedrop/issues/2379
+        headers = Headers([('Accept-Language',
+                            'en-US;q=0.6,fr_FR;q=0.4,nb_NO;q=0.2')])
+        with app.test_request_context(headers=headers):
+            assert not hasattr(request, 'babel_locale')
+            assert not_translated == gettext(not_translated)
+
         translated_cn = 'code chinese'
 
         for lang in ('zh-CN', 'zh-Hans-CN'):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2379.

The language list from the Accept-Languages header is sorted by order
of preference. Store it in a list instead of a set to preserve the
order.

## Testing

It is difficult to verify manually because the order in which the set is stored depends on how the values are hashed. The best next thing is to read and run the test added to tests/test_i18n.py

I implemented the test with values that fail on my machine if the patch is not applied. With a little luck you may have the same on yours.

## Deployment

i18n is not deployed yet.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
