### PR TITLE
Remove OSSEC syscheck monitoring of temporary files produced by bulk download features

### DIFF
--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -27,7 +27,7 @@
     <ignore>/var/lib/securedrop/keys/trustdb.gpg</ignore>
     <ignore>/var/lib/securedrop/keys/trustdb.gpg</ignore>
 
-    <ignore type="sregex">/var/lib/securedrop/tmp/tmp_securedrop_bulk_\.+</ignore>
+    <ignore type="sregex">/var/lib/securedrop/tmp/tmp_securedrop_bulk_dl</ignore>
 
     <ignore>/var/lib/securedrop/store</ignore>
 


### PR DESCRIPTION
Modified `sregex` regular expression to match `/var/lib/securedrop/tmp/tmp_securedrop_bulk_dl` files. [Docs](https://ossec.github.io/docs/syntax/regex.html#os-match-sregex-syntax) state that the only characters permitted for `sregex` type is `^`, `$` and `|`.

## Status

Ready for review 
## Description of Changes

Fixes #1691.

## Testing
See https://github.com/freedomofpress/securedrop/issues/1691
- Deploy to staging
- Access source interface and submit more than one file
- Bulk download the files
- Repeat by adding new files and bulk downloading them
- `vagrant ssh mon-staging`, inspect `/var/ossec/queue/syscheck/\(app-staging\)\ 10.0.1.2-\>syscheck` and ensure that `tmp_securedrop_bulk_dl` files in `/var/lib/securedrop/tmp/` are not being tracked by syscheck.

## Deployment

A new ossec package will need to be published via apt repo.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ :white_check_mark: ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
note: `test_ossec_connectivity` test still fails despite list of agents returned is correct.
### If you made changes to documentation:

- [ ] Doc linting passed locally
