### PR TITLE
[0.6.1] docs: add missing fetch in upgrade instructions

### DIFF
--- a/docs/upgrade/0.5.x_to_0.6.rst
+++ b/docs/upgrade/0.5.x_to_0.6.rst
@@ -17,6 +17,7 @@ need to update the SecureDrop code using the following manual method:
 .. code:: sh
 
    cd ~/Persistent/securedrop
+   git fetch --tags
    git checkout 0.6
    gpg --recv-key "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
    git tag -v 0.6 # Output should include "Good signature"


### PR DESCRIPTION
(cherry picked from commit c5df4c882ece56b0c9594415c638314c557d0693)
## Status

Ready for review

## Description of Changes

Reported by [Jonas Franzen](https://forum.securedrop.club/u/jonas.franzen): add missing fetch in upgrade instructions

## Testing

N/A

## Deployment

N/A

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
