### PR TITLE
[docs] Add link to Reuters article re: 2014 research, correct summary

### DIFF
--- a/docs/what_makes_securedrop_unique.rst
+++ b/docs/what_makes_securedrop_unique.rst
@@ -73,7 +73,7 @@ for an attacker to access.
 Protecting against hackers
 --------------------------
 
-A 2014 study showed that 20 of the top 25 news organization had, at one time or
+A 2014 study showed that 21 of the top 25 news organization had, at one time or
 another, `been targeted <https://www.reuters.com/article/us-media-cybercrime/journalists-media-under-attack-from-hackers-google-researchers-idUSBREA2R0EU20140328>`__
 by state sponsored hackers.
 

--- a/docs/what_makes_securedrop_unique.rst
+++ b/docs/what_makes_securedrop_unique.rst
@@ -74,7 +74,8 @@ Protecting against hackers
 --------------------------
 
 A 2014 study showed that 20 of the top 25 news organization had, at one time or
-another, their networks compromised by state sponsored hackers.
+another, `been targeted <https://www.reuters.com/article/us-media-cybercrime/journalists-media-under-attack-from-hackers-google-researchers-idUSBREA2R0EU20140328>`__
+by state sponsored hackers.
 
 Because of this threat, SecureDrop completely segments its traffic from a news
 organization’s normal network. Submissions are accessed and downloaded using the


### PR DESCRIPTION
AFAICT nowhere is the assertion made that 20 out of 25 networks were
compromised; only that they had been targeted.

## Checklist

- [X] Doc linting (`make docs-lint`) passed locally
