### PR TITLE
Fixed typo in ansible restore script

### DIFF
--- a/install_files/ansible-base/roles/restore/files/restore.py
+++ b/install_files/ansible-base/roles/restore/files/restore.py
@@ -24,7 +24,7 @@ Usage: restore.py <backup file>
         sys.exit(1)
 
     if not os.path.exists(sys.argv[1]):
-        print("<backup file> '{}' not found".format(sys.argv(1)))
+        print("<backup file> '{}' not found".format(sys.argv[1]))
         sys.exit(1)
 
     if os.geteuid() != 0:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes typo in a python restore script where `sys.argv(1)` is called instead of `sys.argv[1]`

