### PR TITLE
Fix .desktop icons for tails 3.3

### DIFF
--- a/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
+++ b/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 
+import grp
 import os
+import pwd
 import sys
 import subprocess
 
@@ -13,6 +15,8 @@ if os.geteuid() != 0:
 path_torrc_additions = '/home/amnesia/Persistent/.securedrop/torrc_additions'
 path_torrc_backup = '/etc/tor/torrc.bak'
 path_torrc = '/etc/tor/torrc'
+path_desktop = '/home/amnesia/Desktop/'
+path_persistent_desktop = '/lib/live/mount/persistence/TailsData_unlocked/dotfiles/Desktop/'
 
 # load torrc_additions
 if os.path.isfile(path_torrc_additions):
@@ -48,7 +52,29 @@ subprocess.call(['/usr/bin/dconf', 'write',
                  '/org/gnome/nautilus/preferences/automatic-decompression',
                  'false'])
 
-# notify the user
+# Set journalist.desktop and source.desktop links as trusted with Nautilus (see
+# https://github.com/freedomofpress/securedrop/issues/2586)
+# set euid and env variables to amnesia user
+amnesia_gid = grp.getgrnam('amnesia').gr_gid
+amnesia_uid = pwd.getpwnam('amnesia').pw_uid
+os.setresgid(amnesia_gid, amnesia_gid, -1)
+os.setresuid(amnesia_uid, amnesia_uid, -1)
+env = os.environ.copy()
+env['XDG_RUNTIME_DIR'] = '/run/user/{}'.format(amnesia_uid)
+env['XDG_DATA_DIR'] = '/usr/share/gnome:/usr/local/share/:/usr/share/'
+env['HOME'] = '/home/amnesia'
+env['LOGNAME'] = 'amnesia'
+env['DBUS_SESSION_BUS_ADDRESS'] = 'unix:path=/run/user/{}/bus'.format(amnesia_uid)
+
+# remove existing shortcut, recreate symlink and change metadata attribute to trust .desktop
+for shortcut in ['source.desktop', 'journalist.desktop']:
+    subprocess.call(['rm', path_desktop + shortcut], env=env)
+    subprocess.call(['ln', '-s', path_persistent_desktop + shortcut, path_desktop + shortcut], env=env)
+    subprocess.call(['gio', 'set', path_desktop + shortcut, 'metadata::trusted', 'yes'], env=env)
+
+# reacquire uid0 and notify the user
+os.setresuid(0,0,-1)
+os.setresgid(0,0,-1)
 subprocess.call(['tails-notify-user',
                  'SecureDrop successfully auto-configured!',
                  'You can now access the Journalist Interface.\nIf you are an admin, you can now SSH to the servers.'])


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #2586.

Changes proposed in this pull request:

`source.desktop` and `journalist.desktop` are now trusted once tor finishes bootstrapping and `securedrop_init.py` is called by Network manager.

Workaround for issues with Nautilus per @kushaldas comments in #2586. 

## Testing

Needs to be tested on both new install and existing installs (upgrades)
```
git checkout $branch
./securedrop-admin tailsconfig
```
- .desktop icons should now have SecureDrop logo and should not require manually making them trusted.
- This should persist across reboots 
