### PR TITLE
Fixes #3310 no sizegrip

### DIFF
--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -130,6 +130,7 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
     def __init__(self, parent=None):
         super(UpdaterApp, self).__init__(parent)
         self.setupUi(self)
+        self.statusbar.setSizeGripEnabled(False)
         self.output = strings.initial_text_box
         self.plainTextEdit.setPlainText(self.output)
         self.update_success = False


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3310 

Removes the sizegrip of the GUI tool.

As suggested in https://github.com/freedomofpress/securedrop/pull/3300#discussion_r184066922

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
