### PR TITLE
Fixes #3228 runs blocking calls on QThread

### DIFF
--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -91,7 +91,6 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
         super(UpdaterApp, self).__init__(parent)
         self.setupUi(self)
         self.output = "Beginning update:"
-        self.testing = False  # True only in testing
         self.update_success = False
 
         pixmap = QtGui.QPixmap(":/images/static/securedrop.png")
@@ -124,8 +123,7 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
         self.plainTextEdit.setPlainText(self.output)
         self.plainTextEdit.setReadOnly = True
         self.progressBar.setProperty("value", 50)
-        if not self.testing:
-            self.call_tailsconfig()
+        self.call_tailsconfig()
 
     def call_tailsconfig(self):
         # Now let us work on tailsconfig part
@@ -141,8 +139,7 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
             self.pushButton_2.setEnabled(True)
             self.statusbar.showMessage(self.failure_reason)
             self.progressBar.setProperty("value", 0)
-            if not self.testing:
-                self.alert_failure(self.failure_reason)
+            self.alert_failure(self.failure_reason)
 
     def tails_status(self, result):
         "This is the slot for Tailsconfig thread"
@@ -154,12 +151,10 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
         if self.update_success:
             self.statusbar.showMessage(strings.finished)
             self.progressBar.setProperty("value", 100)
-            if not self.testing:
-                self.alert_success()
+            self.alert_success()
         else:
             self.statusbar.showMessage(self.failure_reason)
-            if not self.testing:
-                self.alert_failure(self.failure_reason)
+            self.alert_failure(self.failure_reason)
             # Now everything is done, enable the button.
             self.pushButton.setEnabled(True)
             self.pushButton_2.setEnabled(True)

--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -28,8 +28,10 @@ class UpdateThread(QThread):
             if 'Signature verification failed' in self.output:
                 self.update_success = False
                 self.failure_reason = strings.update_failed_sig_failure
-            else:
+            elif "Good signature from" in self.output:
                 self.update_success = True
+            else:
+                self.failure_reason = strings.update_failed_generic_reason
         except subprocess.CalledProcessError as e:
             self.output = str(e.output)
             self.update_success = False

--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -94,6 +94,8 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
         super(UpdaterApp, self).__init__(parent)
         self.setupUi(self)
         self.output = "Beginning update:"
+        self.testing = False  # True only in testing
+        self.update_success = False
 
         pixmap = QtGui.QPixmap(":/images/static/securedrop.png")
         self.label_2.setPixmap(pixmap)
@@ -125,7 +127,10 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
         self.plainTextEdit.setPlainText(self.output)
         self.plainTextEdit.setReadOnly = True
         self.progressBar.setProperty("value", 50)
+        if not self.testing:
+            self.call_tailsconfig()
 
+    def call_tailsconfig(self):
         # Now let us work on tailsconfig part
         if self.update_success:
             self.statusbar.showMessage(strings.updating_tails_env)
@@ -140,7 +145,7 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
 
     def tails_status(self, result):
         "This is the slot for Tailsconfig thread"
-        self.output = result['output']
+        self.output += result['output']
         self.update_success = result['status']
         self.failure_reason = result['failure_reason']
         self.plainTextEdit.setPlainText(self.output)

--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -18,9 +18,6 @@ class UpdateThread(QThread):
         self.update_success = False
         self.failure_reason = ""
 
-    def __del__(self):
-        self.wait()
-
     def run(self):
         sdadmin_path = '/home/amnesia/Persistent/securedrop/securedrop-admin'
         update_command = [sdadmin_path, 'update']
@@ -54,9 +51,6 @@ class TailsconfigThread(QThread):
         self.failure_reason = ""
         self.sudo_password = ""
 
-    def __del__(self):
-        self.wait()
-
     def run(self):
         tailsconfig_command = ("/home/amnesia/Persistent/"
                                "securedrop/securedrop-admin "
@@ -74,7 +68,8 @@ class TailsconfigThread(QThread):
             if 'failed=0' not in self.output:
                 self.update_success = False
                 self.failure_reason = strings.tailsconfig_failed_generic_reason  # noqa
-
+            else:
+                self.update_success = True
         except pexpect.exceptions.TIMEOUT:
             self.update_success = False
             self.failure_reason = strings.tailsconfig_failed_sudo_password

--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -28,7 +28,7 @@ class UpdateThread(QThread):
             if 'Signature verification failed' in self.output:
                 self.update_success = False
                 self.failure_reason = strings.update_failed_sig_failure
-            elif "Good signature from" in self.output:
+            elif "Signature verification successful" in self.output:
                 self.update_success = True
             else:
                 self.failure_reason = strings.update_failed_generic_reason

--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -154,13 +154,16 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
         if self.update_success:
             self.statusbar.showMessage(strings.finished)
             self.progressBar.setProperty("value", 100)
-            self.alert_success()
+            if not self.testing:
+                self.alert_success()
         else:
             self.statusbar.showMessage(self.failure_reason)
-            self.alert_failure(self.failure_reason)
+            if not self.testing:
+                self.alert_failure(self.failure_reason)
             # Now everything is done, enable the button.
             self.pushButton.setEnabled(True)
             self.pushButton_2.setEnabled(True)
+            self.progressBar.setProperty("value", 0)
 
     def update_securedrop(self):
         self.pushButton_2.setEnabled(False)
@@ -187,7 +190,6 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
         self.error_dialog.setText(self.failure_reason)
         self.error_dialog.setWindowTitle(strings.update_failed_dialog_title)
         self.error_dialog.show()
-        self.progressBar.setProperty("value", 0)
 
     def get_sudo_password(self):
         sudo_password, ok_is_pressed = QtWidgets.QInputDialog.getText(
@@ -197,4 +199,3 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
             return sudo_password
         else:
             sys.exit(0)
-

--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -33,7 +33,7 @@ class UpdateThread(QThread):
             else:
                 self.failure_reason = strings.update_failed_generic_reason
         except subprocess.CalledProcessError as e:
-            self.output = str(e.output)
+            self.output = e.output.decode('utf-8')
             self.update_success = False
             self.failure_reason = strings.update_failed_generic_reason
         result = {'status': self.update_success,
@@ -139,6 +139,10 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
         else:
             self.pushButton.setEnabled(True)
             self.pushButton_2.setEnabled(True)
+            self.statusbar.showMessage(self.failure_reason)
+            self.progressBar.setProperty("value", 0)
+            if not self.testing:
+                self.alert_failure(self.failure_reason)
 
     def tails_status(self, result):
         "This is the slot for Tailsconfig thread"

--- a/journalist_gui/test_gui.py
+++ b/journalist_gui/test_gui.py
@@ -23,6 +23,7 @@ class WindowTestCase(AppTestCase):
     def setUp(self):
         super(WindowTestCase, self).setUp()
         self.window = UpdaterApp()
+        self.window.testing = True
         self.window.show()
         QTest.qWaitForWindowExposed(self.window)
 
@@ -55,15 +56,15 @@ class WindowTestCase(AppTestCase):
 
     @mock.patch('subprocess.check_output',
                 return_value=b'Updated to SecureDrop')
-    def test_check_out_latest_tag_success(self, check_output):
-        self.window.check_out_and_verify_latest_tag()
+    def test_updateThread(self, check_output):
+        self.window.update_thread.run()  # Call run directly
         self.assertEqual(self.window.update_success, True)
-        self.assertEqual(self.window.progressBar.value(), 40)
+        self.assertEqual(self.window.progressBar.value(), 50)
 
     @mock.patch('subprocess.check_output',
                 return_value=b'Signature verification failed')
-    def test_check_out_latest_tag_verification_failure(self, check_output):
-        self.window.check_out_and_verify_latest_tag()
+    def test_updateThread_failure(self, check_output):
+        self.window.update_thread.run()  # Call run directly
         self.assertEqual(self.window.update_success, False)
         self.assertEqual(self.window.failure_reason,
                          strings.update_failed_sig_failure)
@@ -71,8 +72,8 @@ class WindowTestCase(AppTestCase):
     @mock.patch('subprocess.check_output',
                 side_effect=subprocess.CalledProcessError(
                     1, 'cmd', 'Generic other failure'))
-    def test_check_out_latest_generic_failure(self, check_output):
-        self.window.check_out_and_verify_latest_tag()
+    def test_updateThread_generic_failure(self, check_output):
+        self.window.update_thread.run()  # Call run directly
         self.assertEqual(self.window.update_success, False)
         self.assertEqual(self.window.failure_reason,
                          strings.update_failed_generic_reason)

--- a/journalist_gui/test_gui.py
+++ b/journalist_gui/test_gui.py
@@ -55,7 +55,7 @@ class WindowTestCase(AppTestCase):
                          self.window.tabWidget.indexOf(self.window.tab_2))
 
     @mock.patch('subprocess.check_output',
-                return_value=b'Good signature from\nUpdated to SecureDrop')
+                return_value=b'Signature verification successful')
     def test_updateThread(self, check_output):
         self.window.update_thread.run()  # Call run directly
         self.assertEqual(self.window.update_success, True)

--- a/journalist_gui/test_gui.py
+++ b/journalist_gui/test_gui.py
@@ -55,7 +55,7 @@ class WindowTestCase(AppTestCase):
                          self.window.tabWidget.indexOf(self.window.tab_2))
 
     @mock.patch('subprocess.check_output',
-                return_value=b'Updated to SecureDrop')
+                return_value=b'Good signature from\nUpdated to SecureDrop')
     def test_updateThread(self, check_output):
         self.window.update_thread.run()  # Call run directly
         self.assertEqual(self.window.update_success, True)
