### PR TITLE
Journalist pytest fixtures

### DIFF
--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -15,6 +15,7 @@ from sdconfig import SDConfig, config as original_config
 from os import path
 
 from db import db
+from journalist_app import create_app as create_journalist_app
 from source_app import create_app as create_source_app
 
 # TODO: the PID file for the redis worker is hard-coded below.
@@ -86,6 +87,14 @@ def config(tmpdir):
 @pytest.fixture(scope='function')
 def source_app(config):
     app = create_source_app(config)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+@pytest.fixture(scope='function')
+def journalist_app(config):
+    app = create_journalist_app(config)
     with app.app_context():
         db.create_all()
     return app

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -271,6 +271,24 @@ class TestPytestJournalistApp:
         text = resp.data.decode('utf-8')
         assert edit_account_link in text
 
+    def test_user_has_link_to_edit_account_page_in_index_page(self,
+                                                              journalist_app):
+        with journalist_app.app_context():
+            user, password = utils.db_helper.init_journalist()
+            username = user.username
+            otp_secret = user.otp_secret
+
+        with journalist_app.test_client() as app:
+            resp = app.post('/login',
+                            data=dict(username=username,
+                                      password=password,
+                                      token=TOTP(otp_secret).now()),
+                            follow_redirects=True)
+        edit_account_link = ('<a href="/account/account" '
+                             'id="link-edit-account">')
+        text = resp.data.decode('utf-8')
+        assert edit_account_link in text
+
 
 class TestJournalistApp(TestCase):
 
@@ -291,16 +309,6 @@ class TestJournalistApp(TestCase):
 
     def tearDown(self):
         utils.env.teardown()
