### PR TITLE
Improvements in image upload functionality

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -51,5 +51,6 @@ appserver_dependencies:
   - apparmor-utils
   - redis-server
   - supervisor
+  - libjpeg-dev
 
 tor_apt_repo_url: https://tor-apt.freedom.press

--- a/install_files/securedrop-app-code/DEBIAN/control
+++ b/install_files/securedrop-app-code/DEBIAN/control
@@ -6,5 +6,5 @@ Homepage: https://securedrop.org
 Package: securedrop-app-code
 Version: 0.6~rc2
 Architecture: amd64
-Depends: python-pip,apparmor-utils,gnupg2,haveged,python,python-pip,secure-delete,sqlite,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor,securedrop-keyring,securedrop-config
+Depends: python-pip,apparmor-utils,gnupg2,haveged,python,python-pip,secure-delete,sqlite,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor,securedrop-keyring,securedrop-config,libjpeg-dev
 Description: Packages the SecureDrop application code pip dependencies and apparmor profiles. This package will put the apparmor profiles in enforce mode. This package does use pip to install the pip wheelhouse

--- a/molecule/builder/Dockerfile
+++ b/molecule/builder/Dockerfile
@@ -8,6 +8,6 @@ LABEL image_name="$NAME"
 
 RUN apt-get -y update && apt-get install -y python rsync sudo bash \
             devscripts git aptitude ipython libssl-dev ntp \
-            python-dev python-pip python-ipdb ruby tmux vim paxctl && \
+            python-dev python-pip python-ipdb ruby tmux vim paxctl libjpeg-dev && \
             aptitude -y dist-upgrade && \
             apt-get clean

--- a/securedrop/Dockerfile
+++ b/securedrop/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install -y devscripts \
                        python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
-                       gettext paxctl x11vnc enchant
+                       gettext paxctl x11vnc enchant libjpeg-dev
 
 RUN gem install sass -v 3.4.23
 

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -27,7 +27,7 @@ if typing.TYPE_CHECKING:
     # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401
     from sdconfig import SDConfig  # noqa: F401
 
-_insecure_views = ['main.login', 'static']
+_insecure_views = ['main.login', 'main.select_logo', 'static']
 
 
 def create_app(config):

--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from PIL import Image
+
 import os
 
 from flask import (Blueprint, render_template, request, url_for, redirect, g,
@@ -31,11 +33,19 @@ def make_blueprint(config):
         form = LogoForm()
         if form.validate_on_submit():
             f = form.logo.data
-            static_filepath = os.path.join(config.SECUREDROP_ROOT,
-                                           "static/i/logo.png")
-            f.save(static_filepath)
-            flash(gettext("Image updated."), "logo-success")
-            return redirect(url_for("admin.manage_config"))
+            custom_logo_filepath = os.path.join(config.SECUREDROP_ROOT,
+                                                "static/i/custom_logo.png")
+            try:
+                with Image.open(f) as im:
+                    im.thumbnail((500, 450), resample=3)
+                    im.save(custom_logo_filepath, "PNG")
+                flash(gettext("Image updated."), "logo-success")
+            except Exception:
+                flash("Unable to process the image file."
+                      " Try another one.", "logo-error")
+            finally:
+                return redirect(url_for("admin.manage_config"))
+
         else:
             for field, errors in form.errors.items():
                 for error in errors:

--- a/securedrop/journalist_app/forms.py
+++ b/securedrop/journalist_app/forms.py
@@ -59,5 +59,6 @@ class LogoForm(FlaskForm):
     logo = FileField(validators=[
         FileRequired(message=gettext('File required.')),
         FileAllowed(['jpg', 'png', 'jpeg'],
-                    message=gettext('Upload images only.'))
+                    message=gettext("You can only upload JPG/JPEG"
+                                    " or PNG image files."))
     ])

--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 from datetime import datetime
 from flask import (Blueprint, request, current_app, session, url_for, redirect,
                    render_template, g, flash, abort)
@@ -42,6 +44,14 @@ def make_blueprint(config):
         session.pop('uid', None)
         session.pop('expires', None)
         return redirect(url_for('main.index'))
+
+    @view.route('/org-logo')
+    def select_logo():
+        if os.path.exists(os.path.join(current_app.static_folder, 'i',
+                          'custom_logo.png')):
+            return redirect(url_for('static', filename='i/custom_logo.png'))
+        else:
+            return redirect(url_for('static', filename='i/logo.png'))
 
     @view.route('/')
     def index():

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -34,7 +34,7 @@
       <div class="container">
         {% block header %}
         <div id="header">
-          <a href="{{ url_for('main.index') }}"><img src="/static/i/{{ header_image }}" class="logo small" alt="SecureDrop" width="250px"></a>
+          <a href="{{ url_for('main.index') }}"><img src="{{ url_for('main.select_logo') }}" class="logo small" alt="SecureDrop" width="250px"></a>
           {% include 'locales.html' %}
           {% if use_custom_header_image %}
           <div class="powered">

--- a/securedrop/journalist_templates/config.html
+++ b/securedrop/journalist_templates/config.html
@@ -23,7 +23,7 @@
 <p>{{ gettext('Here you can update the image displayed on the SecureDrop web interfaces:') }}</p>
 
 <p>
-  <img src="{{ url_for('static', filename='i/logo.png')|autoversion }}" class="logo small" alt="SecureDrop" width="250px">
+  <img src="{{ url_for('main.select_logo') }}" class="logo small" alt="SecureDrop" width="250px">
 </p>
 
 <form method="post" enctype="multipart/form-data">
