### PR TITLE
Preserves 3.14.79 kernel during upgrade

### DIFF
--- a/install_files/securedrop-grsec/DEBIAN/control
+++ b/install_files/securedrop-grsec/DEBIAN/control
@@ -3,7 +3,7 @@ Source: securedrop-grsec
 Version: 4.4.115
 Architecture: amd64
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Depends: linux-image-4.4.115-grsec
+Depends: linux-image-3.14.79-grsec,linux-image-4.4.115-grsec
 Section: admin
 Priority: optional
 Homepage: https://securedrop.org


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Related to #3135, but does not resolve. Preserves dependency on old/current 3.14.79 kernel image, to avoid automatic package cleaning operations removing it. In an ideal world, we'd want to make sure the old kernel image is indeed gone—however, let's provide rollback capability during the 0.6 release, in case folks report problems with the new kernel image.

We can and should drop the older dependency when releasing 0.6.1. 

## Testing

I intend to build new rc debs for 0.6 after this is merged and perform QA in VMs.

## Deployment
Yes, we're trying to improve the reliability of instances by providing fallback capability to admins during the kernel upgrade scheduled with the 0.6 release.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
