### PR TITLE
securedrop: add dev-shell target

### DIFF
--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -31,6 +31,14 @@ dev:
 		-ti $(IMAGE)-test:$(TAG) \
 		./bin/dev
 
+.PHONY: dev-shell
+dev-shell:
+	docker run \
+		-p8080:8080 -p8081:8081 \
+		$(EXTRA_DEV_ARGS) \
+		-v $(shell pwd):/app \
+		-ti $(IMAGE)-test:$(TAG) \
+		bash
 
 config.py: test-config
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2782.

Changes proposed in this pull request:

adds a 'dev-shell' target which runs bash in a bare dev-oriented docker environment

## Testing

`cd securedrop; make images dev-shell`

## Deployment

N/A