### PR TITLE
Fix language picker styling in RTL languages

### DIFF
--- a/securedrop/sass/modules/_menu.sass
+++ b/securedrop/sass/modules/_menu.sass
@@ -63,4 +63,8 @@
   background-color: transparent
 
 .menu__icon
-  margin-right: $spacing-unit
+  &:dir(ltr)
+    margin-right: $spacing-unit
+
+  &:dir(rtl)
+    margin-left: $spacing-unit


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2600.

Changes proposed in this pull request:
  * There should be a space between the flag icon and the text for
RTL languages.

## Testing

In development VM:

1. `./manage.py --verbose translate-messages --compile`
2. Add ‘ar’ to SUPPORTED_LOCALES in config.py
3. Start source interface, select Arabic and you should see a space between the flag and the language label:

<img width="995" alt="screen shot 2017-11-27 at 5 45 09 pm" src="https://user-images.githubusercontent.com/7832803/33298453-4ca701ee-d39b-11e7-921a-e8cc6012d740.png">

## Deployment

SASS will not be directly deployed and instead will be compiled to CSS and shipped in the app code deb package

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM --- CI here I come
