### PR TITLE
Fixes Vagrant box downloading for Vagrant 1.x

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# Workaround for URL breakage, see #2970.
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
+
 Vagrant.configure("2") do |config|
 
   # Vagrant 1.7.0+ removes the insecure_private_key by default


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

The logic to fetch and update Vagrant boxes from Hashicorp's hosting
broken suddenly on or around 2018-02-04. Looks like backend changes on
their part are the culprit, and newer versions such as Vagrant 2.0.2 may
not be affected.

Let's use a workaround, which should be temporary, assuming appropriate
redirects are implemented on the backend, in order to keep fresh
spin-ups of the dev env, as well as updates to the base boxes for
regular developers, working as expected.

Closes #2970.

Changes proposed in this pull request:

## Testing

1. `vagrant destroy -f development`
2. `vagrant box remove bento/ubuntu-14.04`
3. `vagrant up development`

Confirm you are able to redownload the box succesfully. 

## Deployment

No concerns, changes apply exclusively to the development environment.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
