### PR TITLE
docs: abstract firewall rules definition

### DIFF
--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -33,6 +33,9 @@ These are the core components of a SecureDrop instance.
 * *Network Firewall*: 1 physical computer that is used as a dedicated firewall
   for the SecureDrop servers.
 
+An acceptable alternative that requires more technical expertise is
+to :doc:`configure an existing hardware firewall <network_firewall>`.
+
 We are often asked if it is acceptable to run SecureDrop on
 cloud servers (e.g. Amazon EC2, DigitalOcean, etc.) or on dedicated
 servers in third-party datacenters instead of on dedicated hardware

--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -7,7 +7,11 @@ USB* to access the Network Firewall's web interface for configuration.
 
 Unfortunately, due to the wide variety of firewalls that may be used, we
 do not provide specific instructions to cover every type or variation in
-software or hardware. This guide is based on pfSense, and assumes your
+software or hardware.
+However, if you have the necessary
+expertise, we provide `abstract firewall rules`_ that can be
+implemented with iptables, Cisco IOS etc.
+This guide is based on pfSense, and assumes your
 firewall hardware has at least three interfaces: WAN, LAN, and OPT1. For
 hardware, you can build your own network firewall (not covered in this
 guide) and `install
@@ -578,3 +582,25 @@ Once it is complete, you will see a notification of successful upgrade:
 .. [#] Tails screenshots were taken on Tails 3.0~beta4. Please make an issue on
        GitHub if you are using the most recent version of Tails and the
        interface is different from what you see here.
+
+.. _abstract firewall rules:
+
+Abstract firewall rules
+-----------------------
+
+The pfSense instructions using the web interface can also be precisely
+described as follows:
+
+* Disable DHCP (in case the firewall is providing a DHCP server by default)
+* Disallow all traffic by default (inbound or outbound)
+* Allow UDP OSSEC (port 1514) from *Application Server* to *Monitor Server*
+* Allow TCP ossec agent auth (port 1515) from *Application Server* to *Monitor Server*
+* Allow TCP/UDP DNS from *Application Server* and *Monitor Server* to the IPs of known name servers
+* Allow UDP NTP from *Application Server* and *Monitor Server* to all
+* Allow TCP any port from *Application Server* and *Monitor Server* to all (this is needed for making connections to the Tor network)
+* Allow TCP 80/443 from *Admin Workstation* to all (in case there is a need to access the web interface of the firewall)
+* Allow TCP ssh from *Admin Workstation* to *Application Server* and *Monitor Server*
+* Allow TCP any port from *Admin Workstation* to all
+
+This can be implemented with iptables, Cisco IOS etc. if you have the
+necessary expertise.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

It is not uncommon for network engineers working in a media to have
the necessary expertise to translate the firewall recommendations and
implement them on the hardware they already have.

It is error prone to browse the long description using the pfSense web
interface and figure out what needs to be implemented in an abstract
way.

A paragraph is added, precisely describing the intended rules, for the
benefit of skilled network engineers and in the spirit of minimizing
errors.

## Testing

Carefully read the pfSense instructions and verify nothing is missing from the abstract description.

## Deployment

N/A

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
