### PR TITLE
i18n: s/lazy_gettext/gettext/ for pybabel extract

### DIFF
--- a/securedrop/journalist_app/forms.py
+++ b/securedrop/journalist_app/forms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from flask_babel import lazy_gettext
+from flask_babel import lazy_gettext as gettext
 from flask_wtf import FlaskForm
 from wtforms import (TextAreaField, TextField, BooleanField, HiddenField,
                      ValidationError)
@@ -12,7 +12,7 @@ from db import Journalist
 def otp_secret_validation(form, field):
     strip_whitespace = field.data.replace(' ', '')
     if len(strip_whitespace) != 40:
-        raise ValidationError(lazy_gettext(
+        raise ValidationError(gettext(
             'Field must be 40 characters long but '
             'got {num_chars}.'.format(
                 num_chars=len(strip_whitespace)
@@ -22,16 +22,16 @@ def otp_secret_validation(form, field):
 def minimum_length_validation(form, field):
     if len(field.data) < Journalist.MIN_USERNAME_LEN:
         raise ValidationError(
-            lazy_gettext('Field must be at least {min_chars} '
-                         'characters long but only got '
-                         '{num_chars}.'.format(
-                             min_chars=Journalist.MIN_USERNAME_LEN,
-                             num_chars=len(field.data))))
+            gettext('Field must be at least {min_chars} '
+                    'characters long but only got '
+                    '{num_chars}.'.format(
+                        min_chars=Journalist.MIN_USERNAME_LEN,
+                        num_chars=len(field.data))))
 
 
 class NewUserForm(FlaskForm):
     username = TextField('username', validators=[
-        InputRequired(message=lazy_gettext('This field is required.')),
+        InputRequired(message=gettext('This field is required.')),
         minimum_length_validation
     ])
     password = HiddenField('password')
@@ -48,7 +48,7 @@ class ReplyForm(FlaskForm):
         u'Message',
         id="content-area",
         validators=[
-            InputRequired(message=lazy_gettext(
+            InputRequired(message=gettext(
                 'You cannot send an empty reply.')),
         ],
     )

--- a/securedrop/source_app/forms.py
+++ b/securedrop/source_app/forms.py
@@ -1,4 +1,4 @@
-from flask_babel import lazy_gettext
+from flask_babel import lazy_gettext as gettext
 from flask_wtf import FlaskForm
 from wtforms import PasswordField
 from wtforms.validators import InputRequired, Regexp, Length
@@ -8,12 +8,12 @@ from db import Source
 
 class LoginForm(FlaskForm):
     codename = PasswordField('codename', validators=[
-        InputRequired(message=lazy_gettext('This field is required.')),
+        InputRequired(message=gettext('This field is required.')),
         Length(1, Source.MAX_CODENAME_LEN,
-               message=lazy_gettext(
+               message=gettext(
                    'Field must be between 1 and '
                    '{max_codename_len} characters long.'.format(
                        max_codename_len=Source.MAX_CODENAME_LEN))),
         # Make sure to allow dashes since some words in the wordlist have them
-        Regexp(r'[\sA-Za-z0-9-]+$', message=lazy_gettext('Invalid input.'))
+        Regexp(r'[\sA-Za-z0-9-]+$', message=gettext('Invalid input.'))
     ])


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

lazy_gettext is not recognized by pybabel extract: map it to gettext
intead.

## Testing

* vagrant ssh development
* cd /vagrant/securedrop
* ./manage.py translate-messages --extract-update
* verify strings from {source,journalist}_app/forms.py are preserved in translations/messages.pot

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
