### PR TITLE
LINT ALL THE THINGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,9 @@ docs: ## Build project documentation in live reload for editing
 
 .PHONY: flake8
 flake8: ## Validates PEP8 compliance for Python source files.
-	flake8 --exclude='config.py' testinfra securedrop/securedrop-admin \
-		securedrop/*.py securedrop/management \
-		securedrop/journalist_app/*.py \
-		securedrop/source_app/*.py securedrop/tests/pages-layout/*.py \
-		securedrop/tests/functional/*.py securedrop/tests/*.py
+	flake8 --exclude='config.py' \
+		testinfra \
+		securedrop
 
 .PHONY: app-lint
 app-lint: ## Tests pylint lint rule compliance.

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -2,9 +2,8 @@
 """Testing utilities related to setup and teardown of test environment.
 """
 import os
-from os.path import abspath, dirname, exists, isdir, join, realpath
+from os.path import abspath, dirname,  isdir, join, realpath
 import shutil
-import subprocess
 import threading
 
 import gnupg
@@ -65,7 +64,8 @@ def teardown():
     shutil.rmtree(config.TEMP_DIR)
     try:
         shutil.rmtree(config.SECUREDROP_DATA_ROOT)
-        assert not os.path.exists(config.SECUREDROP_DATA_ROOT)  # safeguard for #844
+        # safeguard for #844
+        assert not os.path.exists(config.SECUREDROP_DATA_ROOT)
     except OSError as exc:
         if 'No such file or directory' not in exc:
             raise


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We manually specify all our subdirs. Why not just say everything the `securedrop/` dir?

## Testing

`make flake8`