### PR TITLE
Fixes #3001  initial support for type annotation

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+ignore_missing_imports = True
+python_version = 2.7
+
+[mypy-config]
+ignore_errors = True

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -50,7 +50,7 @@ do_runtime_tests()
 gpg = gnupg.GPG(binary='gpg2', homedir=config.GPG_KEY_DIR)
 
 # map code for a given language to a localized wordlist
-language2words = {}  # type: Dict[Text,List[Text]]
+language2words = {}  # type: Dict[Text,List[str]]
 nouns = open(config.NOUNS).read().rstrip('\n').split('\n')
 adjectives = open(config.ADJECTIVES).read().rstrip('\n').split('\n')
 
@@ -81,6 +81,7 @@ def clean(s, also=''):
 
 
 def _get_wordlist(locale):
+    # type: (Text) -> List[str]
     """" Ensure the wordlist for the desired locale is read and available
     in the words global variable. If there is no wordlist for the
     desired local, fallback to the default english wordlist.

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -9,6 +9,7 @@ from Cryptodome.Random import random
 import gnupg
 from gnupg._util import _is_stream, _make_binary_stream
 import scrypt
+from typing import Dict, List, Text  # noqa: F401
 
 import config
 import store
@@ -49,7 +50,7 @@ do_runtime_tests()
 gpg = gnupg.GPG(binary='gpg2', homedir=config.GPG_KEY_DIR)
 
 # map code for a given language to a localized wordlist
-language2words = {}
+language2words = {}  # type: Dict[Text,List[Text]]
 nouns = open(config.NOUNS).read().rstrip('\n').split('\n')
 adjectives = open(config.ADJECTIVES).read().rstrip('\n').split('\n')
 

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -20,6 +20,7 @@ from rm import srm
 
 
 def logged_in():
+    # type: () -> bool
     # When a user is logged in, we push their user ID (database primary key)
     # into the session. setup_g checks for this value, and if it finds it,
     # stores a reference to the user's Journalist object in g.

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -7,7 +7,7 @@ import binascii
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    from StringIO import StringIO  # type: ignore
 
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import relationship, backref

--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -15,4 +15,5 @@ redis
 rq
 scrypt
 SQLAlchemy
+typing
 Werkzeug==0.12.2

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -27,6 +27,7 @@ rq==0.10.0
 scrypt==0.8.0
 six==1.11.0               # via qrcode
 sqlalchemy==1.2.0
+typing==3.6.4
 webassets==0.12.1         # via flask-assets
 werkzeug==0.12.2
 wtforms==2.1              # via flask-wtf


### PR DESCRIPTION
Co-authored-by: Brett Cannon <brett@python.org>

## Status

Ready for review

## Description of Changes

Fixes #3001 

We have the initial type annotation. Means `typing` module is added as an app dependency.

## Testing

<pre>
sudo apt install python3-dev
python3 -m venv .py3
source .py3/bin/activate
pip install wheel ; pip install mypy
mypy securedrop
</pre>

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
