### PR TITLE
tests: allow override of PAGE_LAYOUT_LOCALES

### DIFF
--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -22,7 +22,9 @@ fi
 
 mkdir -p "/tmp/test-results/logs"
 
-export PAGE_LAYOUT_LOCALES="en_US,ar,fr_FR"
+: "${PAGE_LAYOUT_LOCALES:=en_US,ar,fr_FR}"
+export PAGE_LAYOUT_LOCALES
+
 pytest \
   --page-layout \
   --durations 10 \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

When running tests that create screenshots, we need to have control over the languages being used. 

## Testing

* `DOCKER_RUN_ARGUMENTS='-e PAGE_LAYOUT_LOCALES=en_US'  ./bin/dev-shell ./bin/run-test -v tests/pages-layout`
* verify only `tests/pages-layout/screenshots/en_US` is created

## Deployment

N/A
