### PR TITLE
bin/test: allow running tests outside of ci

### DIFF
--- a/securedrop/bin/test
+++ b/securedrop/bin/test
@@ -9,7 +9,7 @@ ln -s /dev/urandom /dev/random
 
 x11vnc -display :1 -autoport 5901 -shared &
 
-if [ -n "${CIRCLE_BRANCH}" ] ; then
+if [ -n "${CIRCLE_BRANCH:-}" ] ; then
     touch tests/log/firefox.log
     function finish {
         cp tests/log/firefox.log /tmp/test-results/logs/


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2855

Changes proposed in this pull request:
bin/test: allow running tests outside of ci

## Testing

run `securedrop/bin/test` outside of CI.