### PR TITLE
Increases AWS EC2 CI instance t2.small -> t2.medium

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
         environment:
           FPF_CI: true
           CI_SD_ENV: staging
-          CI_AWS_TYPE: t2.small
+          CI_AWS_TYPE: t2.medium
           FPF_GRSEC: false
           TEST_REPORTS: /root/sd
     working_directory: ~/sd


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Related to #2253, but insufficient for close.

Trying out larger AWS EC2 instances, in the hope that more resources will provide greater stability, particularly with regard to SSH connections. (It may be more reasonable simply to increase the connection timeouts in play, but 60s seems enough to me.)

Twice the price, but given the unreliable connections on the smaller option, let's test the old adage of money solving everything. Besides, we've got a hackathon coming up, and restarting CI frequently
for a cadre of contributors is never fun.

## Testing

Make sure CircleCI passes. Would also like confirmation from @msheiny here, and hoping to help out @heartsucker for the hackathon this weekend. 

## Deployment
No, only affects CI.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
