### PR TITLE
Docs: Add sample privacy policy to deployment section

### DIFF
--- a/docs/deployment/sample_privacy_policy.rst
+++ b/docs/deployment/sample_privacy_policy.rst
@@ -1,0 +1,97 @@
+.. _Sample Privacy Policy:
+
+Sample SecureDrop Privacy Policy
+================================
+
+**[DATE]**
+
+SecureDrop strives to create a more secure environment for whistleblowers to
+give information to journalists. It was installed at **[MEDIA ORG]** with the
+help of Freedom of the Press Foundation.
+
+Please read this privacy policy carefully. It explains what information what
+type of information SecureDrop does and does not collect, and why.
+
+Collection of Information From Sources
+--------------------------------------
+
+* We don’t ask or require you to provide any personally identifying information
+  when you submit materials through SecureDrop.
+
+* The system does not record your IP address, information about your browser,
+  computer, or operating system. Furthermore, the SecureDrop pages do not embed
+  third-party content or deliver persistent cookies to your browser.
+
+* The server will only store the date and time of the newest message sent from
+  each source. Once you send a new message, the time and date of your previous
+  message is automatically deleted.
+
+* Journalists decrypt and read each message offline. They are encouraged to
+  delete messages from the server on a regular basis. The date and time of any
+  message will be securely deleted from the server when the message is deleted.
+
+* Please keep in mind that the actual messages you send and receive through
+  SecureDrop may include personally identifying information. For this reason,
+  once you read a journalist’s message, we recommend you delete it. It will
+  then be securely deleted from the file system.
+
+Also please note that when you submit certain types of files through SecureDrop,
+you may be sending us metadata associated with that file.
+
+For example, if you submit a photo through SecureDrop in JPEG format, the
+file may include information about the date, time, and the GPS location of where
+it was taken, and the type of device used to take the photo. Similarly, if you
+submit a Word file (.doc or .docx) through SecureDrop, it may include the
+identity of the document’s author, the author’s operating system, GPS data about
+the author’s location, and the date and time when the document was created.
+
+Our policy is to scrub metadata from the files we receive through SecureDrop
+before publication. If you don’t want to send us metadata, please use the
+Metadata Anonymization Toolkit to scrub the file before you submit it.
+
+Collection of Information About Journalists’ Use of SecureDrop
+--------------------------------------------------------------
+
+**[MEDIA ORG]** collects information about journalists’ use of SecureDrop for
+security monitoring and to make sure the system works properly.
+
+This information we collect about journalists includes details about the device,
+browser, and operating system journalists use when accessing the system, and the
+date and time of each session.
+
+We retain these access logs for **[___]** days, and then delete them.
+
+Data Security
+-------------
+
+**[MEDIA ORG]** works diligently to protect the identities of our sources and
+keep the information they give us confidential.
+
+SecureDrop servers are under the physical control of **[MEDIA ORG]** and do
+not share common elements of the **[MEDIA ORG'S]** other infrastructure.
+
+However, no one can truly guarantee 100% security of any system. Like all
+software, SecureDrop may contain bugs. Ultimately, you use the SecureDrop
+service at your own risk.
+
+Children Under 13
+-----------------
+
+The Children’s Online Privacy Protection Act restricts our ability to collect
+personal information from children under 13. This site is not directed to
+children 12 or younger.
+
+Changes to This Policy
+----------------------
+
+We may revise this Privacy Policy from time to time. The most current version
+of the policy will govern our collection and use of personal information and
+will always be at **[LINK]**. If we make changes that we believe are material, we
+will prominently display a notice on our site **[___]** days before we make those
+changes.
+
+Contact
+-------
+
+**[MEDIA ORG]** welcomes questions, concerns, and feedback about this policy.
+If you have suggestions for us, feel free to let us know at **[EMAIL ADDRESS]**.

--- a/docs/deployment_practices.rst
+++ b/docs/deployment_practices.rst
@@ -11,7 +11,10 @@ protection provided by SecureDrop.
 While SecureDrop itself is located on a Tor hidden service, news
 organizations also need to create a SecureDrop landing page that will
 explain how SecureDrop works, give sources instructions on how to access
-the Tor hidden service, and disclose the risks.
+the Tor hidden service, and disclose the risks. We recommend to also include a
+privacy policy (see our :ref:`Sample Privacy Policy`)
+that describes what data is collected and how it will be used by your
+organization.
 
 It is important to keep in mind that implementing SecureDrop will bring
 more attention to your organization by security researchers, hackers,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@ anonymous sources.
    deployment/landing_page.rst
    deployment/minimum_security_requirements.rst
    deployment/whole_site_changes.rst
+   deployment/sample_privacy_policy.rst
 
 .. toctree::
    :caption: Checklists


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #2340 

Changes proposed in this pull request:
  * Add sample privacy policy to the documentation (this is currently hosted on securedrop.org)

## Testing

Check everything renders well and the links work.

## Deployment

Docs only

## Checklist

- [x] Doc linting passed locally
