### PR TITLE
Journalist unit tests: Add pytest fixtures for test data setup

### DIFF
--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -124,6 +124,15 @@ def test_admin(journalist_app):
                 'otp_secret': otp_secret}
 
 
+@pytest.fixture(scope='function')
+def test_source(journalist_app):
+    with journalist_app.app_context():
+        source, _ = utils.db_helper.init_source()
+        filesystem_id = source.filesystem_id
+        return {'source': source,
+                'filesystem_id': filesystem_id}
+
+
 def _start_test_rqworker(config):
     if not psutil.pid_exists(_get_pid_from_file(TEST_WORKER_PIDFILE)):
         tmp_logfile = open('/tmp/test_rqworker.log', 'w')

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -17,6 +17,7 @@ from os import path
 from db import db
 from journalist_app import create_app as create_journalist_app
 from source_app import create_app as create_source_app
+import utils
 
 # TODO: the PID file for the redis worker is hard-coded below.
 # Ideally this constant would be provided by a test harness.
@@ -98,6 +99,29 @@ def journalist_app(config):
     with app.app_context():
         db.create_all()
     return app
+
+
+@pytest.fixture(scope='function')
+def test_journo(journalist_app):
+    with journalist_app.app_context():
+        user, password = utils.db_helper.init_journalist(is_admin=False)
+        username = user.username
+        otp_secret = user.otp_secret
+        return {'username': username,
+                'password': password,
+                'otp_secret': otp_secret,
+                'id': user.id}
+
+
+@pytest.fixture(scope='function')
+def test_admin(journalist_app):
+    with journalist_app.app_context():
+        user, password = utils.db_helper.init_journalist(is_admin=True)
+        username = user.username
+        otp_secret = user.otp_secret
+        return {'username': username,
+                'password': password,
+                'otp_secret': otp_secret}
 
 
 def _start_test_rqworker(config):

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -60,20 +60,17 @@ class TestPytestJournalistApp:
                     fake_config)
                 assert password == VALID_PASSWORD
 
-    def test_reply_error_logging(self, journalist_app):
+    def test_reply_error_logging(self, journalist_app, test_journo):
         with journalist_app.app_context():
             source, _ = utils.db_helper.init_source()
             filesystem_id = source.filesystem_id
-            user, password = utils.db_helper.init_journalist()
-            username = user.username
-            user_id = user.id
-            otp_secret = user.otp_secret
 
         exception_class = StaleDataError
         exception_msg = 'Potentially sensitive content!'
 
         with journalist_app.test_client() as app:
-            _login_user(app, username, password, otp_secret)
+            _login_user(app, test_journo['username'],
+                        test_journo['password'], test_journo['otp_secret'])
             with patch.object(journalist_app.logger, 'error') \
                     as mocked_error_logger:
                 with patch.object(db.session,
@@ -88,23 +85,21 @@ class TestPytestJournalistApp:
         # Notice the "potentially sensitive" exception_msg is not present in
         # the log event.
         mocked_error_logger.assert_called_once_with(
-            "Reply from '{}' (ID {}) failed: {}!".format(username,
-                                                         user_id,
-                                                         exception_class))
+            "Reply from '{}' (ID {}) failed: {}!".format(
+                test_journo['username'],
+                test_journo['id'],
+                exception_class))
 
-    def test_reply_error_flashed_message(self, journalist_app):
+    def test_reply_error_flashed_message(self, journalist_app, test_journo):
         with journalist_app.app_context():
             source, _ = utils.db_helper.init_source()
             filesystem_id = source.filesystem_id
 
-            user, password = utils.db_helper.init_journalist()
-            username = user.username
-            otp_secret = user.otp_secret
-
         exception_class = StaleDataError
 
         with journalist_app.test_client() as app:
-            _login_user(app, username, password, otp_secret)
+            _login_user(app, test_journo['username'],
+                        test_journo['password'], test_journo['otp_secret'])
 
             with InstrumentedApp(app) as ins:
                 with patch.object(db.session, 'commit',
@@ -117,17 +112,14 @@ class TestPytestJournalistApp:
                     'An unexpected error occurred! Please '
                     'inform your administrator.', 'error')
 
-    def test_empty_replies_are_rejected(self, journalist_app):
+    def test_empty_replies_are_rejected(self, journalist_app, test_journo):
         with journalist_app.app_context():
             source, _ = utils.db_helper.init_source()
             filesystem_id = source.filesystem_id
 
-            user, password = utils.db_helper.init_journalist()
-            username = user.username
-            otp_secret = user.otp_secret
-
         with journalist_app.test_client() as app:
-            _login_user(app, username, password, otp_secret)
+            _login_user(app, test_journo['username'],
+                        test_journo['password'], test_journo['otp_secret'])
             resp = app.post(url_for('main.reply'),
                             data={'filesystem_id': filesystem_id,
                                   'message': ''},
@@ -136,17 +128,16 @@ class TestPytestJournalistApp:
             text = resp.data.decode('utf-8')
             assert EMPTY_REPLY_TEXT in text
 
-    def test_nonempty_replies_are_accepted(self, journalist_app):
+    def test_nonempty_replies_are_accepted(self, journalist_app,
+                                           test_journo):
         with journalist_app.app_context():
             source, _ = utils.db_helper.init_source()
             filesystem_id = source.filesystem_id
 
-            user, password = utils.db_helper.init_journalist()
-            username = user.username
-            otp_secret = user.otp_secret
-
         with journalist_app.test_client() as app:
-            _login_user(app, username, password, otp_secret)
+            _login_user(app, test_journo['username'],
+                        test_journo['password'],
+                        test_journo['otp_secret'])
             resp = app.post(url_for('main.reply'),
                             data={'filesystem_id': filesystem_id,
                                   'message': '_'},
@@ -161,29 +152,27 @@ class TestPytestJournalistApp:
                 resp = app.get('/')
                 ins.assert_redirects(resp, '/login')
 
-    def test_login_throttle(self, journalist_app):
-        with journalist_app.app_context():
-            user, password = utils.db_helper.init_journalist()
-            username = user.username
-
+    def test_login_throttle(self, journalist_app, test_journo):
         # Overwrite the default value used during testing
         # TODO this may break other tests during parallel testing
         models.LOGIN_HARDENING = True
         try:
             with journalist_app.test_client() as app:
                 for _ in range(Journalist._MAX_LOGIN_ATTEMPTS_PER_PERIOD):
-                    resp = app.post('/login',
-                                    data=dict(username=username,
-                                              password='invalid',
-                                              token='invalid'))
+                    resp = app.post(
+                        '/login',
+                        data=dict(username=test_journo['username'],
+                                  password='invalid',
+                                  token='invalid'))
                     assert resp.status_code == 200
                     text = resp.data.decode('utf-8')
                     assert "Login failed" in text
 
-                resp = app.post('/login',
-                                data=dict(username=username,
-                                          password='invalid',
-                                          token='invalid'))
+                resp = app.post(
+                    '/login',
+                    data=dict(username=test_journo['username'],
+                              password='invalid',
+                              token='invalid'))
                 assert resp.status_code == 200
                 text = resp.data.decode('utf-8')
                 assert ("Please wait at least {} seconds".format(
@@ -191,14 +180,10 @@ class TestPytestJournalistApp:
         finally:
             models.LOGIN_HARDENING = False
 
-    def test_login_invalid_credentials(self, journalist_app):
-        with journalist_app.app_context():
-            user, password = utils.db_helper.init_journalist()
-            username = user.username
-
+    def test_login_invalid_credentials(self, journalist_app, test_journo):
         with journalist_app.test_client() as app:
             resp = app.post('/login',
-                            data=dict(username=username,
+                            data=dict(username=test_journo['username'],
                                       password='invalid',
                                       token='mocked'))
         assert resp.status_code == 200
@@ -212,153 +197,121 @@ class TestPytestJournalistApp:
             text = resp.data.decode('utf-8')
             assert "Login to access" in text
 
-    def test_login_valid_credentials(self, journalist_app):
-        with journalist_app.app_context():
-            user, password = utils.db_helper.init_journalist()
-            username = user.username
-            otp_secret = user.otp_secret
-
+    def test_login_valid_credentials(self, journalist_app, test_journo):
         with journalist_app.test_client() as app:
-            resp = app.post('/login',
-                            data=dict(username=username,
-                                      password=password,
-                                      token=TOTP(otp_secret).now()),
-                            follow_redirects=True)
+            resp = app.post(
+                '/login',
+                data=dict(username=test_journo['username'],
+                          password=test_journo['password'],
+                          token=TOTP(test_journo['otp_secret']).now()),
+                follow_redirects=True)
         assert resp.status_code == 200  # successful login redirects to index
         text = resp.data.decode('utf-8')
         assert "Sources" in text
         assert "No documents have been submitted!" in text
 
-    def test_admin_login_redirects_to_index(self, journalist_app):
-        with journalist_app.app_context():
-            user, password = utils.db_helper.init_journalist(is_admin=True)
-            username = user.username
-            otp_secret = user.otp_secret
-
+    def test_admin_login_redirects_to_index(self, journalist_app, test_admin):
         with journalist_app.test_client() as app:
             with InstrumentedApp(journalist_app) as ins:
-                resp = app.post('/login',
-                                data=dict(username=username,
-                                          password=password,
-                                          token=TOTP(otp_secret).now()),
-                                follow_redirects=False)
+                resp = app.post(
+                    '/login',
+                    data=dict(username=test_admin['username'],
+                              password=test_admin['password'],
+                              token=TOTP(test_admin['otp_secret']).now()),
+                    follow_redirects=False)
                 ins.assert_redirects(resp, '/')
 
-    def test_user_login_redirects_to_index(self, journalist_app):
-        with journalist_app.app_context():
-            user, password = utils.db_helper.init_journalist(is_admin=False)
-            username = user.username
-            otp_secret = user.otp_secret
-
+    def test_user_login_redirects_to_index(self, journalist_app,
+                                           test_journo):
         with journalist_app.test_client() as app:
             with InstrumentedApp(journalist_app) as ins:
-                resp = app.post('/login',
-                                data=dict(username=username,
-                                          password=password,
-                                          token=TOTP(otp_secret).now()),
-                                follow_redirects=False)
+                resp = app.post(
+                    '/login',
+                    data=dict(username=test_journo['username'],
+                              password=test_journo['password'],
+                              token=TOTP(test_journo['otp_secret']).now()),
+                    follow_redirects=False)
                 ins.assert_redirects(resp, '/')
 
     def test_admin_has_link_to_edit_account_page_in_index_page(self,
-                                                               journalist_app):
-        with journalist_app.app_context():
-            user, password = utils.db_helper.init_journalist(is_admin=True)
-            username = user.username
-            otp_secret = user.otp_secret
-
+                                                               journalist_app,
+                                                               test_admin):
         with journalist_app.test_client() as app:
-            resp = app.post('/login',
-                            data=dict(username=username,
-                                      password=password,
-                                      token=TOTP(otp_secret).now()),
-                            follow_redirects=True)
+            resp = app.post(
+                '/login',
+                data=dict(username=test_admin['username'],
+                          password=test_admin['password'],
+                          token=TOTP(test_admin['otp_secret']).now()),
+                follow_redirects=True)
         edit_account_link = ('<a href="/account/account" '
                              'id="link-edit-account">')
         text = resp.data.decode('utf-8')
         assert edit_account_link in text
 
     def test_user_has_link_to_edit_account_page_in_index_page(self,
-                                                              journalist_app):
-        with journalist_app.app_context():
-            user, password = utils.db_helper.init_journalist()
-            username = user.username
-            otp_secret = user.otp_secret
-
+                                                              journalist_app,
+                                                              test_journo):
         with journalist_app.test_client() as app:
-            resp = app.post('/login',
-                            data=dict(username=username,
-                                      password=password,
-                                      token=TOTP(otp_secret).now()),
-                            follow_redirects=True)
+            resp = app.post(
+                '/login',
+                data=dict(username=test_journo['username'],
+                          password=test_journo['password'],
+                          token=TOTP(test_journo['otp_secret']).now()),
+                follow_redirects=True)
         edit_account_link = ('<a href="/account/account" '
                              'id="link-edit-account">')
         text = resp.data.decode('utf-8')
         assert edit_account_link in text
 
     def test_admin_has_link_to_admin_index_page_in_index_page(self,
-                                                              journalist_app):
-        with journalist_app.app_context():
-            user, password = utils.db_helper.init_journalist(is_admin=True)
-            username = user.username
-            otp_secret = user.otp_secret
-
+                                                              journalist_app,
+                                                              test_admin):
         with journalist_app.test_client() as app:
-            resp = app.post('/login',
-                            data=dict(username=username,
-                                      password=password,
-                                      token=TOTP(otp_secret).now()),
-                            follow_redirects=True)
+            resp = app.post(
+                '/login',
+                data=dict(username=test_admin['username'],
+                          password=test_admin['password'],
+                          token=TOTP(test_admin['otp_secret']).now()),
+                follow_redirects=True)
         text = resp.data.decode('utf-8')
         assert ADMIN_LINK in text
 
     def test_user_lacks_link_to_admin_index_page_in_index_page(self,
-                                                               journalist_app):
-        with journalist_app.app_context():
-            user, password = utils.db_helper.init_journalist()
-            username = user.username
-            otp_secret = user.otp_secret
-
+                                                               journalist_app,
+                                                               test_journo):
         with journalist_app.test_client() as app:
-            resp = app.post('/login',
-                            data=dict(username=username,
-                                      password=password,
-                                      token=TOTP(otp_secret).now()),
-                            follow_redirects=True)
+            resp = app.post(
+                '/login',
+                data=dict(username=test_journo['username'],
+                          password=test_journo['password'],
+                          token=TOTP(test_journo['otp_secret']).now()),
+                follow_redirects=True)
         text = resp.data.decode('utf-8')
         assert ADMIN_LINK not in text
 
-    def test_admin_logout_redirects_to_index(self, journalist_app):
-        with journalist_app.app_context():
-            user, password = utils.db_helper.init_journalist(is_admin=True)
-            username = user.username
-            otp_secret = user.otp_secret
-
+    def test_admin_logout_redirects_to_index(self, journalist_app, test_admin):
         with journalist_app.test_client() as app:
             with InstrumentedApp(journalist_app) as ins:
-                _login_user(app, username, password, otp_secret)
+                _login_user(app, test_admin['username'],
+                            test_admin['password'],
+                            test_admin['otp_secret'])
                 resp = app.get('/logout')
                 ins.assert_redirects(resp, '/')
 
-    def test_user_logout_redirects_to_index(self, journalist_app):
-        with journalist_app.app_context():
-            user, password = utils.db_helper.init_journalist()
-            username = user.username
-            otp_secret = user.otp_secret
-
+    def test_user_logout_redirects_to_index(self, journalist_app,
+                                            test_journo):
         with journalist_app.test_client() as app:
             with InstrumentedApp(journalist_app) as ins:
-                _login_user(app, username, password, otp_secret)
+                _login_user(app, test_journo['username'],
+                            test_journo['password'],
+                            test_journo['otp_secret'])
                 resp = app.get('/logout')
                 ins.assert_redirects(resp, '/')
 
-    def test_admin_index(self, journalist_app):
-        with journalist_app.app_context():
-            user, password = utils.db_helper.init_journalist(is_admin=True)
-            username = user.username
-            otp_secret = user.otp_secret
-
+    def test_admin_index(self, journalist_app, test_admin):
         with journalist_app.test_client() as app:
-            _login_user(app, username, password, otp_secret)
+            _login_user(app, test_admin['username'], test_admin['password'],
+                        test_admin['otp_secret'])
             resp = app.get('/admin/')
             assert resp.status_code == 200
             text = resp.data.decode('utf-8')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

More towards #2535, followup to #3140

Changes proposed in this pull request:
* This PR adds pytest fixtures for test data to reduce code duplication as more of our test suite is migrated to pytest 

Note to reviewer: The diff looks large, but I recommend stepping commit by commit and reading the corresponding commit messages because it's not so bad - i.e. one commit basically just unindents code which is responsible for a big chunk of the diff.

## Testing

```
cd securedrop
bin/dev-shell bin/run-test tests/test_journalist.py
```

## Deployment

Tests only

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
