### PR TITLE
Implement #2679: Compile translations in development environment

### DIFF
--- a/install_files/ansible-base/securedrop-development.yml
+++ b/install_files/ansible-base/securedrop-development.yml
@@ -18,3 +18,15 @@
     - { role: app, tags: app }
     - { role: app-test, tags: app-test }
   become: yes
+
+  tasks:
+    # Uses creates arg because translation compilation will generate a new
+    # MO file even if the PO file has not changed.
+    - name: Compile translations (convert messages.po files to messages.mo files).
+      command:
+        ./manage.py --verbose translate-messages --compile
+      args:
+        chdir: '{{ securedrop_repo }}/securedrop'
+        creates: '{{ securedrop_repo }}/securedrop/translations/fr_FR/LC_MESSAGES/messages.mo'
+      tags:
+        - development


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2679.

Changes proposed in this pull request:
* Adds compilation of translations to the dev env

## Testing

If you have already compiled translations, run `vagrant provision` to verify that the task added in this PR does not report changes made (due to an `mo` file already being present). 

If you have not already compiled translations, run `vagrant provision` and verify that the task in this PR runs successfully and produces a file e.g. in `/vagrant/securedrop/translations/fr_FR/LC_MESSAGES/messages.mo`.

## Deployment

Dev env only

## Checklist

Dev env only
