### PR TITLE
docs: Update Admin and Journalist terms acc to Docs guidelines

### DIFF
--- a/docs/generate_securedrop_application_key.rst
+++ b/docs/generate_securedrop_application_key.rst
@@ -76,7 +76,7 @@ installation.  Double-click on the newly generated key and change to the
           screenshot.
 
 At this point, you are done with the *Secure Viewing Station* for now. You
-can shut down Tails, grab the *admin Tails USB* and move over to your regular
+can shut down Tails, grab the *Admin Tails USB* and move over to your regular
 workstation.
 
 .. |GPG generate key| image:: images/install/run_gpg_gen_key.png

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -95,12 +95,12 @@ Workstations
   <https://tails.boum.org/news/version_3.0/index.en.html#index3h3>`_.
 
 These components are necessary to do the initial installation of
-SecureDrop and to process submissions using the airgapped workflow.
+SecureDrop and to process submissions using the air-gapped workflow.
 
 Secure Viewing Station (SVS)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1 physical computer used as an airgap to decrypt and view submissions retrieved
+1 physical computer used as an air-gap to decrypt and view submissions retrieved
 from the *Application Server*.
 
 The chosen hardware should be solely used for this purpose and should have any
@@ -123,14 +123,14 @@ USB drive(s)
 ~~~~~~~~~~~~~~~~
 
 *At least 2* USB drives to use as a bootable Tails USB for the *SVS* and the
-**Admin Tails**/**Journalist Tails**.
+*Admin Workstation*/*Journalist Workstation*.
 
 If only one person is maintaining the system, you may use the same Tails
 instance as both the Admin Tails and the Journalist Tails; otherwise, we
 recommend buying 1 drive for each admin and each journalist.
 
 We also recommend buying two additional USBs to use as bootable backups of the
-*SVS* and **Admin Tails**.
+*SVS* and *Admin Workstation*.
 
 **Two-factor authenticator**: Two-factor authentication is used when connecting
 to different parts of the SecureDrop system. Each admin and each journalist
@@ -146,7 +146,7 @@ two-factor authentication:
 .. include:: includes/otp-app.txt
 
 **Transfer Device(s)**: You need a mechanism to transfer encrypted submissions
-from the **Journalist Workstation** to the *SVS* to decrypt and view them. The
+from the *Journalist Workstation* to the *SVS* to decrypt and view them. The
 most common transfer devices are DVD/CD-R discs and USB drives.
 
 From a security perspective, it is preferable to use write-once media such as
@@ -192,7 +192,7 @@ Offline Printer
 It is often useful to print submissions from the *Secure Viewing Station* for
 review and annotation.
 
-.. warning:: To maintain the integrity of the airgap, this printer should be
+.. warning:: To maintain the integrity of the air-gap, this printer should be
              dedicated to use with the *Secure Viewing Station*, connected via
              a wired connection, and should not have any wireless communication
              capabilities.
@@ -409,7 +409,7 @@ these components if they are already present.
 One option is to buy a Linux-compatible laptop such as a
 `Lenovo ThinkPad <http://www3.lenovo.com/us/en/laptops/thinkpad/thinkpad-t-series/c/thinkpadt>`__;
 we've tested the T420 and successfully removed the wireless components with ease.
-It's possible to repurpose old laptops from other manufacturers, as long as the
+It's possible to re-purpose old laptops from other manufacturers, as long as the
 wireless components are removable.
 
 Just as with the servers, you can also use an Intel NUC for the *SVS*. As noted
@@ -453,8 +453,8 @@ accordingly. Drives that are physically larger are often easier to label
 (e.g. with tape, printed sticker or a label from a labelmaker).
 
 If you are using DVD/CD-R's for the transfer device, you will need *two*
-DVD/CD writers: one for burning DVDs from the **Journalist
-Workstation**, and one for reading the burned DVDs on the *SVS*. We
+DVD/CD writers: one for burning DVDs from the *Journalist
+Workstation*, and one for reading the burned DVDs on the *SVS*. We
 recommend using two separate drives instead of sharing the same drive to
 avoid the potential risk of malware exfiltrating data by compromising
 the drive's firmware. We've found the DVD/CD writers from Samsung and LG
@@ -485,12 +485,12 @@ Printers
 Careful consideration should be given to the printer used with the *SVS*.
 Most printers today have wireless functionality (WiFi or Bluetooth
 connectivity) which should be **avoided** because it could be used to
-compromise the airgap.
+compromise the air-gap.
 
 Unfortunately, it is difficult to find printers that work with Tails,
 and it is increasingly difficult to find non-wireless printers at all.
 To assist you, we have compiled the following partial list of
-airgap-safe printers that have been tested and are known to work with
+air-gap-safe printers that have been tested and are known to work with
 Tails:
 
 +-------------------------+--------------+----------------+--------------------+

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -49,7 +49,7 @@ help provide you with a Tails drive.
 
 Each journalist has an authenticated Tor hidden service URL for
 logging in to the *Journalist Interface*. This must be done using the
