### PR TITLE
Add coverage of js functionality with Selenium and resolve js alert regression

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -101,7 +101,7 @@
     <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
     <input type="hidden" name="filesystem_id" value="{{ filesystem_id }}">
     <input type="hidden" name="col_name" value="{{ source.journalist_designation }}">
-    <button type="submit" class="sd-button danger"><i class="fa fa-trash-o"></i> {{ gettext('DELETE COLLECTION') }}</button>
+    <button id="delete-collection-button" type="submit" class="sd-button danger"><i class="fa fa-trash-o"></i> {{ gettext('DELETE COLLECTION') }}</button>
   </form>
 
 </div>

--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -73,7 +73,12 @@
 {% endif %}
 
 {% macro twofa_reset(user, reset_url, type, button_text) %}
-<form method="post" action="{{ reset_url }}" id="reset-two-factor-{{ type }}">
+{% if user %}
+  {% set username = user.username %}
+{% else %}
+  {% set username = g.user.username %}
+{% endif %}
+<form method="post" action="{{ reset_url }}" id="reset-two-factor-{{ type }}" class="reset-two-factor" data-username="{{ username }}">
   {% if user %}
   <input name="uid" type="hidden" value="{{ user.id }}">
   {% endif %}

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -115,7 +115,8 @@ $(function () {
   });
 
   // Confirm before resetting two-factor authentication on edit user page
-  $('form#reset-two-factor').submit(function(event) {
+  $('.reset-two-factor').submit(function(event) {
+      var username = $(this).attr('data-username');
       return confirm(get_string("reset-user-mfa-confirm-string").supplant({ username: username }));
   });
 

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -478,6 +478,10 @@ class JournalistNavigationStepsMixin():
                          'mocked')
         self.wait_for(found_sources)
 
+        # Log back out and log back admin in for subsequent tests
+        self._logout()
+        self._login_user(self.admin.username, self.admin_pw, 'mocked')
+
     @screenshots
     def _journalist_checks_messages(self):
         self.driver.get(self.journalist_location)
@@ -631,6 +635,10 @@ class JournalistNavigationStepsMixin():
         assert ('/admin/reset-2fa-hotp' in
                 hotp_reset_button.get_attribute('action'))
         hotp_reset_button.click()
+
+    def _admin_accepts_2fa_js_alert(self):
+        self._alert_wait()
+        self._alert_accept()
 
     def _admin_visits_reset_2fa_totp(self):
         totp_reset_button = self.driver.find_elements_by_css_selector(

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -253,6 +253,25 @@ class JournalistNavigationStepsMixin():
                          self.new_user['username']) in
                     [el.text for el in flashed_msgs])
 
+    def _admin_deletes_user(self):
+        self.wait_for(lambda: self.driver.find_element_by_css_selector(
+            '.delete-user'), timeout=60)
+
+        # Get the delete user buttons
+        delete_buttons = self.driver.find_elements_by_css_selector(
+            '.delete-user')
+
+        # Try to delete a user
+        delete_buttons[0].click()
+
+        # Wait for JavaScript alert to pop up and accept it.
+        self._alert_wait()
+        self._alert_accept()
+
+        if not hasattr(self, 'accept_languages'):
+            flashed_msg = self.driver.find_element_by_css_selector('.flash')
+            assert "Deleted user" in flashed_msg.text
+
     def _admin_can_send_test_alert(self):
         alert_button = self.driver.find_element_by_id('test-ossec-alert')
         alert_button.click()

