### PR TITLE
i18n: add missing ngettext to a string with a quantity

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -134,10 +134,14 @@ def login():
 
             if isinstance(e, LoginThrottledException):
                 login_flashed_msg += " "
-                login_flashed_msg += gettext(
+                period = Journalist._LOGIN_ATTEMPT_PERIOD
+                # ngettext is needed although we always have period > 1
+                # see https://github.com/freedomofpress/securedrop/issues/2422
+                login_flashed_msg += ngettext(
+                    "Please wait at least {seconds} second "
+                    "before logging in again.",
                     "Please wait at least {seconds} seconds "
-                    "before logging in again.").format(
-                        seconds=Journalist._LOGIN_ATTEMPT_PERIOD)
+                    "before logging in again.", period).format(seconds=period)
             else:
                 try:
                     user = Journalist.query.filter_by(


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2422 

add missing ngettext to a string with a quantity

Plurality is non-trivial in Russian. In short, there are different ways to write things if the number ends in:

    1
    2, 3, 4
    5, 6, 7, 8, 9, 0

So the standard English/French/etc. rule of "more than one" is insufficient. I'm also fairly sure Russian isn't the only language with such a pattern.

## Testing

Running the CI should be enough because securedrop/tests/test_journalist.py::test_login_throttle  verifies the string shows as expected. Ideally we would also verify it shows up as a plural form in messages.pot but we don't have that kind of testing right now. And I'm not sure how it would work

## Deployment

User interface change only, no deployment concern.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
