### PR TITLE
Fix #3151, update docs uname -a to -r

### DIFF
--- a/docs/upgrade/0.5.x_to_0.6.rst
+++ b/docs/upgrade/0.5.x_to_0.6.rst
@@ -174,7 +174,7 @@ Now you can reboot into the old, working kernel.
 The server should come up automatically. From here on, you should be
 able to perform all administrative tasks via SSH as usual. If you want
 additional confirmation of the kernel version, the command 
-``uname -a`` should display ``3.14.79-grsec``.
+``uname -r`` should display ``3.14.79-grsec``.
 
 Please notify us of the compatibility issue so we can help you resolve it ASAP.
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #3151.

Changes proposed in this pull request: Changed uname -a to uname -r, because uname -r would specifically return "3.14.79-grsec", whereas uname -a returns a longer string.

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally.