@@ -32,6 +32,9 @@
     {{ form.logo(id="logo-upload") }}
     <br>
   </p>
+  <h5>
+    {{ gettext('Recommended size: 500px * 450px') }}
+  </h5>
   <button type="submit" class="sd-button" id="submit-logo-update">
     <i class="fas fa-pencil-alt"></i>{{ gettext('UPDATE LOGO') }}
   </button>

--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -17,3 +17,4 @@ scrypt
 SQLAlchemy
 typing
 Werkzeug==0.12.2
+Pillow

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -17,6 +17,7 @@ itsdangerous==0.24        # via flask
 jinja2==2.10
 jsmin==2.2.2
 markupsafe==1.0           # via jinja2
+pillow==5.0.0
 psutil==5.4.3
 pycryptodomex==3.4.7
 pyotp==2.2.6

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -40,6 +40,14 @@ def make_blueprint(config):
         session['new_user'] = True
         return render_template('generate.html', codename=codename)
 
+    @view.route('/org-logo')
+    def select_logo():
+        if os.path.exists(os.path.join(current_app.static_folder, 'i',
+                          'custom_logo.png')):
+            return redirect(url_for('static', filename='i/custom_logo.png'))
+        else:
+            return redirect(url_for('static', filename='i/logo.png'))
+
     @view.route('/create', methods=['POST'])
     def create():
         filesystem_id = current_app.crypto_util.hash_codename(

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -17,7 +17,7 @@
         {% block header %}
         <div id="header">
           <a href="{% if 'logged_in' in session %}{{ url_for('main.lookup') }}{% else %}{{ url_for('main.index') }}{% endif %}">
-            <img src="/static/i/{{ header_image }}" class="logo small" alt="SecureDrop" width="250px">
+            <img src="{{ url_for('main.select_logo') }}" class="logo small" alt="SecureDrop" width="250px">
           </a>
           {% include 'locales.html' %}
           {% if use_custom_header_image %}

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -26,7 +26,7 @@
            See _source_index.sass for a more full understanding. #}
         <div class="index-wrap">
           <div class="header">
-            <img src="/static/i/{{ header_image }}" alt="SecureDrop">
+            <img src="{{ url_for('main.select_logo') }}" alt="SecureDrop">
             {% if use_custom_header_image %}
             <div class="powered">
               {{ gettext('Powered by') }}<br>

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -5,8 +5,10 @@ import io
 import random
 import unittest
 import zipfile
+import base64
 
 from cStringIO import StringIO
+from io import BytesIO
 from flask import url_for, escape, session, current_app, g
 from flask_testing import TestCase
 from mock import patch
@@ -954,9 +956,11 @@ class TestJournalistApp(TestCase):
 
         try:
             self._login_admin()
-
+            # Create 1px * 1px 'white' PNG file from its base64 string
             form = journalist_app_module.forms.LogoForm(
-                logo=(StringIO('imagedata'), 'test.png')
+                logo=(BytesIO(base64.decodestring
+                      ("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQ"
+                       "VR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=")), 'test.png')
             )
             self.client.post(url_for('admin.manage_config'),
                              data=form.data,
@@ -977,8 +981,10 @@ class TestJournalistApp(TestCase):
         resp = self.client.post(url_for('admin.manage_config'),
                                 data=form.data,
                                 follow_redirects=True)
-        self.assertMessageFlashed("Upload images only.", "logo-error")
-        self.assertIn('Upload images only.', resp.data)
+        self.assertMessageFlashed("You can only upload JPG/JPEG"
+                                  " or PNG image files.", "logo-error")
+        self.assertIn("You can only upload JPG/JPEG"
+                      " or PNG image files.", resp.data)
 
     def test_logo_upload_with_empty_input_field_fails(self):
         self._login_admin()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR-

1. Fixes #2807 by resizing the uploaded logo to a maximum width of 500px, or a maximum height of 450px (whichever is higher) while maintaining the original aspect ratio. Maximum limit is chosen in accordance with the recommended size by SecureDrop docs. Images with dimensions below this constraint are not resized.

2. Fixes #3043 by converting JPG/JPEG image files to PNG before saving them. Thus no matter which format the Admin chooses to upload, the final image is always a PNG file.

3. Possibly fixes #2801 by adding a message at the logo upload screen informing the user about the recommended image size as per the docs.

![fofvv3l](https://user-images.githubusercontent.com/29029116/36511428-9f7430a6-178c-11e8-8531-c452183d9436.jpg)

4. Fixes #3058 by only accepting valid image files.

![screenshot from 2018-02-22 22-27-11](https://user-images.githubusercontent.com/29029116/36552564-290a1bf8-1820-11e8-8140-fe1b95977632.jpg)

## Dependencies Introduced

1. Python `Pillow`, installed via `pip`

2. `libjpeg-dev`, installed via `apt`


## Testing

1. After successfully uploading, image size can be verified by checking the dimensions of `securedrop/securedrop/static/i/custom_logo.png`.

2. After successfully uploading a JPG/JPEG image, it can be verified that `securedrop/securedrop/static/i/` always contains `custom_logo.png`

3. Journalist app should display the recommended size on the upload page.

4. Try to upload a non-image file with an extension like JPG/JPEG/PNG. A warning message should appear that image cannot be processed.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM
