### PR TITLE
rebase-develop.sh: use a specific remote for upstream rebasing

### DIFF
--- a/devops/scripts/rebase-develop.sh
+++ b/devops/scripts/rebase-develop.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 # If current branch is not master or doesnt start with release...
 if [[ "$CIRCLE_BRANCH" != "master"  && "$CIRCLE_BRANCH" != release*  ]]; then
@@ -9,9 +9,12 @@ if [[ "$CIRCLE_BRANCH" != "master"  && "$CIRCLE_BRANCH" != release*  ]]; then
   git config --global user.email "ci@freedom.press"
   git config --global user.name "CI User"
 
+  # Ensure presensce of upstream remote
+  git ls-remote --exit-code --quiet upstream 2>/dev/null || git remote add upstream https://github.com/freedomofpress/securedrop.git
+
   # Fetch and rebase onto the latest in develop
-  git fetch origin develop
-  git rebase origin/develop
+  git fetch upstream develop
+  git rebase upstream/develop
 
   # Print out the current head for debugging potential CI issues
   git rev-parse HEAD


### PR DESCRIPTION
## Status
Ready for review

## Description of Changes
This change modifies this rebasing script to use the published code instead of what 'origin' may be for a user.

## Testing

circle docs-lint job

## Deployment
N/A

## Checklist
N/A