### PR TITLE
Disable .map file generation when compiling css files from sass

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/sass.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/sass.yml
@@ -22,7 +22,7 @@
     - "{{ securedrop_code_filtered }}/static/.webassets-cache"
 
 - name: Compile SASS to CSS.
-  shell: "/usr/local/bin/sass --force --stop-on-error --update sass:{{ securedrop_code_filtered }}/static/css --style compressed"
+  shell: "/usr/local/bin/sass --force --stop-on-error --update sass:{{ securedrop_code_filtered }}/static/css --style compressed --sourcemap=none"
   args:
     chdir: "{{ securedrop_code_filtered }}"
 

--- a/molecule/builder/tests/test_securedrop_deb_package.py
+++ b/molecule/builder/tests/test_securedrop_deb_package.py
@@ -218,6 +218,8 @@ def test_deb_package_contains_no_generated_assets(File, Command, deb):
         # no SASS files should exist; only the generated CSS files.
         assert not re.search("^.*sass.*$", c.stdout, re.M)
 
+        #no .map files should exist; only the generated CSS files.
+        assert not re.search("^.*css.map$", c.stdout, re.M)
 
 @pytest.mark.parametrize("deb", deb_packages)
 def test_deb_package_contains_css(File, Command, deb):
@@ -235,9 +237,6 @@ def test_deb_package_contains_css(File, Command, deb):
         for css_type in ['journalist', 'source']:
             assert re.search("^.*\./var/www/securedrop/static/"
                              "css/{}.css$".format(css_type), c.stdout, re.M)
-            assert re.search("^.*\./var/www/securedrop/static/"
-                             "css/{}.css.map$".format(css_type), c.stdout,
-                             re.M)
 
 
 @pytest.mark.parametrize("deb, tag", deb_tags)


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

Fixes #2810.
Disabled `.css.map` generation when compiling css from sass per https://github.com/freedomofpress/securedrop/issues/2810#issuecomment-356253461

## Testing

- `make build-debs` and provision vm with securedrop app code .deb
- navigate to `http://<source or journalist URL>.onion/static/css/source.css.map`
- Observe a document not found error
- No AppArmor and associated OSSEC alerts are triggered.

## Deployment

None.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ :white_check_mark: ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally

  