### PR TITLE
[0.5.1] Fix error in alert ID for ossec agent start alert

### DIFF
--- a/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
+++ b/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
@@ -176,10 +176,10 @@
   purely informational events.
 -->
 <group name="Ossec start notifications">
-  <rule id="400501" level="1">
-    <if_sid>501</if_sid>
+  <rule id="400503" level="1">
+    <if_sid>503</if_sid>
     <match>Agent started</match>
-    <description>This alert overrides 501 to suppress daily email alerts to admins.</description>
+    <description>This alert overrides 503 to suppress daily email alerts to admins.</description>
     <options>no_email_alert</options>
   </rule>
 

--- a/testinfra/vars/mon-staging.yml
+++ b/testinfra/vars/mon-staging.yml
@@ -96,6 +96,6 @@ log_events_with_ossec_alerts:
 
   - name: test_ossec_agent_started_does_not_produce_email
     alert: >
-      ossec: Agent started: 'app->10.20.2.2'.
+      ossec: Agent started
     level: "1"
-    rule_id: "400501"
+    rule_id: "400503"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes
Fixes #2839 
Alerts for ossec agent correctly suppressed on boot.

Changes proposed in this pull request:

## Testing

Reboot server
Observe no "Ossec agent started" alerts on boot. Also ensure that no additional/other emails are sent at boot-time.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
