### PR TITLE
Encourage sources to restart Tor Browser after session timeout

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -180,6 +180,7 @@
   /var/www/securedrop/source_templates/logout_flashed_message.html r,
   /var/www/securedrop/source_templates/locales.html r,
   /var/www/securedrop/source_templates/lookup.html r,
+  /var/www/securedrop/source_templates/session_timeout.html r,
   /var/www/securedrop/source_templates/next_submission_flashed_message.html r,
   /var/www/securedrop/source_templates/notfound.html r,
   /var/www/securedrop/source_templates/tor2web-warning.html r,

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -79,8 +79,8 @@ def create_app(config):
 
         if 'expires' in session and datetime.utcnow() >= session['expires']:
             session.clear()
-            flash(gettext('You have been logged out due to inactivity'),
-                  'error')
+            msg = render_template('session_timeout.html')
+            flash(Markup(msg), "important")
 
         session['expires'] = datetime.utcnow() + \
             timedelta(minutes=getattr(config,

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% block body %}
 
-<h1>{{ gettext('Enter Codename') }}</h1>
-
 {% include 'flashed.html' %}
+
+<h1>{{ gettext('Enter Codename') }}</h1>
 
 <form method="post" action="{{ url_for('main.login') }}" autocomplete="off">
 <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">

--- a/securedrop/source_templates/session_timeout.html
+++ b/securedrop/source_templates/session_timeout.html
@@ -1,0 +1,5 @@
+<div class="icon">
+  <img src="{{ url_for('static', filename='i/hand_with_fingerprint.png') }}">
+</div>
+<div class="message"><strong>{{ gettext('Important!') }}</strong><br>
+<p>{{ gettext('Your session timed out due to inactivity. Please login again if you want to continue using SecureDrop, or select "New Identity" from the green onion button in the Tor browser to clear all history of your SecureDrop usage from this device. If you are not using Tor Browser, restart your browser.') }}</p></div>

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -21,9 +21,10 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
+import config
 import db
 import journalist
-import source
+from source_app import create_app
 import tests.utils.env as env
 
 LOG_DIR = abspath(join(dirname(realpath(__file__)), '..', 'log'))
@@ -41,7 +42,7 @@ class alert_is_not_present(object):
             return True
 
 
-class FunctionalTest():
+class FunctionalTest(object):
 
     def _unused_port(self):
         s = socket.socket()
@@ -80,7 +81,7 @@ class FunctionalTest():
         log_file.flush()
         return firefox_binary.FirefoxBinary(log_file=log_file)
 
-    def setup(self):
+    def setup(self, session_expiration=30):
         # Patch the two-factor verification to avoid intermittent errors
         self.patcher = mock.patch('journalist.Journalist.verify_token')
         self.mock_journalist_verify_token = self.patcher.start()
@@ -98,6 +99,9 @@ class FunctionalTest():
         self.source_location = "http://localhost:%d" % source_port
         self.journalist_location = "http://localhost:%d" % journalist_port
 
+        # Allow custom session expiration lengths
+        self.session_expiration = session_expiration
+
         def start_source_server():
             # We call Random.atfork() here because we fork the source and
             # journalist server from the main Python process we use to drive
@@ -106,7 +110,12 @@ class FunctionalTest():
             # is a problem because they would produce identical output if we
             # didn't re-seed them after forking.
             Random.atfork()
-            source.app.run(
+
+            config.SESSION_EXPIRATION_MINUTES = self.session_expiration
+
+            source_app = create_app(config)
+
+            source_app.run(
                 port=source_port,
                 debug=True,
                 use_reloader=False,

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -236,4 +236,7 @@ class SourceNavigationSteps():
 
     def _source_sees_session_timeout_message(self):
         notification = self.driver.find_element_by_css_selector('.important')
-        assert 'Your session timed out due to inactivity.' in notification.text
+
+        if not hasattr(self, 'accept_languages'):
+            expected_text = 'Your session timed out due to inactivity.'
+            assert expected_text in notification.text

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -1,4 +1,5 @@
 import tempfile
+import time
 
 from selenium.webdriver.common.action_chains import ActionChains
 from step_helpers import screenshots
@@ -14,8 +15,7 @@ class SourceNavigationSteps():
             assert ("SecureDrop | Protecting Journalists and Sources" ==
                     self.driver.title)
 
-    @screenshots
-    def _source_chooses_to_submit_documents(self):
+    def _source_clicks_submit_documents_on_homepage(self):
         # First move the cursor to a known position in case it happens to
         # be hovering over one of the buttons we are testing below.
         header_image = self.driver.find_element_by_css_selector('.header')
@@ -43,6 +43,10 @@ class SourceNavigationSteps():
 
         # The source clicks the submit button.
         submit_button.click()
+
+    @screenshots
+    def _source_chooses_to_submit_documents(self):
+        self._source_clicks_submit_documents_on_homepage()
 
         codename = self.driver.find_element_by_css_selector('#codename')
 
@@ -170,12 +174,8 @@ class SourceNavigationSteps():
 
     @screenshots
     def _source_submits_a_message(self):
-        text_box = self.driver.find_element_by_css_selector('[name=msg]')
-        # send_keys = type into text box
-        text_box.send_keys(self.secret_message)
-
-        submit_button = self.driver.find_element_by_id('submit-doc-button')
-        submit_button.click()
+        self._source_enters_text_in_message_field()
+        self._source_clicks_submit_button_on_submission_page()
 
         if not hasattr(self, 'accept_languages'):
             notification = self.driver.find_element_by_css_selector(
@@ -185,6 +185,10 @@ class SourceNavigationSteps():
     def _source_enters_text_in_message_field(self):
         text_box = self.driver.find_element_by_css_selector('[name=msg]')
         text_box.send_keys(self.secret_message)
+
+    def _source_clicks_submit_button_on_submission_page(self):
+        submit_button = self.driver.find_element_by_id('submit-doc-button')
+        submit_button.click()
 
     @screenshots
     def _source_deletes_a_journalist_reply(self):
@@ -226,3 +230,10 @@ class SourceNavigationSteps():
 
     def _source_why_journalist_key(self):
         self.driver.get(self.source_location + "/why-journalist-key")
+
+    def _source_waits_for_session_to_timeout(self, session_length_minutes):
+        time.sleep(session_length_minutes * 60 + 0.1)
+
+    def _source_sees_session_timeout_message(self):
+        notification = self.driver.find_element_by_css_selector('.important')
+        assert 'Your session timed out due to inactivity.' in notification.text

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -2,7 +2,7 @@ import source_navigation_steps
 import functional_test
 
 
-class TestSourceInterfaceBannerWarnings(
+class TestSourceInterface(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationSteps):
 

--- a/securedrop/tests/functional/test_source_notfound.py
+++ b/securedrop/tests/functional/test_source_notfound.py
@@ -2,7 +2,7 @@ import source_navigation_steps
 import functional_test
 
 
-class TestSourceInterfaceBannerWarnings(
+class TestSourceInterfaceNotFound(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationSteps):
 

--- a/securedrop/tests/functional/test_source_session_timeout.py
+++ b/securedrop/tests/functional/test_source_session_timeout.py
@@ -1,0 +1,26 @@
+import source_navigation_steps
+import functional_test
+
+
+class TestSourceSessions(
+        functional_test.FunctionalTest,
+        source_navigation_steps.SourceNavigationSteps):
+
+    def setup(self):
+        # The session expiration here cannot be set to -1
+        # as it will trigger an exception in /create.
+        # Instead, we pick a 1-2s value to allow the account
+        # to be generated.
+        self.session_length_minutes = 0.03
+        super(TestSourceSessions, self).setup(
+            session_expiration=self.session_length_minutes)
+
+    def test_source_session_timeout(self):
+        self._source_visits_source_homepage()
+        self._source_clicks_submit_documents_on_homepage()
+        self._source_continues_to_submit_page()
+        self._source_waits_for_session_to_timeout(
+            self.session_length_minutes)
+        self._source_enters_text_in_message_field()
+        self._source_clicks_submit_button_on_submission_page()
+        self._source_sees_session_timeout_message()

--- a/securedrop/tests/pages-layout/test_source.py
+++ b/securedrop/tests/pages-layout/test_source.py
@@ -136,3 +136,25 @@ class TestSourceLayout(
     def test_why_journalist_key(self):
         self._source_why_journalist_key()
         self._screenshot('source-why_journalist_key.png')
+
+
+@pytest.mark.pagelayout
+class TestSourceSessionLayout(
+        functional_test.FunctionalTest,
+        source_navigation_steps.SourceNavigationSteps,
+        journalist_navigation_steps.JournalistNavigationSteps):
+
+    def setup(self):
+        self.session_length_minutes = 0.03
+        super(TestSourceSessionLayout, self).setup(
+            session_expiration=self.session_length_minutes)
+
+    def test_source_session_timeout(self):
+        self._source_visits_source_homepage()
+        self._source_clicks_submit_documents_on_homepage()
+        self._source_continues_to_submit_page()
+        self._source_waits_for_session_to_timeout(self.session_length_minutes)
+        self._source_enters_text_in_message_field()
+        self._source_clicks_submit_button_on_submission_page()
+        self._source_sees_session_timeout_message()
+        self._screenshot('source-session_timeout.png')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2400.

Changes proposed in this pull request:
  * The source gets a message indicating that they should restart Tor Browser (this makes the behavior after session timeout the same as logout on the source interface):

![screen shot 2017-10-05 at 3 11 49 pm](https://user-images.githubusercontent.com/7832803/31255846-dfa4da7a-a9e3-11e7-8d86-c84c4b1cd596.png)

## Testing

```
pytest -v --page-layout tests/pages-layout/test_source.py::TestSourceLayout::test_source_session_timeout
```

## Deployment

The new template is already included in `rsync_filter`, and I've added an AppArmor rule for it

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
