### PR TITLE
source: use SUBMIT DOCUMENTS in generate

### DIFF
--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -41,7 +41,7 @@
   <button type="submit" class="sd-button btn btn--space primary pull-right" id="continue-button">
     <img class="icon off-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-white.png') }}" width="17px" height="17px">
     <img class="icon on-hover" src="{{ url_for('static', filename='i/font-awesome/fa-arrow-circle-o-right-blue.png') }}" width="17px" height="17px">
-     {{ gettext('USE NEW CODENAME') }}
+     {{ gettext('SUBMIT DOCUMENTS') }}
   </button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The generate page explains the importance of the code name to the
sources, after they have clicked on the SUBMIT DOCUMENTS button in the
index page. It is an intermediate page that only exists for
information purposes.

To move forward from the generate page and actually submit documents,
it makes sense to re-use the same wording as the index page,
i.e. SUBMIT DOCUMENTS instead of USE NEW CODENAME which could be
confusing.

## Testing

* make dev
* firefox http://127.0.0.1:8080/generate
* see the button has the new wording

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
