### PR TITLE
securedrop-admin: an empty config is {}, not None

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -301,7 +301,7 @@ class SiteConfig(object):
         for desc in self.desc:
             (var, default, type, prompt, validator, transform) = desc
             config[var] = self.user_prompt_config_one(desc,
-                                                      self_config.get(var))
+                                                      self.config.get(var))
         return config
 
     def user_prompt_config_one(self, desc, from_config):

--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -287,7 +287,7 @@ class SiteConfig(object):
         if self.exists():
             self.config = self.load()
         else:
-            self.config = None
+            self.config = {}
         return self.update_config()
 
     def update_config(self):
@@ -298,7 +298,6 @@ class SiteConfig(object):
 
     def user_prompt_config(self):
         config = {}
-        self_config = self.config or {}
         for desc in self.desc:
             (var, default, type, prompt, validator, transform) = desc
             config[var] = self.user_prompt_config_one(desc,

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -326,7 +326,7 @@ class TestSiteConfig(object):
         site_config = securedrop_admin.SiteConfig(args)
         with mock.patch('securedrop_admin.SiteConfig.update_config'):
             site_config.load_and_update_config()
-            assert site_config.config is not None
+            assert site_config.config != {}
 
         args = argparse.Namespace(
             site_config='tests/files/site-specific-missing-entries',
@@ -335,7 +335,7 @@ class TestSiteConfig(object):
         site_config = securedrop_admin.SiteConfig(args)
         with mock.patch('securedrop_admin.SiteConfig.update_config'):
             site_config.load_and_update_config()
-            assert site_config.config is not None
+            assert site_config.config != {}
 
         args = argparse.Namespace(site_config='UNKNOWN',
                                   ansible_path='tests/files',
@@ -343,7 +343,7 @@ class TestSiteConfig(object):
         site_config = securedrop_admin.SiteConfig(args)
         with mock.patch('securedrop_admin.SiteConfig.update_config'):
             site_config.load_and_update_config()
-            assert site_config.config is None
+            assert site_config.config == {}
 
     def get_desc(self, site_config, var):
         for desc in site_config.desc:


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

An empty config is {}, not None, otherwise it cannot be updated and will fail when starting
from scratch when non site-specific file exists

## Testing

In addition to the test added to ensure this regression stays fixed, one can manually test with

* git clone https://github.com/freedomofpress/securedrop
* cd securedrop/admin
* ./securedrop-admin setup
* ./securedrop-admin sdconfig

## Deployment

N/A

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
