### PR TITLE
Explicit docs to reactivate the virtualenv

### DIFF
--- a/docs/https_source_interface.rst
+++ b/docs/https_source_interface.rst
@@ -110,9 +110,10 @@ following: ::
     securedrop_app_https_certificate_chain_src: ca.crt
 
 The filenames should match the names of the files provided to you by DigiCert,
-and should be saved inside the ``install_files/ansible-base/`` directory. Then rerun
-the configuration: ::
+and should be saved inside the ``install_files/ansible-base/`` directory. You'll
+rerun the configuration scripts: ::
 
+    ./securedrop-admin setup
     ./securedrop-admin install
 
 The webserver configuration will be updated to apply the HTTPS settings.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Small fix to the documentation for admins who want to enable HTTPS on their onion site. Related to #2603 but doesn't need to go in at the same time. 

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
