### PR TITLE
Remove legacy prod-specific.yml migration code

### DIFF
--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -1,16 +1,8 @@
 #!/usr/bin/env ansible-playbook
 ---
-- name: Migrate site-specific information in vars files.
+- name: Ensure validation is run before prod install
   hosts: localhost
   connection: local
-  pre_tasks:
-    - name: Copy deprecated prod-specific.yml vars file.
-      command: >
-        cp "{{ playbook_dir }}/prod-specific.yml"
-        "{{ playbook_dir }}/group_vars/all/site-specific"
-      # Don't clobber new vars file with old, just create it.
-      args:
-        creates: "{{ playbook_dir }}/group_vars/all/site-specific"
   roles:
     - { role: validate, tags: validate }
 


### PR DESCRIPTION


## Status

Ready for review / Work in progress

## Description of Changes

This code will never get triggered because we have checks earlier in the inventory scripts that will bomb out if the code is missing. We have enough scaffolding and checks in place to make this piece of helper code
neglible at this point.

Fixes #2746

Changes proposed in this pull request:

## Testing

How should the reviewer test this PR? Test a prod instance run!

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances. --- Nope
2. New installs. --- Nope