### PR TITLE
tests: bump cryptography to 2.2.1

### DIFF
--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -31,7 +31,7 @@ click==6.7                # via click-completion, cookiecutter, git-url-parse, m
 colorama==0.3.7           # via molecule, python-gilt
 configparser==3.5.0       # via flake8, pylint
 cookiecutter==1.5.1       # via molecule
-cryptography==2.0.3       # via ansible, paramiko
+cryptography==2.2.1       # via ansible, paramiko
 docker-py==1.10.6
 docker-pycreds==0.2.1     # via docker-py
 docopt==0.6.2             # via html-linter, template-remover


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

With cryptography version 2.0.3 the following happens:

> import requests
> requests.get('https://weblate.securedrop.org/exports/stats/securedrop/securedrop/?format=json')
From cffi callback <function _verify_callback at 0x7f18204d15f0>:
Traceback (most recent call last):
  File "/home/loic/software/securedrop/virtualenv/local/lib/python2.7/site-packages/OpenSSL/SSL.py", line 313, in wrapper
    _lib.X509_up_ref(x509)
AttributeError: 'module' object has no attribute 'X509_up_ref'

and also in other contexts. Upgrading to 2.2.1 fixes the problem.

## Testing

If CI pases it means the development environment is not broken.

## Deployment

N/A only development
