### PR TITLE
db: enable vacuum and secure delete

### DIFF
--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -41,6 +41,9 @@ if config.DATABASE_ENGINE == "sqlite":
         config.DATABASE_ENGINE + ":///" +
         config.DATABASE_FILE
     )
+
+    engine.execute('PRAGMA secure_delete = ON')
+    engine.execute('PRAGMA auto_vacuum = FULL')
 else:  # pragma: no cover
     engine = create_engine(
         config.DATABASE_ENGINE + '://' +


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2868

Note that auto_vacuum will only be effective on newly created
databases because it needs to be done before any table are created.

* https://www.sqlite.org/pragma.html#pragma_secure_delete
* https://www.sqlite.org/pragma.html#pragma_auto_vacuum


## Testing

* vagrant ssh development
* rm -f /var/lib/securedrop/db.sqlite
* ./manage.py run &
* sqlite3 /var/lib/securedrop/db.sqlite 
<pre>
SQLite version 3.8.2 2013-12-06 14:53:30
Enter ".help" for instructions
Enter SQL statements terminated with a ";"
sqlite> pragma main.auto_vacuum;
1
sqlite> pragma main.secure_delete;
1
</pre>


## Deployment

Runtime options only.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
