### PR TITLE
Allow dashes in words in login form on source interface and add regression test

### DIFF
--- a/securedrop/source_app/forms.py
+++ b/securedrop/source_app/forms.py
@@ -13,7 +13,6 @@ class LoginForm(FlaskForm):
                message=gettext('Field must be between 1 and '
                                '{max_codename_len} characters long. '.format(
                                    max_codename_len=Source.MAX_CODENAME_LEN))),
-        # The regex here allows either whitespace (\s) or
-        # alphanumeric characters (\W) except underscore (_)
-        Regexp(r'(\s|[^\W_])+$', message=gettext('Invalid input.'))
+        # Make sure to allow dashes since some words in the wordlist have them
+        Regexp(r'[\sA-Za-z0-9-]+$', message=gettext('Invalid input.'))
     ])

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -44,6 +44,25 @@ class TestSourceApp(TestCase):
         self.assertIn("Submit documents for the first time", response.data)
         self.assertIn("Already submitted something?", response.data)
 
+    def test_all_words_in_wordlist_validate(self):
+        """Verify that all words in the wordlist are allowed by the form
+        validation. Otherwise a source will have a codename and be unable to
+        return."""
+
+        wordlist_en = crypto_util._get_wordlist('en')
+
+        for word in wordlist_en:
+            with self.client as c:
+                resp = c.post('/login', data=dict(codename=word),
+                              follow_redirects=True)
+                self.assertEqual(resp.status_code, 200)
+                # If the word does not validate, then it will show
+                # 'Invalid input'. If it does validate, it should show that
+                # it isn't a recognized codename.
+                self.assertIn('Sorry, that is not a recognized codename.',
+                              resp.data)
+                self.assertNotIn('logged_in', session)
+
     def _find_codename(self, html):
         """Find a source codename (diceware passphrase) in HTML"""
         # Codenames may contain HTML escape characters, and the wordlist


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2398 using @dachary's suggestion [here](https://github.com/freedomofpress/securedrop/issues/2398#issuecomment-334309339). Adds a test for the default wordlist to make sure each word in the wordlist is valid input in the login form. 

## Testing

Look at the test `test_all_words_in_wordlist_validate` and check you agree that all words in the default wordlist will be tested based on the logic there. Is the test passing in CI? 

## Deployment

This stricter form validation had not been shipped yet. The default wordlist is currently in use. For new wordlists, we can verify that no unexpected characters are present before shipping. I have verified this for the French wordlist. 

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
