### PR TITLE
[0.5] Fix swapped message/document string and numerical value

### DIFF
--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -16,8 +16,8 @@
     {% endif %}
   </div>
   <div class="submission-count">
-    <span><i class="fa fa-file-archive-o"></i> {{ gettext('docs {doc_num}').format(doc_num=docs) }}</span>
-    <span><i class="fa fa-file-text-o"></i> {{ gettext('messages {msg_num}').format(msg_num=msgs) }}</span>
+    <span><i class="fa fa-file-archive-o"></i> {{ gettext('{doc_num} docs').format(doc_num=docs) }}</span>
+    <span><i class="fa fa-file-text-o"></i> {{ gettext('{msg_num} messages').format(msg_num=msgs) }}</span>
     {% if source.num_unread > 0 %}
       <span class="unread">
         <a class="btn small" href="/download_unread/{{ source.filesystem_id }}"><i class="fa fa-download"></i> {{ gettext('{num_unread} unread').format(num_unread=source.num_unread) }}</a>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2654

Changes proposed in this pull request:
* Fixes a style issue (#2654) that is going to ⚠️ ⚠️ ⚠️ require some translation changes

## Testing

View in Tor Browser and in English you should now see "0 messages", "4 documents"

## Deployment

In app code package 

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
