### PR TITLE
[0.5] docs: updates related to i18n/l10n

### DIFF
--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -156,6 +156,15 @@ to the ``develop`` branch via pull requests for merge on a regular basis.
       $ git commit -m 'sync with weblate' translations
       $ git push wip-i18n
 
+Verify the translations are not broken:
+
+.. code:: sh
+
+      $ vagrant ssh development
+      $ cd /vagrant/securedrop
+      $ PAGE_LAYOUT_LOCALES='ar,de_DE,es_ES,fr_FR,nb_NO,nl,pt_BR' \
+          pytest -v --page-layout tests/pages-layout
+
 Go to https://github.com/freedomofpress/securedrop and propose a pull request.
 
 .. note:: contrary to the applications translations, the desktop

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -31,7 +31,7 @@ Updating strings to be translated
 After modifying a string in the code, templates, javascript or desktop
 labels, the ``securedrop/translations/messages.pot`` files must be
 updated by running the following command in ``/vagrant/securedrop``,
-in the development virtual machine::
+in the development virtual machine:
 
 .. code:: sh
 

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -58,6 +58,9 @@ the corresponding application translation.
 
 After pushing the new translation, make sure to unlock the translations.
 
+The list of supported languages in the SecureDrop :doc:`installation documentation <../install>`
+must be updated.
+
 Updating strings to be translated
 ---------------------------------
 

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -148,7 +148,8 @@ to the ``develop`` branch via pull requests for merge on a regular basis.
       $ git remote add lab http://lab.securedrop.club/bot/securedrop/tree/i18n
       $ git fetch lab
       $ git checkout -b wip-i18n origin/develop
-      $ git checkout lab/i18n -- securedrop/translations
+      $ git checkout lab/i18n -- securedrop/translations \
+        install_files/ansible-base/roles/tails-config/templates/{ar,nl,fr,de_DE,nb_NO,pt_BR,es_ES}.po
       $ git add translations
       $ vagrant ssh development
       $ cd /vagrant/securedrop ; ./manage.py --verbose translate-desktop --compile

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -25,6 +25,39 @@ The `pybabel`_ and `gettext`_ command line is wrapped into the
 helpers for convenience. It is designed to be used by developers, to
 run tests with fixtures and for packaging.
 
+Creating new translations
+-------------------------
+
+For the applications, a user with weblate admin rights must visit the
+`Weblate translation creation page`_ and add the desired languages.
+
+For the desktop, the translations must be suspended in `Weblate`_ to
+avoid conflicts.
+
+* Go to the `Weblate commit page for SecureDrop`_
+
+|Weblate commit Lock|
+
+* Click ``Lock``
+
+|Weblate commit Locked|
+
+Now new files must be created and pushed to weblate with:
+
+.. code:: sh
+
+    $ git clone -b i18n http://lab.securedrop.club/bot/securedrop
+    $ cd securedrop/install_files/ansible-base/roles/tails-config/templates
+    $ msginit --no-translator --locale ar --output ar.po --input desktop.pot
+    $ git add ar.po
+    $ git commit -m 'i18n: add ar.po' ar.po
+    $ git push
+
+Where ``ar`` is the name of the locale, exactly matching the name of
+the corresponding application translation.
+
+After pushing the new translation, make sure to unlock the translations.
+
 Updating strings to be translated
 ---------------------------------
 
@@ -200,6 +233,7 @@ requests for the `SecureDrop git repository`_.
 .. _`Weblate SecureDrop branch`: http://lab.securedrop.club/bot/securedrop/tree/i18n
 .. _`patch they contain is unique`: https://git-scm.com/docs/git-patch-id
 .. _`Weblate commit page for SecureDrop`: https://weblate.securedrop.club/projects/securedrop/securedrop/#repository
+.. _`Weblate translation creation page`: https://weblate.securedrop.club/new-lang/securedrop/securedrop/
 
 .. |Weblate commit Lock| image:: ../images/weblate/admin-lock.png
 .. |Weblate commit Locked| image:: ../images/weblate/admin-locked.png

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -160,7 +160,7 @@ The ``develop`` branch can now be merged into ``i18n`` as follows:
       $ git fetch lab
       $ git checkout -b i18n lab/i18n
       $ git merge origin/develop
-      $ ./manage.py translate --extract-update
+      $ make translate
 
 The ``manage.py`` command examines all the source files, looking for
 strings that need to be translated (i.e. gettext('translate me') etc.)

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -236,6 +236,25 @@ requests for the `SecureDrop git repository`_.
 
 |Weblate commit Unlocked|
 
