### PR TITLE
Modify ossec syscheck configuration to run syscheck every 7h and scan /boot

### DIFF
--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -5,7 +5,7 @@
 
   <syscheck>
     <alert_new_files>yes</alert_new_files>
-
+    <frequency>25200</frequency>
     <!-- Directories to check  (perform all possible verifications) -->
     <directories realtime="yes" check_all="yes" report_changes="yes">/etc,/usr/bin,/usr/sbin</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/bin,/sbin</directories>
@@ -15,6 +15,8 @@
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/securedrop</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/tor/services/hostname</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/tor/lock</directories>
+    <directories realtime="yes" check_all="yes" report_changes="yes">/boot</directories>
+
 
     <!-- Files/directories to ignore -->
     <ignore>/var/lib/tor/services/source/private_keys</ignore>

--- a/install_files/securedrop-ossec-server/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-server/var/ossec/etc/ossec.conf
@@ -8,11 +8,12 @@
 
   <syscheck>
     <alert_new_files>yes</alert_new_files>
-
+    <frequency>25200</frequency>
     <!-- Directories to check  (perform all possible verifications) -->
     <directories realtime="yes" check_all="yes" report_changes="yes">/etc,/usr/bin,/usr/sbin</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/bin,/sbin</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/ossec</directories>
+    <directories realtime="yes" check_all="yes" report_changes="yes">/boot</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/var/ossec/queue</ignore>

--- a/testinfra/mon/test_network.py
+++ b/testinfra/mon/test_network.py
@@ -7,7 +7,7 @@ from jinja2 import Template
 securedrop_test_vars = pytest.securedrop_test_vars
 
 
-@pytest.mark.xfail(strict=True)
+@pytest.mark.xfail()
 def test_mon_iptables_rules(SystemInfo, Command, Sudo):
 
     # Build a dict of variables to pass to jinja for iptables comparison

--- a/testinfra/mon/test_ossec.py
+++ b/testinfra/mon/test_ossec.py
@@ -20,7 +20,6 @@ def test_ossec_package(Package, package):
     assert Package(package).is_installed
 
 
-@pytest.mark.xfail(strict=True)
 def test_ossec_connectivity(Command, Sudo):
     """
     Ensure ossec-server machine has active connection to the ossec-agent.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2495 , #2496 .

1. Modified ossec syscheck config to run every 7h to ensure files are properly scanned.
2. Modify ossec syscheck config to monitor integrity of files in /boot.
3. Modified infra tests for mon similar to https://github.com/freedomofpress/securedrop/pull/2490

## Testing

- Ensure syscheck scans every 7h by observing logs in `/var/ossec/logs/ossec.log`
- Ensure syscheck scans files in `/boot` by observing logs in:
    -  `/var/ossec/queue/syscheck/syscheck` for `mon`
    - `/var/ossec/queue/syscheck/($APP_HOST)$APP_IP->syscheck` for `app`
- Ensure the above works when updating existing SecureDrop installs (TODO)

## Deployment

New SecureDrop installs will use this updated configuration upon install.
Existing SecureDrop installs (this has not yet been tested) will need the configuration to be updated via apt.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- :white_check_mark:  [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
