### PR TITLE
Replace occurrences of Mac OS X to macOS in docs

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -37,8 +37,8 @@ be installed via the official documentation links:
 .. _`Docker CE for Debian`: https://docs.docker.com/install/linux/docker-ce/debian/
 
 
-Mac OS X
-~~~~~~~~
+macOS
+~~~~~
 
 Install Docker_.
 
@@ -182,8 +182,8 @@ development-related tooling. Using `virtualenvwrapper
           file is) so that the command-line utilities ``virtualenvwrapper``
           provides are automatically available in the future.
 
-Mac OS X
-~~~~~~~~
+macOS
+~~~~~
 
 Install the dependencies for the development environment:
 

--- a/docs/development/tips_and_tricks.rst
+++ b/docs/development/tips_and_tricks.rst
@@ -65,7 +65,7 @@ Ubuntu/Debian setup
 ~~~~~~~~~~~~~~~~~~~
 You will need to install a specific variant of the ``nc`` tool
 in order to support the ``-x`` option for specifying a proxy host.
-Mac OS X already runs the OpenBSD variant by default.
+macOS already runs the OpenBSD variant by default.
 
 .. code:: sh
 

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -58,7 +58,7 @@ To rebuild the local packages for the app code: ::
 The Debian packages will be rebuilt from the current state of your
 local git repository and then installed on the staging servers.
 
-.. note:: If you are using Mac OS X and you run into errors from Ansible
+.. note:: If you are using macOS and you run into errors from Ansible
           such as ``OSError: [Errno 24] Too many open files``, you may need to
           increase the maximum number of open files. Some guides online suggest
           a procedure to do this that involves booting to recovery mode
@@ -97,8 +97,8 @@ local git repository and then installed on the staging servers.
 
             sudo chown root:wheel /Library/LaunchDaemons/limit.maxfiles.plist
 
-          This will increase the maximum open file limits system wide on Mac
-          OS X (last tested on 10.11.6).
+          This will increase the maximum open file limits system wide on macOS
+          (last tested on 10.11.6).
 
 The web interfaces and SSH are available over Tor. A copy of the the Onion URLs
 for Source and Journalist Interfaces, as well as SSH access, are written to the

--- a/docs/tails_guide.rst
+++ b/docs/tails_guide.rst
@@ -43,11 +43,11 @@ stick. Here are some links to help you out:
 .. _`Install onto a USB stick or SD card`: https://tails.boum.org/doc/first_steps/installation/index.en.html
 .. _`Create & configure the persistent volume`: https://tails.boum.org/doc/first_steps/persistence/configure/index.en.html
 
-Note for Mac OS X Users Manually Installing Tails
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Note for macOS Users Manually Installing Tails
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Tails documentation for `manually installing Tails onto a USB device
-on Mac OS X`_ describes how to copy the downloaded .iso image to a USB stick in
+on macOS`_ describes how to copy the downloaded .iso image to a USB stick in
 Section 4, "Do the copy". This section includes the following ``dd`` invocation
 to copy the .iso to the USB:
 
@@ -66,7 +66,7 @@ the .iso to a USB 2.0 drive. You can speed it up by changing the arguments to
 Note the change from ``diskX`` to ``rdiskX``. This reduced the copy time to 3
 minutes for us.
 
-.. _`manually installing Tails onto a USB device on Mac OS X`: https://tails.boum.org/doc/first_steps/installation/manual/mac/index.en.html
+.. _`manually installing Tails onto a USB device on macOS`: https://tails.boum.org/doc/first_steps/installation/manual/mac/index.en.html
 
 Configure Tails for Use with SecureDrop
 ---------------------------------------


### PR DESCRIPTION
Recent releases of Apple's desktop operating system are now called macOS. In order to make documentation look current and consistent, this updates the documentation to reflect the changes in the name of Apple's desktop operating system, macOS.

## Status

Ready for review

## Description of Changes

Fixes #3069.

Changes proposed in this pull request:

Replace references to Mac OS X with macOS.

## Testing

A reviewer should take care to see if there are any references to Mac OS X, in addition to the standard check for typographical errors.

Additionally, they need to run `make docs-lint` to check linting.

## Deployment

Documentation will be automatically deployed upon release.

## Checklist

- [x] Doc linting passed locally
