### PR TITLE
manual line break in footer to prevent unwanted ugly break

### DIFF
--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -40,7 +40,7 @@
 
       {% block footer %}
       <footer>
-        {{ gettext('Like all software, SecureDrop may contain security bugs. Use at your own risk.') }} {{ gettext('Powered by') }} SecureDrop {{ version }}.
+        {{ gettext('Like all software, SecureDrop may contain security bugs. Use at your own risk.') }} <br>{{ gettext('Powered by') }} SecureDrop {{ version }}.
       </footer>
       {% endblock %}
     </div>

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -81,7 +81,7 @@
         {% include 'locales.html' %}
       </div>
       <footer>
-        {{ gettext('Like all software, SecureDrop may contain security bugs. Use at your own risk.') }} {{ gettext('Powered by') }} SecureDrop {{ version }}.
+        {{ gettext('Like all software, SecureDrop may contain security bugs. Use at your own risk.') }}<br>{{ gettext('Powered by') }} SecureDrop {{ version }}.
       </footer>
     </div>
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #2318.

Changes proposed in this pull request:

I added a `<br>` to break the version number in the footer early and more purposefully.
This is not a perfect cure-all but should improve the situation for most languages.

<img width="999" alt="screen shot 2017-12-07 at 21 18 57" src="https://user-images.githubusercontent.com/1006478/33752106-7e4ae976-db94-11e7-8e76-78c3212150ba.png">



