### PR TITLE
ci: ci improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,11 +68,58 @@ jobs:
       - store_artifacts:
           path: /root/sd/junit
 
+  staging-test-with-rebase:
+    docker:
+      - image: quay.io/freedomofpress/circleci-docker:latest
+        environment:
+          FPF_CI: true
+          CI_SD_ENV: staging
+          CI_AWS_TYPE: t2.medium
+          FPF_GRSEC: false
+          TEST_REPORTS: /root/sd
+    working_directory: ~/sd
+
+    steps:
+
+      - checkout
+
+      - run:
+          name: Installation pre-reqs
+          command: pip install -U -r ./testinfra/requirements.txt
+
+      - run:
+          name: Check Python dependencies for CVEs
+          command: make safety
+
+      - setup_remote_docker
+
+      - run:
+          name: Run Debian builds
+          command: make build-debs
+
+      - run:
+          name: Provision staging servers and run tests
+          command: make ci-go
+
+      - run:
+          name: Ensure environment torn down
+          command: molecule destroy -s aws
+          when: on_fail
+
+      - store_test_results:
+          path: /root/sd/junit
+
+      - store_artifacts:
+          path: /root/sd/junit
+
 workflows:
   version: 2
   securedrop_ci:
     jobs:
       - docs-lint
       - staging-test:
+          requires:
+            - docs-lint
+      - staging-test-with-rebase:
           requires:
             - docs-lint

--- a/devops/scripts/rebase-develop.sh
+++ b/devops/scripts/rebase-develop.sh
@@ -9,9 +9,12 @@ if [[ "$CIRCLE_BRANCH" != "master"  && "$CIRCLE_BRANCH" != release*  ]]; then
   git config --global user.email "ci@freedom.press"
   git config --global user.name "CI User"
 
+  # Ensure presensce of upstream remote
+  git ls-remote --exit-code --quiet upstream 2>/dev/null || git remote add upstream https://github.com/freedomofpress/securedrop.git
+
   # Fetch and rebase onto the latest in develop
-  git fetch origin develop
-  git rebase origin/develop
+  git fetch upstream develop
+  git rebase upstream/develop
 
   # Print out the current head for debugging potential CI issues
   git rev-parse HEAD


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Make rebasing in ci be more specific about the upstream.
* Skips ec2 tests in forks (ec2 tests will likely fail in forks anyways).
* Perform rebasing in a separate job - this separation makes build failures more actionable.

## Testing

circle job

## Deployment
N/A

## Checklist
N/A