### PR TITLE
source: no need to be so specific about tracking

### DIFF
--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -31,7 +31,7 @@
 
 <hr class="no-line">
 
-<p class="explanation">{{ gettext('Because we use none of the traditional means to track users of our <strong>SecureDrop</strong>
+<p class="explanation">{{ gettext('Because we do not track users of our <strong>SecureDrop</strong>
  service, in future visits, using this codename will be the only way we have to communicate with you should we have
  questions or are interested in additional documents. Unlike passwords, there is no way to retrieve a lost codename.') }}
 </p>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The codename can be seen as a way of 'tracking', but SecureDrop does
its very best to not track anything about the sources. Saying "we
don't do the traditional tracking" implies for the suspicious of mind:
"so we fall back on even more sophisticated ways of tracking."

Revert to the simple form "we do not track users".


## Testing

N/A

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
