### PR TITLE
Fixes #3031 type annotation for application config

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -173,6 +173,8 @@
   /var/www/securedrop/secure_tempfile.pyc rw,
   /var/www/securedrop/i18n.py r,
   /var/www/securedrop/i18n.pyc rw,
+  /var/www/securedrop/sdconfig.py r,
+  /var/www/securedrop/sdconfig.pyc rw,
   /var/www/securedrop/source.py r,
   /var/www/securedrop/source.pyc rw,
   /var/www/securedrop/source_app/__init__.py r,

--- a/molecule/builder/tests/test_securedrop_deb_package.py
+++ b/molecule/builder/tests/test_securedrop_deb_package.py
@@ -157,7 +157,7 @@ def test_deb_package_contains_no_config_file(File, Command, deb):
     deb_package = File(deb.format(
         securedrop_test_vars.securedrop_version))
     c = Command("dpkg-deb --contents {}".format(deb_package.path))
-    assert not re.search("^.*config\.py$", c.stdout, re.M)
+    assert not re.search("^.*/config\.py$", c.stdout, re.M)
 
 
 @pytest.mark.parametrize("deb", deb_packages)

--- a/securedrop/create-demo-user.py
+++ b/securedrop/create-demo-user.py
@@ -6,7 +6,7 @@ from sqlalchemy.exc import IntegrityError
 
 os.environ["SECUREDROP_ENV"] = "dev"  # noqa
 import journalist_app
-import config
+from sdconfig import config
 from db import db
 from models import Journalist
 

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -15,7 +15,7 @@ import typing
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
 if typing.TYPE_CHECKING:
     # flake8 can not understand type annotation yet.
-    # That is why all type annotation realted import
+    # That is why all type annotation relative import
     # statements has to be marked as noqa.
     # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401stream
     from typing import Dict, List, Text  # noqa: F401

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -10,7 +10,15 @@ from base64 import b32encode
 from Cryptodome.Random import random
 from flask import current_app
 from gnupg._util import _is_stream, _make_binary_stream
-from typing import Dict, List, Text  # noqa: F401
+
+import typing
+# https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
+if typing.TYPE_CHECKING:
+    # flake8 can not understand type annotation yet.
+    # That is why all type annotation realted import
+    # statements has to be marked as noqa.
+    # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401stream
+    from typing import Dict, List, Text  # noqa: F401
 
 # to fix gpg error #78 on production
 os.environ['USERNAME'] = 'www-data'

--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import config
+from sdconfig import config
 
 from journalist_app import create_app
 

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -18,15 +18,21 @@ from journalist_app.utils import get_source, logged_in
 from models import Journalist
 from store import Storage
 
+MYPY = False
+if MYPY:
+    from sdconfig import SDConfig  # noqa: F401
+
 _insecure_views = ['main.login', 'static']
 
 
 def create_app(config):
+    # type: (SDConfig) -> Flask
     app = Flask(__name__,
                 template_folder=config.JOURNALIST_TEMPLATES_DIR,
                 static_folder=path.join(config.SECUREDROP_ROOT, 'static'))
 
     app.config.from_object(config.JournalistInterfaceFlaskConfig)
+    app.sdconfig = config
 
     CSRFProtect(app)
     Environment(app)
@@ -74,7 +80,7 @@ def create_app(config):
     app.jinja_env.trim_blocks = True
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.globals['version'] = version.__version__
-    if hasattr(config, 'CUSTOM_HEADER_IMAGE'):
+    if config.CUSTOM_HEADER_IMAGE:
         app.jinja_env.globals['header_image'] = config.CUSTOM_HEADER_IMAGE
         app.jinja_env.globals['use_custom_header_image'] = True
     else:

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -18,8 +18,13 @@ from journalist_app.utils import get_source, logged_in
 from models import Journalist
 from store import Storage
 
-MYPY = False
-if MYPY:
+import typing
+# https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
+if typing.TYPE_CHECKING:
+    # flake8 can not understand type annotation yet.
+    # That is why all type annotation realted import
+    # statements has to be marked as noqa.
+    # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401
     from sdconfig import SDConfig  # noqa: F401
 
 _insecure_views = ['main.login', 'static']
