### PR TITLE
 securedrop-admin: implement dev-shell

### DIFF
--- a/admin/.dockerignore
+++ b/admin/.dockerignore
@@ -1,3 +1,0 @@
-*.pyc
-.tox
-.venv

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,10 +1,15 @@
 # debian:stretch Thu Jan 25 08:58:24 CET 2018
 FROM debian@sha256:0a5fcee6f52d5170f557ee2447d7a10a5bdcf715dd7f0250be0b678c556a501b
-
-WORKDIR /opt
+ARG USER_NAME
+ENV USER_NAME ${USER_NAME:-root}
+ARG USER_ID
+ENV USER_ID ${USER_ID:-0}
 
 RUN apt-get update
 RUN apt-get install -y python sudo lsb-release gnupg2
+RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi
+
+WORKDIR /opt
 COPY bootstrap.py .
 COPY requirements.txt .
 RUN python bootstrap.py -v

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -13,6 +13,8 @@ WORKDIR /opt
 COPY bootstrap.py .
 COPY requirements.txt .
 RUN python bootstrap.py -v
+ENV VIRTUAL_ENV /opt/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY requirements-dev.txt .
-RUN .venv/bin/pip install -r requirements-dev.txt
-COPY . .
+RUN pip install -r requirements-dev.txt
+RUN chown -R $USER_NAME /opt

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -22,7 +22,7 @@ update-pip-requirements: ## Updates all Python requirements files via pip-compil
 # 6. Format columns with colon as delimiter.
 .PHONY: help
 help: ## Print this message and exit.
-	@printf "Makefile for developing and testing SecureDrop.\n"
+	@printf "Makefile for developing and testing securedrop-admin.\n"
 	@printf "Subcommands:\n\n"
 	@awk 'BEGIN {FS = ":.*?## "} /^[0-9a-zA-Z_-]+:.*?## / {printf "\033[36m%s\033[0m : %s\n", $$1, $$2}' $(MAKEFILE_LIST) \
 		| sort \

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -1,17 +1,13 @@
 DEFAULT_GOAL: help
 
 .PHONY: test
-test: image  ## Run tox inside a docker container
-	docker run --rm securedrop-admin .venv/bin/tox
-
-.PHONY: image
-image: ## Create the docker image to run tests
-	docker build -f Dockerfile -t securedrop-admin .
+test:  ## Run tox
+	bin/dev-shell tox
 
 .PHONY: update-pip-requirements
 update-pip-requirements: ## Updates all Python requirements files via pip-compile.
-	pip-compile --generate-hashes --output-file requirements.txt requirements.in requirements-ansible.in
-	pip-compile --generate-hashes --output-file requirements-dev.txt requirements-dev.in
+	bin/dev-shell pip-compile --generate-hashes --output-file requirements.txt requirements.in requirements-ansible.in
+	bin/dev-shell pip-compile --generate-hashes --output-file requirements-dev.txt requirements-dev.in
 
 # Explaination of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" and any make targets that might appear between : and ##

--- a/admin/bin/dev-shell
+++ b/admin/bin/dev-shell
@@ -1,0 +1,82 @@
+#!/bin/bash
+# shellcheck disable=SC2086
+# we ignore SC2086 because ${DOCKER_BUILD_ARGUMENTS:-} is intended to
+# be evaluated into multiple strings, not a single argument.
+
+set -euo pipefail
+
+TOPLEVEL=$(git rev-parse --show-toplevel)
+
+function display_dots() {
+    echo -n "Docker image build in progress "
+    trap "echo ' done !' ; exit 0" USR1
+    trap "exit 0" USR2
+    while : ; do
+        sleep 5
+        echo -n .
+    done
+}
+
+function ticker() {
+    local pid
+    display_dots &
+    pid="$!"
+    if "$@" ; then
+        status=0
+        kill -USR1 $pid
+    else
+        status=1
+        kill -USR2 $pid
+    fi
+    wait
+    return $status
+}
+
+function docker_image_circle() {
+    local out
+    out="$(mktemp)"
+    ( cat Dockerfile ; echo COPY . . ) > circle.docker
+    if ! docker build ${DOCKER_BUILD_ARGUMENTS:-} -t securedrop-admin -f circle.docker . >& "$out" ; then
+        cat "$out"
+        status=1
+    else
+        status=0
+    fi
+    rm circle.docker
+    return $status
+}
+
+function docker_run_circle() {
+    docker run --rm -ti ${DOCKER_RUN_ARGUMENTS:-} securedrop-admin "$@"
+}
+
+function docker_image() {
+    local out
+    out="$(mktemp)"
+    if ! docker build \
+         ${DOCKER_BUILD_ARGUMENTS:-} \
+	 --build-arg=USER_ID="$(id -u)" \
+	 --build-arg=USER_NAME="${USER:-root}" \
+         -t securedrop-admin "${TOPLEVEL}/admin" >& "$out" ; then
+        cat "$out"
+        return 1
+    fi
+    return 0
+}
+
+function docker_run() {
+    docker run \
+	   --rm \
+	   --user "${USER:-root}" \
+	   --volume "${TOPLEVEL}:${TOPLEVEL}" \
+	   --workdir "${TOPLEVEL}/admin" \
+	   -ti ${DOCKER_RUN_ARGUMENTS:-} securedrop-admin "$@"
+}
+
+if test -n "${CIRCLE_SHA1:-}" ; then
+   docker_image_circle
+   docker_run_circle "$@"
+else
+   ticker docker_image
+   docker_run "$@"
+fi

