### PR TITLE
[0.4.4] Rename datetimeformat into rel_datetime_format

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -45,7 +45,8 @@ else:
     app.jinja_env.globals['header_image'] = 'logo.png'
     app.jinja_env.globals['use_custom_header_image'] = False
 
-app.jinja_env.filters['datetimeformat'] = template_filters.datetimeformat
+app.jinja_env.filters['rel_datetime_format'] = \
+    template_filters.rel_datetime_format
 app.jinja_env.filters['filesizeformat'] = template_filters.filesizeformat
 
 

--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -1,7 +1,7 @@
 {% set docs = source.documents_messages_count()['documents'] %}
 {% set msgs = source.documents_messages_count()['messages'] %}
 <li class="source" data-source-designation="{{ source.journalist_designation|lower }}">
-  <time class="date" title="{{ source.last_updated|datetimeformat }}" datetime="{{ source.last_updated|datetimeformat(fmt="%Y-%m-%d %H:%M:%S%Z") }}">{{ source.last_updated|datetimeformat(relative=True) }}</time>
+  <time class="date" title="{{ source.last_updated|rel_datetime_format }}" datetime="{{ source.last_updated|rel_datetime_format(fmt="%Y-%m-%d %H:%M:%S%Z") }}">{{ source.last_updated|rel_datetime_format(relative=True) }}</time>
   <div class="designation">
     {% if source.star.starred %}
       <button class="button-star starred" type="submit" formaction="/col/remove_star/{{ source.filesystem_id }}"><i class="fa fa-star"></i></button>

--- a/securedrop/journalist_templates/admin.html
+++ b/securedrop/journalist_templates/admin.html
@@ -1,3 +1,4 @@
+
 {% extends "base.html" %}
 {% block body %}
 <h1>{{ gettext('Admin Interface') }}</h1>
@@ -24,9 +25,9 @@
         <td>{{ user.username }}</td>
         <td><a href="/admin/edit/{{ user.id }}" class="plain" data-username="{{ user.username }}"><i class="fa fa-edit" title="{{ gettext('Edit user {username}').format(username=user.username) }}"></i></a></td>
         <td><button type="submit" class="plain delete-user" formaction="/admin/delete/{{ user.id }}" data-username="{{ user.username}}"><i class="fa fa-trash-o" title="{{ gettext('Delete user {username}').format(username=user.username) }}"></i></button></td>
-        <td><time class="date" title="{{ user.created_on }}">{{ user.created_on|datetimeformat(relative=True) }}</time></td>
+        <td><time class="date" title="{{ user.created_on }}">{{ user.created_on|rel_datetime_format(relative=True) }}</time></td>
         {% if user.last_access %}
-          <td><time class="date" title="{{ user.last_access }}">{{ user.last_access|datetimeformat(relative=True) }}</time></td>
+          <td><time class="date" title="{{ user.last_access }}">{{ user.last_access|rel_datetime_format(relative=True) }}</time></td>
         {% else %}
           <td><time class="date">{{ gettext('never') }}</time></td>
         {% endif %}

--- a/securedrop/journalist_templates/admin.html
+++ b/securedrop/journalist_templates/admin.html
@@ -1,4 +1,3 @@
-
 {% extends "base.html" %}
 {% block body %}
 <h1>{{ gettext('Admin Interface') }}</h1>

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -36,8 +36,6 @@ def create_app(config):
     assets = Environment(app)
     app.config['assets'] = assets
 
-    # this set needs to happen *before* we set the jinja filters otherwise
-    # we get name collisions
     i18n.setup_app(app)
 
     app.jinja_env.globals['version'] = version.__version__
@@ -48,7 +46,8 @@ def create_app(config):
         app.jinja_env.globals['header_image'] = 'logo.png'
         app.jinja_env.globals['use_custom_header_image'] = False
 
