### PR TITLE
localized session expiration banner

### DIFF
--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -79,8 +79,11 @@ def create_app(config):
         g.locales = i18n.get_locale2name()
 
         if 'expires' in session and datetime.utcnow() >= session['expires']:
-            session.clear()
             msg = render_template('session_timeout.html')
+
+            # clear the session after we render the message so it's localized
+            session.clear()
+
             flash(Markup(msg), "important")
 
         session['expires'] = datetime.utcnow() + \

--- a/securedrop/source_templates/session_timeout.html
+++ b/securedrop/source_templates/session_timeout.html
@@ -1,5 +1,8 @@
-<div class="icon">
-  <img src="{{ url_for('static', filename='i/hand_with_fingerprint.png') }}">
+<div class="localized" dir="{{ g.text_direction }}">
+  <div class="icon">
+    <img src="{{ url_for('static', filename='i/hand_with_fingerprint.png') }}">
+  </div>
+  <div class="message"><strong>{{ gettext('Important!') }}</strong><br>
+  <p>{{ gettext('Your session timed out due to inactivity. Please login again if you want to continue using SecureDrop, or select "New Identity" from the green onion button in the Tor browser to clear all history of your SecureDrop usage from this device. If you are not using Tor Browser, restart your browser.') }}</p>
+  </div>
 </div>
-<div class="message"><strong>{{ gettext('Important!') }}</strong><br>
-<p>{{ gettext('Your session timed out due to inactivity. Please login again if you want to continue using SecureDrop, or select "New Identity" from the green onion button in the Tor browser to clear all history of your SecureDrop usage from this device. If you are not using Tor Browser, restart your browser.') }}</p></div>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2470

Localized the session timeout information so that source will see how to clear their session information by closing their browser.

![screenshot_2017-10-24_20-09-27](https://user-images.githubusercontent.com/3998464/31960528-589146e4-b8f8-11e7-98c2-562115908e49.png)

> Note: the text hasn't been fully translated, that's why it's still in English, but Arabic is the only RTL language we have right now.

Their locale preference is in the unencrypted cookie, so an attack already would know that, and thus this message wouldn't tell them anything. However, in the future, if the cookies are encrypted, this could allow an attacker to learn the locale preference. However, this is less of a risk than the codename being in the session, so we really should fix that first.

## Testing

```
mkdir -p translations/ar/LC_MESSAGES/
curl http://lab.securedrop.club/bot/securedrop/raw/i18n/securedrop/translations/ar/LC_MESSAGES/messages.po > translations/ar/LC_MESSAGES/messages.po
./manage.py translate --compile
echo 'SESSION_EXPIRATION_MINUTES = 0.25' >> config.py
```

Create user in Arabic locale. Submit doc. Wait 15 seconds. Refresh page. See localized logout message.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM