### PR TITLE
Add explanatory text for  authenticator reset buttons in Journalist/Admin interface

### DIFF
--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -105,7 +105,7 @@
   <input name="uid" type="hidden" value="{{ user.id }}">
   {% endif %}
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-  <button class="sd-button" id="button-reset-two-factor-{{ type }}" tooltip="{{ tooltip_text }}" type="submit" class="pull-right"><i class="fas fa-sync"></i> {{ button_text }}</button>
+  <button class="sd-button" id="button-reset-two-factor-{{ type }}" tooltip="{{ tooltip_text }}" type="submit" class="pull-right"><i class="fas fa-sync"></i> {{ button_text }}<span class="tooltip">{{ tooltip_text }}</span></button>
 </form>
 {%- endmacro %}
 

--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -94,7 +94,7 @@
   {% set hotp_reset_url = url_for('account.reset_two_factor_hotp') %}
 {% endif %}
 
-{% macro twofa_reset(user, reset_url, type, button_text) %}
+{% macro twofa_reset(user, reset_url, type, tooltip_text, button_text) %}
 {% if user %}
   {% set username = user.username %}
 {% else %}
@@ -105,12 +105,11 @@
   <input name="uid" type="hidden" value="{{ user.id }}">
   {% endif %}
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-  <button class="sd-button" id="button-reset-two-factor-{{ type }}" type="submit" class="pull-right"><i class="fas fa-sync"></i> {{ button_text }}</button>
+  <button class="sd-button" id="button-reset-two-factor-{{ type }}" tooltip="{{ tooltip_text }}" type="submit" class="pull-right"><i class="fas fa-sync"></i> {{ button_text }}</button>
 </form>
 {%- endmacro %}
 
-{{ twofa_reset(user, totp_reset_url, "totp", gettext("RESET TWO-FACTOR AUTHENTICATION (APP)"))}}
-<br>
-{{ twofa_reset(user, hotp_reset_url, "hotp", gettext("RESET TWO-FACTOR AUTHENTICATION (HARDWARE TOKEN)"))}}
+{{ twofa_reset(user, totp_reset_url, "totp", gettext("Reset 2FA for mobile apps such as FreeOTP or Google Authenticator"), gettext("RESET APP TOKEN"))}}
+{{ twofa_reset(user, hotp_reset_url, "hotp", gettext("Reset 2FA for hardware tokens like Yubikey"), gettext("RESET HARDWARE TOKEN"))}}
 
 {% endblock %}

--- a/securedrop/sass/_base.sass
+++ b/securedrop/sass/_base.sass
@@ -26,6 +26,8 @@
 @import modules/text-link
 // Some kind of button possibly sd=standard button. Belongs in button module?
 @import modules/sd-button
+// Tooltips for showing informations
+@import modules/tooltip
 //variation on button for select all / none. In journalist interface only?
 @import modules/select
 // Pull - Quick layout helper classes
@@ -115,6 +117,7 @@
   +doc-check
   +text-link
   +sd-button
+  +tooltip
   +select
   +pull
   +header

--- a/securedrop/sass/journalist.sass
+++ b/securedrop/sass/journalist.sass
@@ -100,7 +100,6 @@ button.small-danger, a.btn.small-danger, .btn.small-danger
   .login-password
     width: 100%
 
-
 .journalist-reply__input
   max-width: 700px
 
@@ -121,3 +120,6 @@ button.small-danger, a.btn.small-danger, .btn.small-danger
 
 .show-password-checkbox-container
   display: none
+
+.reset-two-factor
+  display: inline-block

--- a/securedrop/sass/modules/_tooltip.sass
+++ b/securedrop/sass/modules/_tooltip.sass
@@ -76,5 +76,5 @@
   /* KEYFRAMES */
   @keyframes tooltips-vert
     to
-      opacity: .9
+      opacity: 1
       transform: translate(-50%, 0)

--- a/securedrop/sass/modules/_tooltip.sass
+++ b/securedrop/sass/modules/_tooltip.sass
@@ -5,7 +5,7 @@
 
     /* Applies to all tooltips */
     &:before,
-    &:after
+    .tooltip
       text-transform: none
       font-size: .9em
       line-height: 1
@@ -20,7 +20,7 @@
       border: 5px solid transparent
       z-index: 1001
 
-    &:after
+    .tooltip
       content: attr(tooltip)
       /* most of the rest of this is opinion */
       font-family: Helvetica, sans-serif
@@ -40,12 +40,12 @@
 
     /* Make the tooltips respond to hover */
     &:hover::before,
