### PR TITLE
nicer csrf error pages

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -5,7 +5,7 @@ import functools
 
 from flask import (Flask, request, render_template, send_file, redirect, flash,
                    url_for, g, abort, session)
-from flask_wtf.csrf import CSRFProtect
+from flask_wtf.csrf import CSRFProtect, CSRFError
 from flask_assets import Environment
 from jinja2 import Markup
 from sqlalchemy.orm.exc import NoResultFound
@@ -32,6 +32,16 @@ import worker
 app = Flask(__name__, template_folder=config.JOURNALIST_TEMPLATES_DIR)
 app.config.from_object(config.JournalistInterfaceFlaskConfig)
 CSRFProtect(app)
+
+
+@app.errorhandler(CSRFError)
+def handle_csrf_error(e):
+    # render the message first to ensure it's localized.
+    msg = gettext('You have been logged out due to inactivity')
+    session.clear()
+    flash(msg, 'error')
+    return redirect(url_for('login'))
+
 
 i18n.setup_app(app)
 

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1002,6 +1002,21 @@ class TestJournalistApp(TestCase):
             else:
                 del config.SESSION_EXPIRATION_MINUTES
 
+    def test_csrf_error_page(self):
+        old_enabled = self.app.config['WTF_CSRF_ENABLED']
+        self.app.config['WTF_CSRF_ENABLED'] = True
+
+        try:
+            with self.app.test_client() as app:
+                resp = app.post(url_for('login'))
+                self.assertRedirects(resp, url_for('login'))
+
+                resp = app.post(url_for('login'), follow_redirects=True)
+                self.assertIn('You have been logged out due to inactivity',
+                              resp.data)
+        finally:
+            self.app.config['WTF_CSRF_ENABLED'] = old_enabled
+
 
 class TestJournalistAppTwo(unittest.TestCase):
 

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -5,7 +5,7 @@ from mock import patch, ANY
 import re
 
 from bs4 import BeautifulSoup
-from flask import session, escape
+from flask import session, escape, url_for
 from flask_testing import TestCase
 
 import crypto_util
@@ -493,3 +493,18 @@ class TestSourceApp(TestCase):
                 config.SESSION_EXPIRATION_MINUTES = old_expiration
             else:
                 del config.SESSION_EXPIRATION_MINUTES
+
+    def test_csrf_error_page(self):
+        old_enabled = self.app.config['WTF_CSRF_ENABLED']
+        self.app.config['WTF_CSRF_ENABLED'] = True
+
+        try:
+            with self.app.test_client() as app:
+                resp = app.post(url_for('main.create'))
+                self.assertRedirects(resp, url_for('main.index'))
+
+                resp = app.post(url_for('main.create'), follow_redirects=True)
+                self.assertIn('Your session timed out due to inactivity',
+                              resp.data)
+        finally:
+            self.app.config['WTF_CSRF_ENABLED'] = old_enabled


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2290.

Redirects CSRF errors to better error pages.

## Testing

Open source interface. Go to `/submit`. Open HTML, delete `csrf_token`. Click submit. See pretty logout message.

Open journalist interface. Open HTML. Delete `csrf_token`. Try to login. See sunshine happiness logout message.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM