### PR TITLE
[0.5.1] app: always chmod u+w the logo in postinst

### DIFF
--- a/install_files/securedrop-app-code/DEBIAN/postinst
+++ b/install_files/securedrop-app-code/DEBIAN/postinst
@@ -58,6 +58,9 @@ case "$1" in
       rm /tmp/securedrop_custom_logo.png
     fi
 
+    # in versions prior to 0.5.1 a custom logo was installed with u-w
+    chmod u+w /var/www/securedrop/static/i/logo.png
+
     # This removes the MAC "hmac-sha1" from sshd_config.
     # Ansible was updated, so future instances will not have this line present.
     # This if-block may be removed from this script on 2019-01-01.

--- a/testinfra/development/test_development_application_settings.py
+++ b/testinfra/development/test_development_application_settings.py
@@ -121,14 +121,9 @@ def test_development_clean_tmp_cron_job(Command, Sudo):
 def test_development_default_logo_exists(File):
     """
     Checks for default SecureDrop logo file.
-
-    TODO: Add check for custom logo file.
     """
 
     f = File("{}/static/i/logo.png".format(sd_test_vars.securedrop_code))
     assert f.is_file
     assert f.user == sd_test_vars.securedrop_user
     assert f.group == sd_test_vars.securedrop_user
-    # check if logo is NOT the default securedrop png
-    if not f.md5sum == "92443946d5c9e05020a090f97b62d027":
-        assert oct(f.mode) == "0400"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2853

Prior to 0.5.1 a custom logo was installed with u-w. Now that the
journalist app can write a new logo, this is a problem and write
permissions must be restored.

We chmod u+w unconditionaly because it is cheap although it will be
useless for upgrades after 0.5.1. And it will help people upgrading
from a version < 0.5.1 directly to a version > 0.5.1.

Also get rid of a test that prepared a future custom logo test and
became obsolete.

## Testing

Follow the steps to reproduce from https://github.com/freedomofpress/securedrop/issues/2853

## Deployment

Fixes a deployment bug (see testing).
