### PR TITLE
[docs] Discourage active links to .onion addresses or to SecureDrop.org

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -59,6 +59,30 @@ preload list <https://hstspreload.appspot.com/>`__ if you can meet all
 of the requirements. This will tell web browsers that the site is only
 ever to be reached over HTTPS.
 
+Provide any .onion address without a hyperlink
+----------------------------------------------
+Because a visitor to your landing page may not be using the Tor browser yet,
+clicking a link to your SecureDrop instance or to any other .onion address may
+result in an error message. Worse, depending on the browser and network
+configuration, it may cause lookups that an adversary can use to identify
+SecureDrop-related behavior.
+
+Instead, we recommend including .onion addresses in plain text, without a
+hyperlink.
+
+Avoid direct links to SecureDrop.org from your landing page
+-----------------------------------------------------------
+
+We appreciate that you may want to link to `the SecureDrop website <https://securedrop.org/>`__
+to give landing page visitors more information about the system. Unfortunately,
+if a visitor visits these links without using the Tor browser, this generates
+traffic that an adversary may be able to use to identify SecureDrop-related
+behavior, regardless of the use of HTTPS.
+
+We suggest offering a reference to the SecureDrop hidden service in
+plain text, without a hyperlink (as per the preceding section):
+**secrdrop5wyphb5x.onion**
+
 Perfect Forward Secrecy
 -----------------------
 

--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -59,30 +59,6 @@ preload list <https://hstspreload.appspot.com/>`__ if you can meet all
 of the requirements. This will tell web browsers that the site is only
 ever to be reached over HTTPS.
 
-Provide any .onion address without a hyperlink
-----------------------------------------------
-Because a visitor to your landing page may not be using the Tor browser yet,
-clicking a link to your SecureDrop instance or to any other .onion address may
-result in an error message. Worse, depending on the browser and network
-configuration, it may cause lookups that an adversary can use to identify
-SecureDrop-related behavior.
-
-Instead, we recommend including .onion addresses in plain text, without a
-hyperlink.
-
-Avoid direct links to SecureDrop.org from your landing page
------------------------------------------------------------
-
-We appreciate that you may want to link to `the SecureDrop website <https://securedrop.org/>`__
-to give landing page visitors more information about the system. Unfortunately,
-if a visitor visits these links without using the Tor browser, this generates
-traffic that an adversary may be able to use to identify SecureDrop-related
-behavior, regardless of the use of HTTPS.
-
-We suggest offering a reference to the SecureDrop hidden service in
-plain text, without a hyperlink (as per the preceding section):
-**secrdrop5wyphb5x.onion**
-
 Perfect Forward Secrecy
 -----------------------
 
@@ -141,6 +117,30 @@ services intercept requests between a potential source and the SecureDrop
 *Landing Page* and can be used to `track`_ or collect information on sources.
 
 .. _`track`: https://github.com/Synzvato/decentraleyes/wiki/Frequently-Asked-Questions
+
+Do Not Hyperlink .onion Addresses
+---------------------------------
+Because a visitor to your *Landing Page* may not be using the Tor browser yet,
+clicking a link to your SecureDrop instance or to any other .onion address may
+result in an error message. Worse, depending on the browser and network
+configuration, it may cause lookups that an adversary can use to identify
+SecureDrop-related behavior.
+
+Instead, we recommend including .onion addresses in plain text, without a
+hyperlink.
+
+Avoid Direct Links to SecureDrop.org
+------------------------------------
+
+We appreciate that you may want to link to `the SecureDrop website <https://securedrop.org/>`__
+to give *Landing Page* visitors more information about the system. Unfortunately,
+if a visitor visits these links without using the Tor browser, this generates
+traffic that an adversary may be able to use to identify SecureDrop-related
+behavior, regardless of the use of HTTPS.
+
+We suggest offering a reference to the SecureDrop hidden service in
+plain text, without a hyperlink (as per the preceding section):
+**secrdrop5wyphb5x.onion**
 
 Apply Security Headers
 ----------------------


### PR DESCRIPTION
Fixes #3259

## Status

Ready for review

## Description of Changes

Adds two sections to the landing page docs, one to explain why hyperlinks to .onion addresses are not a good idea, and another to discourage direct links to securedrop.org (as opposed to references to the THS).

## Checklist

- [X] Doc linting (`make docs-lint`) passed locally
