### PR TITLE
Allow symlinks on VirtualBox vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,6 +43,7 @@ Vagrant.configure("2") do |config|
     # more memory than the previous version did.
     development.vm.provider "virtualbox" do |v|
       v.memory = 1024
+      v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
     end
     development.vm.provider "libvirt" do |lv, override|
       lv.memory = 1024

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -15,6 +15,8 @@ one.
 
 .. _`GitHub #1381`: https://github.com/freedomofpress/securedrop/issues/1381
 
+.. note:: If you see test failures due to ``Too many levels of symbolic links``
+          and you are using VirtualBox, try restarting VirtualBox.
 
 .. _development_vm:
 
@@ -72,7 +74,7 @@ Debian packages on the staging machines:
 
 .. code:: sh
 
-   make build-debs 
+   make build-debs
    vagrant up /staging/
    vagrant ssh app-staging
    sudo su
@@ -82,7 +84,7 @@ Debian packages on the staging machines:
 
 To rebuild the local packages for the app code: ::
 
-   make build-debs 
+   make build-debs
 
 The Debian packages will be rebuilt from the current state of your
 local git repository and then installed on the staging servers.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2396 

Changes proposed in this pull request:
 * Adds the fix I used locally for the test failures due to symlinks in VirtualBox

## Testing

1. Destroy development VM, and then `vagrant up`. 
2. Restart VirtualBox.
3. Verify tests pass on this PR in your development VM and you do not see any error related to symlinks.
4. Switch to an older branch e.g. `docs-prod-vms-and-tails` (before the wordlist symlink was made) and then back to `develop` and verify that tests are still all passing. 

## Deployment

Development environment only

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
