### PR TITLE
fixed a small, but important typo in the mac mini section

### DIFF
--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -312,7 +312,7 @@ Mac Minis
 Other than the NUCs we also recommend the 2014 Apple Mac Minis (part number MGEM2)
 for installing SecureDrop. Mac Minis have removable wireless cards that you
 should remove. This requires a screwdriver for non-standard
-`T6 Torx security screws <https://www.amazon.com/Mini-Torx-Security-Screwdriver-Tool/dp/B01BG8P2Q6>`__.
+`TR6 Torx security screws <https://www.amazon.com/Mini-Torx-Security-Screwdriver-Tool/dp/B01BG8P2Q6>`__.
 
 However, on the first install of Ubuntu Server
 the Mac Minis will not boot: this is a known and


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The T6 Tox screwdriver will not open the 2014 Mac Mini models so admins will not be able to remove the internal speakers without this change. We link to the proper model to purchase online but since many hardware kits contain T6 and not TR6, this could lead to confusion. 

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
