### PR TITLE
[0.5] Fix #2656: Ensure buttons with lots of text go to two lines gracefully

### DIFF
--- a/securedrop/sass/_button-rules.sass
+++ b/securedrop/sass/_button-rules.sass
@@ -55,7 +55,8 @@
 
     &.primary
       display: block
-      margin: 0 auto
+      margin-top: 0
+      margin-right: auto
       display: inline-block
 
     &.secondary
@@ -126,3 +127,7 @@
     background-color: $color_purple_medium
     color: orange
     border: none
+
+  .btn--space
+    margin-bottom: 5px
+    margin-left: 5px

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -36,15 +36,13 @@
   <p>{{ gettext('Please either write this codename down and keep it in a safe place, or memorize it.') }}</p>
 </aside>
 
-<div class="pull-right">
 <form id="create-form" method="post" action="/create" autocomplete="off">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-  <button type="submit" class="sd-button btn primary" id="continue-button">
+  <button type="submit" class="sd-button btn btn--space primary pull-right" id="continue-button">
     <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-white.png') }}" width="17px" height="17px">
     <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-blue.png') }}" width="17px" height="17px">
      {{ gettext('USE NEW CODENAME') }}
   </button>
-  <a id="already-have-codename" href="{{ url_for('main.login') }}" class="sd-button btn secondary">{{ gettext('USE EXISTING CODENAME') }}</a>
+  <a id="already-have-codename" href="{{ url_for('main.login') }}" class="sd-button btn btn--space secondary pull-right">{{ gettext('USE EXISTING CODENAME') }}</a>
 </form>
-</div>
 {% endblock %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2656.

Changes proposed in this pull request:

* The buttons on the generate page on the source interface have long text in a few languages. We should have them gracefully go to two lines if needed. Specifically, there should be a small amount of space between each button and they should be right aligned.

* The space is introduced via a new class `btn--space` (BEM syntax) which specifies a 10px margin so that there is a nice space between the buttons. 

* `pull-right` is applied to each button individually so the buttons (not just the div) individually are right aligned (in RTL languages they will be left-aligned).

## Screenshots

### German

<img width="479" alt="screen shot 2017-12-01 at 4 42 01 pm" src="https://user-images.githubusercontent.com/7832803/33509607-e2500884-d6b7-11e7-8e6f-a8cfab5fb5fc.png">

<img width="773" alt="screen shot 2017-12-01 at 4 41 54 pm" src="https://user-images.githubusercontent.com/7832803/33509606-e22feec8-d6b7-11e7-90bc-259a6ffbb4f5.png">

### French

<img width="415" alt="screen shot 2017-12-01 at 4 37 56 pm" src="https://user-images.githubusercontent.com/7832803/33509631-0ea427e4-d6b8-11e7-9b2b-e53f51a3d793.png">
<img width="762" alt="screen shot 2017-12-01 at 4 41 48 pm" src="https://user-images.githubusercontent.com/7832803/33509632-0ec20ade-d6b8-11e7-963b-649b5aa0873e.png">


### Arabic

<img width="787" alt="screen shot 2017-12-01 at 4 47 33 pm" src="https://user-images.githubusercontent.com/7832803/33509612-f5d7de0e-d6b7-11e7-8f7b-4815623bade6.png">
<img width="296" alt="screen shot 2017-12-01 at 4 47 40 pm" src="https://user-images.githubusercontent.com/7832803/33509614-f5f1b02c-d6b7-11e7-8ffe-c40460073d20.png">

## Testing

Check out the interface in German and French and verify the buttons render nicely. 

## Deployment

SASS will be compiled to CSS and delivered along with HTML in app code deb package

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM