### PR TITLE
[qt-journalist-updater] Add a time estimate to the update progress bar

### DIFF
--- a/journalist_gui/journalist_gui/strings.py
+++ b/journalist_gui/journalist_gui/strings.py
@@ -2,8 +2,10 @@ window_title = 'SecureDrop Updater'
 update_in_progress = ("SecureDrop workstation updates are available! "
                       "You should install them now. If you don\'t want to, "
                       "you can install them the next time you reboot.")
-fetching_update = 'Fetching and verifying latest update...'
-updating_tails_env = 'Configuring local Tails environment...'
+fetching_update = ('Fetching and verifying latest update...'
+                   ' (4 mins remaining)')
+updating_tails_env = ('Configuring local Tails environment...'
+                      ' (1 min remaining)')
 finished = 'Update successfully completed!'
 finished_dialog_message = 'Updates completed successfully. Click OK to close.'
 finished_dialog_title = 'SecureDrop Workstation is up to date!'


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3230, adds some user feedback regarding the expected time in the status bar: 

![screen shot 2018-04-11 at 4 46 34 pm](https://user-images.githubusercontent.com/7832803/38648844-3589ae0e-3da8-11e8-8e2d-56eeee89a7ee.png)

This one is simple (the meat is in #3257 to get a predictable update time). Details of testing are in [this comment](https://github.com/freedomofpress/securedrop/issues/3230#issuecomment-380287625).

Note that I could imagine plenty of simple ways to make this better/fancier - i.e. having it tick down and update as a process is occurring. I think this is a good idea but I don't want to prematurely optimize - especially when the entire update is less than 4 minutes. If users in testing next week find the time information that is provided insufficient or confusing, then I propose at that stage we go further down this path. 

## Testing

Simply try an update from this branch to the latest release:

1. Check out this branch in your Tails VM
2.  `python3 journalist_gui/SecureDropUpdater` (or use the network hook on boot)

## Deployment

Nothing special

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
