### PR TITLE
WIP: tests: remove pytest-catchlog

### DIFF
--- a/securedrop/requirements/test-requirements.in
+++ b/securedrop/requirements/test-requirements.in
@@ -7,5 +7,4 @@ pip-tools
 py
 pytest
 pytest-cov
-pytest-catchlog
 selenium < 3

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -24,7 +24,6 @@ mock==2.0.0
 pbr==3.0.1                # via mock
 pip-tools==1.9.0
 py==1.4.34
-pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest==3.1.1
 requests==2.17.3          # via coveralls


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #2787.

Changes proposed in this pull request:

this package has been deprecated as it's functionality  has been upstreamed

as of pytest 3.3.1 this package is ignored by pytest

## Testing

CI

## Deployment

N/A

## Checklist

N/A