### PR TITLE
docs: Clarify setup instructions for TOTP in dev environment

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -92,6 +92,13 @@ the following credentials:
 * password: WEjwn8ZyczDhQSK24YKM8C9a
 * TOTP secret: JHCO GO7V CER3 EJ4L
 
+To generate the six digit token you need for logging in, use the TOTP secret in
+combination with an authenticator application that implements
+`RFC 6238 <https://tools.ietf.org/html/rfc6238>`__, such as
+`FreeOTP <https://freeotp.github.io/>`__ (Android and iOS) or
+`oathtool <http://www.nongnu.org/oath-toolkit/oathtool.1.html>`__
+(command line tool, multiple platforms).
+
 Setting up a multi-machine environment
 --------------------------------------
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3037 - clarifies the use of TOTP in the development environment (docs change only).

## Checklist
- [X] Doc linting passed locally
