### PR TITLE
Fix #2332, use the word admin everywhere

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -1,7 +1,7 @@
-Administrator Guide
-=====================
+Admin Guide
+===========
 
-You (the administrator) should have your own username and password, plus
+You (the admin) should have your own username and password, plus
 two-factor authentication through either the Google Authenticator app
 on your smartphone or a YubiKey.
 
@@ -12,9 +12,9 @@ Responsibilities
 
 The SecureDrop architecture contains multiple hardened servers, and while we have
 automated many of the installation and maintenance tasks, a skilled Linux
-administrator and some manual intervention is required to responsibly run the system.
+admin and some manual intervention is required to responsibly run the system.
 
-This section outlines the tasks the administrator is responsible for in order to
+This section outlines the tasks the admin is responsible for in order to
 ensure that the SecureDrop server continues to be a safe place for sources to
 talk to journalists.
 
@@ -103,7 +103,7 @@ Here, you will hand the keyboard over to the journalist so they can
 create their own username. Once they’re done entering a
 username for themselves, have them write down their pre-generated diceware
 passphrase. Then, you will select whether you would like them
-to also be an administrator (this allows them to add or delete other
+to also be an admin (this allows them to add or delete other
 journalist accounts), and whether they will be using Google
 Authenticator or a YubiKey for two-factor authentication.
 
@@ -213,7 +213,7 @@ need to apply the changes to the servers. From ``~/Persistent/securedrop``:
 .. include:: includes/rerun-install-is-safe.txt
 
 Once the install command has successfully completed, the changes are applied.
-Read the next section if you have multiple administrators.
+Read the next section if you have multiple admins.
 
 Managing ``site-specific`` updates on teams with multiple admins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/backup_workstations.rst
+++ b/docs/backup_workstations.rst
@@ -91,13 +91,13 @@ mounted and ready to access.
 
 |Backup and TailsData Mounted|
 
-Open a Nautilus window with administrator privileges by going to
+Open a Nautilus window with admin privileges by going to
 **Applications** ▸ **System Tools** ▸ **Terminal**.
 
 |Open Terminal|
 
 Type ``gksu nautilus`` at the terminal prompt and hit enter. You'll need to type
-your administrator password.
+your admin password.
 
 |Start gksu nautilus|
 
@@ -106,9 +106,9 @@ your administrator password.
   complains that it can't create a required folder. If that happens, just click
   OK and continue normally.
 
-  If a Nautilus window *doesn't* come up, it might be because an administrator
+  If a Nautilus window *doesn't* come up, it might be because an admin
   password wasn't set. If that's the case, you'll need to restart and set an
-  administrator password before continuing.
+  admin password before continuing.
 
 .. warning::
             Make sure you use keep the `Terminal` window open while you perform

--- a/docs/before_you_begin.rst
+++ b/docs/before_you_begin.rst
@@ -17,7 +17,7 @@ best practices for SecureDrop deployments.
 Installing SecureDrop is an extended manual process which requires a
 bunch of preparation and equipment. You should probably set aside a day
 to complete the install process. A successful install requires an
-administrator with at-least basic familiarity with Linux, the GNU core
+admin with at-least basic familiarity with Linux, the GNU core
 utilities and Bash shell. If you are not proficient in these areas, it
 is strongly recommended that you contact the `Freedom of the Press
 Foundation <https://securedrop.org/help>`__ for installation assistance.

--- a/docs/create_admin_account.rst
+++ b/docs/create_admin_account.rst
@@ -1,7 +1,7 @@
 Create an admin account on the Journalist Interface
 ===================================================
 
-In order for any user (administrator or journalist) to access the
+In order for any user (admin or journalist) to access the
 Journalist Interface, they need:
 
 1. The ``auth-cookie`` for the Journalist Interface's ATHS

--- a/docs/development/updating_ossec.rst
+++ b/docs/development/updating_ossec.rst
@@ -11,10 +11,10 @@ to learn more about how SecureDrop admins set up and monitor OSSEC alerts.
 Alerting Strategy
 -----------------
 
-The goals of the OSSEC alerts in SecureDrop is to notify administrators of:
+The goals of the OSSEC alerts in SecureDrop is to notify admins of:
 
 1. Suspicious security events
-2. Changes that require some kind of administrator action
+2. Changes that require some kind of admin action
 3. Other important notifications regarding system state.
 
 If an alert is purely informational and there is no realistic action an
@@ -91,5 +91,5 @@ configuration files will land on production SecureDrop monitoring servers as
 part of each SecureDrop release. This upgrade will occur automatically.
 
 .. note:: The use of automatic upgrades for release deployment means that any
-          changes made locally by administrators to their OSSEC rules will not
+          changes made locally by admins to their OSSEC rules will not
           persist after a SecureDrop update.

--- a/docs/generate_securedrop_application_key.rst
+++ b/docs/generate_securedrop_application_key.rst
@@ -33,7 +33,7 @@ To set the system time:
 #. Click the upper right down arrow in the menu bar and select the wrench icon:
    |select settings|
 #. Then click **Date & Time**.
-#. Click **Unlock**. Type in the administrator password you set when you
+#. Click **Unlock**. Type in the admin password you set when you
    started up Tails.
 #. Set the correct time, region and city.
 #. Click **Lock**, exit Settings and wait for the system time to update in the

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -28,7 +28,7 @@ These are the core components of a SecureDrop instance.
 * *Application Server*: 1 physical server to run the SecureDrop web services.
 
 * *Monitor Server*: 1 physical server which monitors activity on the
-  *Application Server* and sends email notifications to an administrator.
+  *Application Server* and sends email notifications to an admin.
 
 * *Network Firewall*: 1 physical computer that is used as a dedicated firewall
   for the SecureDrop servers.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -38,7 +38,7 @@ continuing:
    Guide <ossec_alerts>`.
 -  The first username of a journalist who will be using SecureDrop (you
    can add more later)
--  The username of the system administrator
+-  The username of the system admin
 -  (Optional) An image to replace the SecureDrop logo on the *Source
    Interface* and *Journalist Interface*
 

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -3,7 +3,7 @@ Journalist Guide
 
 Journalists viewing documents on SecureDrop must connect to the
 respective Source or Journalist Interface using the `Tails operating
-system <https://tails.boum.org/>`__, which your administrator should
+system <https://tails.boum.org/>`__, which your admin should
 have already set up for you.
 
 Workflow

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -64,7 +64,7 @@ Set up automatic access to the Journalist Interface
 Since the Journalist Interface is an ATHS, we need to set up the
 Journalist Tails USB to auto-configure Tor just as we did with the
 Admin Tails USB. The procedure is essentially identical, except the
-SSH configuration will be skipped, since only Administrators need
+SSH configuration will be skipped, since only admins need
 to access the servers over SSH.
 
 .. tip:: Copy the files ``app-journalist-aths`` and ``app-source-ths`` from
@@ -106,7 +106,7 @@ Add an account on the Journalist Interface
 
 Finally, you need to add an account on the Journalist Interface so the journalist
 can log in and access submissions. See the section on :ref:`Adding Users` in
-the Administrator Guide.
+the admin Guide.
 
 Import GPG keys for journalists with access to SecureDrop to the SVS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -4,7 +4,7 @@ Onboard Journalists
 Congratulations! You've successfully installed SecureDrop.
 
 At this point, the only person who has access to the system is the
-administrator. In order to grant access to journalists, you will need
+admin. In order to grant access to journalists, you will need
 to do some additional setup for each individual journalist.
 
 In order to use SecureDrop, each journalist needs two things:
@@ -55,7 +55,7 @@ used to create a Tails USB with persistence for the Admin Tails USB,
 as documented in the :doc:`Tails Setup Guide <set_up_tails>`.
 
 Once you're done, boot into the new Journalist Tails USB on the
-*Journalist Workstation*. Enable persistence and set an administrator
+*Journalist Workstation*. Enable persistence and set an admin
 password before continuing with the next section.
 
 Set up automatic access to the Journalist Interface
@@ -132,7 +132,7 @@ Verify Journalist Setup
 -----------------------
 
 Once the journalist device and account have been provisioned, then the
-administrator should run through the following steps with *each journalist* to
+admin should run through the following steps with *each journalist* to
 verify the journalist is set up for SecureDrop.
 
 The journalist should verify that they:

--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -68,7 +68,7 @@ For first-time installs, you can use the
 - Password of the email used to send OSSEC alerts: ``sasl_password``
 
 If you don't know what value to enter for one of these, please ask your
-organization's email administrator for the full configuration before
+organization's email admin for the full configuration before
 proceeding. It is better to get these right the first time rather than
 changing them after SecureDrop is installed. If you're not sure of the
 correct ``smtp_relay_port`` number, you can use a simple mail client
@@ -142,7 +142,7 @@ will retrieve and format the fingerprint per our requirements: ::
 
 Next you specify the e-mail that you'll be sending alerts to, as
 ``ossec_alert_email``. This could be your work email, or an alias for a
-group of IT administrators at your organization. It helps for your mail
+group of IT admins at your organization. It helps for your mail
 client to have the ability to filter the numerous messages from OSSEC
 into a separate folder.
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -53,7 +53,7 @@ These computers should all physically be in your organization's office.
 Infrastructure
 --------------
 
-There are four main components of SecureDrop: the servers, the administrators,
+There are four main components of SecureDrop: the servers, the admins,
 the sources, and the journalists.
 
 |SecureDrop architecture overview diagram|
@@ -73,8 +73,8 @@ firewall appliance. They are typically located physically inside the newsroom.
 Administrators
 ~~~~~~~~~~~~~~
 
-The SecureDrop servers are managed by a systems administrator; for larger
-newsrooms, there may be a team of systems administrators. The administrator
+The SecureDrop servers are managed by a systems admin; for larger
+newsrooms, there may be a team of systems admins. The admin
 uses a dedicated *Admin Workstation* running `Tails <https://tails.boum.org>`__
 and connects to the *Application* and *Monitor Servers* over authenticated `Tor Hidden Services
 <https://www.torproject.org/docs/hidden-services.html>`__ and manages them
@@ -117,7 +117,7 @@ Planning & Preparation
 
 Setting up SecureDrop is a multi-step process. Before getting started, you
 should make sure that you're prepared to operate and maintain it. You'll need
-a systems administrator who's familiar with Linux, the GNU utilities, and the
+a systems admin who's familiar with Linux, the GNU utilities, and the
 Bash shell. You'll need the :doc:`hardware <hardware>` on which SecureDrop
 runs — this will normally cost $2000-$3000 dollars. The journalists in your
 organization will need to be trained in the operation of SecureDrop, and
@@ -143,9 +143,9 @@ Provisioning & Training
 Once SecureDrop is installed, journalists will need to be provided with
 accounts, two-factor tokens, workstations, and so on — and then
 :doc:`trained <training_schedule>` to use these tools safely and reliably. You
-will probably also need to train additional backup administrators so that you
+will probably also need to train additional backup admins so that you
 can be sure that your SecureDrop setup keeps running even when your main
-administrator is on holiday.
+admin is on holiday.
 
 Introducing staff to SecureDrop takes half a day. Training a group to use
 SecureDrop proficiently takes at least a day — and a single trainer can only

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -70,8 +70,8 @@ which keeps track of the *Application Server* and sends out alerts if there's a
 problem. These two servers run on dedicated hardware connected to a dedicated
 firewall appliance. They are typically located physically inside the newsroom.
 
-Administrators
-~~~~~~~~~~~~~~
+Admins
+~~~~~~
 
 The SecureDrop servers are managed by a systems admin; for larger
 newsrooms, there may be a team of systems admins. The admin

--- a/docs/passphrase_best_practices.rst
+++ b/docs/passphrase_best_practices.rst
@@ -2,7 +2,7 @@
 Passphrase Best Practices
 #########################
 
-All SecureDrop end users---Sources, Journalists, and Administrators---are
+All SecureDrop end users---Sources, Journalists, and Admins---are
 required to remember one or more passphrases in order to use the system. This
 document describes best practices for passphrase management in the context of
 SecureDrop.
@@ -48,22 +48,22 @@ activity on the SecureDrop server. In order to preserve your anonymity, you
 should avoid creating physical or digital associations between yourself and your
 passphrase as much as possible.
 
-******************************
-For Journalists/Administrators
-******************************
+***********************
+For Journalists/Admins
+***********************
 
 While Sources only have one passphrase that they are required to manage,
-Journalists and Administrators unfortunately have to manage a veritable
+Journalists and Admins unfortunately have to manage a veritable
 menagerie of credentials.
 
 We have tried to minimize the number of credentials that Journalists and
-Administrators actually have to *remember* by automating the storage and entry
+admins actually have to *remember* by automating the storage and entry
 of credentials on the Tails workstations wherever possible. For example,
 shortcut icons are created on the Desktop of each Tails workstation to make it
 easy to access the Tor Hidden Services without having to look up their
 ``.onion`` addresses every time.
 
-Ideally, each Administrator would only have to:
+Ideally, each admin would only have to:
 
 1. Keep track of their Admin Workstation Tails USB.
 2. Remember the passphrase to unlock the persistent storage on that Tails USB.

--- a/docs/passphrase_best_practices.rst
+++ b/docs/passphrase_best_practices.rst
@@ -79,7 +79,7 @@ And each Journalist would only have to:
 Memorizing further passwords beyond the ones listed above is counterproductive:
 an attacker with access to any of those environments would be able to pivot to
 anything they wish to access, and increasing the burden of keeping track of
-additional credentials is unpleasant for journalists and administrators and
+additional credentials is unpleasant for journalists and admins and
 increases the risk that they will either forget their credentials, compromising
 the availability of the system, or compensate for the difficulty by using weak
 or reused credentials, potentially compromising the security of the system.

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -216,7 +216,7 @@ While FDE can be useful in some cases, we currently do not recommend
 that you enable it because there are not many scenarios where it will be
 a net security benefit for SecureDrop operators. Doing so will introduce
 the need for more passwords and add even more responsibility on the
-administrator of the system (see `this GitHub
+admin of the system (see `this GitHub
 issue <https://github.com/freedomofpress/securedrop/issues/511#issuecomment-50823554>`__
 for more information).
 
@@ -225,7 +225,7 @@ installation option that says *Guided - use entire disk and set up LVM*.
 
 However, if you decide to go ahead and enable FDE, please note that
 doing so means SecureDrop will become unreachable after an automatic
-reboot. An administrator will need to be on hand to enter the password
+reboot. An admin will need to be on hand to enter the password
 in order to decrypt the disks and complete the startup process, which
 will occur anytime there is an automatic software update, and also
 several times during SecureDrop's installation. We recommend that the
@@ -235,7 +235,7 @@ receive an alert when the system becomes unavailable.
 To enable FDE, select *Guided - use entire disk and set up encrypted
 LVM* during the disk partitioning step and write the changes to disk.
 Follow the recommendations as to choosing a strong password. As the
-administrator, you will be responsible for keeping this passphrase safe.
+admin, you will be responsible for keeping this passphrase safe.
 Write it down somewhere and memorize it if you can. **If inadvertently
 lost it could result in total loss of the SecureDrop system.**
 

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -148,7 +148,7 @@ To use the template:
 	     file used to protect the database.
 
 In case you wish to manually create a database, the suggested password fields in
-the administrator template are:
+the admin template are:
 
 **Administrator**:
 

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -39,13 +39,13 @@ Application Server
 The *Application Server* runs the SecureDrop application. This server hosts both
 the website that sources access (the *Source Interface*) and the website that
 journalists access (the *Journalist Interface*). Sources, journalists, and
-administrators may only connect to this server using Tor.
+admins may only connect to this server using Tor.
 
 Monitor Server
 --------------
 
 The *Monitor Server* keeps track of the *Application Server* and sends out an
-email alert if something seems wrong. Only system administrators connect
+email alert if something seems wrong. Only system admins connect
 to this server, and they may only do so using Tor.
 
 Source Interface
@@ -85,9 +85,9 @@ Instructions for using the *Journalist Workstation* are available in our
 Admin Workstation
 -----------------
 
-The *Admin Workstation* is a machine that the system administrator can
+The *Admin Workstation* is a machine that the system admin can
 use to connect to the *Application Server* and the *Monitor Server* using Tor
-and SSH. The administrator will also need to have an Android or iOS
+and SSH. The admin will also need to have an Android or iOS
 device with the Google Authenticator app installed.
 
 Secure Viewing Station

--- a/docs/upgrade_to_tails_3x.rst
+++ b/docs/upgrade_to_tails_3x.rst
@@ -111,13 +111,13 @@ mounted and ready to access.
 
 |Backup and TailsData Mounted|
 
-Open a Nautilus window with administrator privileges by going to
+Open a Nautilus window with admin privileges by going to
 **Applications** ▸ **System Tools** ▸ **Terminal**.
 
 |Open Terminal|
 
 Type ``gksu nautilus`` at the terminal prompt and hit enter. You'll need to type
-your administrator password.
+your admin password.
 
 |Start gksu nautilus|
 
@@ -126,9 +126,9 @@ your administrator password.
   complains that it can't create a required folder. If that happens, just click
   OK and continue normally.
 
-  If a Nautilus window *doesn't* come up, it might be because an administrator
+  If a Nautilus window *doesn't* come up, it might be because an admin
   password wasn't set. If that's the case, you'll need to restart and set an
-  administrator password before continuing.
+  admin password before continuing.
 
 .. warning::
             Make sure you use keep the `Terminal` window open while you perform


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #2332 

Use the word *admin* everywhere in the documentation.

## Testing

Make the docs locally, and read.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [x] Doc linting passed locally
