### PR TITLE
In securedrop-admin setup -v: -v, setup can be passed in any order

### DIFF
--- a/securedrop-admin
+++ b/securedrop-admin
@@ -4,13 +4,17 @@
 # is more convenient for the admin to have the script at
 # the top level of the SecureDrop repository
 d=$(dirname "$0")
-if test "$1" = "setup" ; then
+if test "$1" = "setup" || test "$2" = "setup"; then
    # the .venv symlink is to not confuse devs used to
    # finding the directory at the top-level, prior to 0.6
    rm -fr "$d/.venv"
    ln -s "$d/admin/.venv" "$d/.venv"
-   shift
-   exec python "$d/admin/bootstrap.py" "$@"
+   if test "$1" = "setup"; then
+     shift
+     exec python "$d/admin/bootstrap.py" "$@"
+   else
+     exec python "$d/admin/bootstrap.py" "$1"
+   fi
 else
    activate="$d/admin/.venv/bin/activate"
    if test -f "$activate" ; then


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #3109 (not resolving ticket until the change is picked into the 0.6.0 branch).

Changes proposed in this pull request:
* In `securedrop-admin setup -v`, enable `-v` and `setup` to be passed in any order through the wrapper shell script

## Testing

Verify the behavior of `./securedrop-admin -v setup` and `./securedrop-admin setup -v` is consistent

## Deployment

Under version control and admins will check out this version manually

## Checklist

Needs testing in Tails