### PR TITLE
Support tags in securedrop-admin script

### DIFF
--- a/securedrop/securedrop-admin
+++ b/securedrop/securedrop-admin
@@ -215,9 +215,18 @@ def install_securedrop(args):
                    "servers.")
         sdlog.info("The sudo password is only necessary during initial "
                    "installation.")
-        subprocess.check_call([os.path.join(ANSIBLE_PATH,
-                                            'securedrop-prod.yml'),
-                              '--ask-become-pass'], cwd=ANSIBLE_PATH)
+        ansible_cmd = [
+            'ansible-playbook',
+            os.path.join(ANSIBLE_PATH, 'securedrop-prod.yml'),
+            '--ask-become-pass',
+        ]
+        if args.tags:
+            ansible_cmd.append('--tags')
+            ansible_cmd.append(','.join(args.tags))
+
+        sdlog.info("Preparing to run Ansible command:")
+        sdlog.info(ansible_cmd)
+        subprocess.check_call(ansible_cmd, cwd=ANSIBLE_PATH)
 
 
 def backup_securedrop(args):
@@ -310,7 +319,12 @@ if __name__ == "__main__":
 
     parse_install = subparsers.add_parser('install',
                                           help=install_securedrop.__doc__)
+
     parse_install.set_defaults(func=install_securedrop)
+    parse_install.add_argument(
+        '-t', '--tags', action='append',
+        default=[],
+        help="Run only configuration matching specified Ansible tags")
 
     parse_tailsconfig = subparsers.add_parser('tailsconfig',
                                               help=run_tails_config.__doc__)


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #2624.

Each time a SecureDrop Admin wishes to alter the server configuration,
they must run the *entire* production playbook. For an already running
instance, with the connection routed over Tor, the run typically takes
20-30 minutes. Sometimes the underlying change could be made manually
(albeit less reliably) via manual edits in 1-2 minutes. Let's permit
Admins to filter by `--tags` to run only subsets of changes.

We may wish to fine-tune the use of tags throughout the configuration
logic to ensure that tagged subsets of tasks are meaningful and useful.
At present, one useful subset already well tagged is "ossec", e.g.
`./securedrop-admin install --tags ossec`.

## Testing

1. Use Prod VMs and a Tails-based Admin Workstation (virtualized is OK).
2. Install as normal until setup is fully provisioned.
3. Run _only_ the OSSEC tasks with `./securedrop-admin install --tags ossec`. 
4. Run _only_ the "common" tasks with `./securedrop-admin install --tags common`.
5. Observe faster runs without errors.

## Deployment
Should not break any existing configuration logic. The goal is to make configuration more convenient and therefore more predictable: we want to encourage Admins to use the tooling provided for determining server state. If that's going to happen, the tooling must be convenient enough that it's more attractive than ad-hoc manual changes (which are not tracked and easily overwritten).

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
