### PR TITLE
Journalist interface: Add missing singular form on documents/messages 

### DIFF
--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -16,8 +16,8 @@
     {% endif %}
   </div>
   <div class="submission-count">
-    <span><i class="fa fa-file-archive-o"></i> {{ gettext('{doc_num} docs').format(doc_num=docs) }}</span>
-    <span><i class="fa fa-file-text-o"></i> {{ gettext('{msg_num} messages').format(msg_num=msgs) }}</span>
+    <span><i class="fa fa-file-archive-o"></i> {{ ngettext('1 doc', '{doc_num} docs'.format(doc_num=docs), docs) }}</span>
+    <span><i class="fa fa-file-text-o"></i> {{ ngettext('1 message', '{msg_num} messages'.format(msg_num=msgs), msgs) }}</span>
     {% if source.num_unread > 0 %}
       <span class="unread">
         <a class="btn small" href="/download_unread/{{ source.filesystem_id }}"><i class="fa fa-download"></i> {{ gettext('{num_unread} unread').format(num_unread=source.num_unread) }}</a>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2670 and updates strings to be translated (dd9842a)

## Testing

You should see the right singular/plural form in the journalist interface now:

![screen shot 2018-01-05 at 11 51 34 am](https://user-images.githubusercontent.com/7832803/34626066-135b3c50-f210-11e7-87ab-d9400df15877.png)

## Deployment

no big surprises

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
