### PR TITLE
Replace instances of "administrator(s)" with "admin(s)" in docs

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -154,7 +154,7 @@ class SiteConfig(object):
                 os.path.join(appdir, 'translations'))
 
         def get_translations(self):
-            translations = set(['en', 'en_US'])
+            translations = set(['en_US'])
             for dirname in os.listdir(self.translation_dir):
                 if dirname != 'messages.pot':
                     translations.add(dirname)
@@ -291,7 +291,7 @@ class SiteConfig(object):
         return self.update_config()
 
     def update_config(self):
-        self.config = self.user_prompt_config()
+        self.config.update(self.user_prompt_config())
         self.save()
         self.validate_gpg_keys()
         return True

--- a/admin/tests/files/site-specific
+++ b/admin/tests/files/site-specific
@@ -17,3 +17,4 @@ securedrop_supported_locales:
 smtp_relay: smtp.gmail.com
 smtp_relay_port: 587
 ssh_users: sd
+user_defined_variable: "must not be discarded"

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -297,6 +297,7 @@ class TestSiteConfig(object):
         site_config = securedrop_admin.SiteConfig(args)
 
         assert site_config.load_and_update_config()
+        assert 'user_defined_variable' in site_config.config
         mock_save.assert_called_once()
         mock_validate_input.assert_called()
 
@@ -383,9 +384,9 @@ class TestSiteConfig(object):
         assert site_config.user_prompt_config_one(desc, None) == default
         assert type(default) == etype
         assert site_config.user_prompt_config_one(
-            desc, 'en en_US') == ['en', 'en_US']
+            desc, 'fr_FR en_US') == ['fr_FR', 'en_US']
         assert site_config.user_prompt_config_one(
-            desc, ['en', 'en_US']) == ['en', 'en_US']
+            desc, ['fr_FR', 'en_US']) == ['fr_FR', 'en_US']
         assert site_config.user_prompt_config_one(desc, '') == []
         with pytest.raises(ValidationError):
             site_config.user_prompt_config_one(desc, 'wrong')

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -267,9 +267,9 @@ Application Server
 Adding Users (CLI)
 ^^^^^^^^^^^^^^^^^^
 
-After the provisioning of the first administrator account, we recommend
+After the provisioning of the first admin account, we recommend
 using the Admin Interface web application for adding additional journalists
-and administrators.
+and admins.
 
 However, you can also add users via ``./manage.py`` in ``/var/www/securedrop/``
 as described :doc:`during first install <create_admin_account>`. You can use

--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -86,7 +86,7 @@ to debug your connectivity before proceeding further. Make sure:
 
 * The *Admin Workstation* is connected to the Internet.
 * Tor started successfully.
-* The ``HidServAuth`` values from ``app-ssh-aths`` and ``mon-ssh-aths`` are in
+* The ``HidServAuth`` values from ``install_files/ansible-base/app-ssh-aths`` and ``install_files/ansible-base/mon-ssh-aths`` are in
   Tails' ``/etc/tor/torrc``. If they are not, again, see 
   :doc:`configure_admin_workstation_post_install` for detailed instructions.
 
@@ -123,11 +123,11 @@ one. As before, to get started, boot the *Admin Workstation*, ``cd`` to the
 SecureDrop repository, and ensure that you have SecureDrop 0.4 or later
 checked out.
 
-The restore role expects to find a ``.tar.gz`` backup archive in
+The restore command expects to find a ``.tar.gz`` backup archive in
 ``install_files/ansible-base`` under the SecureDrop repository root directory.
 If you are using the same *Admin Workstation* to do a restore from a previous
 backup, it should already be there because it was placed there by the backup
-role. Otherwise, you should copy the backup archive that you wish to restore to
+command. Otherwise, you should copy the backup archive that you wish to restore to
 ``install_files/ansible-base``.
 
 .. note:: The backup strategy used for SecureDrop versions prior to 0.3.7

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -306,20 +306,20 @@ Translations administrators
           :ref:`code maintainers <contributor-permissions>` and
           :ref:`translation maintainers <i18n-administrator-permissions>`.
 
