### PR TITLE
move meta dep. from grsecurity role -> playbook

### DIFF
--- a/install_files/ansible-base/roles/grsecurity/meta/main.yml
+++ b/install_files/ansible-base/roles/grsecurity/meta/main.yml
@@ -1,5 +1,0 @@
----
-# Add dependency for FPF repo installation role,
-# since the securedrop-grsec package is hosted there.
-dependencies:
-  - install-fpf-repo

--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -19,6 +19,7 @@
   roles:
     - { role: common, tags: common }
     - { role: tor-hidden-services, tags: tor }
+    - { role: install-fpf-repo, tags: fpf }
     - { role: grsecurity, when: grsecurity, tags: [grsec, grsecurity] }
   become: yes
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

During a security audit of trying to track down dependencies, this was
overlooked at first pass and makes the logic trickier to debug. Lets
stop using meta dependencies and instead always use top-level
dependencies.

Fixes #2728

Changes proposed in this pull request:

## Testing

How should the reviewer test this PR?

Does it pass CI and not contain any other nits? 👍 

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances. -- nope
2. New installs. -- nope