### PR TITLE
tests: use TAG when possible and default to git rev-parse HEAD

### DIFF
--- a/devops/scripts/dev-shell-ci
+++ b/devops/scripts/dev-shell-ci
@@ -7,6 +7,7 @@ set -eu
 source "${BASH_SOURCE%/*}/ticker"
 
 TOPLEVEL=$(git rev-parse --show-toplevel)
+: "${TAG:=$(git rev-parse HEAD)}"
 
 cd "${TOPLEVEL}"
 
@@ -23,7 +24,7 @@ function docker_image() {
 }
 
 function docker_run() {
-    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -ti securedrop-lint:"$(git rev-parse HEAD)" "$@"
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -ti securedrop-lint:"$TAG" "$@"
 }
 
 ticker docker_image


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

It is important to obey TAG in CircleCI because it will *not* always
match git rev-parse HEAD and will lead to inconsistencies.

## Testing

* make ci-lint locally to verify the defaults work
* the CircleCI should always succeed (difficult to verify except by running multiple times)

## Deployment

N/A
