### PR TITLE
Adds test for mtime gzip header

### DIFF
--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -206,7 +206,10 @@ class TestIntegration(unittest.TestCase):
             sio = StringIO(decrypted_data.data)
             with gzip.GzipFile(mode='rb', fileobj=sio) as gzip_file:
                 unzipped_decrypted_data = gzip_file.read()
+                mtime = gzip_file.mtime
             self.assertEqual(unzipped_decrypted_data, test_file_contents)
+            # Verify gzip file metadata and ensure timestamp is not present.
+            self.assertEqual(mtime, 0)
 
             # delete submission
             resp = app.get(col_url)


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes
The `mtime` header field contains the most recent modification time of the original file being compressed. These changes to the integration tests will ensure the `mtime` header is properly removed.

Fixes #3329 .

## Testing

Tests should pass, and reverting changes in #3305 should make the same test fail.

## Deployment

None.
