### PR TITLE
Use Xenial to install gettext 0.19.*

### DIFF
--- a/install_files/ansible-base/roles/app-test/tasks/modern_gettext.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/modern_gettext.yml
@@ -3,9 +3,9 @@
 # This can be removed when VM against which this is run are more
 # recent than trusty
 #
-- name: Add gettext zesty apt repository
+- name: Add gettext xenial apt repository
   apt_repository:
-    repo: deb http://archive.ubuntu.com/ubuntu/ zesty main
+    repo: deb http://archive.ubuntu.com/ubuntu/ xenial main
     state: present
     update_cache: yes
   tags:
@@ -18,11 +18,10 @@
   tags:
     - apt
 
-- name: Remove gettext zesty apt repository
+- name: Remove gettext xenial apt repository
   apt_repository:
-    repo: deb http://archive.ubuntu.com/ubuntu/ zesty main
+    repo: deb http://archive.ubuntu.com/ubuntu/ xenial main
     state: absent
     update_cache: yes
   tags:
     - apt
-

--- a/securedrop/Dockerfile
+++ b/securedrop/Dockerfile
@@ -19,10 +19,10 @@ RUN curl -LO https://launchpad.net/~ubuntu-mozilla-security/+archive/ubuntu/ppa/
 #
 # This can be removed when upgrading to something more recent than trusty
 #
-RUN echo deb http://archive.ubuntu.com/ubuntu/ zesty main > /etc/apt/sources.list.d/zesty.list && \
+RUN echo deb http://archive.ubuntu.com/ubuntu/ xenial main > /etc/apt/sources.list.d/xenial.list && \
     apt-get update && \
     apt-get install -y gettext && \
-    rm /etc/apt/sources.list.d/zesty.list && \
+    rm /etc/apt/sources.list.d/xenial.list && \
     apt-get update
 
 COPY requirements requirements


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2884, switching to Xenial to install a modern version of gettext

## Testing

Does a development VM provision OK? 

## Deployment

Dev and build only

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
