### PR TITLE
[0.7.0] Improve SSH over Tor or LAN prompt in securedrop-admin sdconfig

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -71,6 +71,13 @@ class SiteConfig(object):
             raise ValidationError(
                 message="Must not be root, amnesia or an empty string")
 
+    class ValidateSSH(Validator):
+        def validate(self, document):
+            text = document.text
+            if text.lower() == 'tor' or text.lower() == 'lan':
+                return True
+            raise ValidationError(message="Must be Tor (recommended) or LAN")
+
     class ValidateIP(Validator):
         def validate(self, document):
             if re.match('((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}$',
@@ -339,9 +346,9 @@ class SiteConfig(object):
              SiteConfig.ValidateOSSECPassword(),
              None],
             ['enable_ssh_over_tor', True, bool,
-             u'Enable SSH over Tor',
-             SiteConfig.ValidateYesNo(),
-             lambda x: x.lower() == 'yes'],
+             u'Enable SSH over Tor (recommended) or LAN',
+             SiteConfig.ValidateSSH(),
+             self.sanitize_ssh_over_tor_or_lan],
             ['securedrop_supported_locales', [], types.ListType,
              u'Space separated list of additional locales to support '
              '(' + translations + ')',
@@ -400,6 +407,12 @@ class SiteConfig(object):
 
     def sanitize_fingerprint(self, value):
         return value.upper().replace(' ', '')
+
+    def sanitize_ssh_over_tor_or_lan(self, value):
+        if value.lower() == 'tor':
+            return True
+        elif value.lower() == 'lan':
+            return False
 
     def validate_gpg_keys(self):
         keys = (('securedrop_app_gpg_public_key',

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -363,6 +363,17 @@ class TestSiteConfig(object):
         assert validator.validate(Document("no"))
         assert validator.validate(Document("NO"))
 
+    def test_validate_ssh_tor_or_lan(self):
+        validator = securedrop_admin.SiteConfig.ValidateSSH()
+        with pytest.raises(ValidationError):
+            validator.validate(Document("not Tor or LAN"))
+        with pytest.raises(ValidationError):
+            validator.validate(Document("yes"))
+        with pytest.raises(ValidationError):
+            validator.validate(Document("no"))
+        assert validator.validate(Document("Tor"))
+        assert validator.validate(Document("LAN"))
+
     def test_validate_fingerprint(self):
         validator = securedrop_admin.SiteConfig.ValidateFingerprint()
         assert validator.validate(Document(
@@ -602,7 +613,6 @@ class TestSiteConfig(object):
 
     verify_prompt_securedrop_app_https_on_source_interface = \
         verify_prompt_boolean
-    verify_prompt_enable_ssh_over_tor = verify_prompt_boolean
 
     verify_prompt_securedrop_app_gpg_public_key = verify_desc_consistency
 
@@ -639,6 +649,7 @@ class TestSiteConfig(object):
     verify_prompt_sasl_domain = verify_desc_consistency_allow_empty
     verify_prompt_sasl_username = verify_prompt_not_empty
     verify_prompt_sasl_password = verify_prompt_not_empty
+    verify_prompt_enable_ssh_over_tor = verify_prompt_not_empty
 
     def verify_prompt_securedrop_supported_locales(self, site_config, desc):
         (var, default, etype, prompt, validator, transform) = desc

--- a/docs/ssh_over_local_net.rst
+++ b/docs/ssh_over_local_net.rst
@@ -4,16 +4,16 @@ SSH Over Local Network
 Under a production installation post-install, the default way to gain SSH
 administrative access is over the Tor network. This provides a number of benefits:
 
-* Allows remote administration outside of the local network
+* Allows remote administration outside of the local network.
 * Provides anonymity to an administrator while logging into the SecureDrop
-  back-end.
+  servers.
 * Can mitigate against an attacker on your local network attempting to exploit
   vulnerabilities against the SSH daemon.
 
 Most administrators will need SSH access during the course of running a
-SecureDrop instance and a few times a year for maintanence. So the
-potential short-falls of having SSH over Tor aren't usually a big deal.
-The cons of having SSH over Tor can include:
+SecureDrop instance and a few times a year for maintenance. So the
+potential shortfalls of having SSH over Tor aren't usually a big deal.
+The cons of having SSH over Tor include:
 
 * Really slow and delayed remote terminal performance
 * Allowing SSH access from outside of your local network can be seen as a
@@ -32,7 +32,7 @@ Configuring SSH for local access
 
 .. warning:: It is important that your firewall is configured adequately if you
           decide you need SSH over the local network. The install process locks
-          down access as much as possible with net restrictions, SSH-keys, and
+          down access as much as possible with net restrictions, SSH keys, and
           google authenticator. However, you could still leave the interface
           exposed to unintended users if you did not properly follow our network
           firewall guide.
@@ -40,7 +40,7 @@ Configuring SSH for local access
 .. warning:: This setting will lock you out of SSH access to your instance if your
           *Admin Workstation* passes through a NAT in order to get to the
           SecureDrop servers. If you are unsure whether this is the case, please
-          consult with your firewall configuration or network administrator.
+          consult your firewall configuration or network administrator.
 
 .. note:: Whichever network you install from will be the one that SSH is
           restricted to post-install. This will come into play particularly if
@@ -55,9 +55,9 @@ latest production release.
     $ ./securedrop-admin update
     $ ./securedrop-admin setup
 
-The setting that controls SSH over LAN access is set during the `sdconfig` step
+The setting that controls SSH over LAN access is set during the ``sdconfig`` step
 of the install. Below is an example of what the prompt will look like. You can
-answer either 'no' or 'false' when you are prompted for `Enable SSH over Tor`:
+answer either 'Tor' or 'LAN' when you are prompted:
 
 .. code:: sh
 
@@ -69,16 +69,16 @@ answer either 'no' or 'false' when you are prompted for `Enable SSH over Tor`:
     Hostname for Application Server: app
     Hostname for Monitor Server: mon
     [...]
-    Enable SSH over Tor: no
+    Enable SSH over Tor (recommended) or LAN: LAN
 
-Then you'll have to run the installation script
+Then you'll have to run the installation script:
 
 .. code:: sh
 
     $ ./securedrop-admin install
 
 .. note:: If you are migrating from a production install previously configured
-          with SSH over Tor, you will be prompted to re-run the `install` portion
+          with SSH over Tor, you will be prompted to re-run the ``install`` portion
           twice. This is due to the behind the scenes configuration changes being
           done to switch between Tor and the local network.
 
@@ -88,10 +88,9 @@ Finally, re-configure your *Admin Workstation* as follows:
 
     $ ./securedrop-admin tailsconfig
 
-Assuming everything is working you should be able to gain SSH access as follows
+Assuming everything is working you should be able to gain SSH access as follows:
 
 .. code:: sh
 
     $ ssh app
     $ ssh mon
-


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
* Improves SSH over Tor or LAN prompt as described in #3324

## Testing

Verify same changes as in #3339 

## Deployment

Feature not in prod yet

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
