### PR TITLE
docs: the screenshots must be updated after translations are merged

### DIFF
--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -55,6 +55,8 @@ prefix the branch name with ``docs-`` to skip the staging run. Project
 maintainers will still need to approve the PR prior to merge, and the linting
 checks will also still run.
 
+.. _updating_screenshots:
+
 Updating screenshots
 --------------------
 

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -327,6 +327,7 @@ The day of the release
 ~~~~~~~~~~~~~~~~~~~~~~
 
 * Merge translations back to develop
+* :ref:`Update the screenshots <updating_screenshots>`
 * Remove the prominent Weblate whiteboard announcement
 * Provide translator credits to add to the SecureDrop release announcement
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

They could also be updated right after string freeze. But by updating
them after translations are merged, we won't have inconsistencies in
case a fix had to be made because of a bad typo, violating the string
freeze.

## Testing

* make -C securedrop docs
* firefox http://localhost:8000/development/i18n.html#the-day-of-the-release

## Deployment

N/A

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
