### PR TITLE
[0.7.0] explicitly tell admins to save the Firewall rules

### DIFF
--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -466,8 +466,10 @@ to add a rule.
 
 |Firewall OPT2 Rules|
 
-Once you've set up the firewall, exit the Unsafe Browser, and continue
-with the "Keeping pfSense up to date" section below.
+Finally, click **Apply Changes**. This will save your changes. You should see a
+message "The changes have been applied successfully". Once you've set up the
+firewall, exit the Unsafe Browser, and continue with the "Keeping pfSense up
+to date" section below.
 
 Configuration Reference Templates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Backports #3332 to the 0.7 release branch.

## Testing

Ensure changes introduced to this branch are identical to those in https://github.com/freedomofpress/securedrop/pull/3332


### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