-    &:hover::after
+    &:hover .tooltip
       display: block
 
   /* don't show empty tooltips */
   [tooltip='']::before,
-  [tooltip='']::after
+  [tooltip=''] .tooltip
     display: none !important
 
 
@@ -56,21 +56,21 @@
     border-bottom-width: 0
     border-top-color: #333
 
-  [tooltip]:not([flow])::after,
-  [tooltip][flow^="up"]::after
+  [tooltip]:not([flow]) .tooltip,
+  [tooltip][flow^="up"] .tooltip
     bottom: calc(100% + 0.3em)
 
   [tooltip]:not([flow])::before,
-  [tooltip]:not([flow])::after,
+  [tooltip]:not([flow]) .tooltip,
   [tooltip][flow^="up"]::before,
-  [tooltip][flow^="up"]::after
+  [tooltip][flow^="up"] .tooltip
     left: 50%
     transform: translate(-50%, -.5em)
 
   [tooltip]:not([flow]):hover::before,
-  [tooltip]:not([flow]):hover::after,
+  [tooltip]:not([flow]):hover .tooltip,
   [tooltip][flow^="up"]:hover::before,
-  [tooltip][flow^="up"]:hover::after
+  [tooltip][flow^="up"]:hover .tooltip
     animation: tooltips-vert 300ms ease-out forwards
 
   /* KEYFRAMES */

--- a/securedrop/sass/modules/_tooltip.sass
+++ b/securedrop/sass/modules/_tooltip.sass
@@ -1,0 +1,80 @@
+=tooltip
+
+  [tooltip]
+    position: relative
+
+    /* Applies to all tooltips */
+    &:before,
+    &:after
+      text-transform: none
+      font-size: .9em
+      line-height: 1
+      user-select: none
+      pointer-events: none
+      position: absolute
+      display: none
+      opacity: 0
+
+    &:before
+      content: ''
+      border: 5px solid transparent
+      z-index: 1001
+
+    &:after
+      content: attr(tooltip)
+      /* most of the rest of this is opinion */
+      font-family: Helvetica, sans-serif
+      text-align: center
+      min-width: 3em
+      max-width: 45em
+      white-space: nowrap
+      overflow: hidden
+      text-overflow: ellipsis
+      padding: 1ch 1.5ch
+      border-radius: .3ch
+      box-shadow: 0 1em 2em -.5em rgba(0, 0, 0, 0.35)
+      background: #333
+      color: #fff
+      z-index: 1000
+
+
+    /* Make the tooltips respond to hover */
+    &:hover::before,
+    &:hover::after
+      display: block
+
+  /* don't show empty tooltips */
+  [tooltip='']::before,
+  [tooltip='']::after
+    display: none !important
+
+
+  /* FLOW: UP */
+  [tooltip]:not([flow])::before,
+  [tooltip][flow^="up"]::before
+    bottom: 100%
+    border-bottom-width: 0
+    border-top-color: #333
+
+  [tooltip]:not([flow])::after,
+  [tooltip][flow^="up"]::after
+    bottom: calc(100% + 0.3em)
+
+  [tooltip]:not([flow])::before,
+  [tooltip]:not([flow])::after,
+  [tooltip][flow^="up"]::before,
+  [tooltip][flow^="up"]::after
+    left: 50%
+    transform: translate(-50%, -.5em)
+
+  [tooltip]:not([flow]):hover::before,
+  [tooltip]:not([flow]):hover::after,
+  [tooltip][flow^="up"]:hover::before,
+  [tooltip][flow^="up"]:hover::after
+    animation: tooltips-vert 300ms ease-out forwards
+
+  /* KEYFRAMES */
+  @keyframes tooltips-vert
+    to
+      opacity: .9
+      transform: translate(-50%, 0)

--- a/securedrop/sass/modules/_tooltip.sass
+++ b/securedrop/sass/modules/_tooltip.sass
@@ -21,8 +21,6 @@
       z-index: 1001
 
     .tooltip
-      content: attr(tooltip)
-      /* most of the rest of this is opinion */
       font-family: Helvetica, sans-serif
       text-align: center
       min-width: 3em
@@ -37,17 +35,19 @@
       color: #fff
       z-index: 1000
 
-
     /* Make the tooltips respond to hover */
     &:hover::before,
     &:hover .tooltip
       display: block
 
+    @media only screen and (max-width: 768px)
+      .tooltip
+        white-space: unset
+
   /* don't show empty tooltips */
   [tooltip='']::before,
   [tooltip=''] .tooltip
     display: none !important
