### PR TITLE
Fix broken link in threat model doc

### DIFF
--- a/docs/development/threat_model.rst
+++ b/docs/development/threat_model.rst
@@ -2,13 +2,12 @@ Threat Model
 ============
 
 This document outlines the threat model for SecureDrop 0.3 and is
-inspired by the `threat model document Adam Langley wrote for Pond
-<https://web-beta.archive.org/web/20150913065100/https://pond.imperialviolet.org/threat.html>`__.
-The threat model
-is defined in terms of what each possible adversary can achieve. This
-document is still a work in progress. If you have questions or comments,
-please open an issue on GitHub or send an email to
-securedrop@freedom.press.
+inspired by a `document Adam Langley wrote for Pond
+<https://web.archive.org/web/20150326154506/https://pond.imperialviolet.org/threat.html>`__.
+The threat model is defined in terms of what each possible adversary
+can achieve. This document is still a work in progress. If you have
+questions or comments, please open an issue on GitHub or send an email
+to securedrop@freedom.press.
 
 Assumptions
 -----------


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2520

Changes proposed in this pull request:

Fixed the broken link, and slightly reworded the text.

## Testing
Does the link work?

- [x] Doc linting passed locally