@@ -80,7 +85,7 @@ def create_app(config):
     app.jinja_env.trim_blocks = True
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.globals['version'] = version.__version__
-    if config.CUSTOM_HEADER_IMAGE:
+    if hasattr(config, 'CUSTOM_HEADER_IMAGE'):
         app.jinja_env.globals['header_image'] = config.CUSTOM_HEADER_IMAGE
         app.jinja_env.globals['use_custom_header_image'] = True
     else:

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -22,7 +22,7 @@ import typing
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
 if typing.TYPE_CHECKING:
     # flake8 can not understand type annotation yet.
-    # That is why all type annotation realted import
+    # That is why all type annotation relative import
     # statements has to be marked as noqa.
     # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401
     from sdconfig import SDConfig  # noqa: F401
@@ -86,7 +86,8 @@ def create_app(config):
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.globals['version'] = version.__version__
     if hasattr(config, 'CUSTOM_HEADER_IMAGE'):
-        app.jinja_env.globals['header_image'] = config.CUSTOM_HEADER_IMAGE
+        app.jinja_env.globals['header_image'] = \
+            config.CUSTOM_HEADER_IMAGE  # type: ignore
         app.jinja_env.globals['use_custom_header_image'] = True
     else:
         app.jinja_env.globals['header_image'] = 'logo.png'

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -16,6 +16,10 @@ from models import (get_one_or_else, Source, Journalist,
                     PasswordError, Submission)
 from rm import srm
 
+MYPY = False
+if MYPY:
+    from sdconfig import SDConfig  # noqa: F401
+
 
 def logged_in():
     # type: () -> bool
@@ -199,6 +203,7 @@ def col_delete(cols_selected):
 
 
 def make_password(config):
