### PR TITLE
l10n: add SUPPORTED_LOCALES to sdconfig

### DIFF
--- a/install_files/ansible-base/roles/app/defaults/main.yml
+++ b/install_files/ansible-base/roles/app/defaults/main.yml
@@ -99,3 +99,5 @@ worker_logs_dir: /var/log/securedrop_worker
 
 # The locale used when the browser or the user do not have a preference
 securedrop_default_locale: en_US
+# The subset of the available locales that will be proposed to the user
+securedrop_supported_locales: []

--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -189,3 +189,12 @@
   when: db.stat.exists
   tags:
     - securedrop_config
+
+- name: Update SUPPORTED_LOCALES in config.py
+  blockinfile:
+    content: "SUPPORTED_LOCALES = {{ securedrop_supported_locales + ['en_US'] }}"
+    path: "{{ securedrop_code }}/config.py"
+    marker: "# {mark} subset of the available locales that will be proposed to the user"
+  when: securedrop_supported_locales is defined
+  tags:
+    - securedrop_config

--- a/install_files/ansible-base/roles/validate/files/validate-supported-locales.sh
+++ b/install_files/ansible-base/roles/validate/files/validate-supported-locales.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Verifies a all arguments match a translation directory
+#
+# Exit codes
+# 0 - all arguments match a translation directory
+# 1 - otherwise
+
+for translation in $1 ; do
+    if test "$translation" = en || test "$translation" = en_US ; then
+        continue
+    fi
+    directory="securedrop/translations/$translation"
+    if ! test -d "../../$directory" ; then
+        echo "$directory does not exist"
+        exit 1
+    fi
+done

--- a/install_files/ansible-base/roles/validate/tasks/main.yml
+++ b/install_files/ansible-base/roles/validate/tasks/main.yml
@@ -3,6 +3,8 @@
 #credentials are not used when running the app and mon playbooks for
 #production.
 
+- include: validate_supported_locales.yml
+
 - include: validate_users.yml
 
 - include: validate_gpg_info.yml

--- a/install_files/ansible-base/roles/validate/tasks/validate_supported_locales.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_supported_locales.yml
@@ -1,0 +1,4 @@
+---
+- name: Verify supported locales exist
+  script: validate-supported-locales.sh "{{ securedrop_supported_locales | join(' ') }}"
+  changed_when: false

--- a/install_files/ansible-base/securedrop-configure.yml
+++ b/install_files/ansible-base/securedrop-configure.yml
@@ -110,6 +110,12 @@
       default: ""
       private: yes
 
+    - name: securedrop_supported_locales
+      # the list is from the securedrop/translations repository
+      prompt: Space separated list of additional locales to support (ar de_DE en_US es_ES fr_FR nb_NO nl)
+      default: ""
+      private: no
+
   pre_tasks:
     - debug:
         msg: >-
@@ -175,6 +181,8 @@
           var_value: "{{ sasl_password }}"
         - var_name: securedrop_app_https_on_source_interface
           var_value: "{{ securedrop_app_https_on_source_interface | bool}}"
+        - var_name: securedrop_supported_locales
+          var_value: "{% if securedrop_supported_locales is string %}{{ securedrop_supported_locales.split() | to_yaml }}{% else %}{{ securedrop_supported_locales | to_yaml }}{% endif %}"
 
 - name: Validate site-specific information.
   hosts: localhost

--- a/securedrop/config.py.example
+++ b/securedrop/config.py.example
@@ -84,9 +84,6 @@ TEMP_DIR = os.path.join(SECUREDROP_DATA_ROOT, "tmp")
 DATABASE_ENGINE = 'sqlite'
 DATABASE_FILE = os.path.join(SECUREDROP_DATA_ROOT, 'db.sqlite')
 
-# A selection of the available locales (optional, defaults to all available
-# locales).
-#SUPPORTED_LOCALES = ['en_US', 'fr_FR', 'nb_NO']
 # Which of the available locales should be displayed by default ?
 DEFAULT_LOCALE = 'en_US'
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2516

Allow the sysadmin installing (or updating) SecureDrop to specify the
content of the SUPPORTED_LOCALES variable when running

   ./securedrop-admin sdconfig

The updated value from the site-specific file will override the value
in config.py in the same way DEFAULT_LOCALE is overriden.

The list of locales entered via sdconfig is validated to match
existing directories from the securedrop/translations directory.

## Testing

### Development VM

For each test case below repeat the following:

* ./securedrop-admin -d sdconfig
* enter the value when prompted for **Space separated list of supported locales**
* the validation will fails because it is not Tails but validation of **securedrop_supported_locales** is done
* ANSIBLE_ARGS="--tags securedrop_config" vagrant provision development
* verify that the task **Update SUPPORTED_LOCALES in config.py** runs successfully
* verify that securedrop/config.py has a SUPPORTED_LOCALES setting matching install_files/ansible-base/group_vars/all/site-specific
* remove the **securedrop_supported_locales** line in install_files/ansible-base/group_vars/all/site-specific

Test cases:

* empty string => securedrop_supported_locales: [] => passes validation
* ar     fr_FR (separated by multiple white space) => [ar, fr_FR] => passes validation
* foobar ar => [foobar, ar] => fails validation on foobar

### Verifying it applies to config.py post installation from packages

* make build-debs
* vagrant up /staging/
* vagrant ssh app-staging
* get the config.py file
* verify the value of SUPPORTED_LOCALES in config.py is consistent with the tests done in **Development VM** above

## Deployment

The variable **SUPPORTED_LOCALES** is added to config.py (when it exists or when it is new). 

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
