### PR TITLE
Release script: do not create tag for release candidates

### DIFF
--- a/securedrop/Dockerfile
+++ b/securedrop/Dockerfile
@@ -6,7 +6,8 @@ ARG USER_ID
 ENV USER_ID ${USER_ID:-0}
 
 RUN apt-get update && \
-    apt-get install -y python-pip libpython2.7-dev libssl-dev secure-delete \
+    apt-get install -y devscripts \
+                       python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
                        gettext paxctl x11vnc enchant
 

--- a/update_version.sh
+++ b/update_version.sh
@@ -10,10 +10,12 @@ if ! which dch > /dev/null ; then
   exit 1
 fi
 
-# Since we're running in a VM, we won't have access to ~/.gitconfig. So the
+cd "$(git rev-parse --show-toplevel)"
+
+# Since we may be running in a container, we may not  have access to ~/.gitconfig. So the
 # repo-level git user config file must be set.
-if ! grep -q '^\[user\]' /vagrant/.git/config; then
-    echo 'Please set your git user config in /vagrant/.git/config and retry!'
+if ! grep -q '^\[user\]' .git/config; then
+    echo 'Please set your git user config in .git/config and retry!'
     exit 1
 fi
 

--- a/update_version.sh
+++ b/update_version.sh
@@ -58,7 +58,7 @@ sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/conf.
 
 # Update the changelog
 sed -i "s/\(## ${OLD_VERSION}\)/## ${NEW_VERSION}\n\n\n\n\1/g" changelog.md
-vim +5 changelog.md
+vi +5 changelog.md
 
 export DEBEMAIL="${DEBEMAIL:-securedrop@freedom.press}"
 export DEBFULLNAME="${DEBFULLNAME:-SecureDrop Team}"

--- a/update_version.sh
+++ b/update_version.sh
@@ -63,12 +63,22 @@ dch -b -v "${NEW_VERSION}" -D trusty -c install_files/securedrop-app-code/usr/sh
 # Due to `set -e`, providing an empty commit message here will cause the script to abort early.
 git commit -a
 
-# Initiate the process of creating a signed tag, using the workflow for signing with the airgapped signing key.
-git tag -a "${NEW_VERSION}"
-TAGFILE="${NEW_VERSION}.tag"
-git cat-file tag "${NEW_VERSION}" > "${TAGFILE}"
-
-echo
 echo "[ok] Version update complete and committed."
-echo "     Please continue the airgapped signing process with the tag file: ${TAGFILE}"
-echo
+
+# We use the version string 0.x.y~rcz for the release candidate deb packages but
+# we use 0.x.y-rcz for the tags as "~" is an invalid character in a git tag.
+if [[ $NEW_VERSION == *~* ]]; then
+  # This is an rc and we should replace "~" with "-" in the tag version.
+  TAG_VERSION="${NEW_VERSION//\~/\-}"
+else
+  # This is a stable release.
+  TAG_VERSION="${NEW_VERSION}"
+fi
+
+git tag -a "${TAG_VERSION}"
+TAGFILE="${TAG_VERSION}.tag"
+git cat-file tag "${TAG_VERSION}" > "${TAGFILE}"
+echo "A tag has been generated: ${TAGFILE}"
+
+# Remind the developer that in order to create a signed tag for release, they must proceed with the airgapped signing process.
+echo "If you wish to release this version, please continue the airgapped signing process with the tag file."

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 ## Usage: ./update_version.sh <version>
 
-# Only run this on the Vagrant development VM, with dch and git available
 set -e
 
-# Only run this on the Vagrant development VM, with dch and git available
-if [[ "$USER" != 'vagrant' || "$(hostname)" != 'development' ]]; then
-  echo 'Only run this on the Vagrant development VM!'
+# Only run this on the development environment, where dch is available
+if ! which dch > /dev/null ; then
+  echo 'dch is missing'
+  echo 'run with securedrop/bin/dev-shell ../update_version.sh <version>'
   exit 1
 fi
 

--- a/update_version.sh
+++ b/update_version.sh
@@ -24,6 +24,11 @@ if [ -z "$NEW_VERSION" ]; then
   exit 1
 fi
 
+if [[ $NEW_VERSION == *-rc* ]]; then
+  echo "Release candidates should use the versioning 0.x.y~rcZ!"
+  exit 1
+fi
+
 # Get the old version from securedrop/version.py
 old_version_regex="^__version__ = '(.*)'$"
 [[ "$(cat securedrop/version.py)" =~ $old_version_regex ]]


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #2950

Previously, we used the version string 0.x.y-rcN for the Nth release
candidate for 0.x.y. Unfortunately, this rc version string was
considered a higher version than the actual release.

In 0.5.2 and beyond, we use the version string 0.x.y\~rcN for the Nth
release candidate for 0.x.y. This versioning scheme is correct, in
that Debian and Ubuntu recognize 0.x.y as a higher version than
0.x.y~rcN.

This commit updates our release script to create valid tags for
release candidates. Since the character "~" is not
a valid character in a git tag, without this change the script
will fail.

## Testing

1. A version string with a `~` produces a tag file with the name `0.x.y-rcZ`:

```
$ ./update_version.sh 0.5.3~rc1
...snip...
[ok] Version update complete and committed.
Since this is a release candidate, no tag has been generated.
```

2. A version string without `~` also produces a tag file:

```
$ ./update_version.sh 0.5.3
...snip...
[ok] Version update complete and committed.
     Please continue the airgapped signing process with the tag file: 0.5.3.tag
```

3. A version string with `-rc` in it exits: 

```
$ ./update_version.sh 0.5.7-rc1
Release candidates should use the versioning 0.x.y~rcZ!
```

## Deployment

Release process only

## Checklist

N/A