-
 
   /* FLOW: UP */
   [tooltip]:not([flow])::before,

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -453,6 +453,49 @@ class JournalistNavigationStepsMixin:
         assert "/account/reset-2fa-totp" in totp_reset_button.get_attribute("action")
         hotp_reset_button = self.driver.find_elements_by_css_selector("#reset-two-factor-hotp")[0]
         assert "/account/reset-2fa-hotp" in hotp_reset_button.get_attribute("action")
+        # 2FA reset buttons show a tooltip with explanatory text on hover.
+        # Also, confirm the text on the tooltip is the correct one.
+        totp_reset_button = self.driver.find_elements_by_css_selector(
+            '#button-reset-two-factor-totp')[0]
+        ActionChains(self.driver).move_to_element(totp_reset_button).perform()
+        time.sleep(1)
+        explanatory_totp_tooltip_opacity = self.driver.execute_script(
+            'return \
+                window.getComputedStyle(\
+                    document.querySelector("#button-reset-two-factor-totp"), \
+                    ":after"\
+                ).getPropertyValue("opacity")'
+        )
+        explanatory_totp_tooltip_content = self.driver.execute_script(
+            'return \
+                window.getComputedStyle(\
+                    document.querySelector("#button-reset-two-factor-totp"), \
+                    ":after"\
+                ).getPropertyValue("content")'
+        )
+        assert explanatory_totp_tooltip_opacity == "1"
+        assert explanatory_totp_tooltip_content == "attr(tooltip)"
+
+        hotp_reset_button = self.driver.find_elements_by_css_selector(
+            '#button-reset-two-factor-hotp')[0]
+        ActionChains(self.driver).move_to_element(hotp_reset_button).perform()
+        time.sleep(1)
+        explanatory_hotp_tooltip_opacity = self.driver.execute_script(
+            'return \
+                window.getComputedStyle(\
+                    document.querySelector("#button-reset-two-factor-hotp"), \
+                    ":after"\
+                ).getPropertyValue("opacity")'
+        )
+        explanatory_hotp_tooltip_content = self.driver.execute_script(
+            'return \
+                window.getComputedStyle(\
+                    document.querySelector("#button-reset-two-factor-hotp"), \
+                    ":after"\
+                ).getPropertyValue("content")'
+        )
+        assert explanatory_hotp_tooltip_opacity == "1"
+        assert explanatory_hotp_tooltip_content == "attr(tooltip)"
 
     def _edit_user(self, username, is_admin=False):
         self.wait_for(lambda: self.driver.find_element_by_id("users"))
@@ -748,6 +791,28 @@ class JournalistNavigationStepsMixin:
     def _admin_visits_reset_2fa_hotp(self):
         for i in range(3):
             try:
+                # 2FA reset buttons show a tooltip with explanatory text on hover.
+                # Also, confirm the text on the tooltip is the correct one.
+                hotp_reset_button = self.driver.find_elements_by_css_selector(
+                    '#button-reset-two-factor-hotp')[0]
+                ActionChains(self.driver).move_to_element(hotp_reset_button).perform()
+                time.sleep(1)
+                explanatory_hotp_tooltip_opacity = self.driver.execute_script(
+                    'return \
+                        window.getComputedStyle(\
+                            document.querySelector("#button-reset-two-factor-hotp"), \
+                            ":after"\
+                        ).getPropertyValue("opacity")'
+                )
+                explanatory_hotp_tooltip_content = self.driver.execute_script(
+                    'return \
+                        window.getComputedStyle(\
+                            document.querySelector("#button-reset-two-factor-hotp"), \
+                            ":after"\
+                        ).getPropertyValue("content")'
+                )
+                assert explanatory_hotp_tooltip_opacity == "1"
+                assert explanatory_hotp_tooltip_content == "attr(tooltip)"
                 self.safe_click_by_id("button-reset-two-factor-hotp")
                 self._alert_wait()
                 self._alert_accept()
@@ -763,6 +828,28 @@ class JournalistNavigationStepsMixin:
     def _admin_visits_reset_2fa_totp(self):
         totp_reset_button = self.driver.find_elements_by_css_selector("#reset-two-factor-totp")[0]
         assert "/admin/reset-2fa-totp" in totp_reset_button.get_attribute("action")
