### PR TITLE
Fixes #2114 Adds clear caution messages

### DIFF
--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -53,9 +53,16 @@ Start by running the following commands to download the git repository.
 .. note:: Since the repository is fairly large and Tor can be slow,
 	  this may take a few minutes.
 
+.. caution:: Do not download SecureDrop Git repository as a Zip file,
+             or any other means. Only download by using the given git
+             command.
+
 
 Verify the Release Tag
 ~~~~~~~~~~~~~~~~~~~~~~
+
+.. caution:: Do not skip this step as this steps validates the files
+             in your Git repository.
 
 First, download and verify the **SecureDrop Release Signing Key**.
 


### PR DESCRIPTION
We should warn the administrators to only use the given git
commands to download the SecureDrop Git repository. This also
adds another caution message about not skipping the GPG
verification step.

## Status

Ready for review

## Description of Changes

Fixes #2114 

This adds two more caution blocks in the docs.

## Testing

`make docs` and read the updated `set_up_admin_tails.html#download-the-securedrop-repository` section.

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [x] Doc linting passed locally
