### PR TITLE
i18n: move format() outside of ngettext

### DIFF
--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -16,8 +16,8 @@
     {% endif %}
   </div>
   <div class="submission-count">
-    <span><i class="fa fa-file-archive-o"></i> {{ ngettext('1 doc', '{doc_num} docs'.format(doc_num=docs), docs) }}</span>
-    <span><i class="fa fa-file-text-o"></i> {{ ngettext('1 message', '{msg_num} messages'.format(msg_num=msgs), msgs) }}</span>
+    <span><i class="fa fa-file-archive-o"></i> {{ ngettext('1 doc', '{doc_num} docs', docs).format(doc_num=docs) }}</span>
+    <span><i class="fa fa-file-text-o"></i> {{ ngettext('1 message', '{msg_num} messages', msgs).format(msg_num=msgs) }}</span>
     {% if source.num_unread > 0 %}
       <span class="unread">
         <a class="btn small" href="/download_unread/{{ source.filesystem_id }}"><i class="fa fa-download"></i> {{ gettext('{num_unread} unread').format(num_unread=source.num_unread) }}</a>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Although it makes more sense to write:

ngettext('1 doc', '{doc_num} docs'.format(doc_num=docs), docs)

the pybabel parser fails to recoginize the call and does not include
it in messages.pot. We add the .format() outside instead. It looks
strange because '1 doc' does not need it but ... it does not hurt.

## Testing

* vagrant ssh development
* cd /vagrant
* make translate
* verify messages.pot contains the string "1 doc"

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
