### PR TITLE
[0.6.0] Fix help string for securedrop-admin check_for_updates

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -590,7 +590,7 @@ def parse_argv(argv):
     parse_update.set_defaults(func=update)
 
     parse_check_updates = subparsers.add_parser('check_for_updates',
-                                                help=update.__doc__)
+                                                help=check_for_updates.__doc__)
     parse_check_updates.set_defaults(func=check_for_updates)
 
     parse_logs = subparsers.add_parser('logs',


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3110.

Changes proposed in this pull request:
 * Fix help string for `securedrop-admin check_for_updates`

## Testing

`./securedrop-admin -h`

## Deployment

Should not be a prob

## Checklist

- [x] All linting, tests pass in securedrop-admin dev container
