### PR TITLE
Fix async genkey logging

### DIFF
--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 
 from datetime import datetime
@@ -78,7 +79,7 @@ def async_genkey(filesystem_id, codename):
         source.last_updated = datetime.utcnow()
         db_session.commit()
     except Exception as e:
-        current_app.logger.error(
+        logging.getLogger(__name__).error(
                 "async_genkey for source (filesystem_id={}): {}"
                 .format(filesystem_id, e))
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

This skips calling current_app which is invalid to do from a separate thread (which async_genkey runs in).

Fixes #2609.

## Testing
CI

## Deployment
N/A

## Checklist
N/A