### PR TITLE
[0.7.0] Backports PR #3340 - Asks journalist email if gpg key is provided

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -247,6 +247,7 @@ class SiteConfig(object):
 
     def __init__(self, args):
         self.args = args
+        self.config = {}
         translations = SiteConfig.Locales(
             self.args.app_path).get_translations()
         translations = " ".join(translations)
@@ -352,8 +353,7 @@ class SiteConfig(object):
     def load_and_update_config(self):
         if self.exists():
             self.config = self.load()
-        else:
-            self.config = {}
+
         return self.update_config()
 
     def update_config(self):
@@ -367,6 +367,16 @@ class SiteConfig(object):
         config = {}
         for desc in self.desc:
             (var, default, type, prompt, validator, transform) = desc
+            if var == 'journalist_gpg_fpr':
+                if not config.get('journalist_alert_gpg_public_key',
+                                  None):
+                    config[var] = ''
+                    continue
+            if var == 'journalist_alert_email':
+                if not config.get('journalist_alert_gpg_public_key',
+                                  None):
+                    config[var] = ''
+                    continue
             config[var] = self.user_prompt_config_one(desc,
                                                       self.config.get(var))
         return config


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
* Backporting changes in #3340 

## Testing

Verify commit here is the same as in #3340

## Deployment

Admins will check this out

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