--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -15,6 +15,14 @@ class TestAdminInterface(
         self._new_user_can_log_in()
         self._admin_can_edit_new_user()
 
+    def test_admin_edits_hotp_secret(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_adds_a_user()
+        self._admin_visits_edit_user()
+        self._admin_visits_reset_2fa_hotp()
+        self._admin_accepts_2fa_js_alert()
+
     def test_admin_deletes_user(self):
         self._admin_logs_in()
         self._admin_visits_admin_interface()

--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -15,6 +15,12 @@ class TestAdminInterface(
         self._new_user_can_log_in()
         self._admin_can_edit_new_user()
 
+    def test_admin_deletes_user(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_adds_a_user()
+        self._admin_deletes_user()
+
     def test_admin_updates_image(self):
         self._admin_logs_in()
         self._admin_visits_admin_interface()

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -26,6 +26,7 @@ class TestJournalist(
         journalist_navigation_steps.JournalistNavigationStepsMixin):
 
     def test_journalist_verifies_deletion_of_one_submission_javascript(self):
+        # This deletion button is displayed on the individual source page
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()
         self._source_continues_to_submit_page()
@@ -33,4 +34,38 @@ class TestJournalist(
         self._source_logs_out()
         self._journalist_logs_in()
         self._journalist_visits_col()
-        self._journalist_verifies_deletion_of_one_submission_javascript()
+        self._journalist_uses_delete_selected_button_javascript()
+
+    def test_journalist_uses_col_delete_collection_button_javascript(self):
+        # This delete button is displayed on the individual source page
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_logs_out()
+        self._journalist_logs_in()
+        self._journalist_visits_col()
+        self._journalist_uses_delete_collection_button_javascript()
+
+    def test_journalist_uses_index_delete_collections_button_javascript(self):
+        # This deletion button is displayed on the index page
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_logs_out()
+        self._journalist_logs_in()
+        self._journalist_uses_delete_collections_button_javascript()
+
+    def test_journalist_interface_ui_with_javascript(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_logs_out()
+        self._journalist_logs_in()
+        self._journalist_uses_js_filter_by_sources()
+        self._journalist_selects_all_sources_then_selects_none()
+        self._journalist_selects_the_first_source()
+        self._journalist_uses_js_buttons_to_download_unread()
+        self._journalist_delete_all_javascript()

--- a/securedrop/tests/functional/test_source_warnings.py
+++ b/securedrop/tests/functional/test_source_warnings.py
@@ -14,3 +14,12 @@ class TestSourceInterfaceBannerWarnings(
 
         assert ("We recommend using Tor Browser to access SecureDrop" in
                 warning_banner.text)
+
+        # User should be able to dismiss the warning
+        warning_dismiss_button = self.driver.find_element_by_id(
+            'use-tor-browser-close')
+        warning_dismiss_button.click()
+
+        def warning_banner_is_hidden():
+            assert warning_banner.is_displayed() is False
+        self.wait_for(warning_banner_is_hidden)

--- a/securedrop/tests/functional/test_submit_and_retrieve_file.py
+++ b/securedrop/tests/functional/test_submit_and_retrieve_file.py
@@ -19,7 +19,6 @@ class TestSubmitAndRetrieveFile(
         self._journalist_logs_in()
         self._journalist_checks_messages()
         self._journalist_stars_and_unstars_single_message()
-        self._journalist_selects_all_sources_then_selects_none()
         self._journalist_downloads_message()
         self._journalist_sends_reply_to_source()
         self._source_visits_source_homepage()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2405 and fixes #2920 (happy to split this up into multiple PRs if desired)

Changes proposed in this pull request:
  * Adds test coverage for js functionality using Selenium -- this should test everything that we can test with _Firefox_ based Selenium tests

We would either need to use Selenium with multiple browsers (i.e. Tor Browser and not Tor Browser) to test the remaining source interface functionality and/or have some js unit tests that [check that the right warnings are rendered based on various user agent strings](https://github.com/freedomofpress/securedrop/compare/test-coverage-source-interface-js#diff-2a4e34a719a23a3734bf355b523558beR13) (#2406). Imho adding js unit tests is easier than rigging up functional tests with many browsers (consider how we'd add test coverage for [resolutions](https://github.com/freedomofpress/securedrop/issues/2510#issuecomment-342007810) to defects like #2510). 

## Testing

Do tests pass? Is there functionality in the js that I have _not_ covered and could via Selenium? 

## Deployment

Just tests and js

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
