### PR TITLE
Remove installed vanilla kernels via cron-apt

### DIFF
--- a/install_files/ansible-base/group_vars/securedrop_application_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_application_server.yml
@@ -7,7 +7,7 @@ ip_info:
 ### Used by the install_local_deb_pkgs role ###
 local_deb_packages:
   - "securedrop-keyring-0.1.1+{{ securedrop_app_code_version }}-amd64.deb"
-  - "securedrop-config-0.1.0+{{ securedrop_app_code_version }}-amd64.deb"
+  - "securedrop-config-0.1.1+{{ securedrop_app_code_version }}-amd64.deb"
   - "securedrop-ossec-agent-2.8.2+{{ securedrop_app_code_version }}-amd64.deb"
   - "{{ securedrop_app_code_deb }}.deb"
   - "ossec-agent-2.8.2-amd64.deb"

--- a/install_files/ansible-base/group_vars/securedrop_monitor_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_monitor_server.yml
@@ -7,7 +7,7 @@ ip_info:
 ### Used by the install_local_deb_pkgs role ###
 local_deb_packages:
   - "securedrop-keyring-0.1.1+{{ securedrop_app_code_version }}-amd64.deb"
-  - "securedrop-config-0.1.0+{{ securedrop_app_code_version }}-amd64.deb"
+  - "securedrop-config-0.1.1+{{ securedrop_app_code_version }}-amd64.deb"
   - "securedrop-ossec-server-2.8.2+{{ securedrop_app_code_version }}-amd64.deb"
   - ossec-server-2.8.2-amd64.deb
 

--- a/install_files/ansible-base/roles/common/files/1-remove
+++ b/install_files/ansible-base/roles/common/files/1-remove
@@ -1,0 +1,1 @@
+remove -y linux-image-generic-lts-xenial linux-image-.*generic -o quiet=2

--- a/install_files/ansible-base/roles/common/tasks/cron_apt.yml
+++ b/install_files/ansible-base/roles/common/tasks/cron_apt.yml
@@ -30,6 +30,16 @@
     - apt
     - cron-apt
 
+  # This action is also added by the securedrop-config package as of 0.1.1 to provide
+  # this logic for existing installs.
+- name: Configure cron-apt to remove vanilla kernels if they are installed.
+  copy:
+    src: 1-remove
+    dest: /etc/cron-apt/action.d/1-remove
+  tags:
+    - apt
+    - cron-apt
+
 - name: Configure cron-apt to upgrade the packages in the security.list repos.
   copy:
     src: 5-security

--- a/install_files/securedrop-config/DEBIAN/control
+++ b/install_files/securedrop-config/DEBIAN/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
 Homepage: https://securedrop.org
 Package: securedrop-config
-Version: 0.1.0+0.7.0~rc1
+Version: 0.1.1+0.7.0~rc1
 Architecture: all
 Description: Establishes baseline system state for running SecureDrop.
  Configures apt repositories.

--- a/install_files/securedrop-config/etc/cron-apt/action.d/1-remove
+++ b/install_files/securedrop-config/etc/cron-apt/action.d/1-remove
@@ -1,0 +1,1 @@
+remove -y linux-image-generic-lts-xenial linux-image-.*generic -o quiet=2

--- a/molecule/builder/tests/vars.yml
+++ b/molecule/builder/tests/vars.yml
@@ -2,7 +2,7 @@
 securedrop_version: "0.7.0~rc1"
 ossec_version: "2.8.2"
 keyring_version: "0.1.1"
-config_version: "0.1.0"
+config_version: "0.1.1"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/testinfra/common/test_cron_apt.py
+++ b/testinfra/common/test_cron_apt.py
@@ -68,6 +68,21 @@ def test_cron_apt_repo_config_update(File):
     assert f.contains('^{}$'.format(repo_config))
 
 
+def test_cron_apt_delete_vanilla_kernels(File):
+    """
+    Ensure cron-apt removes generic linux image packages when installed.
+    """
+
+    f = File('/etc/cron-apt/action.d/1-remove')
+    assert f.is_file
+    assert f.user == "root"
+    assert oct(f.mode) == "0644"
+    command = str('remove -y'
+                  ' linux-image-generic-lts-xenial linux-image-.*generic'
+                  ' -o quiet=2')
+    assert f.contains('^{}$'.format(command))
+
+
 def test_cron_apt_repo_config_upgrade(File):
     """
     Ensure cron-apt upgrades packages from the security.list config.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3180 . A new cron-apt action will ensure that vanilla kernels are always removed from SecureDrop installs.
The addition of the `1-remove` action in the common role is perhaps excessive, as it will overwritten by the same file as part of the `securedrop-config` is installed. 

## Testing

### New installs:

- Install SecureDrop on Production VMs (NOT vagrant boxes, but rather from Ubuntu 14.04.5 server isos).
- Observe that `linux-image-extra-4.4.0-116-generic` is installed by running `dpkg-query -f '${Package} ${Status}\n' -W 'linux-image*'`.
- Run `sudo cron-apt -i -s` and observe that the `linux-image-extra-4.4.0-116 generic` is uninstalled. Note that #3158 will ensure these kernels are also removed at install-time.

### Existing installs:
- Install SecureDrop on Production VMs (NOT vagrant boxes, but rather from Ubuntu 14.04.5 server isos) on SecureDrop release 0.6 branch.
- Observe that `linux-image-extra-4.4.0-116-generic` is installed by running `dpkg-query -f '${Package} ${Status}\n' -W 'linux-image*'`.
- make build-debs on this branch, and install `securedrop-config-0.1.1-0.6-amd64.deb` on apt or mon server
- Verify the existence and content of `/etc/cron-apt/action.d/1-remove`.
- Run `sudo cron-apt -i -s` and observe that  `linux-image-extra-4.4.0-116 generic` is uninstalled.

## Deployment

`securedrop-config-0.1.1-$SD_VERSION-amd64.deb` will need to be uploaded to the apt server and served to running SecureDrop instances.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
