### PR TITLE
Change all instances of `sudo:` to `become:`

### DIFF
--- a/install_files/ansible-base/build-deb-pkgs.yml
+++ b/install_files/ansible-base/build-deb-pkgs.yml
@@ -7,7 +7,7 @@
   hosts: localhost
   connection: local
   gather_facts: no
-  sudo: no
+  become: no
   tasks:
     - name: Check for "build" machine in inventory.
       fail:
@@ -28,7 +28,7 @@
 # last wrapper role will run. This is a known bug and will be fixed in v2.0.
 - name: Build SecureDrop application Debian package from local repository.
   hosts: build
-  sudo: yes
+  become: yes
   pre_tasks:
     - name: Ensure all packages are up to date.
       apt:

--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/sass.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/sass.yml
@@ -7,7 +7,7 @@
     # https://github.com/freedomofpress/securedrop/issues/1594).
     version: "3.4.23"
     user_install: no
-  sudo: yes
+  become: yes
 
 - name: Create static asset directories.
   file:

--- a/install_files/ansible-base/roles/development/tasks/main.yml
+++ b/install_files/ansible-base/roles/development/tasks/main.yml
@@ -27,7 +27,7 @@
     name: sass
     version: "{{ securedrop_sass_ver }}"
     user_install: no
-  sudo: yes
+  become: yes
   tags:
     - development
 

--- a/install_files/ansible-base/roles/grsecurity/tasks/apply_grsec_lock.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/apply_grsec_lock.yml
@@ -26,7 +26,7 @@
     state: present
     reload: yes
   with_items: "{{ grsec_sysctl_flags }}"
-  sudo: yes
+  become: yes
   tags:
     - hardening
     - grsec

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
@@ -24,7 +24,7 @@
     dest: "{{ role_path }}/../../{{ item.item.filename }}"
     src: ths_config.j2
   # Local action, so we don't want elevated privileges
-  sudo: no
+  become: no
   with_items: "{{ tor_hidden_service_hostname_lookup.results }}"
   tags:
     - tor

--- a/install_files/ansible-base/roles/upgrade/handlers/main.yml
+++ b/install_files/ansible-base/roles/upgrade/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: reload tor for port change
   service: name=tor state=reloaded
-  sudo: yes
+  become: yes

--- a/install_files/ansible-base/roles/upgrade/tasks/0-3pre-upgrade.yml
+++ b/install_files/ansible-base/roles/upgrade/tasks/0-3pre-upgrade.yml
@@ -4,15 +4,15 @@
 - name: stop the apache service prior to upgrade tasks
   service: name=apache2 state=stopped
   when: server_role == 'app'
-  sudo: yes
+  become: yes
 
 - name: copy upgrade script to servers
   copy: src="0.3pre_upgrade.py" dest="/tmp" owner="root" mode="740"
-  sudo: yes
+  become: yes
 
 - name: run the upgrade script
   shell: "/tmp/0.3pre_upgrade.py {{ server_role }}"
-  sudo: yes
+  become: yes
 
 - name: remove old 0.3 packages to avoid version error
   apt: name={{ item }} state=absent
@@ -21,11 +21,11 @@
     - securedrop-grsec
     - securedrop-ossec-agent
     - securedrop-ossec-server
-  sudo: yes
+  become: yes
 
 - name: remove the previous signing key
   apt_key: id=BD67D096 state=absent
-  sudo: yes
+  become: yes
 
   # This will update the App servers torrc config file for changing the
   # journalist interface tor port from 8080 to 80. As of this release the prod
@@ -46,7 +46,7 @@
     backrefs: yes
     line: 'HiddenServicePort 80 127.0.0.1:8080'
   notify: reload tor for port change
-  sudo: yes
+  become: yes
 
   # If the config changed, reload tor now instead of after all the remaining
   # upgrade tasks are run so the next task can verify
@@ -55,4 +55,4 @@
 
 - name: ensure tor is running
   service: name=tor state=running
-  sudo: yes
+  become: yes

--- a/install_files/ansible-base/securedrop-development.yml
+++ b/install_files/ansible-base/securedrop-development.yml
@@ -17,4 +17,4 @@
     - { role: development, tags: development }
     - { role: app, tags: app }
     - { role: app-test, tags: app-test }
-  sudo: yes
+  become: yes

--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -20,20 +20,20 @@
     - { role: common, tags: common }
     - { role: tor-hidden-services, tags: tor }
     - { role: grsecurity, when: grsecurity, tags: [grsec, grsecurity] }
-  sudo: yes
+  become: yes
 
 - name: Configure SecureDrop Monitor Server.
   hosts: securedrop_monitor_server
   roles:
     - { role: ossec-server, tags: [ ossec, ossec_server ] }
-  sudo: yes
+  become: yes
 
 - name: Configure SecureDrop Application Server.
   hosts: securedrop_application_server
   roles:
     - { role: ossec-agent, tags: [ ossec, ossec_agent ] }
     - { role: app, tags: app }
-  sudo: yes
+  become: yes
 
   # This section will put the ssh and iptables rules in place
   # It will then add any staging exemptions required
