### PR TITLE
Page layout tests: Add ar locale so RTL languages tested in CI

### DIFF
--- a/molecule/aws/scripts/app-tests.sh
+++ b/molecule/aws/scripts/app-tests.sh
@@ -10,4 +10,4 @@ cd "$1" || exit 1
 # are time consuming.
 # * en_US: source strings
 # * fr_FR: left-to-right translations
-PAGE_LAYOUT_LOCALES='en_US,fr_FR' pytest --page-layout --junit-xml=/tmp/apptest.xml --junit-prefix=apptest tests/
+PAGE_LAYOUT_LOCALES='en_US,ar,fr_FR' pytest --page-layout --junit-xml=/tmp/apptest.xml --junit-prefix=apptest tests/

--- a/securedrop/bin/test
+++ b/securedrop/bin/test
@@ -15,7 +15,7 @@ fi
 
 mkdir -p "/tmp/test-results/logs"
 
-export PAGE_LAYOUT_LOCALES="en_US,fr_FR"
+export PAGE_LAYOUT_LOCALES="en_US,ar,fr_FR"
 pytest \
   --page-layout \
   --durations 10 \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2677.

We removed the ar locale from tests when we pulled Arabic
from the 0.5 release. We should have the page
layout tests running on the Arabic locale in CI so that we can
catch any RTL-specific breakage

## Testing

Does CI pass?

## Deployment

CI only

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM
