### PR TITLE
Handle TypeErrors on /account/reset-2fa-hotp, add regression tests

### DIFF
--- a/securedrop/journalist_app/account.py
+++ b/securedrop/journalist_app/account.py
@@ -6,7 +6,7 @@ from flask_babel import gettext
 
 from db import db
 from journalist_app.utils import (make_password, set_diceware_password,
-                                  validate_user)
+                                  validate_user, validate_hotp_secret)
 
 
 def make_blueprint(config):
@@ -60,6 +60,8 @@ def make_blueprint(config):
     def reset_two_factor_hotp():
         otp_secret = request.form.get('otp_secret', None)
         if otp_secret:
+            if not validate_hotp_secret(g.user, otp_secret):
+                return render_template('account_edit_hotp_secret.html')
             g.user.set_hotp_secret(otp_secret)
             db.session.commit()
             return redirect(url_for('account.new_two_factor'))

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -111,6 +111,39 @@ def validate_user(username, password, token, error_message=None):
         return None
 
 
+def validate_hotp_secret(user, otp_secret):
+    """
+    Validates and sets the HOTP provided by a user
+    :param user: the change is for this instance of the User object
+    :param otp_secret: the new HOTP secret
+    :return: True if it validates, False if it does not
+    """
+    try:
+        user.set_hotp_secret(otp_secret)
+    except TypeError as e:
+        if "Non-hexadecimal digit found" in str(e):
+            flash(gettext(
+                "Invalid secret format: "
+                "please only submit letters A-F and numbers 0-9."),
+                  "error")
+            return False
+        elif "Odd-length string" in str(e):
+            flash(gettext(
+                "Invalid secret format: "
+                "odd-length secret. Did you mistype the secret?"),
+                  "error")
+            return False
+        else:
+            flash(gettext(
+                "An unexpected error occurred! "
+                "Please inform your administrator."), "error")
+            current_app.logger.error(
+                "set_hotp_secret '{}' (id {}) failed: {}".format(
+                    otp_secret, user.id, e))
+            return False
+    return True
+
+
 def download(zip_basename, submissions):
     """Send client contents of ZIP-file *zip_basename*-<timestamp>.zip
     containing *submissions*. The ZIP-file, being a

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -543,6 +543,55 @@ class TestJournalistApp(TestCase):
         # should redirect to verification page
         self.assertRedirects(resp, url_for('account.new_two_factor'))
 
+    def test_user_resets_user_hotp_format_odd(self):
+        self._login_user()
+        old_hotp = self.user.hotp.secret
+
+        self.client.post(url_for('account.reset_two_factor_hotp'),
+                         data=dict(uid=self.user.id, otp_secret='123'))
+        new_hotp = self.user.hotp.secret
+
+        self.assertEqual(old_hotp, new_hotp)
+        self.assertMessageFlashed(
+            "Invalid secret format: "
+            "odd-length secret. Did you mistype the secret?", "error")
+
+    def test_user_resets_user_hotp_format_non_hexa(self):
+        self._login_user()
+        old_hotp = self.user.hotp.secret
+
+        self.client.post(url_for('account.reset_two_factor_hotp'),
+                         data=dict(uid=self.user.id, otp_secret='ZZ'))
+        new_hotp = self.user.hotp.secret
+
+        self.assertEqual(old_hotp, new_hotp)
+        self.assertMessageFlashed(
+            "Invalid secret format: "
+            "please only submit letters A-F and numbers 0-9.", "error")
+
+    @patch('models.Journalist.set_hotp_secret')
+    @patch('journalist.app.logger.error')
+    def test_user_resets_user_hotp_error(self,
+                                         mocked_error_logger,
+                                         mock_set_hotp_secret):
+        self._login_user()
+        old_hotp = self.user.hotp.secret
+
+        error_message = 'SOMETHING WRONG!'
+        mock_set_hotp_secret.side_effect = TypeError(error_message)
+
+        otp_secret = '1234'
+        self.client.post(url_for('account.reset_two_factor_hotp'),
+                         data=dict(uid=self.user.id, otp_secret=otp_secret))
+        new_hotp = self.user.hotp.secret
+
+        self.assertEqual(old_hotp, new_hotp)
+        self.assertMessageFlashed("An unexpected error occurred! "
+                                  "Please inform your administrator.", "error")
+        mocked_error_logger.assert_called_once_with(
+            "set_hotp_secret '{}' (id {}) failed: {}".format(
+                otp_secret, self.user.id, error_message))
+
     def test_admin_resets_user_totp(self):
         self._login_admin()
         old_totp = self.user.totp


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #3124 (not closing until these changes are backported into the 0.6 release branch). 

Changes proposed in this pull request:
 * Adds regression tests for the unhandled `TypeError`s for the user 2FA HOTP reset functionality. A `TypeError` is possible via the submission of an odd-length OTP secret, and another is possible via non-hex characters in the OTP secret.
 * Fixes by using a common function for validation shared with the admin route (which was not subject to the bug in #3124)

## Testing

I would test both user and admin HOTP reset for the following cases:
1. Odd length input: '123'
2. Non hex characters in input: 'zz'
3. Expected even length hex input e.g. '1234'

The following gif shows the expected behavior:

![hotp-bugfix](https://user-images.githubusercontent.com/7832803/37178736-3e305ec6-22d8-11e8-9d0c-dbbe8249b5b4.gif)

## Deployment

No special considerations

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass in the development container
