### PR TITLE
Rewrite overly mocked tests in preparation for journalist refactor

### DIFF
--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1040,6 +1040,17 @@ class TestJournalistApp(TestCase):
         finally:
             self.app.config['WTF_CSRF_ENABLED'] = old_enabled
 
+    def test_col_process_aborts_with_bad_action(self):
+        """If the action is not a valid choice, a 500 should occur"""
+        self._login_user()
+
+        form_data = {'cols_selected': 'does not matter',
+                     'action': 'this action does not exist'}
+
+        resp = self.client.post(url_for('col_process'), data=form_data)
+
+        self.assert500(resp)
+
 
 class TestJournalistAppTwo(unittest.TestCase):
 
@@ -1084,15 +1095,6 @@ class TestJournalistAppTwo(unittest.TestCase):
         journalist.col_process()
 
         col_un_star.assert_called_with(cols_selected)
-
-    @patch("journalist.abort")
-    def test_col_process_returns_404_with_bad_action(self, abort):
-        cols_selected = ['source_id']
-        self._set_up_request(cols_selected, 'something-random')
-
-        journalist.col_process()
-
-        abort.assert_called_with(ANY)
 
     @patch("journalist.make_star_true")
     @patch("journalist.db_session")

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -7,7 +7,7 @@ import zipfile
 
 from flask import url_for, escape, session
 from flask_testing import TestCase
-from mock import patch, ANY, MagicMock
+from mock import patch
 from sqlalchemy.orm.exc import StaleDataError
 from sqlalchemy.exc import IntegrityError
 
@@ -993,6 +993,23 @@ class TestJournalistApp(TestCase):
         # Assert source is starred
         self.assertTrue(source.star.starred)
 
+    def test_single_source_is_successfully_unstarred(self):
+        source, _ = utils.db_helper.init_source()
+        self._login_user()
+
+        # First star the source
+        self.client.post(url_for('add_star',
+                                 filesystem_id=source.filesystem_id))
+
+        # Now unstar the source
+        resp = self.client.post(url_for('remove_star',
+                                filesystem_id=source.filesystem_id))
+
+        self.assertRedirects(resp, url_for('index'))
+
+        # Assert source is not starred
+        self.assertFalse(source.star.starred)
+
     def test_journalist_session_expiration(self):
         try:
             old_expiration = config.SESSION_EXPIRATION_MINUTES
@@ -1155,44 +1172,6 @@ class TestJournalistLogin(unittest.TestCase):
         self.assertFalse(
             mock_scrypt_hash.called,
             "Called _scrypt_hash for password w/ invalid length")
-
-    @classmethod
-    def tearDownClass(cls):
-        # Reset the module variables that were changed to mocks so we don't
-        # break other tests
-        reload(journalist)
-
-
-class TestJournalist(unittest.TestCase):
-
-    def setUp(self):
-        journalist.logged_in = MagicMock()
-        journalist.make_star_true = MagicMock()
-        journalist.db_session = MagicMock()
-        journalist.url_for = MagicMock()
-        journalist.redirect = MagicMock()
-        journalist.get_one_or_else = MagicMock()
-
-    @patch('journalist.url_for')
-    @patch('journalist.redirect')
-    def test_remove_star_renders_template(self, redirect, url_for):
-        redirect_template = journalist.remove_star('filesystem_id')
-
-        self.assertEqual(redirect_template, redirect(url_for('index')))
-
-    @patch('journalist.db_session')
-    def test_remove_star_makes_commits(self, db_session):
-        journalist.remove_star('filesystem_id')
-
-        db_session.commit.assert_called_with()
-
-    @patch('journalist.make_star_false')
-    def test_remove_star_delegates_to_make_star_false(self, make_star_false):
-        filesystem_id = 'filesystem_id'
-
-        journalist.remove_star(filesystem_id)
-
-        make_star_false.assert_called_with(filesystem_id)
 
     @classmethod
     def tearDownClass(cls):

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -982,12 +982,16 @@ class TestJournalistApp(TestCase):
                         submission.filename)
                     )
 
