### PR TITLE
Add a Code of Conduct to the SecureDrop project

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,57 @@
+# Code of Conduct - Freedom of the Press Foundation
+
+Like the the broader technical and activism communities as a whole, the Freedom of the Press Foundation (FPF) team is made up of a mixture of staff and volunteers from all over the world, working on every aspect of our mission—including operations, software development, mentorship, and building connections with great people and organizations.
+
+To work together effectively in a large, diverse and open community, we have a few ground rules that we expect everyone to adhere to, be it FPF staff and board members, volunteers and event attendees; mentors, veterans, novices, or those seeking help and guidance.
+
+This isn’t an exhaustive list of things that you cannot do. Rather, take it in the spirit in which it’s intended—a guide to make it easier to enrich all of us and the communities in which we participate.
+
+This code of conduct applies to all spaces and events managed by the Freedom of the Press Foundation. This includes physical offices, GitHub repositories, online chat systems, the Support Forum, FPF hosted or sponsored events, and any other forums created by the Foundation which our team uses for communication. In addition, we take violations of this code outside these spaces into account when determining a person's ability to participate within them.
+
+If you believe someone is violating the code of conduct, we ask that you report it by talking to Emmanuel, or emailing **emmanuel@freedom.press**. If, for whatever reason, you are uncomfortable reporting the issue to Emmanuel, you may contact FPF’s Executive Director (**trevor@freedom.press**).  
+
+We are committed to taking fair, timely and appropriate corrective action against any violations of this code.
+
+* **Be friendly and patient.**
+
+- **Be welcoming.** We strive to be a workplace that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+
+- **Be kind and considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we work with people as part of an international community, so you might not be communicating in someone else's primary language.
+
+- **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior or poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a workplace where people feel uncomfortable or threatened is not a productive one. Freedom of the Press Foundation staff should be respectful when dealing with other staff as well as with people outside the Foundation, such as clients, outside contributors, and the SecureDrop community. Avoid making assumptions, e.g., about people’s gender identity, preferred pronoun, willingness to be photographed, etc.—when in doubt, ask at the right moment.
+
+- **Harassment, public or private, is unacceptable and won’t be tolerated.** This includes but is not limited to:
+  - Intimidation
+  - Stalking
+  - Unwelcome following
+  - Enlisting the help of others, whether in person or online, in order to target an attendee
+  - Taking photographs, video, or audio recordings or recordings without consent
+  - Obscene or intimidating gestures
+  - Shouting
+  - Sustained disruption of talks and events
+  - Disruption of meetings
+  - Inappropriate physical contact
+  - Unwelcome sexual attention
+  - Posting (or threatening to post) other people's personally identifying information ("doxing")
+
+
+- No matter who you are, if you feel you have been or are being harassed or made uncomfortable by another person in relation to your work on FPF projects, please report it immediately.  We are aware that harassment and sexual violence are systemic and pervasive social issues that demand continued awareness and attention, and that a code of conduct is only a small component of that.  We are committed to taking proactive action to make our organizational spaces safe and comfortable for everyone.
+
+
+- **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Exclusionary behavior is absolutely unacceptable. This includes, but is not limited to:
+  - Discriminatory jokes and language.
+  - Posting sexually explicit or violent material.
+  - Personal insults, especially those using racist or sexist terms.
+  - Unwelcome sexual attention.
+  - Advocating for, or encouraging, any of the above behavior.
+
+
+- **When we disagree, try to understand why.** Disagreements — both social and technical — happen all the time, even at Freedom of the Press Foundation. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of FPF comes from its varied team, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn't mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn't get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+
+- **Name things appropriately.** Avoid giving your user accounts, servers, repositories, etc. names that are overtly sexual or that might otherwise detract from a friendly, safe and welcoming environment for all.
+
+## Sanctions
+
+We will deal with violations of this code of conduct on a case by case basis, depending on the severity of the behavior and any prior violations. Sanctions may range from a simple warning not to engage in a particular kind of behavior (e.g., in response to a single mildly inappropriate comment), to separation from FPF (termination in the case of employment, removal from all FPF technical and social spaces in the case of volunteers) and other consequences in the most severe cases.
+
+Original text courtesy of the [Django project](https://www.djangoproject.com/conduct/), which in turn was inspired by the [Speak Up! Code of Conduc](https://web.archive.org/web/20141109123859/http://speakup.io/coc.html)t. License: [Creative Commons Attribution](https://creativecommons.org/licenses/by/4.0/) (CC-BY).


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Resolves #3251.

A code of conduct is essential for any substantial free software project, and SecureDrop is no exception. This code of conduct will set a standard for how contributors should conduct themselves in relation to SecureDrop.

This was originally spearheaded by myself, and made possible by the help of several collaborators, including @eloquence, @redshiftzero, and @olivemartini.

This code of conduct complies with [GitHub's recommended file format for codes of conduct](https://help.github.com/articles/adding-a-code-of-conduct-to-your-project/).

## Testing

Reviewers should check this PR for typographical errors and especially for content.

## Deployment

The code of conduct shall be considered ratified and effective upon merge.
