### PR TITLE
tests: squelch gnupg debug messages

### DIFF
--- a/docs/development/testing_application_tests.rst
+++ b/docs/development/testing_application_tests.rst
@@ -74,6 +74,13 @@ Some Selenium tests are decorated to produce before and after screenshots to aid
 in debugging. This behavior is enabled with the ``SCREENSHOTS_ENABLED`` environment
 variable. Output PNG files will be placed in the ``tests/log/`` directory.
 
+The `gnupg
+<https://pythonhosted.org/python-gnupg>`_ library can be quite verbose in its
+output. The default log level applied to this package is ``ERROR`` but this can
+be controlled via the ``GNUPG_LOG_LEVEL`` environment variable. It can have values
+such as ``INFO`` or ``DEBUG`` if some particular test case or test run needs
+greater verbosity.
+
 .. code:: sh
 
     SCREENSHOTS_ENABLED=1 pytest tests/functional/

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -3,7 +3,9 @@ import os
 import shutil
 import signal
 import subprocess
+import logging
 
+import gnupg
 import psutil
 import pytest
 
@@ -15,6 +17,14 @@ import config
 # It has been intentionally omitted from `config.py.example`
 # in order to isolate the test vars from prod vars.
 TEST_WORKER_PIDFILE = '/tmp/securedrop_test_worker.pid'
+
+# Quiet down gnupg output. (See Issue #2595)
+gnupg_logger = logging.getLogger(gnupg.__name__)
+gnupg_logger.setLevel(logging.ERROR)
+valid_levels = {'INFO': logging.INFO, 'DEBUG': logging.DEBUG}
+gnupg_logger.setLevel(
+   valid_levels.get(os.environ.get('GNUPG_LOG_LEVEL', None), logging.ERROR)
+)
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

Fixes #2595 

Changes proposed in this pull request:
separates gnupg logging level management from app verbosity.

## Testing

How should the reviewer test this PR?
run 
```sh
pytest -s -v
```
and compare to
```sh
GNUPG_LOG_LEVEL=INFO pytest -s -v
```

## Deployment
N/A
