### PR TITLE
source: explicitly add space for <strong> in flash message

### DIFF
--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -71,8 +71,10 @@ def create_app(config):
         # about Tor2Web, corresponding to the initial page load.
         if 'X-tor2web' in request.headers:
             flash(Markup(gettext(
-                '<strong>WARNING:</strong> You appear to be using Tor2Web. '
-                'This <strong>does not</strong> provide anonymity. '
+                '<strong>WARNING:&nbsp;</strong> '
+                'You appear to be using Tor2Web. '
+                'This <strong>&nbsp;does not&nbsp;</strong> '
+                'provide anonymity. '
                 '<a href="{url}">Why is this dangerous?</a>')
                 .format(url=url_for('info.tor2web_warning'))),
                   "banner-warning")


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2693

When using display: flex CSS on the outer element of &lt;b>A&lt;/b> B, it will
show as AB instead of A B. Add a non breakable space.

## Testing

* vagrant up /staging/
* firefox http://$(cat install_files/ansible-base/app-source-ths).to/

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
