### PR TITLE
testinfra: add missing test in the grsec skip list

### DIFF
--- a/testinfra/common/test_grsecurity.py
+++ b/testinfra/common/test_grsecurity.py
@@ -143,6 +143,8 @@ def test_grub_pc_marked_manual(Command):
     assert c.stdout == "grub-pc"
 
 
+@pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",
+                    reason="Need to skip in environment w/o grsec")
 def test_apt_autoremove(Command):
     """
     Ensure old packages have been autoremoved.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2253

There is no reason to check for autoremove if another kernel was not
installed.

## Testing

Verify that it passes locally with testinfra on app-staging.

    ./testinfra/test.py app-staging

## Deployment

No deployment considerations, this is for tests only.
