### PR TITLE
implement jinja whitespace control in html templates

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -37,6 +37,8 @@ i18n.setup_app(app)
 
 assets = Environment(app)
 
+app.jinja_env.trim_blocks = True
+app.jinja_env.lstrip_blocks = True
 app.jinja_env.globals['version'] = version.__version__
 if getattr(config, 'CUSTOM_HEADER_IMAGE', None):
     app.jinja_env.globals['header_image'] = config.CUSTOM_HEADER_IMAGE

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -38,6 +38,8 @@ def create_app(config):
 
     i18n.setup_app(app)
 
+    app.jinja_env.trim_blocks = True
+    app.jinja_env.lstrip_blocks = True
     app.jinja_env.globals['version'] = version.__version__
     if getattr(config, 'CUSTOM_HEADER_IMAGE', None):
         app.jinja_env.globals['header_image'] = config.CUSTOM_HEADER_IMAGE


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2413.

Strips whitespace when templates are rendered.

## Testing

`pytest -vx tests`. Also, open any page and verify the rendered template has no leading whitespace where a `{% block foo %}` would be.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM