### PR TITLE
[0.7.0] Backport PR #3338

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -550,6 +550,12 @@ def run_tails_config(args):
                                  cwd=args.ansible_path)
 
 
+def check_for_updates_wrapper(args):
+    res, tag = check_for_updates(args)
+    # Because the command worked properly exit with 0.
+    return 0
+
+
 def check_for_updates(args):
     """Check for SecureDrop updates"""
     sdlog.info("Checking for SecureDrop updates...")
@@ -702,7 +708,7 @@ def parse_argv(argv):
 
     parse_check_updates = subparsers.add_parser('check_for_updates',
                                                 help=check_for_updates.__doc__)
-    parse_check_updates.set_defaults(func=check_for_updates)
+    parse_check_updates.set_defaults(func=check_for_updates_wrapper)
 
     parse_logs = subparsers.add_parser('logs',
                                        help=get_logs.__doc__)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
 - Backports changes in #3338 into 0.7.0, ensuring a clean exit from `securedrop-admin check_for_updates`

## Testing

Verify changes are identical to #3338

## Deployment

None

## Checklist

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container
