### PR TITLE
[0.5] app: use lazy_gettext instead of gettext in wtforms

### DIFF
--- a/securedrop/journalist_app/forms.py
+++ b/securedrop/journalist_app/forms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from flask_babel import gettext
+from flask_babel import lazy_gettext
 from flask_wtf import FlaskForm
 from wtforms import (TextAreaField, TextField, BooleanField, HiddenField,
                      ValidationError)
@@ -12,25 +12,26 @@ from db import Journalist
 def otp_secret_validation(form, field):
     strip_whitespace = field.data.replace(' ', '')
     if len(strip_whitespace) != 40:
-        raise ValidationError(gettext('Field must be 40 characters long but '
-                                      'got {num_chars}.'.format(
-                                          num_chars=len(strip_whitespace)
-                                      )))
+        raise ValidationError(lazy_gettext(
+            'Field must be 40 characters long but '
+            'got {num_chars}.'.format(
+                num_chars=len(strip_whitespace)
+            )))
 
 
 def minimum_length_validation(form, field):
     if len(field.data) < Journalist.MIN_USERNAME_LEN:
         raise ValidationError(
-            gettext('Field must be at least {min_chars} '
-                    'characters long but only got '
-                    '{num_chars}.'.format(
-                        min_chars=Journalist.MIN_USERNAME_LEN,
-                        num_chars=len(field.data))))
+            lazy_gettext('Field must be at least {min_chars} '
+                         'characters long but only got '
+                         '{num_chars}.'.format(
+                             min_chars=Journalist.MIN_USERNAME_LEN,
+                             num_chars=len(field.data))))
 
 
 class NewUserForm(FlaskForm):
     username = TextField('username', validators=[
-        InputRequired(message=gettext('This field is required.')),
+        InputRequired(message=lazy_gettext('This field is required.')),
         minimum_length_validation
     ])
     password = HiddenField('password')
@@ -47,6 +48,7 @@ class ReplyForm(FlaskForm):
         u'Message',
         id="content-area",
         validators=[
-            InputRequired(message=gettext('You cannot send an empty reply.')),
+            InputRequired(message=lazy_gettext(
+                'You cannot send an empty reply.')),
         ],
     )

--- a/securedrop/source_app/forms.py
+++ b/securedrop/source_app/forms.py
@@ -1,4 +1,4 @@
-from flask_babel import gettext
+from flask_babel import lazy_gettext
 from flask_wtf import FlaskForm
 from wtforms import PasswordField
 from wtforms.validators import InputRequired, Regexp, Length
@@ -8,11 +8,12 @@ from db import Source
 
 class LoginForm(FlaskForm):
     codename = PasswordField('codename', validators=[
-        InputRequired(message=gettext('This field is required.')),
+        InputRequired(message=lazy_gettext('This field is required.')),
         Length(1, Source.MAX_CODENAME_LEN,
-               message=gettext('Field must be between 1 and '
-                               '{max_codename_len} characters long.'.format(
-                                   max_codename_len=Source.MAX_CODENAME_LEN))),
+               message=lazy_gettext(
+                   'Field must be between 1 and '
+                   '{max_codename_len} characters long.'.format(
+                       max_codename_len=Source.MAX_CODENAME_LEN))),
         # Make sure to allow dashes since some words in the wordlist have them
-        Regexp(r'[\sA-Za-z0-9-]+$', message=gettext('Invalid input.'))
+        Regexp(r'[\sA-Za-z0-9-]+$', message=lazy_gettext('Invalid input.'))
     ])


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2644

The wtforms classes are evaluated outside of the context of a
request. When gettext is used to set a parameter, it has no way to
know which language is going to be used and default to english.

We need to use lazy_gettext which delays the evaluation until the
string is used, i.e. when the user session is active and the language
preferences can influence the translation.

## Testing

* vagrant ssh development
* cd /vagrant/securedrop
* ./manage.py run
* firefox http://localhost:8080/login
* switch to non default language
* type enter for an empty passphrase
* verify the error message is not displayed in english

## Deployment

User interface only.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
