### PR TITLE
Push grsecurity tasks to top of the install

### DIFF
--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -17,10 +17,10 @@
 - name: Add FPF apt repository and install base packages.
   hosts: securedrop
   roles:
-    - { role: common, tags: common }
-    - { role: tor-hidden-services, tags: tor }
     - { role: install-fpf-repo, tags: fpf }
     - { role: grsecurity, when: grsecurity, tags: [grsec, grsecurity] }
+    - { role: common, tags: common }
+    - { role: tor-hidden-services, tags: tor }
   become: yes
 
 - name: Configure SecureDrop Monitor Server.

--- a/install_files/ansible-base/securedrop-staging.yml
+++ b/install_files/ansible-base/securedrop-staging.yml
@@ -23,10 +23,10 @@
   roles:
     - role: ci-tweaks
       when: amazon_builder
-    - { role: common, tags: common }
-    - { role: tor-hidden-services, tags: tor }
     - { role: install-fpf-repo, tags: [fpfrepo] }
     - { role: grsecurity, when: grsecurity, tags: [grsec, grsecurity] }
+    - { role: common, tags: common }
+    - { role: tor-hidden-services, tags: tor }
     - { role: install-local-packages, tags: [install_local_packages, rebuild],
         when: install_local_packages }
   become: yes


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Move grsec logic to the top of the play. Reasoning behind move is:
* we want grsec on the box as fast as possible
* we want a fail fast experience so if grsec kernel bombs out on a particular piece of hardware we arent also locking out the box and installing un-necessary networking

Fixes #2737 

## Testing

How should the reviewer test this PR?
Test a local prod run ... make sure CI is passing.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.  -- Nope
2. New installs. -- Nope