+Updating the full text index
+----------------------------
+
+The full text index can occasionally not be up to date. The symptom
+may be that the search function fails to find a word that you know
+exists in the source strings. If that happens you can rebuild the
+index from scratch with:
+
+.. code:: sh
+
+      $ ssh debian@weblate.securedrop.club
+      $ cd /app/weblate
+      $ sudo docker-compose run weblate rebuild_index --all --clean
+
+Note that the new index will not be used right away, some workers may
+still have the old index open. Rebooting the machine is an option,
+waiting for a few hours is another option.
+
+
 .. _`gettext`: https://www.gnu.org/software/gettext/
 .. _`pybabel`: http://babel.pocoo.org/
 .. _`Weblate`: http://weblate.securedrop.club/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,6 +84,7 @@ anonymous sources.
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/0.4.x_to_0.5.rst
    upgrade/0.3.x_to_0.4.rst
    upgrade_to_tails_2x.rst
    upgrade_to_tails_3x.rst

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,6 +25,26 @@ on network speed and computing power.
 
 .. _configure_securedrop:
 
+Localization of the source and journalist interfaces
+----------------------------------------------------
+
+The source and journalist interface are translated in the following
+languages:
+
+* Arabic (ar)
+* German (de_DE)
+* Spanish (es_ES)
+* French (fr_FR)
+* Norwegian (nb_NO)
+* Dutch (nl)
+* Portuguese, Brasil (pt_BR)
+
+During the installation you will be given the opportunity to choose the
+list of supported languages to display, using the code shown in
+parentheses. When the source interface is displayed in French (for
+instance), people submitting documents will expect a journalist fluent
+in French is available to read them and followup.
+
 Configure the Installation
 --------------------------
 

--- a/docs/upgrade/0.4.x_to_0.5.rst
+++ b/docs/upgrade/0.4.x_to_0.5.rst
@@ -1,0 +1,77 @@
+Upgrade from 0.4.x to 0.5.x
+===========================
+
+.. note::
+   First follow the instructions in the 0.3 to 0.4
+   :doc:`migration document <0.3.x_to_0.4>`
+   if you have not yet updated your **Admin Workstation** to 0.4.
+
+Beginning with SecureDrop 0.5, the source and journalist interfaces
+are localized. After an unattended upgrade of the application server,
+these translations are available but are not activated by default.
+
+.. note::
+   See the :doc:`installation documenation <../install>` for a list
+   of supported languages.
+
+The steps below should be performed on the **Admin Workstation**
+associated with your SecureDrop instance.
+
+Pull the latest release
+-----------------------
+
+Open a **Terminal** and navigate to your SecureDrop directory.
+
+.. code:: sh
+
+   cd ~/Persistent/securedrop
+
+Fetch the latest code, and verify the tag for the latest release (0.5):
+
+.. code:: sh
+
+   git fetch
+   git tag -v 0.5
+
+The output of the above commands should include ``Good signature from
+"SecureDrop Release Signing Key"``. If it does
+not, please contact us immediately at support@freedom.press.
+
+.. note::
+  You may also see output from GPG warning you that the key is not certified
+  with a trusted signature. This means that there is not a trust path to the
+  release signing key. As long as you see the fingerprint ``2224 5C81 E3BA EB41
+  38B3 6061 310F 5612 00F4 AD77`` displayed and the signature verifies as
+  described above then you can proceed safely.
+
+Once you've verified the latest release, check it out:
+
+.. code:: sh
+
+   git checkout 0.5
+
+Choose the list of supported languages
+--------------------------------------
+
+You need to run the ``./securedrop-admin sdconfig`` command again,
+following the same instructions as during the :doc:`first installation
+<../install>`.  This will not modify the existing configuration but
+you will be asked for a list of supported languages because this
+option did not exist before.  You should decide which languages you
+prefer :doc:`as explained in the installation documenation
+<../install>`.
+
+You should then proceed to update the application server with:
+
+.. code:: sh
+
+    ./securedrop-admin install
+
+.. include:: ../includes/rerun-install-is-safe.txt
+
+Verify the source interface displays the selected languages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The source and journalist interfaces will display the current language
+with a flag and clicking on the flag will show a menu with all
+supported languages.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* instructions on how to create new translations 
* document language selection during install/upgrade Fixes #2637

## Testing

* vagrant ssh development
* cd /vagrant
* make docs
* firefox http://localhost:8000/development/i18n.html#creating-new-translations

## Deployment

Nope.

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
