### PR TITLE
i18n: do not expose unsupported locales

### DIFF
--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -20,7 +20,6 @@ from flask_babel import Babel
 from babel import core
 
 import collections
-import config
 import os
 import re
 
@@ -36,7 +35,7 @@ class LocaleNotFound(Exception):
     """Raised when the desired locale is not in the translations directory"""
 
 
-def setup_app(app, translation_dirs=None):
+def setup_app(config, app, translation_dirs=None):
     global LOCALES
     global babel
 
@@ -66,10 +65,10 @@ def setup_app(app, translation_dirs=None):
         getattr(config, 'DEFAULT_LOCALE', None),
         translation_directories)
 
-    babel.localeselector(get_locale)
+    babel.localeselector(lambda: get_locale(config))
 
 
-def get_locale():
+def get_locale(config):
     """
     Get the locale as follows, by order of precedence:
     - l request argument or session['locale']
@@ -163,5 +162,5 @@ def locale_to_rfc_5646(locale):
         return LOCALE_SPLIT.split(locale)[0]
 
 
-def get_language():
-    return get_locale().split('_')[0]
+def get_language(config):
+    return get_locale(config).split('_')[0]

--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -35,9 +35,11 @@ class LocaleNotFound(Exception):
     """Raised when the desired locale is not in the translations directory"""
 
 
-def setup_app(config, app, translation_dirs=None):
+def setup_app(config, app):
     global LOCALES
     global babel
+
+    translation_dirs = getattr(config, 'TRANSLATION_DIRS', None)
 
     if translation_dirs is None:
             translation_dirs = \

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -36,7 +36,7 @@ def create_app(config):
         flash(msg, 'error')
         return redirect(url_for('main.login'))
 
-    i18n.setup_app(app)
+    i18n.setup_app(config, app)
 
     app.jinja_env.trim_blocks = True
     app.jinja_env.lstrip_blocks = True
@@ -75,7 +75,7 @@ def create_app(config):
         if uid:
             g.user = Journalist.query.get(uid)
 
-        g.locale = i18n.get_locale()
+        g.locale = i18n.get_locale(config)
         g.text_direction = i18n.get_text_direction(g.locale)
         g.html_lang = i18n.locale_to_rfc_5646(g.locale)
         g.locales = i18n.get_locale2name()

--- a/securedrop/journalist_app/account.py
+++ b/securedrop/journalist_app/account.py
@@ -14,7 +14,7 @@ def make_blueprint(config):
 
     @view.route('/account', methods=('GET',))
     def edit():
-        password = make_password()
+        password = make_password(config)
         return render_template('edit_account.html',
                                password=password)
 

--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -70,7 +70,8 @@ def make_blueprint(config):
                 return redirect(url_for('admin.new_user_two_factor',
                                         uid=new_user.id))
 
-        return render_template("admin_add_user.html", password=make_password(),
+        return render_template("admin_add_user.html",
+                               password=make_password(config),
                                form=form)
 
     @view.route('/2fa', methods=('GET', 'POST'))
@@ -171,7 +172,7 @@ def make_blueprint(config):
 
             commit_account_changes(user)
 
-        password = make_password()
+        password = make_password(config)
         return render_template("edit_account.html", user=user,
                                password=password)
 

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -198,9 +198,9 @@ def col_delete(cols_selected):
     return redirect(url_for('main.index'))
 
 
-def make_password():
+def make_password(config):
     while True:
-        password = crypto_util.genrandomid(7, i18n.get_language())
+        password = crypto_util.genrandomid(7, i18n.get_language(config))
         try:
             Journalist.check_password_acceptable(password)
             return password

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -44,7 +44,7 @@ def create_app(config):
     assets = Environment(app)
     app.config['assets'] = assets
 
-    i18n.setup_app(app)
+    i18n.setup_app(config, app)
 
     app.jinja_env.trim_blocks = True
     app.jinja_env.lstrip_blocks = True
@@ -81,7 +81,7 @@ def create_app(config):
     @ignore_static
     def setup_g():
         """Store commonly used values in Flask's special g object"""
-        g.locale = i18n.get_locale()
+        g.locale = i18n.get_locale(config)
         g.text_direction = i18n.get_text_direction(g.locale)
         g.html_lang = i18n.locale_to_rfc_5646(g.locale)
         g.locales = i18n.get_locale2name()

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -36,7 +36,7 @@ def make_blueprint(config):
                   "notification")
             return redirect(url_for('.lookup'))
 
-        codename = generate_unique_codename()
+        codename = generate_unique_codename(config)
         session['codename'] = codename
         session['new_user'] = True
         return render_template('generate.html', codename=codename)

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -28,11 +28,11 @@ def valid_codename(codename):
     return source is not None
 
 
-def generate_unique_codename():
+def generate_unique_codename(config):
     """Generate random codenames until we get an unused one"""
     while True:
         codename = crypto_util.genrandomid(Source.NUM_WORDS,
-                                           i18n.get_language())
+                                           i18n.get_language(config))
 
         # The maximum length of a word in the wordlist is 9 letters and the
         # codename length is 7 words, so it is currently impossible to

--- a/securedrop/tests/test_2fa.py
+++ b/securedrop/tests/test_2fa.py
@@ -119,9 +119,3 @@ class TestJournalist2FA(flask_testing.TestCase):
         # A flashed message should appear
         self.assertMessageFlashed(
             'Could not verify token in two-factor authentication.', 'error')