-    def test_add_star_redirects_to_index(self):
+    def test_single_source_is_successfully_starred(self):
         source, _ = utils.db_helper.init_source()
         self._login_user()
         resp = self.client.post(url_for('add_star',
                                         filesystem_id=source.filesystem_id))
+
         self.assertRedirects(resp, url_for('index'))
+
+        # Assert source is starred
+        self.assertTrue(source.star.starred)
 
     def test_journalist_session_expiration(self):
         try:
@@ -1168,27 +1172,6 @@ class TestJournalist(unittest.TestCase):
         journalist.url_for = MagicMock()
         journalist.redirect = MagicMock()
         journalist.get_one_or_else = MagicMock()
-
-    @patch('journalist.url_for')
-    @patch('journalist.redirect')
-    def test_add_star_renders_template(self, redirect, url_for):
-        redirect_template = journalist.add_star('filesystem_id')
-
-        self.assertEqual(redirect_template, redirect(url_for('index')))
-
-    @patch('journalist.db_session')
-    def test_add_star_makes_commits(self, db_session):
-        journalist.add_star('filesystem_id')
-
-        db_session.commit.assert_called_with()
-
-    @patch('journalist.make_star_true')
-    def test_single_delegates_to_make_star_true(self, make_star_true):
-        filesystem_id = 'filesystem_id'
-
-        journalist.add_star(filesystem_id)
-
-        make_star_true.assert_called_with(filesystem_id)
 
     @patch('journalist.url_for')
     @patch('journalist.redirect')

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1051,6 +1051,28 @@ class TestJournalistApp(TestCase):
 
         self.assert500(resp)
 
+    def test_col_process_successfully_deletes_multiple_sources(self):
+        # Create two sources with one submission each
+        source_1, _ = utils.db_helper.init_source()
+        utils.db_helper.submit(source_1, 1)
+        source_2, _ = utils.db_helper.init_source()
+        utils.db_helper.submit(source_2, 1)
+
+        self._login_user()
+
+        form_data = {'cols_selected': [source_1.filesystem_id,
+                                       source_2.filesystem_id],
+                     'action': 'delete'}
+
+        resp = self.client.post(url_for('col_process'), data=form_data,
+                                follow_redirects=True)
+
+        self.assert200(resp)
+
+        # Verify there are no remaining sources
+        remaining_sources = db_session.query(db.Source).all()
+        self.assertEqual(len(remaining_sources), 0)
+
 
 class TestJournalistAppTwo(unittest.TestCase):
 
@@ -1068,15 +1090,6 @@ class TestJournalistAppTwo(unittest.TestCase):
         journalist.request.form.__contains__.return_value = True
         journalist.request.form.getlist = MagicMock(return_value=cols_selected)
         journalist.request.form.__getitem__.return_value = action
-
-    @patch("journalist.col_delete")
-    def test_col_process_delegates_to_col_delete(self, col_delete):
-        cols_selected = ['source_id']
-        self._set_up_request(cols_selected, 'delete')
-
-        journalist.col_process()
-
-        col_delete.assert_called_with(cols_selected)
 
     @patch("journalist.col_star")
     def test_col_process_delegates_to_col_star(self, col_star):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Progress towards #2057. 

In #2369, @heartsucker started refactoring the journalist interface and ran into problems due to two test classes `TestJournalistAppTwo` and `TestJournalist` failing. The tests in these classes [overuse mocks](https://testing.googleblog.com/2013/05/testing-on-toilet-dont-overuse-mocks.html) and are very brittle. 

In this PR, these two test classes are replaced with tests that cover the same lines of code, but without all the mocking. These tests will be less brittle during the refactor. See commit messages for details.

Note: I applied these changes (along with a small unrelated fix) on top of the journalist refactor thus far in [`redshiftzero-journalist-refactor`](https://github.com/freedomofpress/securedrop/tree/redshiftzero-journalist-refactor) and [all tests pass](https://travis-ci.org/freedomofpress/securedrop/builds/287926366). 

## Testing

Step through each commit, which details how each test was rewritten. 

## Deployment

None, tests only.

## Checklist

- [x] Unit and functional tests pass on the development VM
