### PR TITLE
builder: do not silence logs when destroying the vm

### DIFF
--- a/molecule/builder/destroy.yml
+++ b/molecule/builder/destroy.yml
@@ -3,7 +3,6 @@
   hosts: localhost
   connection: local
   gather_facts: False
-  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

do not silence logs when destroying the vm

## Testing

* make build-debs

## Deployment

N/A
