### PR TITLE
Fix button styling for Arabic

### DIFF
--- a/securedrop/sass/_base.sass
+++ b/securedrop/sass/_base.sass
@@ -69,7 +69,10 @@
 
   .sd-button
     font-weight: normal
-    letter-spacing: 0.15em
+    &:not([lang=ar])
+      letter-spacing: 0.15em
+    &:lang(ar)
+      letter-spacing: 0em
 
   .select
     border: 1px #C4C2C2 solid


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2223

Changes proposed in this pull request:
 * Modifies SASS to use `lang` to skip the letter spacing if Arabic is in use

## Testing

0. In development VM, download Arabic translations:

```
cd /vagrant/securedrop
mkdir -p translations/ar/LC_MESSAGES
wget http://lab.securedrop.club/bot/securedrop/raw/i18n/securedrop/translations/ar/LC_MESSAGES/messages.po
cp messages.po translations/ar/LC_MESSAGES
./manage.py --verbose translate --compile
```

1. Run the source interface
2. Look at English interface and verify the buttons _do_ have the spacing like this:
![screen shot 2017-09-29 at 9 22 03 am](https://user-images.githubusercontent.com/7832803/31025945-5f9a10e6-a4f9-11e7-8c89-b3d08458ea39.png)

3. Look at Arabic interface and verify the buttons do _not_ have spacing, like this:

![screen shot 2017-09-29 at 9 22 22 am](https://user-images.githubusercontent.com/7832803/31025961-6c1a2090-a4f9-11e7-9458-a15244047639.png)

(You can flip between `develop` and this branch to see the difference or refer to the image in #2223 for comparison)

## Deployment

SASS will be compiled into CSS in the app code package and be deployed on both existing and current installs without issue

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM