### PR TITLE
Builds securedrop metapackage

### DIFF
--- a/install_files/ansible-base/build-deb-pkgs.yml
+++ b/install_files/ansible-base/build-deb-pkgs.yml
@@ -68,4 +68,8 @@
     - role: build-generic-pkg
       tags: "securedrop-keyring"
       package_name: "securedrop-keyring"
+
+    - role: build-generic-pkg
+      tags: "securedrop-grsec"
+      package_name: "securedrop-grsec"
   tags: rebuild

--- a/install_files/securedrop-grsec/DEBIAN/control
+++ b/install_files/securedrop-grsec/DEBIAN/control
@@ -1,0 +1,12 @@
+Package: securedrop-grsec
+Source: securedrop-grsec
+Version: 3.14.79+r1
+Architecture: amd64
+Maintainer: SecureDrop Team <securedrop@freedom.press>
+Depends: linux-image-3.14.79-grsec
+Section: admin
+Priority: optional
+Homepage: https://securedrop.org
+Description: Metapackage providing a grsecurity-patched Linux kernel for use
+ with SecureDrop. Depends on the most recently built patched kernel maintained
+ by FPF. Package also includes sysctl and PaX flags calls for GRUB.

--- a/install_files/securedrop-grsec/etc/kernel/postinst.d/paxctl-grub
+++ b/install_files/securedrop-grsec/etc/kernel/postinst.d/paxctl-grub
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Set PaX flags on GRUB binaries. Required when running under a grsec kernel,
+# i.e. during kernel upgrades. If the GRUB binaries do not have the proper flags,
+# the kernel image will fail to install.
+#
+# This script must run prior to the `zz-update-grub` kernel postinst hook,
+# which will happen automatically due to sorting of the postinst scripts.
+#
+# Enabling EMUTRAMP on grub binaries, which requires `CONFIG_PAX_EMUTRAMP=y`
+# to be set in the kernel config. Using `-z` to clear out any other flags,
+# so the binaries will get only the intended settings, and all others
+# not maintained by this script will be removed.
+paxctl -zCE /usr/sbin/grub-probe
+paxctl -zCE /usr/sbin/grub-mkdevicemap
+paxctl -zCE /usr/bin/grub-script-check

--- a/install_files/securedrop-grsec/etc/sysctl.d/30-securedrop.conf
+++ b/install_files/securedrop-grsec/etc/sysctl.d/30-securedrop.conf
@@ -1,0 +1,1 @@
+vm.heap_stack_gap=1048576

--- a/molecule/builder/tests/test_securedrop_deb_package.py
+++ b/molecule/builder/tests/test_securedrop_deb_package.py
@@ -260,3 +260,24 @@ def test_deb_app_package_contains_https_validate_dir(host, deb):
         # static/gen/ directory should exist
         assert re.search("^.*\./var/www/securedrop/"
                 ".well-known/$", c.stdout, re.M)
+
+@pytest.mark.parametrize("deb", deb_packages)
+def test_grsec_metapackage(host, deb):
+    """
+    Sanity checks on the securedrop-grsec metapackage. Mostly checks
+    for presence of PaX flags hook and sysctl settings.
+    Does not validate file contents, just presence.
+    """
+
+    deb_package = host.file(deb.format(
+        securedrop_test_vars.securedrop_version))
+
+    if "securedrop-grsec" in deb_package.path:
+        c = host.run("dpkg-deb --contents {}".format(deb_package.path))
+        # Custom sysctl options should be present
+        assert re.search("^.*\./etc/sysctl.d/30-securedrop.conf$",
+                         c.stdout, re.M)
+        c = host.run("dpkg-deb --contents {}".format(deb_package.path))
+        # Post-install kernel hook for managing PaX flags must exist.
+        assert re.search("^.*\./etc/kernel/postinst.d/paxctl-grub$",
+                         c.stdout, re.M)


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #2696.

Changes proposed in this pull request:

* Brings in build logic for `securedrop-grsec` metapackage from external repo
* Does _not_ include build logic for underlying custom kernel image
* Adds basic config tests to validate package structure

There are two unintuitive aspects of these changes.

First, the securedrop-grsec deb package is not installed in the staging environment along with the other built deb packages. Without _also_ building linux-image packages for the staging, there's not much use in installing _just_ the metapackage. The utility of having the metapackage here is that changes can be made to the kernel images and then published to `apt-test`—a staging apt repository never used in production instances—for intensive QA on kernel changes, suhc as the upcoming 3.x -> 4.x transition.

Second, the "Version" field in the control file is currently set to `3.14.79+r1` and does _not_ include the SecureDrop version suffix as most of the other packages do. For the `securedrop-keyring` package, we're currently on version `0.1.1+0.5`. It'd be grand to have a similarly semantic versioning setup for the kernel metapackage, but we must make sure that versions always increment above 3.14.79+r1. Thus the version remains hardcoded and is not included in the `update_version.sh` script—because updates to the kernel package are currently not aligned with the regular SecureDrop release cycle.


## Testing

CI passing is sufficient here. Sanity checking the control fields is a good idea, but they've been copied from the upstream repo. 

## Deployment

No concerns for production installs at present. These changes are designed to accommodate intensive QA toward the next kernel upgrade, making use of a staging apt server (managed outside of this repository). 

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
