### PR TITLE
added hashes for pluggy python wheels

### DIFF
--- a/admin/requirements-dev.txt
+++ b/admin/requirements-dev.txt
@@ -125,6 +125,8 @@ pip-tools==1.11.0 \
     --hash=sha256:ba427b68443466c389e3b0b0ef55f537ab39344190ea980dfebb333d0e6a50a3
 pluggy==0.6.0 \
     --hash=sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff \
+    --hash=sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c \
+    --hash=sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5 \
     # via pytest, tox
 py==1.5.2 \
     --hash=sha256:8cca5c229d225f8c1e3085be4fcf306090b00850fefad892f9d96c7b6e2f310f \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3269

As we can see from the PyPI [page for `pluggy`](https://pypi.python.org/pypi/pluggy), two python wheels were added yesterday. These are breaking our dev installs.

## Testing

```
cd admin && make test
```

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container