### PR TITLE
tests: staging tests must be run as root

### DIFF
--- a/docs/development/testing_application_tests.rst
+++ b/docs/development/testing_application_tests.rst
@@ -48,9 +48,14 @@ Or the app-staging VM:
 .. code:: sh
 
     vagrant ssh app-staging
-    sudo su www-data -s /bin/bash
+    sudo bash
     cd /var/www/securedrop
     pytest -v tests
+    chown -R www-data /var/lib/securedrop /var/www/securedrop
+
+.. warning:: The ``chown`` is necessary because running the tests as
+             root will change ownership of some files, creating
+             problems with the source and journalist interfaces.
 
 For explanation of the difference between these machines, see
 :doc:`virtual_environments`.


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #2980

staging tests must be run as root because iptables restricts what www-data can do, including
connecting to arbitrary TCP port and therefore successfully running
firefox and the selenium driver.

## Testing

* Run the modified instructions

## Deployment

N/A

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
