### PR TITLE
tests: only upload coverage information if running on CircleCI

### DIFF
--- a/securedrop/bin/test
+++ b/securedrop/bin/test
@@ -9,12 +9,14 @@ ln -s /dev/urandom /dev/random
 
 x11vnc -display :1 -autoport 5901 -shared &
 
-touch tests/log/firefox.log
-function finish {
-  cp tests/log/firefox.log /tmp/test-results/logs/
-  bash <(curl -s https://codecov.io/bash)
-}
-trap finish EXIT
+if [ -n "${CIRCLE_BRANCH}" ] ; then
+    touch tests/log/firefox.log
+    function finish {
+        cp tests/log/firefox.log /tmp/test-results/logs/
+        bash <(curl -s https://codecov.io/bash)
+    }
+    trap finish EXIT
+fi
 
 mkdir -p "/tmp/test-results/logs"
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Trying to upload to codecov while running **make dev** on the local machine will likely result in failure. Unless the developer has codecov credentials properly setup which is rare.

## Testing

* cd securedrop
* make test

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
