### PR TITLE
explicitly tell admins to save the firewall rules

### DIFF
--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -466,8 +466,10 @@ to add a rule.
 
 |Firewall OPT2 Rules|
 
-Once you've set up the firewall, exit the Unsafe Browser, and continue
-with the "Keeping pfSense up to date" section below.
+Finally, click **Apply Changes**. This will save your changes. You should see a
+message "The changes have been applied successfully". Once you've set up the
+firewall, exit the Unsafe Browser, and continue with the "Keeping pfSense up
+to date" section below.
 
 Configuration Reference Templates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

I was setting up a new hardware firewall and it realized we explicitly say to save the settings earlier while setting up aliases but we aren't explicit when setting up the firewall rules. This small PR makes those edits.  

Changes proposed in this pull request:

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
