### PR TITLE
Prevent OSSEC from sending emails on startup

### DIFF
--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -493,21 +493,8 @@ Common OSSEC Alerts
 ~~~~~~~~~~~~~~~~~~~
 
 The SecureDrop *Application* and *Monitor Servers* reboot every night, as part
-of the unattended upgrades process. When the servers come back up, OSSEC will
-start again and report the change in status. Therefore you should receive an
-email alert every morning containing text similar to: ::
-
-    Received From: mon->ossec-monitord
-    Rule: 502 fired (level 3) -> "Ossec server started."
-    Portion of the log(s):
-
-    ossec: Ossec started.
-
-This is a normal alert, and informs you that the system is working as expected.
-
-Similarly, your SecureDrop Application and Monitoring Servers will
-check for application updates on your servers. Should your servers require
-updates, OSSEC will alarm because the packages binaries will have changed
+of the unattended upgrades process. Therefore, on nights where packages were updated,
+you should receive email alerts every morning indicating binaries have changed.
 Below is a sample alert, but you may see any number of these records in the
 logs. This will happen in batches so these emails might be longer than the
 below alert. You should also see them in an email named ``Daily Report:
@@ -520,7 +507,7 @@ can review the logs in ``/var/log/apt/history.log``. ::
 
     status installed <package name> <version>
 
-This is a normal alert, it tells you your system is up-to-date and patched.
+These are normal alerts, they tell you your system is up-to-date and patched.
 
 Occasionally your SecureDrop Servers will send an alert for failing to connect
 to Tor relays. Since SecureDrop runs as a Tor Onion Service, it is possible

--- a/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
+++ b/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
@@ -170,3 +170,23 @@
     <description>Ansible playbook run on server (securedrop-admin install, backup, or restore).</description>
   </rule>
 </group>
+
+<!--
+  Do not send an email alert on OSSEC server/agent started message. These are
+  purely informational events.
+-->
+<group name="Ossec start notifications">
+  <rule id="400501" level="1">
+    <if_sid>501</if_sid>
+    <match>Agent started</match>
+    <description>This alert overrides 501 to suppress daily email alerts to admins.</description>
+    <options>no_email_alert</options>
+  </rule>
+
+  <rule id="400502" level="1">
+    <if_sid>502</if_sid>
+    <match>Ossec started</match>
+    <description>This alert overrides 502 to suppress daily email alerts to admins.</description>
+    <options>no_email_alert</options>
+  </rule>
+</group>

--- a/testinfra/vars/mon-staging.yml
+++ b/testinfra/vars/mon-staging.yml
@@ -85,3 +85,17 @@ log_events_with_ossec_alerts:
       iEwEExECAAwFAkqg7nQFgwll/3cACgkQ#0123nqvbpTAnH+GJA
     level: "13"
     rule_id: "400001"
+
+  # Override and Log (as to not send email of messages pertaining to pssec
+  # server and agent starting up after each reboot.
+  - name: test_ossec_server_started_does_not_produce_email
+    alert: >
+      ossec: Ossec started.
+    level: "1"
+    rule_id: "400502"
+
+  - name: test_ossec_agent_started_does_not_produce_email
+    alert: >
+      ossec: Agent started: 'app->10.20.2.2'.
+    level: "1"
+    rule_id: "400501"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2155

OSSEC will not send alerts on startup, specifically the following:
```
Rule: 503 fired (level 3) -> "Ossec agent started."
[...]
Rule: 502 fired (level 3) -> "Ossec server started."
```

Release notes should state that this email is suppressed, as I assume perhaps certain admins see this alert as a heartbeat feature.

## Testing

New installs:
* Provision production VMS on this branch
* Configure SecureDrop (including OSSEC/email credentials)
* Alerts `OSSEC Server started` and `OSSEC agent started` should still be in `/var/ossec/logs/alerts/alerts.log`
* These alerts will not send emails

update installs:
* Provision production VMS on another branch
* checkout this branch, `make build-debs and `vagrant provision mon-production`
* Configure SecureDrop (including OSSEC/email credentials)
* Alerts `OSSEC Server started` and `OSSEC agent started` should still be in `/var/ossec/logs/alerts/alerts.log`
* These alerts will not send emails

 ## Checklist
 [ :heavy_check_mark: ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