@@ -45,7 +45,7 @@
   hosts: securedrop
   roles:
     - { role: restrict-direct-access, tags: [ common, restrict-direct-access ] }
-  sudo: yes
+  become: yes
 
 - name: Reboot Application and Monitor Servers.
   hosts: securedrop
@@ -56,4 +56,4 @@
     reboot_wait: no
   tasks:
     - include: tasks/reboot_if_first_install.yml
-  sudo: yes
+  become: yes

--- a/install_files/ansible-base/securedrop-staging.yml
+++ b/install_files/ansible-base/securedrop-staging.yml
@@ -29,13 +29,13 @@
     - { role: grsecurity, when: grsecurity, tags: [grsec, grsecurity] }
     - { role: install-local-packages, tags: [install_local_packages, rebuild],
         when: install_local_packages }
-  sudo: yes
+  become: yes
 
 - name: Configure OSSEC manager.
   hosts: mon-staging
   roles:
     - { role: ossec-server, tags: [ ossec, ossec_server ] }
-  sudo: yes
+  become: yes
 
 - name: Configure SecureDrop Application Server.
   hosts: app-staging
@@ -43,7 +43,7 @@
     - { role: ossec-agent, tags: [ ossec, ossec_agent ] }
     - { role: app, tags: app }
     - { role: app-test, tags: app-test }
-  sudo: yes
+  become: yes
 
   # Set iptables rules with exemptions for staging that permit direct access for SSH.
   # The overrides that permit direct access are managed in group_vars/staging.yml,
@@ -52,11 +52,11 @@
   hosts: staging
   roles:
     - { role: restrict-direct-access, tags: [ common, restrict-direct-access ] }
-  sudo: yes
+  become: yes
 
 - name: Reboot Application and Monitor Servers.
   hosts: staging
   tasks:
     - include: tasks/reboot_if_first_install.yml
       when: not amazon_builder
-  sudo: yes
+  become: yes

--- a/install_files/ansible-base/tasks/reboot.yml
+++ b/install_files/ansible-base/tasks/reboot.yml
@@ -24,7 +24,7 @@
     search_regex: OpenSSH
     state: started
   # Wait action runs on localhost, and does NOT require sudo.
-  sudo: false
+  become: false
   # Provide opt-out ability for waiting for the host to come back.
   # During initial installation, waiting won't work, since the connection
   # switches from IPv4 to Onion URLs.


### PR DESCRIPTION
These changes remove the Ansible deprecation warning.

## Status

Code is ready to review, running tests locally now.

## Description of Changes

Fixes https://github.com/freedomofpress/securedrop/issues/2415

Changes proposed in this pull request:

Replace all uses of the `sudo:` directive in all Ansible playbook to `become:`, as per recommendation from the current docs: http://docs.ansible.com/ansible/latest/become.html

## Testing

How should the reviewer test this PR?

Perform fresh provision with `vagrant up` or `vagrant provision`, at the very beginning, you would see the deprecation warning before the first ansible playbook.

Before:

```text
Vagrant has automatically selected the compatibility mode '2.0'
according to the Ansible version installed (2.2.1.0).

Alternatively, the compatibility mode can be specified in your Vagrantfile:
https://www.vagrantup.com/docs/provisioning/ansible_common.html#compatibility_mode

    development: Running ansible-playbook...
PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_HOST_KEY_CHECKING=false ANSIBLE_SSH_ARGS='-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ControlMaster=auto -o ControlPersist=60s' ansible-playbook --connection=ssh --timeout=30 --limit="development" --inventory-file=/home/james/git/temp/securedrop/.vagrant/provisioners/ansible/inventory -v install_files/ansible-base/securedrop-development.yml
Using /home/james/git/temp/securedrop/ansible.cfg as config file
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and 
make sure become_method is 'sudo' (default).
This feature will be removed in a 
future release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
 __________________________________________________ 
< PLAY [Configure SecureDrop Development machine.] >
 -------------------------------------------------- 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```

After:

```text
==> development: Running provisioner: ansible...
Vagrant has automatically selected the compatibility mode '2.0'
according to the Ansible version installed (2.2.1.0).

Alternatively, the compatibility mode can be specified in your Vagrantfile:
https://www.vagrantup.com/docs/provisioning/ansible_common.html#compatibility_mode

    development: Running ansible-playbook...
PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_HOST_KEY_CHECKING=false ANSIBLE_SSH_ARGS='-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ControlMaster=auto -o ControlPersist=60s' ansible-playbook --connection=ssh --timeout=30 --limit="development" --inventory-file=/home/james/git/temp/securedrop/.vagrant/provisioners/ansible/inventory -v install_files/ansible-base/securedrop-development.yml
Using /home/james/git/temp/securedrop/ansible.cfg as config file
 __________________________________________________ 
< PLAY [Configure SecureDrop Development machine.] >
 -------------------------------------------------- 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

This change should not affect current installations, or change the behavior of new installations. This should be a drop-in replacement with the same functionality.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