+        # 2FA reset buttons show a tooltip with explanatory text on hover.
+        # Also, confirm the text on the tooltip is the correct one.
+        totp_reset_button = self.driver.find_elements_by_css_selector(
+            '#button-reset-two-factor-totp')[0]
+        ActionChains(self.driver).move_to_element(totp_reset_button).perform()
+        time.sleep(1)
+        explanatory_totp_tooltip_opacity = self.driver.execute_script(
+            'return \
+                window.getComputedStyle(\
+                    document.querySelector("#button-reset-two-factor-totp"), \
+                    ":after"\
+                ).getPropertyValue("opacity")'
+        )
+        explanatory_totp_tooltip_content = self.driver.execute_script(
+            'return \
+                window.getComputedStyle(\
+                    document.querySelector("#button-reset-two-factor-totp"), \
+                    ":after"\
+                ).getPropertyValue("content")'
+        )
+        assert explanatory_totp_tooltip_opacity == "1"
+        assert explanatory_totp_tooltip_content == "attr(tooltip)"
         totp_reset_button.click()
 
     def _admin_creates_a_user(self, hotp):

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -707,16 +707,17 @@ class JournalistNavigationStepsMixin:
         )
         assert "/account/reset-2fa-" + otp_type in reset_form.get_attribute("action")
         reset_button = self.driver.find_elements_by_css_selector(
-            "#button-reset-two-factor-" + type)[0]
+            "#button-reset-two-factor-" + otp_type)[0]
 
         # 2FA reset buttons show a tooltip with explanatory text on hover.
         # Also, confirm the text on the tooltip is the correct one.
+        reset_button.location_once_scrolled_into_view
         ActionChains(self.driver).move_to_element(reset_button).perform()
         time.sleep(1)
         explanatory_tooltip_opacity = self.driver.find_elements_by_css_selector(
-            "#button-reset-two-factor-" + type + " span")[0].value_of_css_property("opacity")
+            "#button-reset-two-factor-" + otp_type + " span")[0].value_of_css_property("opacity")
         explanatory_tooltip_content = self.driver.find_elements_by_css_selector(
-            "#button-reset-two-factor-" + type + " span")[0].text
+            "#button-reset-two-factor-" + otp_type + " span")[0].text
 
         assert explanatory_tooltip_opacity == "1"
         if not hasattr(self, "accept_languages"):
@@ -769,18 +770,21 @@ class JournalistNavigationStepsMixin:
             try:
                 # 2FA reset buttons show a tooltip with explanatory text on hover.
                 # Also, confirm the text on the tooltip is the correct one.
+                self.wait_for(lambda: self.driver.find_elements_by_css_selector(
+                    "#button-reset-two-factor-hotp")[0])
                 hotp_reset_button = self.driver.find_elements_by_css_selector(
                     "#button-reset-two-factor-hotp")[0]
+                hotp_reset_button.location_once_scrolled_into_view
                 ActionChains(self.driver).move_to_element(hotp_reset_button).perform()
                 time.sleep(1)
-                explanatory_tooltip_opacity = self.driver.find_elements_by_css_selector(
+                tip_opacity = self.driver.find_elements_by_css_selector(
                     "#button-reset-two-factor-hotp span")[0].value_of_css_property('opacity')
-                explanatory_tooltip_content = self.driver.find_elements_by_css_selector(
+                tip_text = self.driver.find_elements_by_css_selector(
                     "#button-reset-two-factor-hotp span")[0].text
 
-                assert explanatory_tooltip_opacity == "1"
+                assert tip_opacity == "1"
                 if not hasattr(self, "accept_languages"):
-                    assert explanatory_tooltip_content == "Reset 2FA for hardware tokens like Yubikey"
+                    assert tip_text == "Reset 2FA for hardware tokens like Yubikey"
                 self.safe_click_by_id("button-reset-two-factor-hotp")
                 self._alert_wait()
                 self._alert_accept()
@@ -800,17 +804,20 @@ class JournalistNavigationStepsMixin:
         # Also, confirm the text on the tooltip is the correct one.
         totp_reset_button = self.driver.find_elements_by_css_selector(
             "#button-reset-two-factor-totp")[0]
+        totp_reset_button.location_once_scrolled_into_view
         ActionChains(self.driver).move_to_element(totp_reset_button).perform()
         time.sleep(1)
-        explanatory_tooltip_opacity = self.driver.find_elements_by_css_selector(
+        tip_opacity = self.driver.find_elements_by_css_selector(
             "#button-reset-two-factor-totp span")[0].value_of_css_property('opacity')
-        explanatory_tooltip_content = self.driver.find_elements_by_css_selector(
+        tip_text = self.driver.find_elements_by_css_selector(
             "#button-reset-two-factor-totp span")[0].text
 
-        assert explanatory_tooltip_opacity == "1"
+        assert tip_opacity == "1"
         if not hasattr(self, "accept_languages"):
-            assert explanatory_tooltip_content == "Reset 2FA for mobile apps such as FreeOTP or Google Authenticator"
-        totp_reset_button.click()
+            assert tip_text == "Reset 2FA for mobile apps such as FreeOTP or Google Authenticator"
+        self.safe_click_by_id("button-reset-two-factor-totp")
+        self._alert_wait()
+        self._alert_accept()
 
     def _admin_creates_a_user(self, hotp):
         self.safe_click_by_id("add-user")

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -453,49 +453,6 @@ class JournalistNavigationStepsMixin:
         assert "/account/reset-2fa-totp" in totp_reset_button.get_attribute("action")
         hotp_reset_button = self.driver.find_elements_by_css_selector("#reset-two-factor-hotp")[0]
         assert "/account/reset-2fa-hotp" in hotp_reset_button.get_attribute("action")
-        # 2FA reset buttons show a tooltip with explanatory text on hover.
-        # Also, confirm the text on the tooltip is the correct one.
-        totp_reset_button = self.driver.find_elements_by_css_selector(
-            '#button-reset-two-factor-totp')[0]
-        ActionChains(self.driver).move_to_element(totp_reset_button).perform()
-        time.sleep(1)
-        explanatory_totp_tooltip_opacity = self.driver.execute_script(
-            'return \
-                window.getComputedStyle(\
-                    document.querySelector("#button-reset-two-factor-totp"), \
-                    ":after"\
-                ).getPropertyValue("opacity")'
-        )
-        explanatory_totp_tooltip_content = self.driver.execute_script(
-            'return \
-                window.getComputedStyle(\
-                    document.querySelector("#button-reset-two-factor-totp"), \
-                    ":after"\
-                ).getPropertyValue("content")'
-        )
-        assert explanatory_totp_tooltip_opacity == "1"
-        assert explanatory_totp_tooltip_content == "attr(tooltip)"
-
-        hotp_reset_button = self.driver.find_elements_by_css_selector(
-            '#button-reset-two-factor-hotp')[0]
-        ActionChains(self.driver).move_to_element(hotp_reset_button).perform()
-        time.sleep(1)
-        explanatory_hotp_tooltip_opacity = self.driver.execute_script(
-            'return \
-                window.getComputedStyle(\
-                    document.querySelector("#button-reset-two-factor-hotp"), \
-                    ":after"\
-                ).getPropertyValue("opacity")'
-        )
-        explanatory_hotp_tooltip_content = self.driver.execute_script(
-            'return \
-                window.getComputedStyle(\
-                    document.querySelector("#button-reset-two-factor-hotp"), \
-                    ":after"\
-                ).getPropertyValue("content")'
-        )
-        assert explanatory_hotp_tooltip_opacity == "1"
-        assert explanatory_hotp_tooltip_content == "attr(tooltip)"
 
     def _edit_user(self, username, is_admin=False):
         self.wait_for(lambda: self.driver.find_element_by_id("users"))
@@ -750,19 +707,20 @@ class JournalistNavigationStepsMixin:
         )
         assert "/account/reset-2fa-" + otp_type in reset_form.get_attribute("action")
         reset_button = self.driver.find_elements_by_css_selector(
-            '#button-reset-two-factor-' + type)[0]
+            "#button-reset-two-factor-" + type)[0]
 
         # 2FA reset buttons show a tooltip with explanatory text on hover.
         # Also, confirm the text on the tooltip is the correct one.
         ActionChains(self.driver).move_to_element(reset_button).perform()
         time.sleep(1)
         explanatory_tooltip_opacity = self.driver.find_elements_by_css_selector(
-            '#button-reset-two-factor-' + type + ' span')[0].value_of_css_property('opacity')
+            "#button-reset-two-factor-" + type + " span")[0].value_of_css_property("opacity")
         explanatory_tooltip_content = self.driver.find_elements_by_css_selector(
-            '#button-reset-two-factor-' + type + ' span')[0].text
+            "#button-reset-two-factor-" + type + " span")[0].text
 
-        assert explanatory_tooltip_opacity == '1'
-        assert explanatory_tooltip_content == tooltip_text
+        assert explanatory_tooltip_opacity == "1"
+        if not hasattr(self, "accept_languages"):
+            assert explanatory_tooltip_content == tooltip_text
         reset_form.submit()
 
         alert = self.driver.switch_to_alert()
