### PR TITLE
fix pyenchant dependency conflict in development vm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.vagrant
+**/venv
+
+**/__pycache__
+**/*.pyc
+securedrop/.sass-cache
+securedrop/static/gen
+securedrop/static/.webassets-cache
+securedrop/tests/log/*
+securedrop/tests/pages-layout/

--- a/devops/docker/Dockerfile.linting
+++ b/devops/docker/Dockerfile.linting
@@ -5,6 +5,12 @@ RUN sudo apt-get install -y enchant
 
 COPY securedrop/requirements securedrop/requirements
 RUN sudo pip install -r securedrop/requirements/develop-requirements.txt
+#
+# temporary fix (see https://github.com/freedomofpress/securedrop/issues/2906)
+# should be moved to securedrop/requirements/develop-requirements.in when it
+# no longer is a problem
+#
+RUN sudo pip install pyenchant==2.0.0
 
 WORKDIR /src
 COPY . /src

--- a/securedrop/db.py
+++ b/securedrop/db.py
@@ -6,7 +6,7 @@ import binascii
 # Find the best implementation available on this platform
 try:
     from cStringIO import StringIO
-except:
+except ImportError:
     from StringIO import StringIO
 
 from sqlalchemy import create_engine, ForeignKey

--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -87,7 +87,7 @@ def get_locale(config):
             sep = '_'
         try:
             accept_languages.append(str(core.Locale.parse(l, sep)))
-        except:
+        except Exception:
             pass
     if 'l' in request.args:
         if len(request.args['l']) == 0:

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -95,7 +95,7 @@ def validate_user(username, password, token, error_message=None):
                     login_flashed_msg += gettext(
                         "Please wait for a new code from your two-factor token"
                         " or application before trying again.")
-            except:
+            except Exception:
                 pass
 
         flash(login_flashed_msg, "error")

--- a/securedrop/requirements/develop-requirements.in
+++ b/securedrop/requirements/develop-requirements.in
@@ -6,7 +6,10 @@ flake8
 html-linter
 molecule>=2.*
 pip-tools>=1.10
-pyenchant
+#
+# pyenchant should be included here but is in Dockerfile.linting
+# because of https://github.com/freedomofpress/securedrop/issues/2906
+#
 pylint
 pytest-xdist
 safety

--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -78,7 +78,6 @@ pyasn1==0.3.1             # via paramiko
 pycodestyle==2.3.1        # via flake8
 pycparser==2.18           # via cffi
 pycrypto==2.6.1           # via ansible
-pyenchant==2.0.0
 pyflakes==1.5.0           # via flake8
 pygments==2.2.0           # via sphinx
 pylint==1.8.1

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -144,7 +144,7 @@ class FunctionalTest(object):
             try:
                 requests.get(self.source_location)
                 requests.get(self.journalist_location)
-            except:
+            except Exception:
                 time.sleep(1)
             else:
                 break


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2906

Split the dev dependencies further to prevent vagrant env from requiring the `apt` package `enchant`.

Also, snuck in a fix to the `.dockerignore` that stops us from sending 400MB to the daemon (now only 70MB).

## Testing

`make ci-lint-image && make ci-lint && vagrant destroy -f && vagrant up`