### PR TITLE
Enable vnc in containerized test and dev

### DIFF
--- a/securedrop/Dockerfile
+++ b/securedrop/Dockerfile
@@ -10,6 +10,7 @@ RUN gem install sass -v 3.4.23
 # test requirements:
 RUN apt-get install -y firefox
 RUN apt-get install -y git xvfb haveged curl gettext paxctl
+RUN apt-get install -y x11vnc
 
 # pinned firefox version for selenium compatibility. See bd795e2f5865b4f6e6e1b88bcbbacef704675c74
 ENV FIREFOX_CHECKSUM=88d25053306d33658580973b063cd459a56e3596a3a298c1fb8ab1d52171d860
@@ -50,5 +51,6 @@ RUN make test-config
 RUN ./manage.py reset
 
 EXPOSE 8080 8081
+EXPOSE 5901
 
 CMD ["./manage.py", "run"]

--- a/securedrop/bin/dev
+++ b/securedrop/bin/dev
@@ -1,10 +1,13 @@
 #!/bin/bash
+export DISPLAY=:1
 Xvfb :1 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &
 haveged &
 redis-server &
 
 rm /dev/random
 ln -s /dev/urandom /dev/random
+
+x11vnc -display :1 -autoport 5901 -shared &
 
 make config.py
 ./manage.py run

--- a/securedrop/bin/test
+++ b/securedrop/bin/test
@@ -10,6 +10,8 @@ echo -n 4096 > /proc/sys/kernel/random/write_wakeup_threshold
 rm /dev/random
 ln -s /dev/urandom /dev/random
 
+x11vnc -display :1 -autoport 5901 -shared &
+
 touch tests/log/firefox.log
 function cleanup {
   cp tests/log/firefox.log /tmp/test-results/logs/


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Depends on #2523 (should be rebased once that lands).

Adds x11vnc on port 5901 for test and dev environments to aid in debugging selenium tests.

## Testing

Connect a vnc client to :5901 when running dev container via 'make images dev'

## Deployment
N/A

## Checklist
N/A