### PR TITLE
[0.5] app: remove generated assets after installation

### DIFF
--- a/install_files/securedrop-app-code/DEBIAN/postinst
+++ b/install_files/securedrop-app-code/DEBIAN/postinst
@@ -47,6 +47,9 @@ case "$1" in
     # Restart apache so it loads with the apparmor profiles in enforce mode.
     service apache2 restart
 
+    # cleanup dynamically generated assets
+    rm -fr /var/www/securedrop/static/gen/*
+
     # Version migrations
 
     if [ -n "$2" ] && [ "$2" = "0.3" ] ; then


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2651

Flask-Assets uses Python's webassets to rebuild static assets, and
webassets will not rebuild them in static/gen if the are more
recent than the installed files. Which typically happens if:

* package is built at time T
* install package built at time T
* package is built at time T+1
* use installed packages for the first at time T+2 which generates
  assets in static/gen dated T+2
* install package built at time T+1
* the generated assets are more recent (T+2) than the installed
  files sources (T+1) and will not be rebuilt and therefore reflecting
  the content of the package built at time T instead of the content of
  the package built at time T+1

This is a rare condition which is only likely to show when testing
release candidates

## Testing

* make build-debs
* vagrant up /staging/
* vagrant provision app-staging
* torbrowser $(cat install_files/ansible-base/app-source-ths)
* vagrant ssh app-staging
* ls /var/www/securedrop/static/gen/ # contains source.js
* dpkg -i /root/securedrop-app-code-0.5-rc5-amd64.deb
* ls /var/www/securedrop/static/gen/ # contains nothing
* torbrowser $(cat install_files/ansible-base/app-source-ths)
* ls /var/www/securedrop/static/gen/ # contains source.js

## Deployment

It will remove content of the static/gen directory which is empty during a first install and populated automatically when the user first visits the source/journalist page containing javascript.