@@ -806,23 +764,23 @@ class JournalistNavigationStepsMixin:
             self.safe_click_by_css_selector(selector)
             self.wait_for(lambda: self.driver.find_element_by_id("new-password"))
 
-<<<<<<< HEAD
     def _admin_visits_reset_2fa_hotp(self):
         for i in range(3):
             try:
                 # 2FA reset buttons show a tooltip with explanatory text on hover.
                 # Also, confirm the text on the tooltip is the correct one.
                 hotp_reset_button = self.driver.find_elements_by_css_selector(
-                    '#button-reset-two-factor-hotp')[0]
+                    "#button-reset-two-factor-hotp")[0]
                 ActionChains(self.driver).move_to_element(hotp_reset_button).perform()
                 time.sleep(1)
                 explanatory_tooltip_opacity = self.driver.find_elements_by_css_selector(
-                    '#button-reset-two-factor-hotp span')[0].value_of_css_property('opacity')
+                    "#button-reset-two-factor-hotp span")[0].value_of_css_property('opacity')
                 explanatory_tooltip_content = self.driver.find_elements_by_css_selector(
-                    '#button-reset-two-factor-hotp span')[0].text
+                    "#button-reset-two-factor-hotp span")[0].text
 
                 assert explanatory_tooltip_opacity == "1"
-                assert explanatory_tooltip_content == "Reset 2FA for hardware tokens like Yubikey"
+                if not hasattr(self, "accept_languages"):
+                    assert explanatory_tooltip_content == "Reset 2FA for hardware tokens like Yubikey"
                 self.safe_click_by_id("button-reset-two-factor-hotp")
                 self._alert_wait()
                 self._alert_accept()
@@ -841,54 +799,18 @@ class JournalistNavigationStepsMixin:
         # 2FA reset buttons show a tooltip with explanatory text on hover.
         # Also, confirm the text on the tooltip is the correct one.
         totp_reset_button = self.driver.find_elements_by_css_selector(
-            '#button-reset-two-factor-totp')[0]
+            "#button-reset-two-factor-totp")[0]
         ActionChains(self.driver).move_to_element(totp_reset_button).perform()
         time.sleep(1)
         explanatory_tooltip_opacity = self.driver.find_elements_by_css_selector(
-            '#button-reset-two-factor-' + type + ' span')[0].value_of_css_property('opacity')
+            "#button-reset-two-factor-totp span")[0].value_of_css_property('opacity')
         explanatory_tooltip_content = self.driver.find_elements_by_css_selector(
-            '#button-reset-two-factor-' + type + ' span')[0].text
+            "#button-reset-two-factor-totp span")[0].text
 
-        assert explanatory_tooltip_opacity == '1'
-        assert explanatory_tooltip_content == 'Reset 2FA for mobile apps such as FreeOTP or Google Authenticator'
+        assert explanatory_tooltip_opacity == "1"
+        if not hasattr(self, "accept_languages"):
+            assert explanatory_tooltip_content == "Reset 2FA for mobile apps such as FreeOTP or Google Authenticator"
         totp_reset_button.click()
-=======
-    def _admin_visits_reset_secret(self, type, tooltip_text=''):
-        reset_form = self.driver.find_elements_by_css_selector(
-            '#reset-two-factor-' + type)[0]
-        assert ('/admin/reset-2fa-' + type in
-                reset_form.get_attribute('action'))
-
-        # 2FA reset buttons show a tooltip with explanatory text on hover.
-        # Also, confirm the text on the tooltip is the correct one.
-        reset_button = self.driver.find_elements_by_css_selector(
-            '#button-reset-two-factor-' + type)[0]
-
-        ActionChains(self.driver).move_to_element(reset_button).perform()
-        time.sleep(1)
-        explanatory_tooltip_opacity = self.driver.find_elements_by_css_selector(
-            '#button-reset-two-factor-' + type + ' span')[0].value_of_css_property('opacity')
-        explanatory_tooltip_content = self.driver.find_elements_by_css_selector(
-            '#button-reset-two-factor-' + type + ' span')[0].text
-
-        assert explanatory_tooltip_opacity == '1'
-        assert explanatory_tooltip_content == tooltip_text
-        reset_button.click()
-
-    def _admin_visits_reset_2fa_hotp(self):
-        self._admin_visits_reset_secret(
-            'hotp',
-            'Reset 2FA for hardware tokens like Yubikey')
-
-    def _admin_accepts_2fa_js_alert(self):
-        self._alert_wait()
-        self._alert_accept()
-
-    def _admin_visits_reset_2fa_totp(self):
-        self._admin_visits_reset_secret(
-            'totp',
-            'Reset 2FA for mobile apps such as FreeOTP or Google Authenticator')
->>>>>>> Tests: Fixes functional tests based on the new tooltip SASS
 
     def _admin_creates_a_user(self, hotp):
         self.safe_click_by_id("add-user")

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -744,11 +744,25 @@ class JournalistNavigationStepsMixin:
     def _visit_edit_account(self):
         self.safe_click_by_id("link-edit-account")
 
-    def _visit_edit_secret(self, otp_type):
+    def _visit_edit_secret(self, otp_type, tooltip_text=''):
         reset_form = self.wait_for(
             lambda: self.driver.find_element_by_id("reset-two-factor-" + otp_type)
         )
         assert "/account/reset-2fa-" + otp_type in reset_form.get_attribute("action")
+        reset_button = self.driver.find_elements_by_css_selector(
+            '#button-reset-two-factor-' + type)[0]
+
+        # 2FA reset buttons show a tooltip with explanatory text on hover.
+        # Also, confirm the text on the tooltip is the correct one.
+        ActionChains(self.driver).move_to_element(reset_button).perform()
+        time.sleep(1)
+        explanatory_tooltip_opacity = self.driver.find_elements_by_css_selector(
+            '#button-reset-two-factor-' + type + ' span')[0].value_of_css_property('opacity')
+        explanatory_tooltip_content = self.driver.find_elements_by_css_selector(
+            '#button-reset-two-factor-' + type + ' span')[0].text
+
+        assert explanatory_tooltip_opacity == '1'
+        assert explanatory_tooltip_content == tooltip_text
         reset_form.submit()
 
         alert = self.driver.switch_to_alert()
@@ -764,10 +778,14 @@ class JournalistNavigationStepsMixin:
         submit_button.click()
 
     def _visit_edit_hotp_secret(self):
-        self._visit_edit_secret("hotp")
+        self._visit_edit_secret(
+            "hotp",
+            "Reset 2FA for hardware tokens like Yubikey")
 
     def _visit_edit_totp_secret(self):
-        self._visit_edit_secret("totp")
+        self._visit_edit_secret(
+            "totp",
+            "Reset 2FA for mobile apps such as FreeOTP or Google Authenticator")
 
     def _admin_visits_add_user(self):
         add_user_btn = self.driver.find_element_by_css_selector("button#add-user")
@@ -788,6 +806,7 @@ class JournalistNavigationStepsMixin:
             self.safe_click_by_css_selector(selector)
             self.wait_for(lambda: self.driver.find_element_by_id("new-password"))
 
+<<<<<<< HEAD
     def _admin_visits_reset_2fa_hotp(self):
         for i in range(3):
             try:
@@ -797,22 +816,13 @@ class JournalistNavigationStepsMixin:
                     '#button-reset-two-factor-hotp')[0]
                 ActionChains(self.driver).move_to_element(hotp_reset_button).perform()
                 time.sleep(1)
-                explanatory_hotp_tooltip_opacity = self.driver.execute_script(
-                    'return \
-                        window.getComputedStyle(\
-                            document.querySelector("#button-reset-two-factor-hotp"), \
-                            ":after"\
-                        ).getPropertyValue("opacity")'
-                )
-                explanatory_hotp_tooltip_content = self.driver.execute_script(
-                    'return \
-                        window.getComputedStyle(\
-                            document.querySelector("#button-reset-two-factor-hotp"), \
-                            ":after"\
-                        ).getPropertyValue("content")'
-                )
-                assert explanatory_hotp_tooltip_opacity == "1"
-                assert explanatory_hotp_tooltip_content == "attr(tooltip)"
+                explanatory_tooltip_opacity = self.driver.find_elements_by_css_selector(
+                    '#button-reset-two-factor-hotp span')[0].value_of_css_property('opacity')
+                explanatory_tooltip_content = self.driver.find_elements_by_css_selector(
+                    '#button-reset-two-factor-hotp span')[0].text
+
+                assert explanatory_tooltip_opacity == "1"
+                assert explanatory_tooltip_content == "Reset 2FA for hardware tokens like Yubikey"
                 self.safe_click_by_id("button-reset-two-factor-hotp")
                 self._alert_wait()
                 self._alert_accept()
@@ -834,23 +844,51 @@ class JournalistNavigationStepsMixin:
             '#button-reset-two-factor-totp')[0]
         ActionChains(self.driver).move_to_element(totp_reset_button).perform()
         time.sleep(1)
