### PR TITLE
Change "password" to "passphrase" throughout docs

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -1,7 +1,7 @@
 Admin Guide
 ===========
 
-You (the admin) should have your own username and password, plus
+You (the admin) should have your own username and passphrase, plus
 two-factor authentication through either the Google Authenticator app
 on your smartphone or a YubiKey.
 
@@ -163,7 +163,7 @@ factor token successfully verified for user *new username*!".
 
 Congratulations! You have successfully set up a journalist on
 SecureDrop. Make sure the journalist remembers their username and
-password and always has their 2 factor authentication device in their
+passphrase and always has their 2 factor authentication device in their
 possession when they attempt to log in to SecureDrop.
 
 .. |SecureDrop main page|

--- a/docs/backup_workstations.rst
+++ b/docs/backup_workstations.rst
@@ -97,7 +97,7 @@ Open a Nautilus window with admin privileges by going to
 |Open Terminal|
 
 Type ``gksu nautilus`` at the terminal prompt and hit enter. You'll need to type
-your admin password.
+your admin passphrase.
 
 |Start gksu nautilus|
 
@@ -107,8 +107,8 @@ your admin password.
   OK and continue normally.
 
   If a Nautilus window *doesn't* come up, it might be because an admin
-  password wasn't set. If that's the case, you'll need to restart and set an
-  admin password before continuing.
+  passphrase wasn't set. If that's the case, you'll need to restart and set an
+  admin passphrase before continuing.
 
 .. warning::
             Make sure you use keep the `Terminal` window open while you perform

--- a/docs/create_admin_account.rst
+++ b/docs/create_admin_account.rst
@@ -9,7 +9,7 @@ Journalist Interface, they need:
    credentials to log in:
 
    * Username
-   * Password
+   * Passphrase
    * Two-factor authentication code
 
 You should create a separate account on the Journalist Interface for
@@ -45,7 +45,7 @@ output like this:
 .. highlight:: none
 .. code::
 
-    This journalist's password is: delivery propose requisite stunner dragonfly unstamped stowaway
+    This journalist's passphrase is: delivery propose requisite stunner dragonfly unstamped stowaway
 
 Passphrases include the spaces between the words, but not leading or trailing
 whitespace. Be sure to save this passphrase in the appropriate KeePassX database.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -113,7 +113,7 @@ the remote servers. ::
 
     ./securedrop-admin install
 
-You will be prompted to enter the sudo password for the *Application* and
+You will be prompted to enter the sudo passphrase for the *Application* and
 *Monitor Servers* (which should be the same).
 
 The install process will take some time, and it will return

--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -167,7 +167,7 @@ Connect to the pfSense WebGUI
    |Your Connection is Insecure|
 
 #. You should see the login page for the pfSense GUI. Log in with the
-   default username and password (``admin`` / ``pfsense``).
+   default username and passphrase (``admin`` / ``pfsense``).
 
    |Default pfSense|
 
@@ -203,7 +203,7 @@ Setup Wizard
 
    |Configure LAN Interface|
 
-#. Set a strong admin password. We recommend generating a strong password
+#. Set a strong admin passphrase. We recommend generating a strong passphrase
    with KeePassX, and saving it in the Tails Persistent folder using the
    provided KeePassX database template. Click **Next**.
 

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -56,7 +56,7 @@ as documented in the :doc:`Tails Setup Guide <set_up_tails>`.
 
 Once you're done, boot into the new Journalist Tails USB on the
 *Journalist Workstation*. Enable persistence and set an admin
-password before continuing with the next section.
+passphrase before continuing with the next section.
 
 Set up automatic access to the Journalist Interface
 ---------------------------------------------------

--- a/docs/passphrase_best_practices.rst
+++ b/docs/passphrase_best_practices.rst
@@ -29,7 +29,7 @@ General Best Practices
 
    If you use your SecureDrop passphrase on another system, a compromise of that
    system could theoretically be used to compromise SecureDrop. You should avoid
-   reusing passwords in general, but it is especially important to avoid doing
+   reusing passphrases in general, but it is especially important to avoid doing
    so in the context of SecureDrop.
 
 For Sources
@@ -67,7 +67,7 @@ And each Journalist would only have to:
 #. Remember the passphrases to unlock the persistent storage on both of these
    Tails USBs.
 
-Memorizing further passwords beyond the ones listed above is counterproductive:
+Memorizing further passphrases beyond the ones listed above is counterproductive:
 an attacker with access to any of those environments would be able to pivot to
 anything they wish to access, and increasing the burden of keeping track of
 additional credentials is unpleasant for journalists and admins and

--- a/docs/passphrases.rst
+++ b/docs/passphrases.rst
@@ -10,7 +10,7 @@ each role in a SecureDrop installation.
 .. note:: We encourage each end user to use KeePassX, an easy-to-use
           password manager included in Tails, to generate and retain
           strong and unique passphrases. We have created a template
-          password database that you can use to get started. For more
+          passphrase database that you can use to get started. For more
           information, see the :doc:`tails_guide`.
 
 .. tip:: For best practices on managing passphrases, see
