### PR TITLE
[0.5] Fix #2653: Set max width of journalist reply box

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -78,7 +78,7 @@
     <form action="{{ url_for('main.reply') }}" method="post" autocomplete="off">
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
       <input type="hidden" name="filesystem_id" value="{{ filesystem_id }}">
-      {{ form.message(id="reply-text-field", rows='10', cols='72') }}
+      {{ form.message(id="reply-text-field", rows='10', cols='72', class="journalist-reply__input") }}
       <hr class="no-line">
       <button id="reply-button" class="sd-button" type="submit">{{ gettext('SUBMIT') }}</button>
     </form>

--- a/securedrop/sass/journalist.sass
+++ b/securedrop/sass/journalist.sass
@@ -95,3 +95,6 @@ button.small-danger, a.btn.small-danger, .btn.small-danger
   max-width: 445px
   input
     width: 100%
+
+.journalist-reply__input
+  max-width: 700px


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2653.

Changes proposed in this pull request:
* This fixes a minor style issue by restricting the size of the reply
box to 700px. Otherwise if the font size is large, the box can
overflow the column.

## Testing

Follow steps described here in [this comment](https://github.com/freedomofpress/securedrop/issues/2653#issuecomment-348673674) and verify the box does _not_ overflow the column. 

Note: if you want to verify that 700px is a good call, you can use Firefox's rulers (F2 -> `rulers`) and measure the box:

<img width="822" alt="screen shot 2017-12-01 at 11 00 51 pm" src="https://user-images.githubusercontent.com/7832803/33512911-5831dec6-d6ed-11e7-90ae-6de409d56ce1.png">

## Deployment

Will be deployed in securedrop app code package

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
