### PR TITLE
l18n: parse source_app/*.py

### DIFF
--- a/securedrop/babel.cfg
+++ b/securedrop/babel.cfg
@@ -1,6 +1,9 @@
 [python: *.py]
 silent=False
 
+[python: source_app/*.py]
+silent=False
+
 [jinja2: */*.html]
 silent=False
 extensions=jinja2.ext.autoescape,jinja2.ext.with_,webassets.ext.jinja2.AssetsExtension


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Now that the source app is in a sub-directory, pybabel needs to parse the py it contains to get all the strings.

## Testing

* ./manage.py translate --extract-update
* verify strings from the source app are missing from translations/messages.pot
* apply the patch
* ./manage.py translate --extract-update
* verify strings from the source app are no longer missing from translations/messages.pot

## Deployment

No deployment impact.
