### PR TITLE
tests: flake8 --exclude must be combined in the same value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ docs: ## Build project documentation in live reload for editing
 
 .PHONY: flake8
 flake8: ## Validates PEP8 compliance for Python source files.
-	flake8 --exclude='config.py' --exclude='.venv/'
+	flake8 --exclude='config.py,.venv/'
 
 .PHONY: app-lint
 app-lint: ## Tests pylint lint rule compliance.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

There cannot be multiple --exclude options, the last one will take
precedence.

## Testing

* checkout develop
* create a securedrop/config.py file
* devops/scripts/dev-shell-ci sudo make flake8
* see that it succeeds instead of complaining on config.py

## Deployment

N/A
