### PR TITLE
pytest: turn off output squelching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   # are time consuming.
   # * en_US: source strings
   # * fr_FR: left-to-right translations
-  - sh -c "export DISPLAY=:1 ; cd securedrop && PAGE_LAYOUT_LOCALES='en_US,fr_FR' pytest -v tests --page-layout"
+  - sh -c "export DISPLAY=:1 ; cd securedrop && PAGE_LAYOUT_LOCALES='en_US,fr_FR' pytest -s -v tests --page-layout"
   - pip freeze -l
   - SECUREDROP_TESTINFRA_TARGET_HOST=travis testinfra -v testinfra/development/
 after_success:

--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -16,7 +16,7 @@ test:
 		$(EXTRA_TEST_ARGS) \
 		--name $(IMAGE)-test \
 		-ti $(IMAGE)-test:$(TAG) \
-		./bin/test -v $(TESTFILES)
+		./bin/test -s -v $(TESTFILES)
 
 .PHONY: testclean
 testclean:


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

While noisy, not silencing output hides exceptions raised in other threads.

## Testing

## Deployment
