### PR TITLE
Docs: Encourage journalists and admins to provide feedback

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -1,6 +1,8 @@
 Admin Guide
 ===========
 
+.. include:: ./includes/provide-feedback.txt
+
 You (the admin) should have your own username and passphrase, plus
 two-factor authentication through either the FreeOTP app
 on your smartphone or a YubiKey.

--- a/docs/includes/provide-feedback.txt
+++ b/docs/includes/provide-feedback.txt
@@ -1,0 +1,4 @@
+.. note:: SecureDrop wants your help to improve! Do you find something in
+          our documentation confusing? Please send us feedback via
+          `an issue on GitHub <https://github.com/freedomofpress/securedrop/issues/new>`_
+          or the `community forum <https://forum.securedrop.club/>`_.

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -1,6 +1,8 @@
 Journalist Guide
 ================
 
+.. include:: ./includes/provide-feedback.txt
+
 This guide presents an overview of the SecureDrop system for a
 journalist. It covers the core functions necessary to start working
 with the platform: logging in securely, viewing documents, editing


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes the journalist/admin side of #2893. I did not implement a warning for sources as we should ensure we have a secure way to get their feedback, i.e. we should not solicit information like email addresses or encourage them to make accounts on 3rd party services like GitHub without careful consideration. I created the post https://forum.securedrop.club/t/getting-user-feedback-from-securedrop-sources-via-securedrop/376 to discuss the possibility of using SecureDrop to get feedback about SecureDrop (:xzibit:) from sources. 

## Testing

See if this is a nice message

## Deployment

Docs only

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
