### PR TITLE
circleci: wait 60 seconds for an AWS vm to show up

### DIFF
--- a/molecule/aws/aws-launch.yml
+++ b/molecule/aws/aws-launch.yml
@@ -28,7 +28,7 @@
       wait_for:
         host: "{{ item.tagged_instances[0]['public_dns_name'] }}"
         port: 22
-        timeout: 20
+        timeout: 60
         state: started
       register: ec2_launch_results
       with_items: "{{ reg_ec_instance.results }}"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Related to #2253

Changes proposed in this pull request:

## Testing

If the CI passes it show nothing broke. It will take time to know if things are improved.

## Deployment

no.