--- a/admin/tox.ini
+++ b/admin/tox.ini
@@ -10,7 +10,7 @@ whitelist_externals = *
 commands = env \
          {envbindir}/coverage run --source=securedrop_admin,bootstrap \
          {envbindir}/py.test -v {posargs:tests}
-         {envbindir}/coverage report --omit=*test*,*tox* --show-missing --fail-under 70
+         {envbindir}/coverage report --omit=*test*,*tox* --show-missing
 
 [testenv:flake8]
 commands =

--- a/docs/development/admin_development.rst
+++ b/docs/development/admin_development.rst
@@ -1,0 +1,48 @@
+Development of securedrop-admin in the admin directory
+======================================================
+
+The ``admin`` directory contains the source of the
+``securedrop-admin`` script which is used in Tails to perform various
+administrative tasks. It is a standalone python module which can be
+tested on Debian GNU/Linux stretch with:
+
+.. code::
+
+   python bootstrap.py
+   source .venv/bin/activate
+   pip install -r requirements-dev.txt
+   tox
+
+A Docker helper is provided to simplify the installation and make
+it portable on various operating systems.
+
+Run only flake8 with:
+
+.. code::
+
+   bin/dev-shell tox -e flake8
+
+Run only one test foobar with:
+
+.. code::
+
+   bin/dev-shell tox -e py2 -- -k foobar
+
+Docker has the admin directory mounted from the host into the
+container, at the same location to avoid any trouble with hardcoded
+absolute paths. It runs with the id of the host user so files created
+in the container are owned by the host user instead of root. If a
+script needs root access, it has passwordless sudo permissions.
+
+Convenience ``Makefile`` targets are also provided for the most common
+tasks:
+
+.. code::
+
+   $ make
+   Makefile for developing and testing securedrop-admin.
+   Subcommands:
+
+   help                       Print this message and exit.
+   test                       Run tox
+   update-pip-requirements    Updates all Python requirements files via pip-compile.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,6 +96,7 @@ anonymous sources.
 
    development/getting_started
    development/setup_development
+   development/admin_development   
    development/virtual_environments
    development/virtualizing_tails
    development/contributor_guidelines


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The dev-shell script refresh the securedrop-admin docker image if the
requirements or the bootstrap script are updated. It is done by
running docker build at the begining of the script and the
dependencies mechanism do the rest. The resulting image has an up to
date virtualenv in /opt/.venv ready to use and all the system
dependencies installed.

docker run has the admin directory mounted from the host into the
container, at the same location to avoid any trouble with hardcoded
absolute paths. It runs with the id of the host user so files created
in the container are owned by the host user instead of root. If a
script needs root access, it has passwordless sudo permissions.

Convenience makefile targets (make test, ...) are converted to use
dev-shell.

Example usages:

Run only flake8 with

     bin/dev-shell tox -e flake8

Run only one test foobar with

     bin/dev-shell tox -e py2 -- -k foobar


## Testing

* The admin-testing CI job uses `cd admin ; make test` which uses dev-shell
* cd admin ; bin/dev-shell tox -e py2 -- -k test_validate_gpg_key # check only this test runs
* cd admin ; bin/dev-shell bash # look around

## Deployment

N/A (only CI and developers)

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
