### PR TITLE
[0.7.0] Backports #3335 (adds test for mtime gzip header)

### DIFF
--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -206,7 +206,10 @@ class TestIntegration(unittest.TestCase):
             sio = StringIO(decrypted_data.data)
             with gzip.GzipFile(mode='rb', fileobj=sio) as gzip_file:
                 unzipped_decrypted_data = gzip_file.read()
+                mtime = gzip_file.mtime
             self.assertEqual(unzipped_decrypted_data, test_file_contents)
+            # Verify gzip file metadata and ensure timestamp is not present.
+            self.assertEqual(mtime, 0)
 
             # delete submission
             resp = app.get(col_url)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
 - Backporting changes in #3335 into 0.7.0

## Testing

Verify commit is the same as that added in #3335

## Deployment

Tests only

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
