### PR TITLE
Set Referrer-Policy in vhost config + landing page guidelines

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -130,6 +130,7 @@ If you use Apache, you can use these:
     Header set X-Download-Options: noopen
     Header set X-Permitted-Cross-Domain-Policies: master-only
     Header set Content-Security-Policy: "default-src 'self'"
+    Header set Referrer-Policy "no-referrer"
 
 If you intend to run nginx as your webserver instead, this will work:
 
@@ -141,9 +142,10 @@ If you intend to run nginx as your webserver instead, this will work:
     add_header X-Frame-Options DENY;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
-    add_header Content-Security-Policy "default-src 'self'";
     add_header X-Download-Options: noopen;
     add_header X-Permitted-Cross-Domain-Policies master-only;
+    add_header Content-Security-Policy "default-src 'self'";
+    add_header Referrer-Policy "no-referrer";
 
 
 Additional Apache configuration

--- a/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
@@ -24,6 +24,7 @@ XSendFilePath    /var/lib/securedrop/tmp/
 
 Header edit Set-Cookie ^(.*)$ $1;HttpOnly
 Header always append X-Frame-Options: DENY
+Header set Referrer-Policy "no-referrer"
 Header set X-XSS-Protection: "1; mode=block"
 Header set X-Content-Type-Options: nosniff
 Header set X-Download-Options: noopen

--- a/install_files/ansible-base/roles/app/templates/sites-available/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/source.conf
@@ -47,6 +47,7 @@ XSendFile        Off
 
 Header edit Set-Cookie ^(.*)$ $1;HttpOnly
 Header always append X-Frame-Options: DENY
+Header set Referrer-Policy "no-referrer"
 Header set X-XSS-Protection: "1; mode=block"
 Header set X-Content-Type-Options: nosniff
 Header set X-Content-Security-Policy: "default-src 'self'"

--- a/testinfra/app/apache/test_apache_journalist_interface.py
+++ b/testinfra/app/apache/test_apache_journalist_interface.py
@@ -8,6 +8,7 @@ securedrop_test_vars = pytest.securedrop_test_vars
 wanted_apache_headers = [
   'Header edit Set-Cookie ^(.*)$ $1;HttpOnly',
   'Header always append X-Frame-Options: DENY',
+  'Header set Referrer-Policy "no-referrer"',
   'Header set X-XSS-Protection: "1; mode=block"',
   'Header set X-Content-Type-Options: nosniff',
   'Header set X-Download-Options: noopen',

--- a/testinfra/app/apache/test_apache_journalist_interface.py
+++ b/testinfra/app/apache/test_apache_journalist_interface.py
@@ -14,6 +14,7 @@ wanted_apache_headers = [
   'Header set X-Download-Options: noopen',
   "Header set X-Content-Security-Policy: \"default-src 'self'\"",
   "Header set Content-Security-Policy: \"default-src 'self'\"",
+  'Header set Referrer-Policy "no-referrer"',
   'Header unset Etag',
 ]
 

--- a/testinfra/app/apache/test_apache_source_interface.py
+++ b/testinfra/app/apache/test_apache_source_interface.py
@@ -27,6 +27,7 @@ def test_apache_headers_source_interface(File, header):
     'WSGIProcessGroup source',
     'WSGIScriptAlias / /var/www/source.wsgi',
     'Header set Cache-Control "no-store"',
+    'Header set Referrer-Policy "no-referrer"',
     "Alias /static {}/static".format(securedrop_test_vars.securedrop_code),
     """
 <Directory {}/static>

--- a/testinfra/vars/app-staging.yml
+++ b/testinfra/vars/app-staging.yml
@@ -3,6 +3,7 @@
 wanted_apache_headers:
   - 'Header edit Set-Cookie ^(.*)$ $1;HttpOnly'
   - 'Header always append X-Frame-Options: DENY'
+  - 'Header set Referrer-Policy "no-referrer"'
   - 'Header set X-XSS-Protection: "1; mode=block"'
   - 'Header set X-Content-Type-Options: nosniff'
   - 'Header set X-Download-Options: noopen'


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes: #2762

[Referrer-Policy](https://www.w3.org/TR/referrer-policy/) is a new HTTP security header which was recommended and specified by W3C at the beginning of 2017. This setting allows us to instruct browsers to never send a 'Referer' header for all requests originating from the site. It would be extremely rare or unheard of for any off-site links to be present on a SecureDrop page, but it's worth including this in the headers anyhow.

Adds another security header to Apache2 virtual host configuration files, landing page deployment recommendations, and tests.

## Testing

n/a

## Deployment

No special considerations. If merged in then the change will propagate with new installs.

## Checklist

n/a, haven't familiarized myself with or tried running your tests locally but I will next time 