### PR TITLE
Reduce time information leakage of file uploads and file downloads

### DIFF
--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -131,7 +131,7 @@ class Storage:
         encrypted_file_path = self.path(filesystem_id, encrypted_file_name)
         with SecureTemporaryFile("/tmp") as stf:  # nosec
             with gzip.GzipFile(filename=sanitized_filename,
-                               mode='wb', fileobj=stf) as gzf:
+                               mode='wb', fileobj=stf, mtime=0) as gzf:
                 # Buffer the stream into the gzip file to avoid excessive
                 # memory consumption
                 while True:

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -428,7 +428,8 @@ def test_submit_sanitizes_filename(source_app):
             assert resp.status_code == 200
             gzipfile.assert_called_with(filename=sanitized_filename,
                                         mode=ANY,
-                                        fileobj=ANY)
+                                        fileobj=ANY,
+                                        mtime=0)
 
 
 def test_tor2web_warning_headers(source_app):


### PR DESCRIPTION
The proposed fix together with the existing implementation performed for ticket #301 should be enough to avoid complete leakage of the file upload date.

Fixes #3304 