### PR TITLE
Monitor only hostname in /var/lib/tor/services

### DIFF
--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -13,7 +13,9 @@
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/securedrop</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/www</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/securedrop</directories>
-    <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/tor/services</directories>
+    <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/tor/services/source/hostname</directories>
+    <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/tor/services/journalist/hostname</directories>
+    <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/tor/services/ssh/hostname</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/tor/lock</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/boot</directories>
 


### PR DESCRIPTION
PR #2963 introduced monitoring of /var/lib/tor folder, however these folders contain private key material. It would be more prudent (and at no cost integrity monitoring capabilities) to exclusively monitor the hostname.
Fixes #3090

## Status

Ready for review

## Description of Changes

Fixes #3090 

## Testing

`/var/ossec/queue/syscheck/\(app-staging\)\ 10.0.1.2-\>syscheck` should not contain any file named `private_key` within the `/var/lib/tor/services` directory.

It should be monitoring only files named `hostname` which contain the onion URL of the respective services.

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting passed locally
