### PR TITLE
tests: create $USER in Dockerfile and allow sudo

### DIFF
--- a/securedrop/Dockerfile
+++ b/securedrop/Dockerfile
@@ -1,5 +1,9 @@
 # ubuntu:14.04 as of 2017-12-15
 FROM ubuntu@sha256:084989eb923bd86dbf7e706d464cf3587274a826b484f75b69468c19f8ae354c
+ARG USER_NAME
+ENV USER_NAME ${USER_NAME:-root}
+ARG USER_ID
+ENV USER_ID ${USER_ID:-0}
 
 RUN apt-get update && \
     apt-get install -y python-pip libpython2.7-dev libssl-dev secure-delete \
@@ -27,6 +31,8 @@ RUN echo deb http://archive.ubuntu.com/ubuntu/ xenial main > /etc/apt/sources.li
 COPY requirements requirements
 RUN pip install -r requirements/securedrop-app-code-requirements.txt && \
     pip install -r requirements/test-requirements.txt
+
+RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi
 
 WORKDIR /app
 

--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -12,7 +12,10 @@ lint-full:  ## Run the python linter with nothing disabled
 
 .PHONY: images
 images: ## Build the docker images
-	docker build $(EXTRA_BUILD_ARGS) -f Dockerfile -t $(IMAGE)-test:$(TAG) .
+	docker build $(EXTRA_BUILD_ARGS) -f Dockerfile \
+	   --build-arg=USER_ID=$(shell id -u) \
+	   --build-arg=USER_NAME=$(USER) \
+	   -t $(IMAGE)-test:$(TAG) .
 
 TESTFILES ?= tests
 .PHONY: test


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2862

When run from the developer environment, it allows for docker run
--user $USER to work. Instead of running scripts as root by default,
it allows to run them using this unprivileged user and use sudo when
root privileges are necessary. It also allows to modify host files
exposed via --volume without changing their ownership.

## Testing

* make -C securedrop images
<pre>
$ docker run --user=$USER -ti securedrop-test:$(docker images -q securedrop-test |head -n1) bash
loic@b2eb0286b61d:/app$ sudo id
uid=0(root) gid=0(root) groups=0(root)
</pre>

## Deployment

N/A
