### PR TITLE
i18n: manage.py translate --extract needs journalist_app

### DIFF
--- a/securedrop/babel.cfg
+++ b/securedrop/babel.cfg
@@ -4,6 +4,9 @@ silent=False
 [python: source_app/*.py]
 silent=False
 
+[python: journalist_app/*.py]
+silent=False
+
 [jinja2: */*.html]
 silent=False
 extensions=jinja2.ext.autoescape,jinja2.ext.with_,webassets.ext.jinja2.AssetsExtension

--- a/securedrop/translations/ar/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ar/LC_MESSAGES/messages.po
@@ -1217,40 +1217,14 @@ msgstr ""
 msgid "Back to submission page"
 msgstr "الرجوع الى صفحة الارسال"
 
-#~ msgid "{source_name}'s collection deleted"
-#~ msgstr "تم حذف مجموعة {source_name}"
 
-#~ msgid "Edit Account"
-#~ msgstr "تعديل حساب"
 
-#~ msgid "Learn how to set it to high"
-#~ msgstr "تعرف على كيفية الضبط للأعلى"
 
-#~ msgid ", or ignore this warning to continue."
-#~ msgstr "، أو تجاهل هذا التنبيه للمتابعة."
 
-#~ msgid ""
-#~ "<strong>We recommend using Tor Browser to access SecureDrop:</strong>"
-#~ msgstr ""
-#~ "<strong>نوصي باستخدام متصفح تور Tor Browser للوصول إلى Securedrop:</"
-#~ "strong>"
 
-#~ msgid "Learn how to install it"
-#~ msgstr "تعرف على كيفية تثبيته"
 
-#~ msgid "Click the"
-#~ msgstr "انقر على"
 
-#~ msgid "Tor icon in the toolbar above"
-#~ msgstr "أيقونة تور Tor في شريط الأدوات أعلاه"
 
 #, fuzzy
-#~| msgid "No collections selected to delete!"
-#~ msgid "No collections selected for deletion!"
-#~ msgstr "لم يتم تحديد مجموعات للحذف!"
 
-#~ msgid "Two-factor token failed to verify"
-#~ msgstr "أخفق التحقق من الرمز المكون من عاملين"
 
-#~ msgid "Two-factor token successfully verified!"
-#~ msgstr "تم التحقق بنجاح من الرمز المكون من عاملين!"

--- a/securedrop/translations/de_DE/LC_MESSAGES/messages.po
+++ b/securedrop/translations/de_DE/LC_MESSAGES/messages.po
@@ -1271,61 +1271,20 @@ msgstr ""
 msgid "Back to submission page"
 msgstr "Zurück zur Einreichungsseite"
 
-#~ msgid "{source_name}'s collection deleted"
-#~ msgstr "{source_name}s Sammlung wird gelöscht"
 
-#~ msgid "Edit Account"
-#~ msgstr "Konto Bearbeiten"
 
-#~ msgid "Learn how to set it to high"
-#~ msgstr "Lernen Sie, wie sie es auf 'hoch' setzen"
 
-#~ msgid ", or ignore this warning to continue."
-#~ msgstr ", oder ignorieren Sie diese Warnung, um fortzufahren."
 
-#~ msgid ""
-#~ "<strong>We recommend using Tor Browser to access SecureDrop:</strong>"
-#~ msgstr ""
-#~ "<strong>Wir empfehlen, den Tor-Browser zu nutzen, um auf SecureDrop "
-#~ "zuzugreifen:</strong>"
 
-#~ msgid "Learn how to install it"
-#~ msgstr "Lernen Sie, wie die Installation funktioniert"
 
-#~ msgid "Click the"
-#~ msgstr "anklicken"
 
-#~ msgid "Tor icon in the toolbar above"
-#~ msgstr "Tor-Symbol in der obenstehenden Werkzeugleiste"
 
-#~ msgid "No collections selected for deletion!"
-#~ msgstr "Es sind keine Sammlungen zum Löschen ausgewählt!"
 
-#~ msgid "{n} second"
-#~ msgid_plural "{n} seconds"
-#~ msgstr[0] "{n} Sekunde"
-#~ msgstr[1] "{n} Sekunden"
 
-#~ msgid "a minute"
-#~ msgstr "eine Minute"
 
