### PR TITLE
[0.5.1] tests: wait for source key generation in functional tests

### DIFF
--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -25,6 +25,7 @@ import config
 import db
 import journalist
 from source_app import create_app
+import crypto_util
 import tests.utils.env as env
 
 LOG_DIR = abspath(join(dirname(realpath(__file__)), '..', 'log'))
@@ -173,6 +174,14 @@ class FunctionalTest(object):
 
         self.secret_message = ('These documents outline a major government '
                                'invasion of privacy.')
+
+    def wait_for_source_key(self, source_name):
+        filesystem_id = crypto_util.hash_codename(source_name)
+
+        def key_available(filesystem_id):
+            assert crypto_util.getkey(filesystem_id)
+        self.wait_for(
+            lambda: key_available(filesystem_id))
 
     def teardown(self):
         self.patcher.stop()

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -603,9 +603,6 @@ class JournalistNavigationStepsMixin():
 
     def _source_delete_key(self):
         filesystem_id = crypto_util.hash_codename(self.source_name)
-        key = None
-        while not key:
-            key = crypto_util.getkey(filesystem_id)
         crypto_util.delete_reply_keypair(filesystem_id)
 
     def _journalist_continues_after_flagging(self):

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -166,6 +166,7 @@ class SourceNavigationStepsMixin():
             assert toggled_submit_button_icon.is_displayed()
 
             submit_button.click()
+            self.wait_for_source_key(self.source_name)
 
             if not hasattr(self, 'accept_languages'):
                 notification = self.driver.find_element_by_css_selector(
@@ -191,6 +192,7 @@ class SourceNavigationStepsMixin():
     def _source_clicks_submit_button_on_submission_page(self):
         submit_button = self.driver.find_element_by_id('submit-doc-button')
         submit_button.click()
+        self.wait_for_source_key(self.source_name)
 
     @screenshots
     def _source_deletes_a_journalist_reply(self):

--- a/securedrop/tests/functional/test_source_session_timeout.py
+++ b/securedrop/tests/functional/test_source_session_timeout.py
@@ -21,6 +21,5 @@ class TestSourceSessions(
         self._source_continues_to_submit_page()
         self._source_waits_for_session_to_timeout(
             self.session_length_minutes)
-        self._source_enters_text_in_message_field()
-        self._source_clicks_submit_button_on_submission_page()
+        self._source_visits_source_homepage()
         self._source_sees_session_timeout_message()

--- a/securedrop/tests/pages-layout/test_source.py
+++ b/securedrop/tests/pages-layout/test_source.py
@@ -155,6 +155,5 @@ class TestSourceSessionLayout(
         self._source_continues_to_submit_page()
         self._source_waits_for_session_to_timeout(self.session_length_minutes)
         self._source_enters_text_in_message_field()
-        self._source_clicks_submit_button_on_submission_page()
-        self._source_sees_session_timeout_message()
+        self._source_visits_source_homepage()
         self._screenshot('source-session_timeout.png')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

All functional tests assume the source GPG key is created when a
document or a message is submitted. But it really is generated
asynchronously and therefore races with the tests. It is fine most of
the time but leads to subtle bugs.

For instance when a journalist functional test tries to reply to a
source. If the GPG is being created the selector will not be
displayed: instead the "flagged for reply" display will show and the
test will fail to reply.

This race was incorrectly fixed by waiting for the key to be generated
before deleting it, because it happened relatively frequently.

A support function is added to wait until the GPG key for a given
source becomes available. It is called whenever a source submits a
document and effectively waits until the async_genkey completes.


## Testing

N/A (covered by CI)

## Deployment

N/A
