### PR TITLE
journalist: show the number of deleted submissions

### DIFF
--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -136,7 +136,8 @@ def bulk_delete(filesystem_id, items_selected):
     db_session.commit()
 
     flash(ngettext("Submission deleted.",
-                   "Submissions deleted.",
+                   "{num} submissions deleted.".format(
+                       num=len(items_selected)),
                    len(items_selected)), "notification")
     return redirect(url_for('col.col', filesystem_id=filesystem_id))
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

It helps with localization when there is more than one or many. This is a followup of https://forum.securedrop.club/t/something-happened-to-some-and-many-things/278/5

## Testing

* vagrant ssh development
* cd /vagrant/securedrop
* ./manage.py translate-messages --extract-update
* verify translations/messages.pot contains
<pre>
#: journalist_app/utils.py:141
msgid "Submission deleted."
msgid_plural "{num} submissions deleted."
msgstr[0] ""
msgstr[1] ""
</pre>

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
