### PR TITLE
Fixes #3063 uses io.open call everywhere

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -26,6 +26,7 @@ instances.
 import argparse
 import logging
 import os
+import io
 import re
 import string
 import subprocess
@@ -363,14 +364,14 @@ class SiteConfig(object):
         return os.path.exists(self.args.site_config)
 
     def save(self):
-        with open(self.args.site_config, 'w') as site_config_file:
+        with io.open(self.args.site_config, 'w') as site_config_file:
             yaml.safe_dump(self.config,
                            site_config_file,
                            default_flow_style=False)
 
     def load(self):
         try:
-            with open(self.args.site_config) as site_config_file:
+            with io.open(self.args.site_config) as site_config_file:
                 return yaml.safe_load(site_config_file)
         except IOError:
             sdlog.error("Config file missing, re-run with sdconfig")

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import io
 import argparse
 from os.path import dirname, join, basename, exists
 import mock
@@ -347,7 +348,7 @@ class TestSiteConfig(object):
         var1: val1
         var2: val2
         """)
-        assert expected == open(site_config_path).read()
+        assert expected == io.open(site_config_path).read()
 
     def test_validate_gpg_key(self, caplog):
         args = argparse.Namespace(site_config='INVALID',

--- a/install_files/ansible-base/inventory-dynamic
+++ b/install_files/ansible-base/inventory-dynamic
@@ -5,6 +5,7 @@ for SSH. The THS must already be provisioned on the target host.
 """
 import json
 import os
+import io
 import subprocess
 import yaml
 
@@ -41,7 +42,7 @@ def lookup_local_ipv4_address(hostname):
     Tor Hidden Services.
     """
     try:
-        with open(SECUREDROP_SITE_VARS, 'r') as f:
+        with io.open(SECUREDROP_SITE_VARS, 'r') as f:
             site_vars = yaml.safe_load(f)
             app_ip = site_vars['app_ip']
             monitor_ip = site_vars['monitor_ip']
@@ -69,7 +70,7 @@ def lookup_admin_username():
     vars file contains a list for this value.
     """
     try:
-        with open(SECUREDROP_SITE_VARS, 'r') as f:
+        with io.open(SECUREDROP_SITE_VARS, 'r') as f:
             site_vars = yaml.safe_load(f)
             admin_username = site_vars['ssh_users']
 
@@ -98,7 +99,7 @@ def lookup_tor_hostname(hostname):
     """
     aths_path = os.path.join(SECUREDROP_ANSIBLE_DIRECTORY,
                              "{}-ssh-aths".format(hostname))
-    with open(aths_path, 'r') as f:
+    with io.open(aths_path, 'r') as f:
         tor_config = f.readline().rstrip().split()
         try:
             # Ordinarily the Onion URL would be the first field in the file,

--- a/install_files/ansible-base/roles/backup/files/0.3_collect.py
+++ b/install_files/ansible-base/roles/backup/files/0.3_collect.py
@@ -9,6 +9,7 @@ to backup the 0.3 system and stores it in /tmp/sd-backup-0.3-TIME_STAMP.zip.gpg
 
 import sys
 import os
+import io
 import zipfile
 from datetime import datetime
 # Import the application config.py file
@@ -58,7 +59,7 @@ def encrypt_zip_file(zf_fn):
     gpg = gnupg.GPG(binary='gpg2', homedir=config.GPG_KEY_DIR)
     e_fn = '{}.gpg'.format(zf_fn)
 
-    stream = open(zf_fn, "rb")
+    stream = io.open(zf_fn, "rb")
     gpg.encrypt_file(stream, config.JOURNALIST_KEY, always_trust='True',
                      output=e_fn)
 

--- a/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
+++ b/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
@@ -2,6 +2,7 @@
 
 import grp
 import os
+import io
 import pwd
 import sys
 import subprocess
@@ -20,28 +21,28 @@ path_persistent_desktop = '/lib/live/mount/persistence/TailsData_unlocked/dotfil
 
 # load torrc_additions
 if os.path.isfile(path_torrc_additions):
-    with open(path_torrc_additions) as f:
+    with io.open(path_torrc_additions) as f:
         torrc_additions = f.read()
 else:
     sys.exit('Error opening {0} for reading'.format(path_torrc_additions))
 
 # load torrc
 if os.path.isfile(path_torrc_backup):
-    with open(path_torrc_backup) as f:
+    with io.open(path_torrc_backup) as f:
         torrc = f.read()
 else:
     if os.path.isfile(path_torrc):
-        with open(path_torrc) as f:
+        with io.open(path_torrc) as f:
             torrc = f.read()
     else:
         sys.exit('Error opening {0} for reading'.format(path_torrc))
 
     # save a backup
-    with open(path_torrc_backup, 'w') as f:
+    with io.open(path_torrc_backup, 'w') as f:
         f.write(torrc)
 
 # append the additions
-with open(path_torrc, 'w') as f:
+with io.open(path_torrc, 'w') as f:
     f.write(torrc + torrc_additions)
 
 # reload tor

--- a/molecule/ansible-config/tests/test_max_fail_percentage.py
+++ b/molecule/ansible-config/tests/test_max_fail_percentage.py
@@ -1,5 +1,5 @@
 import os
-
+import io
 import pytest
 import yaml
 
@@ -55,7 +55,7 @@ def test_max_fail_percentage(host, playbook):
     the parameter, but we'll play it safe and require it everywhere,
     to avoid mistakes down the road.
     """
-    with open(playbook, 'r') as f:
+    with io.open(playbook, 'r') as f:
         playbook_yaml = yaml.safe_load(f)
         # Descend into playbook list structure to validate play attributes.
         for play in playbook_yaml:
@@ -71,7 +71,7 @@ def test_any_errors_fatal(host, playbook):
     to "0", doing so ensures that any errors will cause an immediate failure
     on the playbook.
     """
-    with open(playbook, 'r') as f:
+    with io.open(playbook, 'r') as f:
         playbook_yaml = yaml.safe_load(f)
         # Descend into playbook list structure to validate play attributes.
         for play in playbook_yaml:

--- a/molecule/aws/tests/test_tor_interfaces.py
+++ b/molecule/aws/tests/test_tor_interfaces.py
@@ -1,3 +1,4 @@
+import io
 import os
 import re
 import pytest
@@ -20,7 +21,7 @@ def test_www(host, site):
         os.path.dirname(__file__),
         "../../../install_files/ansible-base/{}".format(site['file'])
     )
-    onion_url_raw = open(onion_url_filepath, 'ro').read()
+    onion_url_raw = io.open(onion_url_filepath, 'ro').read()
     onion_url = re.search("\w+\.onion", onion_url_raw).group()
 
     # Fetch Onion URL via curl to confirm interface is rendered correctly.

--- a/molecule/builder/tests/conftest.py
+++ b/molecule/builder/tests/conftest.py
@@ -3,6 +3,7 @@ Import variables from vars.yml and inject into pytest namespace
 """
 
 import os
+import io
 import yaml
 
 
@@ -11,5 +12,5 @@ def pytest_namespace():
         global namespace
     """
     filepath = os.path.join(os.path.dirname(__file__), "vars.yml")
-    with open(filepath, 'r') as f:
+    with io.open(filepath, 'r') as f:
         return dict(securedrop_test_vars=yaml.safe_load(f))

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -3,6 +3,7 @@
 
 import gnupg
 import os
+import io
 import scrypt
 import subprocess
 
@@ -64,10 +65,10 @@ class CryptoUtil:
         # map code for a given language to a localized wordlist
         self.__language2words = {}  # type: Dict[Text, List[str]]
 
-        with open(nouns_file) as f:
+        with io.open(nouns_file) as f:
             self.nouns = f.read().splitlines()
 
-        with open(adjectives_file) as f:
+        with io.open(adjectives_file) as f:
             self.adjectives = f.read().splitlines()
 
     # Make sure these pass before the app can run
@@ -104,7 +105,7 @@ class CryptoUtil:
             else:
                 wordlist_path = self.__word_list
 
-            with open(wordlist_path) as f:
+            with io.open(wordlist_path) as f:
                 content = f.read().splitlines()
                 self.__language2words[locale] = content
 

--- a/securedrop/secure_tempfile.py
+++ b/securedrop/secure_tempfile.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import base64
 import os
+import io
 from tempfile import _TemporaryFileWrapper
 
 from gnupg._util import _STREAMLIKE_TYPES
@@ -47,7 +48,7 @@ class SecureTemporaryFile(_TemporaryFileWrapper, object):
         self.tmp_file_id = base64.urlsafe_b64encode(os.urandom(32)).strip('=')
         self.filepath = os.path.join(store_dir,
                                      '{}.aes'.format(self.tmp_file_id))
-        self.file = open(self.filepath, 'w+b')
+        self.file = io.open(self.filepath, 'w+b')
         super(SecureTemporaryFile, self).__init__(self.file, self.filepath)
 
     def create_key(self):

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -1,5 +1,6 @@
 import operator
 import os
+import io
 
 from datetime import datetime
 from flask import (Blueprint, render_template, flash, redirect, url_for, g,
@@ -73,7 +74,7 @@ def make_blueprint(config):
                 reply.filename,
             )
             try:
-                with open(reply_path) as f:
+                with io.open(reply_path, "rb") as f:
                     contents = f.read()
                 reply.decrypted = current_app.crypto_util.decrypt(
                     g.codename,

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import subprocess
 
@@ -60,7 +61,7 @@ def generate_unique_codename(config):
 
 
 def get_entropy_estimate():
-    with open('/proc/sys/kernel/random/entropy_avail') as f:
+    with io.open('/proc/sys/kernel/random/entropy_avail') as f:
         return int(f.read())
 
 

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -3,6 +3,7 @@
 import gnupg
 import logging
 import os
+import io
 import psutil
 import pytest
 import shutil
@@ -71,9 +72,9 @@ def config(tmpdir):
     sqlite = data.join('db.sqlite')
 
     gpg = gnupg.GPG(homedir=str(keys))
-    with open(path.join(path.dirname(__file__),
-                        'files',
-                        'test_journalist_key.pub')) as f:
+    with io.open(path.join(path.dirname(__file__),
+                           'files',
+                           'test_journalist_key.pub')) as f:
         gpg.import_keys(f.read())
 
     cnf.SECUREDROP_DATA_ROOT = str(data)
@@ -138,7 +139,7 @@ def test_source(journalist_app):
 
 def _start_test_rqworker(config):
     if not psutil.pid_exists(_get_pid_from_file(TEST_WORKER_PIDFILE)):
-        tmp_logfile = open('/tmp/test_rqworker.log', 'w')
+        tmp_logfile = io.open('/tmp/test_rqworker.log', 'w')
         subprocess.Popen(['rqworker', 'test',
                           '-P', config.SECUREDROP_ROOT,
                           '--pid', TEST_WORKER_PIDFILE],
@@ -158,7 +159,7 @@ def _stop_test_rqworker():
 
 def _get_pid_from_file(pid_file_name):
     try:
-        return int(open(pid_file_name).read())
+        return int(io.open(pid_file_name).read())
     except IOError:
         return None
 

--- a/securedrop/tests/functional/test_submission_not_in_memory.py
+++ b/securedrop/tests/functional/test_submission_not_in_memory.py
@@ -2,6 +2,7 @@ from functional_test import FunctionalTest
 import subprocess
 from source_navigation_steps import SourceNavigationStepsMixin
 import os
+import io
 import pytest
 import getpass
 import re
@@ -11,7 +12,7 @@ class TestSubmissionNotInMemory(FunctionalTest,
                                 SourceNavigationStepsMixin):
 
     def setup(self):
-        self.devnull = open('/dev/null', 'r')
+        self.devnull = io.open('/dev/null', 'r')
         FunctionalTest.setup(self)
 
     def teardown(self):
@@ -26,7 +27,7 @@ class TestSubmissionNotInMemory(FunctionalTest,
                             stderr=self.devnull)
             subprocess.call(["sudo", "chown", getpass.getuser(),
                             core_dump_file_name])
-            with open(core_dump_file_name, 'r') as fp:
+            with io.open(core_dump_file_name, 'r') as fp:
                 return fp.read()
         finally:
             pass

--- a/securedrop/tests/pages-layout/functional_test.py
+++ b/securedrop/tests/pages-layout/functional_test.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import os
+import io
 from os.path import abspath, dirname, realpath
 import pytest
 
@@ -74,5 +75,5 @@ class FunctionalTest(functional_test.FunctionalTest):
         actions.perform()
 
     def _save_alert(self, filename):
-        fd = open(os.path.join(self.log_dir, filename), 'wb')
+        fd = io.open(os.path.join(self.log_dir, filename), 'wb')
         fd.write(self.driver.switch_to.alert.text.encode('utf-8'))

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import io
 import unittest
 
 from flask import current_app
@@ -98,7 +99,7 @@ class TestCryptoUtil(unittest.TestCase):
         `gnupg._util._is_stream(plaintext)` returns `True`).
         """
         source, codename = utils.db_helper.init_source()
-        with open(os.path.realpath(__file__)) as fh:
+        with io.open(os.path.realpath(__file__)) as fh:
             ciphertext = current_app.crypto_util.encrypt(
                 fh,
                 [current_app.crypto_util.getkey(source.filesystem_id),
@@ -106,7 +107,7 @@ class TestCryptoUtil(unittest.TestCase):
                 current_app.storage.path(source.filesystem_id, 'somefile.gpg'))
         plaintext = current_app.crypto_util.decrypt(codename, ciphertext)
 
-        with open(os.path.realpath(__file__)) as fh:
+        with io.open(os.path.realpath(__file__)) as fh:
             self.assertEqual(fh.read(), plaintext)
 
     def test_encrypt_fingerprints_not_a_list_or_tuple(self):

--- a/securedrop/tests/test_i18n_tool.py
+++ b/securedrop/tests/test_i18n_tool.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import io
 import os
 from os.path import abspath, dirname, exists, getmtime, join, realpath
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
@@ -37,8 +38,9 @@ class TestI18NTool(object):
         i18n_tool.translate_desktop(args)
         messages_file = join(str(tmpdir), 'desktop.pot')
         assert exists(messages_file)
-        pot = open(messages_file).read()
-        assert 'SecureDrop Source Interfaces' in pot
+        with io.open(messages_file) as fobj:
+            pot = fobj.read()
+            assert 'SecureDrop Source Interfaces' in pot
         # pretend this happened a few seconds ago
         few_seconds_ago = time.time() - 60
         os.utime(messages_file, (few_seconds_ago, few_seconds_ago))
@@ -81,11 +83,13 @@ class TestI18NTool(object):
         old_messages_mtime = current_messages_mtime
         i18n_tool.translate_desktop(args)
         assert old_messages_mtime == getmtime(messages_file)
-        po = open(po_file).read()
-        assert 'SecureDrop Source Interfaces' in po
-        assert 'SecureDrop Journalist Interfaces' not in po
-        i18n = open(i18n_file).read()
-        assert 'SOURCE FR' in i18n
+        with io.open(po_file) as fobj:
+            po = fobj.read()
+            assert 'SecureDrop Source Interfaces' in po
+            assert 'SecureDrop Journalist Interfaces' not in po
+        with io.open(i18n_file) as fobj:
+            i18n = fobj.read()
+            assert 'SOURCE FR' in i18n
 
     def test_translate_messages_l10n(self, tmpdir):
         source = [
@@ -106,9 +110,10 @@ class TestI18NTool(object):
         i18n_tool.translate_messages(args)
         messages_file = join(str(tmpdir), 'messages.pot')
         assert exists(messages_file)
-        pot = open(messages_file).read()
-        assert 'code hello i18n' in pot
-        assert 'template hello i18n' in pot
+        with io.open(messages_file) as fobj:
+            pot = fobj.read()
+            assert 'code hello i18n' in pot
+            assert 'template hello i18n' in pot
 
         locale = 'en_US'
         locale_dir = join(str(tmpdir), locale)
@@ -121,9 +126,10 @@ class TestI18NTool(object):
         assert not exists(mo_file)
         i18n_tool.translate_messages(args)
         assert exists(mo_file)
-        mo = open(mo_file).read()
-        assert 'code hello i18n' in mo
-        assert 'template hello i18n' in mo
+        with io.open(mo_file) as fobj:
+            mo = fobj.read()
+            assert 'code hello i18n' in mo
+            assert 'template hello i18n' in mo
 
     def test_translate_messages_compile_arg(self, tmpdir):
         source = [
@@ -143,8 +149,9 @@ class TestI18NTool(object):
         i18n_tool.translate_messages(args)
         messages_file = join(str(tmpdir), 'messages.pot')
         assert exists(messages_file)
-        pot = open(messages_file).read()
-        assert 'code hello i18n' in pot
+        with io.open(messages_file) as fobj:
+            pot = fobj.read()
+            assert 'code hello i18n' in pot
 
         locale = 'en_US'
         locale_dir = join(str(tmpdir), locale)
@@ -184,9 +191,10 @@ class TestI18NTool(object):
         old_po_mtime = current_po_mtime
         i18n_tool.translate_messages(args)
         assert old_po_mtime == getmtime(po_file)
-        mo = open(mo_file).read()
-        assert 'code hello i18n' in mo
-        assert 'template hello i18n' not in mo
+        with io.open(mo_file) as fobj:
+            mo = fobj.read()
+            assert 'code hello i18n' in mo
+            assert 'template hello i18n' not in mo
 
 
 class TestSh(object):

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import pytest
+import io
 import random
 import unittest
 import zipfile
@@ -948,7 +949,7 @@ class TestJournalistApp(TestCase):
         # Save original logo to restore after test run
         logo_image_location = os.path.join(config.SECUREDROP_ROOT,
                                            "static/i/logo.png")
-        with open(logo_image_location) as logo_file:
+        with io.open(logo_image_location, 'rb') as logo_file:
             original_image = logo_file.read()
 
         try:
@@ -964,7 +965,7 @@ class TestJournalistApp(TestCase):
             self.assertMessageFlashed("Image updated.", "logo-success")
         finally:
             # Restore original image to logo location for subsequent tests
-            with open(logo_image_location, 'w') as logo_file:
+            with io.open(logo_image_location, 'wb') as logo_file:
                 logo_file.write(original_image)
 
     def test_logo_upload_with_invalid_filetype_fails(self):

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import io
 import logging
 import os
 import manage
@@ -162,7 +163,6 @@ def test_get_username_to_delete(mocker):
     return_value = manage._get_username_to_delete()
     assert return_value == 'test-user-12345'
 
-
 def test_reset(journalist_app, test_journo, config):
     original_config = manage.config
     try:
@@ -202,7 +202,7 @@ def test_clean_tmp_too_young(config, caplog):
                               directory=config.TEMP_DIR,
                               verbose=logging.DEBUG)
     # create a file
-    open(os.path.join(config.TEMP_DIR, 'FILE'), 'a').close()
+    io.open(os.path.join(config.TEMP_DIR, 'FILE'), 'a').close()
 
     manage.setup_verbosity(args)
     manage.clean_tmp(args)
@@ -214,7 +214,7 @@ def test_clean_tmp_removed(config, caplog):
                               directory=config.TEMP_DIR,
                               verbose=logging.DEBUG)
     fname = os.path.join(config.TEMP_DIR, 'FILE')
-    with open(fname, 'a'):
+    with io.open(fname, 'a'):
         old = time.time() - 24*60*60
         os.utime(fname, (old, old))
     manage.setup_verbosity(args)

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -163,6 +163,7 @@ def test_get_username_to_delete(mocker):
     return_value = manage._get_username_to_delete()
     assert return_value == 'test-user-12345'
 
+
 def test_reset(journalist_app, test_journo, config):
     original_config = manage.config
     try:

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import io
 import unittest
 
 from gnupg._util import _is_stream
@@ -62,7 +63,7 @@ class TestSecureTempfile(unittest.TestCase):
 
     def test_file_seems_encrypted(self):
         self.f.write(self.msg)
-        with open(self.f.filepath, 'rb') as fh:
+        with io.open(self.f.filepath, 'rb') as fh:
             contents = fh.read().decode()
 
         self.assertNotIn(self.msg, contents)

--- a/securedrop/tests/test_store.py
+++ b/securedrop/tests/test_store.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import io
 import pytest
 import re
 import shutil
@@ -37,7 +38,7 @@ class TestStore(unittest.TestCase):
         os.makedirs(source_directory)
 
         file_path = os.path.join(source_directory, filename)
-        with open(file_path, 'a'):
+        with io.open(file_path, 'a'):
             os.utime(file_path, None)
 
         return source_directory, file_path
@@ -140,7 +141,7 @@ class TestStore(unittest.TestCase):
         archivefile_contents = archive.namelist()
 
         for archived_file, actual_file in zip(archivefile_contents, filenames):
-            actual_file_content = open(actual_file).read()
+            actual_file_content = io.open(actual_file, 'rb').read()
             zipped_file_content = archive.read(archived_file)
             self.assertEquals(zipped_file_content, actual_file_content)
 

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -3,6 +3,7 @@
 """
 import gnupg
 import os
+import io
 import shutil
 import threading
 
@@ -40,7 +41,7 @@ def init_gpg():
     # Faster to import a pre-generated key than to gen a new one every time.
     for keyfile in (join(FILES_DIR, "test_journalist_key.pub"),
                     join(FILES_DIR, "test_journalist_key.sec")):
-        gpg.import_keys(open(keyfile).read())
+        gpg.import_keys(io.open(keyfile).read())
     return gpg
 
 

--- a/testinfra/app/test_network.py
+++ b/testinfra/app/test_network.py
@@ -1,4 +1,5 @@
 import os
+import io
 import difflib
 import pytest
 from jinja2 import Template
@@ -27,7 +28,7 @@ def test_app_iptables_rules(SystemInfo, Command, Sudo):
                           environment)
 
     # template out a local iptables jinja file
-    jinja_iptables = Template(open(iptables_file, 'r').read())
+    jinja_iptables = Template(io.open(iptables_file, 'r').read())
     iptables_expected = jinja_iptables.render(**kwargs)
 
     with Sudo():

--- a/testinfra/conftest.py
+++ b/testinfra/conftest.py
@@ -6,6 +6,7 @@ can be reused across multiple hosts, with varied targets.
 Vars should be placed in `testinfra/vars/<hostname>.yml`.
 """
 
+import io
 import os
 import yaml
 
@@ -23,7 +24,7 @@ def securedrop_import_testinfra_vars(hostname, with_header=False):
     Vars must be stored in `testinfra/vars/<hostname>.yml`.
     """
     filepath = os.path.join(os.path.dirname(__file__), "vars", hostname+".yml")
-    with open(filepath, 'r') as f:
+    with io.open(filepath, 'r') as f:
         hostvars = yaml.safe_load(f)
 
     if with_header:

--- a/testinfra/mon/test_network.py
+++ b/testinfra/mon/test_network.py
@@ -1,3 +1,4 @@
+import io
 import os
 import difflib
 import pytest
@@ -27,7 +28,7 @@ def test_mon_iptables_rules(SystemInfo, Command, Sudo):
         environment)
 
     # template out a local iptables jinja file
-    jinja_iptables = Template(open(iptables_file, 'r').read())
+    jinja_iptables = Template(io.open(iptables_file, 'r').read())
     iptables_expected = jinja_iptables.render(**kwargs)
 
     with Sudo():


### PR DESCRIPTION
We are now using `io.open` call instead of `open` builtin.
This will help us to move forward one step to the Python3 world.
https://docs.python.org/3/howto/pyporting.html#update-your-code

## Status

Ready for review

## Description of Changes

Fixes #3063 

Changes proposed in this pull request:

## Testing

`make test`

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
