### PR TITLE
[0.5.1] Use absolute path in autoversion Jinja2 filter

### DIFF
--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -55,8 +55,9 @@ def create_app(config):
     @app.template_filter('autoversion')
     def autoversion_filter(filename):
         """Use this template filter for cache busting"""
-        if path.exists(filename[1:]):
-            timestamp = str(path.getmtime(filename[1:]))
+        absolute_filename = path.join(config.SECUREDROP_ROOT, filename[1:])
+        if path.exists(absolute_filename):
+            timestamp = str(path.getmtime(absolute_filename))
         else:
             return filename
         versioned_filename = "{0}?v={1}".format(filename, timestamp)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes item 2 in #2844. This resolves an issue where a relative path caused the autoversioning to fail in staging and prod - see [here](https://github.com/freedomofpress/securedrop/issues/2844#issuecomment-357390944) for full details.

## Testing

In staging, verify that the logo update does not require a hard refresh - the logo in the form should update immediately to provide feedback that it worked.  

## Deployment

No issues

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