-
-    def test_user_has_link_to_edit_account_page_in_index_page(self):
-        resp = self.client.post(url_for('main.login'),
-                                data=dict(username=self.user.username,
-                                          password=self.user_pw,
-                                          token='mocked'),
-                                follow_redirects=True)
-        edit_account_link = '<a href="{}" id="link-edit-account">'.format(
-            url_for('account.edit'))
-        self.assertIn(edit_account_link, resp.data)
 
     def test_admin_has_link_to_admin_index_page_in_index_page(self):
         resp = self.client.post(url_for('main.login'),

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -289,6 +289,23 @@ class TestPytestJournalistApp:
         text = resp.data.decode('utf-8')
         assert edit_account_link in text
 
+    def test_admin_has_link_to_admin_index_page_in_index_page(self,
+                                                              journalist_app):
+        with journalist_app.app_context():
+            user, password = utils.db_helper.init_journalist(is_admin=True)
+            username = user.username
+            otp_secret = user.otp_secret
+
+        with journalist_app.test_client() as app:
+            resp = app.post('/login',
+                            data=dict(username=username,
+                                      password=password,
+                                      token=TOTP(otp_secret).now()),
+                            follow_redirects=True)
+        admin_link = '<a href="/admin/" id="link-admin-index">'
+        text = resp.data.decode('utf-8')
+        assert admin_link in text
+
 
 class TestJournalistApp(TestCase):
 
@@ -309,16 +326,6 @@ class TestJournalistApp(TestCase):
 
     def tearDown(self):
         utils.env.teardown()
-
-    def test_admin_has_link_to_admin_index_page_in_index_page(self):
-        resp = self.client.post(url_for('main.login'),
-                                data=dict(username=self.admin.username,
-                                          password=self.admin_pw,
-                                          token='mocked'),
-                                follow_redirects=True)
-        admin_link = '<a href="{}" id="link-admin-index">'.format(
-            url_for('admin.index'))
-        self.assertIn(admin_link, resp.data)
 
     def test_user_lacks_link_to_admin_index_page_in_index_page(self):
         resp = self.client.post(url_for('main.login'),

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -185,6 +185,20 @@ class TestPytestJournalistApp:
         finally:
             models.LOGIN_HARDENING = False
 
+    def test_login_invalid_credentials(self, journalist_app):
+        with journalist_app.app_context():
+            user, password = utils.db_helper.init_journalist()
+            username = user.username
+
+        with journalist_app.test_client() as app:
+            resp = app.post('/login',
+                            data=dict(username=username,
+                                      password='invalid',
+                                      token='mocked'))
+        assert resp.status_code == 200
+        text = resp.data.decode('utf-8')
+        assert "Login failed" in text
+
 
 class TestJournalistApp(TestCase):
 
@@ -205,14 +219,6 @@ class TestJournalistApp(TestCase):
 
     def tearDown(self):
         utils.env.teardown()
-
-    def test_login_invalid_credentials(self):
-        resp = self.client.post(url_for('main.login'),
-                                data=dict(username=self.user.username,
-                                          password='invalid',
-                                          token='mocked'))
-        self.assert200(resp)
-        self.assertIn("Login failed", resp.data)
 
     def test_validate_redirect(self):
         resp = self.client.post(url_for('main.index'),

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -351,6 +351,19 @@ class TestPytestJournalistApp:
                 resp = app.get('/logout')
                 ins.assert_redirects(resp, '/')
 
+    def test_admin_index(self, journalist_app):
+        with journalist_app.app_context():
+            user, password = utils.db_helper.init_journalist(is_admin=True)
+            username = user.username
+            otp_secret = user.otp_secret
+
+        with journalist_app.test_client() as app:
+            _login_user(app, username, password, otp_secret)
+            resp = app.get('/admin/')
+            assert resp.status_code == 200
+            text = resp.data.decode('utf-8')
+            assert "Admin Interface" in text
+
 
 class TestJournalistApp(TestCase):
 
@@ -388,12 +401,6 @@ class TestJournalistApp(TestCase):
 
     def _login_user(self):
         self._ctx.g.user = self.user
-
-    def test_admin_index(self):
-        self._login_admin()
-        resp = self.client.get(url_for('admin.index'))
-        self.assert200(resp)
-        self.assertIn("Admin Interface", resp.data)
 
     def test_admin_delete_user(self):
         # Verify journalist is in the database

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -327,6 +327,18 @@ class TestPytestJournalistApp:
         text = resp.data.decode('utf-8')
         assert ADMIN_LINK not in text
 
+    def test_admin_logout_redirects_to_index(self, journalist_app):
+        with journalist_app.app_context():
+            user, password = utils.db_helper.init_journalist(is_admin=True)
+            username = user.username
+            otp_secret = user.otp_secret
+
+        with journalist_app.test_client() as app:
+            with InstrumentedApp(journalist_app) as ins:
+                _login_user(app, username, password, otp_secret)
+                resp = app.get('/logout')
+                ins.assert_redirects(resp, '/')
+
 
 class TestJournalistApp(TestCase):
 
@@ -364,11 +376,6 @@ class TestJournalistApp(TestCase):
 
     def _login_user(self):
         self._ctx.g.user = self.user
-
-    def test_admin_logout_redirects_to_index(self):
-        self._login_admin()
-        resp = self.client.get(url_for('main.logout'))
-        self.assertRedirects(resp, url_for('main.index'))
 
     def test_user_logout_redirects_to_index(self):
         self._login_user()

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -223,6 +223,21 @@ class TestPytestJournalistApp:
         assert "Sources" in text
         assert "No documents have been submitted!" in text
 
+    def test_admin_login_redirects_to_index(self, journalist_app):
+        with journalist_app.app_context():
+            user, password = utils.db_helper.init_journalist(is_admin=True)
+            username = user.username
+            otp_secret = user.otp_secret
+
+        with journalist_app.test_client() as app:
+            with InstrumentedApp(journalist_app) as ins:
+                resp = app.post('/login',
+                                data=dict(username=username,
+                                          password=password,
+                                          token=TOTP(otp_secret).now()),
+                                follow_redirects=False)
+                ins.assert_redirects(resp, '/')
+
 
 class TestJournalistApp(TestCase):
 
@@ -243,13 +258,6 @@ class TestJournalistApp(TestCase):
 
     def tearDown(self):
         utils.env.teardown()
-
-    def test_admin_login_redirects_to_index(self):
-        resp = self.client.post(url_for('main.login'),
-                                data=dict(username=self.admin.username,
-                                          password=self.admin_pw,
-                                          token='mocked'))
-        self.assertRedirects(resp, url_for('main.index'))
 
     def test_user_login_redirects_to_index(self):
         resp = self.client.post(url_for('main.login'),

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -32,6 +32,12 @@ random.seed('¯\_(ツ)_/¯')
 VALID_PASSWORD = 'correct horse battery staple generic passphrase hooray'
 VALID_PASSWORD_2 = 'another correct horse battery staple generic passphrase'
 
+# These are factored out of the tests because some test have a
+# postive/negative case under varying conditions, and we don't want
+# false postives after modifying a string in the application.
+EMPTY_REPLY_TEXT = "You cannot send an empty reply."
+ADMIN_LINK = '<a href="/admin/" id="link-admin-index">'
+
 
 def _login_user(app, username, password, otp_secret):
     resp = app.post('/login', data={'username': username,
@@ -128,7 +134,7 @@ class TestPytestJournalistApp:
                             follow_redirects=True)
 
             text = resp.data.decode('utf-8')
-            assert "You cannot send an empty reply." in text
+            assert EMPTY_REPLY_TEXT in text
 
     def test_nonempty_replies_are_accepted(self, journalist_app):
         with journalist_app.app_context():
@@ -147,7 +153,7 @@ class TestPytestJournalistApp:
                             follow_redirects=True)
 
             text = resp.data.decode('utf-8')
-            assert "You cannot send an empty reply." not in text
+            assert EMPTY_REPLY_TEXT not in text
 
     def test_unauthorized_access_redirects_to_login(self, journalist_app):
         with journalist_app.test_client() as app:
@@ -302,9 +308,8 @@ class TestPytestJournalistApp:
                                       password=password,
                                       token=TOTP(otp_secret).now()),
                             follow_redirects=True)
-        admin_link = '<a href="/admin/" id="link-admin-index">'
         text = resp.data.decode('utf-8')
-        assert admin_link in text
+        assert ADMIN_LINK in text
 
     def test_user_lacks_link_to_admin_index_page_in_index_page(self,
                                                                journalist_app):
@@ -319,9 +324,8 @@ class TestPytestJournalistApp:
                                       password=password,
                                       token=TOTP(otp_secret).now()),
                             follow_redirects=True)
