### PR TITLE
Added Flask WTForm to journalist reply form when verifying message length

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -12,6 +12,10 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.expression import false
 
+from flask_wtf import FlaskForm
+from wtforms import TextAreaField
+from wtforms.validators import InputRequired
+
 import config
 import version
 import crypto_util
@@ -43,6 +47,12 @@ else:
 
 app.jinja_env.filters['datetimeformat'] = template_filters.datetimeformat
 app.jinja_env.filters['filesizeformat'] = template_filters.filesizeformat
+
+
+class ReplyForm(FlaskForm):
+    message = TextAreaField(u'Message', id="content-area", validators=[
+        InputRequired(message=gettext('You cannot send an empty reply.'))
+    ])
 
 
 @app.teardown_appcontext
@@ -553,10 +563,11 @@ def index():
 @app.route('/col/<filesystem_id>')
 @login_required
 def col(filesystem_id):
+    form = ReplyForm()
     source = get_source(filesystem_id)
     source.has_key = crypto_util.getkey(filesystem_id)
     return render_template("col.html", filesystem_id=filesystem_id,
-                           source=source)
+                           source=source, form=form)
 
 
 def delete_collection(filesystem_id):
@@ -698,16 +709,16 @@ def reply():
            collection view, regardless if the Reply is created
            successfully.
     """
-    msg = request.form['msg']
-    # Reject empty replies
-    if not msg:
-        flash(gettext("You cannot send an empty reply."), "error")
+    form = ReplyForm()
+    if not form.validate_on_submit():
+        for error in form.message.errors:
+            flash(error, "error")
         return redirect(url_for('col', filesystem_id=g.filesystem_id))
 
     g.source.interaction_count += 1
     filename = "{0}-{1}-reply.gpg".format(g.source.interaction_count,
                                           g.source.journalist_filename)
-    crypto_util.encrypt(msg,
+    crypto_util.encrypt(form.message.data,
                         [crypto_util.getkey(g.filesystem_id),
                          config.JOURNALIST_KEY],
                         output=store.path(g.filesystem_id, filename))

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -76,7 +76,7 @@
     <form action="/reply" method="post" autocomplete="off">
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
       <input type="hidden" name="filesystem_id" value="{{ filesystem_id }}">
-      <textarea id="reply-text-field" name="msg" cols="72" rows="10"></textarea>
+      {{ form.message(id="reply-text-field", rows='10', cols='72') }}
       <hr class="no-line">
       <button id="reply-button" class="sd-button" type="submit">{{ gettext('SUBMIT') }}</button>
     </form>

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -344,7 +344,7 @@ class TestIntegration(unittest.TestCase):
         for i in range(2):
             resp = self.journalist_app.post('/reply', data=dict(
                 filesystem_id=filesystem_id,
-                msg=test_reply
+                message=test_reply
             ), follow_redirects=True)
             self.assertEqual(resp.status_code, 200)
 
@@ -419,10 +419,12 @@ class TestIntegration(unittest.TestCase):
         # first, add a source
         self.source_app.get('/generate')
         self.source_app.post('/create')
-        self.source_app.post('/submit', data=dict(
+        resp = self.source_app.post('/submit', data=dict(
             msg="This is a test.",
             fh=(StringIO(''), ''),
         ), follow_redirects=True)
+
+        assert resp.status_code == 200, resp.data.decode('utf-8')
 
         resp = self.journalist_app.get('/')
         # navigate to the collection page

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -63,7 +63,8 @@ class TestJournalistApp(TestCase):
         with patch('db.db_session.commit',
                    side_effect=exception_class(exception_msg)):
             self.client.post(url_for('reply'),
-                             data={'filesystem_id': filesystem_id, 'msg': '_'})
+                             data={'filesystem_id': filesystem_id,
+                             'message': '_'})
 
         # Notice the "potentially sensitive" exception_msg is not present in
         # the log event.
@@ -81,7 +82,8 @@ class TestJournalistApp(TestCase):
 
         with patch('db.db_session.commit', side_effect=exception_class()):
             self.client.post(url_for('reply'),
-                             data={'filesystem_id': filesystem_id, 'msg': '_'})
+                             data={'filesystem_id': filesystem_id,
+                             'message': '_'})
 
         self.assertMessageFlashed(
             'An unexpected error occurred! Please check '
@@ -94,7 +96,7 @@ class TestJournalistApp(TestCase):
 
         resp = self.client.post(url_for('reply'),
                                 data={'filesystem_id': filesystem_id,
-                                      'msg': ''},
+                                      'message': ''},
                                 follow_redirects=True)
 
         self.assertIn("You cannot send an empty reply.", resp.data)
@@ -106,7 +108,7 @@ class TestJournalistApp(TestCase):
 
         resp = self.client.post(url_for('reply'),
                                 data={'filesystem_id': filesystem_id,
-                                      'msg': '_'},
+                                      'message': '_'},
                                 follow_redirects=True)
 
         self.assertNotIn("You cannot send an empty reply.", resp.data)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This changes the reply message from in the journalist side-app to use WTForms both for display and verification. For clarification purposed the name of the parameter was changed from "msg" to "message"

## Testing

As a journalist, send a message to a source.
a) Enter some text. - It should be received
b) Enter no text and press submit - You should see an warning on top telling you that the message cannot be empty.

## Deployment

none

## Checklist

### If you made changes to the app code:

- [x ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [x ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [x ] Doc linting passed locally