### PR TITLE
Remove regular staging-test in bid to keep complexity down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,54 +77,6 @@ jobs:
       - store_artifacts:
           path: ~/test-results
 
-  staging-test:
-    docker:
-      - image: quay.io/freedomofpress/circleci-docker:latest
-        environment:
-          FPF_CI: true
-          CI_SD_ENV: staging
-          CI_AWS_TYPE: t2.medium
-          FPF_GRSEC: false
-          TEST_REPORTS: /root/sd
-    working_directory: ~/sd
-
-    steps:
-
-      - checkout
-
-      - run:
-          name: Rebase on-top of latest develop
-          command: ./devops/scripts/rebase-develop.sh
-
-      - run:
-          name: Installation pre-reqs
-          command: pip install -U -r securedrop/requirements/develop-requirements.txt
-
-      - run:
-          name: Check Python dependencies for CVEs
-          command: make safety
-
-      - setup_remote_docker
-
-      - run:
-          name: Run Debian builds
-          command: make build-debs
-
-      - run:
-          name: Provision staging servers and run tests
-          command: make ci-go
-
-      - run:
-          name: Ensure environment torn down
-          command: molecule destroy -s aws
-          when: on_fail
-
-      - store_test_results:
-          path: /root/sd/junit
-
-      - store_artifacts:
-          path: /root/sd/junit
-
   staging-test-with-rebase:
     docker:
       - image: quay.io/freedomofpress/circleci-docker:latest
@@ -175,9 +127,6 @@ workflows:
     jobs:
       - lint
       - tests
-      - staging-test:
-          requires:
-            - lint
       - staging-test-with-rebase:
           requires:
             - lint

--- a/molecule/aws/destroy.yml
+++ b/molecule/aws/destroy.yml
@@ -18,6 +18,9 @@
         name: "sdci-{{ job_id }}"
         state: absent
         region: "{{ aws_ec2_ci_region }}"
+      # If the tear-down fails with the in-ability to remove a key, lets not
+      # fail the actual tear-down process!!
+      ignore_errors: true
 
     - name: Destroy molecule EC2 instance(s)
       ec2:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Semi-repairs  #2881 as a short-term fix. Really we want to rethink how/when we run the full staging suite in the long-term

This is a hot fix to reduce the number of AWS calls we are making per CI run. Specfically, we have started seeing issues with rate-limiting against the `CreateKeyPair` that need to be mitigated. This PR does something really simple, removes the staging test against the branch that doesnt perform the rebase against develop.

Really a longer term goal is to rethink how/when we want to run the staging full VM
tests in CI. Shorter term we can also analyze how we create SSH keys -maybe we take the same key and shove it in circleci?


## Testing

How should the reviewer test this PR?
Does it pass `CI`? and do you see results for `lint` , `tests`, and `staging-test-with-rebase` ? What should be missing is the previous `staging-test` target.

## Deployment

Any special considerations for deployment? N/A only affects CI - specifically CircleCI

## Checklist

### If you made changes to the app code:
Noopee

### If you made changes to the system configuration:
Nooppppe!!
### If you made changes to documentation:
Nooooooooooooooooooooooopee!!