### PR TITLE
Remove mentions of coveralls, update requirements, update badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ script:
   - pip freeze -l
   - SECUREDROP_TESTINFRA_TARGET_HOST=travis testinfra -v testinfra/development/
 after_success:
-  cd securedrop/ && coveralls
+  cd securedrop/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 [![Build Status](https://travis-ci.org/freedomofpress/securedrop.svg?branch=develop)](https://travis-ci.org/freedomofpress/securedrop)
-[![Coverage Status](https://coveralls.io/repos/freedomofpress/securedrop/badge.svg?branch=develop&service=github)](https://coveralls.io/github/freedomofpress/securedrop?branch=develop)
+[![codecov](https://codecov.io/gh/freedomofpress/securedrop/branch/develop/graph/badge.svg)](https://codecov.io/gh/freedomofpress/securedrop)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/freedomofpress/securedrop?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 SecureDrop is an open-source whistleblower submission system that media organizations can use to securely accept documents from, and communicate with anonymous sources. It was originally created by the late Aaron Swartz and is currently managed by the [Freedom of the Press Foundation](https://freedom.press).

--- a/docs/development/testing_application_tests.rst
+++ b/docs/development/testing_application_tests.rst
@@ -7,7 +7,6 @@ The application test suite uses:
 
   * Pytest_
   * Selenium_
-  * Coveralls_
 
 The application tests consist of unit tests for the Python application code
 and functional tests that verify the functionality of the application code
@@ -24,7 +23,6 @@ recent Tor Browser.
 
 .. _Pytest: https://docs.pytest.org/en/latest/
 .. _Selenium: http://docs.seleniumhq.org/docs/
-.. _Coveralls: https://github.com/coveralls-clients/coveralls-python
 
 Installation
 ------------

--- a/securedrop/requirements/test-requirements.in
+++ b/securedrop/requirements/test-requirements.in
@@ -1,6 +1,5 @@
 beautifulsoup4
 blinker
-coveralls
 Flask-Testing
 mock
 pip-tools

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -7,17 +7,12 @@
 attrs==17.4.0             # via pytest
 beautifulsoup4==4.6.0
 blinker==1.4
-certifi==2017.4.17        # via requests
-chardet==3.0.4            # via requests
 click==6.7                # via flask, pip-tools
-coverage==4.4.1           # via coveralls, pytest-cov
-coveralls==1.1
-docopt==0.6.2             # via coveralls
+coverage==4.4.1           # via pytest-cov
 first==2.0.1              # via pip-tools
 flask-testing==0.6.2
 flask==0.12.2             # via flask-testing
 funcsigs==1.0.2           # via mock, pytest
-idna==2.5                 # via requests
 itsdangerous==0.24        # via flask
 jinja2==2.9.6             # via flask
 markupsafe==1.0           # via jinja2
@@ -28,8 +23,6 @@ pluggy==0.6.0             # via pytest
 py==1.5.2
 pytest-cov==2.5.1
 pytest==3.3.1
-requests==2.17.3          # via coveralls
 selenium==2.53.6
 six==1.10.0               # via mock, pip-tools, pytest
-urllib3==1.21.1           # via requests
 werkzeug==0.12.2          # via flask


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #2261. 

Changes proposed in this pull request:
 * Codecov reports are working thanks to #2584: https://codecov.io/gh/freedomofpress/securedrop
 * This PR just updates requirements, docs, and the badge in the README to remove coveralls references

## Testing

Reviewing diff should be sufficient

## Deployment

None, dev/test environment only

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [x] Doc linting passed locally
