### PR TITLE
include token reuse under login hardening flag

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -419,11 +419,11 @@ class Journalist(db.Model):
         if LOGIN_HARDENING:
             cls.throttle_login(user)
 
-        # Prevent TOTP token reuse
-        if user.last_token is not None:
-            if pyotp.utils.compare_digest(token, user.last_token):
-                raise BadTokenException("previously used token "
-                                        "{}".format(token))
+            # Prevent TOTP token reuse
+            if user.last_token is not None:
+                if pyotp.utils.compare_digest(token, user.last_token):
+                    raise BadTokenException("previously used token "
+                                            "{}".format(token))
         if not user.verify_token(token):
             raise BadTokenException("invalid token")
         if not user.valid_password(password):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Relates to #3173

Move the token reuse check under the `LOGIN_HARDENING` flag. This simplifies some tests cases so that instead of 2FA, we can enable it and then just disable hardening for other actions that require passphrases (pw change, account edit, etc). 

## Testing

`make test`

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container