### PR TITLE
docker: move the docker image capture logic in ticker

### DIFF
--- a/admin/bin/dev-shell
+++ b/admin/bin/dev-shell
@@ -28,17 +28,11 @@ function docker_run_circle() {
 }
 
 function docker_image() {
-    local out
-    out="$(mktemp)"
-    if ! docker build \
-         ${DOCKER_BUILD_ARGUMENTS:-} \
-	 --build-arg=USER_ID="$(id -u)" \
-	 --build-arg=USER_NAME="${USER:-root}" \
-         -t securedrop-admin "${TOPLEVEL}/admin" >& "$out" ; then
-        cat "$out"
-        return 1
-    fi
-    return 0
+    docker build \
+           ${DOCKER_BUILD_ARGUMENTS:-} \
+	   --build-arg=USER_ID="$(id -u)" \
+	   --build-arg=USER_NAME="${USER:-root}" \
+           -t securedrop-admin "${TOPLEVEL}/admin"
 }
 
 function docker_run() {

--- a/devops/scripts/dev-shell-ci
+++ b/devops/scripts/dev-shell-ci
@@ -11,21 +11,9 @@ TOPLEVEL=$(git rev-parse --show-toplevel)
 
 cd "${TOPLEVEL}"
 
-function docker_image() {
-    local out
-    out="$(mktemp)"
-    if ! make ci-lint-image >& "$out" ; then
-        cat "$out"
-        status=1
-    else
-        status=0
-    fi
-    return $status
-}
-
 function docker_run() {
     docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -ti securedrop-lint:"$TAG" "$@"
 }
 
-ticker docker_image
+ticker make ci-lint-image
 docker_run "$@"

--- a/devops/scripts/ticker
+++ b/devops/scripts/ticker
@@ -12,13 +12,24 @@ function display_dots() {
 
 function ticker() {
     local pid
+    local out
+    local status
+
+    out="$(mktemp)"
     display_dots &
     pid="$!"
-    if "$@" ; then
-        status=0
+    status=0
+    if test -n "${DOCKER_BUILD_VERBOSE:-}" ; then
+        "$@" || status=1
+    else
+        echo "Run with DOCKER_BUILD_VERBOSE=true for more information"
+        "$@" >& "$out" || status=1
+    fi
+
+    if test $status = 0 ; then
         kill -USR1 $pid
     else
-        status=1
+        cat "$out"
         kill -USR2 $pid
     fi
     wait

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -62,7 +62,15 @@ Using the Docker environment
 The Docker based helpers are intended for rapid development on the
 SecureDrop web application and documentation. They use Docker images
 that contain all the dependencies required to run the tests, a demo
-server etc. The SecureDrop repository is bind mounted into the
+server etc.
+
+.. tip:: When run for the first time, building Docker images will take
+         a few minutes, even one hour when your Internet connection is
+         not fast. If you are unsure about what happens, you can get a
+         more verbose output by setting the environment
+         variable ``export DOCKER_BUILD_VERBOSE=true``.
+
+The SecureDrop repository is bind mounted into the
 container and files modified in the container are also modified in the
 repository. This container has no security hardening or monitoring.
 

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -13,7 +13,7 @@ function docker_image_circle() {
     local out
     out="$(mktemp)"
     ( cat Dockerfile ; echo WORKDIR /app ; echo COPY . . ) > circle.docker
-    if ! docker build ${DOCKER_BUILD_ARGUMENTS:-} -t "securedrop-test:${CIRCLE_SHA1}" -f circle.docker . >& "$out" ; then
+    if ! docker build ${DOCKER_BUILD_ARGUMENTS:-} -t "securedrop-test:${CIRCLE_SHA1}" -f circle.docker . >& "${out}" ; then
         cat "$out"
         status=1
     else
@@ -28,17 +28,11 @@ function docker_run_circle() {
 }
 
 function docker_image() {
-    local out
-    out="$(mktemp)"
-    if ! docker build \
-         ${DOCKER_BUILD_ARGUMENTS:-} \
-	 --build-arg=USER_ID="$(id -u)" \
-	 --build-arg=USER_NAME="${USER:-root}" \
-         -t securedrop-test "${TOPLEVEL}/securedrop" >& "$out" ; then
-        cat "$out"
-        return 1
-    fi
-    return 0
+    docker build \
+           ${DOCKER_BUILD_ARGUMENTS:-} \
+	   --build-arg=USER_ID="$(id -u)" \
+	   --build-arg=USER_NAME="${USER:-root}" \
+           -t securedrop-test "${TOPLEVEL}/securedrop"
 }
 
 function docker_run() {


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

If DOCKER_BUILD_VERBOSE=true is set, do not capture the docker image
output which is useful for debuging.

## Testing

* make -C securedrop dev
* DOCKER_BUILD_VERBOSE=true make -C securedrop dev
* make -C admin test
* DOCKER_BUILD_VERBOSE=true make -C admin test
* make ci-lint
* DOCKER_BUILD_VERBOSE=true make ci-lint

## Deployment

N/A