+    # type: (SDConfig) -> str
     while True:
         password = current_app.crypto_util.genrandomid(
             7,

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -16,8 +16,13 @@ from models import (get_one_or_else, Source, Journalist,
                     PasswordError, Submission)
 from rm import srm
 
-MYPY = False
-if MYPY:
+import typing
+# https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
+if typing.TYPE_CHECKING:
+    # flake8 can not understand type annotation yet.
+    # That is why all type annotation realted import
+    # statements has to be marked as noqa.
+    # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401
     from sdconfig import SDConfig  # noqa: F401
 
 

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -20,7 +20,7 @@ import typing
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
 if typing.TYPE_CHECKING:
     # flake8 can not understand type annotation yet.
-    # That is why all type annotation realted import
+    # That is why all type annotation relative import
     # statements has to be marked as noqa.
     # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401
     from sdconfig import SDConfig  # noqa: F401

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -21,7 +21,7 @@ from sqlalchemy import text
 from sqlalchemy.orm.exc import NoResultFound
 
 os.environ['SECUREDROP_ENV'] = 'dev'  # noqa
-import config
+from sdconfig import config
 import journalist_app
 
 from db import db

--- a/securedrop/sdconfig.py
+++ b/securedrop/sdconfig.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+import config as _config
+
+MYPY = False
+if MYPY:
+    from typing import List  # noqa: F401
+
+
+class SDConfig(object):
+    def __init__(self):
+        # type: () -> None
+        self.ADJECTIVES = _config.ADJECTIVES
+        self.DATABASE_ENGINE = _config.DATABASE_ENGINE
+        self.DEFAULT_LOCALE = _config.DEFAULT_LOCALE
+        self.FlaskConfig = _config.FlaskConfig
+        self.GPG_KEY_DIR = _config.GPG_KEY_DIR
+        self.JOURNALIST_KEY = _config.JOURNALIST_KEY
+        self.JOURNALIST_TEMPLATES_DIR = _config.JOURNALIST_TEMPLATES_DIR
+        self.JournalistInterfaceFlaskConfig = \
+            _config.JournalistInterfaceFlaskConfig
+        self.NOUNS = _config.NOUNS
+        self.SCRYPT_GPG_PEPPER = _config.SCRYPT_GPG_PEPPER
+        self.SCRYPT_ID_PEPPER = _config.SCRYPT_ID_PEPPER
+        self.SCRYPT_PARAMS = _config.SCRYPT_PARAMS
+        self.SECUREDROP_DATA_ROOT = _config.SECUREDROP_DATA_ROOT
+        self.SECUREDROP_ROOT = _config.SECUREDROP_ROOT
+        self.SESSION_EXPIRATION_MINUTES = _config.SESSION_EXPIRATION_MINUTES
+        self.SOURCE_TEMPLATES_DIR = _config.SOURCE_TEMPLATES_DIR
+        self.STORE_DIR = _config.STORE_DIR
+        self.SUPPORTED_LOCALES = []  # type: List[str]
+        self.SourceInterfaceFlaskConfig = _config.SourceInterfaceFlaskConfig
+        self.TEMP_DIR = _config.TEMP_DIR
+        self.WORD_LIST = _config.WORD_LIST
+        self.WORKER_PIDFILE = _config.WORKER_PIDFILE
+        self.env = _config.env
+        self.os = _config.os
+        # Below 4 attributes are only for non-sqlite env
+        self.DATABASE_USERNAME = ""
+        self.DATABASE_PASSWORD = ""
+        self.DATABASE_HOST = ""
+        self.DATABASE_NAME = ""
+        self.DATABASE_FILE = ""
+        # This by default is an empty string
+        self.CUSTOM_HEADER_IMAGE = ""
+
+        if _config.DATABASE_ENGINE != "sqlite":
+            self.DATABASE_USERNAME = _config.DATABASE_USERNAME  # type: ignore
+            self.DATABASE_PASSWORSD = \
+                _config.DATABASE_PASSWORD   # type: ignore
+            self.DATABASE_HOST = _config.DATABASE_HOST  # type: ignore
+            self.DATABASE_NAME = _config.DATABASE_NAME  # type: ignore
+        else:
+            self.DATABASE_FILE = _config.DATABASE_FILE
+
+        if hasattr(_config, 'CUSTOM_HEADER_IMAGE'):
+            self.CUSTOM_HEADER_IMAGE = \
+                _config.CUSTOM_HEADER_IMAGE  # type: ignore
+
+        if hasattr(_config, 'SUPPORTED_LOCALES'):
+            self.SUPPORTED_LOCALES = \
+                _config.SUPPORTED_LOCALES  # type: ignore
+
+
+config = SDConfig()  # type: SDConfig

--- a/securedrop/sdconfig.py
+++ b/securedrop/sdconfig.py
@@ -2,56 +2,47 @@
 
 import config as _config
 
-MYPY = False
-if MYPY:
-    from typing import List  # noqa: F401
+import typing
+# https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
+if typing.TYPE_CHECKING:
+    # flake8 can not understand type annotation yet.
+    # That is why all type annotation realted import
+    # statements has to be marked as noqa.
+    # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401
+    from typing import List, Dict  # noqa: F401
 
 
 class SDConfig(object):
     def __init__(self):
         # type: () -> None
-        self.ADJECTIVES = _config.ADJECTIVES
-        self.DATABASE_ENGINE = _config.DATABASE_ENGINE
-        self.DEFAULT_LOCALE = _config.DEFAULT_LOCALE
-        self.FlaskConfig = _config.FlaskConfig
-        self.GPG_KEY_DIR = _config.GPG_KEY_DIR
-        self.JOURNALIST_KEY = _config.JOURNALIST_KEY
-        self.JOURNALIST_TEMPLATES_DIR = _config.JOURNALIST_TEMPLATES_DIR
-        self.JournalistInterfaceFlaskConfig = \
-            _config.JournalistInterfaceFlaskConfig
-        self.NOUNS = _config.NOUNS
-        self.SCRYPT_GPG_PEPPER = _config.SCRYPT_GPG_PEPPER
-        self.SCRYPT_ID_PEPPER = _config.SCRYPT_ID_PEPPER
-        self.SCRYPT_PARAMS = _config.SCRYPT_PARAMS
-        self.SECUREDROP_DATA_ROOT = _config.SECUREDROP_DATA_ROOT
-        self.SECUREDROP_ROOT = _config.SECUREDROP_ROOT
-        self.SESSION_EXPIRATION_MINUTES = _config.SESSION_EXPIRATION_MINUTES
-        self.SOURCE_TEMPLATES_DIR = _config.SOURCE_TEMPLATES_DIR
-        self.STORE_DIR = _config.STORE_DIR
-        self.SUPPORTED_LOCALES = []  # type: List[str]
-        self.SourceInterfaceFlaskConfig = _config.SourceInterfaceFlaskConfig
-        self.TEMP_DIR = _config.TEMP_DIR
-        self.WORD_LIST = _config.WORD_LIST
-        self.WORKER_PIDFILE = _config.WORKER_PIDFILE
-        self.env = _config.env
-        self.os = _config.os
-        # Below 4 attributes are only for non-sqlite env
-        self.DATABASE_USERNAME = ""
-        self.DATABASE_PASSWORD = ""
-        self.DATABASE_HOST = ""
-        self.DATABASE_NAME = ""
-        self.DATABASE_FILE = ""
-        # This by default is an empty string
-        self.CUSTOM_HEADER_IMAGE = ""
+        if hasattr(_config, 'FlaskConfig'):
+            self.FlaskConfig = _config.FlaskConfig  # type: ignore
 
-        if _config.DATABASE_ENGINE != "sqlite":
+        if hasattr(_config, 'JournalistInterfaceFlaskConfig'):
+            self.JournalistInterfaceFlaskConfig = \
+                _config.JournalistInterfaceFlaskConfig  # type: ignore
+
+        if hasattr(_config, 'SourceInterfaceFlaskConfig'):
+            self.SourceInterfaceFlaskConfig = \
+                _config.SourceInterfaceFlaskConfig  # type: ignore
+
+        if hasattr(_config, "DATABASE_ENGINE"):
+            self.DATABASE_ENGINE = _config.DATABASE_ENGINE  # type: ignore
+
+        if hasattr(_config, "DATABASE_FILE"):
+            self.DATABASE_FILE = _config.DATABASE_FILE  # type: ignore
+
+        if hasattr(_config, "DATABASE_USERNAME"):
             self.DATABASE_USERNAME = _config.DATABASE_USERNAME  # type: ignore
-            self.DATABASE_PASSWORSD = \
-                _config.DATABASE_PASSWORD   # type: ignore
+
+        if hasattr(_config, "DATABASE_PASSWORD"):
+            self.DATABASE_PASSWORD = _config.DATABASE_PASSWORD  # type: ignore
+
+        if hasattr(_config, "DATABASE_HOST"):
             self.DATABASE_HOST = _config.DATABASE_HOST  # type: ignore
+
+        if hasattr(_config, "DATABASE_NAME"):
             self.DATABASE_NAME = _config.DATABASE_NAME  # type: ignore
-        else:
-            self.DATABASE_FILE = _config.DATABASE_FILE
 
         if hasattr(_config, 'CUSTOM_HEADER_IMAGE'):
             self.CUSTOM_HEADER_IMAGE = \
@@ -60,6 +51,77 @@ class SDConfig(object):
         if hasattr(_config, 'SUPPORTED_LOCALES'):
             self.SUPPORTED_LOCALES = \
                 _config.SUPPORTED_LOCALES  # type: ignore
+
+        # Now we will fill up existing values from config.py
+        if hasattr(_config, "ADJECTIVES"):
+            self.ADJECTIVES = _config.ADJECTIVES  # type: str
+
+        if hasattr(_config, "DATABASE_ENGINE"):
+            self.DATABASE_ENGINE = _config.DATABASE_ENGINE  # type: str
+
+        if hasattr(_config, "DATABASE_FILE"):
+            self.DATABASE_FILE = _config.DATABASE_FILE  # type: str
+
+        if hasattr(_config, "DEFAULT_LOCALE"):
+            self.DEFAULT_LOCALE = _config.DEFAULT_LOCALE  # type: ignore
+
+        if hasattr(_config, "GPG_KEY_DIR"):
+            self.GPG_KEY_DIR = _config.GPG_KEY_DIR  # type: str
+
+        if hasattr(_config, "JOURNALIST_KEY"):
+            self.JOURNALIST_KEY = _config.JOURNALIST_KEY  # type: str
+
+        if hasattr(_config, "JOURNALIST_TEMPLATES_DIR"):
+            self.JOURNALIST_TEMPLATES_DIR = \
+                _config.JOURNALIST_TEMPLATES_DIR  # type: str
+
+        if hasattr(_config, "NOUNS"):
+            self.NOUNS = _config.NOUNS  # type: str
+
+        if hasattr(_config, "SCRYPT_GPG_PEPPER"):
+            self.SCRYPT_GPG_PEPPER = _config.SCRYPT_GPG_PEPPER  # type: str
+
+        if hasattr(_config, "SCRYPT_ID_PEPPER"):
+            self.SCRYPT_ID_PEPPER = _config.SCRYPT_ID_PEPPER  # type: str
+
+        if hasattr(_config, "SCRYPT_PARAMS"):
+            self.SCRYPT_PARAMS = _config.SCRYPT_PARAMS  # type: Dict[str,int]
+
+        if hasattr(_config, "SECUREDROP_DATA_ROOT"):
+            self.SECUREDROP_DATA_ROOT = \
+                _config.SECUREDROP_DATA_ROOT  # type: str
+
+        if hasattr(_config, "SECUREDROP_ROOT"):
+            self.SECUREDROP_ROOT = _config.SECUREDROP_ROOT  # type: str
+
+        if hasattr(_config, "SESSION_EXPIRATION_MINUTES"):
+            self.SESSION_EXPIRATION_MINUTES = \
+                _config.SESSION_EXPIRATION_MINUTES  # type: ignore
+
+        if hasattr(_config, "SOURCE_TEMPLATES_DIR"):
+            self.SOURCE_TEMPLATES_DIR = \
+                _config.SOURCE_TEMPLATES_DIR   # type: str
+
+        if hasattr(_config, "STORE_DIR"):
+            self.STORE_DIR = _config.STORE_DIR  # type: str
+
+        if hasattr(_config, "SUPPORTED_LOCALES"):
+            self.SUPPORTED_LOCALES = _config.SUPPORTED_LOCALES  # type: ignore
+
+        if hasattr(_config, "TEMP_DIR"):
+            self.TEMP_DIR = _config.TEMP_DIR  # type: str
+
+        if hasattr(_config, "WORD_LIST"):
+            self.WORD_LIST = _config.WORD_LIST  # type: str
+
+        if hasattr(_config, "WORKER_PIDFILE"):
+            self.WORKER_PIDFILE = _config.WORKER_PIDFILE  # type: str
+
+        if hasattr(_config, "TRANSLATION_DIRS"):
+            self.TRANSLATION_DIRS = _config.TRANSLATION_DIRS  # type: ignore
+
+        if hasattr(_config, "env"):
+            self.env = _config.env  # type: str
 
 
 config = SDConfig()  # type: SDConfig

--- a/securedrop/sdconfig.py
+++ b/securedrop/sdconfig.py
@@ -6,7 +6,7 @@ import typing
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
 if typing.TYPE_CHECKING:
     # flake8 can not understand type annotation yet.
-    # That is why all type annotation realted import
+    # That is why all type annotation relative import
     # statements has to be marked as noqa.
     # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401
     from typing import List, Dict  # noqa: F401
@@ -15,113 +15,150 @@ if typing.TYPE_CHECKING:
 class SDConfig(object):
     def __init__(self):
         # type: () -> None
-        if hasattr(_config, 'FlaskConfig'):
-            self.FlaskConfig = _config.FlaskConfig  # type: ignore
-
-        if hasattr(_config, 'JournalistInterfaceFlaskConfig'):
+        try:
             self.JournalistInterfaceFlaskConfig = \
                 _config.JournalistInterfaceFlaskConfig  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, 'SourceInterfaceFlaskConfig'):
