### PR TITLE
Use lintian to test built deb package

### DIFF
--- a/molecule/builder/tests/test_securedrop_deb_package.py
+++ b/molecule/builder/tests/test_securedrop_deb_package.py
@@ -47,6 +47,23 @@ def get_deb_packages():
 deb_packages = get_deb_packages()
 
 
+def get_deb_tags():
+    """
+    Helper function to build array of package and tag tuples
+    for lintian.
+    """
+    deb_tags = []
+
+    for deb in get_deb_packages():
+        for tag in securedrop_test_vars.lintian_tags:
+            deb_tags.append((deb, tag))
+
+    return deb_tags
+
+
+deb_tags = get_deb_tags()
+
+
 @pytest.mark.parametrize("deb", deb_packages)
 def test_build_deb_packages(File, deb):
     """
@@ -123,33 +140,6 @@ def test_deb_package_control_fields_homepage(File, Command, deb):
 
 
 @pytest.mark.parametrize("deb", deb_packages)
-def test_deb_package_contains_no_update_dependencies_file(File, Command, deb):
-    """
-    Ensures the update_python_dependencies script is not shipped via the
-    Debian packages.
-    """
-    deb_package = File(deb.format(
-        securedrop_test_vars.securedrop_version))
-    # Using `dpkg-deb` but `lintian --tag package-installs-python-bytecode`
-    # would be cleaner. Will defer to adding lintian tests later.
-    c = Command("dpkg-deb --contents {}".format(deb_package.path))
-    assert not re.search("^.*update_python_dependencies$", c.stdout, re.M)
-
-
-@pytest.mark.parametrize("deb", deb_packages)
-def test_deb_package_contains_no_pyc_files(File, Command, deb):
-    """
-    Ensures no .pyc files are shipped via the Debian packages.
-    """
-    deb_package = File(deb.format(
-        securedrop_test_vars.securedrop_version))
-    # Using `dpkg-deb` but `lintian --tag package-installs-python-bytecode`
-    # would be cleaner. Will defer to adding lintian tests later.
-    c = Command("dpkg-deb --contents {}".format(deb_package.path))
-    assert not re.search("^.*\.pyc$", c.stdout, re.M)
-
-
-@pytest.mark.parametrize("deb", deb_packages)
 def test_deb_package_contains_no_config_file(File, Command, deb):
     """
     Ensures the `securedrop-app-code` package does not ship a `config.py`
@@ -160,8 +150,6 @@ def test_deb_package_contains_no_config_file(File, Command, deb):
     """
     deb_package = File(deb.format(
         securedrop_test_vars.securedrop_version))
-    # Using `dpkg-deb` but `lintian --tag package-installs-python-bytecode`
-    # would be cleaner. Will defer to adding lintian tests later.
     c = Command("dpkg-deb --contents {}".format(deb_package.path))
     assert not re.search("^.*config\.py$", c.stdout, re.M)
 
@@ -245,3 +233,15 @@ def test_deb_package_contains_css(File, Command, deb):
             assert re.search("^.*\./var/www/securedrop/static/"
                              "css/{}.css.map$".format(css_type), c.stdout,
                              re.M)
+
+
+@pytest.mark.parametrize("deb, tag", deb_tags)
+def test_deb_package_lintian(File, Command, deb, tag):
+    """
+    Ensures lintian likes our  Debian packages.
+    """
+    deb_package = File(deb.format(
+        securedrop_test_vars.securedrop_version))
+    c = Command("""lintian --tags {} --no-tag-display-limit {}""".format(
+        tag, deb_package.path))
+    assert len(c.stdout) == 0

--- a/molecule/builder/tests/vars.yml
+++ b/molecule/builder/tests/vars.yml
@@ -23,3 +23,10 @@ build_deb_packages:
   - /tmp/build/ossec-server-{ossec_version}-amd64.deb
   - /tmp/build/ossec-agent-{ossec_version}-amd64.deb
   - /tmp/build/securedrop-keyring-{keyring_version}+{securedrop_version}-amd64.deb
+
+lintian_tags:
+  # - non-standard-file-perm
+  - package-contains-vcs-control-file
+  - package-installs-python-bytecode
+  # - wrong-file-owner-uid-or-gid
+


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #1637 .

Changes proposed in this pull request:
 
* Test every package against every tag
* Replace some old manual test with lintian tags
* I used the list of tags supplied by @conorsch
* Uncomment more tags to add additional checks, but those will currently fail as the packages are not ready yet.

```
lintian_tags:
  # - non-standard-file-perm
  - package-contains-vcs-control-file
  - package-installs-python-bytecode
  # - wrong-file-owner-uid-or-gid
```

## Testing

```
molecule verify -s builder
```  

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

