### PR TITLE
docs: update-user-guides needs to force update sass to ensure the latest

### DIFF
--- a/securedrop/bin/update-user-guides
+++ b/securedrop/bin/update-user-guides
@@ -9,7 +9,7 @@ run_xvfb &
 run_redis &
 run_x11vnc &
 urandom
-run_sass
+run_sass --force --update
 maybe_create_config_py
 
 ./i18n_tool.py translate-messages --compile


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

If the directory `sass` already exists, it fails with:

<pre>
Errno::EISDIR: Is a directory - sass
  Use --trace for backtrace.
</pre>

## Testing

* make -C securedrop test # will create the `sass` directory
* make -C securedrop update-user-guides

## Deployment

N/A
