### PR TITLE
[0.5] Fix #2647: Make sure source interface logout preserves user locale

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -221,8 +221,11 @@ def make_blueprint(config):
         if logged_in():
             msg = render_template('logout_flashed_message.html')
 
-            # clear the session after we render the message so it's localized
+            # Clear the session after we render the message so it's localized
+            # If a user specified a locale, save it and restore it
+            user_locale = g.locale
             session.clear()
+            session['locale'] = user_locale
 
             flash(Markup(msg), "important hide-if-not-tor-browser")
         return redirect(url_for('.index'))

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -194,7 +194,9 @@ class TestSourceApp(TestCase):
 
             # sessions always have 'expires', so pop it for the next check
             session.pop('expires', None)
-            self.assertTrue(not session)
+
+            self.assertNotIn('logged_in', session)
+            self.assertNotIn('codename', session)
 
             self.assertIn('Thank you for exiting your session!', resp.data)
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2647.

Changes proposed in this pull request:
   * Preserve user locale after logout on the source interface. 

## Testing

0. Open source interface
1. Change language
2. Submit doc
3. Logout
4. Page should not be multilingual:

<img width="1008" alt="screen shot 2017-11-30 at 2 15 31 pm" src="https://user-images.githubusercontent.com/7832803/33457916-f2472e3c-d5d8-11e7-9faa-6b7168225275.png">

## Deployment

Not yet in prod

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM