### PR TITLE
user logout on password reset

### DIFF
--- a/securedrop/journalist_app/account.py
+++ b/securedrop/journalist_app/account.py
@@ -31,6 +31,7 @@ def make_blueprint(config):
             set_diceware_password(user, password)
             session.pop('uid', None)
             session.pop('expires', None)
+            return redirect(url_for('main.login'))
         return redirect(url_for('account.edit'))
 
     @view.route('/2fa', methods=('GET', 'POST'))

--- a/securedrop/journalist_app/account.py
+++ b/securedrop/journalist_app/account.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from flask import (Blueprint, render_template, request, g, redirect, url_for,
-                   flash)
+                   flash, session)
 from flask_babel import gettext
 
 from db import db_session
@@ -29,6 +29,8 @@ def make_blueprint(config):
                          error_message):
             password = request.form.get('password')
             set_diceware_password(user, password)
+            session.pop('uid', None)
+            session.pop('expires', None)
         return redirect(url_for('account.edit'))
 
     @view.route('/2fa', methods=('GET', 'POST'))

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -737,14 +737,6 @@ class TestJournalistApp(TestCase):
         text = resp.data.decode('utf-8')
         self.assertIn('Incorrect password or two-factor code', text)
 
-    def test_invalid_user_password_change(self):
-        self._login_user()
-        res = self.client.post(url_for('account.new_password'),
-                               data=dict(password='badpw',
-                                         token='mocked',
-                                         current_password=self.user_pw))
-        self.assertRedirects(res, url_for('account.edit'))
-
     def test_too_long_user_password_change(self):
         self._login_user()
 

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1069,16 +1069,17 @@ class TestJournalistApp(TestCase):
 
         try:
             with self.client as client:
-                # do a real login to get a real session
-                # (none of the mocking `g` hacks)
-                resp = self.client.post(url_for('main.login'),
-                                        data=dict(username=self.user.username,
-                                                  password=VALID_PASSWORD,
-                                                  token='mocked'))
-                assert resp.status_code == 200
-
                 # set the expiration to ensure we trigger an expiration
                 config.SESSION_EXPIRATION_MINUTES = -1
+
+                # do a real login to get a real session
+                # (none of the mocking `g` hacks)
+                resp = client.post(url_for('main.login'),
+                                   data=dict(username=self.user.username,
+                                             password=self.user_pw,
+                                             token='mocked'))
+                self.assertRedirects(resp, url_for('main.index'))
+                assert 'uid' in session
 
                 resp = client.get(url_for('account.edit'),
                                   follow_redirects=True)

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -301,7 +301,7 @@ class TestJournalistApp(TestCase):
         assert ('There was an error, and the new password might not have '
                 'been saved correctly.') in resp.data.decode('utf-8')
 
-    def test_user_edits_password_success_reponse(self):
+    def test_user_edits_password_success_response(self):
         self._login_user()
         resp = self.client.post(
             url_for('account.new_password'),


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Logs the user out when the user resets their password.

Fixes #2303.

Changes proposed in this pull request:
- clear session values on password reset 

## Testing

How should the reviewer test this PR?
1. reset password on journalist application
2. attempt to navigate journalist page e.g. /account/account route and confirm that the session is invalid
3. login with the new password to confirm that the password was reset 

## Deployment

Any special considerations for deployment? Consider both:
1. Upgrading existing production instances.
2. New installs.

No

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM