### PR TITLE
Change venv python binary setup docs on macOS

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -209,7 +209,7 @@ different version, the path to ``virtualenvwrapper.sh`` will differ. Running
     sudo easy_install pip # if you don't already have pip
     sudo -H pip install -U virtualenvwrapper --ignore-installed six
     source /usr/local/bin/virtualenvwrapper.sh
-    mkvirtualenv -p python2 securedrop
+    mkvirtualenv -p python securedrop
 
 .. note:: You'll want to add the command to source ``virtualenvwrapper.sh``
           to your ``~/.bashrc`` (or whatever your default shell configuration


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Make a one line change in the documentation regarding setting up the development environment on macOS.

In a default install of macOS High Sierra, there is no `python2` binary in PATH. `python` in PATH defaults to Python 2, so simply renaming `python2` to `python` as the python binary when creating a virtualenv is good here.

## Testing

How should the reviewer test this PR?

Besides making sure to check for doc building and linting, checking for typos would be good. Additionally, if the reviewer is on macOS High Sierra, or on an older supported version of macOS, following the instructions in a new virtualenv would be great.

Write out any special testing steps here.

When testing the docs on a macOS High Sierra box, instead of making a `securedrop` env, consider choosing another unused name, like `securedrop2`.

## Deployment

The docs changes will be deployed upon release of the next version of SecureDrop.

## Checklist

- [x] Doc linting passed locally
