### PR TITLE
Fixes #3301 Updates UI in case of missing tails admin password

### DIFF
--- a/journalist_gui/journalist_gui/strings.py
+++ b/journalist_gui/journalist_gui/strings.py
@@ -16,6 +16,7 @@ updating_tails_env = ('Configuring local Tails environment...'
 finished = 'Update successfully completed!'
 finished_dialog_message = 'Updates completed successfully. '
 finished_dialog_title = 'SecureDrop Workstation is up to date!'
+missing_sudo_password = 'Missing Tails Administrator password'
 update_failed_dialog_title = 'Error Updating SecureDrop Workstation'
 update_failed_generic_reason = ("Update failed. "
                                 "Please contact your SecureDrop "

--- a/journalist_gui/test_gui.py
+++ b/journalist_gui/test_gui.py
@@ -123,10 +123,7 @@ class WindowTestCase(AppTestCase):
 
         with mock.patch.object(QInputDialog, 'getText',
                                return_value=[test_password, False]):
-            # If the user does not provide a sudo password, we exit
-            # as we cannot update.
-            with self.assertRaises(SystemExit):
-                self.window.get_sudo_password()
+            self.assertIsNone(self.window.get_sudo_password())
 
     @mock.patch('pexpect.spawn')
     def test_tailsconfigThread_no_failures(self, pt):


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #3301

Changes proposed in this pull request:

## Testing

Run the tool, when it asks for the `Tails Administrator` password, either close that window or press cancel. It should not close the whole application.



## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
