### PR TITLE
Bugfix: Update installer.patch against latest tails-installer 5.0.4

### DIFF
--- a/docs/development/virtualizing_tails.rst
+++ b/docs/development/virtualizing_tails.rst
@@ -71,43 +71,44 @@ to Tails, and enter an administration password and start Tails.
 
 .. code:: python
 
-  --- /usr/lib/python2.7/dist-packages/tails_installer/creator.py	2017-06-30 11:14:11.000000000 +0000
-  +++ /usr/lib/python2.7/dist-packages/tails_installer/creator.py.mod	2017-07-20 06:53:31.152000000 +0000
-  @@ -615,15 +615,6 @@
-               if not data['removable']:
-                   self.log.debug('Skipping non-removable device: %s' % data['device'])
+    --- /usr/lib/python2.7/dist-packages/tails_installer/creator.py      2018-01-22 14:59:40.000000000 +0100
+    +++ /usr/lib/python2.7/dist-packages/tails_installer/creator.py.mod  2018-03-05 05:15:00.000000000 -0800
+    @@ -595,16 +595,6 @@ class LinuxTailsInstallerCreator(TailsInstallerCreator):
+                    self.log.debug('Skipping non-removable device: %s'
+                                    % data['device'])
 
-  -            # Only pay attention to USB and SDIO devices, unless --force'd
-  -            iface = drive.props.connection_bus
-  -            if iface != 'usb' and iface != 'sdio' and self.opts.force != data['device']:
-  -                self.log.warning(
-  -                    "Skipping device '%(device)s' connected to '%(interface)s' interface"
-  -                    % {'device': data['udi'], 'interface': iface}
-  -                )
-  -                continue
-  -
-               # Skip optical drives
-               if data['is_optical'] and self.opts.force != data['device']:
-                   self.log.debug('Skipping optical device: %s' % data['device'])
-  --- /usr/lib/python2.7/dist-packages/tails_installer/gui.py	2017-06-30 11:14:11.000000000 +0000
-  +++ /usr/lib/python2.7/dist-packages/tails_installer/gui.py.mod	2017-07-20 06:53:44.040000000 +0000
-  @@ -483,16 +483,6 @@
-                       'model':   info['model'],
-                       'details': details
-                   }
-  -                # Skip devices with non-removable bit enabled
-  -                if not info['removable']:
-  -                    message =_('The USB stick "%(pretty_name)s"'
-  -                               ' is configured as non-removable by its'
-  -                               ' manufacturer and Tails will fail to start on it.'
-  -                               ' Please try installing on a different model.') % {
-  -                               'pretty_name':  pretty_name
-  -                               }
-  -                    self.status(message)
-  -                    continue
-                   # Skip too small devices, but inform the user
-                   if not info['is_device_big_enough']:
-                       message =_('The device "%(pretty_name)s"'
+    -            # Only pay attention to USB and SDIO devices, unless --force'd
+    -            iface = drive.props.connection_bus
+    -            if iface != 'usb' and iface != 'sdio' \
+    -               and self.opts.force != data['device']:
+    -                self.log.warning(
+    -                    "Skipping device '%(device)s' connected to '%(interface)s' interface"
+    -                    % {'device': data['udi'], 'interface': iface}
+    -                )
+    -                continue
+    -
+                # Skip optical drives
+                if data['is_optical'] and self.opts.force != data['device']:
+                    self.log.debug('Skipping optical device: %s' % data['device'])
+    --- /usr/lib/python2.7/dist-packages/tails_installer/gui.py      2018-01-22 14:59:40.000000000 +0100
+    +++ /usr/lib/python2.7/dist-packages/tails_installer/gui.py.mod  2018-03-05 05:15:00.000000000 -0800
+    @@ -568,16 +568,6 @@ class TailsInstallerWindow(Gtk.ApplicationWindow):
+                        self.devices_with_persistence.append(info['parent'])
+                        continue
+                    pretty_name = self.get_device_pretty_name(info)
+    -                # Skip devices with non-removable bit enabled
+    -                if not info['removable']:
+    -                    message =_('The USB stick "%(pretty_name)s"'
+    -                               ' is configured as non-removable by its'
+    -                               ' manufacturer and Tails will fail to start on it.'
+    -                               ' Please try installing on a different model.') % {
+    -                               'pretty_name':  pretty_name
+    -                               }
+    -                    self.status(message)
+    -                    continue
+                    # Skip too small devices, but inform the user
+                    if not info['is_device_big_enough_for_installation']:
+                        message =_('The device "%(pretty_name)s"'
 
 2. Now run the following two commands in a Terminal in your Tails VM:
 


### PR DESCRIPTION
[tails-installer](https://anonscm.debian.org/git/pkg-privacy/packages/tails-installer.git) is a Python application, currently at version 5.0.4+dfsg. That version was tagged on January 22nd and uploaded to [Debian repositories](https://packages.debian.org/sid/tails-installer) on Feb 3rd plus [Launchpad PPA](https://launchpad.net/~tails-team/+archive/ubuntu/tails-installer) on Feb 4th, causing the included patch in this document to fail because some lines in `gui.py` and `creator.py` had changed.

See: https://klistrain.se/p/0491dbc, bug was discovered by @Anonymous26.
```
root@amnesia:/home/amnesia/temp# sudo patch -p0 -d/ < installer.patch
patching file /usr/lib/python2.7/dist-packages/tails_installer/creator.py
Reversed (or previously applied) patch detected!  Assume -R? [n] n
Apply anyway? [n] y
Hunk #1 FAILED at 615.
1 out of 1 hunk FAILED -- saving rejects to file /usr/lib/python2.7/dist-packages/tails_installer/creator.py.rej
patching file /usr/lib/python2.7/dist-packages/tails_installer/gui.py
Hunk #1 FAILED at 483.
1 out of 1 hunk FAILED -- saving rejects to file /usr/lib/python2.7/dist-packages/tails_installer/gui.py.rej
```

This updates the patch in the "virtualizing Tails" documentation based on the latest version of tails-installer.

Here is the new patch ([link](https://paste.cointel.pro/?7b5492e3840adfaa#jdd32xc0lILACFZRozLiDRPwYTdR8SvrIZB9N3IZF2c=)):
```
--- /usr/lib/python2.7/dist-packages/tails_installer/creator.py      2018-01-22 14:59:40.000000000 +0100
+++ /usr/lib/python2.7/dist-packages/tails_installer/creator.py.mod  2018-03-05 05:15:00.000000000 -0800
@@ -595,16 +595,6 @@ class LinuxTailsInstallerCreator(TailsInstallerCreator):
                 self.log.debug('Skipping non-removable device: %s'
                                % data['device'])

-            # Only pay attention to USB and SDIO devices, unless --force'd
-            iface = drive.props.connection_bus
-            if iface != 'usb' and iface != 'sdio' \
-               and self.opts.force != data['device']:
-                self.log.warning(
-                    "Skipping device '%(device)s' connected to '%(interface)s' interface"
-                    % {'device': data['udi'], 'interface': iface}
-                )
-                continue
-
             # Skip optical drives
             if data['is_optical'] and self.opts.force != data['device']:
                 self.log.debug('Skipping optical device: %s' % data['device'])
--- /usr/lib/python2.7/dist-packages/tails_installer/gui.py      2018-01-22 14:59:40.000000000 +0100
+++ /usr/lib/python2.7/dist-packages/tails_installer/gui.py.mod  2018-03-05 05:15:00.000000000 -0800
@@ -568,16 +568,6 @@ class TailsInstallerWindow(Gtk.ApplicationWindow):
                     self.devices_with_persistence.append(info['parent'])
                     continue
                 pretty_name = self.get_device_pretty_name(info)
-                # Skip devices with non-removable bit enabled
-                if not info['removable']:
-                    message =_('The USB stick "%(pretty_name)s"'
-                               ' is configured as non-removable by its'
-                               ' manufacturer and Tails will fail to start on it.'
-                               ' Please try installing on a different model.') % {
-                               'pretty_name':  pretty_name
-                               }
-                    self.status(message)
-                    continue
                 # Skip too small devices, but inform the user
                 if not info['is_device_big_enough_for_installation']:
                     message =_('The device "%(pretty_name)s"'
```

## Status

Ready for review.

## Description of Changes

Updates `installer.patch` in the "virtualizing Tails" documentation to work with tails-installer 5.0.4, which was released one month ago. Fixes #3105.

## Testing

Needs to be tested against actual Tails 3.5, with the full procedure described in the documentation of installing to a virtual hard disk image. 