### PR TITLE
i18n: en is not a valid locale, only en_US is

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -154,7 +154,7 @@ class SiteConfig(object):
                 os.path.join(appdir, 'translations'))
 
         def get_translations(self):
-            translations = set(['en', 'en_US'])
+            translations = set(['en_US'])
             for dirname in os.listdir(self.translation_dir):
                 if dirname != 'messages.pot':
                     translations.add(dirname)

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -383,9 +383,9 @@ class TestSiteConfig(object):
         assert site_config.user_prompt_config_one(desc, None) == default
         assert type(default) == etype
         assert site_config.user_prompt_config_one(
-            desc, 'en en_US') == ['en', 'en_US']
+            desc, 'fr_FR en_US') == ['fr_FR', 'en_US']
         assert site_config.user_prompt_config_one(
-            desc, ['en', 'en_US']) == ['en', 'en_US']
+            desc, ['fr_FR', 'en_US']) == ['fr_FR', 'en_US']
         assert site_config.user_prompt_config_one(desc, '') == []
         with pytest.raises(ValidationError):
             site_config.user_prompt_config_one(desc, 'wrong')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2983

en is not a valid locale, only en_US is

## Testing

* ./securedrop-admin sdconfig
* try to enter **en** in the list of supported locale
* verify **en** triggers an error

## Deployment

We are in no risk of having a SecureDrop deployment running with the faulty **en** locale because it crashes the server.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

