### PR TITLE
Docs wip dachary contributor privilege

### DIFF
--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -118,8 +118,15 @@ should be removed. If you are unfamiliar with how to squash commits with rebase,
 check out this
 `blog post <http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html>`__.
 
+.. _contributor-permissions:
+
 Privileges
 ----------
+
+.. note:: the translation workflow is different from the code and
+          documentation development workflow, see the associated
+          :ref:`privilege escalation <i18n-administrator-permissions>`
+          documentation.
 
 Dedicated contributors to SecureDrop will be granted extra privileges
 such as the right to push new branches or to merge pull requests. Any

--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -122,12 +122,19 @@ Privileges
 ----------
 
 Dedicated contributors to SecureDrop will be granted extra privileges
-such as the right to push new branches or to merge pull
-requests. There is no formal process at the moment but the general
-idea is that any contributor with the right technical and social
-skills is entitled to ask. The people who have the power to grant such
-privileges are committed to do so in a transparent way to avoid any
-disputes.
+such as the right to push new branches or to merge pull requests. Any
+contributor with the right technical and social skills is entitled to
+ask. The people who have the power to grant such privileges are
+committed to do so in a transparent way as follows:
+
+* Step 1: the contributor posts a message `in the forum
+  <https://forum.securedrop.club/>`__ asking for privileges (review or
+  merge, etc.).
+* Step 2: after at least a week, someone with permissions to grant such
+  privilege reviews the thread and either:
+    * grants the privilege and adds a message to the thread
+    * explains what is expected from the contributor before they can be granted the privilege
+* Step 3: the thread is closed
 
 Other Tips
 ----------

--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -143,6 +143,9 @@ committed to do so in a transparent way as follows:
     * explains what is expected from the contributor before they can be granted the privilege
 * Step 3: the thread is closed
 
+The privileges of a developer who has not been active for a year or
+more are revoked. They can apply again at any time.
+
 Other Tips
 ----------
 

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -297,8 +297,15 @@ We do not want to publish the translator emails so we strip them:
        git log --pretty='%aN' $previous_version..lab/i18n -- \
         securedrop/translations install_files/ansible-base/roles/tails-config/templates | sort -u
 
+.. _i18n-administrator-permissions:
+
 Translations administrators
 ---------------------------
+
+.. note:: the translation workflow is different from the code and
+          documentation development workflow, see the associated
+          :ref:`privilege escalation <contributor-permissions>`
+          documentation.
 
 A translation administrator is a person who is actively performing
 administrative duties. They have special permissions on the

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -320,9 +320,8 @@ among the current administrators.
 All administrators are listed in the `forum introduction page
 <https://forum.securedrop.club/t/about-the-translations-category/16/1>`_
 
-An administrator who has not be active for two months or more is
-removed from the list and their permissions revoked. They can apply
-again at anytime.
+The privileges of an administrator who has not been active for a year
+or more are revoked. They can apply again at any time.
 
 The community of SecureDrop translators works very closely with the
 SecureDrop developers and some of them participate in both


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

https://forum.securedrop.club/t/adding-mickael-as-new-maintainer/375

was the first public discussion about elevating privileges for a
SecureDrop contributor. Since we're a small community there probably
is no need to estabish a complicated formal process. However, for the
sake of transparency we have a three step process that allows everyone
to discuss and possibly disagree with the privileges asked by a
contributor.

The contributor is to initiate the process because it would not make
sense to grant privileges to someone who is unlikely to use them. For
instance if a contributor has time to propose occasional pull
requests but is not motivated by reviewing.

## Testing

* read the documentation and point to my borken English ;-)

## Deployment

N/A

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
