### PR TITLE
circleci: wait 120 seconds for an AWS vm to show up

### DIFF
--- a/molecule/aws/aws-launch.yml
+++ b/molecule/aws/aws-launch.yml
@@ -28,7 +28,7 @@
       wait_for:
         host: "{{ item.tagged_instances[0]['public_dns_name'] }}"
         port: 22
-        timeout: 60
+        timeout: 120
         state: started
       register: ec2_launch_results
       with_items: "{{ reg_ec_instance.results }}"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Improves #2253

Bump timeout to 120 sec when launching AWS. It failed today with the 60 sec timeout at https://github.com/freedomofpress/securedrop/pull/2430#issuecomment-336643737

## Testing

If it passes CI nothing is broken. We'll have to wait to know if the timeout is large enough.

