### PR TITLE
Pytest fixtures for management commands

### DIFF
--- a/securedrop/requirements/test-requirements.in
+++ b/securedrop/requirements/test-requirements.in
@@ -6,4 +6,5 @@ pip-tools
 py
 pytest
 pytest-cov
+pytest-mock
 selenium < 3

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -22,6 +22,7 @@ pip-tools==1.11.0
 pluggy==0.6.0             # via pytest
 py==1.5.2
 pytest-cov==2.5.1
+pytest-mock==1.7.1
 pytest==3.3.2
 selenium==2.53.6
 six==1.11.0               # via mock, pip-tools, pytest

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -19,194 +19,204 @@ YUBIKEY_HOTP = ['cb a0 5f ad 41 a2 ff 4e eb 53 56 3a 1b f7 23 2e ce fc dc',
                 'cb a0 5f ad 41 a2 ff 4e eb 53 56 3a 1b f7 23 2e ce fc dc d7']
 
 
-class TestManagePy(object):
-
-    def test_parse_args(self):
-        # just test that the arg parser is stable
-        manage.get_args()
-
-    def test_not_verbose(self, caplog):
-        args = manage.get_args().parse_args(['run'])
-        manage.setup_verbosity(args)
-        manage.log.debug('INVISIBLE')
-        assert 'INVISIBLE' not in caplog.text
-
-    def test_verbose(self, caplog):
-        args = manage.get_args().parse_args(['--verbose', 'run'])
-        manage.setup_verbosity(args)
-        manage.log.debug('VISIBLE')
-        assert 'VISIBLE' in caplog.text
+def test_parse_args():
+    # just test that the arg parser is stable
+    manage.get_args()
 
 
-class TestManagementCommand:
+def test_not_verbose(caplog):
+    args = manage.get_args().parse_args(['run'])
+    manage.setup_verbosity(args)
+    manage.log.debug('INVISIBLE')
+    assert 'INVISIBLE' not in caplog.text
 
-    def test_get_username_success(self):
-        with mock.patch("__builtin__.raw_input", return_value='jen'):
-            assert manage._get_username() == 'jen'
 
-    def test_get_username_fail(self):
-        bad_username = 'a' * (Journalist.MIN_USERNAME_LEN - 1)
-        with mock.patch("__builtin__.raw_input",
-                        side_effect=[bad_username, 'jen']):
-            assert manage._get_username() == 'jen'
+def test_verbose(caplog):
+    args = manage.get_args().parse_args(['--verbose', 'run'])
+    manage.setup_verbosity(args)
+    manage.log.debug('VISIBLE')
+    assert 'VISIBLE' in caplog.text
 
-    def test_get_yubikey_usage_yes(self):
-        with mock.patch("__builtin__.raw_input", return_value='y'):
-            assert manage._get_yubikey_usage()
 
-    def test_get_yubikey_usage_no(self):
-        with mock.patch("__builtin__.raw_input", return_value='n'):
-            assert not manage._get_yubikey_usage()
+def test_get_username_success():
+    with mock.patch("__builtin__.raw_input", return_value='jen'):
+        assert manage._get_username() == 'jen'
 
-    # Note: we use the `journalist_app` fixture because it creates the DB
-    def test_handle_invalid_secret(self, journalist_app, config, mocker):
-        """Regression test for bad secret logic in manage.py"""
 
-        mocker.patch("manage._get_username", return_value='ntoll'),
-        mocker.patch("manage._get_yubikey_usage", return_value=True),
-        mocker.patch("__builtin__.raw_input", side_effect=YUBIKEY_HOTP),
-        mocker.patch("sys.stdout", new_callable=StringIO),
+def test_get_username_fail():
+    bad_username = 'a' * (Journalist.MIN_USERNAME_LEN - 1)
+    with mock.patch("__builtin__.raw_input",
+                    side_effect=[bad_username, 'jen']):
+        assert manage._get_username() == 'jen'
 
-        original_config = manage.config
 
-        try:
-            # We need to override the config to point at the per-test DB
-            manage.config = config
+def test_get_yubikey_usage_yes():
+    with mock.patch("__builtin__.raw_input", return_value='y'):
+        assert manage._get_yubikey_usage()
 
-            # We will try to provide one invalid and one valid secret
-            return_value = manage._add_user()
 
-            assert return_value == 0
-            assert 'Try again.' in sys.stdout.getvalue()
-            assert 'successfully added' in sys.stdout.getvalue()
-        finally:
-            manage.config = original_config
+def test_get_yubikey_usage_no():
+    with mock.patch("__builtin__.raw_input", return_value='n'):
+        assert not manage._get_yubikey_usage()
 
-    # Note: we use the `journalist_app` fixture because it creates the DB
-    def test_exception_handling_when_duplicate_username(self,
-                                                        journalist_app,
-                                                        config,
-                                                        mocker):
-        """Regression test for duplicate username logic in manage.py"""
 
-        mocker.patch("manage._get_username", return_value='foo-bar-baz')
-        mocker.patch("manage._get_yubikey_usage", return_value=False)
-        mocker.patch("sys.stdout", new_callable=StringIO)
+# Note: we use the `journalist_app` fixture because it creates the DB
+def test_handle_invalid_secret(journalist_app, config, mocker):
+    """Regression test for bad secret logic in manage.py"""
 
-        original_config = manage.config
+    mocker.patch("manage._get_username", return_value='ntoll'),
+    mocker.patch("manage._get_yubikey_usage", return_value=True),
+    mocker.patch("__builtin__.raw_input", side_effect=YUBIKEY_HOTP),
+    mocker.patch("sys.stdout", new_callable=StringIO),
 
-        try:
-            # We need to override the config to point at the per-test DB
-            manage.config = config
+    original_config = manage.config
 
-            # Inserting the user for the first time should succeed
-            return_value = manage._add_user()
-            assert return_value == 0
-            assert 'successfully added' in sys.stdout.getvalue()
+    try:
+        # We need to override the config to point at the per-test DB
+        manage.config = config
 
-            # Inserting the user for a second time should fail
-            return_value = manage._add_user()
-            assert return_value == 1
-            assert ('ERROR: That username is already taken!' in
-                    sys.stdout.getvalue())
-        finally:
-            manage.config = original_config
+        # We will try to provide one invalid and one valid secret
+        return_value = manage._add_user()
 
-    # Note: we use the `journalist_app` fixture because it creates the DB
-    def test_delete_user(self, journalist_app, config, mocker):
-        mocker.patch("manage._get_username", return_value='test-user-56789')
-        mocker.patch("manage._get_yubikey_usage", return_value=False)
-        mocker.patch("manage._get_username_to_delete",
-                     return_value='test-user-56789')
-        mocker.patch('manage._get_delete_confirmation', return_value=True)
+        assert return_value == 0
+        assert 'Try again.' in sys.stdout.getvalue()
+        assert 'successfully added' in sys.stdout.getvalue()
+    finally:
+        manage.config = original_config
 
-        original_config = manage.config
 
-        try:
-            # We need to override the config to point at the per-test DB
-            manage.config = config
+# Note: we use the `journalist_app` fixture because it creates the DB
+def test_exception_handling_when_duplicate_username(journalist_app,
+                                                    config,
+                                                    mocker):
+    """Regression test for duplicate username logic in manage.py"""
 
-            return_value = manage._add_user()
-            assert return_value == 0
+    mocker.patch("manage._get_username", return_value='foo-bar-baz')
+    mocker.patch("manage._get_yubikey_usage", return_value=False)
+    mocker.patch("sys.stdout", new_callable=StringIO)
 
-            return_value = manage.delete_user(args=None)
-            assert return_value == 0
-        finally:
-            manage.config = original_config
+    original_config = manage.config
 
-    # Note: we use the `journalist_app` fixture because it creates the DB
-    def test_delete_non_existent_user(self, journalist_app, config, mocker):
-        mocker.patch("manage._get_username_to_delete",
-                     return_value='does-not-exist')
-        mocker.patch('manage._get_delete_confirmation', return_value=True)
-        mocker.patch("sys.stdout", new_callable=StringIO)
+    try:
+        # We need to override the config to point at the per-test DB
+        manage.config = config
 
-        original_config = manage.config
+        # Inserting the user for the first time should succeed
+        return_value = manage._add_user()
+        assert return_value == 0
+        assert 'successfully added' in sys.stdout.getvalue()
 
-        try:
-            # We need to override the config to point at the per-test DB
-            manage.config = config
-            return_value = manage.delete_user(args=None)
-            assert return_value == 0
-            assert 'ERROR: That user was not found!' in sys.stdout.getvalue()
-        finally:
-            manage.config = original_config
+        # Inserting the user for a second time should fail
+        return_value = manage._add_user()
+        assert return_value == 1
+        assert ('ERROR: That username is already taken!' in
+                sys.stdout.getvalue())
+    finally:
+        manage.config = original_config
 
-    def test_get_username_to_delete(self, mocker):
-        mocker.patch("__builtin__.raw_input", return_value='test-user-12345')
-        return_value = manage._get_username_to_delete()
-        assert return_value == 'test-user-12345'
 
-    def test_reset(self, journalist_app, test_journo, config):
-        original_config = manage.config
-        try:
-            # We need to override the config to point at the per-test DB
-            manage.config = config
+# Note: we use the `journalist_app` fixture because it creates the DB
+def test_delete_user(journalist_app, config, mocker):
+    mocker.patch("manage._get_username", return_value='test-user-56789')
+    mocker.patch("manage._get_yubikey_usage", return_value=False)
+    mocker.patch("manage._get_username_to_delete",
+                 return_value='test-user-56789')
+    mocker.patch('manage._get_delete_confirmation', return_value=True)
 
-            return_value = manage.reset(args=None)
-            assert return_value == 0
-            assert os.path.exists(config.DATABASE_FILE)
-            assert os.path.exists(config.STORE_DIR)
+    original_config = manage.config
 
-            # Verify journalist user present in the database is gone
-            with journalist_app.app_context():
-                res = Journalist.query \
-                    .filter_by(username=test_journo['username']).one_or_none()
-                assert res is None
-        finally:
-            manage.config = original_config
+    try:
+        # We need to override the config to point at the per-test DB
+        manage.config = config
 
-    def test_get_username(self, mocker):
-        mocker.patch("__builtin__.raw_input", return_value='foo-bar-baz')
-        assert manage._get_username() == 'foo-bar-baz'
+        return_value = manage._add_user()
+        assert return_value == 0
 
-    def test_clean_tmp_do_nothing(self, caplog):
-        args = argparse.Namespace(days=0,
-                                  directory=' UNLIKELY::::::::::::::::: ',
-                                  verbose=logging.DEBUG)
-        manage.setup_verbosity(args)
-        manage.clean_tmp(args)
-        assert 'does not exist, do nothing' in caplog.text
+        return_value = manage.delete_user(args=None)
+        assert return_value == 0
+    finally:
+        manage.config = original_config
 
-    def test_clean_tmp_too_young(self, config, caplog):
-        args = argparse.Namespace(days=24*60*60,
-                                  directory=config.TEMP_DIR,
-                                  verbose=logging.DEBUG)
-        # create a file
-        open(os.path.join(config.TEMP_DIR, 'FILE'), 'a').close()
 
-        manage.setup_verbosity(args)
-        manage.clean_tmp(args)
-        assert 'modified less than' in caplog.text
+# Note: we use the `journalist_app` fixture because it creates the DB
+def test_delete_non_existent_user(journalist_app, config, mocker):
+    mocker.patch("manage._get_username_to_delete",
+                 return_value='does-not-exist')
+    mocker.patch('manage._get_delete_confirmation', return_value=True)
+    mocker.patch("sys.stdout", new_callable=StringIO)
 
-    def test_clean_tmp_removed(self, config, caplog):
-        args = argparse.Namespace(days=0,
-                                  directory=config.TEMP_DIR,
-                                  verbose=logging.DEBUG)
-        fname = os.path.join(config.TEMP_DIR, 'FILE')
-        with open(fname, 'a'):
-            old = time.time() - 24*60*60
-            os.utime(fname, (old, old))
-        manage.setup_verbosity(args)
-        manage.clean_tmp(args)
-        assert 'FILE removed' in caplog.text
+    original_config = manage.config
+
+    try:
+        # We need to override the config to point at the per-test DB
+        manage.config = config
+        return_value = manage.delete_user(args=None)
+        assert return_value == 0
+        assert 'ERROR: That user was not found!' in sys.stdout.getvalue()
+    finally:
+        manage.config = original_config
+
+
+def test_get_username_to_delete(mocker):
+    mocker.patch("__builtin__.raw_input", return_value='test-user-12345')
+    return_value = manage._get_username_to_delete()
+    assert return_value == 'test-user-12345'
+
+
+def test_reset(journalist_app, test_journo, config):
+    original_config = manage.config
+    try:
+        # We need to override the config to point at the per-test DB
+        manage.config = config
+
+        return_value = manage.reset(args=None)
+        assert return_value == 0
+        assert os.path.exists(config.DATABASE_FILE)
+        assert os.path.exists(config.STORE_DIR)
+
+        # Verify journalist user present in the database is gone
+        with journalist_app.app_context():
+            res = Journalist.query \
+                .filter_by(username=test_journo['username']).one_or_none()
+            assert res is None
+    finally:
+        manage.config = original_config
+
+
+def test_get_username(mocker):
+    mocker.patch("__builtin__.raw_input", return_value='foo-bar-baz')
+    assert manage._get_username() == 'foo-bar-baz'
+
+
+def test_clean_tmp_do_nothing(caplog):
+    args = argparse.Namespace(days=0,
+                              directory=' UNLIKELY::::::::::::::::: ',
+                              verbose=logging.DEBUG)
+    manage.setup_verbosity(args)
+    manage.clean_tmp(args)
+    assert 'does not exist, do nothing' in caplog.text
+
+
+def test_clean_tmp_too_young(config, caplog):
+    args = argparse.Namespace(days=24*60*60,
+                              directory=config.TEMP_DIR,
+                              verbose=logging.DEBUG)
+    # create a file
+    open(os.path.join(config.TEMP_DIR, 'FILE'), 'a').close()
+
+    manage.setup_verbosity(args)
+    manage.clean_tmp(args)
+    assert 'modified less than' in caplog.text
+
+
+def test_clean_tmp_removed(config, caplog):
+    args = argparse.Namespace(days=0,
+                              directory=config.TEMP_DIR,
+                              verbose=logging.DEBUG)
+    fname = os.path.join(config.TEMP_DIR, 'FILE')
+    with open(fname, 'a'):
+        old = time.time() - 24*60*60
+        os.utime(fname, (old, old))
+    manage.setup_verbosity(args)
+    manage.clean_tmp(args)
+    assert 'FILE removed' in caplog.text

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -50,6 +50,12 @@ class TestPytestManagementCommand(unittest.TestCase):
         with mock.patch("__builtin__.raw_input", return_value='jen'):
             assert manage._get_username() == 'jen'
 
+    def test_get_username_fail(self):
+        bad_username = 'a' * (Journalist.MIN_USERNAME_LEN - 1)
+        with mock.patch("__builtin__.raw_input",
+                        side_effect=[bad_username, 'jen']):
+            assert manage._get_username() == 'jen'
+
 
 class TestManagementCommand(unittest.TestCase):
 
@@ -63,11 +69,6 @@ class TestManagementCommand(unittest.TestCase):
         self.__context.push()
         utils.env.teardown()
         self.__context.pop()
-
-    @mock.patch("__builtin__.raw_input",
-                side_effect=['a' * (Journalist.MIN_USERNAME_LEN - 1), 'jen'])
-    def test_get_username_fail(self, mock_stdin):
-        assert manage._get_username() == 'jen'
 
     @mock.patch("__builtin__.raw_input", return_value='y')
     def test_get_yubikey_usage_yes(self, mock_stdin):

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -158,6 +158,11 @@ class TestPytestManagementCommand:
         finally:
             manage.config = original_config
 
+    def test_get_username_to_delete(self, mocker):
+        mocker.patch("__builtin__.raw_input", return_value='test-user-12345')
+        return_value = manage._get_username_to_delete()
+        assert return_value == 'test-user-12345'
+
 
 class TestManagementCommand(unittest.TestCase):
 
@@ -171,11 +176,6 @@ class TestManagementCommand(unittest.TestCase):
         self.__context.push()
         utils.env.teardown()
         self.__context.pop()
-
-    @mock.patch("__builtin__.raw_input", return_value='test-user-12345')
-    def test_get_username_to_delete(self, mock_username):
-        return_value = manage._get_username_to_delete()
-        self.assertEqual(return_value, 'test-user-12345')
 
     def test_reset(self):
         test_journalist, _ = utils.db_helper.init_journalist()

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -184,6 +184,14 @@ class TestManagementCommand:
         mocker.patch("__builtin__.raw_input", return_value='foo-bar-baz')
         assert manage._get_username() == 'foo-bar-baz'
 
+    def test_clean_tmp_do_nothing(self, caplog):
+        args = argparse.Namespace(days=0,
+                                  directory=' UNLIKELY::::::::::::::::: ',
+                                  verbose=logging.DEBUG)
+        manage.setup_verbosity(args)
+        manage.clean_tmp(args)
+        assert 'does not exist, do nothing' in caplog.text
+
 
 class TestManage(object):
 
@@ -196,14 +204,6 @@ class TestManage(object):
     def teardown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    def test_clean_tmp_do_nothing(self, caplog):
-        args = argparse.Namespace(days=0,
-                                  directory=' UNLIKELY ',
-                                  verbose=logging.DEBUG)
-        manage.setup_verbosity(args)
-        manage.clean_tmp(args)
-        assert 'does not exist, do nothing' in caplog.text
 
     def test_clean_tmp_too_young(self, caplog):
         args = argparse.Namespace(days=24*60*60,

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -56,6 +56,10 @@ class TestPytestManagementCommand(unittest.TestCase):
                         side_effect=[bad_username, 'jen']):
             assert manage._get_username() == 'jen'
 
+    def test_get_yubikey_usage_yes(self):
+        with mock.patch("__builtin__.raw_input", return_value='y'):
+            assert manage._get_yubikey_usage()
+
 
 class TestManagementCommand(unittest.TestCase):
 
@@ -69,10 +73,6 @@ class TestManagementCommand(unittest.TestCase):
         self.__context.push()
         utils.env.teardown()
         self.__context.pop()
-
-    @mock.patch("__builtin__.raw_input", return_value='y')
-    def test_get_yubikey_usage_yes(self, mock_stdin):
-        assert manage._get_yubikey_usage()
 
     @mock.patch("__builtin__.raw_input", return_value='n')
     def test_get_yubikey_usage_no(self, mock_stdin):

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -60,6 +60,10 @@ class TestPytestManagementCommand(unittest.TestCase):
         with mock.patch("__builtin__.raw_input", return_value='y'):
             assert manage._get_yubikey_usage()
 
+    def test_get_yubikey_usage_no(self):
+        with mock.patch("__builtin__.raw_input", return_value='n'):
+            assert not manage._get_yubikey_usage()
+
 
 class TestManagementCommand(unittest.TestCase):
 
@@ -73,10 +77,6 @@ class TestManagementCommand(unittest.TestCase):
         self.__context.push()
         utils.env.teardown()
         self.__context.pop()
-
-    @mock.patch("__builtin__.raw_input", return_value='n')
-    def test_get_yubikey_usage_no(self, mock_stdin):
-        assert not manage._get_yubikey_usage()
 
     @mock.patch("manage._get_username", return_value='ntoll')
     @mock.patch("manage._get_yubikey_usage", return_value=True)

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -180,6 +180,10 @@ class TestManagementCommand:
         finally:
             manage.config = original_config
 
+    def test_get_username(self, mocker):
+        mocker.patch("__builtin__.raw_input", return_value='foo-bar-baz')
+        assert manage._get_username() == 'foo-bar-baz'
+
 
 class TestManage(object):
 
@@ -192,10 +196,6 @@ class TestManage(object):
     def teardown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    @mock.patch("__builtin__.raw_input", return_value='foo-bar-baz')
-    def test_get_username(self, mock_get_usernam):
-        assert manage._get_username() == 'foo-bar-baz'
 
     def test_clean_tmp_do_nothing(self, caplog):
         args = argparse.Namespace(days=0,

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -44,6 +44,13 @@ class TestManagePy(object):
         assert 'VISIBLE' in caplog.text
 
 
+class TestPytestManagementCommand(unittest.TestCase):
+
+    def test_get_username_success(self):
+        with mock.patch("__builtin__.raw_input", return_value='jen'):
+            assert manage._get_username() == 'jen'
+
+
 class TestManagementCommand(unittest.TestCase):
 
     def setUp(self):
@@ -56,10 +63,6 @@ class TestManagementCommand(unittest.TestCase):
         self.__context.push()
         utils.env.teardown()
         self.__context.pop()
-
-    @mock.patch("__builtin__.raw_input", return_value='jen')
-    def test_get_username_success(self, mock_stdin):
-        assert manage._get_username() == 'jen'
 
     @mock.patch("__builtin__.raw_input",
                 side_effect=['a' * (Journalist.MIN_USERNAME_LEN - 1), 'jen'])

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -192,6 +192,17 @@ class TestManagementCommand:
         manage.clean_tmp(args)
         assert 'does not exist, do nothing' in caplog.text
 
+    def test_clean_tmp_too_young(self, config, caplog):
+        args = argparse.Namespace(days=24*60*60,
+                                  directory=config.TEMP_DIR,
+                                  verbose=logging.DEBUG)
+        # create a file
+        open(os.path.join(config.TEMP_DIR, 'FILE'), 'a').close()
+
+        manage.setup_verbosity(args)
+        manage.clean_tmp(args)
+        assert 'modified less than' in caplog.text
+
 
 class TestManage(object):
 
@@ -204,15 +215,6 @@ class TestManage(object):
     def teardown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    def test_clean_tmp_too_young(self, caplog):
-        args = argparse.Namespace(days=24*60*60,
-                                  directory=config.TEMP_DIR,
-                                  verbose=logging.DEBUG)
-        open(os.path.join(config.TEMP_DIR, 'FILE'), 'a').close()
-        manage.setup_verbosity(args)
-        manage.clean_tmp(args)
-        assert 'modified less than' in caplog.text
 
     def test_clean_tmp_removed(self, caplog):
         args = argparse.Namespace(days=0,

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -7,16 +7,12 @@ import manage
 import mock
 import sys
 import time
-import utils
 
-from os.path import abspath, dirname, realpath
 from StringIO import StringIO
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import journalist_app
 
 from models import Journalist
-from sdconfig import config
 
 
 YUBIKEY_HOTP = ['cb a0 5f ad 41 a2 ff 4e eb 53 56 3a 1b f7 23 2e ce fc dc',
@@ -203,20 +199,7 @@ class TestManagementCommand:
         manage.clean_tmp(args)
         assert 'modified less than' in caplog.text
 
-
-class TestManage(object):
-
-    def setup(self):
-        self.__context = journalist_app.create_app(config).app_context()
-        self.__context.push()
-        self.dir = abspath(dirname(realpath(__file__)))
-        utils.env.setup()
-
-    def teardown(self):
-        utils.env.teardown()
-        self.__context.pop()
-
-    def test_clean_tmp_removed(self, caplog):
+    def test_clean_tmp_removed(self, config, caplog):
         args = argparse.Namespace(days=0,
                                   directory=config.TEMP_DIR,
                                   verbose=logging.DEBUG)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #2877 

`pytest` fixtures for `test_manage.py`.

## Testing

```
make test TESTFILES=test/test_manage.py
```

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container