### PR TITLE
Circle CI: Rebase before running tests and lint jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
     steps:
       - run: apt-get install -y make
       - checkout
+      - run:
+          name: Rebase on-top of latest develop
+          command: ./devops/scripts/rebase-develop.sh
       - setup_remote_docker
 
       - run: TAG=${CIRCLE_SHA1} make ci-lint-image
@@ -23,6 +26,9 @@ jobs:
     steps:
       - run: apt-get install -y make
       - checkout
+      - run:
+          name: Rebase on-top of latest develop
+          command: ./devops/scripts/rebase-develop.sh
       - setup_remote_docker
 
       - restore_cache:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2934.

Changes proposed in this pull request:
 * We should be running CI on PR branches that have been rebased on latest develop

## Testing

Make sure that the "Rebase on-top of latest develop" steps run for both the tests and linting CI jobs

## Deployment

CI only

## Checklist

CI only
