### PR TITLE
docs: refactor make update-user-guides to run as non-root

### DIFF
--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -54,9 +54,10 @@ update-user-guides: ## Runs the page layout tests to regenerate screenshots
 	docker run \
 		--name $(IMAGE)-update-user-guides \
 		--rm \
-		-e USER_ID=$(shell id -u) \
-		-v $(shell git rev-parse --show-toplevel):$(shell git rev-parse --show-toplevel) \
-		-w $(shell pwd) \
+		--user $(USER) \
+		--volume $(shell git rev-parse --show-toplevel):$(shell git rev-parse --show-toplevel) \
+		--workdir $(shell pwd) \
+		--publish 5901:5901 \
 		-ti $(IMAGE)-test:$(TAG) \
 		./bin/update-user-guides
 

--- a/securedrop/bin/update-user-guides
+++ b/securedrop/bin/update-user-guides
@@ -2,11 +2,19 @@
 
 set -e
 export DISPLAY=:1
-Xvfb :1 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &
-redis-server &
 
 rm /dev/random
 ln -s /dev/urandom /dev/random
+function run_xvfb() {
+    Xvfb :1 -screen 0 1024x768x24 -ac +extension GLX +render -noreset >& /tmp/xvfb.out || cat /tmp/xvfb.out
+}
+
+function run_redis() {
+    redis-server >& /tmp/redis.out || cat /tmp/redis.out
+}
+
+run_xvfb &
+run_redis &
 
 if ! test -f config.py ; then
     trap "rm config.py" EXIT

--- a/securedrop/bin/update-user-guides
+++ b/securedrop/bin/update-user-guides
@@ -13,8 +13,13 @@ function run_redis() {
     redis-server >& /tmp/redis.out || cat /tmp/redis.out
 }
 
+function run_x11vnc() {
+    x11vnc -display :1 -autoport 5901 -shared >& /tmp/x11vnc.out || cat /tmp/x11vnc.out
+}
+
 run_xvfb &
 run_redis &
+run_x11vnc &
 
 if ! test -f config.py ; then
     trap "rm config.py" EXIT

--- a/securedrop/bin/update-user-guides
+++ b/securedrop/bin/update-user-guides
@@ -3,8 +3,6 @@
 set -e
 export DISPLAY=:1
 
-rm /dev/random
-ln -s /dev/urandom /dev/random
 function run_xvfb() {
     Xvfb :1 -screen 0 1024x768x24 -ac +extension GLX +render -noreset >& /tmp/xvfb.out || cat /tmp/xvfb.out
 }
@@ -21,14 +19,15 @@ run_xvfb &
 run_redis &
 run_x11vnc &
 
+sudo rm /dev/random
+sudo ln -s /dev/urandom /dev/random
+
 if ! test -f config.py ; then
     trap "rm config.py" EXIT
     make test-config
 fi
 
 sass --force --stop-on-error --update sass:static/css --style compressed
-chown -R "$USER_ID" static .sass-cache
 
 pytest -v tests/pages-layout --page-layout
 cp tests/pages-layout/screenshots/en_US/*.png ../docs/images/manual/screenshots
-chown -R "$USER_ID" tests/pages-layout/screenshots ../docs/images/manual/screenshots ./*/__pycache__ ./*/*/__pycache__ || true


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Depends #2862
Fixes #2864 

When running update-user-guides it creates files that are on the host,
to update screenshots. The script runs as root in the docker
container and these files must be chown to developer user to avoid
permission problems. But a number of other files can also be created
as root as a side effect (pyc, etc.) and ensuring they all belong to
the user is error prone.

Instead of running the script as root, run it as the develper user and
rely on sudo for actions that require root permissions in the
container.

A VNC proxy is added to enable the developer to run

    xtightvncviewer localhost:1

and see the X11 display used by the tests, for debugging purposes.

## Testing

* make -C securedrop images update-user-guides
* (while it is running) xtightvncviewer localhost:1

## Deployment

N/A