+        try:
             self.SourceInterfaceFlaskConfig = \
                 _config.SourceInterfaceFlaskConfig  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "DATABASE_ENGINE"):
-            self.DATABASE_ENGINE = _config.DATABASE_ENGINE  # type: ignore
-
-        if hasattr(_config, "DATABASE_FILE"):
+        try:
             self.DATABASE_FILE = _config.DATABASE_FILE  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "DATABASE_USERNAME"):
+        try:
             self.DATABASE_USERNAME = _config.DATABASE_USERNAME  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "DATABASE_PASSWORD"):
+        try:
             self.DATABASE_PASSWORD = _config.DATABASE_PASSWORD  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "DATABASE_HOST"):
+        try:
             self.DATABASE_HOST = _config.DATABASE_HOST  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "DATABASE_NAME"):
+        try:
             self.DATABASE_NAME = _config.DATABASE_NAME  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, 'CUSTOM_HEADER_IMAGE'):
-            self.CUSTOM_HEADER_IMAGE = \
-                _config.CUSTOM_HEADER_IMAGE  # type: ignore
+        try:
+            self.ADJECTIVES = _config.ADJECTIVES  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, 'SUPPORTED_LOCALES'):
-            self.SUPPORTED_LOCALES = \
-                _config.SUPPORTED_LOCALES  # type: ignore
+        try:
+            self.DATABASE_ENGINE = _config.DATABASE_ENGINE  # type: ignore
+        except AttributeError:
+            pass
 
