### PR TITLE
docs: add instructions to developers to show the l10n menu

### DIFF
--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -45,6 +45,7 @@ To get started working with the development environment:
    ./manage.py run         # run development servers
    ./manage.py reset       # resets the state of the development instance
    ./manage.py add-admin   # create a user to use when logging in to the Journalist Interface
+   ./manage.py translate-messages --compile   # add languages and display the i18n menu
    pytest -v tests/        # run the unit and functional tests
 
 .. sidebar:: Note to Qubes users


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

When setting up the development virtual machine, the language menu
will not be displayed by default because the .po files are not
compiled into .mo files. We add instructions to setup the development
virtual machines so the menu is always displayed.

The translations need to be updated manually by running this
compilation step every time a source string changes in the source or
journalist interface.

## Testing

* follow the instructions and copy paste the line to check there is no typo

## Deployment

N/A

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
