### PR TITLE
text-align: right for rtl text directions

### DIFF
--- a/securedrop/sass/_base.sass
+++ b/securedrop/sass/_base.sass
@@ -28,6 +28,9 @@
     text-align: left
     font-size: 30px
 
+    &:dir(rtl)
+      text-align: right
+
   h2
     font-size: 25px
 
@@ -61,6 +64,9 @@
     margin-bottom: 20px
     text-align: left
 
+    &:dir(rtl)
+      text-align: right
+
   .doc-check
     margin-right: 10px
 
@@ -89,11 +95,20 @@
   .pull-left
     float: left
 
+    &:dir(rtl)
+      float: right
+
   .pull-right
     float: right
 
+    &:dir(rtl)
+      text-align: left
+
   #header
     float: left
+
+    &:dir(rtl)
+      float: right
 
     .powered
       margin-top: 10px
@@ -111,6 +126,9 @@
       border-bottom: 1px solid #ddd
       padding: 6px
       text-align: left
+
+      &:dir(rtl)
+        text-align: right
 
       &:last-child
         border-bottom: none
@@ -271,6 +289,9 @@
     text-align: left
     font-size: medium
 
+    &:dir(rtl)
+      text-align: right
+
   .flash
     display: flex
     flex-flow: row nowrap
@@ -348,7 +369,7 @@
 
   .logo
     width: 250px
-    margin-right: 20px
+    margin-right: 9px
     margin-top: 36px
     margin-left: 9px
 
@@ -359,11 +380,17 @@
   .submissions
     padding-left: 0px
 
+    &:dir(rtl)
+      padding-right: 0px
+
   .submission
     background: $color_grey_xlight
     border-bottom: 1px solid #ddd
     padding: 10px
     text-align: left
+
+    &:dir(rtl)
+      text-align: right
 
     &:last-child
       border-bottom: none

--- a/securedrop/sass/_source_index.sass
+++ b/securedrop/sass/_source_index.sass
@@ -22,6 +22,9 @@
       text-align: left
       margin: 0
 
+      &:dir(rtl)
+        text-align: right
+
     .index-row
       display: flex
       justify-content: space-between

--- a/securedrop/sass/journalist.sass
+++ b/securedrop/sass/journalist.sass
@@ -12,6 +12,9 @@
     margin-bottom: 1em
     border-radius: 5px
 
+    &:dir(rtl)
+      text-align: right
+
     .date
       float: right
       background-color: $color_grey_medium
@@ -47,10 +50,16 @@ p.breadcrumbs
   text-align: left
   position: relative
 
+  &:dir(rtl)
+    text-align: right
+
 #regenerate-code .confirm-prompt
   font-size: 14px
   font-style: italic
   text-align: left
+
+  &:dir(rtl)
+    text-align: right
 
   button
     padding: 5px 15px

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -168,6 +168,9 @@ p#codename
     border-radius: 5px
     position: relative
 
+    &:dir(rtl)
+      text-align: right
+
     p
       color: #777
       font-style: italic
@@ -221,11 +224,17 @@ p.explanation
   text-align: left
   color: $color_grey_dark
 
+  &:dir(rtl)
+    text-align: right
+
 #replies blockquote
   margin: 1em 1em
 
 p.breadcrumbs
   text-align: left
+
+  &:dir(rtl)
+    text-align: right
 
 p#max-file-size
   font-size: 10px


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2381

![screenshot_2017-10-03_12-00-31](https://user-images.githubusercontent.com/3998464/31119796-7c9ee6f8-a832-11e7-970e-8298376cc042.png)

Uses the pseudo selector `dir()` to correctly align content for languages that are set RTL.

> Note: this only works in TB and FF according to [this](https://css-tricks.com/almanac/selectors/d/dir/).

I think this is a better solution than the trick I mentioned in https://github.com/freedomofpress/securedrop/issues/2381#issuecomment-333780521 on the grounds that it only leads to a tiny increase in the size of the CSS and for now it is a much simpler solution.

## Testing

Setup:

```bash
cd /vagrant/securedrop
mkdir -p translations/ar/LC_MESSAGES
curl http://lab.securedrop.club/bot/securedrop/raw/i18n/securedrop/translations/ar/LC_MESSAGES/messages.po > translations/ar/LC_MESSAGES/messages.po
./manage.py translate --compile
PAGE_LAYOUT_LOCALES='ar' pytest -v --page-layout tests/pages-layout
```

Using Tor Browser: Create a source (in Arabic locale), submit a doc. Create a journalist (in Arabic locale), respond. Check the response as a source. This should display most everything.