### PR TITLE
localize logout messages to help protect souces

### DIFF
--- a/securedrop/sass/_base.sass
+++ b/securedrop/sass/_base.sass
@@ -55,6 +55,12 @@
       &:hover
         color: $color_purple_medium
 
+  .localized
+    text-align: left
+
+    &:dir(rtl)
+      text-align: right
+
   .codename, .password
     font-family: monospace
     letter-spacing: 0.15em

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -215,8 +215,11 @@ def make_blueprint(config):
     @view.route('/logout')
     def logout():
         if logged_in():
-            session.clear()
             msg = render_template('logout_flashed_message.html')
+
+            # clear the session after we render the message so it's localized
+            session.clear()
+
             flash(Markup(msg), "important hide-if-not-tor-browser")
         return redirect(url_for('.index'))
 

--- a/securedrop/source_templates/logout_flashed_message.html
+++ b/securedrop/source_templates/logout_flashed_message.html
@@ -1,5 +1,8 @@
-<div class="icon">
-  <img src="{{ url_for('static', filename='i/hand_with_fingerprint.png') }}">
+<div class="localized" dir="{{ g.text_direction }}">
+  <div class="icon">
+    <img src="{{ url_for('static', filename='i/hand_with_fingerprint.png') }}">
+  </div>
+  <div class="message"><strong>{{ gettext('Important!') }}</strong><br>
+    <p>{{ gettext('Thank you for exiting your session! Please select "New Identity" from the green Onion button in the Tor browser to clear all history of your SecureDrop usage from this device.') }}</p>
+  </div>
 </div>
-<div class="message"><strong>{{ gettext('Important!') }}</strong><br>
-<p>{{ gettext('Thank you for exiting your session! Please select "New Identity" from the green Onion button in the Tor browser to clear all history of your SecureDrop usage from this device.') }}</p></div>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2391.

![screenshot_2017-10-22_15-53-45](https://user-images.githubusercontent.com/3998464/31862642-7f9254b2-b741-11e7-9bf1-35109c5f3763.png)

Changes proposed in this pull request:

## Testing

```
mkdir -p translations/ar/LC_MESSAGES/
curl http://lab.securedrop.club/bot/securedrop/raw/i18n/securedrop/translations/ar/LC_MESSAGES/messages.po > translations/ar/LC_MESSAGES/messages.po
./manage.py translate --compile
```

Using Tor Browser, Log in as a user, use `?l=ar` to set the locale. Submit doc. Log out. Expect correctly translated and oriented logout message.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
