### PR TITLE
Pytest fixtures for test_2fa.py

### DIFF
--- a/securedrop/tests/test_2fa.py
+++ b/securedrop/tests/test_2fa.py
@@ -1,15 +1,71 @@
 # -*- coding: utf-8 -*-
 import os
+import pytest
+import time
 
+from contextlib import contextmanager
+from datetime import datetime, timedelta
 from flask import url_for
+from pyotp import TOTP
 import flask_testing
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 from models import Journalist, BadTokenException
+from utils.instrument import InstrumentedApp
 
 import models
 import journalist
 import utils
+
+
+@contextmanager
+def totp_window():
+    # To ensure we have enough time during a single TOTP window to do the
+    # whole test, optionally sleep.
+    now = datetime.now()
+    mod = now.second % 30
+    if mod < 3:
+        time.sleep(mod % 30)
+        now = datetime.now()
+
+    yield
+
+    # This check ensures that the token was used during the same window
+    # in the event that the app's logic only checks for token reuse if the
+    # token was valid.
+    then = datetime.now()
+    assert then < now + timedelta(seconds=(30 - mod))
+
+
+def test_totp_reuse_protections(journalist_app, test_journo):
+    """Ensure that logging in twice with the same TOTP token fails."""
+    original_hardening = models.LOGIN_HARDENING
+    try:
+        models.LOGIN_HARDENING = True
+
+        with totp_window():
+            token = TOTP(test_journo['otp_secret']).now()
+
+            with journalist_app.test_client() as app:
+                with InstrumentedApp(journalist_app) as ins:
+                    resp = app.post('/login',
+                                    data=dict(username=test_journo['username'],
+                                              password=test_journo['password'],
+                                              token=token))
+                    ins.assert_redirects(resp, '/')
+                resp = app.get('/logout', follow_redirects=True)
+                assert resp.status_code == 200
+
+            with journalist_app.test_client() as app:
+                resp = app.post('/login',
+                                data=dict(username=test_journo['username'],
+                                          password=test_journo['password'],
+                                          token=token))
+                assert resp.status_code == 200
+                text = resp.data.decode('utf-8')
+                assert "Login failed" in text
+    finally:
+        models.LOGIN_HARDENING = original_hardening
 
 
 class TestJournalist2FA(flask_testing.TestCase):
@@ -50,23 +106,6 @@ class TestJournalist2FA(flask_testing.TestCase):
                                           password=self.user_pw,
                                           token=token))
         return resp
-
-    def test_totp_reuse_protections(self):
-        """Ensure that logging in twice with the same TOTP token
-        fails.
-        """
-        original_hardening = models.LOGIN_HARDENING
-        try:
-            models.LOGIN_HARDENING = True
-            token = self.user.totp.now()
-            resp = self._login_user(token)
-            self.assertRedirects(resp, url_for('main.index'))
-
-            resp = self._login_user(token)
-            self.assert200(resp)
-            self.assertIn("Login failed", resp.data)
-        finally:
-            models.LOGIN_HARDENING = original_hardening
 
     def test_totp_reuse_protections2(self):
         """More granular than the preceeding test, we want to make sure

--- a/securedrop/tests/utils/__init__.py
+++ b/securedrop/tests/utils/__init__.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from flask import g
+from pyotp import TOTP
+
 import async  # noqa
 import db_helper  # noqa
 import env  # noqa
+
+
+def login_user(app, test_user):
+    resp = app.post('/login',
+                    data={'username': test_user['username'],
+                          'password': test_user['password'],
+                          'token': TOTP(test_user['otp_secret']).now()},
+                    follow_redirects=True)
+    assert resp.status_code == 200
+    assert hasattr(g, 'user')  # ensure logged in


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Toward #2877 

Use `pytest` fixtures for `test_2fa.py`. Note that there is as significant amount more code for each of these to ensure the behavior we want. The tests not include a check to ensure that the test happens inside the same TOTP 30 second window to ensure that future refactors don't break these tests. This is done with the `totp_window` context manger.

## Testing

```
make test TESTFILES=tests/test_2fa.py
```

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container