@@ -23,8 +23,8 @@ The admin will be using the *Admin Workstation* with Tails to connect to
 the *Application Server* and the *Monitor Server* using Tor and SSH. The tasks
 performed by the admin will require the following set of passphrases:
 
--  A password for the persistent volume on the Admin Live USB.
--  A master password for the KeePassX password manager, which unlocks
+-  A passphrase for the persistent volume on the Admin Live USB.
+-  A master passphrase for the KeePassX password manager, which unlocks
    passphrases to:
 
    -  The *Application Server* and the *Monitor Server* (required to be the same).
@@ -51,8 +51,8 @@ The journalist will be using the *Journalist Workstation* with Tails to
 connect to the Journalist Interface. The tasks performed by the journalist
 will require the following set of passphrases:
 
--  A master password for the persistent volume on the Tails device.
--  A master password for the KeePassX password manager, which unlocks
+-  A master passphrase for the persistent volume on the Tails device.
+-  A master passphrase for the KeePassX password manager, which unlocks
    passphrases to:
 
    -  The Hidden Service value required to connect to the Journalist
@@ -75,7 +75,7 @@ The journalist will be using the *Secure Viewing Station* with Tails to
 decrypt and view submitted documents. The tasks performed by the
 journalist will require the following passphrases:
 
--  A master password for the persistent volume on the Tails device.
+-  A master passphrase for the persistent volume on the Tails device.
 
 The backup that is created during the installation of SecureDrop is also
 encrypted with the application's GPG key. The backup is stored on the

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -189,10 +189,10 @@ firewall. If you did not, adjust these settings accordingly.
 Continue the installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can choose whatever username and password you would like. To make
-things easier later you should use the same username and same password
-on both servers (but not the same password as username). Make sure to
-save this password in your admin KeePassX database afterwards.
+You can choose whatever username and passphrase you would like. To make
+things easier later you should use the same username and same passphrase
+on both servers (but not the same passphrase as username). Make sure to
+save this passphrase in your admin KeePassX database afterwards.
 
 Click 'no' when asked to encrypt the home directory. Then configure your
 time zone.
@@ -215,7 +215,7 @@ information on them stays private in case they are seized or stolen.
 While FDE can be useful in some cases, we currently do not recommend
 that you enable it because there are not many scenarios where it will be
 a net security benefit for SecureDrop operators. Doing so will introduce
-the need for more passwords and add even more responsibility on the
+the need for more passphrases and add even more responsibility on the
 admin of the system (see `this GitHub
 issue <https://github.com/freedomofpress/securedrop/issues/511#issuecomment-50823554>`__
 for more information).
@@ -225,7 +225,7 @@ installation option that says *Guided - use entire disk and set up LVM*.
 
 However, if you decide to go ahead and enable FDE, please note that
 doing so means SecureDrop will become unreachable after an automatic
-reboot. An admin will need to be on hand to enter the password
+reboot. An admin will need to be on hand to enter the passphrase
 in order to decrypt the disks and complete the startup process, which
 will occur anytime there is an automatic software update, and also
 several times during SecureDrop's installation. We recommend that the
@@ -234,7 +234,7 @@ receive an alert when the system becomes unavailable.
 
 To enable FDE, select *Guided - use entire disk and set up encrypted
 LVM* during the disk partitioning step and write the changes to disk.
-Follow the recommendations as to choosing a strong password. As the
+Follow the recommendations as to choosing a strong passphrase. As the
 admin, you will be responsible for keeping this passphrase safe.
 Write it down somewhere and memorize it if you can. **If inadvertently
 lost it could result in total loss of the SecureDrop system.**
@@ -281,7 +281,7 @@ When you are done, make sure you save the following information:
 
 -  The IP address of the *Application Server*
 -  The IP address of the *Monitor Server*
--  The non-root user's name and password for the servers.
+-  The non-root user's name and passphrase for the servers.
 
 .. _test_connectivity:
 
@@ -294,7 +294,7 @@ Workstation to both of the servers before continuing with the
 installation.
 
 In a terminal, verify that you can SSH into both servers,
-authenticating with your password:
+authenticating with your passphrase:
 
 .. code:: sh
 
@@ -310,7 +310,7 @@ Set up SSH keys
 ---------------
 
 Ubuntu's default SSH configuration authenticates users with their
-passwords; however, public key authentication is more secure, and once
+passphrases; however, public key authentication is more secure, and once
 it's set up it is also easier to use. In this section, we will create
 a new SSH key for authenticating to both servers. Since the Admin Live
 USB was set up with `SSH Client Persistence`_, this key will be saved
