### PR TITLE
Spelling: QR code.

### DIFF
--- a/docs/servers_2fa.rst
+++ b/docs/servers_2fa.rst
@@ -12,7 +12,7 @@ follow the steps below.
 
 .. include:: includes/otp-app.txt
 
-- Tap the QRcode symbol at the top
+- Tap the QR code symbol at the top
 - Scan the barcode using your phone's camera
 
 A new entry will automatically be added to the list. If you wish to edit

--- a/securedrop/journalist_templates/account_new_two_factor.html
+++ b/securedrop/journalist_templates/account_new_two_factor.html
@@ -7,7 +7,7 @@
 <ol>
   <li>{{ gettext('Install FreeOTP on your phone') }}</li>
   <li>{{ gettext('Open the FreeOTP app') }}</li>
-  <li>{{ gettext('Tap the QRcode symbol at the top') }}</li>
+  <li>{{ gettext('Tap the QR code symbol at the top') }}</li>
   <li>{{ gettext('Your phone will now be in "scanning" mode. When you are in this mode, scan the barcode below:') }}</li>
 </ol>
 <div id="qrcode-container">{{ user.shared_secret_qrcode }}</div>

--- a/securedrop/journalist_templates/admin_new_user_two_factor.html
+++ b/securedrop/journalist_templates/admin_new_user_two_factor.html
@@ -8,7 +8,7 @@
 <ol>
   <li>{{ gettext('Install FreeOTP on your phone') }}</li>
   <li>{{ gettext('Open the FreeOTP app') }}</li>
-  <li>{{ gettext('Tap the QRcode symbol at the top') }}</li>
+  <li>{{ gettext('Tap the QR code symbol at the top') }}</li>
   <li>{{ gettext('Your phone will now be in "scanning" mode. When you are in this mode, scan the barcode below:') }}</li>
 </ol>
 <div id="qrcode-container">{{ user.shared_secret_qrcode }}</div>


### PR DESCRIPTION
If you prefer nospace, go for barcode.

## Status

Ready for review

## Description of Changes

Changes proposed in this pull request: don't have both QRcode and QR code in the user interface, stick to the one that Oxford dictionary and Wikipedia prefer.

## Testing

n.a.

## Deployment

It's minor, you might want to hold off after 0.5.1, to not bother translators.
