### PR TITLE
Consistently use the term "third-party" throughout docs

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -79,17 +79,17 @@ signature:
 
     openssl req -new -newkey rsa:4096 -nodes -sha256 -keyout domain.com.key -out domain.com.csr
 
-**Don't load any resources (scripts, web fonts, etc.) from 3rd parties
+**Don't load any resources (scripts, web fonts, etc.) from third parties
 (e.g. Google Web Fonts)**
 
 This will potentially leak information about sources to third parties,
 which can more easily be accessed by law enforcement agencies. Simply
 copy them to your server and serve them yourself to avoid this problem.
 
-Don't use 3rd party analytics, tracking, or advertising
--------------------------------------------------------
+Do not use third-party analytics, tracking, or advertising
+----------------------------------------------------------
 
-Most news websites, even those that are non-profits, use 3rd-party
+Most news websites, even those that are non-profits, use third-party
 analytics tools or tracking bugs on their websites. It is vital that
 these are disabled for the SecureDrop landing page.
 

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -153,7 +153,7 @@ Visit our repository_ fork it and clone it on you local machine:
 Install python requirments
 --------------------------
 
-SecureDrop uses many 3rd party open source packages from the python community.
+SecureDrop uses many third-party open source packages from the python community.
 Ensure your virtualenv is activated and install the packages.
 
 .. code:: sh

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -35,7 +35,7 @@ These are the core components of a SecureDrop instance.
 
 We are often asked if it is acceptable to run SecureDrop on
 cloud servers (e.g. Amazon EC2, DigitalOcean, etc.) or on dedicated
-servers in third party datacenters instead of on dedicated hardware
+servers in third-party datacenters instead of on dedicated hardware
 hosted in the organization. This request is generally motivated by a
 desire for cost savings and/or convenience. However: we consider it
 **critical** to have dedicated physical machines hosted within the
@@ -63,12 +63,12 @@ organization for both technical and legal reasons:
 * In addition, attackers with legal authority such as law
   enforcement agencies may (depending on the jurisdiction) be able
   to compel physical access, potentially with a gag order attached,
-  meaning that the 3rd party hosting your servers or VMs may be
+  meaning that the third party hosting your servers or VMs may be
   legally unable to tell you that law enforcement has been given
   access to your SecureDrop servers.
 
 One of the core goals of SecureDrop is to avoid the potential
-compromise of sources through the compromise of third party
+compromise of sources through the compromise of third-party
 communications providers. Therefore, we consider the use of
 virtualization for production instances of SecureDrop to be an
 unacceptable compromise and do not support it. Instead, dedicated

--- a/docs/what_makes_securedrop_unique.rst
+++ b/docs/what_makes_securedrop_unique.rst
@@ -16,7 +16,7 @@ than betray a source.
 
 More recently, there have been a record number of leak prosecutions largely because
 the government has learned they don’t need reporters to testify against their
-sources anymore. Instead, they can just secretly subpoena third party services
+sources anymore. Instead, they can just secretly subpoena third-party services
 like Google or AT&T or Verizon or Facebook and get a treasure trove of digital
 information on reporters and sources’ communications. For example, the Associated
 Press had twenty of their phone lines subpoenaed without their knowledge in order
@@ -101,7 +101,7 @@ Free and open source software
 can install SecureDrop themselves, but the code is available online for security
 experts to test for vulnerabilities.
 
-SecureDrop has gone through four audits by third party penetration testing firms
+SecureDrop has gone through four audits by third-party penetration testing firms
 and will continue to go through audits when major changes are made to the code
 base in the future. We always publish these audits publicly so everyone can be
 assured that SecureDrop is as safe to use as possible.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Made use of the hyphenated phrasal adjective "third-party" consistent throughout. Also fixed up similar phrases.

## Testing

```
$ cd docs/
$ grep -ri 3rd *
$ grep -ri third *
```
(See Chicago Manual of Style 5.91, "Phrasal adjectives.")

### If you made changes to documentation:

- [x] Doc linting passed locally