-        admin_link = '<a href="/admin/" id="link-admin-index">'
         text = resp.data.decode('utf-8')
-        assert admin_link not in text
+        assert ADMIN_LINK not in text
 
 
 class TestJournalistApp(TestCase):

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -199,6 +199,13 @@ class TestPytestJournalistApp:
         text = resp.data.decode('utf-8')
         assert "Login failed" in text
 
+    def test_validate_redirect(self, journalist_app):
+        with journalist_app.test_client() as app:
+            resp = app.post('/', follow_redirects=True)
+            assert resp.status_code == 200
+            text = resp.data.decode('utf-8')
+            assert "Login to access" in text
+
 
 class TestJournalistApp(TestCase):
 
@@ -219,12 +226,6 @@ class TestJournalistApp(TestCase):
 
     def tearDown(self):
         utils.env.teardown()
-
-    def test_validate_redirect(self):
-        resp = self.client.post(url_for('main.index'),
-                                follow_redirects=True)
-        self.assert200(resp)
-        self.assertIn("Login to access", resp.data)
 
     def test_login_valid_credentials(self):
         resp = self.client.post(url_for('main.login'),

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -238,6 +238,21 @@ class TestPytestJournalistApp:
                                 follow_redirects=False)
                 ins.assert_redirects(resp, '/')
 
+    def test_user_login_redirects_to_index(self, journalist_app):
+        with journalist_app.app_context():
+            user, password = utils.db_helper.init_journalist(is_admin=False)
+            username = user.username
+            otp_secret = user.otp_secret
+
+        with journalist_app.test_client() as app:
+            with InstrumentedApp(journalist_app) as ins:
+                resp = app.post('/login',
+                                data=dict(username=username,
+                                          password=password,
+                                          token=TOTP(otp_secret).now()),
+                                follow_redirects=False)
+                ins.assert_redirects(resp, '/')
+
 
 class TestJournalistApp(TestCase):
 
@@ -258,13 +273,6 @@ class TestJournalistApp(TestCase):
 
     def tearDown(self):
         utils.env.teardown()
-
-    def test_user_login_redirects_to_index(self):
-        resp = self.client.post(url_for('main.login'),
-                                data=dict(username=self.user.username,
-                                          password=self.user_pw,
-                                          token='mocked'))
-        self.assertRedirects(resp, url_for('main.index'))
 
     def test_admin_has_link_to_edit_account_page_in_index_page(self):
         resp = self.client.post(url_for('main.login'),

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -339,6 +339,18 @@ class TestPytestJournalistApp:
                 resp = app.get('/logout')
                 ins.assert_redirects(resp, '/')
 
+    def test_user_logout_redirects_to_index(self, journalist_app):
+        with journalist_app.app_context():
+            user, password = utils.db_helper.init_journalist()
+            username = user.username
+            otp_secret = user.otp_secret
+
+        with journalist_app.test_client() as app:
+            with InstrumentedApp(journalist_app) as ins:
+                _login_user(app, username, password, otp_secret)
+                resp = app.get('/logout')
+                ins.assert_redirects(resp, '/')
+
 
 class TestJournalistApp(TestCase):
 
@@ -376,11 +388,6 @@ class TestJournalistApp(TestCase):
 
     def _login_user(self):
         self._ctx.g.user = self.user
-
-    def test_user_logout_redirects_to_index(self):
-        self._login_user()
-        resp = self.client.get(url_for('main.logout'))
-        self.assertRedirects(resp, url_for('main.index'))
 
     def test_admin_index(self):
         self._login_admin()

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -149,6 +149,12 @@ class TestPytestJournalistApp:
             text = resp.data.decode('utf-8')
             assert "You cannot send an empty reply." not in text
 
+    def test_unauthorized_access_redirects_to_login(self, journalist_app):
+        with journalist_app.test_client() as app:
+            with InstrumentedApp(journalist_app) as ins:
+                resp = app.get('/')
+                ins.assert_redirects(resp, '/login')
+
 
 class TestJournalistApp(TestCase):
 
@@ -169,10 +175,6 @@ class TestJournalistApp(TestCase):
 
     def tearDown(self):
         utils.env.teardown()
-
-    def test_unauthorized_access_redirects_to_login(self):
-        resp = self.client.get(url_for('main.index'))
-        self.assertRedirects(resp, url_for('main.login'))
 
     def test_login_throttle(self):
         models.LOGIN_HARDENING = True


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #2877.

This starts moving some of the journalist interfaces tests to the new pytest fixtures. This isn't all of the test in `test_journalist.py`, because some of them are going to be a little complicated. Also, these PRs are giant nightmares to review, so I'm trying to get this in so that between this and #2948, there shouldn't be any blockers on other contributors refactoring the other tests (except functional which will be another huge block).

## Testing

```
cd securedrop
make test TESTFILES=test/test_journalist.py
```

## Checklist

### If you made changes to the app code:

- [x] Unit and functional tests pass on the development VM