### PR TITLE
Moar pytest fixtures

### DIFF
--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -244,6 +244,14 @@ def test_verify_default_locale_en_us_if_not_defined_in_config(config):
         assert not_translated == gettext(not_translated)
 
 
+def test_locale_to_rfc_5646():
+    assert i18n.locale_to_rfc_5646('en') == 'en'
+    assert i18n.locale_to_rfc_5646('en-US') == 'en'
+    assert i18n.locale_to_rfc_5646('en_US') == 'en'
+    assert i18n.locale_to_rfc_5646('en-us') == 'en'
+    assert i18n.locale_to_rfc_5646('zh-hant') == 'zh-Hant'
+
+
 class TestI18N(unittest.TestCase):
 
     def setUp(self):
@@ -264,13 +272,6 @@ class TestI18N(unittest.TestCase):
 
     def get_fake_config(self):
         return SDConfig()
-
-    def test_locale_to_rfc_5646(self):
-        assert i18n.locale_to_rfc_5646('en') == 'en'
-        assert i18n.locale_to_rfc_5646('en-US') == 'en'
-        assert i18n.locale_to_rfc_5646('en_US') == 'en'
-        assert i18n.locale_to_rfc_5646('en-us') == 'en'
-        assert i18n.locale_to_rfc_5646('zh-hant') == 'zh-Hant'
 
     def test_html_en_lang_correct(self):
         fake_config = self.get_fake_config()

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -37,6 +37,22 @@ import version
 import utils
 
 
+def test_get_supported_locales():
+    locales = ['en_US', 'fr_FR']
+    assert ['en_US'] == i18n._get_supported_locales(
+        locales, None, None, None)
+    locales = ['en_US', 'fr_FR']
+    supported = ['en_US', 'not_found']
+    with pytest.raises(i18n.LocaleNotFound) as excinfo:
+        i18n._get_supported_locales(locales, supported, None, None)
+    assert "contains ['not_found']" in str(excinfo.value)
+    supported = ['fr_FR']
+    locale = 'not_found'
+    with pytest.raises(i18n.LocaleNotFound) as excinfo:
+        i18n._get_supported_locales(locales, supported, locale, None)
+    assert "DEFAULT_LOCALE 'not_found'" in str(excinfo.value)
+
+
 class TestI18N(unittest.TestCase):
 
     def setUp(self):
@@ -57,21 +73,6 @@ class TestI18N(unittest.TestCase):
 
     def get_fake_config(self):
         return SDConfig()
-
-    def test_get_supported_locales(self):
-        locales = ['en_US', 'fr_FR']
-        assert ['en_US'] == i18n._get_supported_locales(
-            locales, None, None, None)
-        locales = ['en_US', 'fr_FR']
-        supported = ['en_US', 'not_found']
-        with pytest.raises(i18n.LocaleNotFound) as excinfo:
-            i18n._get_supported_locales(locales, supported, None, None)
-        assert "contains ['not_found']" in str(excinfo.value)
-        supported = ['fr_FR']
-        locale = 'not_found'
-        with pytest.raises(i18n.LocaleNotFound) as excinfo:
-            i18n._get_supported_locales(locales, supported, locale, None)
-        assert "DEFAULT_LOCALE 'not_found'" in str(excinfo.value)
 
     def verify_i18n(self, app):
         not_translated = 'code hello i18n'

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -232,6 +232,18 @@ def test_i18n(journalist_app, config):
         verify_i18n(app)
 
 
+def test_verify_default_locale_en_us_if_not_defined_in_config(config):
+    class Config:
+        def __getattr__(self, name):
+            if name == 'DEFAULT_LOCALE':
+                raise AttributeError()
+            return getattr(config, name)
+    not_translated = 'code hello i18n'
+    with source_app.create_app(Config()).test_client() as c:
+        c.get('/')
+        assert not_translated == gettext(not_translated)
+
+
 class TestI18N(unittest.TestCase):
 
     def setUp(self):
@@ -252,17 +264,6 @@ class TestI18N(unittest.TestCase):
 
     def get_fake_config(self):
         return SDConfig()
-
-    def test_verify_default_locale_en_us_if_not_defined_in_config(self):
-        class Config:
-            def __getattr__(self, name):
-                if name == 'DEFAULT_LOCALE':
-                    raise AttributeError()
-                return getattr(config, name)
-        not_translated = 'code hello i18n'
-        with source_app.create_app(Config()).test_client() as c:
-            c.get('/')
-            assert not_translated == gettext(not_translated)
 
     def test_locale_to_rfc_5646(self):
         assert i18n.locale_to_rfc_5646('en') == 'en'

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -252,6 +252,27 @@ def test_locale_to_rfc_5646():
     assert i18n.locale_to_rfc_5646('zh-hant') == 'zh-Hant'
 
 
+# Grab the journalist_app fixture to trigger creation of resources
+def test_html_en_lang_correct(journalist_app, config):
+    # Then delete it because using it won't test what we want
+    del journalist_app
+
+    app = journalist_app_module.create_app(config).test_client()
+    resp = app.get('/', follow_redirects=True)
+    html = resp.data.decode('utf-8')
+    assert re.compile('<html .*lang="en".*>').search(html), html
+
+    app = source_app.create_app(config).test_client()
+    resp = app.get('/', follow_redirects=True)
+    html = resp.data.decode('utf-8')
+    assert re.compile('<html .*lang="en".*>').search(html), html
+
+    # check '/generate' too because '/' uses a different template
+    resp = app.get('/generate', follow_redirects=True)
+    html = resp.data.decode('utf-8')
+    assert re.compile('<html .*lang="en".*>').search(html), html
+
+
 class TestI18N(unittest.TestCase):
 
     def setUp(self):
@@ -272,23 +293,6 @@ class TestI18N(unittest.TestCase):
 
     def get_fake_config(self):
         return SDConfig()
-
-    def test_html_en_lang_correct(self):
-        fake_config = self.get_fake_config()
-        app = journalist_app_module.create_app(fake_config).test_client()
-        resp = app.get('/', follow_redirects=True)
-        html = resp.data.decode('utf-8')
-        assert re.compile('<html .*lang="en".*>').search(html), html
-
-        app = source_app.create_app(fake_config).test_client()
-        resp = app.get('/', follow_redirects=True)
-        html = resp.data.decode('utf-8')
-        assert re.compile('<html .*lang="en".*>').search(html), html
-
-        # check '/generate' too because '/' uses a different template
-        resp = app.get('/generate', follow_redirects=True)
-        html = resp.data.decode('utf-8')
-        assert re.compile('<html .*lang="en".*>').search(html), html
 
     def test_html_fr_lang_correct(self):
         """Check that when the locale is fr_FR the lang property is correct"""

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -92,6 +92,21 @@ def test_SecureTemporaryFile_is_a_STREAMLIKE_TYPE():
     assert _is_stream(SecureTemporaryFile('/tmp'))
 
 
+def test_buffered_read():
+    f = SecureTemporaryFile('/tmp')
+    msg = MESSAGE * 1000
+    f.write(msg)
+    out = ''
+    while True:
+        chars = f.read(1024)
+        if chars:
+            out += chars
+        else:
+            break
+
+    assert out == msg
+
+
 class TestSecureTempfile(unittest.TestCase):
 
     def setUp(self):
@@ -104,19 +119,6 @@ class TestSecureTempfile(unittest.TestCase):
     def tearDown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    def test_buffered_read(self):
-        msg = self.msg * 1000
-        self.f.write(msg)
-        str = ''
-        while True:
-            char = self.f.read(1024)
-            if char:
-                str += char
-            else:
-                break
-
-        self.assertEqual(str, msg)
 
     def test_tmp_file_id_omits_invalid_chars(self):
         """The `SecureTempFile.tmp_file_id` instance attribute is used as the filename

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -30,6 +30,13 @@ def test_write_then_read_once():
     assert f.read() == MESSAGE
 
 
+def test_write_twice_then_read_once():
+    f = SecureTemporaryFile('/tmp')
+    f.write(MESSAGE)
+    f.write(MESSAGE)
+    assert f.read() == MESSAGE * 2
+
+
 class TestSecureTempfile(unittest.TestCase):
 
     def setUp(self):
@@ -42,12 +49,6 @@ class TestSecureTempfile(unittest.TestCase):
     def tearDown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    def test_write_twice_then_read_once(self):
-        self.f.write(self.msg)
-        self.f.write(self.msg)
-
-        self.assertEqual(self.f.read(), self.msg*2)
 
     def test_write_then_read_twice(self):
         self.f.write(self.msg)

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -44,6 +44,16 @@ def test_write_then_read_twice():
     assert f.read() == ''
 
 
+def test_write_then_read_then_write():
+    f = SecureTemporaryFile('/tmp')
+    f.write(MESSAGE)
+    f.read()
+
+    with pytest.raises(AssertionError) as err:
+        f.write('be gentle to each other so we can be dangerous together')
+    assert 'You cannot write after reading!' in str(err)
+
+
 class TestSecureTempfile(unittest.TestCase):
 
     def setUp(self):
@@ -56,14 +66,6 @@ class TestSecureTempfile(unittest.TestCase):
     def tearDown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    def test_write_then_read_then_write(self):
-        self.f.write(self.msg)
-        self.f.read()
-
-        with self.assertRaisesRegexp(AssertionError,
-                                     'You cannot write after reading!'):
-            self.f.write('BORN TO DIE')
 
     def test_read_write_unicode(self):
         unicode_msg = u'鬼神 Kill Em All 1989'

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-import os
 import io
+import os
+import pytest
 import unittest
 
 from gnupg._util import _is_stream
@@ -10,6 +11,15 @@ from sdconfig import config
 import journalist_app
 import secure_tempfile
 import utils
+
+from secure_tempfile import SecureTemporaryFile
+
+
+def test_read_before_writing():
+    f = SecureTemporaryFile('/tmp')
+    with pytest.raises(AssertionError) as err:
+        f.read()
+    assert 'You must write before reading!' in str(err)
 
 
 class TestSecureTempfile(unittest.TestCase):
@@ -24,11 +34,6 @@ class TestSecureTempfile(unittest.TestCase):
     def tearDown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    def test_read_before_writing(self):
-        with self.assertRaisesRegexp(AssertionError,
-                                     'You must write before reading!'):
-            self.f.read()
 
     def test_write_then_read_once(self):
         self.f.write(self.msg)

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -61,6 +61,16 @@ def test_read_write_unicode():
     assert f.read().decode('utf-8') == unicode_msg
 
 
+def test_file_seems_encrypted():
+    f = SecureTemporaryFile('/tmp')
+    f.write(MESSAGE)
+    with io.open(f.filepath, 'rb') as fh:
+        contents = fh.read()
+
+    assert MESSAGE.encode('utf-8') not in contents
+    assert MESSAGE not in contents.decode()
+
+
 class TestSecureTempfile(unittest.TestCase):
 
     def setUp(self):
@@ -73,13 +83,6 @@ class TestSecureTempfile(unittest.TestCase):
     def tearDown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    def test_file_seems_encrypted(self):
-        self.f.write(self.msg)
-        with io.open(self.f.filepath, 'rb') as fh:
-            contents = fh.read().decode()
-
-        self.assertNotIn(self.msg, contents)
 
     def test_file_is_removed_from_disk(self):
         fp = self.f.filepath

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -71,6 +71,23 @@ def test_file_seems_encrypted():
     assert MESSAGE not in contents.decode()
 
 
+def test_file_is_removed_from_disk():
+    # once without reading the contents
+    f = SecureTemporaryFile('/tmp')
+    f.write(MESSAGE)
+    assert os.path.exists(f.filepath)
+    f.close()
+    assert not os.path.exists(f.filepath)
+
+    # once with reading the contents
+    f = SecureTemporaryFile('/tmp')
+    f.write(MESSAGE)
+    f.read()
+    assert os.path.exists(f.filepath)
+    f.close()
+    assert not os.path.exists(f.filepath)
+
+
 class TestSecureTempfile(unittest.TestCase):
 
     def setUp(self):
@@ -83,17 +100,6 @@ class TestSecureTempfile(unittest.TestCase):
     def tearDown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    def test_file_is_removed_from_disk(self):
-        fp = self.f.filepath
-        self.f.write(self.msg)
-        self.f.read()
-
-        self.assertTrue(os.path.exists(fp))
-
-        self.f.close()
-
-        self.assertFalse(os.path.exists(fp))
 
     def test_SecureTemporaryFile_is_a_STREAMLIKE_TYPE(self):
         self.assertTrue(_is_stream(

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -14,12 +14,20 @@ import utils
 
 from secure_tempfile import SecureTemporaryFile
 
+MESSAGE = '410,757,864,530'
+
 
 def test_read_before_writing():
     f = SecureTemporaryFile('/tmp')
     with pytest.raises(AssertionError) as err:
         f.read()
     assert 'You must write before reading!' in str(err)
+
+
+def test_write_then_read_once():
+    f = SecureTemporaryFile('/tmp')
+    f.write(MESSAGE)
+    assert f.read() == MESSAGE
 
 
 class TestSecureTempfile(unittest.TestCase):
@@ -34,11 +42,6 @@ class TestSecureTempfile(unittest.TestCase):
     def tearDown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    def test_write_then_read_once(self):
-        self.f.write(self.msg)
-
-        self.assertEqual(self.f.read(), self.msg)
 
     def test_write_twice_then_read_once(self):
         self.f.write(self.msg)

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -37,6 +37,13 @@ def test_write_twice_then_read_once():
     assert f.read() == MESSAGE * 2
 
 
+def test_write_then_read_twice():
+    f = SecureTemporaryFile('/tmp')
+    f.write(MESSAGE)
+    assert f.read() == MESSAGE
+    assert f.read() == ''
+
+
 class TestSecureTempfile(unittest.TestCase):
 
     def setUp(self):
@@ -49,12 +56,6 @@ class TestSecureTempfile(unittest.TestCase):
     def tearDown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    def test_write_then_read_twice(self):
-        self.f.write(self.msg)
-
-        self.assertEqual(self.f.read(), self.msg)
-        self.assertEqual(self.f.read(), '')
 
     def test_write_then_read_then_write(self):
         self.f.write(self.msg)

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -88,6 +88,10 @@ def test_file_is_removed_from_disk():
     assert not os.path.exists(f.filepath)
 
 
+def test_SecureTemporaryFile_is_a_STREAMLIKE_TYPE():
+    assert _is_stream(SecureTemporaryFile('/tmp'))
+
+
 class TestSecureTempfile(unittest.TestCase):
 
     def setUp(self):
@@ -100,10 +104,6 @@ class TestSecureTempfile(unittest.TestCase):
     def tearDown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    def test_SecureTemporaryFile_is_a_STREAMLIKE_TYPE(self):
-        self.assertTrue(_is_stream(
-            secure_tempfile.SecureTemporaryFile('/tmp')))
 
     def test_buffered_read(self):
         msg = self.msg * 1000

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -2,16 +2,10 @@
 import io
 import os
 import pytest
-import unittest
 
 from gnupg._util import _is_stream
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-from sdconfig import config
-import journalist_app
-import secure_tempfile
-import utils
-
 from secure_tempfile import SecureTemporaryFile
 
 MESSAGE = '410,757,864,530'
@@ -107,22 +101,10 @@ def test_buffered_read():
     assert out == msg
 
 
-class TestSecureTempfile(unittest.TestCase):
-
-    def setUp(self):
-        self.__context = journalist_app.create_app(config).app_context()
-        self.__context.push()
-        utils.env.setup()
-        self.f = secure_tempfile.SecureTemporaryFile(config.STORE_DIR)
-        self.msg = '410,757,864,530'
-
-    def tearDown(self):
-        utils.env.teardown()
-        self.__context.pop()
-
-    def test_tmp_file_id_omits_invalid_chars(self):
-        """The `SecureTempFile.tmp_file_id` instance attribute is used as the filename
-        for the secure temporary file. This attribute should not contain
-        invalid characters such as '/' and '\0' (null)."""
-        self.assertNotIn('/', self.f.tmp_file_id)
-        self.assertNotIn('\0', self.f.tmp_file_id)
+def test_tmp_file_id_omits_invalid_chars():
+    """The `SecureTempFile.tmp_file_id` instance attribute is used as the filename
+    for the secure temporary file. This attribute should not contain
+    invalid characters such as '/' and '\0' (null)."""
+    f = SecureTemporaryFile('/tmp')
+    assert '/' not in f.tmp_file_id
+    assert '\0' not in f.tmp_file_id

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -54,6 +54,13 @@ def test_write_then_read_then_write():
     assert 'You cannot write after reading!' in str(err)
 
 
+def test_read_write_unicode():
+    f = SecureTemporaryFile('/tmp')
+    unicode_msg = u'鬼神 Kill Em All 1989'
+    f.write(unicode_msg)
+    assert f.read().decode('utf-8') == unicode_msg
+
+
 class TestSecureTempfile(unittest.TestCase):
 
     def setUp(self):
@@ -66,12 +73,6 @@ class TestSecureTempfile(unittest.TestCase):
     def tearDown(self):
         utils.env.teardown()
         self.__context.pop()
-
-    def test_read_write_unicode(self):
-        unicode_msg = u'鬼神 Kill Em All 1989'
-        self.f.write(unicode_msg)
-
-        self.assertEqual(self.f.read().decode('utf-8'), unicode_msg)
 
     def test_file_seems_encrypted(self):
         self.f.write(self.msg)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #2877 

`pytest` fixtures for `test_secure_tempfile.py` and `test_i18n.py`.

## Testing

```
make test TESTFILES=tests/test_i18n.py && \
make test TESTFILES=tests/test_secure_tempfile.py
```

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container