### PR TITLE
tests: wait up to one minute for the worker to srm

### DIFF
--- a/securedrop/tests/utils/async.py
+++ b/securedrop/tests/utils/async.py
@@ -7,7 +7,7 @@ import time
 REDIS_SUCCESS_RETURN_VALUE = 'success'
 
 
-def wait_for_redis_worker(job, timeout=5):
+def wait_for_redis_worker(job, timeout=60):
     """Raise an error if the Redis job doesn't complete successfully
     before a timeout.
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2455

It is not an error for a machine to require more than 5 seconds to srm
a file. What we really want here is for the function to not wait
forever in case nothing is happening. Since all files involved in
tests are small, it is reasonable to assume that they can be removed
within 60 seconds, even on the slowest virtual machine running on the
slowest hardware.

## Testing

If the tests pass all is well. It would be interesting to try on a slow machine and verify it keeps working. But it's difficult to reproduce.

## Deployment

No deployment considerations.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
