### PR TITLE
Fixes 2311, validates 20 bytes Yubikey secret

### DIFF
--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -159,6 +159,13 @@ def _add_user(is_admin=False):
             otp_secret = raw_input(
                 "Please configure this user's YubiKey and enter the secret: ")
             if otp_secret:
+                tmp_str = otp_secret.replace(" ", "")
+                if len(tmp_str) != 40:
+                    print("The length of the secret is not correct. "
+                          "Expected 40 characters, but received {0}. "
+                          "Try again.".format(len(tmp_str)))
+                    continue
+            if otp_secret:
                 break
 
     try:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2311 

Checking the length of the secret (20 bytes) before accepting a secret key in the manage.py

## Testing

How should the reviewer test this PR?

Try to add a new user with an invalid key (length wise).

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
