### PR TITLE
remove hmac-sha1 from sshd_config

### DIFF
--- a/install_files/ansible-base/roles/restrict-direct-access/templates/sshd_config
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/sshd_config
@@ -35,7 +35,7 @@ ClientAliveInterval 300
 ClientAliveCountMax 0
 Ciphers aes256-gcm@openssh.com,aes256-ctr,chacha20-poly1305@openssh.com
 KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
-MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1
+MACs hmac-sha2-256,hmac-sha2-512
 GatewayPorts no
 AllowGroups ssh
 AllowTcpForwarding no

--- a/install_files/securedrop-app-code/DEBIAN/postinst
+++ b/install_files/securedrop-app-code/DEBIAN/postinst
@@ -55,6 +55,13 @@ case "$1" in
       rm /tmp/securedrop_custom_logo.png
     fi
 
+    # This removes the MAC "hmac-sha1" from sshd_config.
+    # Ansible was updated, so future instances will not have this line present.
+    # This if-block may be removed from this script on 2019-01-01.
+    if grep -qE 'MACs\s.*hmac-sha1' /etc/ssh/sshd_config; then
+        sed -i 's/^\s*MACs\s.*/MACs hmac-sha2-256,hmac-sha2-512/' /etc/ssh/sshd_config;
+    fi
+
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Removes a comparatively weak MAC algorithm from the `sshd_config`.

## Deployment

1. Upgrading existing production instances: a `sed` command could be added to `postinst` to fix existing instances
2. New installs: no change

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass