### PR TITLE
docs: apt-get update before apt-get install to avoid 404 on old packages

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -23,6 +23,7 @@ Ubuntu/Debian
 
 .. code:: sh
 
+   sudo apt-get update
    sudo apt-get install -y build-essential libssl-dev libffi-dev python-dev \
        dpkg-dev git linux-headers-$(uname -r) virtualbox
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

apt-get update before apt-get install to avoid 404 on old packages

## Testing

N/A

## Deployment

N/A

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
