### PR TITLE
these docs add support for a clean OS X python install

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -122,7 +122,7 @@ different version, the path to ``virtualenvwrapper.sh`` will differ. Running
 .. code:: sh
 
     sudo easy_install pip # if you don't already have pip
-    pip install -U virtualenvwrapper
+    sudo -H pip install -U virtualenvwrapper --ignore-installed six
     source /usr/local/bin/virtualenvwrapper.sh
     mkvirtualenv -p python2 securedrop
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2698.

## Testing

Ran through a clean SecureDrop install (from scratch including VirtualBox, Vagrant, python etc) on a brand new OS X machine. 

### If you made changes to documentation:

- [x] Doc linting passed locally
