### PR TITLE
AppArmor: Whitelist fa-globe-black.png

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -245,6 +245,7 @@
   /var/www/securedrop/static/i/font-awesome/exclamation-triangle-black.png r,
   /var/www/securedrop/static/i/font-awesome/fa-arrow-circle-o-right-blue.png r,
   /var/www/securedrop/static/i/font-awesome/fa-arrow-circle-o-right-white.png r,
+  /var/www/securedrop/static/i/font-awesome/fa-globe-black.png r,
   /var/www/securedrop/static/i/font-awesome/info-circle-black.png r,
   /var/www/securedrop/static/i/font-awesome/lock-black.png r,
   /var/www/securedrop/static/i/font-awesome/refresh-blue.png r,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3224.

Changes proposed in this pull request:
* Update AppArmor to allow Apache to read `fa-globe-black.png`

## Testing

In staging, check that the globe described in #3121 is now visible

## Deployment

Delivered in app code package

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

