### PR TITLE
Change sad crypto_util doctest sample text

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -206,10 +206,10 @@ def encrypt(plaintext, fingerprints, output=None):
 def decrypt(secret, ciphertext):
     """
     >>> key = genkeypair('randomid', 'randomid')
-    >>> decrypt('randomid',
-    ...   encrypt('Goodbye, cruel world!', str(key))
-    ... )
-    'Goodbye, cruel world!'
+    >>> message = u'Buenos días, mundo hermoso!'
+    >>> ciphertext = encrypt(message, str(key))
+    >>> decrypt('randomid', ciphertext) == message.encode('utf-8')
+    True
     """
     hashed_codename = hash_codename(secret, salt=SCRYPT_GPG_PEPPER)
     return gpg.decrypt(ciphertext, passphrase=hashed_codename).data


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Given the loss of two great contributors to this project to suicide, I think it would be nice to remove this rather depressing doctest function sample text. The new text reads, in Spanish, "Good day, beautiful world!"

## Testing

`python -m doctest -v crypto_util.py` should suffice as only doctest function documentation is changing.