### PR TITLE
Improve login form validation on source interface

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -161,6 +161,8 @@
   /var/www/securedrop/source_app/api.pyc rw,
   /var/www/securedrop/source_app/decorators.py r,
   /var/www/securedrop/source_app/decorators.pyc rw,
+  /var/www/securedrop/source_app/forms.py r,
+  /var/www/securedrop/source_app/forms.pyc rw,
   /var/www/securedrop/source_app/info.py r,
   /var/www/securedrop/source_app/info.pyc rw,
   /var/www/securedrop/source_app/main.py r,

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -261,3 +261,7 @@ div.bubble
     border-color: transparent transparent #fff #fff
     left: 33px
     top: -43px
+
+span.form-validation-error
+  color: red
+  font-size: small

--- a/securedrop/source_app/forms.py
+++ b/securedrop/source_app/forms.py
@@ -1,0 +1,19 @@
+from flask_babel import gettext
+from flask_wtf import FlaskForm
+from wtforms import PasswordField
+from wtforms.validators import InputRequired, Regexp, Length
+
+from db import Source
+
+
+class LoginForm(FlaskForm):
+    codename = PasswordField('codename', validators=[
+        InputRequired(message=gettext('This field is required.')),
+        Length(1, Source.MAX_CODENAME_LEN,
+               message=gettext('Field must be between 1 and '
+                               '{max_codename_len} characters long. '.format(
+                                   max_codename_len=Source.MAX_CODENAME_LEN))),
+        # The regex here allows either whitespace (\s) or
+        # alphanumeric characters (\W) except underscore (_)
+        Regexp(r'(\s|[^\W_])+$', message=gettext('Invalid input.'))
+    ])

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -16,6 +16,7 @@ from source_app.decorators import login_required
 from source_app.utils import (logged_in, generate_unique_codename,
                               async_genkey, normalize_timestamps,
                               valid_codename)
+from source_app.forms import LoginForm
 
 
 def make_blueprint(config):
@@ -196,7 +197,8 @@ def make_blueprint(config):
 
     @view.route('/login', methods=('GET', 'POST'))
     def login():
-        if request.method == 'POST':
+        form = LoginForm()
+        if form.validate_on_submit():
             codename = request.form['codename'].strip()
             if valid_codename(codename):
                 session.update(codename=codename, logged_in=True)
@@ -206,7 +208,7 @@ def make_blueprint(config):
                         "Login failed for invalid codename".format(codename))
                 flash(gettext("Sorry, that is not a recognized codename."),
                       "error")
-        return render_template('login.html')
+        return render_template('login.html', form=form)
 
     @view.route('/logout')
     def logout():

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -15,12 +15,6 @@ def logged_in():
 
 
 def valid_codename(codename):
-    # Ignore codenames that are too long to avoid DoS
-    if len(codename) > Source.MAX_CODENAME_LEN:
-        current_app.logger.info(
-                "Ignored attempted login because the codename was too long.")
-        return False
-
     try:
         filesystem_id = crypto_util.hash_codename(codename)
     except crypto_util.CryptoException as e:

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -8,7 +8,14 @@
 <form method="post" action="{{ url_for('main.login') }}" autocomplete="off">
 <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
 
-<p class="center"><input id="login-with-existing-codename" type="password" name="codename" class="codename-box" autocomplete="off" placeholder="{{ gettext('Enter your codename') }}" autofocus></p>
+<p class="center">
+  {{ form.codename(id="login-with-existing-codename", class="codename-box", autocomplete="off", placeholder=gettext('Enter your codename'), autofocus=True) }}
+  <br>
+  {% for error in form.codename.errors %}
+    <span class="form-validation-error">{{ error }}</span>
+  {% endfor %}
+</p>
+
 <div class="pull-right">
   <a href="{{ url_for('main.index') }}" class="sd-button btn secondary" id="cancel">{{ gettext('CANCEL') }}</a>
   <button type="submit" class="sd-button btn primary" id="login">

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -408,4 +408,21 @@ class TestSourceApp(TestCase):
         logger.assert_called_once_with(
             "Found no Sources when one was expected: "
             "No row was found for one()"
+
+    @patch('source.app.logger.info')
+    def test_login_with_invalid_codename(self, logger):
+        """Logging in with a codename that causes a CryptoException should
+        log an error and throw a 500"""
+
+        invalid_codename = '[]'
+
+        with self.client as c:
+            resp = c.post('/login', data=dict(codename=invalid_codename),
+                          follow_redirects=True)
+            self.assertEqual(resp.status_code, 500)
+
+        logger.assert_called_once_with(
+            "Could not compute filesystem ID for "
+            "codename '{codename}': invalid input: {codename}".format(
+                codename=invalid_codename)
         )

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -353,7 +353,8 @@ class TestSourceApp(TestCase):
             resp = c.post('/login', data=dict(codename=overly_long_codename),
                           follow_redirects=True)
             self.assertEqual(resp.status_code, 200)
-            self.assertIn("Sorry, that is not a recognized codename.",
+            self.assertIn("Field must be between 1 and {} "
+                          "characters long.".format(Source.MAX_CODENAME_LEN),
                           resp.data)
             self.assertFalse(mock_hash_codename.called,
                              "Called hash_codename for codename w/ invalid "
@@ -407,22 +408,16 @@ class TestSourceApp(TestCase):
 
         logger.assert_called_once_with(
             "Found no Sources when one was expected: "
-            "No row was found for one()"
+            "No row was found for one()")
 
-    @patch('source.app.logger.info')
-    def test_login_with_invalid_codename(self, logger):
-        """Logging in with a codename that causes a CryptoException should
-        log an error and throw a 500"""
+    def test_login_with_invalid_codename(self):
+        """Logging in with a codename with invalid characters should return
+        an informative message to the user."""
 
         invalid_codename = '[]'
 
         with self.client as c:
             resp = c.post('/login', data=dict(codename=invalid_codename),
                           follow_redirects=True)
-            self.assertEqual(resp.status_code, 500)
-
-        logger.assert_called_once_with(
-            "Could not compute filesystem ID for "
-            "codename '{codename}': invalid input: {codename}".format(
-                codename=invalid_codename)
-        )
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn("Invalid input.", resp.data)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes 

Changes proposed in this pull request:
* This PR creates a `forms.py` file on the source interface with the login form defined using WTForm's `FlaskForm`. This form uses WTForm's validators (a dependency we already have installed on the SecureDrop app server, but were only using it for CSRF protection) to validate form inputs. A nice feature of this is that you can just look at that one file to see what validation is performed on form inputs. This is issue #2312. 
* The bug (a 500 error) caused by an invalid character working its way into `crypto_util.py` and throwing a `CryptoException` is fixed by this. Closes #2376.
* For displaying of form validation errors on the source interface login form, I followed the advice in this [guide to UI patterns best practices for input validation](http://uipatterns.io/input-validation). It looks like this:

![loginform](https://user-images.githubusercontent.com/7832803/31041928-113af54c-a552-11e7-8be7-dca31d169b17.gif)

Note there's one other form on the source interface (the submission form) but I wanted to handle refactoring that into `forms.py` in a separate PR to keep the changes small here. 

## Testing

Follow the STR in defect #2376 to test this

## Deployment

* `source_app/forms.py` already is added to `.rsync_filter` (since it copies all *.py files under `source_app`) so it will be shipped in the app code
* `source_app/forms.py` is added to the AppArmor rules in this PR

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