@@ -335,7 +335,7 @@ type it (Tails' pinentry will not allow you to copy and paste a passphrase).
 
 Once the key has finished generating, you need to copy the public key
 to both servers. Use ``ssh-copy-id`` to copy the public key to each
-server, authenticating with your password:
+server, authenticating with your passphrase:
 
 .. code:: sh
 

--- a/docs/set_up_tails.rst
+++ b/docs/set_up_tails.rst
@@ -68,7 +68,7 @@ drive. This information will remain available to you even if you reboot
 Tails. (Tails securely erases all other data on every shutdown.)
 
 You will need to create a persistent storage on each Tails drive, with a
-unique password for each.
+unique passphrase for each.
 
 Please use the instructions on the `Tails website
 <https://tails.boum.org/doc/first_steps/persistence/index.en.html>`__

--- a/docs/tails_guide.rst
+++ b/docs/tails_guide.rst
@@ -88,9 +88,9 @@ Start Tails and enable the persistent volume
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When starting Tails, you should see a "Welcome to Tails" screen with two
-options. Select *Yes* to enable the persistent volume and enter your password.
+options. Select *Yes* to enable the persistent volume and enter your passphrase.
 Select *Yes* to show more options and click *Forward*. Enter an *Administration
-password* for use with this specific Tails session and click *Login*.
+passphrase* for use with this specific Tails session and click *Login*.
 
 Download the repository
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -108,10 +108,10 @@ repository is fairly large and Tor can be slow, this may take a few minutes.
 Passphrase Database
 ~~~~~~~~~~~~~~~~~~~
 
-We provide a KeePassX password database template to make it easier for
+We provide a KeePassX passphrase database template to make it easier for
 admins and journalists to generate strong, unique passphrases and
 store them securely. Once you have set up Tails with persistence and
-have cloned the repo, you can set up your personal password database
+have cloned the repo, you can set up your personal passphrase database
 using this template.
 
 You can find the template in ``tails_files/securedrop-keepassx.kdbx``
@@ -127,12 +127,12 @@ To use the template:
 -  Click **Database** and **Save Database As**
 -  Save the database in the Persistent folder
 
-.. tip:: If you would like to add a master password, navigate to **Database** and
+.. tip:: If you would like to add a master passphrase, navigate to **Database** and
    **Change master key**. Note that since each KeePassX database is stored
    on the encrypted persistent volume, this additional passphrase is not necessary.
 
-.. warning:: You will not be able to access your passwords if you
-	     forget the master password or the location of the key
+.. warning:: You will not be able to access your passphrases if you
+	     forget the master passphrase or the location of the key
 	     file used to protect the database.
 
 
@@ -150,7 +150,7 @@ by typing these commands into the terminal:
 
     ./securedrop-admin tailsconfig
 
-Type the administration password that you selected when starting Tails and hit
+Type the administration passphrase that you selected when starting Tails and hit
 enter. This installation script does the following:
 
 * Downloads additional software
@@ -171,7 +171,7 @@ for each interface, provided to you by the admin.
 We use an "authenticated" Tor Hidden Service so that adversaries cannot access
 the Journalist Interface, providing a layer of defense-in-depth which protects the
 Journalist Interface even if there is a security vulnerability in the web
-application, or if the journalist's username, password, and two-factor token
+application, or if the journalist's username, passphrase, and two-factor token
 are stolen. The extra configuration that is required is handled by this script.
 
 Our ``./securedrop-admin tailsconfig`` tool sets up Tails to work with SecureDrop

--- a/docs/test_the_installation.rst
+++ b/docs/test_the_installation.rst
@@ -34,7 +34,7 @@ supported, but require 2FA to be configured. See the :doc:`2FA setup guide
 Test the 2FA functionality by connecting a keyboard and display to each server,
 then login with the Admin username. You will need:
 
-* sudo password for the Admin username
+* sudo passphrase for the Admin username
 * TOTP code from a 2FA app such as Google Authenticator or FreeOTP
 
 Confirm that logging in via TTY prompts for a 2FA code, and that the code
@@ -76,7 +76,7 @@ Test the web interfaces
    in as the admin user you just created.
 
    - Open the Tor Browser and navigate to the onion URL from
-     app-journalist-aths. Enter your password and two-factor
+     app-journalist-aths. Enter your passphrase and two-factor
      authentication code to log in.
    - If you have problems logging in to the Admin/Journalist Interface,
      SSH to the *Application Server* and restart the ntp daemon to synchronize

--- a/docs/training_schedule.rst
+++ b/docs/training_schedule.rst
@@ -134,7 +134,7 @@ Participants: admins
 -  Backups
 -  Disk space monitoring
 -  Updating SMTP and OSSEC alert configs
--  Changing passwords (for FDE, persistent volumes, 2FA, KeePassX
+-  Changing passphrases (for FDE, persistent volumes, 2FA, KeePassX
    managers...)
 -  What will happen to local modifications to prod system after updates
 -  Updating SecureDrop Application

--- a/docs/yubikey_setup.rst
+++ b/docs/yubikey_setup.rst
@@ -21,7 +21,7 @@ Download and Launch the YubiKey Personalization Tool
 ----------------------------------------------------
 
 #. Start Tails. At the log in-screen, choose the option to allow an
-   administrator password.
+   administrator passphrase.
 #. Open a terminal and enter
 
 .. code:: sh


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Contributes to #2176 (in docs, at least).

Changed "password" to "passphrase" throughout the main docs.

I tried to make sure nothing creeped in that didn't sound right. For instance: I didn't change "password manager" to "passphrase manager". I also left the tails upgrade and tails admin docs untouched to avoid changing anything where **password** appears onscreen.

### If you made changes to documentation:

- [x] Doc linting passed locally
