### PR TITLE
Reword warning re: decrypting off SVS

### DIFF
--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -244,9 +244,9 @@ command will tell you what key was used to encrypt the file. If you are not
 comfortable at the command line, contact your SecureDrop administrator or
 Freedom of the Press Foundation for assistance.
 
-.. warning:: You should not transfer source material off the SVS for decryption,
-             and should instead transfer cryptographic keys *to* the device for
-             decryption and metadata removal.
+.. warning:: **Do not** transfer source material off the *Secure Viewing Station*
+             for decryption. Instead, transfer cryptographic keys *to* the SVS
+             device for decryption and metadata removal.
 
 Researching Submissions
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Reworded the warning in the journalist guide about decrypting source material off the SVS: changed it to the imperative mood. I think the result is a strong and clear warning.

### If you made changes to documentation:

- [x] Doc linting passed locally
