### PR TITLE
Fix codename bar on source interface in RTL + LTR languages

### DIFF
--- a/securedrop/sass/_base.sass
+++ b/securedrop/sass/_base.sass
@@ -111,7 +111,7 @@
     float: right
 
     &:dir(rtl)
-      text-align: left
+      float: left
 
   #header
     float: left
@@ -215,7 +215,7 @@
     padding: 10px 15px
     border-bottom: 2px solid $color_warning_red
     font-size: large
-    direction: ltr
+    text-align: center
 
   .snippet
     border: 1px solid #c3c3c3

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -110,6 +110,9 @@ input.codename-box
   letter-spacing: 0.15em
   font-weight: normal
   font-size: 0.85em
+  // Direction is explicitly set to ltr until rtl wordlists
+  // are available.
+  direction: ltr
 
 #index-locales
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2626 

Changes proposed in this pull request:
* The padlock and refresh codenames should appear at opposite
sides of the codename in both RTL and LTR languages
* The text should be centered in the middle of the bar:

<img width="775" alt="screen shot 2017-11-28 at 2 53 14 pm" src="https://user-images.githubusercontent.com/7832803/33349478-1ba12b88-d44f-11e7-9641-358dac5e333d.png">

## Testing

View the generate page on the source interface in both arabic and english

## Deployment

Change will be delivered in app code package

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

