### PR TITLE
Uses `max_fail_percentage` to force immediate Ansible exits (again)

### DIFF
--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -21,6 +21,8 @@
 
 - name: Configure OSSEC.
   hosts: securedrop
+  max_fail_percentage: 0
+  any_errors_fatal: yes
   roles:
     - role: ossec
       tags: ossec

--- a/install_files/ansible-base/securedrop-staging.yml
+++ b/install_files/ansible-base/securedrop-staging.yml
@@ -37,6 +37,8 @@
 
 - name: Configure OSSEC.
   hosts: staging
+  max_fail_percentage: 0
+  any_errors_fatal: yes
   roles:
     - role: ossec
       tags: ossec

--- a/molecule/ansible-config/tests/test_max_fail_percentage.py
+++ b/molecule/ansible-config/tests/test_max_fail_percentage.py
@@ -64,7 +64,7 @@ def test_max_fail_percentage(host, playbook):
 
 
 @pytest.mark.parametrize('playbook', find_ansible_playbooks())
-def test_max_fail_percentage(host, playbook):
+def test_any_errors_fatal(host, playbook):
     """
     All SecureDrop playbooks should set `any_errors_fatal` to "yes"
     on each and every play. In conjunction with `max_fail_percentage` set


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Follow-up to #2922. Please read the commit messages here and comment if you do not completely understand what went wrong. I want to ensure the commit messages are crystal clear for maintainers in the future.

## Testing

CI passing is sufficient. (Famous last words.)

## Deployment

Admittedly some—but what we've already addressed and accommodated for during review of #2922.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
