### PR TITLE
Remove vanilla Xenial Ubuntu kernels at install-time

### DIFF
--- a/install_files/ansible-base/roles/grsecurity/tasks/clean_packages.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/clean_packages.yml
@@ -12,12 +12,15 @@
     - linux-image-generic-lts-xenial
     - 'linux-image-.*generic'
     - 'linux-headers-.*'
+  register: apt_removed_kernels
+  changed_when: "'The following packages will be REMOVED' in apt_removed_kernels.stdout"
   tags:
     - apt
 
 - name: Get list of all installed kernels.
   shell: dpkg-query -f '${Package} ${Status}\n' -W 'linux-image*' | awk '$NF == "installed"{print $1}'
   register: apt_installed_kernels
+  changed_when: false
   tags:
     - apt
 

--- a/install_files/ansible-base/roles/grsecurity/tasks/clean_packages.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/clean_packages.yml
@@ -3,16 +3,30 @@
 # old generic kernels to avoid accidental
 # boots into a less secure environment.
 - name: Remove generic kernel packages.
-  apt:
-    name: "{{ item }}"
-    state: absent
+  command: apt-get remove -y {{ item }}
   with_items:
     - linux-signed-generic
     - linux-signed-generic-lts-utopic
     - linux-signed-image-generic
     - linux-signed-image-generic-lts-utopic
-    - 'linux-image-*generic'
-    - 'linux-headers-*'
+    - linux-image-generic-lts-xenial
+    - 'linux-image-.*generic'
+    - 'linux-headers-.*'
+  tags:
+    - apt
+
+- name: Get list of all installed kernels.
+  shell: dpkg-query -f '${Package} ${Status}\n' -W 'linux-image*' | awk '$NF == "installed"{print $1}'
+  register: apt_installed_kernels
+  tags:
+    - apt
+
+- name: Validate that all installed kernels are grsecurity-hardened.
+  assert:
+    that:
+      - item | search('-grsec')
+    msg: "Not all non-grsec kernels have been removed, run dpkg-query -W 'linux-image*' for more details."
+  with_items: "{{ apt_installed_kernels.stdout_lines }}"
   tags:
     - apt
 


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

Fixes #3135 .

New SecureDrop installs will now remove all vanilla kernels that were installed as dependencies of the  `linux-image-generic-lts-xenial` metapackage.

A fix to the regex (instead of using wildcard) will ensure the default trusty kernels are correctly removed at install time. The command module instead of apt, as apt module does[ not support regex wildcards](https://docs.ansible.com/ansible/latest/apt_module.html).

## Testing

1- Install SecureDrop on Production VMs (NOT vagrant boxes, but rather from Ubuntu 14.04.5 server isos) or hardware with the logic provided in this branch.
2- ssh into server and `ls /boot` or `sudo apt list --installed` and observe no vanilla kernels installed (only 3.14.79-grsec and 4.4.115-grsec)

## Deployment

This will remove vanilla kernels for new installs only. For (if any), see #3180. 

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
