### PR TITLE
Require credentials when changing password

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -26,7 +26,8 @@ import store
 import template_filters
 from db import (db_session, Source, Journalist, Submission, Reply,
                 SourceStar, get_one_or_else, LoginThrottledException,
-                PasswordError, InvalidUsernameException)
+                PasswordError, InvalidUsernameException,
+                BadTokenException, WrongPasswordException)
 import worker
 
 app = Flask(__name__, template_folder=config.JOURNALIST_TEMPLATES_DIR)
@@ -142,7 +143,10 @@ def validate_user(username, password, token, error_message=None):
     """
     try:
         return Journalist.login(username, password, token)
-    except Exception as e:
+    except (InvalidUsernameException,
+            BadTokenException,
+            WrongPasswordException,
+            LoginThrottledException) as e:
         app.logger.error("Login for '{}' failed: {}".format(
             username, e))
         if not error_message:

--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -34,11 +34,11 @@
   <p>{{ gettext('Please enter your current password and two-factor code.') }}</p>
 {% endif %}
 
-<form action="{{ password_reset_url }}" method="post" id="new-password">
+<form action="{{ password_reset_url }}" method="post" id="new-password" class="login-form">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   {% if not user or g.user == user %}
-  <input type="password" name="current_password" placeholder="{{ gettext('Current Password') }}">
-  <input name="token" id="token" type="text" placeholder="{{ gettext('Two-factor Code') }}">
+  <p><input type="password" name="current_password" placeholder="{{ gettext('Current Password') }}"></p>
+  <p><input name="token" id="token" type="text" placeholder="{{ gettext('Two-factor Code') }}"></p>
   {% endif %}
   <input name="password" type="hidden" value="{{ password }}">
   <p>

--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -27,14 +27,19 @@
 <p>{{ gettext('SecureDrop now uses automatically generated diceware passwords.') }}</p>
 <p>{{ gettext('Your password will be changed immediately, so you will need to save it before pressing the "Reset Password" button.') }}</p>
 
-{% if user %}
+{% if user and g.user != user %}
   {% set password_reset_url = url_for('admin_new_password', user_id=user.id) %}
 {% else %}
   {% set password_reset_url = url_for('new_password') %}
+  <p>{{ gettext('Please enter your current password and two-factor code.') }}</p>
 {% endif %}
 
 <form action="{{ password_reset_url }}" method="post" id="new-password">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+  {% if not user or g.user == user %}
+  <input type="password" name="current_password" placeholder="{{ gettext('Current Password') }}">
+  <input name="token" id="token" type="text" placeholder="{{ gettext('Two-factor Code') }}">
+  {% endif %}
   <input name="password" type="hidden" value="{{ password }}">
   <p>
     {% if user %}

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -545,7 +545,9 @@ class TestIntegration(unittest.TestCase):
         # change password
         new_pw = 'another correct horse battery staply long password'
         self.journalist_app.post('/account/new-password',
-                                 data=dict(password=new_pw))
+                                 data=dict(password=new_pw,
+                                           current_password=self.user_pw,
+                                           token='mocked'))
 
         # logout
         self.journalist_app.get('/logout')


### PR DESCRIPTION
Users will have to enter their password and TOTP token when changing their passwords. Admins will also need to do the same for their own accounts, although this isn't specifically validated in the backend (I consider it a sanity check more than security from the admin side).

## Status

Ready for review

## Description of Changes

Fixes #2304 .

Changes proposed in this pull request:

- Users must enter their existing password and two-factor code when changing their passwords.
- Admins changing their own password via the Admin console will also be prompted for their current password and token.

## Testing

Besides running unit tests, this can be validated as a user by doing the following:

1. Login as a user
2. Go to account page (click on username in top right).
3. See login failure by failing to provide valid existing password.
4. See additional failure by failing to provide valid two-factor code.
5. Enter valid credentials and notice the password is appropriately changed.

## Deployment

No special deployment considerations

## Checklist

- [X] Unit and functional tests pass on the development VM