### PR TITLE
docs: add warning about MAT being unmaintained

### DIFF
--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -270,6 +270,11 @@ We recommend always doing as much work as possible inside of Tails
 before copying documents back to your *Journalist Workstation*. This
 includes stripping metadata with MAT.
 
+.. warning:: MAT is no longer actively maintained and **will not**
+             strip all metadata, even when the output claims the
+             document is clean. Some metadata are likely to persist:
+             you must **never** assume MAT has removed all metadata.
+
 When you no longer need documents, you can right-click on them and
 choose **Wipe** to delete them.
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Contributes to #2721

add warning about MAT being unmaintained

## Testing

N/A

## Deployment

N/A

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
