### PR TITLE
Remove random_seed spurious OSSEC alert on first install

### DIFF
--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -22,6 +22,7 @@
     <ignore>/var/lib/tor/services/journalist/client_keys</ignore>
     <ignore>/var/lib/tor/services/ssh/client_keys</ignore>
 
+    <ignore>/var/lib/securedrop/keys/random_seed</ignore>
     <ignore>/var/lib/securedrop/keys/pubring.gpg</ignore>
     <ignore>/var/lib/securedrop/keys/secring.gpg</ignore>
     <ignore>/var/lib/securedrop/keys/trustdb.gpg</ignore>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2596.

Changes proposed in this pull request:
 * Remove `random_seed` spurious alert on first install

## Testing

1. Make new debian packages via `make build-debs` and provision staging
2. Visit source interface and submit a test message
3. Verify that no `syscheck` OSSEC alerts related to `random_seed` appear in `/var/ossec/logs/alerts/alerts.log` on `mon`

## Deployment

Changes will be deployed in the `securedrop-ossec-agent` debian package. 

## Checklist

We have no testing for `syscheck` (see: #2134) so either inspect the diff manually or follow the test plan. 
