### PR TITLE
build: pip wheel must fail when it does not build a python module

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/build_securedrop_app_code_deb.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/build_securedrop_app_code_deb.yml
@@ -33,10 +33,11 @@
 - include: sass.yml
 
 - name: Create pip wheel archive for Debian package requirements.
-  command: >
-    pip wheel
-    -r {{ securedrop_code_filtered }}/requirements/securedrop-app-code-requirements.txt
-    -w {{ securedrop_app_code_deb_dir }}/var/securedrop/wheelhouse
+  shell: |
+    pip wheel \
+      -r {{ securedrop_code_filtered }}/requirements/securedrop-app-code-requirements.txt \
+      -w {{ securedrop_app_code_deb_dir }}/var/securedrop/wheelhouse 2>&1 | tee /tmp/w.out
+      ! grep -i --quiet 'Failed to build' /tmp/w.out
   tags: pip
 
 - include: translations.yml

--- a/molecule/builder/Dockerfile
+++ b/molecule/builder/Dockerfile
@@ -1,5 +1,5 @@
-# ubuntu:14.04 as of 2017-12-15
-FROM ubuntu@sha256:084989eb923bd86dbf7e706d464cf3587274a826b484f75b69468c19f8ae354c
+ARG IMAGE
+FROM $IMAGE
 
 RUN apt-get -y update && apt-get install -y python rsync sudo bash \
             devscripts git aptitude ipython libssl-dev ntp \

--- a/molecule/builder/Dockerfile
+++ b/molecule/builder/Dockerfile
@@ -2,6 +2,7 @@ ARG IMAGE
 FROM $IMAGE
 
 # additional meta-data makes it easier to clean up, find
+ARG NAME
 LABEL org="Freedom of the Press"
 LABEL image_name="$NAME"
 

--- a/molecule/builder/Dockerfile
+++ b/molecule/builder/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:14.04
+# ubuntu:14.04 as of 2017-12-15
+FROM ubuntu@sha256:084989eb923bd86dbf7e706d464cf3587274a826b484f75b69468c19f8ae354c
 
 RUN apt-get -y update && apt-get install -y python rsync sudo bash \
             devscripts git aptitude ipython libssl-dev ntp \

--- a/molecule/builder/Dockerfile
+++ b/molecule/builder/Dockerfile
@@ -1,6 +1,10 @@
 ARG IMAGE
 FROM $IMAGE
 
+# additional meta-data makes it easier to clean up, find
+LABEL org="Freedom of the Press"
+LABEL image_name="$NAME"
+
 RUN apt-get -y update && apt-get install -y python rsync sudo bash \
             devscripts git aptitude ipython libssl-dev ntp \
             python-dev python-pip python-ipdb ruby tmux vim paxctl && \

--- a/molecule/builder/Dockerfile.j2
+++ b/molecule/builder/Dockerfile.j2
@@ -1,7 +1,0 @@
-FROM {{ item.image }}
-
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
-    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
-    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
-    elif [ $(command -v dnf) ]; then dnf makecache fast && dnf --assumeyes install python python-devel python2-dnf bash && dnf clean all; fi

--- a/molecule/builder/create.yml
+++ b/molecule/builder/create.yml
@@ -8,13 +8,17 @@
     molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
     molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
-    docker_hash: "{{ lookup('file', '../docker_hashes.yml') | from_yaml }}"
   tasks:
+    - name: Create builder image
+      docker_image:
+        name: builder
+        path: .
+        force: yes
     - name: Create molecule instance(s)
       docker_container:
         name: "{{ item.name }}"
         hostname: "{{ item.name }}"
-        image: "{{ item.image }}@{{ docker_hash[item.hash_name] }}"
+        image: builder
         state: started
         recreate: True
         command: "tail -f /dev/null"

--- a/molecule/builder/create.yml
+++ b/molecule/builder/create.yml
@@ -13,7 +13,10 @@
       docker_image:
         name: builder
         path: .
-        force: yes
+        buildargs:
+          IMAGE: "{{ item.image }}"
+      with_items: "{{ molecule_yml.platforms }}"
+
     - name: Create molecule instance(s)
       docker_container:
         name: "{{ item.name }}"

--- a/molecule/builder/create.yml
+++ b/molecule/builder/create.yml
@@ -15,6 +15,7 @@
         path: .
         buildargs:
           IMAGE: "{{ item.image }}"
+          NAME: "{{ item.name }}"
       with_items: "{{ molecule_yml.platforms }}"
 
     - name: Create molecule instance(s)

--- a/molecule/builder/create.yml
+++ b/molecule/builder/create.yml
@@ -9,9 +9,24 @@
     molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
   tasks:
+    - name: Get hash of our molecule folder, plus dockerfile
+      stat:
+        path: "./{{ item }}"
+        get_md5: "no"
+        checksum_algorithm: sha256
+      register: file_hashes
+      with_items:
+        - Dockerfile
+        - molecule.yml
+
+    - name: Get a unique concatenated hash for docker tagging
+      set_fact:
+        docker_tag: "{{ docker_tag|default('') + item[0:8] }}"
+      with_items: "{{ file_hashes.results| map(attribute='stat.checksum') | list }}"
+
     - name: Create builder image
       docker_image:
-        name: builder
+        name: "sd.local/{{ item.name }}:{{ docker_tag }}"
         path: .
         buildargs:
           IMAGE: "{{ item.image }}"
@@ -22,7 +37,7 @@
       docker_container:
         name: "{{ item.name }}"
         hostname: "{{ item.name }}"
-        image: builder
+        image: "sd.local/{{ item.name }}:{{ docker_tag }}"
         state: started
         recreate: True
         command: "tail -f /dev/null"

--- a/molecule/builder/molecule.yml
+++ b/molecule/builder/molecule.yml
@@ -4,7 +4,9 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: build
+  - name: trusty-sd-builder
+    # Trusty from 2017-12-15
+    image: ubuntu@sha256:084989eb923bd86dbf7e706d464cf3587274a826b484f75b69468c19f8ae354c
     groups:
       - build
 provisioner:

--- a/molecule/builder/molecule.yml
+++ b/molecule/builder/molecule.yml
@@ -5,8 +5,6 @@ lint:
   name: yamllint
 platforms:
   - name: build
-    image: quay.io/freedomofpress/ubuntu:trusty
-    hash_name: ubuntu
     groups:
       - build
 provisioner:

--- a/molecule/docker_hashes.yml
+++ b/molecule/docker_hashes.yml
@@ -1,2 +1,0 @@
----
-ubuntu: "sha256:d91507c5b56b53cd213edf78be44707efb12495eb07f51c3172b79fdb357ee91"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

It's not a catastrophy to not fail when pip wheel fails because it will eventually fail when installed. But it's non-intuitive to see a failure during installation and much easier to debug if it fails early.

## Testing

* Add **pillow==5.0.0** to `securedrop/requirements/securedrop-app-code-requirements.txt`
* make build-debs # it must fail
* Add libjpeg-dev to **molecule/builder/Dockerfile**
* make build-debs # it must succeed

## Deployment

N/A
