### PR TITLE
HTTPS docs update: Suggest admin run securedrop-admin install if needed

### DIFF
--- a/docs/https_source_interface.rst
+++ b/docs/https_source_interface.rst
@@ -67,6 +67,10 @@ We have support for this workflow:
     # Replace <unique_hash> with the token provided by Digicert
     $ sudo vi /var/www/securedrop/.well-known/pki-validation/<unique_hash>.txt
 
+.. note:: If you see "File Not Found" when navigating to this file in Tor Browser,
+    check out the latest release in your *Admin Workstation* and re-run
+    ``./securedrop-admin install``.
+
 While the `CAB forum`_ has specified that ``.onion`` certificates may have a
 maximum lifetime of 15 months, we have heard that some folks have run into
 issues with such certificates, and currently it seems safest to give the


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request: 

* Followup to #3116 based on support interaction with a current administrator

* We require the well-known stanza in the source
interface Apache config. If this is not present, for
example if an admin installed SecureDrop a year ago,
then the user will get a 404 when navigating to the
validation file. If this is the case, then they should
run securedrop-admin install such that the latest
Apache configs are copied over to the servers and
Apache is restarted.

* We should not instruct admins to run
securedrop-admin install "just in case" as this will
result in a 20 minute+ install run (and they have to
do it again when they get the cert) which should
be avoided if unnecessary.

## Testing

Verify my logic as described above makes sense

## Deployment

Docs as followed result in HTTPS validation working for both new, existing, and older installs. This PR specifically tackles the "older installs" (i.e. those that do not already have the required `well-known` stanza in the Apache source interface config).

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
