### PR TITLE
tests: no need to remove *.pyc before docker build

### DIFF
--- a/securedrop/.dockerignore
+++ b/securedrop/.dockerignore
@@ -1,4 +1,5 @@
-*.pyc
+**/__pycache__
+**/*.pyc
 .sass-cache
 static/gen
 static/.webassets-cache

--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -15,7 +15,6 @@ assets:
 
 .PHONY: images
 images:
-	find . -name '*.pyc' | xargs --no-run-if-empty rm
 	docker build $(EXTRA_BUILD_ARGS) -f Dockerfile -t $(IMAGE)-test:$(TAG) .
 
 TESTFILES ?= tests


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

because they are already excluded by .dockerignore. In addition the
--no-run-if-empty option is not implemented on some operating systems
and will fail

## Testing

On MacOS verify that 

* make test

works.

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
