### PR TITLE
[qt-journalist-updater] Run securedrop-admin setup first

### DIFF
--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -164,7 +164,7 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
         self.output += result['output']
         self.update_success = result['status']
         self.failure_reason = result['failure_reason']
-        self.progressBar.setProperty("value", 30)
+        self.progressBar.setProperty("value", 60)
         self.plainTextEdit.setPlainText(self.output)
         self.plainTextEdit.setReadOnly = True
         if not self.update_success:  # Failed to do setup update
@@ -174,6 +174,7 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
             self.progressBar.setProperty("value", 0)
             self.alert_failure(self.failure_reason)
             return
+        self.progressBar.setProperty("value", 70)
         self.call_tailsconfig()
 
     # This will update the output text after the git commands.

--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -7,6 +7,35 @@ import pexpect
 
 from journalist_gui import updaterUI, strings, resources_rc  # noqa
 
+class SetupThread(QThread):
+    signal = pyqtSignal('PyQt_PyObject')
+
+    def __init__(self):
+        QThread.__init__(self)
+        self.output = ""
+        self.update_success = False
+        self.failure_reason = ""
+
+    def run(self):
+        sdadmin_path = '/home/amnesia/Persistent/securedrop/securedrop-admin'
+        update_command = [sdadmin_path, 'setup']
+        try:
+            self.output = subprocess.check_output(
+                update_command,
+                stderr=subprocess.STDOUT).decode('utf-8')
+            if 'Failed to install' in self.output:
+                self.update_success = False
+                self.failure_reason = strings.update_failed_generic_reason
+            else:
+                self.update_success = True
+        except subprocess.CalledProcessError as e:
+            self.output += e.output.decode('utf-8')
+            self.update_success = False
+            self.failure_reason = strings.update_failed_generic_reason
+        result = {'status': self.update_success,
+                  'output': self.output,
+                  'failure_reason': self.failure_reason}
+        self.signal.emit(result)
 
 # This thread will handle the ./securedrop-admin update command
 class UpdateThread(QThread):
@@ -123,6 +152,27 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
         self.update_thread.signal.connect(self.update_status)
         self.tails_thread = TailsconfigThread()
         self.tails_thread.signal.connect(self.tails_status)
+        self.setup_thread = SetupThread()
+        self.setup_thread.signal.connect(self.setup_status)
+
+    def setup_status(self, result):
+        "This is the slot for setup thread"
+        self.output += result['output']
+        self.update_success = result['status']
+        self.failure_reason = result['failure_reason']
+        self.progressBar.setProperty("value", 30)
+        self.plainTextEdit.setPlainText(self.output)
+        self.plainTextEdit.setReadOnly = True
+        if not self.update_success:  # Failed to do setup update
+            self.pushButton.setEnabled(True)
+            self.pushButton_2.setEnabled(True)
+            self.update_status_bar_and_output(self.failure_reason)
+            self.progressBar.setProperty("value", 0)
+            self.alert_failure(self.failure_reason)
+            return
+        self.update_status_bar_and_output(strings.fetching_update)
+        # Now start the git and gpg commands
+        self.update_thread.start()
 
     # This will update the output text after the git commands.
     # At the end of this function, we will try to do tailsconfig.
@@ -184,10 +234,9 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
         self.pushButton_2.setEnabled(False)
         self.pushButton.setEnabled(False)
         self.progressBar.setProperty("value", 10)
-        self.update_status_bar_and_output(strings.fetching_update)
-        self.progressBar.setProperty("value", 20)
-        # Now start the git and gpg commands
-        self.update_thread.start()
+        self.update_status_bar_and_output(strings.doing_setup)
+        self.setup_thread.start()
+
 
     def alert_success(self):
         self.success_dialog = QtWidgets.QMessageBox()

--- a/journalist_gui/journalist_gui/strings.py
+++ b/journalist_gui/journalist_gui/strings.py
@@ -10,7 +10,7 @@ update_in_progress = ("SecureDrop workstation updates are available! "
                       "automatically appear if you have not "
                       "completed any required updates.\n")
 fetching_update = ('Fetching and verifying latest update...'
-                   ' (4 mins remaining)')
+                   ' (5 mins remaining)')
 updating_tails_env = ('Configuring local Tails environment...'
                       ' (1 min remaining)')
 finished = 'Update successfully completed!'
@@ -40,3 +40,4 @@ main_tab = 'Updates Available'
 output_tab = 'Detailed Update Progress'
 initial_text_box = ("When the update begins, this area will populate with "
                     "output.\n")
+doing_setup = "Checking dependencies are up to date... (2 mins remaining)"

--- a/journalist_gui/test_gui.py
+++ b/journalist_gui/test_gui.py
@@ -57,7 +57,7 @@ class WindowTestCase(AppTestCase):
                 return_value=b'Python dependencies for securedrop-admin')
     def test_setupThread(self, check_output):
         with mock.patch.object(self.window, "call_tailsconfig",
-                               return_value=""):
+                               return_value=MagicMock()):
             self.window.setup_thread.run()  # Call run directly
             self.assertEqual(self.window.update_success, True)
             self.assertEqual(self.window.progressBar.value(), 70)
@@ -66,7 +66,7 @@ class WindowTestCase(AppTestCase):
                 return_value=b'Failed to install pip dependencies')
     def test_setupThread_failure(self, check_output):
         with mock.patch.object(self.window, "call_tailsconfig",
-                               return_value=""):
+                               return_value=MagicMock()):
             self.window.setup_thread.run()  # Call run directly
             self.assertEqual(self.window.update_success, False)
             self.assertEqual(self.window.progressBar.value(), 0)
