### PR TITLE
Let's target 18.04 and skip 16.04 for the upgrade

### DIFF
--- a/testinfra/common/test_platform.py
+++ b/testinfra/common/test_platform.py
@@ -14,7 +14,7 @@ def test_ansible_version(host):
 def test_platform(SystemInfo):
     """
     SecureDrop requires Ubuntu Trusty 14.04 LTS. The shelf life
-    of that release means we'll need to migrate to Xenial LTS
+    of that release means we'll need to migrate to Bionic LTS
     at some point; until then, require hosts to be running
     Ubuntu.
     """


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes expectations.

Changes proposed in this pull request are tiny.

## Testing

Look up which get released when, and realize that putting effort into 18.04 is more fruitful in the long term.

## Deployment

1. Upgrading existing production instances: skipping is going to be though, if intermediate upgrade is necessary needs to be tested.

