### PR TITLE
Unit tests: Verify journalist username containing whitespace can login

### DIFF
--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -51,6 +51,22 @@ def _login_user(app, username, password, otp_secret):
     assert hasattr(g, 'user')  # ensure logged in
 
 
+def test_user_with_whitespace_in_username_can_login(journalist_app):
+    # Create a user with whitespace at the end of the username
+    with journalist_app.app_context():
+        username_with_whitespace = 'journalist '
+        user, password = utils.db_helper.init_journalist(is_admin=False)
+        otp_secret = user.otp_secret
+        user.username = username_with_whitespace
+        db.session.add(user)
+        db.session.commit()
+
+    # Verify that user is able to login successfully
+    with journalist_app.test_client() as app:
+        _login_user(app, username_with_whitespace, password,
+                    otp_secret)
+
+
 def test_make_password(journalist_app):
     with patch.object(crypto_util.CryptoUtil, 'genrandomid',
                       side_effect=['bad', VALID_PASSWORD]):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Relates to #3216.

Changes proposed in this pull request:
* There may be journalist accounts in production 
that have whitespace in the username, so we should ensure they are
able to login going forward by including this case in our test suite.

## Testing

Does this test pass? Does the logic properly test that a user with a whitespace-containing username can login? 

## Deployment

None, this is merely a guard for future Stewards of SecureDrop

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container