### PR TITLE
explicitly mention the directory for admins

### DIFF
--- a/docs/configure_admin_workstation_post_install.rst
+++ b/docs/configure_admin_workstation_post_install.rst
@@ -33,7 +33,7 @@ reboots, the Tails instance must have persistence enabled (specifically, the
 .. note:: Starting in version 0.3.7, SecureDrop requires Tails 2.x or greater.
 
 To install the auto-connect configuration, start by navigating to the directory
-with these scripts, and run the install script:
+with these scripts (``~/Persistent/securedrop/``), and run the install script:
 
 .. code:: sh
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Small fix to docs to be more verbose. I needed to check the directory of the `./securedrop-admin tailsconfig` path and went directly to `configure_admin_workstation_post_install` but didn't find the directory before it. 

### If you made changes to documentation:

- [x] Doc linting passed locally
