### PR TITLE
Securedrop-admin update: Try alternate keyserver if primary is not available

### DIFF
--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -139,6 +139,17 @@ class TestSecureDropAdmin(object):
             for patcher in patchers:
                 patcher.stop()
 
+    def test_get_release_key_from_valid_keyserver(self, tmpdir, caplog):
+        git_repo_path = str(tmpdir)
+        args = argparse.Namespace(root=git_repo_path)
+        with mock.patch('subprocess.check_call'):
+            # Check that no exception is raised when the process is fast
+            securedrop_admin.get_release_key_from_keyserver(args)
+
+            # Check that use of the keyword arg also raises no exception
+            securedrop_admin.get_release_key_from_keyserver(
+                args, keyserver='test.com')
+
     def test_update_signature_verifies(self, tmpdir, caplog):
         git_repo_path = str(tmpdir)
         args = argparse.Namespace(root=git_repo_path)

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -109,22 +109,35 @@ class TestSecureDropAdmin(object):
     def test_update_gpg_recv_primary_key_failure(self, tmpdir, caplog):
         """We should try a secondary keyserver if for some reason the primary
         keyserver is not available."""
+
         git_repo_path = str(tmpdir)
         args = argparse.Namespace(root=git_repo_path)
 
         git_output = 'Good signature from "SecureDrop Release Signing Key"'
 
-        with mock.patch('securedrop_admin.check_for_updates',
-                        return_value=(True, "0.6.1")):
-            with mock.patch('subprocess.check_call',
-                            side_effect=['', subprocess.CalledProcessError(
-                                1, 'gpg', 'Keyserver receive failed')]):
-                with mock.patch('subprocess.check_output',
-                                return_value=git_output):
-                    securedrop_admin.update(args)
-                    assert "Applying SecureDrop updates..." in caplog.text
-                    assert "Signature verification successful." in caplog.text
-                    assert "Updated to SecureDrop" in caplog.text
+        patchers = [
+            mock.patch('securedrop_admin.check_for_updates',
+                       return_value=(True, "0.6.1")),
+            mock.patch('subprocess.check_call'),
+            mock.patch('subprocess.check_output',
+                       return_value=git_output),
+            mock.patch('securedrop_admin.get_release_key_from_keyserver',
+                       side_effect=[
+                           subprocess.CalledProcessError(1, 'cmd', 'BANG'),
+                           None])
+            ]
+
+        for patcher in patchers:
+            patcher.start()
+
+        try:
+            securedrop_admin.update(args)
+            assert "Applying SecureDrop updates..." in caplog.text
+            assert "Signature verification successful." in caplog.text
+            assert "Updated to SecureDrop" in caplog.text
+        finally:
+            for patcher in patchers:
+                patcher.stop()
 
     def test_update_signature_verifies(self, tmpdir, caplog):
         git_repo_path = str(tmpdir)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3243.

Changes proposed in this pull request:
 * Try an alternative keyserver for getting the release key in case the primary is not available. This is basically automating the documented workaround in #1842.
 * Note that this implements a timeout strategy such that the failures occur fast so we have a predictable update time for #3230.

## Testing

Testing in Tails is probably the best thing to do here, though you'll need to reproduce the issue in #3243 first. Once you've done that check out this branch and:

```
$ cd ~/Persistent/securedrop
$ gpg --delete-keys 22245C81E3BAEB4138B36061310F561200F4AD77
$ ./securedrop-admin update
```

## Deployment

Will be updated along with the entire workstation repo with `securedrop-admin update`

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container