### PR TITLE
source: genkey runs in a thread and must have its own session

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -90,7 +90,8 @@ def make_blueprint(config):
         # Only do this if the journalist has flagged the source as one
         # that they would like to reply to. (Issue #140.)
         if not crypto_util.getkey(g.filesystem_id) and g.source.flagged:
-            async_genkey(g.filesystem_id, g.codename)
+            db_uri = current_app.config['SQLALCHEMY_DATABASE_URI']
+            async_genkey(db_uri, g.filesystem_id, g.codename)
 
         return render_template(
             'lookup.html',
@@ -164,7 +165,8 @@ def make_blueprint(config):
             # (gpg reads 300 bytes from /dev/random)
             entropy_avail = get_entropy_estimate()
             if entropy_avail >= 2400:
-                async_genkey(g.filesystem_id, g.codename)
+                db_uri = current_app.config['SQLALCHEMY_DATABASE_URI']
+                async_genkey(db_uri, g.filesystem_id, g.codename)
                 current_app.logger.info("generating key, entropy: {}".format(
                     entropy_avail))
             else:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2978 

The session available from Source.query belongs to the main thread
and is bound to a Flask app context. However, since async_genkey runs
in a separate thread, it is entirely possible that there is no active
app context when it tries to access the session and it will fail with
an error like:

    No application found. Either work inside a view function or
    push an application context.
    See http://flask-sqlalchemy.pocoo.org/contexts/

In addition the query from the thread races against the queries from
the main thread and it may lead to failure or corruption.

Since there is no need for async_genkey to work in an app_context, we
create a new engine and a new session for the duration of the thread.
Writing to SQLite from multiple processes or threads is protected by
locks (http://www.sqlite.org/wal.html)

## Testing

The modified code is extensively used in the integration tests.

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