-        # Now we will fill up existing values from config.py
-        if hasattr(_config, "ADJECTIVES"):
-            self.ADJECTIVES = _config.ADJECTIVES  # type: str
-
-        if hasattr(_config, "DATABASE_ENGINE"):
-            self.DATABASE_ENGINE = _config.DATABASE_ENGINE  # type: str
-
-        if hasattr(_config, "DATABASE_FILE"):
-            self.DATABASE_FILE = _config.DATABASE_FILE  # type: str
-
-        if hasattr(_config, "DEFAULT_LOCALE"):
+        try:
             self.DEFAULT_LOCALE = _config.DEFAULT_LOCALE  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "GPG_KEY_DIR"):
-            self.GPG_KEY_DIR = _config.GPG_KEY_DIR  # type: str
+        try:
+            self.GPG_KEY_DIR = _config.GPG_KEY_DIR  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "JOURNALIST_KEY"):
-            self.JOURNALIST_KEY = _config.JOURNALIST_KEY  # type: str
+        try:
+            self.JOURNALIST_KEY = _config.JOURNALIST_KEY  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "JOURNALIST_TEMPLATES_DIR"):
-            self.JOURNALIST_TEMPLATES_DIR = \
-                _config.JOURNALIST_TEMPLATES_DIR  # type: str
+        try:
+            self.JOURNALIST_TEMPLATES_DIR = _config.JOURNALIST_TEMPLATES_DIR  # type: ignore # noqa: E501
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "NOUNS"):
-            self.NOUNS = _config.NOUNS  # type: str
+        try:
+            self.NOUNS = _config.NOUNS  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "SCRYPT_GPG_PEPPER"):
-            self.SCRYPT_GPG_PEPPER = _config.SCRYPT_GPG_PEPPER  # type: str
+        try:
+            self.SCRYPT_GPG_PEPPER = _config.SCRYPT_GPG_PEPPER  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "SCRYPT_ID_PEPPER"):
-            self.SCRYPT_ID_PEPPER = _config.SCRYPT_ID_PEPPER  # type: str
+        try:
+            self.SCRYPT_ID_PEPPER = _config.SCRYPT_ID_PEPPER  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "SCRYPT_PARAMS"):
-            self.SCRYPT_PARAMS = _config.SCRYPT_PARAMS  # type: Dict[str,int]
+        try:
+            self.SCRYPT_PARAMS = _config.SCRYPT_PARAMS  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "SECUREDROP_DATA_ROOT"):
-            self.SECUREDROP_DATA_ROOT = \
-                _config.SECUREDROP_DATA_ROOT  # type: str
+        try:
+            self.SECUREDROP_DATA_ROOT = _config.SECUREDROP_DATA_ROOT  # type: ignore # noqa: E501
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "SECUREDROP_ROOT"):
-            self.SECUREDROP_ROOT = _config.SECUREDROP_ROOT  # type: str
+        try:
+            self.SECUREDROP_ROOT = _config.SECUREDROP_ROOT  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "SESSION_EXPIRATION_MINUTES"):
+        try:
             self.SESSION_EXPIRATION_MINUTES = \
                 _config.SESSION_EXPIRATION_MINUTES  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "SOURCE_TEMPLATES_DIR"):