-        explanatory_totp_tooltip_opacity = self.driver.execute_script(
-            'return \
-                window.getComputedStyle(\
-                    document.querySelector("#button-reset-two-factor-totp"), \
-                    ":after"\
-                ).getPropertyValue("opacity")'
-        )
-        explanatory_totp_tooltip_content = self.driver.execute_script(
-            'return \
-                window.getComputedStyle(\
-                    document.querySelector("#button-reset-two-factor-totp"), \
-                    ":after"\
-                ).getPropertyValue("content")'
-        )
-        assert explanatory_totp_tooltip_opacity == "1"
-        assert explanatory_totp_tooltip_content == "attr(tooltip)"
+        explanatory_tooltip_opacity = self.driver.find_elements_by_css_selector(
+            '#button-reset-two-factor-' + type + ' span')[0].value_of_css_property('opacity')
+        explanatory_tooltip_content = self.driver.find_elements_by_css_selector(
+            '#button-reset-two-factor-' + type + ' span')[0].text
+
+        assert explanatory_tooltip_opacity == '1'
+        assert explanatory_tooltip_content == 'Reset 2FA for mobile apps such as FreeOTP or Google Authenticator'
         totp_reset_button.click()
+=======
+    def _admin_visits_reset_secret(self, type, tooltip_text=''):
+        reset_form = self.driver.find_elements_by_css_selector(
+            '#reset-two-factor-' + type)[0]
+        assert ('/admin/reset-2fa-' + type in
+                reset_form.get_attribute('action'))
+
+        # 2FA reset buttons show a tooltip with explanatory text on hover.
+        # Also, confirm the text on the tooltip is the correct one.
+        reset_button = self.driver.find_elements_by_css_selector(
+            '#button-reset-two-factor-' + type)[0]
+
+        ActionChains(self.driver).move_to_element(reset_button).perform()
+        time.sleep(1)
+        explanatory_tooltip_opacity = self.driver.find_elements_by_css_selector(
+            '#button-reset-two-factor-' + type + ' span')[0].value_of_css_property('opacity')
+        explanatory_tooltip_content = self.driver.find_elements_by_css_selector(
+            '#button-reset-two-factor-' + type + ' span')[0].text
+
+        assert explanatory_tooltip_opacity == '1'
+        assert explanatory_tooltip_content == tooltip_text
+        reset_button.click()
+
+    def _admin_visits_reset_2fa_hotp(self):
+        self._admin_visits_reset_secret(
+            'hotp',
+            'Reset 2FA for hardware tokens like Yubikey')
+
+    def _admin_accepts_2fa_js_alert(self):
+        self._alert_wait()
+        self._alert_accept()
+
+    def _admin_visits_reset_2fa_totp(self):
+        self._admin_visits_reset_secret(
+            'totp',
+            'Reset 2FA for mobile apps such as FreeOTP or Google Authenticator')
+>>>>>>> Tests: Fixes functional tests based on the new tooltip SASS
 
     def _admin_creates_a_user(self, hotp):
         self.safe_click_by_id("add-user")

--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -21,6 +21,14 @@ class TestAdminInterface(
         self._admin_visits_reset_2fa_hotp()
         self._admin_visits_edit_hotp()
 
+    def test_admin_edits_totp_secret(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_adds_a_user()
+        self._admin_visits_edit_user()
+        self._admin_visits_reset_2fa_totp()
+        self._admin_accepts_2fa_js_alert()
+
     def test_admin_deletes_user(self):
         self._admin_logs_in()
         self._admin_visits_admin_interface()

--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -27,7 +27,6 @@ class TestAdminInterface(
         self._admin_adds_a_user()
         self._admin_visits_edit_user()
         self._admin_visits_reset_2fa_totp()
-        self._admin_accepts_2fa_js_alert()
 
     def test_admin_deletes_user(self):
         self._admin_logs_in()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1572 .

Changes proposed in this pull request:
- Adds a reusable tooltip sass
- Adds a SASS only approach to show tooltips and avoids large button labels
- Adds necessary functional and page layout tests for the same

## Testing

How should the reviewer test this PR?

- Login to the journalist interface.
- Go to the `/account/account` endpoint
- Hover over the Reset Two-Factor Authentication buttons.
- You should see tooltips similar to this:
![screen shot 2018-04-17 at 2 48 36 am](https://user-images.githubusercontent.com/9530293/38836045-7ad64b0c-41ea-11e8-9adf-cfb99b73530f.png)

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
