### PR TITLE
Qt no escape

### DIFF
--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -3,12 +3,14 @@ from PyQt5 import QtGui, QtWidgets
 from PyQt5.QtCore import QThread, pyqtSignal
 import subprocess
 import os
+import re
 import pexpect
 
 from journalist_gui import updaterUI, strings, resources_rc  # noqa
 
 
 FLAG_LOCATION = "/home/amnesia/Persistent/.securedrop/securedrop_update.flag"  # noqa
+ESCAPE_POD = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
 
 
 class SetupThread(QThread):
@@ -121,7 +123,7 @@ class TailsconfigThread(QThread):
             self.update_success = False
             self.failure_reason = strings.tailsconfig_failed_generic_reason
         result = {'status': self.update_success,
-                  'output': self.output,
+                  'output': ESCAPE_POD.sub('', self.output),
                   'failure_reason': self.failure_reason}
         self.signal.emit(result)
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #3308 

Removed (strips out) all the ANSI escape sequence from the ansible output in the GUI.

## Testing

Run the `journalist_gui` tool, it should not show the output like in https://github.com/freedomofpress/securedrop/pull/3300#discussion_r184053702

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
