### PR TITLE
source: fix regression on /generate page display

### DIFF
--- a/securedrop/sass/_base.sass
+++ b/securedrop/sass/_base.sass
@@ -224,7 +224,9 @@
     .attachment
       background-color: $color_grey_xlight
       padding: 12px
-      width: 100%
+      width: 330px
+      @media only screen and (max-width: 815px)
+        width: 100%
       display: inline-block
       vertical-align: top
 
@@ -241,7 +243,9 @@
     .message
       display: inline-block
       vertical-align: top
-      width: 100%
+      width: 401px
+      @media only screen and (max-width: 815px)
+        width: 100%
       background: white
       overflow: hidden
 
@@ -249,8 +253,9 @@
         vertical-align: top
         display: block
         padding: 10px
-        min-width: 406px
-        max-width: 406px
+        width: 406px
+        @media only screen and (max-width: 815px)
+          width: 100%
         min-height: 168px
         border: none
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2540

22de405cb78d2a2cb9bb7c6eff55be4c55afa68c improved the display of the
/generate page on mobile. Unfortunately it also introduced a
regression when the screen is large enough to accomodate the
.attachement and .message blocks next to each other: the message block
only occupies half the space. The user would be confused and click on
the right size of the block, doing nothing instead of focusing on the
text area.

Conditionally activate the mobile display if the viewport has a size
of 768px maximum. This is consistent with a similar adaptation
introduced for the index page in _source_index.sass file

## Testing

* vagrant ssh development
* cd /vagrant/securedrop ; ./manage.py run
* firefox http;//localhost:8080/generate
* shrink the window size until the .attachement and .message block are on top of each other
* verify the .message block occupies 100% of the width

## Deployment

User interface only, no deployment considerations.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
