### PR TITLE
Improved page responsiveness and buttons clarity for source interface

### DIFF
--- a/securedrop/sass/_base.sass
+++ b/securedrop/sass/_base.sass
@@ -224,7 +224,7 @@
     .attachment
       background-color: $color_grey_xlight
       padding: 12px
-      width: 330px
+      width: 100%
       display: inline-block
       vertical-align: top
 
@@ -241,7 +241,7 @@
     .message
       display: inline-block
       vertical-align: top
-      width: 401px
+      width: 100%
       background: white
       overflow: hidden
 

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -98,7 +98,7 @@ html
       overflow: visible
 
 input.codename-box
-  width: 400px
+  width: 100%
   padding: 10px
   font-weight: bold
 

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -39,12 +39,12 @@
 <div class="pull-right">
 <form id="create-form" method="post" action="/create" autocomplete="off">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-  <a id="already-have-codename" href="{{ url_for('main.login') }}" class="sd-button btn secondary">{{ gettext('ALREADY HAVE A CODENAME?') }}</a>
   <button type="submit" class="sd-button btn primary" id="continue-button">
     <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-white.png') }}" width="17px" height="17px">
     <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-blue.png') }}" width="17px" height="17px">
-     {{ gettext('CONTINUE') }}
+     {{ gettext('USE NEW CODENAME') }}
   </button>
+  <a id="already-have-codename" href="{{ url_for('main.login') }}" class="sd-button btn secondary">{{ gettext('USE EXISTING CODENAME') }}</a>
 </form>
 </div>
 {% endblock %}

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -17,12 +17,12 @@
 </p>
 
 <div class="pull-right">
-  <a href="{{ url_for('main.index') }}" class="sd-button btn secondary" id="cancel">{{ gettext('CANCEL') }}</a>
   <button type="submit" class="sd-button btn primary" id="login">
     <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-white.png') }}" width="18px" height="18px">
     <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-blue.png') }}" width="18px" height="18px">
     {{ gettext('CONTINUE') }}
   </button>
+  <a href="{{ url_for('main.index') }}" class="sd-button btn secondary" id="cancel">{{ gettext('CANCEL') }}</a>
 </div>
 
 </form>

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -39,12 +39,12 @@
 
   <hr class="no-line">
   <div class="pull-right">
-    <a href="{{ url_for('main.lookup') }}" class="btn secondary" id="cancel">{{ gettext('CANCEL') }}</a>
     <button type="submit" class="sd-button btn primary" id="submit-doc-button">
       <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-white.png') }}" width="20px" height="14px">
       <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/cloud-upload-blue.png') }}" width="20px" height="14px">
       {{ gettext('SUBMIT') }}
     </button>
+    <a href="{{ url_for('main.lookup') }}" class="btn secondary" id="cancel">{{ gettext('CANCEL') }}</a>
   </div>
 </form>
 

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -95,7 +95,7 @@ class TestSourceApp(TestCase):
            if they already have a codename, rather than create a new one.
         """
         resp = self.client.get('/generate')
-        self.assertIn("ALREADY HAVE A CODENAME?", resp.data)
+        self.assertIn("USE EXISTING CODENAME", resp.data)
         soup = BeautifulSoup(resp.data, 'html.parser')
         already_have_codename_link = soup.select('a#already-have-codename')[0]
         self.assertEqual(already_have_codename_link['href'], '/login')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

- Percent widths added to non-responsive elements in the source interface.
<img width="335" alt="securedrop___protecting_journalists_and_sources" src="https://user-images.githubusercontent.com/4096005/32421529-79303202-c24e-11e7-84f3-668af495da1b.png">

- In codename generation page, buttons changed from “Continue” and "Already have a codename?" to "Use new codename" and "Use existing codename" for clarity.
<img width="332" alt="securedrop___protecting_journalists_and_sources" src="https://user-images.githubusercontent.com/4096005/32421641-7d865c5e-c24f-11e7-9cb0-b9768bea645a.png">


- Primary buttons (“Submit”, “Continue”, “Use New Codename”) in the source interface are now before the secondary buttons. This lends proximity between the content of pages and the primary action.
<img width="326" alt="image" src="https://user-images.githubusercontent.com/4096005/32421664-9e4d2b0c-c24f-11e7-88d0-4a4fdbf6b86c.png">
_Above: Text field is now responsive and buttons have been reversed so "Continue" is next to field rather than "Cancel"_


## Testing

I'm mainly concerned about the changes to classes ".message" and ".attachment" in _base.css. I'm not sure if they are used anywhere else in the application other than for the document submission form.

## Deployment
None

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
