### PR TITLE
Fix help strings for securedrop-admin check_for_updates

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -590,7 +590,7 @@ def parse_argv(argv):
     parse_update.set_defaults(func=update)
 
     parse_check_updates = subparsers.add_parser('check_for_updates',
-                                                help=update.__doc__)
+                                                help=check_for_updates.__doc__)
     parse_check_updates.set_defaults(func=check_for_updates)
 
     parse_logs = subparsers.add_parser('logs',


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #3110 (not resolving ticket until the change is picked into the 0.6.0 branch).

Changes proposed in this pull request:
 * Fix help string for `securedrop-admin check_for_updates`

## Testing

`./securedrop-admin -h`

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

- [x] All linting, tests pass in `securedrop-admin` dev container
