### PR TITLE
Documentation update for using gmail for OSSEC

### DIFF
--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -191,6 +191,8 @@ in this configuration — it will not work; instead you must navigate
 passwords, and generate a new App password which you will use as the
 ``sasl_passwd``.
 
+.. important::  You must go into the mailbox settings under "Forwarding and POP/IMAP" and enable POP.
+
 Once the account is created you can log out and provide the values for
 ``sasl_username`` as your new Gmail username (without the domain),
 ``sasl_domain``, which is typically gmail.com (or your custom Google


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Better documentation on using Gmail for OSSEC alerts. As a SD administrator, I should be able to follow the documentation and be able to receive encrypted emails. 

### If you made changes to documentation:

- [x] Doc linting passed locally
