### PR TITLE
Substitute administrator with admin in docs

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -267,9 +267,9 @@ Application Server
 Adding Users (CLI)
 ^^^^^^^^^^^^^^^^^^
 
-After the provisioning of the first administrator account, we recommend
+After the provisioning of the first admin account, we recommend
 using the Admin Interface web application for adding additional journalists
-and administrators.
+and admins.
 
 However, you can also add users via ``./manage.py`` in ``/var/www/securedrop/``
 as described :doc:`during first install <create_admin_account>`. You can use

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -299,27 +299,27 @@ We do not want to publish the translator emails so we strip them:
 
 .. _i18n-administrator-permissions:
 
-Translations administrators
----------------------------
+Translations admins
+-------------------
 
 .. note:: The privilege escalation workflow is different for
           :ref:`code maintainers <contributor-permissions>` and
           :ref:`translation maintainers <i18n-administrator-permissions>`.
 
-A translation administrator is a person who is actively performing
+A translation admin is a person who is actively performing
 administrative duties. They have special permissions on the
 repositories and the translation platform. When someone is willing to
-become an administrator, a thread is started in `the translation
+become an admin, a thread is started in `the translation
 section of the forum
 <https://forum.securedrop.club/c/translations>`_. If there is a
-consensus, the permissions of the new administrator are elevated after
+consensus, the permissions of the new admin are elevated after
 a week or more. If there is no consensus, a public vote is organized
-among the current administrators.
+among the current admins.
 
-All administrators are listed in the `forum introduction page
+All admins are listed in the `forum introduction page
 <https://forum.securedrop.club/t/about-the-translations-category/16/1>`_
 
-The privileges of an administrator who has not been active for six months
+The privileges of an admin who has not been active for six months
 or more are revoked. They can apply again at any time.
 
 The community of SecureDrop translators works very closely with the
@@ -328,10 +328,10 @@ groups. However, the translators community has a different set of
 rules and permissions, reason why it makes sense to have an
 independent policy.
 
-Administrator permissions
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Admin permissions
+~~~~~~~~~~~~~~~~~
 
-An administrator may not need or want all permissions but they are
+An admin may not need or want all permissions but they are
 entitled to have all of them.
 
 * https://weblate.securedrop.club/admin/auth/user/ grant staff and superuser status

--- a/docs/development/virtualizing_tails.rst
+++ b/docs/development/virtualizing_tails.rst
@@ -64,7 +64,7 @@ Next you will install Tails onto the Virtual Hard Disk Image. Start the VM, boot
 to Tails, and enter an administration password and start Tails.
 
 .. note:: For all the instructions that follow, you will need to configure an
-          administrator password each time you boot Tails.
+          administration password each time you boot Tails.
 
 1. Copy the following patch and save it as ``installer.patch`` in a folder in
    your Tails VM:

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -36,7 +36,7 @@ Connecting to the *Journalist Interface*
 
 Journalists viewing documents on SecureDrop must connect to the
 *Journalist Interface* using the `Tails operating system
-<https://tails.boum.org/>`__ on a USB drive. Your administrator can
+<https://tails.boum.org/>`__ on a USB drive. Your admin can
 help provide you with a Tails drive.
 
 .. important:: See our guide on setting up :doc:`Tails for the Admin
@@ -243,7 +243,7 @@ can open the ``Terminal``, navigate to the file, and use:
 
 replacing ``NAME_OF_FILE`` with the name of the file you wish to decrypt. This
 command will tell you what key was used to encrypt the file. If you are not
-comfortable at the command line, contact your SecureDrop administrator or
+comfortable at the command line, contact your SecureDrop admin or
 Freedom of the Press Foundation for assistance.
 
 .. warning:: **Do not** transfer source material off the *Secure Viewing Station*

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -150,7 +150,7 @@ To use the template:
 In case you wish to manually create a database, the suggested password fields in
 the admin template are:
 
-**Administrator**:
+**Admin**:
 
 - Admin account username
 - App Server SSH Onion URL

--- a/docs/yubikey_setup.rst
+++ b/docs/yubikey_setup.rst
@@ -80,7 +80,7 @@ top of the window.
 Adding Users
 ------------
 
-When adding new users, a SecureDrop administrator will need the
+When adding new users, a SecureDrop admin will need the
 **Secret Key** value described above. She will enter it after
 selecting the **I'm Using a YubiKey** option while :ref:`adding users
 <Adding Users>`.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

As proposed in #2332, this modifies occurrences of "Administrator(s)/administrator(s)" in docs.

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