@@ -77,7 +77,7 @@ class WindowTestCase(AppTestCase):
                 return_value=b'Signature verification successful')
     def test_updateThread(self, check_output):
         with mock.patch.object(self.window, "setup_thread",
-                               return_value=""):
+                               return_value=MagicMock()):
             self.window.update_thread.run()  # Call run directly
             self.assertEqual(self.window.update_success, True)
             self.assertEqual(self.window.progressBar.value(), 50)
@@ -86,7 +86,7 @@ class WindowTestCase(AppTestCase):
                 return_value=b'Signature verification failed')
     def test_updateThread_failure(self, check_output):
         with mock.patch.object(self.window, "setup_thread",
-                               return_value=""):
+                               return_value=MagicMock()):
             self.window.update_thread.run()  # Call run directly
             self.assertEqual(self.window.update_success, False)
             self.assertEqual(self.window.failure_reason,
@@ -97,7 +97,7 @@ class WindowTestCase(AppTestCase):
                     1, 'cmd', b'Generic other failure'))
     def test_updateThread_generic_failure(self, check_output):
         with mock.patch.object(self.window, "setup_thread",
-                               return_value=""):
+                               return_value=MagicMock()):
             self.window.update_thread.run()  # Call run directly
             self.assertEqual(self.window.update_success, False)
             self.assertEqual(self.window.failure_reason,

--- a/journalist_gui/test_gui.py
+++ b/journalist_gui/test_gui.py
@@ -56,28 +56,27 @@ class WindowTestCase(AppTestCase):
     @mock.patch('subprocess.check_output',
                 return_value=b'Python dependencies for securedrop-admin')
     def test_setupThread(self, check_output):
-        with mock.patch.object(self.window, "update_thread",
-                               return_value=MagicMock()):
+        with mock.patch.object(self.window, "call_tailsconfig",
+                               return_value=""):
             self.window.setup_thread.run()  # Call run directly
             self.assertEqual(self.window.update_success, True)
-            self.assertEqual(self.window.progressBar.value(), 20)
+            self.assertEqual(self.window.progressBar.value(), 70)
 
     @mock.patch('subprocess.check_output',
                 return_value=b'Failed to install pip dependencies')
     def test_setupThread_failure(self, check_output):
-        with mock.patch.object(self.window, "update_thread",
-                               return_value=MagicMock()):
+        with mock.patch.object(self.window, "call_tailsconfig",
+                               return_value=""):
             self.window.setup_thread.run()  # Call run directly
             self.assertEqual(self.window.update_success, False)
             self.assertEqual(self.window.progressBar.value(), 0)
             self.assertEqual(self.window.failure_reason,
                              strings.update_failed_generic_reason)
 
-
     @mock.patch('subprocess.check_output',
                 return_value=b'Signature verification successful')
     def test_updateThread(self, check_output):
-        with mock.patch.object(self.window, "call_tailsconfig",
+        with mock.patch.object(self.window, "setup_thread",
                                return_value=""):
             self.window.update_thread.run()  # Call run directly
             self.assertEqual(self.window.update_success, True)
@@ -86,7 +85,7 @@ class WindowTestCase(AppTestCase):
     @mock.patch('subprocess.check_output',
                 return_value=b'Signature verification failed')
     def test_updateThread_failure(self, check_output):
-        with mock.patch.object(self.window, "call_tailsconfig",
+        with mock.patch.object(self.window, "setup_thread",
                                return_value=""):
             self.window.update_thread.run()  # Call run directly
             self.assertEqual(self.window.update_success, False)
@@ -97,7 +96,7 @@ class WindowTestCase(AppTestCase):
                 side_effect=subprocess.CalledProcessError(
                     1, 'cmd', b'Generic other failure'))
     def test_updateThread_generic_failure(self, check_output):
-        with mock.patch.object(self.window, "call_tailsconfig",
+        with mock.patch.object(self.window, "setup_thread",
                                return_value=""):
             self.window.update_thread.run()  # Call run directly
             self.assertEqual(self.window.update_success, False)

--- a/journalist_gui/test_gui.py
+++ b/journalist_gui/test_gui.py
@@ -54,6 +54,27 @@ class WindowTestCase(AppTestCase):
                          self.window.tabWidget.indexOf(self.window.tab_2))
 
     @mock.patch('subprocess.check_output',
+                return_value=b'Python dependencies for securedrop-admin')
+    def test_setupThread(self, check_output):
+        with mock.patch.object(self.window, "update_thread",
+                               return_value=MagicMock()):
+            self.window.setup_thread.run()  # Call run directly
+            self.assertEqual(self.window.update_success, True)
+            self.assertEqual(self.window.progressBar.value(), 20)
+
+    @mock.patch('subprocess.check_output',
+                return_value=b'Failed to install pip dependencies')
+    def test_setupThread_failure(self, check_output):
+        with mock.patch.object(self.window, "update_thread",
+                               return_value=MagicMock()):
+            self.window.setup_thread.run()  # Call run directly
+            self.assertEqual(self.window.update_success, False)
+            self.assertEqual(self.window.progressBar.value(), 0)
+            self.assertEqual(self.window.failure_reason,
+                             strings.update_failed_generic_reason)
+
+
+    @mock.patch('subprocess.check_output',
                 return_value=b'Signature verification successful')
     def test_updateThread(self, check_output):
         with mock.patch.object(self.window, "call_tailsconfig",


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3284.

Changes proposed in this pull request:
 * The GUI now also runs `securedrop-admin setup`

## Testing

The GUI test CI job should pass

## Deployment

Not yet :innocent:

## Checklist

### If you made changes to the updater GUI:

- [x] Linting (`make ci-lint`) and tests (`python3 journalist_gui/test_gui.py`) pass