### PR TITLE
Add docs for installing on Mac Mini servers

### DIFF
--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -301,6 +301,43 @@ before it can be used. We recommend:
     attempts to suspend. This has `since been fixed <https://communities.intel.com/message/432692#432692>`__
     in a BIOS update. See these `release notes <https://downloadmirror.intel.com/26263/eng/RY_0359_ReleaseNotes.pdf>`__ (PDF) for more details.
 
+Other than the NUCs we also recommend the 2014 Apple Mac Minis (part number MGEM2)
+for installing SecureDrop. However, on the first install of Ubuntu Server
+the Mac Minis will not boot: this is a known and
+`documented <https://nsrc.org/workshops/2015/nsrc-icann-dns-ttt-dubai/raw-attachment/wiki/Agenda/install-ubuntu-mac-mini.htm#your-mac-does-not-boot>`__
+issue. The workaround requires a one-time installation configuration after you
+install Ubuntu but before you move on to
+`install SecureDrop <https://docs.securedrop.org/en/stable/install.html>`__.
+This requires rebooting your Mac Minis from the same USB device and entering
+``recovery mode`` after entering your keyboard setting; once you see ``Configure
+Network`` hit the Escape key and drop down to ``Enter rescue mode``.
+In the drop-down menu execute a shell with the server hostnames, i.e. ``/dev/mon-vg/root/``.
+Follow the prompts until you have a login shell and type ``efibootmgr``.
+You should see the following:
+
+.. code::
+
+    BootCurrent: 0000
+    Timeout: 5 seconds
+    BootOrder: 0080
+    Boot0000* ubuntu
+    Boot0080* Mac OS X
+    BootFFFF*
+
+After this you should type ``efibootmgr -o 00`` and again type ``efibootmgr``.
+This time you should see the following:
+
+.. code::
+
+    BootCurrent: 0000
+    Timeout: 5 seconds
+    BootOrder: 0000
+    Boot0000* ubuntu
+    Boot0080* Mac OS X
+    BootFFFF*
+
+Mac Minis also have removable wireless cards which we recommend removing but
+require a screwdriver for non-standard T6 Torx security screws.
 
 Secure Viewing Station (SVS)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -263,6 +263,11 @@ Specific Hardware Recommendations
 Application and Monitor Servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+We currently recommend Intel NUCs or Mac Minis for SecureDrop servers.
+
+Intel NUCs
+~~~~~~~~~~
+
 The Intel NUC (Next Unit of Computing) is a capable, inexpensive, quiet, and
 low-power device that can be used for the SecureDrop servers. There
 are a `variety of
@@ -301,43 +306,61 @@ before it can be used. We recommend:
     attempts to suspend. This has `since been fixed <https://communities.intel.com/message/432692#432692>`__
     in a BIOS update. See these `release notes <https://downloadmirror.intel.com/26263/eng/RY_0359_ReleaseNotes.pdf>`__ (PDF) for more details.
 
+Mac Minis
+~~~~~~~~~
+
 Other than the NUCs we also recommend the 2014 Apple Mac Minis (part number MGEM2)
-for installing SecureDrop. However, on the first install of Ubuntu Server
+for installing SecureDrop. Mac Minis have removable wireless cards that you
+should remove. This requires a screwdriver for non-standard
+`T6 Torx security screws <https://www.amazon.com/Mini-Torx-Security-Screwdriver-Tool/dp/B01BG8P2Q6>`__.
+
+However, on the first install of Ubuntu Server
 the Mac Minis will not boot: this is a known and
 `documented <https://nsrc.org/workshops/2015/nsrc-icann-dns-ttt-dubai/raw-attachment/wiki/Agenda/install-ubuntu-mac-mini.htm#your-mac-does-not-boot>`__
-issue. The workaround requires a one-time installation configuration after you
+issue. The workaround requires a one-time modification after you
 install Ubuntu but before you move on to
 `install SecureDrop <https://docs.securedrop.org/en/stable/install.html>`__.
-This requires rebooting your Mac Minis from the same USB device and entering
-``recovery mode`` after entering your keyboard setting; once you see ``Configure
-Network`` hit the Escape key and drop down to ``Enter rescue mode``.
-In the drop-down menu execute a shell with the server hostnames, i.e. ``/dev/mon-vg/root/``.
-Follow the prompts until you have a login shell and type ``efibootmgr``.
-You should see the following:
+After Ubuntu is installed, for each Mac Mini you should:
 
-.. code::
+#. Connect your Ubuntu installation media (USB drive or CD)
+#. Boot your Mac Mini while holding down the **Option** key.
+#. Select **EFI Boot** and select **Rescue a broken system** at the Ubuntu
+   install screen.
+#. Accept the default options for the install steps until you get to **Device to
+   use as root file system**.
+#. At the **Device to use as root file system** prompt, select
+   ``/dev/mon-vg/root`` or ``/dev/app-vg/root`` for the monitor and application
+   servers respectively.
+#. Select to mount the separate ``/boot`` partition.
+#. Select **Execute a shell in** ``/dev/mon-vg/root`` (or ``/dev/app-vg/root``)
+   and select **Continue**.
+#. You should now be at a rescue Linux shell. Type ``efibootmgr``, and you
+   should see the following:
 
-    BootCurrent: 0000
-    Timeout: 5 seconds
-    BootOrder: 0080
-    Boot0000* ubuntu
-    Boot0080* Mac OS X
-    BootFFFF*
+    .. code::
 
-After this you should type ``efibootmgr -o 00`` and again type ``efibootmgr``.
-This time you should see the following:
+        BootCurrent: 0000
+        Timeout: 5 seconds
+        BootOrder: 0080
+        Boot0000* ubuntu
+        Boot0080* Mac OS X
+        BootFFFF*
 
-.. code::
+#. Type ``efibootmgr -o 00``.
+#. Again type ``efibootmgr``. This time you should see the following:
 
-    BootCurrent: 0000
-    Timeout: 5 seconds
-    BootOrder: 0000
-    Boot0000* ubuntu
-    Boot0080* Mac OS X
-    BootFFFF*
+    .. code::
 
-Mac Minis also have removable wireless cards which we recommend removing but
-require a screwdriver for non-standard T6 Torx security screws.
+        BootCurrent: 0000
+        Timeout: 5 seconds
+        BootOrder: 0000
+        Boot0000* ubuntu
+        Boot0080* Mac OS X
+        BootFFFF*
+
+#. Type ``exit``.
+#. Select **Reboot the system** and remove the installation media.
+   Your server should now boot to Ubuntu by default.
 
 Secure Viewing Station (SVS)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Added documentation on how to install on a Mac Mini server

## Testing

Physical install on 4 Mac Mini servers including screenshots along the way. Unfortunately, there is not great way to screenshot in a VM (after installing Ubuntu Server) so high quality screenshots are not included in this PR. 

### If you made changes to documentation:

- [X] Doc linting passed locally
