### PR TITLE
source: make codename hint visible on first submission

### DIFF
--- a/securedrop/source_templates/first_submission_flashed_message.html
+++ b/securedrop/source_templates/first_submission_flashed_message.html
@@ -1,7 +1,7 @@
 <img src="{{ url_for('static', filename='i/success_checkmark.png') }}" height="64px" width="74px">
 <div class="message"><strong>{{ gettext('Success!') }}</strong>
   <p>{{ gettext('Thank you for sending this information to us. Please check back later for replies.') }}
-    <a href="#codename-hint">
+    <a href="#codename-hint-visible">
     {{ gettext('Forgot your codename?') }}
     </a>
   </p>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The link is not correct, fix it by adding -visible

## Testing

* make images dev # yeah, that's the modern docker way of doing things !
* firefox http://127.0.0.1:8080/generate
* submit a message
* click on "Forgot your codename? " in the thank you green box
* see the codename shows at the bottom of the page

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