-    app.jinja_env.filters['datetimeformat'] = template_filters.datetimeformat
+    app.jinja_env.filters['rel_datetime_format'] = \
+        template_filters.rel_datetime_format
     app.jinja_env.filters['nl2br'] = evalcontextfilter(template_filters.nl2br)
     app.jinja_env.filters['filesizeformat'] = template_filters.filesizeformat
 

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -60,7 +60,7 @@
     <hr class="no-line">
     {% for reply in replies %}
       <div class="reply">
-        <time class="date" title="{{ reply.date|datetimeformat }}" datetime="{{ reply.date }}">{{ reply.date|datetimeformat(relative=True) }}</time>
+        <time class="date" title="{{ reply.date|rel_datetime_format }}" datetime="{{ reply.date }}">{{ reply.date|rel_datetime_format(relative=True) }}</time>
         <form id="delete" class="message" method="post" action="{{ url_for('main.delete') }}" autocomplete="off">
           <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
           <input type="hidden" name="reply_filename" value="{{ reply.filename }}" autocomplete="off">

--- a/securedrop/template_filters.py
+++ b/securedrop/template_filters.py
@@ -6,7 +6,7 @@ from jinja2 import Markup, escape
 import math
 
 
-def datetimeformat(dt, fmt=None, relative=False):
+def rel_datetime_format(dt, fmt=None, relative=False):
     """Template filter for readable formatting of datetime.datetime"""
     if relative:
         time = dates.format_timedelta(datetime.utcnow() - dt,

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -18,34 +18,36 @@ import version
 
 class TestTemplateFilters(object):
 
-    def verify_datetimeformat(self, app):
+    def verify_rel_datetime_format(self, app):
         with app.test_client() as c:
             c.get('/')
             assert session.get('locale') is None
-            result = template_filters.datetimeformat(
+            result = template_filters.rel_datetime_format(
                 datetime(2016, 1, 1, 1, 1, 1))
             assert "Jan 01, 2016 01:01 AM" == result
 
-            result = template_filters.datetimeformat(
+            result = template_filters.rel_datetime_format(
                 datetime(2016, 1, 1, 1, 1, 1), fmt="yyyy")
             assert "2016" == result
 
             test_time = datetime.utcnow() - timedelta(hours=2)
-            result = template_filters.datetimeformat(test_time, relative=True)
+            result = template_filters.rel_datetime_format(test_time,
+                                                          relative=True)
             assert "2 hours ago" == result
 
             c.get('/?l=fr_FR')
             assert session.get('locale') == 'fr_FR'
-            result = template_filters.datetimeformat(
+            result = template_filters.rel_datetime_format(
                 datetime(2016, 1, 1, 1, 1, 1))
             assert "janv. 01, 2016 01:01 AM" == result
 
-            result = template_filters.datetimeformat(
+            result = template_filters.rel_datetime_format(
                 datetime(2016, 1, 1, 1, 1, 1), fmt="yyyy")
             assert "2016" == result
 
             test_time = datetime.utcnow() - timedelta(hours=2)
-            result = template_filters.datetimeformat(test_time, relative=True)
+            result = template_filters.rel_datetime_format(test_time,
+                                                          relative=True)
             assert "2 heures ago" == result
 
     def verify_filesizeformat(self, app):
@@ -106,7 +108,7 @@ class TestTemplateFilters(object):
             app.config['BABEL_TRANSLATION_DIRECTORIES'] = config.TEMP_DIR
             i18n.setup_app(app)
             self.verify_filesizeformat(app)
-            self.verify_datetimeformat(app)
+            self.verify_rel_datetime_format(app)
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2374. Extension of #2424. I've pulled the contributor's commit in here, leaving their PR open such that their PR will show as merged when/if this followup is merged. In another commit I've completed the renaming of `datetimeformat` -> `rel_datetime_format` and addressed @heartsucker's comments in the code review of #2424. We should merge this in for 0.4.4 prior to the code freeze EOD tomorrow.

## Testing

Does CI pass?

## Deployment

All files shipped in securedrop-app-code package.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
