### PR TITLE
circleci: do not cache docker layers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,38 +25,10 @@ jobs:
       - checkout
       - setup_remote_docker
 
-      - restore_cache:
-          keys:
-            - v1-sd-layers-{{ .Branch }}-
-            - v1-sd-layers-
-          paths:
-            - /caches/layers.tar.gz
-
-      - run:
-          name: Load image layer cache
-          command: |
-            set +o pipefail
-            docker load -i /caches/layers.tar |true
-
       - run:
           name: Build Docker images
           command: |
-            set +o pipefail
-            docker images
-            fromtag=$(docker images |grep securedrop-test |head -n1 |awk '{print $2}')
-            cd securedrop && TAG=${CIRCLE_SHA1} EXTRA_BUILD_ARGS="--cache-from securedrop-test:${fromtag:-latest}" make images
-
-      - run:
-          name: Save Docker image layer cache
-          command: |
-            mkdir -p /caches
-            docker images
-            docker save -o /caches/layers.tar securedrop-test:${CIRCLE_SHA1}
-
-      - save_cache:
-          key: v1-sd-layers-{{ .Branch }}-{{ epoch }}
-          paths:
-            - /caches/layers.tar
+            cd securedrop && TAG=${CIRCLE_SHA1} make images
 
       - run: mkdir -p ~/test-results
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

When a RUN apt-get update layer is cached it may become obsolete. This
will manifest with apt-get install failing on 404 because the cache
references packages that no longer exist.

The developer who sees this error is unlikely to link that to the
fact that docker layers are cached accross runs. And it will not occur
to them to change the line of the Dockerfile to force an update.

The benefit of maintaining a cache is to speed up tests (skipping
apt-get install and pip install on every run). But this benefit is
less appealing when developer are confused by the errors it may
induce.

## Testing

N/A

## Deployment

N/A

