### PR TITLE
source: add missing i18n string

### DIFF
--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -33,7 +33,7 @@
       <p class="center" id="max-file-size">{{ gettext('Maximum upload size: 500 MB') }}</p>
     </div>
     <div class="message grid-item">
-      <textarea name="msg" class="fill-parent" placeholder="Write a message."></textarea>
+      <textarea name="msg" class="fill-parent" placeholder="{{ gettext('Write a message.') }}"></textarea>
     </div>
   </div>
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

A string in securedrop/source_templates/lookup.html was not wrapped in gettext()

## Testing

* connect as a source
* click "Submit documents for the first time"
* verify "Write a message." shows in the page

## Deployment

Just a user facing string.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM
