### PR TITLE
Update AppArmor profiles for Apache

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -72,6 +72,7 @@
   /proc/ r,
   /proc/*/mounts r,
   /proc/*/stat r,
+  /proc/*/status r,
   /proc/sys/kernel/random/entropy_avail r,
   /run/apache2/apache2.pid rw,
   /run/apache2/wsgi.*.lock rwk,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #2456. Closes #2507.

Updates the AppArmor profile for Apache to prevent spurious alerts. 

## Testing

### Reproduce existing alert

0. Checkout `develop`
1. Provision staging VMs and `vagrant ssh app-staging` 
2. `tail -f /var/log/syslog`
2. Go to journalist interface.
3. You should see the same alerts described in #2456 and #2507. 

### Test the fix in this PR

0. Checkout this PR
1. Provision staging VMs and `vagrant ssh app-staging` 
2. `tail -f /var/log/syslog`
2. Go to journalist interface.
3. You should _not_ see unusual AppArmor alerts.

## Deployment

Changes here will be delivered in `securedrop-app-code` package. 

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
