### PR TITLE
faster wordlist validation test

### DIFF
--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -51,9 +51,13 @@ class TestSourceApp(TestCase):
 
         wordlist_en = crypto_util._get_wordlist('en')
 
-        for word in wordlist_en:
+        # chunk the words to cut down on the number of requets we make
+        # otherwise this test is *slow*
+        chunks = [wordlist_en[i:i + 7] for i in range(0, len(wordlist_en), 7)]
+
+        for words in chunks:
             with self.client as c:
-                resp = c.post('/login', data=dict(codename=word),
+                resp = c.post('/login', data=dict(codename=' '.join(words)),
                               follow_redirects=True)
                 self.assertEqual(resp.status_code, 200)
                 # If the word does not validate, then it will show


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Speeds up the wordlist validation test by chunking the wordlist into realistic codenames instead of sending them one word at a time.

## Testing

`pytest -v tests/test_source.py::TestSourceApp::test_all_words_in_wordlist_validate`

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM