### PR TITLE
Landing page: Fix error_log nginx directive

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -237,7 +237,7 @@ In nginx, logging can be disabled like so:
 ::
 
     access_log off;
-    error_log off;
+    error_log /dev/null;
 
 Further Security Considerations
 -------------------------------


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2487.

Changes proposed in this pull request:
* The `off` option available in `access_log` is not available
for `error_log`, causing the output of error logging to be sent
to a file called `off`. As suggested in #2487, we should fix by 
sending output to `/dev/null`.

## Testing

Compare documentation for [`access_log`](https://nginx.org/en/docs/http/ngx_http_log_module.html) and [`error_log`](https://nginx.org/en/docs/ngx_core_module.html#error_log)

## Deployment

Some sites may be using this incorrect config option in their config. We should include a note in the 0.6 release notes about this option for admins. 

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
