### PR TITLE
source: resolve generate interaction confusion

### DIFF
--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -43,6 +43,5 @@
     <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-blue.png') }}" width="17px" height="17px">
      {{ gettext('USE NEW CODENAME') }}
   </button>
-  <a id="already-have-codename" href="{{ url_for('main.login') }}" class="sd-button btn btn--space secondary pull-right">{{ gettext('USE EXISTING CODENAME') }}</a>
 </form>
 {% endblock %}

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -4,7 +4,6 @@ import gzip
 from mock import patch, ANY
 import re
 
-from bs4 import BeautifulSoup
 from flask import session, escape, url_for
 from flask_testing import TestCase
 
@@ -89,16 +88,6 @@ class TestSourceApp(TestCase):
         # codename is also stored in the session - make sure it matches the
         # codename displayed to the source
         self.assertEqual(codename, escape(session_codename))
-
-    def test_generate_has_login_link(self):
-        """The generate page should have a link to remind people to login
-           if they already have a codename, rather than create a new one.
-        """
-        resp = self.client.get('/generate')
-        self.assertIn("USE EXISTING CODENAME", resp.data)
-        soup = BeautifulSoup(resp.data, 'html.parser')
-        already_have_codename_link = soup.select('a#already-have-codename')[0]
-        self.assertEqual(already_have_codename_link['href'], '/login')
 
     def test_generate_already_logged_in(self):
         with self.client as client:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2692

If sources arrive at the generate page, it is because they clicked on
the "Submit Document" button in the index page. We remove the "USE
EXISTING CODENAME" from the generate page because it means the exact
opposite. If sources change their mind, they can go back to the index
page.

Removing this button is important for another reason: the wording may
confuse sources. Some may think "EXISTING CODENAME" refers to the
codename displayed in the generate page although it means the exact
opposite. And the "NEW CODENAME" could also be interpreted as a way to
create a codename that is different from the one displayed in the
page (for instance because it is difficult to memorize). But it
actually means the opposite.

Removing this button is also a way to avoid confusion in the
future. The previous wording of the buttons (using CONTINUE) was
slightly confusing. And I merged the current wording because it
sounded like it was an improvement but it turns out to be worse.  This
is a hint that the problem is not in the wording of the buttons.

## Testing

* vagrant ssh development
* cd /vagrant/securedrop
* ./manage.py run
* firefox http://127.0.0.1:8080/generate

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
