### PR TITLE
tests: pytest-catchlog is obsolete

### DIFF
--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -13,6 +13,7 @@ argh==0.26.2              # via sphinx-autobuild, watchdog
 arrow==0.10.0             # via jinja2-time
 asn1crypto==0.22.0        # via cryptography
 astroid==1.6.0            # via pylint
+attrs==17.4.0             # via pytest
 babel==2.4.0              # via sphinx
 backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.4  # via astroid, pylint
@@ -39,6 +40,7 @@ execnet==1.4.1            # via pytest-xdist
 fasteners==0.14.1         # via python-gilt
 first==2.0.1              # via pip-tools
 flake8==3.3.0
+funcsigs==1.0.2           # via pytest
 future==0.16.0            # via cookiecutter
 git-url-parse==1.0.2      # via python-gilt
 html-linter==0.4.0
@@ -62,11 +64,12 @@ pathtools==0.1.2          # via sphinx-autobuild, watchdog
 pbr==3.0.1                # via git-url-parse, molecule, python-gilt
 pexpect==4.2.1            # via molecule
 pip-tools==1.10.1
+pluggy==0.6.0             # via pytest
 port-for==0.3.1           # via sphinx-autobuild
 poyo==0.4.1               # via cookiecutter
 psutil==5.2.2             # via molecule
 ptyprocess==0.5.2         # via pexpect
-py==1.4.34                # via pytest
+py==1.5.2                 # via pytest
 pyasn1==0.3.1             # via paramiko
 pycodestyle==2.3.1        # via flake8
 pycparser==2.18           # via cffi
@@ -76,8 +79,9 @@ pygments==2.2.0           # via sphinx
 pylint==1.8.1
 pynacl==1.1.2             # via paramiko
 pyparsing==2.2.0          # via packaging
-pytest-xdist==1.18.2
-pytest==3.2.0             # via pytest-xdist, testinfra
+pytest-forked==0.2        # via pytest-xdist
+pytest-xdist==1.21.0
+pytest==3.3.1             # via pytest-forked, pytest-xdist, testinfra
 python-dateutil==2.6.1    # via arrow
 python-gilt==1.1.0        # via molecule
 pytz==2017.2              # via babel
@@ -86,7 +90,7 @@ requests==2.18.3          # via docker-py, safety, sphinx
 safety==1.6.1
 sh==1.12.14               # via molecule, python-gilt
 singledispatch==3.4.0.3   # via astroid, pylint, tornado
-six==1.10.0               # via ansible-lint, astroid, bcrypt, click-completion, cryptography, docker-py, docker-pycreds, dparse, fasteners, git-url-parse, livereload, packaging, pip-tools, pylint, pynacl, python-dateutil, singledispatch, sphinx, testinfra, websocket-client
+six==1.10.0               # via ansible-lint, astroid, bcrypt, click-completion, cryptography, docker-py, docker-pycreds, dparse, fasteners, git-url-parse, livereload, packaging, pip-tools, pylint, pynacl, pytest, python-dateutil, singledispatch, sphinx, testinfra, websocket-client
 snowballstemmer==1.2.1    # via sphinx
 sphinx-autobuild==0.7.1
 sphinx-rtd-theme==0.2.4

--- a/securedrop/requirements/test-requirements.in
+++ b/securedrop/requirements/test-requirements.in
@@ -7,5 +7,4 @@ pip-tools
 py
 pytest
 pytest-cov
-pytest-catchlog
 selenium < 3

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file securedrop/requirements/test-requirements.txt securedrop/requirements/test-requirements.in
 #
+attrs==17.4.0             # via pytest
 beautifulsoup4==4.6.0
 blinker==1.4
 certifi==2017.4.17        # via requests
@@ -15,7 +16,7 @@ docopt==0.6.2             # via coveralls
 first==2.0.1              # via pip-tools
 flask-testing==0.6.2
 flask==0.12.2             # via flask-testing
-funcsigs==1.0.2           # via mock
+funcsigs==1.0.2           # via mock, pytest
 idna==2.5                 # via requests
 itsdangerous==0.24        # via flask
 jinja2==2.9.6             # via flask
@@ -23,12 +24,12 @@ markupsafe==1.0           # via jinja2
 mock==2.0.0
 pbr==3.0.1                # via mock
 pip-tools==1.9.0
