### PR TITLE
Allow blank sasl_domain in sdconfig

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -200,14 +200,6 @@ class SiteConfig(object):
                 message=("Must contain a @ and be set to "
                          "something other than ossec@ossec.test"))
 
-    class ValidateSASLDomain(Validator):
-        def validate(self, document):
-            if document.text == '' or SiteConfig.ValidateFQDN():
-                return True
-            raise ValidationError(
-                message=("Must contain a valid domain or be empty")
-            )
-
     def __init__(self, args):
         self.args = args
         translations = SiteConfig.Locales(
@@ -274,7 +266,7 @@ class SiteConfig(object):
              int],
             ['sasl_domain', "gmail.com", str,
              u'SASL domain for sending OSSEC alerts',
-             SiteConfig.ValidateSASLDomain(),
+             None,
              None],
             ['sasl_username', '', str,
              u'SASL username for sending OSSEC alerts',

--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -200,6 +200,14 @@ class SiteConfig(object):
                 message=("Must contain a @ and be set to "
                          "something other than ossec@ossec.test"))
 
+    class ValidateSASLDomain(Validator):
+        def validate(self, document):
+            if document.text == '' or SiteConfig.ValidateFQDN():
+                return True
+            raise ValidationError(
+                message=("Must contain a valid domain or be empty")
+            )
+
     def __init__(self, args):
         self.args = args
         translations = SiteConfig.Locales(
@@ -266,7 +274,7 @@ class SiteConfig(object):
              int],
             ['sasl_domain', "gmail.com", str,
              u'SASL domain for sending OSSEC alerts',
-             SiteConfig.ValidateNotEmpty(),
+             SiteConfig.ValidateSASLDomain(),
              None],
             ['sasl_username', '', str,
              u'SASL username for sending OSSEC alerts',

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -287,6 +287,26 @@ class TestSiteConfig(object):
             site_config.validate_gpg_keys()
         assert 'FAIL does not match' in e.value.message
 
+    def test_validate_sasl_domain(self, caplog):
+        args = argparse.Namespace(site_config='INVALID',
+                                  ansible_path='tests/files',
+                                  app_path=dirname(__file__))
+        site_config = securedrop_admin.SiteConfig(args)
+        site_config.config = {
+            'ossec_alert_gpg_public_key':
+            'test_journalist_key.pub',
+
+            'ossec_gpg_fpr':
+            '65A1B5FF195B56353CC63DFFCC40EF1228271441',
+
+            'sasl_username':
+            'alice',
+
+            'sasl_domain':
+            '',
+        }
+        assert site_config.ValidateSASLDomain()
+
     @mock.patch('securedrop_admin.SiteConfig.validated_input',
                 side_effect=lambda p, d, v, t: d)
     @mock.patch('securedrop_admin.SiteConfig.save')

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -287,26 +287,6 @@ class TestSiteConfig(object):
             site_config.validate_gpg_keys()
         assert 'FAIL does not match' in e.value.message
 
-    def test_validate_sasl_domain(self, caplog):
-        args = argparse.Namespace(site_config='INVALID',
-                                  ansible_path='tests/files',
-                                  app_path=dirname(__file__))
-        site_config = securedrop_admin.SiteConfig(args)
-        site_config.config = {
-            'ossec_alert_gpg_public_key':
-            'test_journalist_key.pub',
-
-            'ossec_gpg_fpr':
-            '65A1B5FF195B56353CC63DFFCC40EF1228271441',
-
-            'sasl_username':
-            'alice',
-
-            'sasl_domain':
-            '',
-        }
-        assert site_config.ValidateSASLDomain()
-
     @mock.patch('securedrop_admin.SiteConfig.validated_input',
                 side_effect=lambda p, d, v, t: d)
     @mock.patch('securedrop_admin.SiteConfig.save')
@@ -387,13 +367,19 @@ class TestSiteConfig(object):
         clean_fpr = site_config.sanitize_fingerprint(fpr)
         assert site_config.user_prompt_config_one(desc, fpr) == clean_fpr
 
+    def verify_desc_consistency_allow_empty(self, site_config, desc):
+        (var, default, etype, prompt, validator, transform) = desc
+        # verify the default passes validation
+        assert site_config.user_prompt_config_one(desc, None) == default
+        assert type(default) == etype
+
     verify_prompt_securedrop_app_gpg_fingerprint = verify_prompt_fingerprint
     verify_prompt_ossec_alert_gpg_public_key = verify_desc_consistency
     verify_prompt_ossec_gpg_fpr = verify_prompt_fingerprint
     verify_prompt_ossec_alert_email = verify_prompt_not_empty
     verify_prompt_smtp_relay = verify_prompt_not_empty
     verify_prompt_smtp_relay_port = verify_desc_consistency
-    verify_prompt_sasl_domain = verify_desc_consistency
+    verify_prompt_sasl_domain = verify_desc_consistency_allow_empty
     verify_prompt_sasl_username = verify_prompt_not_empty
     verify_prompt_sasl_password = verify_prompt_not_empty
 

--- a/install_files/ansible-base/roles/postfix/templates/sasl_passwd
+++ b/install_files/ansible-base/roles/postfix/templates/sasl_passwd
@@ -1,1 +1,1 @@
-[{{ smtp_relay }}]:{{ smtp_relay_port }}   {{ sasl_username }}@{{ sasl_domain }}:{{ sasl_password }}
+[{{ smtp_relay }}]:{{ smtp_relay_port }}   {{ sasl_username }}{% if sasl_domain %}@{{ sasl_domain }}{% endif %}:{{ sasl_password }}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

SecureDrop configuration should now allow `sasl_domain` to be empty string. Fixes #2482 .

## Testing

Test both with sasl_domain set as fqdn or empty string and observe the configuration in `/etc/postfix/sasl_passwd`

## Deployment

Should only affect new installs, as existing installs should have their email setup correctly.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