-Tails operating system. Click the **Journalist Interface** icon on the
+Tails operating system. Click the *Journalist Interface* icon on the
 desktop. This will open Tor Browser to a ".onion" page. Log in with
 your username, passphrase, and two-factor authentication token, as
 shown in the first screenshot below. (See :doc:`Using YubiKey with the

--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -2,7 +2,7 @@ Set up the Network Firewall
 ===========================
 
 Now that you've set up your password manager, you can move on to setting
-up the Network Firewall. You should stay logged in to your *admin Tails
+up the Network Firewall. You should stay logged in to your *Admin Tails
 USB* to access the Network Firewall's web interface for configuration.
 
 Unfortunately, due to the wide variety of firewalls that may be used, we

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -11,7 +11,7 @@ In order to use SecureDrop, each journalist needs two things:
 
 1. A *Journalist Tails USB*.
 
-     The Journalist Interface is only accessible as an authenticated Tor
+     The Journalist Interface is only accessible as an Authenticated Tor
      Hidden Service (ATHS). For ease of configuration and security, we
      require journalists to set up a Tails USB with persistence that
      they are required to use to access the Journalist Interface.

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -1,17 +1,17 @@
 Set up the Admin Workstation
 ============================
 
-Earlier, you should have created the *admin Tails USB* along with a
+Earlier, you should have created the *Admin Tails USB* along with a
 persistence volume for it. Now, we are going to add a couple more
-features to the *admin Tails USB* to facilitate SecureDrop's setup.
+features to the *Admin Tails USB* to facilitate SecureDrop's setup.
 
-If you have not switched to and booted the *admin Tails USB* on your
+If you have not switched to and booted the *Admin Tails USB* on your
 regular workstation, do so now.
 
 Start Tails with Persistence Enabled
 ------------------------------------
 
-After you boot the *admin Tails USB* on your normal workstation, you
+After you boot the *Admin Tails USB* on your normal workstation, you
 should see a *Welcome to Tails* screen with *Encrypted Persistent
 Storage*.  Enter your password and click *Unlock*. Do NOT click *Start
 Tails* yet. Under *Additional Settings* click the *plus* sign.

--- a/docs/tails_guide.rst
+++ b/docs/tails_guide.rst
@@ -6,12 +6,12 @@ must be using the Tails operating system. The admin must also use Tails to
 access the *Journalist Interface* and create new users.
 
 If you followed the :doc:`SecureDrop Installation instructions <install>`
-correctly, you should have already created a *journalist Tails USB* and an
-*admin Tails USB* and enabled the persistence volume on each. If you have not,
-or need to create another *journalist Tails USB* for a second journalist,
+correctly, you should have already created a *Journalist Tails USB* and an
+*Admin Tails USB* and enabled the persistence volume on each. If you have not,
+or need to create another *Journalist Tails USB* for a second journalist,
 follow the steps below.
 
-If you already know how to boot the *admin Tails USB* or the *journalist Tails
+If you already know how to boot the *Admin Tails USB* or the *Journalist Tails
 USB* with persistence, you can skip down to the step 'download the repository'.
 
 Note that for all of these instructions to work, you should have already

--- a/docs/threat_model/threat_model.rst
+++ b/docs/threat_model/threat_model.rst
@@ -159,7 +159,7 @@ What the Workstations can achieve
    :doc:`database with passphrases <../passphrases>`
    for the *Application Server*, the *Monitor Server*, and the GPG key the
    *Monitor Server* will encrypt OSSEC alerts to.
--  The **Journalist Workstation** requires Tails with a persistent
+-  The *Journalist Workstation* requires Tails with a persistent
    volume, which stores information such as the Hidden Service value
    required to connect to the Journalist Interface, as well as a :doc:`database
    with passphrases <../passphrases>` for the
@@ -261,7 +261,7 @@ What a compromise of the admin's property can achieve
       to.
    -  Access the admin's personal GPG key.
 
--  An attacker with admin access to the **Journalist Interface** can:
+-  An attacker with admin access to the *Journalist Interface* can:
 
    -  Add, modify, and delete journalist users.
    -  Change the codenames associated with sources within the Interface.
@@ -342,7 +342,7 @@ What a compromise of the journalist's property can achieve
       *Monitor Server*.
    -  Access the journalist's personal GPG key.
 
--  An attacker with journalist access to the **Journalist Interface** can:
+-  An attacker with journalist access to the *Journalist Interface* can:
 
    -  Change the codenames associated with sources within the Interface.
    -  Download, but not decrypt, submissions.

--- a/docs/upgrade/0.4.x_to_0.5.rst
+++ b/docs/upgrade/0.4.x_to_0.5.rst
@@ -4,7 +4,7 @@ Upgrade from 0.4.x to 0.5.x
 .. note::
    First follow the instructions in the 0.3 to 0.4
    :doc:`migration document <0.3.x_to_0.4>`
-   if you have not yet updated your **Admin Workstation** to 0.4.
+   if you have not yet updated your *Admin Workstation* to 0.4.
 
 Beginning with SecureDrop 0.5, the source and journalist interfaces
 are localized. After an unattended upgrade of the application server,
@@ -14,7 +14,7 @@ these translations are available but are not activated by default.
    See the :doc:`installation documenation <../install>` for a list
    of supported languages.
 
-The steps below should be performed on the **Admin Workstation**
+The steps below should be performed on the *Admin Workstation*
 associated with your SecureDrop instance.
 
 Pull the latest release


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Relates to : #3023 #3014 

Changes proposed in this pull request: Replaced all the alternatives of *Journalist Workstation* and *Admin Workstation*.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [x] Doc linting passed locally