-#~ msgid "{n} minutes"
-#~ msgstr "{n} Minuten"
 
-#~ msgid "an hour"
-#~ msgstr "eine Stunde"
 
-#~ msgid "{n} hours"
-#~ msgstr "{n} Stunden"
 
-#~ msgid "a day"
-#~ msgstr "ein Tag"
 
-#~ msgid "{n} days"
-#~ msgstr "{n} Tage"
 
-#~ msgid "Logout"
-#~ msgstr "Abmelden"
 
-#~ msgid "EXIT"
-#~ msgstr "EXIT"

--- a/securedrop/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/securedrop/translations/fr_FR/LC_MESSAGES/messages.po
@@ -1271,64 +1271,21 @@ msgstr ""
 msgid "Back to submission page"
 msgstr "Revenir à la page d'envoi"
 
-#~ msgid "{source_name}'s collection deleted"
-#~ msgstr "La collection de {source_name} a été supprimée"
 
-#~ msgid "Edit Account"
-#~ msgstr "Modifier le compte"
 
-#~ msgid "Learn how to set it to high"
-#~ msgstr "Apprenez à le régler sur « Élevé »"
 
-#~ msgid ", or ignore this warning to continue."
-#~ msgstr "ou ignorez cet avertissement pour continuer."
 
-#~ msgid ""
-#~ "<strong>We recommend using Tor Browser to access SecureDrop:</strong>"
-#~ msgstr ""
-#~ "<strong>Nous recommandons d'utiliser le navigateur Tor pour accéder à "
-#~ "SecureDrop</strong>"
 
-#~ msgid "Learn how to install it"
-#~ msgstr "Apprenez à l'installer"
 
-#~ msgid "Click the"
-#~ msgstr "Cliquez sur l'"
 
-#~ msgid "Tor icon in the toolbar above"
-#~ msgstr "icône Tor dans la barre d'outil ci-dessus"
 
-#~ msgid "No collections selected for deletion!"
-#~ msgstr "Aucune collection n'a été sélectionnée pour être supprimée !"
 
-#~ msgid "{n} second"
-#~ msgid_plural "{n} seconds"
-#~ msgstr[0] "{n} seconde"
-#~ msgstr[1] "{n} secondes"
 
-#~ msgid "a minute"
-#~ msgstr "une minute"
 
-#~ msgid "{n} minutes"
-#~ msgstr "{n} minutes"
 
-#~ msgid "an hour"
-#~ msgstr "une heure"
 
-#~ msgid "{n} hours"
-#~ msgstr "{n} heures"
 
-#~ msgid "a day"
-#~ msgstr "un jour"
 
-#~ msgid "{n} days"
-#~ msgstr "{n} jours"
 
-#~ msgid "Logout"
-#~ msgstr "Déconnexion"
 
-#~ msgid "EXIT"
-#~ msgstr "QUITTER"
 
-#~ msgid "Edit user"
-#~ msgstr "Modifier l'utilisateur"

--- a/securedrop/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/securedrop/translations/nb_NO/LC_MESSAGES/messages.po
@@ -1284,64 +1284,21 @@ msgstr ""
 msgid "Back to submission page"
 msgstr "Tilbake til innsendelsesside"
 
-#~ msgid "{source_name}'s collection deleted"
-#~ msgstr "{source_name}s kildedata slettet"
 
-#~ msgid "Edit Account"
-#~ msgstr "Rediger konto"
 
-#~ msgid "Learn how to set it to high"
-#~ msgstr "Lær hvordan du setter nivået til Høyt"
 
-#~ msgid ", or ignore this warning to continue."
-#~ msgstr ", eller ignorer denne advarselen for å fortsette."
 
-#~ msgid ""
-#~ "<strong>We recommend using Tor Browser to access SecureDrop:</strong>"
-#~ msgstr ""
-#~ "<strong>Vi anbefaler at du bruker Tor-nettleseren for å koble til "
-#~ "SecureDrop:</strong>"
 
-#~ msgid "Learn how to install it"
-#~ msgstr "Lær hvordan du installerer den"
 
-#~ msgid "Click the"
-#~ msgstr "Klikk på"
 
-#~ msgid "Tor icon in the toolbar above"
-#~ msgstr "Tor-ikonet i verktøylinjen ovenfor"
 
