### PR TITLE
Syscheck monitoring of /var/lib/tor/services/ 

### DIFF
--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -13,7 +13,7 @@
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/securedrop</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/www</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/securedrop</directories>
-    <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/tor/services/hostname</directories>
+    <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/tor/services</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/tor/lock</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/boot</directories>
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2960:
Modify ossec-agent configuration to monitor `/var/lib/tor/services/` directory.

## Testing

* `make build-debs`
* `vagrant up /staging/`
* `vagrant ssh mon-staging`
* `/var/ossec/queue/syscheck/\(app-staging\)\ 10.0.1.2-\>syscheck` should contain hashes all files and folders in `/var/lib/tor/services` and monitor/alert on changes.

## Deployment

Will require a new ossec-agent package to published.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
