### PR TITLE
Source: only show codename on first session

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -38,6 +38,7 @@ def make_blueprint(config):
 
         codename = generate_unique_codename()
         session['codename'] = codename
+        session['new_user'] = True
         return render_template('generate.html', codename=codename)
 
     @view.route('/create', methods=['POST'])
@@ -91,6 +92,7 @@ def make_blueprint(config):
             codename=g.codename,
             replies=replies,
             flagged=g.source.flagged,
+            new_user=session.get('new_user', None),
             haskey=crypto_util.getkey(
                 g.filesystem_id))
 

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -94,14 +94,17 @@
 
 <hr class="no-line">
 
+{% if new_user %}
 <div class="code-reminder" id="codename-hint">
   <div id="codename-hint-visible">
     <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/lock-black.png') }}" width="17px" height="20px"> {{ gettext('Remember your codename is:') }}
     <a id="codename-hint-show" class="show pull-right visible-codename" href="#codename-hint-visible">{{ gettext('Show') }}</a>
     <div id="codename-hint-content" class="hidden-codename codename">
-      <p>{{ codename }} <a id="codename-hint-hide" class="pull-right" href="#codename-hint">{{ gettext('Hide') }}</a></p>
+      <a id="codename-hint-hide" class="pull-right" href="#codename-hint">{{ gettext('Hide') }}</a>
+      <p>{{ codename }}</p>
     </div>
   </div>
 </div>
+{% endif %}
 
 {% endblock %}

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -54,12 +54,19 @@ class SourceNavigationSteps():
         assert not content.is_displayed()
         self.driver.find_element_by_id('codename-hint-show').click()
         assert content.is_displayed()
+        content_content = self.driver.find_element_by_css_selector(
+                '#codename-hint-content p')
+        assert content_content.text == self.source_name
 
     def _source_hides_codename(self):
         content = self.driver.find_element_by_id('codename-hint-content')
         assert content.is_displayed()
         self.driver.find_element_by_id('codename-hint-hide').click()
         assert not content.is_displayed()
+
+    def _source_sees_no_codename(self):
+        codename = self.driver.find_elements_by_css_selector('.code-reminder')
+        assert len(codename) == 0
 
     @screenshots
     def _source_chooses_to_login(self):
@@ -90,6 +97,10 @@ class SourceNavigationSteps():
 
         assert ("SecureDrop | Protecting Journalists and Sources" ==
                 self.driver.title)
+        # Check that we've logged in
+
+        replies = self.driver.find_elements_by_id("replies")
+        assert len(replies) == 1
 
     def _source_enters_codename_in_login_form(self):
         codename_input = self.driver.find_element_by_id(

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -12,3 +12,8 @@ class TestSourceInterfaceBannerWarnings(
         self._source_continues_to_submit_page()
         self._source_shows_codename()
         self._source_hides_codename()
+        self._source_logs_out()
+        self._source_visits_source_homepage()
+        self._source_chooses_to_login()
+        self._source_proceeds_to_login()
+        self._source_sees_no_codename()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes
When a source logs back in, they can can retrieve their codename, which isn't good. It means that if a session is compromised, all future sessions are also compromised.

Instead, only show the codename on first login. Given that the user had to supply their codename for all subsequent sessions, re-displaying it has no value.

Fixes #2327.

## Testing
1. Create a source and submit a document
2. See that your code name is visible in the source "home page"
3. Log out and log back in
4. See that your code name is no longer supplied

## Deployment
No special considerations

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM