### PR TITLE
[0.7.0] Improve exit codes in securedrop-admin

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -497,9 +497,9 @@ def install_securedrop(args):
                "servers.")
     sdlog.info("The sudo password is only necessary during initial "
                "installation.")
-    subprocess.check_call([os.path.join(args.ansible_path,
-                                        'securedrop-prod.yml'),
-                          '--ask-become-pass'], cwd=args.ansible_path)
+    return subprocess.check_call([os.path.join(args.ansible_path,
+                                 'securedrop-prod.yml'), '--ask-become-pass'],
+                                 cwd=args.ansible_path)
 
 
 def backup_securedrop(args):
@@ -512,7 +512,7 @@ def backup_securedrop(args):
         'ansible-playbook',
         os.path.join(args.ansible_path, 'securedrop-backup.yml'),
     ]
-    subprocess.check_call(ansible_cmd, cwd=args.ansible_path)
+    return subprocess.check_call(ansible_cmd, cwd=args.ansible_path)
 
 
 def restore_securedrop(args):
@@ -531,7 +531,7 @@ def restore_securedrop(args):
         '-e',
         "restore_file='{}'".format(restore_file_basename),
     ]
-    subprocess.check_call(ansible_cmd, cwd=args.ansible_path)
+    return subprocess.check_call(ansible_cmd, cwd=args.ansible_path)
 
 
 def run_tails_config(args):
@@ -546,8 +546,8 @@ def run_tails_config(args):
         # inventory script, which fails if no site vars are configured.
         '-i', '/dev/null',
     ]
-    subprocess.check_call(ansible_cmd,
-                          cwd=args.ansible_path)
+    return subprocess.check_call(ansible_cmd,
+                                 cwd=args.ansible_path)
 
 
 def check_for_updates(args):
@@ -622,10 +622,11 @@ def update(args):
 
     if 'Good signature' not in sig_result:
         sdlog.info("Signature verification failed.")
-        sys.exit(1)
+        return -1
     sdlog.info("Signature verification successful.")
 
     sdlog.info("Updated to SecureDrop {}.".format(latest_tag))
+    return 0
 
 
 def get_logs(args):
@@ -638,6 +639,7 @@ def get_logs(args):
     subprocess.check_call(ansible_cmd, cwd=args.ansible_path)
     sdlog.info("Encrypt logs and send to securedrop@freedom.press or upload "
                "to the SecureDrop support portal.")
+    return 0
 
 
 def set_default_paths(args):
@@ -713,17 +715,18 @@ def main(argv):
     args = parse_argv(argv)
     setup_logger(args.v)
     if args.v:
-        args.func(args)
+        return_code = args.func(args)
+        sys.exit(return_code)
     else:
         try:
-            args.func(args)
+            return_code = args.func(args)
         except KeyboardInterrupt:
-            sys.exit(0)
+            sys.exit(-1)
         except Exception as e:
             raise SystemExit(
                 'ERROR (run with -v for more): {msg}'.format(msg=e))
         else:
-            sys.exit(0)
+            sys.exit(return_code)
 
 
 if __name__ == "__main__":

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -102,9 +102,10 @@ class TestSecureDropAdmin(object):
 
         with mock.patch('securedrop_admin.check_for_updates',
                         return_value=(False, "0.6.1")):
-            securedrop_admin.update(args)
+            ret_code = securedrop_admin.update(args)
             assert "Applying SecureDrop updates..." in caplog.text
             assert "Updated to SecureDrop" not in caplog.text
+            assert ret_code == 0
 
     def test_update_gpg_recv_primary_key_failure(self, tmpdir, caplog):
         """We should try a secondary keyserver if for some reason the primary
@@ -131,10 +132,11 @@ class TestSecureDropAdmin(object):
             patcher.start()
 
         try:
-            securedrop_admin.update(args)
+            ret_code = securedrop_admin.update(args)
             assert "Applying SecureDrop updates..." in caplog.text
             assert "Signature verification successful." in caplog.text
             assert "Updated to SecureDrop" in caplog.text
+            assert ret_code == 0
         finally:
             for patcher in patchers:
                 patcher.stop()
@@ -161,10 +163,11 @@ class TestSecureDropAdmin(object):
             with mock.patch('subprocess.check_call'):
                 with mock.patch('subprocess.check_output',
                                 return_value=git_output):
-                    securedrop_admin.update(args)
+                    ret_code = securedrop_admin.update(args)
                     assert "Applying SecureDrop updates..." in caplog.text
                     assert "Signature verification successful." in caplog.text
                     assert "Updated to SecureDrop" in caplog.text
+                    assert ret_code == 0
 
     def test_update_signature_does_not_verify(self, tmpdir, caplog):
         git_repo_path = str(tmpdir)
@@ -177,11 +180,11 @@ class TestSecureDropAdmin(object):
             with mock.patch('subprocess.check_call'):
                 with mock.patch('subprocess.check_output',
                                 return_value=git_output):
-                    with pytest.raises(SystemExit):
-                        securedrop_admin.update(args)
-                        assert "Applying SecureDrop updates..." in caplog.text
-                        assert "Signature verification failed." in caplog.text
-                        assert "Updated to SecureDrop" not in caplog.text
+                    ret_code = securedrop_admin.update(args)
+                    assert "Applying SecureDrop updates..." in caplog.text
+                    assert "Signature verification failed." in caplog.text
+                    assert "Updated to SecureDrop" not in caplog.text
+                    assert ret_code != 0
 
 
 class TestSiteConfig(object):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
 * Some minor return code changes for `securedrop-admin`
 * Cherry picked from commit 0525baa6c3df35292e9059587495a013bb2ecf09)

## Testing

Verify commit here is the same as #3327

## Deployment

All should be well

## Checklist

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container