### PR TITLE
securedrop-admin: user defined site-config variables must be preserved

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -291,7 +291,7 @@ class SiteConfig(object):
         return self.update_config()
 
     def update_config(self):
-        self.config = self.user_prompt_config()
+        self.config.update(self.user_prompt_config())
         self.save()
         self.validate_gpg_keys()
         return True

--- a/admin/tests/files/site-specific
+++ b/admin/tests/files/site-specific
@@ -17,3 +17,4 @@ securedrop_supported_locales:
 smtp_relay: smtp.gmail.com
 smtp_relay_port: 587
 ssh_users: sd
+user_defined_variable: "must not be discarded"

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -297,6 +297,7 @@ class TestSiteConfig(object):
         site_config = securedrop_admin.SiteConfig(args)
 
         assert site_config.load_and_update_config()
+        assert 'user_defined_variable' in site_config.config
         mock_save.assert_called_once()
         mock_validate_input.assert_called()
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2955

## Testing

* edit `/install_files/ansible-base/group-vars/all/site-specific` and add another value
* run ./securedrop-admin sdconfig
* open `/install_files/ansible-base/group-vars/all/site-specific` and observe your value is still present

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