@@ -71,7 +71,7 @@ class WindowTestCase(AppTestCase):
 
     @mock.patch('subprocess.check_output',
                 side_effect=subprocess.CalledProcessError(
-                    1, 'cmd', 'Generic other failure'))
+                    1, 'cmd', b'Generic other failure'))
     def test_updateThread_generic_failure(self, check_output):
         self.window.update_thread.run()  # Call run directly
         self.assertEqual(self.window.update_success, False)

--- a/journalist_gui/test_gui.py
+++ b/journalist_gui/test_gui.py
@@ -123,7 +123,7 @@ class WindowTestCase(AppTestCase):
     def test_tailsconfigThread_sudo_password_is_wrong(self, pt):
         child = pt()
         before = MagicMock()
-        before.decode.side_effect = ["some data",\
+        before.decode.side_effect = ["some data",
                                      pexpect.exceptions.TIMEOUT(1)]
         child.before = before
         self.window.tails_thread.run()

--- a/journalist_gui/test_gui.py
+++ b/journalist_gui/test_gui.py
@@ -23,7 +23,6 @@ class WindowTestCase(AppTestCase):
     def setUp(self):
         super(WindowTestCase, self).setUp()
         self.window = UpdaterApp()
-        self.window.testing = True
         self.window.show()
         QTest.qWaitForWindowExposed(self.window)
 
@@ -57,26 +56,32 @@ class WindowTestCase(AppTestCase):
     @mock.patch('subprocess.check_output',
                 return_value=b'Signature verification successful')
     def test_updateThread(self, check_output):
-        self.window.update_thread.run()  # Call run directly
-        self.assertEqual(self.window.update_success, True)
-        self.assertEqual(self.window.progressBar.value(), 50)
+        with mock.patch.object(self.window, "call_tailsconfig",
+                               return_value=""):
+            self.window.update_thread.run()  # Call run directly
+            self.assertEqual(self.window.update_success, True)
+            self.assertEqual(self.window.progressBar.value(), 50)
 
     @mock.patch('subprocess.check_output',
                 return_value=b'Signature verification failed')
     def test_updateThread_failure(self, check_output):
-        self.window.update_thread.run()  # Call run directly
-        self.assertEqual(self.window.update_success, False)
-        self.assertEqual(self.window.failure_reason,
-                         strings.update_failed_sig_failure)
+        with mock.patch.object(self.window, "call_tailsconfig",
+                               return_value=""):
+            self.window.update_thread.run()  # Call run directly
+            self.assertEqual(self.window.update_success, False)
+            self.assertEqual(self.window.failure_reason,
+                             strings.update_failed_sig_failure)
 
     @mock.patch('subprocess.check_output',
                 side_effect=subprocess.CalledProcessError(
                     1, 'cmd', b'Generic other failure'))
     def test_updateThread_generic_failure(self, check_output):
-        self.window.update_thread.run()  # Call run directly
-        self.assertEqual(self.window.update_success, False)
-        self.assertEqual(self.window.failure_reason,
-                         strings.update_failed_generic_reason)
+        with mock.patch.object(self.window, "call_tailsconfig",
+                               return_value=""):
+            self.window.update_thread.run()  # Call run directly
+            self.assertEqual(self.window.update_success, False)
+            self.assertEqual(self.window.failure_reason,
+                             strings.update_failed_generic_reason)
 
     def test_get_sudo_password_when_password_provided(self):
         expected_password = "password"


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #3228 

The two blocking calls `securedrop-admin update` and `securedrop-admin tailsconfig` now runs in their own QThreads.

## Testing

- To run the unittests: `python3 test_gui.py`
- Currently gpg is failing to fetch the key from the server (read #3257), so run trying to execute this will show the right error message (that is the generic error happened).
- If you manually add `keyserver hkps://hkps.pool.sks-keyservers.net`  entry to the `~/.gnupg/gpg.conf` file, then you will see a successful run including tailsconfig.


## Deployment

Nothing right now.

