### PR TITLE
Improve the login form usability by making input fields larger

### DIFF
--- a/securedrop/journalist_templates/login.html
+++ b/securedrop/journalist_templates/login.html
@@ -3,12 +3,14 @@
 
 <h1>{{ gettext('Login to access the journalist interface') }}</h1>
 
-<form method="post" action="/login" autocomplete="off">
+<form method="post" action="/login" autocomplete="off" class="login-form">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-  <p class="center"><input type="text" name="username" autocomplete="off" placeholder="{{ gettext('Username') }}" autofocus></p>
-  <p class="center"><input type="password" name="password" placeholder="{{ gettext('Password') }}"></p>
-  <p class="center"><input name="token" id="token" type="text" placeholder="{{ gettext('Two-factor Code') }}"></p>
-  <p class="pull-right"><button class="sd-button" type="submit"><i class="fa fa-arrow-circle-o-right"></i> {{ gettext('LOG IN') }}</button></p>
+  <p><input type="text" name="username" autocomplete="off" placeholder="{{ gettext('Username') }}" autofocus></p>
+  <p><input type="password" name="password" placeholder="{{ gettext('Password') }}"></p>
+  <p><input name="token" id="token" type="text" placeholder="{{ gettext('Two-factor Code') }}"></p>
+  <p class="pull-right">
+    <button class="sd-button" type="submit"><i class="fa fa-arrow-circle-o-right"></i> {{ gettext('LOG IN') }}</button>
+  </p>
 </form>
 
 {% endblock %}

--- a/securedrop/sass/journalist.sass
+++ b/securedrop/sass/journalist.sass
@@ -87,3 +87,8 @@ button.small-danger, a.btn.small-danger, .btn.small-danger
 #cols li.source
   .button-star
     background-color: $color_grey_light
+
+.login-form
+  max-width: 445px
+  input
+    width: 100%


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In this commit, we are changing the login form style so the input fields are larger, especially on big screens.

The inputs are set to a maximum width of 445px, the ideal size in order to display all the characters of the password if the user is using diceware passphrases.

The login form is now also mobile-friendly since it has a responsive width and the input fields will adapt to the screen size as well.

Fixes #2288.

## Testing

These are some screenshots of the new login form:

On a laptop screen
![securedrop](https://user-images.githubusercontent.com/208312/31316726-5944d398-ac33-11e7-971e-5890ee483683.png)

On Nexus 5X
![securedrop nexus 5x](https://user-images.githubusercontent.com/208312/31316721-51b31fea-ac33-11e7-88b0-eb4703972959.png)

On iPad
![securedrop ipad](https://user-images.githubusercontent.com/208312/31316713-3e6287d2-ac33-11e7-96d3-981173afc58c.png)

## Deployment

No special considerations for deployment.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- ~[Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass~

### If you made changes to documentation:

- ~Doc linting passed locally~