+        try:
             self.SOURCE_TEMPLATES_DIR = \
-                _config.SOURCE_TEMPLATES_DIR   # type: str
+                _config.SOURCE_TEMPLATES_DIR  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "STORE_DIR"):
-            self.STORE_DIR = _config.STORE_DIR  # type: str
+        try:
+            self.STORE_DIR = _config.STORE_DIR  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "SUPPORTED_LOCALES"):
-            self.SUPPORTED_LOCALES = _config.SUPPORTED_LOCALES  # type: ignore
+        try:
+            self.SUPPORTED_LOCALES = \
+                _config.SUPPORTED_LOCALES  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "TEMP_DIR"):
-            self.TEMP_DIR = _config.TEMP_DIR  # type: str
+        try:
+            self.TEMP_DIR = _config.TEMP_DIR  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "WORD_LIST"):
-            self.WORD_LIST = _config.WORD_LIST  # type: str
+        try:
+            self.WORD_LIST = _config.WORD_LIST  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "WORKER_PIDFILE"):
-            self.WORKER_PIDFILE = _config.WORKER_PIDFILE  # type: str
+        try:
+            self.WORKER_PIDFILE = _config.WORKER_PIDFILE  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "TRANSLATION_DIRS"):
+        try:
             self.TRANSLATION_DIRS = _config.TRANSLATION_DIRS  # type: ignore
