### PR TITLE
Improve ux successful logo upload

### DIFF
--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -34,9 +34,12 @@ def make_blueprint(config):
             static_filepath = os.path.join(config.SECUREDROP_ROOT,
                                            "static/i/logo.png")
             f.save(static_filepath)
-            flash(gettext("Image updated."), "notification")
+            flash(gettext("Image updated."), "logo-success")
             return redirect(url_for("admin.manage_config"))
         else:
+            for field, errors in form.errors.items():
+                for error in errors:
+                    flash(error, "logo-error")
             return render_template("config.html", form=form)
 
     @view.route('/add', methods=('GET', 'POST'))

--- a/securedrop/journalist_templates/config.html
+++ b/securedrop/journalist_templates/config.html
@@ -31,13 +31,11 @@
   <p>
     {{ form.logo(id="logo-upload") }}
     <br>
-    {% for error in form.logo.errors %}
-      <span class="form-validation-error">{{ error }}</span>
-    {% endfor %}
   </p>
   <button type="submit" class="sd-button" id="submit-logo-update">
     <i class="fa fa-pencil"></i>{{ gettext('UPDATE LOGO') }}
   </button>
+  {% include 'logo_upload_flashed.html' %}
 </form>
 
 {% endblock %}

--- a/securedrop/journalist_templates/flashed.html
+++ b/securedrop/journalist_templates/flashed.html
@@ -1,7 +1,7 @@
 {% with messages = get_flashed_messages(with_categories=true) %}
 {% if messages %}
   {% for category, message in messages %}
-    {% if category != "banner-warning" %}
+    {% if category != "banner-warning" and category != "logo-success" and category != "logo-error"%}
       <div class="flash {{ category }}">
         {% if category == "notification" %}
         <img src="{{ url_for('static', filename='i/font-awesome/info-circle-black.png') }}" height="16" width="20">

--- a/securedrop/journalist_templates/logo_upload_flashed.html
+++ b/securedrop/journalist_templates/logo_upload_flashed.html
@@ -1,0 +1,14 @@
+{# these are flashed messages for the logo upload file verifiaction #}
+{% with messages = get_flashed_messages(with_categories=True, category_filter=["logo-success", "logo-error"]) %}
+  {% for category, message in messages %}
+    {% set category_status = category[5:] %}
+      <div class="flash {{ category_status }}">
+        {% if category_status == "success" %}
+          <img src="{{ url_for('static', filename='i/success_checkmark.png') }}" height="17" width="20">
+        {% elif category_status == "error" %}
+          <img src="{{ url_for('static', filename='i/font-awesome/exclamation-triangle-black.png') }}" height="17" width="20">
+        {% endif %}
+        {{ message }}
+      </div>
+  {% endfor %}
+{% endwith %}

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -746,7 +746,7 @@ class TestJournalistApp(TestCase):
                              data=form.data,
                              follow_redirects=True)
 
-            self.assertMessageFlashed("Image updated.", "notification")
+            self.assertMessageFlashed("Image updated.", "logo-success")
         finally:
             # Restore original image to logo location for subsequent tests
             with open(logo_image_location, 'w') as logo_file:
@@ -761,7 +761,7 @@ class TestJournalistApp(TestCase):
         resp = self.client.post(url_for('admin.manage_config'),
                                 data=form.data,
                                 follow_redirects=True)
-
+        self.assertMessageFlashed("Upload images only.", "logo-error")
         self.assertIn('Upload images only.', resp.data)
 
     def test_logo_upload_with_empty_input_field_fails(self):
@@ -774,6 +774,7 @@ class TestJournalistApp(TestCase):
                                 data=form.data,
                                 follow_redirects=True)
 
+        self.assertMessageFlashed("File required.", "logo-error")
         self.assertIn('File required.', resp.data)
 
     @patch('journalist.app.logger.error')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2876 .

These changes move unify the messages from the logo upload to support flashing. The flash messages are then rendered below the submit button on the admin config page. 

## Testing

In the admin configuration page try three different forms of logo upload attempts: upload a valid image (verify success), upload a nonimage file (verify image filetype error), submit the form without any file selected (no file error).

Note:
This changes cause test_logo_upload_with_valid_image_succeeds in journalist_tests.py to fail. The original test fails because the test is checking for a flashed message of "notification" type, but I changed the valid image upload flashed message type to "success" The "success" flashed messages have a little green check mark and I thought it seemed like a better fit. After changing the type of the flashed message in the test to "success" it passes. 

## Deployment

Any special considerations for deployment? Consider both:
 
1. Upgrading existing production instances.
2. New installs.

No 

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM


![flash_success](https://user-images.githubusercontent.com/8660111/35012348-818e8e64-fad7-11e7-9600-5c7f01a4be03.png)
![flash_filetype](https://user-images.githubusercontent.com/8660111/35012349-819e04f2-fad7-11e7-9d07-6a54472a658d.png)
![flash_file_required](https://user-images.githubusercontent.com/8660111/35012351-81b794da-fad7-11e7-9af5-ad3b54eb4eca.png)


