### PR TITLE
Add administrator instructions for updating system config

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -184,6 +184,37 @@ possession when they attempt to log in to SecureDrop.
 Updating the Servers
 --------------------
 
+Sometimes you will want to update the system configuration on the SecureDrop
+servers. For example, to customize the logo on the source interface,
+or change the PGP key that OSSEC alerts are encrypted to. You can do this from
+your *Admin Workstation* by following the procedure described in this
+section.
+
+Updating system configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The server configuration is stored on the *Admin Workstation* in
+``~/Persistent/securedrop/install_files/ansible-base/group_vars/all/site-specific``.
+
+If you want to update the system configuration, there are two options:
+
+1. Manually edit the ``site-specific`` file to make the desired modifications.
+2. From ``~/Persistent/securedrop``, run
+   ``./securedrop-admin sdconfig --force``, which will require you to retype
+   each variable in ``site-specific``.
+
+Once you have edited the ``site-specific`` server configuration file, you will
+need to apply the changes to the servers. From ``~/Persistent/securedrop``:
+
+.. code:: sh
+
+  ./securedrop-admin install
+
+.. include:: includes/rerun-install-is-safe.txt
+
+Once the install command has successfully completed, the changes are applied.
+Read the next section if you have multiple administrators.
+
 Managing ``site-specific`` updates on teams with multiple admins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/includes/rerun-install-is-safe.txt
+++ b/docs/includes/rerun-install-is-safe.txt
@@ -1,0 +1,5 @@
+.. note:: If you see an error running ``./securedrop-admin install``, and
+          believe it may be an intermittent issue (for example, due to losing
+          network connectivity to the servers), it is safe to run the
+          ``./securedrop-admin install`` command again. If you see the same
+          issue consistently, then you will need to troubleshoot it.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -70,8 +70,8 @@ match your environment: ::
 The script will automatically validate the answers you provided, and display
 error messages if any problems were detected. The answers you provided will be
 written to the file ``install_files/ansible-base/group_vars/all/site-specific``,
-which you can edit in case of errors such as typos before rerunning the script. 
-You can also run ``./securedrop-admin sdconfig --force`` to remove your entire 
+which you can edit in case of errors such as typos before rerunning the script.
+You can also run ``./securedrop-admin sdconfig --force`` to remove your entire
 configuration file and start over.
 
 When you're done, save the file and quit the editor.
@@ -91,9 +91,15 @@ You will be prompted to enter the sudo password for the *Application* and
 *Monitor Servers* (which should be the same).
 
 The install process will take some time, and it will return
-the terminal to you when it is complete. If an error occurs while
-running the install, please check all of the details of the error output
-and if needed, make edits to the file located at ``install_files/ansible-base/group_vars/all/site-specific``
+the terminal to you when it is complete.
+
+If an error occurs while
+running the install, please check all of the details of the error output.
+
+.. include:: includes/rerun-install-is-safe.txt
+
+If needed, make edits to the file located at
+``install_files/ansible-base/group_vars/all/site-specific``
 as described above. If you continue to have issues please submit a detailed `GitHub
 issue <https://github.com/freedomofpress/securedrop/issues/new>`__ or
 send an email to securedrop@freedom.press.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2098 and fixes #2163 

Changes proposed in this pull request:
 * Document how to update server configuration for admins
 * Add reusable text snippet indicating it's safe to rerun the install

## Testing

Are these the right steps? Are they clear?

## Deployment

Just docs

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
