### PR TITLE
Add securedrop-admin update and securedrop-admin check_for_updates

### DIFF
--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -51,6 +51,50 @@ class TestSecureDropAdmin(object):
         assert 'HIDDEN' not in out
         assert 'VISIBLE' in out
 
+    def test_check_for_updates_update_needed(self, tmpdir, caplog):
+        git_repo_path = str(tmpdir)
+        args = argparse.Namespace(root=git_repo_path)
+        current_tag = "0.6"
+        tags_available = "0.6\n0.6-rc1\n0.6.1\n"
+
+        with mock.patch('subprocess.check_call'):
+            with mock.patch('subprocess.check_output',
+                            side_effect=[current_tag, tags_available]):
+                update_status, tag = securedrop_admin.check_for_updates(args)
+                assert "Update needed" in caplog.text
+                assert update_status is True
+                assert tag == '0.6.1'
+
+    def test_check_for_updates_update_not_needed(self, tmpdir, caplog):
+        git_repo_path = str(tmpdir)
+        args = argparse.Namespace(root=git_repo_path)
+        current_tag = "0.6.1"
+        tags_available = "0.6\n0.6-rc1\n0.6.1\n"
+
+        with mock.patch('subprocess.check_call'):
+            with mock.patch('subprocess.check_output',
+                            side_effect=[current_tag, tags_available]):
+                update_status, tag = securedrop_admin.check_for_updates(args)
+                assert "All updates applied" in caplog.text
+                assert update_status is False
+                assert tag == '0.6.1'
+
+    def test_check_for_updates_if_most_recent_tag_is_rc(self, tmpdir, caplog):
+        """During pre-release QA, the most recent tag ends in *-rc. We
+        verify that users will not accidentally check out this tag."""
+        git_repo_path = str(tmpdir)
+        args = argparse.Namespace(root=git_repo_path)
+        current_tag = "0.6.1"
+        tags_available = "0.6\n0.6-rc1\n0.6.1\n0.6.1-rc1\n"
+
+        with mock.patch('subprocess.check_call'):
+            with mock.patch('subprocess.check_output',
+                            side_effect=[current_tag, tags_available]):
+                update_status, tag = securedrop_admin.check_for_updates(args)
+                assert "All updates applied" in caplog.text
+                assert update_status is False
+                assert tag == '0.6.1'
+
 
 class TestSiteConfig(object):
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2976 

Changes proposed in this pull request:
* Adds `securedrop-admin update` and `securedrop-admin check_for_updates` commands

## Testing

In your Tails VM you can do the following after checking out this branch:

```
amnesia@amnesia:~/Persistent/securedrop$ ./securedrop-admin check_for_updates
INFO: Checking for SecureDrop updates...
Fetching origin
INFO: Update needed

amnesia@amnesia:~/Persistent/securedrop$ ./securedrop-admin update
INFO: Applying SecureDrop updates...
INFO: Checking for SecureDrop updates...
Fetching origin
INFO: Update needed
Note: checking out '0.5.2'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at b2484519... SecureDrop 0.5.2
INFO: Verifying signature on latest update...
gpg: key 0x310F561200F4AD77: "SecureDrop Release Signing Key" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
INFO: Signature verification successful.
INFO: Updated to SecureDrop 0.5.2.
```

## Deployment

Nothing I can think of at this stage

## Checklist

### If you made changes to `securedrop-admin`

- [x] in the `admin` directory, `make test` passed locally 

