### PR TITLE
admin: do not ignore setup arguments

### DIFF
--- a/securedrop-admin
+++ b/securedrop-admin
@@ -4,8 +4,9 @@
 # is more convenient for the admin to have the script at
 # the top level of the SecureDrop repository
 d=$(dirname "$0")
-if test "${!#}" = "setup" ; then
-   exec python "$d/admin/bootstrap.py"
+if test "$1" = "setup" ; then
+   shift
+   exec python "$d/admin/bootstrap.py" "$@"
 else
    activate="$d/admin/.venv/bin/activate"
    if test -f "$activate" ; then


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Contributes to: #3060 *

The -v argument of ./securedrop-admin setup -v is necessary to debug
installation problems because the detailed output of an error only
shows in debug mode.

## Testing

* $ ./securedrop-admin -v setup
please run './securedrop-admin setup' first
* ./securedrop-admin setup
<pre>
INFO: Installing SecureDrop Admin dependencies
INFO: You'll be prompted for the temporary Tails admin password, which was set on Tails login screen
Ign:1 http://ftp.fr.debian.org/debian stretch InRelease
Hit:2 http://ftp.fr.debian.org/debian stretch-updates InRelease
...
  nodejs-doc x11-apps x11-session-utils xbitmaps xinit xorg
Use 'sudo apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 58 not upgraded.
INFO: Setting up virtualenv
INFO: Checking Python dependencies for securedrop-admin
INFO: Python dependencies for securedrop-admin upgraded
INFO: Finished installing SecureDrop dependencies
</pre>
* ./securedrop-admin setup -v
<pre>
INFO: Virtualenv already exists, not creating
INFO: Checking Python dependencies for securedrop-admin
DEBUG: Requirement already up-to-date: ansible==2.4.2 in ./admin/.venv/lib/python2.7/site-packages (from -r /home/loic/software/securedrop/securedrop/admin/requirements.txt (line 7))
...
Requirement already up-to-date: wcwidth==0.1.7 in ./admin/.venv/lib/python2.7/site-packages (from -r /home/loic/software/securedrop/securedrop/admin/requirements.txt (line 171))
Requirement not upgraded as not directly required: setuptools in ./admin/.venv/lib/python2.7/site-packages (from ansible==2.4.2->-r /home/loic/software/securedrop/securedrop/admin/requirements.txt (line 7))

INFO: Python dependencies for securedrop-admin are up-to-date
INFO: Finished installing SecureDrop dependencies
</pre>
* ./securedrop-admin setup --help
</pre>
usage: bootstrap.py [-h] [-v]

optional arguments:
  -h, --help  show this help message and exit
  -v          Increase verbosity on output
</pre>
## Deployment

After a git pull in a production environment the new ./securedrop-admin will override the previous one and use a different .venv, therefore not be influenced by leftovers.
