### PR TITLE
test: the demo user needs to be admin

### DIFF
--- a/securedrop/create-demo-user.py
+++ b/securedrop/create-demo-user.py
@@ -38,4 +38,5 @@ def add_test_user(username, password, otp_secret, is_admin=False):
 if __name__ == "__main__":  # pragma: no cover
     add_test_user("journalist",
                   "WEjwn8ZyczDhQSK24YKM8C9a",
-                  "JHCOGO7VCER3EJ4L")
+                  "JHCOGO7VCER3EJ4L",
+                  is_admin=True)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

A demo user without admin rights does not allow to exercise all aspects of the journalist interface.

## Testing

* make -C securedrop dev
* firefox localhost:8081
* login as the demo user (see http://demo.securedrop.club/)

## Deployment

N/A
