### PR TITLE
fix formatting of otp secret for i18n with long sentenes

### DIFF
--- a/securedrop/journalist_templates/admin_new_user_two_factor.html
+++ b/securedrop/journalist_templates/admin_new_user_two_factor.html
@@ -12,7 +12,9 @@
   <li>{{ gettext('Your phone will now be in "scanning" mode. When you are in this mode, scan the barcode below:') }}</li>
 </ol>
 <div id="qrcode-container">{{ user.shared_secret_qrcode }}</div>
-<p>{{ gettext("Can't scan the barcode? Enter the following code manually:") }} <span id="shared-secret">{{ user.formatted_otp_secret }}</span></p>
+<p>{{ gettext("Can't scan the barcode? Enter the following code manually:") }}</p>
+<p class="center"><span id="shared-secret">{{ user.formatted_otp_secret }}</span></p>
+
 <p>{{ gettext('Once you have scanned the barcode, enter the 6-digit code below:') }}</p>
 {% else %}
 <h1>{{ gettext('Enable YubiKey (OATH-HOTP)') }}</h1>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2316.

Move OTP secret to own line in HTML.

## Testing

Create admin. Attempt to reset TOTP secret. See formatted OTP secret on a new line.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM