### PR TITLE
Add Orbot warning in source interface

### DIFF
--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -16,6 +16,7 @@
   <body>
     <div class="js-warning warning">{{ gettext('<strong>It is recommended to move the Security Slider to Safest to protect your anonymity:</strong> <a id="disable-js" href="">Learn how to set it to Safest</a>, or ignore this warning to continue.') }} <img id="js-warning-close" src="{{ url_for('static', filename='i/font-awesome/times-white.png') }}" width="12px" height="12px"></div>
     <div class="use-tor-browser warning">{{ gettext('<strong>It is recommended to use the Tor Browser to access SecureDrop:</strong> <a id="recommend-tor" href="{tor_browser_url}">Learn how to install it</a>, or ignore this warning to continue.').format(tor_browser_url=url_for('info.recommend_tor_browser')) }} <img id="use-tor-browser-close" src="{{ url_for('static', filename='i/font-awesome/times-white.png') }}" width="12px" height="12px"></div>
+    <div class="orfox-browser warning">{{ gettext('<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Orfox does not provide the same level of security and anonymity as the desktop versions.</strong> <a id="recommend-tor" href="{tor_browser_url}">Learn how to install it</a>, or ignore this warning to continue.').format(tor_browser_url=url_for('info.recommend_tor_browser')) }} <img id="orfox-browser-close" src="{{ url_for('static', filename='i/font-awesome/times-white.png') }}" width="12px" height="12px"></div>
 
     {% include 'banner_warning_flashed.html' %}
 

--- a/securedrop/static/js/source.js
+++ b/securedrop/static/js/source.js
@@ -1,4 +1,5 @@
 var TBB_UA_REGEX = /Mozilla\/5\.0 \(Windows NT 6\.1; rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/;
+var ORFOX_UA_REGEX = /Mozilla\/5\.0 \(Android; Mobile; rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/;
 
 function is_likely_tor_browser() {
   return window.navigator.userAgent.match(TBB_UA_REGEX) &&
@@ -10,6 +11,12 @@ function tbb_version() {
   var ua_match = window.navigator.userAgent.match(TBB_UA_REGEX);
   var major_version = ua_match[1];
   return Number(major_version);
+}
+
+function is_likely_orfox() {
+  return window.navigator.userAgent.match(ORFOX_UA_REGEX) &&
+         (window.navigator.mimeTypes &&
+          window.navigator.mimeTypes.length === 0);
 }
 
 // Warn about using JavaScript and not using Tor Browser
@@ -48,11 +55,21 @@ $(function(){
       e.stopPropagation();
     });
   } else {
-    // If the user is not using Tor Browser, we want to encourage them to do so.
-    $('.use-tor-browser').show();
-    $('.hide-if-not-tor-browser').hide();
-    $('#use-tor-browser-close').click(function(){
-      $('.use-tor-browser').hide(200);
-    });
+    // If the user is running Orfox, we want to encourage them to use the desktop
+    // version of Tor Browser for stronger security and anonymity.
+    if(is_likely_orfox()){
+      $('.orfox-browser').show();
+      $('.hide-if-not-tor-browser').hide();
+      $('#orfox-browser-close').click(function(){
+        $('.orfox-browser').hide(200);
+      });
+    } else {
+      // If the user is not using neither Tor Browser nor Orfox, we want to encourage them to do so.
+      $('.use-tor-browser').show();
+      $('.hide-if-not-tor-browser').hide();
+      $('#use-tor-browser-close').click(function(){
+        $('.use-tor-browser').hide(200);
+      });
+    }
   }
 });

--- a/securedrop/tests/functional/test_source_warnings.py
+++ b/securedrop/tests/functional/test_source_warnings.py
@@ -1,5 +1,6 @@
 import source_navigation_steps
 import functional_test
+from selenium import webdriver
 
 
 class TestSourceInterfaceBannerWarnings(
@@ -18,6 +19,34 @@ class TestSourceInterfaceBannerWarnings(
         # User should be able to dismiss the warning
         warning_dismiss_button = self.driver.find_element_by_id(
             'use-tor-browser-close')
+        warning_dismiss_button.click()
+
+        def warning_banner_is_hidden():
+            assert warning_banner.is_displayed() is False
+        self.wait_for(warning_banner_is_hidden)
+
+    def test_warning_appears_if_orbot_is_used(self):
+        orbotUserAgent = ("Mozilla/5.0 (Android; Mobile;"
+                          " rv:52.0) Gecko/20100101 Firefox/52.0")
+
+        # Create new profile and driver with the orbot user agent for this test
+        profile = webdriver.FirefoxProfile()
+        profile.set_preference("general.useragent.override", orbotUserAgent)
+        self.driver = webdriver.Firefox(profile)
+        self.driver.get(self.source_location)
+
+        currentAgent = self.driver.execute_script("return navigator.userAgent")
+        assert currentAgent == orbotUserAgent
+
+        warning_banner = self.driver.find_element_by_class_name(
+            'orfox-browser')
+
+        assert ("It is recommended you use the desktop version of Tor Browser"
+                in warning_banner.text)
+
+        # User should be able to dismiss the warning
+        warning_dismiss_button = self.driver.find_element_by_id(
+            'orfox-browser-close')
         warning_dismiss_button.click()
 
         def warning_banner_is_hidden():

--- a/securedrop/tests/functional/test_source_warnings.py
+++ b/securedrop/tests/functional/test_source_warnings.py
@@ -19,11 +19,7 @@ class TestSourceInterfaceBannerWarnings(
         # User should be able to dismiss the warning
         warning_dismiss_button = self.driver.find_element_by_id(
             'use-tor-browser-close')
-        warning_dismiss_button.click()
-
-        def warning_banner_is_hidden():
-            assert warning_banner.is_displayed() is False
-        self.wait_for(warning_banner_is_hidden)
+        self.banner_is_dismissed(warning_banner, warning_dismiss_button)
 
     def test_warning_appears_if_orbot_is_used(self):
         orbotUserAgent = ("Mozilla/5.0 (Android; Mobile;"
@@ -47,7 +43,11 @@ class TestSourceInterfaceBannerWarnings(
         # User should be able to dismiss the warning
         warning_dismiss_button = self.driver.find_element_by_id(
             'orfox-browser-close')
-        warning_dismiss_button.click()
+        self.banner_is_dismissed(warning_banner, warning_dismiss_button)
+
+    def banner_is_dismissed(self, warning_banner, dismiss_button):
+
+        dismiss_button.click()
 
         def warning_banner_is_hidden():
             assert warning_banner.is_displayed() is False


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes
If a user accesses the Source interface with Orbot, a warning will appear informing them that the security and privacy properties of their browser and device may be affected, and recommend the use of the desktop version of Tor Browser.

Fixes #3186 .
## Testing

- [x] If visiting with non-Tor browser, "It is recommended to use the Tor Browser ..." should be displayed.
- [x] If visiting with Tor browser in default configuration, "It is recommended to move the Security Slider to Safest ..." should be displayed.
- [x] If visiting with Orfox, "It is recommended you use the desktop version of Tor Browser ..." should be displayed.
- [x] The text displayed in the Orfox scenario should adequately convey the risks of using Orfox as opposed to its desktop counterpart.

## Deployment

None
## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
