### PR TITLE
[0.6.0] Preserves 3.14.79 kernel during upgrade

### DIFF
--- a/install_files/securedrop-grsec/DEBIAN/control
+++ b/install_files/securedrop-grsec/DEBIAN/control
@@ -3,7 +3,7 @@ Source: securedrop-grsec
 Version: 4.4.115
 Architecture: amd64
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Depends: linux-image-4.4.115-grsec
+Depends: linux-image-3.14.79-grsec,linux-image-4.4.115-grsec
 Section: admin
 Priority: optional
 Homepage: https://securedrop.org


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
* Same changes as #3142

## Testing

Verify this is the same commit as in #3142 

## Deployment

Enable admins to rollback to existing grsec kernels if they choose

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