+        except AttributeError:
+            pass
 
-        if hasattr(_config, "env"):
-            self.env = _config.env  # type: str
+        try:
+            self.env = _config.env  # type: ignore
+        except AttributeError:
+            pass
 
 
 config = SDConfig()  # type: SDConfig

--- a/securedrop/source.py
+++ b/securedrop/source.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import config
+from sdconfig import config
 
 from source_app import create_app
 

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -21,8 +21,13 @@ from source_app.decorators import ignore_static
 from source_app.utils import logged_in
 from store import Storage
 
+MYPY = False
+if MYPY:
+    from sdconfig import SDConfig  # noqa: F401
+
 
 def create_app(config):
+    # type: (SDConfig) -> Flask
     app = Flask(__name__,
                 template_folder=config.SOURCE_TEMPLATES_DIR,
                 static_folder=path.join(config.SECUREDROP_ROOT, 'static'))
@@ -79,7 +84,7 @@ def create_app(config):
     app.jinja_env.trim_blocks = True
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.globals['version'] = version.__version__
-    if getattr(config, 'CUSTOM_HEADER_IMAGE', None):
+    if config.CUSTOM_HEADER_IMAGE:
         app.jinja_env.globals['header_image'] = config.CUSTOM_HEADER_IMAGE
         app.jinja_env.globals['use_custom_header_image'] = True
     else:
@@ -92,7 +97,7 @@ def create_app(config):
     app.jinja_env.filters['filesizeformat'] = template_filters.filesizeformat
 
     for module in [main, info, api]:
-        app.register_blueprint(module.make_blueprint(config))
+        app.register_blueprint(module.make_blueprint(config))  # type: ignore
 
     @app.before_request
     @ignore_static

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -21,8 +21,13 @@ from source_app.decorators import ignore_static
 from source_app.utils import logged_in
 from store import Storage
 
-MYPY = False
-if MYPY:
+import typing
+# https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
+if typing.TYPE_CHECKING:
+    # flake8 can not understand type annotation yet.
+    # That is why all type annotation realted import
+    # statements has to be marked as noqa.
+    # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401
     from sdconfig import SDConfig  # noqa: F401
 
 
@@ -33,6 +38,7 @@ def create_app(config):
                 static_folder=path.join(config.SECUREDROP_ROOT, 'static'))
     app.request_class = RequestThatSecuresFileUploads
     app.config.from_object(config.SourceInterfaceFlaskConfig)
+    app.sdconfig = config
 
     # The default CSRF token expiration is 1 hour. Since large uploads can
     # take longer than an hour over Tor, we increase the valid window to 24h.
@@ -84,7 +90,7 @@ def create_app(config):
     app.jinja_env.trim_blocks = True
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.globals['version'] = version.__version__
-    if config.CUSTOM_HEADER_IMAGE:
+    if getattr(config, 'CUSTOM_HEADER_IMAGE', None):
         app.jinja_env.globals['header_image'] = config.CUSTOM_HEADER_IMAGE
         app.jinja_env.globals['use_custom_header_image'] = True
     else:

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -25,7 +25,7 @@ import typing
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
 if typing.TYPE_CHECKING:
     # flake8 can not understand type annotation yet.
-    # That is why all type annotation realted import
+    # That is why all type annotation relative import
     # statements has to be marked as noqa.
     # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401
     from sdconfig import SDConfig  # noqa: F401
@@ -91,7 +91,8 @@ def create_app(config):
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.globals['version'] = version.__version__
     if getattr(config, 'CUSTOM_HEADER_IMAGE', None):
-        app.jinja_env.globals['header_image'] = config.CUSTOM_HEADER_IMAGE
+        app.jinja_env.globals['header_image'] = \
+            config.CUSTOM_HEADER_IMAGE  # type: ignore
         app.jinja_env.globals['use_custom_header_image'] = True
     else:
         app.jinja_env.globals['header_image'] = 'logo.png'

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -10,7 +10,7 @@ import psutil
 import pytest
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import config
+from sdconfig import config
 
 # TODO: the PID file for the redis worker is hard-coded below.
 # Ideally this constant would be provided by a test harness.

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -21,7 +21,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import config
+from sdconfig import config
 import journalist_app
 import source_app
 import tests.utils.env as env

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -10,7 +10,7 @@ from selenium.webdriver.common.keys import Keys
 
 import tests.utils.db_helper as db_helper
 from models import Journalist