-py==1.4.34
-pytest-catchlog==1.2.2
+pluggy==0.6.0             # via pytest
+py==1.5.2
 pytest-cov==2.5.1
-pytest==3.1.1
+pytest==3.3.1
 requests==2.17.3          # via coveralls
 selenium==2.53.6
-six==1.10.0               # via mock, pip-tools
+six==1.10.0               # via mock, pip-tools, pytest
 urllib3==1.21.1           # via requests
 werkzeug==0.12.2          # via flask

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -35,13 +35,13 @@ class TestManagePy(object):
         args = manage.get_args().parse_args(['run'])
         manage.setup_verbosity(args)
         manage.log.debug('INVISIBLE')
-        assert 'INVISIBLE' not in caplog.text()
+        assert 'INVISIBLE' not in caplog.text
 
     def test_verbose(self, caplog):
         args = manage.get_args().parse_args(['--verbose', 'run'])
         manage.setup_verbosity(args)
         manage.log.debug('VISIBLE')
-        assert 'VISIBLE' in caplog.text()
+        assert 'VISIBLE' in caplog.text
 
 
 class TestManagementCommand(unittest.TestCase):
@@ -341,7 +341,7 @@ class TestManage(object):
                                   verbose=logging.DEBUG)
         manage.setup_verbosity(args)
         manage.clean_tmp(args)
-        assert 'does not exist, do nothing' in caplog.text()
+        assert 'does not exist, do nothing' in caplog.text
 
     def test_clean_tmp_too_young(self, caplog):
         args = argparse.Namespace(days=24*60*60,
@@ -350,7 +350,7 @@ class TestManage(object):
         open(os.path.join(config.TEMP_DIR, 'FILE'), 'a').close()
         manage.setup_verbosity(args)
         manage.clean_tmp(args)
-        assert 'modified less than' in caplog.text()
+        assert 'modified less than' in caplog.text
 
     def test_clean_tmp_removed(self, caplog):
         args = argparse.Namespace(days=0,
@@ -362,7 +362,7 @@ class TestManage(object):
             os.utime(fname, (old, old))
         manage.setup_verbosity(args)
         manage.clean_tmp(args)
-        assert 'FILE removed' in caplog.text()
+        assert 'FILE removed' in caplog.text
 
 
 class TestSh(object):
@@ -375,7 +375,7 @@ class TestSh(object):
 
     def test_sh_progress(self, caplog):
         manage.sh("echo AB ; sleep 5 ; echo C")
-        records = caplog.records()
+        records = caplog.records
         assert ':sh: ' in records[0].message
         assert records[0].levelname == 'DEBUG'
         assert 'AB' == records[1].message
@@ -394,7 +394,7 @@ class TestSh(object):
             manage.sh("echo AB ; echo C ; exit 111")
         manage.log.setLevel(level)
         assert excinfo.value.returncode == 111
-        records = caplog.records()
+        records = caplog.records
         assert 'AB' == records[0].message
         assert records[0].levelname == 'ERROR'
         assert 'C' == records[1].message

--- a/testinfra/development/test_development_environment.py
+++ b/testinfra/development/test_development_environment.py
@@ -32,9 +32,9 @@ def test_development_app_dependencies(Package):
     ('mock', '2.0.0'),
     ('pbr', '3.0.1'),
     ('pip-tools', '1.9.0'),
-    ('py', '1.4.34'),
+    ('py', '1.5.2'),
     ('pytest-cov', '2.5.1'),
-    ('pytest', '3.1.1'),
+    ('pytest', '3.3.1'),
     ('selenium', '2.53.6'),
     ('six', '1.10.0'),
 ])

--- a/testinfra/vars/app-staging.yml
+++ b/testinfra/vars/app-staging.yml
@@ -32,7 +32,7 @@ pip_deps:
   - name: 'mock'
     version: '2.0.0'
   - name: 'pytest'
-    version: '3.1.1'
+    version: '3.3.1'
   - name: 'selenium'
     version: '2.53.6'
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2787

https://docs.pytest.org/en/latest/logging.html is a drop-in
replacement for the pytest-catchlog plugin and they will conflict with
each other

## Testing

This is an upgrade of the tests with no impact on anything but the tests themselves. If the CI passes it shows the capture log API change introduced by pytest 3.3.1 was fixed

## Deployment

N/A
