### PR TITLE
[0.7.0] source: double space in translated string

### DIFF
--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -9,7 +9,7 @@
       <img src="{{ url_for('static', filename='i/relieved_face.png')  }}" alt="relieved-face" class="icon">
       <div class="message">
         <strong>{{ gettext('Whew, it’s you! Now, the embarrassing part...') }}</strong>
-        <p>{{ gettext('Our servers experienced an unusual surge of new activity, when you last visited. To err on the side of caution, we put a hold on sending all  files and messages from that day through to our journalists.') }}</p>
+        <p>{{ gettext('Our servers experienced an unusual surge of new activity, when you last visited. To err on the side of caution, we put a hold on sending all files and messages from that day through to our journalists.') }}</p>
 
         <p>{{ gettext('Now that we know you’re really a human, though, we’ll get your previous submission into the hands of a journalist straight away. We’re sorry for the delay. Please do check back again in a week or so.') }}</p>
       </div>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

It does not change the user experience. But it shows as two dots in
the weblate interface and localizers who catch that may wonder if it
is intentional or not.

Spotted by: AO localizationlab French coordinator

(cherry picked from commit 817a5ab484af17b4e2f6f18ef96f38ef7a4301da)

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Deployment

N/A

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
