### PR TITLE
testinfra: do not be strict about IPv6 tests failing

### DIFF
--- a/testinfra/app/test_network.py
+++ b/testinfra/app/test_network.py
@@ -7,7 +7,7 @@ from jinja2 import Template
 securedrop_test_vars = pytest.securedrop_test_vars
 
 
-@pytest.mark.xfail(strict=True)
+@pytest.mark.xfail()
 def test_app_iptables_rules(SystemInfo, Command, Sudo):
 
     # Build a dict of variables to pass to jinja for iptables comparison

--- a/testinfra/common/test_ip6tables.py
+++ b/testinfra/common/test_ip6tables.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.xfail(strict=True)
+@pytest.mark.xfail()
 def test_ip6tables_drop_everything(Command, Sudo):
     """
     Ensure that all IPv6 packets are dropped by default.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2489

https://github.com/freedomofpress/securedrop/commit/3da5605
temporarily expects IPv6 tests to fail in CircleCI because the virtual
machine does not reboot. However, when run on a laptop they will
succeed because IPv6 is presumably already properly set, even if a
reboot did not happen.

By removing the strict=True we accept the test may fail or succeed,
depending on the context.

## Testing

If the CircleCI test pass it means the failing IPv6 tests are not failing the entire suite. Running locally with:

* vagrant up --no-provision /staging/
* make build-debs
* vagrant provision app-staging
* ./testinfra/test.py app-staging

will show success with **291 passed, 1 skipped, 1 xfailed, 2 xpassed, 1 warnings** instead of failure.

## Deployment

Test only.

