### PR TITLE
added `safety check` to python dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,10 @@ jobs:
           name: Installation pre-reqs
           command: pip install -U -r ./testinfra/requirements.txt
 
+      - run:
+          name: Check Python dependencies for CVEs
+          command: make safety
+
       - setup_remote_docker
 
       - run:

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,15 @@ docker-build-ubuntu: ## Builds SD Ubuntu docker container
 build-debs: ## Builds and tests debian packages
 	@if [[ "${CIRCLE_BRANCH}" != docs-* ]]; then molecule test -s builder; else echo Not running on docs branch...; fi
 
+.PHONY: safety
+safety: ## Runs `safety check` to check python dependencies for vulnerabilities
+	@for req_file in `find . -type f -name '*requirements.txt'`; do \
+		echo "Checking file $$req_file" \
+		&& safety check --full-report -r $$req_file \
+		&& echo -e '\n' \
+		|| exit 1; \
+	done
+
 # Explaination of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" and any make targets that might appear between : and ##
 # 2. Use sed-like syntax to remove the make targets

--- a/securedrop/requirements/update_python_dependencies
+++ b/securedrop/requirements/update_python_dependencies
@@ -37,10 +37,13 @@ trap 'rm -rf "${VENV}" && popd' EXIT
 virtualenv -p python2 "${VENV}"
 # shellcheck disable=SC1090
 source "${VENV}"/bin/activate
-pip install -U pip-tools
+pip install -U pip-tools safety
 
 # Compile new requirements (.txt) files from our top-level dependency (.in)
 # files (see http://nvie.com/posts/better-package-management/).
+# Then runs a dependency checker to ensure ther are no known CVEs present
+# in any of the dependencies.
 for prefix in "${REQUIREMENTS_FILE_PREFIXES[@]}"; do
   pip-compile -U -o "${prefix}"-requirements.txt "${prefix}"-requirements.in
+  safety check --full-report -r "${prefix}"-requirements.txt
 done

--- a/testinfra/requirements.in
+++ b/testinfra/requirements.in
@@ -5,3 +5,4 @@ molecule>=2.*
 pip-tools
 pytest-xdist
 testinfra
+safety

--- a/testinfra/requirements.txt
+++ b/testinfra/requirements.txt
@@ -18,13 +18,14 @@ certifi==2017.7.27.1      # via requests
 cffi==1.10.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via binaryornot, requests
 click-completion==0.2.1   # via molecule
-click==6.7                # via click-completion, cookiecutter, git-url-parse, molecule, pip-tools, python-gilt
+click==6.7                # via click-completion, cookiecutter, git-url-parse, molecule, pip-tools, python-gilt, safety
 colorama==0.3.7           # via molecule, python-gilt
 configparser==3.5.0       # via flake8
 cookiecutter==1.5.1       # via molecule
 cryptography==2.0.3       # via paramiko
 docker-py==1.10.6
 docker-pycreds==0.2.1     # via docker-py
+dparse==0.2.1             # via safety
 enum34==1.1.6             # via cryptography, flake8
 execnet==1.4.1            # via pytest-xdist
 fasteners==0.14.1         # via python-gilt
@@ -41,6 +42,7 @@ marshmallow==2.13.5       # via molecule
 mccabe==0.6.1             # via flake8
 molecule==2.0.0.0rc16
 monotonic==1.3            # via fasteners
+packaging==16.8           # via dparse, safety
 paramiko==2.2.1           # via ansible
 pathspec==0.5.3           # via yamllint
 pbr==3.0.1                # via git-url-parse, molecule, python-gilt
@@ -56,15 +58,17 @@ pycparser==2.18           # via cffi
 pycrypto==2.6.1           # via ansible
 pyflakes==1.5.0           # via flake8
 pynacl==1.1.2             # via paramiko
+pyparsing==2.2.0          # via packaging
 pytest-forked==0.2        # via pytest-xdist
 pytest-xdist==1.20.0
 pytest==3.2.1             # via pytest-forked, pytest-xdist, testinfra
 python-dateutil==2.6.1    # via arrow
 python-gilt==1.1.0        # via molecule
-pyyaml==3.12              # via ansible, ansible-lint, molecule, python-gilt, yamllint
-requests==2.18.4          # via docker-py
+pyyaml==3.12              # via ansible, ansible-lint, dparse, molecule, python-gilt, yamllint
+requests==2.18.4          # via docker-py, safety
+safety==1.6.1
 sh==1.12.14               # via molecule, python-gilt
-six==1.10.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker-py, docker-pycreds, fasteners, git-url-parse, pip-tools, pynacl, python-dateutil, testinfra, websocket-client
+six==1.10.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker-py, docker-pycreds, dparse, fasteners, git-url-parse, packaging, pip-tools, pynacl, python-dateutil, testinfra, websocket-client
 tabulate==0.7.7           # via molecule
 testinfra==1.6.3
 tree-format==0.1.1        # via molecule


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2451

Adds `safety check` to a few scripts and `Makefile`s as well as CI.

## Testing

`make safety`

This breaks right now as we have a CVE in the code. Once it's removed, we can merge this in.