-A translation administrator is a person who is actively performing
+A translation admin is a person who is actively performing
 administrative duties. They have special permissions on the
 repositories and the translation platform. When someone is willing to
-become an administrator, a thread is started in `the translation
+become an admin, a thread is started in `the translation
 section of the forum
 <https://forum.securedrop.club/c/translations>`_. If there is a
-consensus, the permissions of the new administrator are elevated after
+consensus, the permissions of the new admin are elevated after
 a week or more. If there is no consensus, a public vote is organized
-among the current administrators.
+among the current admins.
 
-All administrators are listed in the `forum introduction page
+All admins are listed in the `forum introduction page
 <https://forum.securedrop.club/t/about-the-translations-category/16/1>`_
 
-The privileges of an administrator who has not been active for six months
+The privileges of an admin who has not been active for six months
 or more are revoked. They can apply again at any time.
 
 The community of SecureDrop translators works very closely with the
@@ -331,7 +331,7 @@ independent policy.
 Administrator permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-An administrator may not need or want all permissions but they are
+An admin may not need or want all permissions but they are
 entitled to have all of them.
 
 * https://weblate.securedrop.club/admin/auth/user/ grant staff and superuser status

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -36,7 +36,7 @@ Connecting to the *Journalist Interface*
 
 Journalists viewing documents on SecureDrop must connect to the
 *Journalist Interface* using the `Tails operating system
-<https://tails.boum.org/>`__ on a USB drive. Your administrator can
+<https://tails.boum.org/>`__ on a USB drive. Your admin can
 help provide you with a Tails drive.
 
 .. important:: See our guide on setting up :doc:`Tails for the Admin
@@ -243,7 +243,7 @@ can open the ``Terminal``, navigate to the file, and use:
 
 replacing ``NAME_OF_FILE`` with the name of the file you wish to decrypt. This
 command will tell you what key was used to encrypt the file. If you are not
-comfortable at the command line, contact your SecureDrop administrator or
+comfortable at the command line, contact your SecureDrop admin or
 Freedom of the Press Foundation for assistance.
 
 .. warning:: **Do not** transfer source material off the *Secure Viewing Station*

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -119,7 +119,7 @@ Setting up SecureDrop is a multi-step process. Before getting started, you
 should make sure that you're prepared to operate and maintain it. You'll need
 a systems admin who's familiar with Linux, the GNU utilities, and the
 Bash shell. You'll need the :doc:`hardware <hardware>` on which SecureDrop
-runs — this will normally cost $2000-$3000 dollars. The journalists in your
+runs — this will normally cost $2000-$3000. The journalists in your
 organization will need to be trained in the operation of SecureDrop, and
 you'll need to publish and promote your new SecureDrop instance afterwards —
 using your existing websites, mailing lists, and social media.

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -150,7 +150,7 @@ To use the template:
 In case you wish to manually create a database, the suggested password fields in
 the admin template are:
 
-**Administrator**:
+**Admin**:
 
 - Admin account username
 - App Server SSH Onion URL

--- a/docs/yubikey_setup.rst
+++ b/docs/yubikey_setup.rst
@@ -80,7 +80,7 @@ top of the window.
 Adding Users
 ------------
 
-When adding new users, a SecureDrop administrator will need the
+When adding new users, a SecureDrop admin will need the
 **Secret Key** value described above. She will enter it after
 selecting the **I'm Using a YubiKey** option while :ref:`adding users
 <Adding Users>`.

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -31,22 +31,24 @@
     {% endif %}
 
     <div class="content">
-      {% block header %}
-      <div id="header">
-        <a href="{{ url_for('main.index') }}"><img src="/static/i/{{ header_image }}" class="logo small" alt="SecureDrop" width="250px"></a>
-        {% include 'locales.html' %}
-        {% if use_custom_header_image %}
-        <div class="powered">
-          {{ gettext('Powered by <br> <img src="/static/i/securedrop_small.png" alt="SecureDrop">') }}
+      <div class="container">
+        {% block header %}
+        <div id="header">
+          <a href="{{ url_for('main.index') }}"><img src="/static/i/{{ header_image }}" class="logo small" alt="SecureDrop" width="250px"></a>
+          {% include 'locales.html' %}
+          {% if use_custom_header_image %}
+          <div class="powered">
+            {{ gettext('Powered by <br> <img src="/static/i/securedrop_small.png" alt="SecureDrop">') }}
+          </div>
+          {% endif %}
         </div>
-        {% endif %}
-      </div>
-      {% endblock %}
+        {% endblock %}
 
-      <div class="panel selected">
-        {% include 'flashed.html' %}
+        <div class="panel selected">
+          {% include 'flashed.html' %}
 
-        {% block body %}{% endblock %}
+          {% block body %}{% endblock %}
+        </div>
       </div>
 
       {% block footer %}

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -24,8 +24,8 @@
       <p>
         <div id="select-container"></div>
         <button type="submit" name="action" value="download" class="small"><i class="fa fa-download"></i> {{ gettext('Download Selected') }}</button>
-        <a href="#delete-selected-confirmation-modal" id="delete-selected-link" class="btn small danger">
-          <i class="fa fa-trash-o"></i> {{ gettext('Delete Selected') }}
+        <a href="#delete-selected-confirmation-modal" id="delete-selected-link">
+          <button type="button" class="small danger"><i class="fa fa-trash-o"></i> {{ gettext('Delete Selected') }}</button>
         </a>
       </p>
 
@@ -118,8 +118,8 @@
     <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
     <input type="hidden" name="filesystem_id" value="{{ filesystem_id }}">
     <input type="hidden" name="col_name" value="{{ source.journalist_designation }}">
-    <a href="#delete-collection-confirmation-modal" id="delete-collection-link" class="btn sd-button danger">
-      <i class="fa fa-trash-o"></i> {{ gettext('DELETE COLLECTION') }}
+    <a href="#delete-collection-confirmation-modal" id="delete-collection-link">
+      <button type="button" class="sd-button danger"><i class="fa fa-trash-o"></i> {{ gettext('DELETE COLLECTION') }}</button>
     </a>
 
     <!-- Confirmation modal for entire collection deletion -->

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -12,8 +12,8 @@
         <button type="submit" name="action" value="download-all" class="small"><i class="fa fa-download"></i> {{ gettext('Download') }}</button>
         <button type="submit" name="action" value="star" class="small"><i class="fa fa-star"></i> {{ gettext('Star') }}</button>
         <button type="submit" name="action" value="un-star" class="small"><i class="fa fa-star-half-full"></i> {{ gettext('Un-star') }}</button>
-        <a href="#delete-confirmation-modal" id="delete-collections-link" class="btn small danger">
-          <i class="fa fa-trash-o"></i> {{ gettext('Delete') }}
+        <a href="#delete-confirmation-modal" id="delete-collections-link">
+          <button type="button" class="small danger"><i class="fa fa-trash-o"></i> {{ gettext('Delete') }}</button>
         </a>
       </p>
 

--- a/securedrop/sass/modules/_button.sass
+++ b/securedrop/sass/modules/_button.sass
@@ -4,6 +4,7 @@
     box-sizing: border-box
     -moz-box-sizing: border-box
     padding: 10px 15px
+    margin: 2px auto
     border: 1px solid transparent
     color: white
     font-size: medium

--- a/securedrop/sass/modules/_cols.sass
+++ b/securedrop/sass/modules/_cols.sass
@@ -27,7 +27,7 @@
 
       .designation
         display: inline-block
-        min-width: 260px
+        min-width: 35%
 
         a
           color: #333

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -75,47 +75,55 @@ class JournalistNavigationStepsMixin():
     def _journalist_selects_first_doc(self):
         self.driver.find_elements_by_name('doc_names_selected')[0].click()
 
+    def _journalist_clicks_on_modal(self, click_id):
+        self.driver.find_element_by_id(click_id).click()
+
+        def link_not_displayed():
+            assert (
+                (not self.driver.find_elements_by_id(click_id)) or
+                (not self.driver.find_element_by_id(click_id).is_displayed()))
+        self.wait_for(link_not_displayed)
+
     def _journalist_clicks_delete_collections_cancel_on_modal(self):
-        self.driver.find_element_by_id('cancel-collections-deletions').click()
+        self._journalist_clicks_on_modal('cancel-collections-deletions')
 
     def _journalist_clicks_delete_selected_cancel_on_modal(self):
-        self.driver.find_element_by_id('cancel-selected-deletions').click()
+        self._journalist_clicks_on_modal('cancel-selected-deletions')
 
     def _journalist_clicks_delete_collection_cancel_on_modal(self):
-        self.driver.find_element_by_id('cancel-collection-deletions').click()
+        self._journalist_clicks_on_modal('cancel-collection-deletions')
 
     def _journalist_clicks_delete_collections_on_modal(self):
-        self.driver.find_element_by_id('delete-collections').click()
+        self._journalist_clicks_on_modal('delete-collections')
 
     def _journalist_clicks_delete_selected_on_modal(self):
-        self.driver.find_element_by_id('delete-selected').click()
+        self._journalist_clicks_on_modal('delete-selected')
 
     def _journalist_clicks_delete_collection_on_modal(self):
-        self.driver.find_element_by_id('delete-collection-button').click()
+        self._journalist_clicks_on_modal('delete-collection-button')
 
-    def _journalist_sees_delete_collections_confirmation(self):
-        assert self.driver.find_element_by_id(
-            'delete-confirmation-modal').is_displayed()
+    def _journalist_clicks_delete_link(self, click_id, displayed_id):
+        assert not self.driver.find_element_by_id(displayed_id).is_displayed()
+        self.driver.find_element_by_id(click_id).click()
 
-    def _journalist_sees_delete_selected_confirmation(self):
-        assert self.driver.find_element_by_id(
-            'delete-selected-confirmation-modal').is_displayed()
-
-    def _journalist_sees_delete_collection_confirmation(self):
-        assert self.driver.find_element_by_id(
-            'delete-collection-confirmation-modal').is_displayed()
+        def link_displayed():
+            assert self.driver.find_element_by_id(displayed_id).is_displayed()
+        self.wait_for(link_displayed)
 
     def _journalist_clicks_delete_selected_link(self):
-        self.driver.find_element_by_id('delete-selected-link').click()
-        self._journalist_sees_delete_selected_confirmation()
+        self._journalist_clicks_delete_link(
+            'delete-selected-link',
+            'delete-selected-confirmation-modal')
 
     def _journalist_clicks_delete_collections_link(self):
-        self.driver.find_element_by_id('delete-collections-link').click()
-        self._journalist_sees_delete_collections_confirmation()
+        self._journalist_clicks_delete_link(
+            'delete-collections-link',
+            'delete-confirmation-modal')
 
     def _journalist_clicks_delete_collection_link(self):
-        self.driver.find_element_by_id('delete-collection-link').click()
-        self._journalist_sees_delete_collection_confirmation()
+        self._journalist_clicks_delete_link(
+            'delete-collection-link',
+            'delete-collection-confirmation-modal')
 
     def _journalist_uses_delete_selected_button_confirmation(self):
         selected_count = len(self.driver.find_elements_by_name(
@@ -139,8 +147,10 @@ class JournalistNavigationStepsMixin():
 
         # After deletion the button will redirect us. Let's ensure we still
         # see the delete collection button.
-        assert self.driver.find_element_by_id(
-            'delete-collection-link').is_displayed()
+        def delete_collection_link_displayed():
+            assert self.driver.find_element_by_id(
+                'delete-collection-link').is_displayed()
+        self.wait_for(delete_collection_link_displayed, timeout=60)
 
         self._journalist_clicks_delete_collection_link()
         self._journalist_clicks_delete_collection_on_modal()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

As proposed in #2332, this replaces instances of "Administrator(s)/administrator(s)" currently present in docs with "Admin(s)/admin(s)".

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
