### PR TITLE
Add checks for the HTML lang property when the lang is fr_FR

### DIFF
--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -239,7 +239,7 @@ class TestI18N(object):
         assert i18n.locale_to_rfc_5646('en-us') == 'en'
         assert i18n.locale_to_rfc_5646('zh-hant') == 'zh-Hant'
 
-    def test_html_lang_correct(self):
+    def test_html_en_lang_correct(self):
         app = journalist.app.test_client()
         resp = app.get('/', follow_redirects=True)
         html = resp.data.decode('utf-8')
@@ -254,6 +254,23 @@ class TestI18N(object):
         resp = app.get('/generate', follow_redirects=True)
         html = resp.data.decode('utf-8')
         assert re.compile('<html .*lang="en".*>').search(html), html
+
+    def test_html_fr_lang_correct(self):
+        """Check that when the locale is fr_FR the lang property is correct"""
+        app = journalist.app.test_client()
+        resp = app.get('/?l=fr_FR', follow_redirects=True)
+        html = resp.data.decode('utf-8')
+        assert re.compile('<html .*lang="fr".*>').search(html), html
+
+        app = source.app.test_client()
+        resp = app.get('/?l=fr_FR', follow_redirects=True)
+        html = resp.data.decode('utf-8')
+        assert re.compile('<html .*lang="fr".*>').search(html), html
+
+        # check '/generate' too because '/' uses a different template
+        resp = app.get('/generate?l=fr_FR', follow_redirects=True)
+        html = resp.data.decode('utf-8')
+        assert re.compile('<html .*lang="fr".*>').search(html), html
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2230. Completes last to do [here](https://github.com/freedomofpress/securedrop/issues/2230#issuecomment-331618079) after merging in the translations (adds test to verify the HTML lang property is set properly). 

## Testing

Do the tests pass? 

## Deployment

Tests only.

## Checklist

- [x] Unit and functional tests pass on the development VM
