### PR TITLE
tests: wait up to 60 seconds to generate a GPG key

### DIFF
--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -181,7 +181,7 @@ class FunctionalTest(object):
         def key_available(filesystem_id):
             assert crypto_util.getkey(filesystem_id)
         self.wait_for(
-            lambda: key_available(filesystem_id))
+            lambda: key_available(filesystem_id), timeout=60)
 
     def teardown(self):
         self.patcher.stop()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

If the machine is slow, 5 seconds may not be enough. Since there is no entropy shortage (urandom in use), 60 seconds should be plenty.

## Testing

Use a slow machine and verify functional tests pass.

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
