### PR TITLE
tests: replace abandoned pytest-capturelog with pytest-catchlog

### DIFF
--- a/securedrop/requirements/test-requirements.in
+++ b/securedrop/requirements/test-requirements.in
@@ -7,5 +7,5 @@ pip-tools
 py
 pytest
 pytest-cov
-pytest-capturelog
+pytest-catchlog
 selenium < 3

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -24,7 +24,7 @@ mock==2.0.0
 pbr==3.0.1                # via mock
 pip-tools==1.9.0
 py==1.4.34
-pytest-capturelog==0.7
+pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest==3.1.1
 requests==2.17.3          # via coveralls


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2773.

Changes proposed in this pull request:

This addressing deprecation warnings you see when running tests with `pytest -s`

Unfortunately these two can't be installed concurrently which could mean development environments could be negatively impacted by this change (see #2773).

## Testing

CI

## Deployment

N/A

## Checklist

N/A