-
-    @classmethod
-    def tearDownClass(cls):
-        # Reset the module variables that were changed to mocks so we don't
-        # break other tests
-        reload(journalist)

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -283,8 +283,3 @@ class TestI18N(object):
         resp = app.get('/generate?l=fr_FR', follow_redirects=True)
         html = resp.data.decode('utf-8')
         assert re.compile('<html .*lang="fr".*>').search(html), html
-
-    @classmethod
-    def teardown_class(cls):
-        reload(journalist)
-        reload(source)

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -44,16 +44,17 @@ class TestI18N(object):
 
     def test_get_supported_locales(self):
         locales = ['en_US', 'fr_FR']
-        assert ['en_US'] == i18n._get_supported_locales(locales, None, None)
+        assert ['en_US'] == i18n._get_supported_locales(
+            locales, None, None, None)
         locales = ['en_US', 'fr_FR']
         supported = ['en_US', 'not_found']
         with pytest.raises(i18n.LocaleNotFound) as excinfo:
-            i18n._get_supported_locales(locales, supported, None)
+            i18n._get_supported_locales(locales, supported, None, None)
         assert "contains ['not_found']" in str(excinfo.value)
         supported = ['fr_FR']
         locale = 'not_found'
         with pytest.raises(i18n.LocaleNotFound) as excinfo:
-            i18n._get_supported_locales(locales, supported, locale)
+            i18n._get_supported_locales(locales, supported, locale, None)
         assert "DEFAULT_LOCALE 'not_found'" in str(excinfo.value)
 
     def verify_i18n(self, app):
@@ -209,6 +210,10 @@ class TestI18N(object):
         pybabel init -i {d}/messages.pot -d {d} -l nb_NO
         sed -i -e '/code hello i18n/,+1s/msgstr ""/msgstr "code norwegian"/' \
               {d}/nb_NO/LC_MESSAGES/messages.po
+
+        pybabel init -i {d}/messages.pot -d {d} -l es_ES
+        sed -i -e '/code hello i18n/,+1s/msgstr ""/msgstr "code spanish"/' \
+              {d}/es_ES/LC_MESSAGES/messages.po
         """.format(d=config.TEMP_DIR))
 
         manage.translate_messages(args)
@@ -221,6 +226,8 @@ class TestI18N(object):
                 config.SUPPORTED_LOCALES = [
                     'en_US', 'fr_FR', 'zh_Hans_CN', 'ar', 'nb_NO']
                 i18n.setup_app(app, translation_dirs=config.TEMP_DIR)
+                # es_ES must not be in LOCALES
+                assert i18n.LOCALES == config.SUPPORTED_LOCALES
                 self.verify_i18n(app)
         finally:
             if supported:

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -50,7 +50,10 @@ class TestJournalistApp(TestCase):
 
     @patch('crypto_util.genrandomid', side_effect=['bad', VALID_PASSWORD])
     def test_make_password(self, mocked_pw_gen):
-        assert journalist_app.utils.make_password() == VALID_PASSWORD
+        class fake_config:
+            pass
+        assert (journalist_app.utils.make_password(fake_config) ==
+                VALID_PASSWORD)
 
     @patch('journalist.app.logger.error')
     def test_reply_error_logging(self, mocked_error_logger):

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1211,6 +1211,8 @@ class TestJournalistApp(TestCase):
         finally:
             if supported:
                 config.SUPPORTED_LOCALES = supported
+            else:
+                del config.SUPPORTED_LOCALES
 
 
 class TestJournalistLogin(unittest.TestCase):

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1252,9 +1252,3 @@ class TestJournalistLogin(unittest.TestCase):
         self.assertFalse(
             mock_scrypt_hash.called,
             "Called _scrypt_hash for password w/ invalid length")
-
-    @classmethod
-    def tearDownClass(cls):
-        # Reset the module variables that were changed to mocks so we don't
-        # break other tests
-        reload(journalist)

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -62,6 +62,7 @@ def teardown():
         if t.is_alive() and not isinstance(t, threading._MainThread):
             t.join()
     db_session.remove()
+    shutil.rmtree(config.TEMP_DIR)
     try:
         shutil.rmtree(config.SECUREDROP_DATA_ROOT)
         assert not os.path.exists(config.SECUREDROP_DATA_ROOT)  # safeguard for #844


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #2681

The SUPPORTED_LOCALES list is enforced so the user cannot select a
language that it does not contain. The restriction based on the
SUPPORTED_LOCALES variable is done at setup and used to narrow the
content of the LOCALES variable.

The SUPPORTED_LOCALES content was previously only used to select the
languages displayed via the language menu. This is incorrect because
it would allow a user to add ?l=unsupported to see the interface in
one of the available languages even if it is not in the
SUPPORTED_LOCALES list. This was also true if the browser it configured
to prefer a given locale.

## Testing

* Set the SUPPORTED_LOCALES to ['en_US'] only
* Change the preferred language of your browser to French and visit the source interface
* Visit the source interface and manually add **l=fr_FR** to the URL
* In both cases the interface must show in English

## Deployment

Only changes the locale selection logic, no impact on deployment.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

## Comment

The **i18n: do not expose unsupported locales** commit is standalone. In the spirit of minimizing the changes for 0.5.1 it can be cherry-picked.