### PR TITLE
i18n: add the l param to existing params

### DIFF
--- a/securedrop/journalist_templates/locales.html
+++ b/securedrop/journalist_templates/locales.html
@@ -6,7 +6,11 @@
       {% if locale == g.locale %}
         {{ g.locales[locale] }}
       {% else %}
-        <a href="?l={{ locale }}" rel="nofollow">{{ g.locales[locale] }}</a>
+        {% set args = {} %}
+        {% set _ = args.update(request.args or {}) %}
+        {% set _ = args.update(request.view_args or {}) %}
+        {% set _ = args.update({'l': locale}) %}
+        <a href="{{ url_for(request.endpoint or 'main.index', **args) }}" rel="nofollow">{{ g.locales[locale] }}</a>
       {% endif %}
       </li>
     {% endfor %}

--- a/securedrop/source_templates/locales.html
+++ b/securedrop/source_templates/locales.html
@@ -6,7 +6,11 @@
       {% if locale == g.locale %}
         {{ g.locales[locale] }}
       {% else %}
-        <a href="?l={{ locale }}" rel="nofollow">{{ g.locales[locale] }}</a>
+        {% set args = {} %}
+        {% set _ = args.update(request.args or {}) %}
+        {% set _ = args.update(request.view_args or {}) %}
+        {% set _ = args.update({'l': locale}) %}
+        <a href="{{ url_for(request.endpoint or 'main.index', **args) }}" rel="nofollow">{{ g.locales[locale] }}</a>
       {% endif %}
       </li>
     {% endfor %}

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -112,13 +112,18 @@ class TestI18N(object):
                 ''').strip() == translated_ar
 
         with app.test_client() as c:
-            c.get('/')
+            page = c.get('/login')
             assert session.get('locale') is None
             assert not_translated == gettext(not_translated)
+            assert '?l=fr_FR' in page.data
+            assert '?l=en_US' not in page.data
 
-            c.get('/?l=fr_FR', headers=Headers([('Accept-Language', 'en_US')]))
+            page = c.get('/login?l=fr_FR',
+                         headers=Headers([('Accept-Language', 'en_US')]))
             assert session.get('locale') == 'fr_FR'
             assert translated_fr == gettext(not_translated)
+            assert '?l=fr_FR' not in page.data
+            assert '?l=en_US' in page.data
 
             c.get('/', headers=Headers([('Accept-Language', 'en_US')]))
             assert session.get('locale') == 'fr_FR'

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1137,6 +1137,30 @@ class TestJournalistApp(TestCase):
         # Verify the source is not starred
         self.assertFalse(source_1.star.starred)
 
+    def test_render_locales(self):
+        """the locales.html template must collect both request.args (l=XX) and
+        request.view_args (/<filesystem_id>) to build the URL to
+        change the locale
+
+        """
+        supported = getattr(config, 'SUPPORTED_LOCALES', None)
+        try:
+            if supported:
+                del config.SUPPORTED_LOCALES
+            config.SUPPORTED_LOCALES = ['en_US', 'fr_FR', 'ar']
+
+            source, _ = utils.db_helper.init_source()
+            self._login_user()
+
+            url = url_for('col.col', filesystem_id=source.filesystem_id)
+            resp = self.client.get(url + '?l=fr_FR')
+            self.assertNotIn('?l=fr_FR', resp.data)
+            self.assertIn(url + '?l=en_US', resp.data)
+
+        finally:
+            if supported:
+                config.SUPPORTED_LOCALES = supported
+
 
 class TestJournalistLogin(unittest.TestCase):
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2517

The l param to switch languages must not clobber existing params
when they exist.

## Testing

* add **SUPPORTED_LOCALES = ['ar', 'en_US']** to config.py
* vagrant ssh development
* cd /vagrant/securedrop
* ./manage.py run
* firefox http://locahost:8081
* change language by clicking the links
* firefox http://locahost:8080
* change language by clicking the links

## Deployment

Only UX change, no impact on deployment.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
