### PR TITLE
[0.6.0] Docs: Update Admin guide to remove --force option

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -334,18 +334,16 @@ You should see a message appear indicating the change was a success:
 Updating system configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Other server configuration is stored on the *Admin Workstation* in
-``~/Persistent/securedrop/install_files/ansible-base/group_vars/all/site-specific``.
+If you want to update the system configuration, you should use the
+``securedrop-admin`` tool on the *Admin Workstation*. From
+``~/Persistent/securedrop``, run:
 
-If you want to update the system configuration, there are two options:
+.. code:: sh
 
-1. Manually edit the ``site-specific`` file to make the desired modifications.
-2. From ``~/Persistent/securedrop``, run
-   ``./securedrop-admin sdconfig --force``, which will require you to retype
-   each variable in ``site-specific``.
+  ./securedrop-admin sdconfig
 
-Once you have edited the ``site-specific`` server configuration file, you will
-need to apply the changes to the servers. From ``~/Persistent/securedrop``:
+This will give you the opportunity to edit any variable. Next, you will
+need to apply the changes to the servers. Again from ``~/Persistent/securedrop``:
 
 .. code:: sh
 
@@ -355,6 +353,10 @@ need to apply the changes to the servers. From ``~/Persistent/securedrop``:
 
 Once the install command has successfully completed, the changes are applied.
 Read the next section if you have multiple admins.
+
+.. note::
+  Server configuration is stored on the *Admin Workstation* in
+  ``~/Persistent/securedrop/install_files/ansible-base/group_vars/all/site-specific``.
 
 Managing ``site-specific`` updates on teams with multiple admins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -92,10 +92,7 @@ match your environment: ::
 
 The script will automatically validate the answers you provided, and display
 error messages if any problems were detected. The answers you provided will be
-written to the file ``install_files/ansible-base/group_vars/all/site-specific``,
-which you can edit in case of errors such as typos before rerunning the script.
-You can also run ``./securedrop-admin sdconfig --force`` to remove your entire
-configuration file and start over.
+written to the file ``install_files/ansible-base/group_vars/all/site-specific``.
 
 When you're done, save the file and quit the editor.
 


### PR DESCRIPTION
(cherry picked from commit 342182e709d99d8b555f47968c24504457d1d4dc)

## Status

Ready for review

## Description of Changes

Fixes #3101 

Changes proposed in this pull request:
* The new sdconfig handles the editing of config variables in an
improved way that doesn't require the admin to retype the variable

## Testing

no remaining references to the `--force` option should be in the docs

## Deployment

Docs only

## Checklist

### If you made changes to documentation:

- [x] Doc linting passed locally