-import config
+from sdconfig import config
 
 
 class JournalistNavigationStepsMixin():

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -5,7 +5,7 @@ import unittest
 from flask import current_app
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import config
+from sdconfig import config
 import crypto_util
 import journalist_app
 import models

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -27,7 +27,7 @@ from flask_babel import gettext
 from werkzeug.datastructures import Headers
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import config
+from sdconfig import SDConfig, config
 import i18n
 import journalist_app
 import manage
@@ -56,10 +56,7 @@ class TestI18N(unittest.TestCase):
         self.__context.pop()
 
     def get_fake_config(self):
-        class Config:
-            def __getattr__(self, name):
-                return getattr(config, name)
-        return Config()
+        return SDConfig()
 
     def test_get_supported_locales(self):
         locales = ['en_US', 'fr_FR']

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -17,7 +17,7 @@ from flask import session, g, escape, current_app
 from mock import patch
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import config
+from sdconfig import config
 import journalist_app
 import source_app
 import utils

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1175,7 +1175,7 @@ class TestJournalistApp(TestCase):
 
     def test_journalist_session_expiration(self):
         try:
-            old_expiration = self.app.sdconfig.SESSION_EXPIRATION_MINUTES
+            old_expiration = config.SESSION_EXPIRATION_MINUTES
             has_session_expiration = True
         except AttributeError:
             has_session_expiration = False
@@ -1183,7 +1183,7 @@ class TestJournalistApp(TestCase):
         try:
             with self.client as client:
                 # set the expiration to ensure we trigger an expiration
-                self.app.sdconfig.SESSION_EXPIRATION_MINUTES = -1
+                config.SESSION_EXPIRATION_MINUTES = -1
 
                 # do a real login to get a real session
                 # (none of the mocking `g` hacks)
@@ -1206,7 +1206,9 @@ class TestJournalistApp(TestCase):
                         resp.data.decode('utf-8'))
         finally:
             if has_session_expiration:
-                self.app.sdconfig.SESSION_EXPIRATION_MINUTES = old_expiration
+                config.SESSION_EXPIRATION_MINUTES = old_expiration
+            else:
+                del config.SESSION_EXPIRATION_MINUTES
 
     def test_csrf_error_page(self):
         old_enabled = self.app.config['WTF_CSRF_ENABLED']

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -4,7 +4,7 @@ import argparse
 import os
 from os.path import abspath, dirname, exists, getmtime, join, realpath
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import config
+from sdconfig import config
 import logging
 import manage
 import mock

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -5,7 +5,7 @@ import unittest
 from gnupg._util import _is_stream
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import config
+from sdconfig import config
 import journalist_app
 import secure_tempfile
 import utils

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -8,7 +8,7 @@ from flask import session, escape, url_for, current_app
 from flask_testing import TestCase
 from mock import patch, ANY
 
-import config
+from sdconfig import config
 import source
 import utils
 import version

--- a/securedrop/tests/test_store.py
+++ b/securedrop/tests/test_store.py
@@ -10,7 +10,7 @@ import zipfile
 from flask import current_app
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import config
+from sdconfig import config
 import journalist_app
 import utils
 

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -7,7 +7,7 @@ import os
 from flask import session
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import config
+from sdconfig import SDConfig, config
 import i18n
 import journalist_app
 import manage
@@ -19,10 +19,7 @@ import version
 class TestTemplateFilters(object):
 
     def get_fake_config(self):
-        class Config:
-            def __getattr__(self, name):
-                return getattr(config, name)
-        return Config()
+        return SDConfig()
 
     def verify_rel_datetime_format(self, app):
         with app.test_client() as c:

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -8,7 +8,7 @@ import os
 from flask import current_app
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import config
+from sdconfig import config
 import models
 
 from db import db

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -9,7 +9,7 @@ import threading
 from os.path import abspath, dirname, isdir, join, realpath
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import config
+from sdconfig import config
 
 from db import db
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #3031 

We now pass around `SDConfig` which can be checked by mypy.

## Testing

`make ci-typinglint-image ci-typelint`


## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
