### PR TITLE
i18n: use bin/dev-shell to run translate-{message,desktop}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,11 +138,6 @@ libvirt-share: ## Configure ACLs to allow RWX for libvirt VM (e.g. Admin Worksta
 	@find "$(PWD)" -type d -and -user $$USER -exec setfacl -m u:libvirt-qemu:rwx {} +
 	@find "$(PWD)" -type f -and -user $$USER -exec setfacl -m u:libvirt-qemu:rw {} +
 
-.PHONY: translate
-translate: ## Update POT translation files from sources
-	@cd securedrop ; ./manage.py translate-messages --extract-update
-	@cd securedrop ; ./manage.py translate-desktop --extract-update
-
 # Explaination of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" and any make targets that might appear between : and ##
 # 2. Use sed-like syntax to remove the make targets

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -250,18 +250,19 @@ The ``develop`` branch can now be merged into ``i18n`` as follows:
       $ git fetch lab
       $ git checkout -b i18n lab/i18n
       $ git merge origin/develop
-      $ make translate
+      $ make -C securedrop translate
 
-The ``manage.py`` command examines all the source files, looking for
-strings that need to be translated (i.e. gettext('translate me') etc.)
-and update the ``*.pot`` and ``*.po`` files, removing, updating and inserting
-strings to keep them in sync withe the sources. Carefully review the
-output of ``git diff``. Check ``messages.pot`` first for updated strings,
-looking for formatting problems. Then review the ``messages.po`` of one
-existing translation, with a focus on ``fuzzy`` translations. There is
-no need to review other translations because they are processed in the
-same way. When you are satisfied with the result, it can be merged
-with:
+The ``translate`` Makefile target relies on the ``manage.py`` command
+to examine all the source files, looking for strings that need to be
+translated (i.e. ``gettext('translate me')`` etc.)  and update the
+``*.pot`` and ``*.po`` files, removing, updating and inserting strings
+to keep them in sync with the sources. Carefully review the output of
+``git diff``. Check ``messages.pot`` first for updated strings,
+looking for formatting problems. Then review the ``messages.po`` of
+one existing translation, with a focus on ``fuzzy``
+translations. There is no need to review other translations because
+they are processed in the same way. When you are satisfied with the
+result, it can be merged with:
 
 .. code:: sh
 

--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -38,6 +38,11 @@ test-config: ## Generate the test config
 update-user-guides: ## Runs the page layout tests to regenerate screenshots
 	./bin/dev-shell ./bin/update-user-guides
 
+.PHONY: translate
+translate: ## Update POT translation files from sources
+	./bin/dev-shell ./manage.py translate-messages --extract-update
+	./bin/dev-shell ./manage.py translate-desktop --extract-update
+
 # For an explanation of this shell magic, see the Makefile in the root of the repository
 .PHONY: help
 help: ## Print this message and exit.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

use bin/dev-shell to run translate-{message,desktop}

## Testing

* make -C securedrop translate
* see that .pot and .po files are modified

## Deployment

N/A

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
