### PR TITLE
tests: one rqworker per session is enough

### DIFF
--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -52,11 +52,6 @@ def setup():
     init_db()
     # Do tests that should always run on app startup
     crypto_util.do_runtime_tests()
-    # Start the Python-RQ worker if it's not already running
-    if not exists(TEST_WORKER_PIDFILE):
-        subprocess.Popen(["rqworker",
-                          "-P", config.SECUREDROP_ROOT,
-                          "--pid", TEST_WORKER_PIDFILE])
 
 
 def teardown():


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The attempt to run another rqworker in securedrop/tests/utils/env.py
does not serve any purpose and races with the run from
securedrop/tests/conftest.py

Fixes #2613

## Testing

If the travis tests pass, it means the change is good and the double run was unecessary.

## Deployment
Nope.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

