### PR TITLE
Bumps securedrop-grsec metapackage to 4.4.115

### DIFF
--- a/docs/development/apt_repo.rst
+++ b/docs/development/apt_repo.rst
@@ -5,12 +5,9 @@ This document contains a brief description of the Debian packages which are
 hosted and maintained by Freedom of the Press Foundation in our apt repository
 at `apt.freedom.press`_.
 
-linux-image-3.14.*-grsec
+linux-image-4.4.*-grsec
     This package contains the Linux kernel image, patched with grsecurity.
     Listed as a dependency of ``securedrop-grsec``.
-
-linux-headers-3.14.*-grsec
-    Header files related to the Linux kernel.
 
 `ossec-agent <https://github.com/ossec/ossec-hids>`_
     Installs the OSSEC agent, repackaged for Ubuntu.

--- a/install_files/securedrop-grsec/DEBIAN/control
+++ b/install_files/securedrop-grsec/DEBIAN/control
@@ -1,9 +1,9 @@
 Package: securedrop-grsec
 Source: securedrop-grsec
-Version: 3.14.79+r1
+Version: 4.4.115
 Architecture: amd64
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Depends: linux-image-3.14.79-grsec
+Depends: linux-image-4.4.115-grsec
 Section: admin
 Priority: optional
 Homepage: https://securedrop.org

--- a/testinfra/common/test_grsecurity.py
+++ b/testinfra/common/test_grsecurity.py
@@ -76,7 +76,7 @@ def test_grsecurity_kernel_is_running(Command):
     """
     c = Command('uname -r')
     assert c.stdout.endswith('-grsec')
-    assert c.stdout == '3.14.79-grsec'
+    assert c.stdout == '4.4.115-grsec'
 
 
 @pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

We plan to release new kernel images as part of the SecureDrop 0.6 release. Right now, the new 4.4.115 kernel image package is only on apt-test, and that's where the metapackage (hereby updated) will land for pre-release QA, as well.

## Testing

Nothing specifically to be done here: we want to test the 4.4.115 kernel images as part of the 0.6 QA process. As long as CI passes here, let's get it in. 

I haven't actually tested this against the CI infra before—changes introduced by including the metapackage logic in this repository via #2703 may require further refinement. Inspect any CI errors carefully. 

## Deployment

Not yet! 

## Checklist

### If you made changes to the app code:

- [ ] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
