### PR TITLE
Add 1 second sleep before css modal screenshot

### DIFF
--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -710,7 +710,7 @@ class JournalistNavigationStepsMixin():
             checkbox.click()
         self.driver.find_element_by_id('delete-selected-link').click()
 
-    def _journalist_confirm_delete_all(self):
+    def _journalist_confirm_delete_selected(self):
         self.wait_for(
             lambda: self.driver.find_element_by_id('delete-selected'))
         confirm_btn = self.driver.find_element_by_id('delete-selected')

--- a/securedrop/tests/pages-layout/test_journalist.py
+++ b/securedrop/tests/pages-layout/test_journalist.py
@@ -132,7 +132,7 @@ class TestJournalistLayout(
         self._journalist_logs_in()
         self._journalist_visits_col()
         self._journalist_delete_all()
-        self._journalist_confirm_delete_all()
+        self._journalist_confirm_delete_selected()
         self._screenshot('journalist-col_no_document.png')
 
     def test_col_has_no_key(self):
@@ -250,7 +250,7 @@ class TestJournalistLayout(
         self._journalist_logs_in()
         self._journalist_visits_col()
         self._journalist_delete_one()
-        time.sleep(1)
+        self._journalist_confirm_delete_selected()
         self._screenshot('journalist-delete_one.png')
 
     def test_delete_all(self):
@@ -263,7 +263,7 @@ class TestJournalistLayout(
         self._journalist_logs_in()
         self._journalist_visits_col()
         self._journalist_delete_all()
-        time.sleep(1)
+        self._journalist_confirm_delete_selected()
         self._screenshot('journalist-delete_all.png')
 
     def test_edit_account_user(self):

--- a/securedrop/tests/pages-layout/test_journalist.py
+++ b/securedrop/tests/pages-layout/test_journalist.py
@@ -19,6 +19,7 @@ from tests.functional import journalist_navigation_steps
 from tests.functional import source_navigation_steps
 import functional_test
 import pytest
+import time
 
 import models
 
@@ -222,6 +223,7 @@ class TestJournalistLayout(
         self._journalist_visits_col()
         self._journalist_selects_first_doc()
         self._journalist_clicks_delete_selected_link()
+        time.sleep(1)
         self._screenshot('journalist-delete_one_confirmation.png')
 
     def test_delete_all_confirmation(self):
@@ -235,6 +237,7 @@ class TestJournalistLayout(
         self._journalist_logs_in()
         self._journalist_visits_col()
         self._journalist_delete_all_confirmation()
+        time.sleep(1)
         self._screenshot('journalist-delete_all_confirmation.png')
 
     def test_delete_one(self):
@@ -247,6 +250,7 @@ class TestJournalistLayout(
         self._journalist_logs_in()
         self._journalist_visits_col()
         self._journalist_delete_one()
+        time.sleep(1)
         self._screenshot('journalist-delete_one.png')
 
     def test_delete_all(self):
@@ -259,6 +263,7 @@ class TestJournalistLayout(
         self._journalist_logs_in()
         self._journalist_visits_col()
         self._journalist_delete_all()
+        time.sleep(1)
         self._screenshot('journalist-delete_all.png')
 
     def test_edit_account_user(self):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2959 .

For page layout screenshot of css modals on clicking delete
button, add a 1 second sleep to allow the modal to appear in
complete opacity.

## Testing

How should the reviewer test this PR?

* `pytest --page-layout tests/pages-layout`
* view securedrop/tests/pages-layout/screenshots/en_US
  * journalist-delete_all_confirmation.png
  * journalist-delete_one_confirmation.png
  * journalist-delete_one.png
  * journalist-delete_all.png

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
