### PR TITLE
removed asserts from main code and added explicit exceptions

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -35,7 +35,8 @@ DEFAULT_WORDS_IN_RANDOM_ID = 8
 # Make sure these pass before the app can run
 # TODO: Add more tests
 def do_runtime_tests():
-    assert(config.SCRYPT_ID_PEPPER != config.SCRYPT_GPG_PEPPER)
+    if config.SCRYPT_ID_PEPPER == config.SCRYPT_GPG_PEPPER:
+        raise AssertionError('SCRYPT_ID_PEPPER == SCRYPT_GPG_PEPPER')
     # crash if we don't have srm:
     try:
         subprocess.check_call(['srm'], stdout=subprocess.PIPE)

--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -49,7 +49,11 @@ def setup_app(app, translation_dirs=None):
     app.config['BABEL_TRANSLATION_DIRECTORIES'] = translation_dirs
 
     babel = Babel(app)
-    assert len(list(babel.translation_directories)) == 1
+    if len(list(babel.translation_directories)) != 1:
+        raise AssertionError(
+            'Expected exactly one translation directory but got {}.'
+            .format(babel.translation_directories))
+
     for dirname in os.listdir(next(babel.translation_directories)):
         if dirname != 'messages.pot':
             LOCALES.add(dirname)

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -76,9 +76,9 @@ def reset(args):
     3. Erases stored submissions and replies from the store dir.
     """
     # Erase the development db file
-    assert hasattr(config, 'DATABASE_FILE'), ("TODO: ./manage.py doesn't know "
-                                              'how to clear the db if the '
-                                              'backend is not sqlite')
+    if not hasattr(config, 'DATABASE_FILE'):
+        raise Exception("TODO: ./manage.py doesn't know how to clear the db "
+                        'if the backend is not sqlite')
     try:
         os.remove(config.DATABASE_FILE)
     except OSError:

--- a/securedrop/secure_tempfile.py
+++ b/securedrop/secure_tempfile.py
@@ -77,7 +77,8 @@ class SecureTemporaryFile(_TemporaryFileWrapper, object):
         but after calling :meth:`read`, you cannot write to the file
         again.
         """
-        assert self.last_action != 'read', 'You cannot write after reading!'
+        if self.last_action == 'read':
+            raise AssertionError('You cannot write after reading!')
         self.last_action = 'write'
 
         if isinstance(data, unicode):  # noqa
@@ -103,7 +104,8 @@ class SecureTemporaryFile(_TemporaryFileWrapper, object):
             count (int): the number of bytes to try to read from the
                 file from the current position.
         """
-        assert self.last_action != 'init', 'You must write before reading!'
+        if self.last_action == 'init':
+            raise AssertionError('You must write before reading!')
         if self.last_action == 'write':
             self.seek(0, 0)
             self.last_action = 'read'


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2429

Removes asserts and uses exceptions to prevent the asserts from ever being optimized away.

## Testing

`pytest -vx tests` like usual.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM