### PR TITLE
Css: Delete confirmation with css-only modal

### DIFF
--- a/securedrop/journalist_templates/_confirmation_modal.html
+++ b/securedrop/journalist_templates/_confirmation_modal.html
@@ -1,0 +1,10 @@
+<div id="{{ modal_data.modal_id }}" class="modal-dialog">
+  <a href="#close" class="external"></a>
+  <div>
+    <a href="#close" title="{{ gettext('Close') }}" class="close">X</a>
+    <h2>{{ modal_data.modal_header }}</h2>
+    <p>{{ modal_data.modal_body }}</p>
+    <a href="#close" id="{{ modal_data.cancel_id }}" title="{{ gettext('Cancel') }}" class="btn sd-button">{{ gettext('Cancel') }}</a>
+    <button type="submit" id="{{ modal_data.submit_id }}" name="action" value="delete" class="sd-button {{ modal_data.submit_btn_type }}">{{ modal_data.submit_btn_text }}</button>
+  </div>
+</div>

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -24,7 +24,7 @@
       <p>
         <div id="select-container"></div>
         <button type="submit" name="action" value="download" class="small"><i class="fa fa-download"></i> {{ gettext('Download Selected') }}</button>
-        <button type="submit" name="action" value="confirm_delete" id="delete-selected" class="small danger"><i class="fa fa-trash-o"></i> {{ gettext('Delete Selected') }}</button>
+        <a href="#delete-selected-confirmation-modal" class="btn small danger"><i class="fa fa-trash-o"></i> {{ gettext('Delete Selected') }}</a>
       </p>
 
       <ul id="submissions" class="plain submissions">
@@ -61,6 +61,18 @@
           </li>
         {% endfor %}
       </ul>
+
+      <!-- Confirmation modal for selected documents -->
+      <div id="delete-selected-confirmation-modal" class="modal-dialog">
+        <a href="#close" class="external"></a>
+        <div>
+          <a href="#close" title="Close" class="close">X</a>
+          <h2>{{ gettext('Delete Confirmation') }}</h2>
+          <p>{{ gettext('Are you sure you want to delete the selected documents?') }}</p>
+          <a href="#close" title="Cancel" class="btn sd-button">Cancel</a>
+          <button type="submit" name="action" value="confirm_delete" id="delete-selected" class="sd-button danger">Delete</button>
+        </div>
+      </div>
 
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
       <input type="hidden" name="filesystem_id" value="{{ filesystem_id }}">
@@ -101,7 +113,19 @@
     <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
     <input type="hidden" name="filesystem_id" value="{{ filesystem_id }}">
     <input type="hidden" name="col_name" value="{{ source.journalist_designation }}">
-    <button id="delete-collection-button" type="submit" class="sd-button danger"><i class="fa fa-trash-o"></i> {{ gettext('DELETE COLLECTION') }}</button>
+    <a href="#delete-collection-confirmation-modal" class="btn sd-button danger"><i class="fa fa-trash-o"></i> {{ gettext('DELETE COLLECTION') }}</a>
+
+    <!-- Confirmation modal for entire collection deletion -->
+    <div id="delete-collection-confirmation-modal" class="modal-dialog">
+      <a href="#close" class="external"></a>
+      <div>
+        <a href="#close" title="Close" class="close">X</a>
+        <h2>{{ gettext('Delete Confirmation') }}</h2>
+        <p>{{ gettext('Are you sure you want to delete this collection?') }}</p>
+        <a href="#close" title="Cancel" class="btn sd-button">Cancel</a>
+        <button type="submit" id="delete-collection-button" name="action" value="delete" class="sd-button danger">Delete</button>
+      </div>
+    </div>
   </form>
 
 </div>

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -65,16 +65,19 @@
       </ul>
 
       <!-- Confirmation modal for selected documents -->
-      <div id="delete-selected-confirmation-modal" class="modal-dialog">
-        <a href="#close" class="external"></a>
-        <div>
-          <a href="#close" title="{{ gettext('Close') }}" class="close">X</a>
-          <h2>{{ gettext('Delete Confirmation') }}</h2>
-          <p>{{ gettext('Are you sure you want to delete the selected documents?') }}</p>
-          <a href="#close" id="cancel-selected-deletions" title="{{ gettext('Cancel') }}" class="btn sd-button">{{ gettext('Cancel') }}</a>
-          <button type="submit" name="action" value="confirm_delete" id="delete-selected" class="sd-button danger">{{ gettext('Delete') }}</button>
-        </div>
-      </div>
+      {% with %}
+        {% set modal_data = {
+                              "modal_id": "delete-selected-confirmation-modal",
+                              "modal_header": gettext('Delete Confirmation'),
+                              "modal_body": gettext('Are you sure you want to delete the selected documents?'),
+                              "cancel_id": "cancel-selected-deletions",
+                              "submit_id": "delete-selected",
+                              "submit_btn_type": "danger",
+                              "submit_btn_text": gettext('Delete')
+                            }
+        %}
+        {% include '_confirmation_modal.html' %}
+      {% endwith %}
 
       <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
       <input type="hidden" name="filesystem_id" value="{{ filesystem_id }}">
@@ -120,16 +123,19 @@
     </a>
 
     <!-- Confirmation modal for entire collection deletion -->
-    <div id="delete-collection-confirmation-modal" class="modal-dialog">
-      <a href="#close" class="external"></a>
-      <div>
-        <a href="#close" title="{{ gettext('Close') }}" class="close">X</a>
-        <h2>{{ gettext('Delete Confirmation') }}</h2>
-        <p>{{ gettext('Are you sure you want to delete this collection?') }}</p>
-        <a href="#close" id="cancel-collection-deletions" title="{{ gettext('Cancel') }}" class="btn sd-button">{{ gettext('Cancel') }}</a>
-        <button type="submit" id="delete-collection-button" name="action" value="delete" class="sd-button danger">{{ gettext('Delete') }}</button>
-      </div>
-    </div>
+    {% with %}
+      {% set modal_data = {
+                            "modal_id": "delete-collection-confirmation-modal",
+                            "modal_header": gettext('Delete Confirmation'),
+                            "modal_body": gettext('Are you sure you want to delete this collection?'),
+                            "cancel_id": "cancel-collection-deletions",
+                            "submit_id": "delete-collection-button",
+                            "submit_btn_type": "danger",
+                            "submit_btn_text": gettext('Delete')
+                          }
+      %}
+      {% include '_confirmation_modal.html' %}
+    {% endwith %}
   </form>
 
 </div>

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -24,7 +24,9 @@
       <p>
         <div id="select-container"></div>
         <button type="submit" name="action" value="download" class="small"><i class="fa fa-download"></i> {{ gettext('Download Selected') }}</button>
-        <a href="#delete-selected-confirmation-modal" class="btn small danger"><i class="fa fa-trash-o"></i> {{ gettext('Delete Selected') }}</a>
+        <a href="#delete-selected-confirmation-modal" id="delete-selected-link" class="btn small danger">
+          <i class="fa fa-trash-o"></i> {{ gettext('Delete Selected') }}
+        </a>
       </p>
 
       <ul id="submissions" class="plain submissions">
@@ -69,7 +71,7 @@
           <a href="#close" title="Close" class="close">X</a>
           <h2>{{ gettext('Delete Confirmation') }}</h2>
           <p>{{ gettext('Are you sure you want to delete the selected documents?') }}</p>
-          <a href="#close" title="Cancel" class="btn sd-button">Cancel</a>
+          <a href="#close" id="cancel-selected-deletions" title="Cancel" class="btn sd-button">Cancel</a>
           <button type="submit" name="action" value="confirm_delete" id="delete-selected" class="sd-button danger">Delete</button>
         </div>
       </div>
@@ -113,7 +115,9 @@
     <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
     <input type="hidden" name="filesystem_id" value="{{ filesystem_id }}">
     <input type="hidden" name="col_name" value="{{ source.journalist_designation }}">
-    <a href="#delete-collection-confirmation-modal" class="btn sd-button danger"><i class="fa fa-trash-o"></i> {{ gettext('DELETE COLLECTION') }}</a>
+    <a href="#delete-collection-confirmation-modal" id="delete-collection-link" class="btn sd-button danger">
+      <i class="fa fa-trash-o"></i> {{ gettext('DELETE COLLECTION') }}
+    </a>
 
     <!-- Confirmation modal for entire collection deletion -->
     <div id="delete-collection-confirmation-modal" class="modal-dialog">
@@ -122,7 +126,7 @@
         <a href="#close" title="Close" class="close">X</a>
         <h2>{{ gettext('Delete Confirmation') }}</h2>
         <p>{{ gettext('Are you sure you want to delete this collection?') }}</p>
-        <a href="#close" title="Cancel" class="btn sd-button">Cancel</a>
+        <a href="#close" id="cancel-collection-deletions" title="Cancel" class="btn sd-button">Cancel</a>
         <button type="submit" id="delete-collection-button" name="action" value="delete" class="sd-button danger">Delete</button>
       </div>
     </div>

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -68,11 +68,11 @@
       <div id="delete-selected-confirmation-modal" class="modal-dialog">
         <a href="#close" class="external"></a>
         <div>
-          <a href="#close" title="Close" class="close">X</a>
+          <a href="#close" title="{{ gettext('Close') }}" class="close">X</a>
           <h2>{{ gettext('Delete Confirmation') }}</h2>
           <p>{{ gettext('Are you sure you want to delete the selected documents?') }}</p>
-          <a href="#close" id="cancel-selected-deletions" title="Cancel" class="btn sd-button">Cancel</a>
-          <button type="submit" name="action" value="confirm_delete" id="delete-selected" class="sd-button danger">Delete</button>
+          <a href="#close" id="cancel-selected-deletions" title="{{ gettext('Cancel') }}" class="btn sd-button">{{ gettext('Cancel') }}</a>
+          <button type="submit" name="action" value="confirm_delete" id="delete-selected" class="sd-button danger">{{ gettext('Delete') }}</button>
         </div>
       </div>
 
@@ -123,11 +123,11 @@
     <div id="delete-collection-confirmation-modal" class="modal-dialog">
       <a href="#close" class="external"></a>
       <div>
-        <a href="#close" title="Close" class="close">X</a>
+        <a href="#close" title="{{ gettext('Close') }}" class="close">X</a>
         <h2>{{ gettext('Delete Confirmation') }}</h2>
         <p>{{ gettext('Are you sure you want to delete this collection?') }}</p>
-        <a href="#close" id="cancel-collection-deletions" title="Cancel" class="btn sd-button">Cancel</a>
-        <button type="submit" id="delete-collection-button" name="action" value="delete" class="sd-button danger">Delete</button>
+        <a href="#close" id="cancel-collection-deletions" title="{{ gettext('Cancel') }}" class="btn sd-button">{{ gettext('Cancel') }}</a>
+        <button type="submit" id="delete-collection-button" name="action" value="delete" class="sd-button danger">{{ gettext('Delete') }}</button>
       </div>
     </div>
   </form>

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -40,16 +40,19 @@
       {% endif %}
 
       <!-- Delete confirmation modal -->
-      <div id="delete-confirmation-modal" class="modal-dialog">
-        <a href="#close" class="external"></a>
-        <div>
-          <a href="#close" title="{{ gettext('Close') }}" class="close">X</a>
-          <h2>{{ gettext('Delete Confirmation') }}</h2>
-          <p>{{ gettext('Are you sure you want to delete the selected collections?') }}</p>
-          <a href="#close" id="cancel-collections-deletions" title="{{ gettext('Cancel') }}" class="btn sd-button">{{ gettext('Cancel') }}</a>
-          <button type="submit" id="delete-collections" name="action" value="delete" class="sd-button danger">{{ gettext('Delete') }}</button>
-        </div>
-      </div>
+      {% with %}
+        {% set modal_data = {
+                              "modal_id": "delete-confirmation-modal",
+                              "modal_header": gettext('Delete Confirmation'),
+                              "modal_body": gettext('Are you sure you want to delete the selected collections?'),
+                              "cancel_id": "cancel-collections-deletions",
+                              "submit_id": "delete-collections",
+                              "submit_btn_type": "danger",
+                              "submit_btn_text": gettext('Delete')
+                            }
+        %}
+        {% include '_confirmation_modal.html' %}
+      {% endwith %}
 
     </form>
   {% else %}

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -12,7 +12,9 @@
         <button type="submit" name="action" value="download-all" class="small"><i class="fa fa-download"></i> {{ gettext('Download') }}</button>
         <button type="submit" name="action" value="star" class="small"><i class="fa fa-star"></i> {{ gettext('Star') }}</button>
         <button type="submit" name="action" value="un-star" class="small"><i class="fa fa-star-half-full"></i> {{ gettext('Un-star') }}</button>
-        <button type="submit" id="delete-collections" name="action" value="delete" class="small-danger"><i class="fa fa-trash-o"></i> {{ gettext('Delete') }}</button>
+        <a href="#delete-confirmation-modal" class="btn small danger">
+          <i class="fa fa-trash-o"></i> {{ gettext('Delete') }}
+        </a>
       </p>
 
       {% if starred %}
@@ -36,6 +38,18 @@
           {% endfor %}
         </ul>
       {% endif %}
+
+      <!-- Delete confirmation modal -->
+      <div id="delete-confirmation-modal" class="modal-dialog">
+        <a href="#close" class="external"></a>
+        <div>
+          <a href="#close" title="Close" class="close">X</a>
+          <h2>{{ gettext('Delete Confirmation') }}</h2>
+          <p>{{ gettext('Are you sure you want to delete the selected collections?') }}</p>
+          <a href="#close" title="Cancel" class="btn sd-button">Cancel</a>
+          <button type="submit" id="delete-collections" name="action" value="delete" class="sd-button danger">Delete</button>
+        </div>
+      </div>
 
     </form>
   {% else %}

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -43,11 +43,11 @@
       <div id="delete-confirmation-modal" class="modal-dialog">
         <a href="#close" class="external"></a>
         <div>
-          <a href="#close" title="Close" class="close">X</a>
+          <a href="#close" title="{{ gettext('Close') }}" class="close">X</a>
           <h2>{{ gettext('Delete Confirmation') }}</h2>
           <p>{{ gettext('Are you sure you want to delete the selected collections?') }}</p>
-          <a href="#close" id="cancel-collections-deletions" title="Cancel" class="btn sd-button">Cancel</a>
-          <button type="submit" id="delete-collections" name="action" value="delete" class="sd-button danger">Delete</button>
+          <a href="#close" id="cancel-collections-deletions" title="{{ gettext('Cancel') }}" class="btn sd-button">{{ gettext('Cancel') }}</a>
+          <button type="submit" id="delete-collections" name="action" value="delete" class="sd-button danger">{{ gettext('Delete') }}</button>
         </div>
       </div>
 

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -12,7 +12,7 @@
         <button type="submit" name="action" value="download-all" class="small"><i class="fa fa-download"></i> {{ gettext('Download') }}</button>
         <button type="submit" name="action" value="star" class="small"><i class="fa fa-star"></i> {{ gettext('Star') }}</button>
         <button type="submit" name="action" value="un-star" class="small"><i class="fa fa-star-half-full"></i> {{ gettext('Un-star') }}</button>
-        <a href="#delete-confirmation-modal" class="btn small danger">
+        <a href="#delete-confirmation-modal" id="delete-collections-link" class="btn small danger">
           <i class="fa fa-trash-o"></i> {{ gettext('Delete') }}
         </a>
       </p>
@@ -46,7 +46,7 @@
           <a href="#close" title="Close" class="close">X</a>
           <h2>{{ gettext('Delete Confirmation') }}</h2>
           <p>{{ gettext('Are you sure you want to delete the selected collections?') }}</p>
-          <a href="#close" title="Cancel" class="btn sd-button">Cancel</a>
+          <a href="#close" id="cancel-collections-deletions" title="Cancel" class="btn sd-button">Cancel</a>
           <button type="submit" id="delete-collections" name="action" value="delete" class="sd-button danger">Delete</button>
         </div>
       </div>

--- a/securedrop/journalist_templates/js-strings.html
+++ b/securedrop/journalist_templates/js-strings.html
@@ -4,9 +4,6 @@
   <div id="select-all-string" hidden>{{ gettext('Select All') }}</div>
   <div id="select-unread-string" hidden>{{ gettext('Select Unread') }}</div>
   <div id="select-none-string" hidden>{{ gettext('Select None') }}</div>
-  <div id="collection-delete-confirm-string" hidden>{{ gettext('Are you sure you want to delete this collection?') }}</div>
-  <div id="collection-multi-delete-confirm-string" hidden>{{ gettext('Are you sure you want to delete the {size} selected collections?') }}</div>
-  <div id="submission-multi-delete-confirm-string" hidden>{{ gettext('Are you sure you want to delete the {size} selected submissions?') }}</div>
   <div id="delete-user-confirm-string" hidden>{{ gettext('Are you sure you want to delete the user {username}?') }}</div>
   <div id="reset-user-mfa-confirm-string" hidden>{{ gettext('Are you sure you want to reset two-factor authentication for {username}?') }}</div>
 </div>

--- a/securedrop/sass/journalist.sass
+++ b/securedrop/sass/journalist.sass
@@ -55,6 +55,61 @@ p.breadcrumbs
   &:dir(rtl)
     text-align: right
 
+.modal-dialog
+  position: fixed
+  top: 0
+  right: 0
+  bottom: 0
+  left: 0
+  background: rgba(0, 0, 0, 0.8)
+  z-index: 99999
+  opacity: 0
+  -webkit-transition: opacity 100ms ease-in
+  -moz-transition: opacity 100ms ease-in
+  transition: opacity 100ms ease-in
+  pointer-events: none
+
+  &:target
+    opacity: 1
+    pointer-events: auto
+
+  .external
+    position: fixed
+    top: 0
+    left: 0
+    width: 100%
+    height: 100%
+
+  div
+    width: 400px
+    position: relative
+    margin: 10% auto
+    padding: 5px 20px 13px 20px
+    border-radius: 10px
+    background: white
+
+  .close
+    background: $color_grey_medium
+    color: white
+    line-height: 25px
+    position: absolute
+    right: -12px
+    text-align: center
+    top: -10px
+    width: 24px
+    text-decoration: none
+    font-weight: bold
+    -webkit-border-radius: 12px
+    -moz-border-radius: 12px
+    border-radius: 12px
+    -moz-box-shadow: 1px 1px 3px #000
+    -webkit-box-shadow: 1px 1px 3px #000
+    box-shadow: 1px 1px 3px #000
+
+    &:hover
+      background: $color_purple_medium
+
+
 #regenerate-code .confirm-prompt
   font-size: 14px
   font-style: italic

--- a/securedrop/sass/journalist.sass
+++ b/securedrop/sass/journalist.sass
@@ -1,6 +1,7 @@
 @import base
 @import modules/visually-hidden
 @import modules/menu
+@import modules/confirm-modal
 
 +base_rules
 
@@ -54,58 +55,6 @@ p.breadcrumbs
 
   &:dir(rtl)
     text-align: right
-
-.modal-dialog
-  position: fixed
-  top: 0
-  right: 0
-  bottom: 0
-  left: 0
-  background: rgba(0, 0, 0, 0.8)
-  z-index: 99999
-  opacity: 0
-  -moz-transition: opacity 100ms ease-in
-  transition: opacity 100ms ease-in
-  pointer-events: none
-
-  &:target
-    opacity: 1
-    pointer-events: auto
-
-  .external
-    position: fixed
-    top: 0
-    left: 0
-    width: 100%
-    height: 100%
-
-  div
-    width: 400px
-    position: relative
-    margin: 10% auto
-    padding: 5px 20px 13px 20px
-    border-radius: 10px
-    background: white
-
-  .close
-    background: $color_grey_medium
-    color: white
-    line-height: 25px
-    position: absolute
-    right: -12px
-    text-align: center
-    top: -10px
-    width: 24px
-    text-decoration: none
-    font-weight: bold
-    -moz-border-radius: 12px
-    border-radius: 12px
-    -moz-box-shadow: 1px 1px 3px #000
-    box-shadow: 1px 1px 3px #000
-
-    &:hover
-      background: $color_purple_medium
-
 
 #regenerate-code .confirm-prompt
   font-size: 14px

--- a/securedrop/sass/journalist.sass
+++ b/securedrop/sass/journalist.sass
@@ -64,7 +64,6 @@ p.breadcrumbs
   background: rgba(0, 0, 0, 0.8)
   z-index: 99999
   opacity: 0
-  -webkit-transition: opacity 100ms ease-in
   -moz-transition: opacity 100ms ease-in
   transition: opacity 100ms ease-in
   pointer-events: none
@@ -99,11 +98,9 @@ p.breadcrumbs
     width: 24px
     text-decoration: none
     font-weight: bold
-    -webkit-border-radius: 12px
     -moz-border-radius: 12px
     border-radius: 12px
     -moz-box-shadow: 1px 1px 3px #000
-    -webkit-box-shadow: 1px 1px 3px #000
     box-shadow: 1px 1px 3px #000
 
     &:hover

--- a/securedrop/sass/modules/_confirm-modal.sass
+++ b/securedrop/sass/modules/_confirm-modal.sass
@@ -1,0 +1,50 @@
+.modal-dialog
+  position: fixed
+  top: 0
+  right: 0
+  bottom: 0
+  left: 0
+  background: rgba(0, 0, 0, 0.8)
+  z-index: 99999
+  opacity: 0
+  -moz-transition: opacity 100ms ease-in
+  transition: opacity 100ms ease-in
+  pointer-events: none
+
+  &:target
+    opacity: 1
+    pointer-events: auto
+
+  .external
+    position: fixed
+    top: 0
+    left: 0
+    width: 100%
+    height: 100%
+
+  div
+    width: 400px
+    position: relative
+    margin: 10% auto
+    padding: 5px 20px 13px 20px
+    border-radius: 10px
+    background: white
+
+  .close
+    background: $color_grey_medium
+    color: white
+    line-height: 25px
+    position: absolute
+    right: -12px
+    text-align: center
+    top: -10px
+    width: 24px
+    text-decoration: none
+    font-weight: bold
+    -moz-border-radius: 12px
+    border-radius: 12px
+    -moz-box-shadow: 1px 1px 3px #000
+    box-shadow: 1px 1px 3px #000
+
+    &:hover
+      background: $color_purple_medium

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -52,39 +52,13 @@ $(function () {
     checkboxes.prop('checked', false);
   });
   unread.click(function() {
-      var checkboxes = document.querySelectorAll(".submission > [type='checkbox']");
-      for (var i = 0; i < checkboxes.length; i++) {
-          if (checkboxes[i].className.includes("unread-cb"))
-              checkboxes[i].checked = true;
-          else
-              checkboxes[i].checked = false;
-      }
-    });
-
-  $("#delete-collection").submit(function () {
-    return confirm(get_string("collection-delete-confirm-string"));
-  });
-
-  $("#delete-collections").click(function () {
-    var checked = $(".panel ul#cols li :checkbox").filter(":visible").filter(function(index) {
-        return $(this).prop('checked');
-    });
-    if (checked.length > 0) {
-      return confirm(get_string("collection-multi-delete-confirm-string").supplant({ size: checked.length }));
+    var checkboxes = document.querySelectorAll(".submission > [type='checkbox']");
+    for (var i = 0; i < checkboxes.length; i++) {
+        if (checkboxes[i].className.includes("unread-cb"))
+            checkboxes[i].checked = true;
+        else
+            checkboxes[i].checked = false;
     }
-    // Don't submit the form if no collections are selected
-    return false;
-  });
-
-  $("#delete-selected").click(function () {
-      var checked = $(".panel ul#submissions li :checkbox").filter(function() {
-          return $(this).prop('checked')
-      });
-      if (checked.length > 0) {
-          return confirm(get_string('submission-multi-delete-confirm-string').supplant({ size: checked.length }));
-      }
-      // Don't submit the form if no submissions are selected
-      return false;
   });
 
   $("#unread a").click(function(){

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -52,14 +52,14 @@ $(function () {
     checkboxes.prop('checked', false);
   });
   unread.click(function() {
-    var checkboxes = document.querySelectorAll(".submission > [type='checkbox']");
-    for (var i = 0; i < checkboxes.length; i++) {
-        if (checkboxes[i].className.includes("unread-cb"))
-            checkboxes[i].checked = true;
-        else
-            checkboxes[i].checked = false;
-    }
-  });
+      var checkboxes = document.querySelectorAll(".submission > [type='checkbox']");
+      for (var i = 0; i < checkboxes.length; i++) {
+          if (checkboxes[i].className.includes("unread-cb"))
+              checkboxes[i].checked = true;
+          else
+              checkboxes[i].checked = false;
+      }
+    });
 
   $("#unread a").click(function(){
     $("#unread").html("unread: 0");

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -93,31 +93,31 @@ class JournalistNavigationStepsMixin():
     def _journalist_clicks_delete_collection_on_modal(self):
         self.driver.find_element_by_id('delete-collection-button').click()
 
-    def _journalist_sees_delete_collections_confirmation_javascript(self):
+    def _journalist_sees_delete_collections_confirmation(self):
         assert self.driver.find_element_by_id(
             'delete-confirmation-modal').is_displayed()
 
-    def _journalist_sees_delete_selected_confirmation_javascript(self):
+    def _journalist_sees_delete_selected_confirmation(self):
         assert self.driver.find_element_by_id(
             'delete-selected-confirmation-modal').is_displayed()
 
-    def _journalist_sees_delete_collection_confirmation_javascript(self):
+    def _journalist_sees_delete_collection_confirmation(self):
         assert self.driver.find_element_by_id(
             'delete-collection-confirmation-modal').is_displayed()
 
     def _journalist_clicks_delete_selected_link(self):
         self.driver.find_element_by_id('delete-selected-link').click()
-        self._journalist_sees_delete_selected_confirmation_javascript()
+        self._journalist_sees_delete_selected_confirmation()
 
     def _journalist_clicks_delete_collections_link(self):
         self.driver.find_element_by_id('delete-collections-link').click()
-        self._journalist_sees_delete_collections_confirmation_javascript()
+        self._journalist_sees_delete_collections_confirmation()
 
     def _journalist_clicks_delete_collection_link(self):
         self.driver.find_element_by_id('delete-collection-link').click()
-        self._journalist_sees_delete_collection_confirmation_javascript()
+        self._journalist_sees_delete_collection_confirmation()
 
-    def _journalist_uses_delete_selected_button_javascript(self):
+    def _journalist_uses_delete_selected_button_confirmation(self):
         self._journalist_selects_first_doc()
         self._journalist_clicks_delete_selected_link()
         self._journalist_clicks_delete_selected_cancel_on_modal()
@@ -131,7 +131,7 @@ class JournalistNavigationStepsMixin():
         assert selected_count > len(self.driver.find_elements_by_name(
             'doc_names_selected'))
 
-    def _journalist_uses_delete_collection_button_javascript(self):
+    def _journalist_uses_delete_collection_button_confirmation(self):
         self._journalist_clicks_delete_collection_link()
         self._journalist_clicks_delete_collection_cancel_on_modal()
 
@@ -147,7 +147,7 @@ class JournalistNavigationStepsMixin():
         if not hasattr(self, 'accept-languages'):
             assert "Sources" in self.driver.find_element_by_tag_name('h1').text
 
-    def _journalist_uses_delete_collections_button_javascript(self):
+    def _journalist_uses_delete_collections_button_confirmation(self):
         self.driver.find_element_by_id('select_all').click()
 
         self._journalist_clicks_delete_collections_link()

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -118,13 +118,15 @@ class JournalistNavigationStepsMixin():
         self._journalist_sees_delete_collection_confirmation()
 
     def _journalist_uses_delete_selected_button_confirmation(self):
-        self._journalist_selects_first_doc()
-        self._journalist_clicks_delete_selected_link()
-        self._journalist_clicks_delete_selected_cancel_on_modal()
-
         selected_count = len(self.driver.find_elements_by_name(
             'doc_names_selected'))
         assert selected_count > 0
+
+        self._journalist_selects_first_doc()
+        self._journalist_clicks_delete_selected_link()
+        self._journalist_clicks_delete_selected_cancel_on_modal()
+        assert selected_count == len(self.driver.find_elements_by_name(
+            'doc_names_selected'))
 
         self._journalist_clicks_delete_selected_link()
         self._journalist_clicks_delete_selected_on_modal()
@@ -148,8 +150,10 @@ class JournalistNavigationStepsMixin():
             assert "Sources" in self.driver.find_element_by_tag_name('h1').text
 
     def _journalist_uses_delete_collections_button_confirmation(self):
-        self.driver.find_element_by_id('select_all').click()
+        sources = self.driver.find_elements_by_class_name("code-name")
+        assert len(sources) > 0
 
+        self.driver.find_element_by_id('select_all').click()
         self._journalist_clicks_delete_collections_link()
         self._journalist_clicks_delete_collections_cancel_on_modal()
 

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -694,12 +694,12 @@ class JournalistNavigationStepsMixin():
         for checkbox in self.driver.find_elements_by_name(
                 'doc_names_selected'):
             checkbox.click()
-        self.driver.find_element_by_id('delete-selected').click()
+        self.driver.find_element_by_id('delete-selected-link').click()
 
     def _journalist_confirm_delete_all(self):
         self.wait_for(
-            lambda: self.driver.find_element_by_id('confirm-delete'))
-        confirm_btn = self.driver.find_element_by_id('confirm-delete')
+            lambda: self.driver.find_element_by_id('delete-selected'))
+        confirm_btn = self.driver.find_element_by_id('delete-selected')
         confirm_btn.click()
 
     def _source_delete_key(self):
@@ -712,14 +712,13 @@ class JournalistNavigationStepsMixin():
     def _journalist_delete_none(self):
         self.driver.find_element_by_id('delete-selected').click()
 
-    def _journalist_delete_all_javascript(self):
+    def _journalist_delete_all_confirmation(self):
         self.driver.find_element_by_id('select_all').click()
-        self.driver.find_element_by_id('delete-selected').click()
-        # self._alert_wait()
+        self.driver.find_element_by_id('delete-selected-link').click()
 
     def _journalist_delete_one(self):
         self.driver.find_elements_by_name('doc_names_selected')[0].click()
-        self.driver.find_element_by_id('delete-selected').click()
+        self.driver.find_element_by_id('delete-selected-link').click()
 
     def _journalist_flags_source(self):
         self.driver.find_element_by_id('flag-button').click()

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -75,43 +75,73 @@ class JournalistNavigationStepsMixin():
     def _journalist_selects_first_doc(self):
         self.driver.find_elements_by_name('doc_names_selected')[0].click()
 
-    def _journalist_clicks_delete_selected_javascript(self):
-        self.driver.find_element_by_id('delete-selected').click()
-        self._alert_wait()
+    def _journalist_clicks_delete_collections_cancel_on_modal(self):
+        self.driver.find_element_by_id('cancel-collections-deletions').click()
 
-    def _journalist_clicks_delete_collections_javascript(self):
+    def _journalist_clicks_delete_selected_cancel_on_modal(self):
+        self.driver.find_element_by_id('cancel-selected-deletions').click()
+
+    def _journalist_clicks_delete_collection_cancel_on_modal(self):
+        self.driver.find_element_by_id('cancel-collection-deletions').click()
+
+    def _journalist_clicks_delete_collections_on_modal(self):
         self.driver.find_element_by_id('delete-collections').click()
-        self._alert_wait()
 
-    def _journalist_clicks_delete_collection_javascript(self):
+    def _journalist_clicks_delete_selected_on_modal(self):
+        self.driver.find_element_by_id('delete-selected').click()
+
+    def _journalist_clicks_delete_collection_on_modal(self):
         self.driver.find_element_by_id('delete-collection-button').click()
-        self._alert_wait()
+
+    def _journalist_sees_delete_collections_confirmation_javascript(self):
+        assert self.driver.find_element_by_id(
+            'delete-confirmation-modal').is_displayed()
+
+    def _journalist_sees_delete_selected_confirmation_javascript(self):
+        assert self.driver.find_element_by_id(
+            'delete-selected-confirmation-modal').is_displayed()
+
+    def _journalist_sees_delete_collection_confirmation_javascript(self):
+        assert self.driver.find_element_by_id(
+            'delete-collection-confirmation-modal').is_displayed()
+
+    def _journalist_clicks_delete_selected_link(self):
+        self.driver.find_element_by_id('delete-selected-link').click()
+        self._journalist_sees_delete_selected_confirmation_javascript()
+
+    def _journalist_clicks_delete_collections_link(self):
+        self.driver.find_element_by_id('delete-collections-link').click()
+        self._journalist_sees_delete_collections_confirmation_javascript()
+
+    def _journalist_clicks_delete_collection_link(self):
+        self.driver.find_element_by_id('delete-collection-link').click()
+        self._journalist_sees_delete_collection_confirmation_javascript()
 
     def _journalist_uses_delete_selected_button_javascript(self):
         self._journalist_selects_first_doc()
-        self._journalist_clicks_delete_selected_javascript()
-        self._alert_dismiss()
+        self._journalist_clicks_delete_selected_link()
+        self._journalist_clicks_delete_selected_cancel_on_modal()
 
         selected_count = len(self.driver.find_elements_by_name(
             'doc_names_selected'))
         assert selected_count > 0
 
-        self._journalist_clicks_delete_selected_javascript()
-        self._alert_accept()
+        self._journalist_clicks_delete_selected_link()
+        self._journalist_clicks_delete_selected_on_modal()
         assert selected_count > len(self.driver.find_elements_by_name(
             'doc_names_selected'))
 
     def _journalist_uses_delete_collection_button_javascript(self):
-        self._journalist_clicks_delete_collection_javascript()
-        self._alert_dismiss()
+        self._journalist_clicks_delete_collection_link()
+        self._journalist_clicks_delete_collection_cancel_on_modal()
 
         # After deletion the button will redirect us. Let's ensure we still
         # see the delete collection button.
         assert self.driver.find_element_by_id(
-            'delete-collection-button').is_displayed()
+            'delete-collection-link').is_displayed()
 
-        self._journalist_clicks_delete_collection_javascript()
-        self._alert_accept()
+        self._journalist_clicks_delete_collection_link()
+        self._journalist_clicks_delete_collection_on_modal()
 
         # Now we should be redirected to the index.
         if not hasattr(self, 'accept-languages'):
@@ -120,15 +150,15 @@ class JournalistNavigationStepsMixin():
     def _journalist_uses_delete_collections_button_javascript(self):
         self.driver.find_element_by_id('select_all').click()
 
-        self._journalist_clicks_delete_collections_javascript()
-        self._alert_dismiss()
+        self._journalist_clicks_delete_collections_link()
+        self._journalist_clicks_delete_collections_cancel_on_modal()
 
         self.driver.find_element_by_id('select_all').click()
         sources = self.driver.find_elements_by_class_name("code-name")
         assert len(sources) > 0
 
-        self._journalist_clicks_delete_collections_javascript()
-        self._alert_accept()
+        self._journalist_clicks_delete_collections_link()
+        self._journalist_clicks_delete_collections_on_modal()
 
         # We should be redirected to the index without those boxes selected.
         sources = self.driver.find_elements_by_class_name("code-name")
@@ -685,7 +715,7 @@ class JournalistNavigationStepsMixin():
     def _journalist_delete_all_javascript(self):
         self.driver.find_element_by_id('select_all').click()
         self.driver.find_element_by_id('delete-selected').click()
-        self._alert_wait()
+        # self._alert_wait()
 
     def _journalist_delete_one(self):
         self.driver.find_elements_by_name('doc_names_selected')[0].click()

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -68,4 +68,4 @@ class TestJournalist(
         self._journalist_selects_all_sources_then_selects_none()
         self._journalist_selects_the_first_source()
         self._journalist_uses_js_buttons_to_download_unread()
-        self._journalist_delete_all_javascript()
+        self._journalist_delete_all_confirmation()

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -25,7 +25,7 @@ class TestJournalist(
         source_navigation_steps.SourceNavigationStepsMixin,
         journalist_navigation_steps.JournalistNavigationStepsMixin):
 
-    def test_journalist_verifies_deletion_of_one_submission_javascript(self):
+    def test_journalist_verifies_deletion_of_one_submission_modal(self):
         # This deletion button is displayed on the individual source page
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()
@@ -34,9 +34,9 @@ class TestJournalist(
         self._source_logs_out()
         self._journalist_logs_in()
         self._journalist_visits_col()
-        self._journalist_uses_delete_selected_button_javascript()
+        self._journalist_uses_delete_selected_button_confirmation()
 
-    def test_journalist_uses_col_delete_collection_button_javascript(self):
+    def test_journalist_uses_col_delete_collection_button_modal(self):
         # This delete button is displayed on the individual source page
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()
@@ -45,9 +45,9 @@ class TestJournalist(
         self._source_logs_out()
         self._journalist_logs_in()
         self._journalist_visits_col()
-        self._journalist_uses_delete_collection_button_javascript()
+        self._journalist_uses_delete_collection_button_confirmation()
 
-    def test_journalist_uses_index_delete_collections_button_javascript(self):
+    def test_journalist_uses_index_delete_collections_button_modal(self):
         # This deletion button is displayed on the index page
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()
@@ -55,9 +55,9 @@ class TestJournalist(
         self._source_submits_a_file()
         self._source_logs_out()
         self._journalist_logs_in()
-        self._journalist_uses_delete_collections_button_javascript()
+        self._journalist_uses_delete_collections_button_confirmation()
 
-    def test_journalist_interface_ui_with_javascript(self):
+    def test_journalist_interface_ui_with_modal(self):
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()
         self._source_continues_to_submit_page()

--- a/securedrop/tests/pages-layout/test_journalist.py
+++ b/securedrop/tests/pages-layout/test_journalist.py
@@ -210,7 +210,7 @@ class TestJournalistLayout(
         self._journalist_delete_none()
         self._screenshot('journalist-delete_none.png')
 
-    def test_delete_one_javascript(self):
+    def test_delete_one_confirmation(self):
         self._javascript_toggle()
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()
@@ -221,11 +221,10 @@ class TestJournalistLayout(
         self._journalist_logs_in()
         self._journalist_visits_col()
         self._journalist_selects_first_doc()
-        self._journalist_clicks_delete_selected_javascript()
-        self._save_alert('journalist-delete_one_javascript.txt')
-        self._alert_accept()
+        self._journalist_clicks_delete_selected_link()
+        self._screenshot('journalist-delete_one_confirmation.png')
 
-    def test_delete_all_javascript(self):
+    def test_delete_all_confirmation(self):
         self._javascript_toggle()
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()
@@ -235,9 +234,8 @@ class TestJournalistLayout(
         self._source_logs_out()
         self._journalist_logs_in()
         self._journalist_visits_col()
-        self._journalist_delete_all_javascript()
-        self._save_alert('journalist-delete_all_javascript.txt')
-        self._alert_accept()
+        self._journalist_delete_all_confirmation()
+        self._screenshot('journalist-delete_all_confirmation.png')
 
     def test_delete_one(self):
         self._source_visits_source_homepage()


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #295.

Changes proposed in this pull request:
According to the discussions in #295 and #2506, I have implemented a CSS-only modal for confirmation of deletion of collections or documents. In this PR, I have replaced the js confirmation by the CSS confirmation modal for 
* multiple collection deletions
* single collection deletion
* multiple documents of a single collection deletion

## Testing

How should the reviewer test this PR?
Send a message as a whistleblower, log as a journalist mark the message and press `Delete`. A confirmation modal will appear with options to `Cancel` or `Delete`. You can click on `Cancel`, close icon or anywhere outside the modal to close the modal. On clicking `Delete`, the selection collection(s)/document(s) will get deleted.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

