### PR TITLE
securedrop-admin: symlink ancient .venv to admin/.venv

### DIFF
--- a/securedrop-admin
+++ b/securedrop-admin
@@ -5,6 +5,10 @@
 # the top level of the SecureDrop repository
 d=$(dirname "$0")
 if test "$1" = "setup" ; then
+   # the .venv symlink is to not confuse devs used to
+   # finding the directory at the top-level, prior to 0.6
+   rm -fr "$d/.venv"
+   ln -s "$d/admin/.venv" "$d/.venv"
    shift
    exec python "$d/admin/bootstrap.py" "$@"
 else


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3088 

Prior to securedrop-admin moving to the admin directory, its
virtualenv directory was in the .venv directory at the toplevel of the
git tree. It is now in the admin/.venv directory instead.

For the regular admin following the instructions from the
documentation the existence of the ancient .venv will not be noticed
and can be ignored.

However the more knowledgeable SecureDrop admin who manually source
the .venv will be confused. We remove the .venv and symlink the new
admin/.venv so the change is transparent.

## Testing

* ./securedrop-admin setup # with 0.5.2
* see .venv exits and is a directory
* /securedrop-admin setup # with 0.6 rc2
* see .venv exists and is a symlink to admin/.venv
* source .venv/bin/activate
* ansible --version
ansible 2.4.2.0

## Deployment

1. SecureDrop admin following the documentation will not be affected. It will however fix a bug for the SecureDrop admin who source .venv even though it is not documented to exist 
2. N/A this is only for upgrades