-#~ msgid "No collections selected for deletion!"
-#~ msgstr "Ingen kildeoppføringer valgt for sletting."
 
-#~ msgid "{n} second"
-#~ msgid_plural "{n} seconds"
-#~ msgstr[0] "{n} sekund"
-#~ msgstr[1] "{n} sekunder"
 
-#~ msgid "a minute"
-#~ msgstr "ett minutt"
 
-#~ msgid "{n} minutes"
-#~ msgstr "{n} minutter"
 
-#~ msgid "an hour"
-#~ msgstr "én time"
 
-#~ msgid "{n} hours"
-#~ msgstr "{n} timer"
 
-#~ msgid "a day"
-#~ msgstr "én dag"
 
-#~ msgid "{n} days"
-#~ msgstr "{n} dager"
 
-#~ msgid "Logout"
-#~ msgstr "Logg ut"
 
-#~ msgid "EXIT"
-#~ msgstr "AVSLUTT"
 
-#~ msgid "Edit user"
-#~ msgstr "Rediger bruker"

--- a/securedrop/translations/nl/LC_MESSAGES/messages.po
+++ b/securedrop/translations/nl/LC_MESSAGES/messages.po
@@ -1257,75 +1257,25 @@ msgstr ""
 msgid "Back to submission page"
 msgstr "Terug naar inzendingenpagina"
 
-#~ msgid "{source_name}'s collection deleted"
-#~ msgstr "{source_name}s collectie verwijderd"
 
-#~ msgid "Edit Account"
-#~ msgstr "Wijzig Account"
 
-#~ msgid "Learn how to set it to high"
-#~ msgstr "Ontdek hoe je deze instelling op Hoog kan zetten"
 
-#~ msgid ", or ignore this warning to continue."
-#~ msgstr "of negeer deze waarschuwing en ga door."
 
-#~ msgid ""
-#~ "<strong>We recommend using Tor Browser to access SecureDrop:</strong>"
-#~ msgstr ""
-#~ "<strong>We raden aan om de Tor Browser te gebruiken om SecureDrop te "
-#~ "gebruiken:</strong>"
 
-#~ msgid "Learn how to install it"
-#~ msgstr "Ontdek hoe je de Tor Browser installeert"
 
-#~ msgid "Click the"
-#~ msgstr "Klik op"
 
-#~ msgid "Tor icon in the toolbar above"
-#~ msgstr "het Tor-icoon in de taakbalk bovenin"
 
 #, fuzzy
-#~| msgid "No collections selected to delete!"
-#~ msgid "No collections selected for deletion!"
-#~ msgstr "Geen collecties geselecteerd om te verwijderen!"
 
-#~ msgid "{n} second"
-#~ msgid_plural "{n} seconds"
-#~ msgstr[0] "{n} seconde"
-#~ msgstr[1] "{n} seconden"
 
-#~ msgid "a minute"
-#~ msgstr "een minuut"
 
-#~ msgid "{n} minutes"
-#~ msgstr "{n} minuten"
 
-#~ msgid "an hour"
-#~ msgstr "een uur"
 
-#~ msgid "{n} hours"
-#~ msgstr "{n} uur"
 
-#~ msgid "a day"
-#~ msgstr "een dag"
 
-#~ msgid "{n} days"
-#~ msgstr "{n} dagen"
 
-#~ msgid "Logout"
-#~ msgstr "Uitloggen"
 
 #, fuzzy
-#~ msgid "EXIT"
-#~ msgstr "UITGANG"
 
-#~ msgid "Edit user"
-#~ msgstr "Wijzig gebruiker"
 
-#~ msgid "Two-factor token failed to verify"
-#~ msgstr ""
-#~ "Beveiligingscode voor authenticatie in twee stappen kon niet geverifieerd "
-#~ "worden"
 
-#~ msgid "Two-factor token successfully verified!"
-#~ msgstr "Authenticatie in twee stappen succesvol geverifieerd!"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

babel.cfg needs to look into the journalist_app directory to catch strings to be translated

## Testing

* vagrant ssh development
* cd /vagrant/securedrop
* ./manage.py translate --extract-update

Look at the result in translations/messages.pot and verify strings from journalist_app/*.py are present.

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
