### PR TITLE
[0.5] Fix RTL rendering of time box on journalist interface

### DIFF
--- a/securedrop/sass/_base.sass
+++ b/securedrop/sass/_base.sass
@@ -144,6 +144,8 @@
 
       .date
         float: right
+        &:dir(rtl)
+          float: left
         background-color: $color_grey_medium
         color: #ffffff
         font-size: 10px


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2662.

Changes proposed in this pull request:
   * Style fix to move the time box onto the correct side of the journalist interface in RTL languages

## Testing

Look at journalist interface in Arabic, you should see the time box appear on the far left:

<img width="779" alt="screen shot 2017-12-02 at 3 00 05 pm" src="https://user-images.githubusercontent.com/7832803/33520565-5925efae-d772-11e7-858c-0b996211ec8a.png">

## Deployment

app code deb pkg

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
