### PR TITLE
Fixes #3006 Adds Makefile target for type linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,14 @@ ci-lint-image: ## Builds linting container.
 ci-lint: ## Runs linting in linting container.
 	docker run --rm -ti -v /var/run/docker.sock:/var/run/docker.sock securedrop-lint:${TAG}
 
+.PHONY: ci-typelint-image
+ci-typelint-image: ## Builds type glinting container.
+	docker build $(EXTRA_BUILD_ARGS) -t securedrop-typelint:${TAG} -f devops/docker/Dockerfile.typeannotation .
+
+.PHONY: ci-typelint
+ci-typelint: ## Runs type linting in container.
+	docker run --rm -ti -v /var/run/docker.sock:/var/run/docker.sock securedrop-typelint:${TAG}
+
 .PHONY: ansible-config-lint
 ansible-config-lint: ## Runs custom Ansible env linting tasks.
 	molecule verify -s ansible-config

--- a/devops/docker/Dockerfile.typeannotation
+++ b/devops/docker/Dockerfile.typeannotation
@@ -1,0 +1,10 @@
+FROM circleci/python:3.6.4-stretch
+
+
+RUN  sudo pip3 install mypy
+
+WORKDIR /src
+COPY . /src
+
+
+CMD ["sudo", "mypy", "./securedrop", "./admin"]


### PR DESCRIPTION
Co-authored-by: Brett Cannon brett@python.org

## Status

Ready for review

## Description of Changes

Fixes #3006 

We now have a new Makefile target and related Dockerfile to check type annotations using mypy.
I am building the container on top of Fedora 27 as it has the latest Python3 packaged from the distribution.



## Testing

```
make ci-typelint-image
make ci-typelint
```

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
