### PR TITLE
use context managers to properly close resources

### DIFF
--- a/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
+++ b/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
@@ -20,24 +20,29 @@ path_persistent_desktop = '/lib/live/mount/persistence/TailsData_unlocked/dotfil
 
 # load torrc_additions
 if os.path.isfile(path_torrc_additions):
-    torrc_additions = open(path_torrc_additions).read()
+    with open(path_torrc_additions) as f:
+        torrc_additions = f.read()
 else:
     sys.exit('Error opening {0} for reading'.format(path_torrc_additions))
 
 # load torrc
 if os.path.isfile(path_torrc_backup):
-    torrc = open(path_torrc_backup).read()
+    with open(path_torrc_backup) as f:
+        torrc = f.read()
 else:
     if os.path.isfile(path_torrc):
-        torrc = open(path_torrc).read()
+        with open(path_torrc) as f:
+            torrc = f.read()
     else:
         sys.exit('Error opening {0} for reading'.format(path_torrc))
 
     # save a backup
-    open(path_torrc_backup, 'w').write(torrc)
+    with open(path_torrc_backup, 'w') as f:
+        f.write(torrc)
 
 # append the additions
-open(path_torrc, 'w').write(torrc + torrc_additions)
+with open(path_torrc, 'w') as f:
+    f.write(torrc + torrc_additions)
 
 # reload tor
 try:

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -73,9 +73,11 @@ def make_blueprint(config):
                 reply.filename,
             )
             try:
+                with open(reply_path) as f:
+                    contents = f.read()
                 reply.decrypted = current_app.crypto_util.decrypt(
                     g.codename,
-                    open(reply_path).read()).decode('utf-8')
+                    contents).decode('utf-8')
             except UnicodeDecodeError:
                 current_app.logger.error("Could not decode reply %s" %
                                          reply.filename)

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -60,7 +60,8 @@ def generate_unique_codename(config):
 
 
 def get_entropy_estimate():
-    return int(open('/proc/sys/kernel/random/entropy_avail').read())
+    with open('/proc/sys/kernel/random/entropy_avail') as f:
+        return int(f.read())
 
 
 def async(f):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3052

Use context managers when opening files in the application. This doesn't cover test cases since it needlessly clutters the test code.

## Testing

```bash
cd securedrop
make test
```
## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM