### PR TITLE
l10n: contributor credits

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,16 @@
+#
+# Normalization of contributors to the translation.
+#
+#   git log --pretty='%aN' securedrop/translations | sort -u
+#
+Alain-Olivier <french.coordinator@rbox.me>
+Eric H. <heartsucker@riseup.net>
+Jennifer Helsby <jen@freedom.press>
+Anna Skaja <annskaja@riseup.net>
+Beatrice Martini <mail@beatricemartini.it>
+Shih-Chieh Ilya Li <ilyaericlee@gmail.com>
+Benny Daon <bennydaon@gmail.com>
+Camille Fassett <camillefassett@gmail.com>
+Jean-Marc Manach <weblatesecuredrop@rewriting.net>
+A. Nonymous <noreply@weblate.org>
+A. Nonymous <noreply@weblate.org> <8pj8w9+49mls08deq3l4@sharklasers.com>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Normalize contributor credits.

## Testing

<pre>
$ git log --pretty='%aN' securedrop/translations/ | sort -u
Alain-Olivier
Ali
Allan Nordhøy
Anna Skaja
Anne M
A. Nonymous
Beatrice Martini
Benny Daon
Bernardo Tonasse
Camille Fassett
Chi-Hsun Tsai
Daniel Arauz
Eric H.
Ettore Atalan
Gabriele Kahlout
H.-L. Lee
Jasmine Khalil
Jean-Marc Manach
Jennifer Helsby
Jin Lin Wright
Jose
kwadronaut
Loic Dachary
Maria Ovsyannikova
Michal Čihař
Øyvind Bye Skille
Scharik yousif
Shih-Chieh Ilya Li
Thalia Rahme
Tiago Manuel Ventura Loureiro
Yarno Ritzen
</pre>

## Deployment

Credits only, no deployment.
