### PR TITLE
Resolve HTTPS CSRF validation failure due to Referrer-Policy on source interface

### DIFF
--- a/install_files/ansible-base/roles/app/templates/sites-available/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/source.conf
@@ -47,7 +47,7 @@ XSendFile        Off
 
 Header edit Set-Cookie ^(.*)$ $1;HttpOnly
 Header always append X-Frame-Options: DENY
-Header set Referrer-Policy "no-referrer"
+Header set Referrer-Policy "same-origin"
 Header set X-XSS-Protection: "1; mode=block"
 Header set X-Content-Type-Options: nosniff
 Header set X-Content-Security-Policy: "default-src 'self'"

--- a/testinfra/app/apache/test_apache_source_interface.py
+++ b/testinfra/app/apache/test_apache_source_interface.py
@@ -27,7 +27,7 @@ def test_apache_headers_source_interface(File, header):
     'WSGIProcessGroup source',
     'WSGIScriptAlias / /var/www/source.wsgi',
     'Header set Cache-Control "no-store"',
-    'Header set Referrer-Policy "no-referrer"',
+    'Header set Referrer-Policy "same-origin"',
     "Alias /static {}/static".format(securedrop_test_vars.securedrop_code),
     """
 <Directory {}/static>

--- a/testinfra/vars/app-staging.yml
+++ b/testinfra/vars/app-staging.yml
@@ -3,7 +3,7 @@
 wanted_apache_headers:
   - 'Header edit Set-Cookie ^(.*)$ $1;HttpOnly'
   - 'Header always append X-Frame-Options: DENY'
-  - 'Header set Referrer-Policy "no-referrer"'
+  - 'Header set Referrer-Policy "same-origin"'
   - 'Header set X-XSS-Protection: "1; mode=block"'
   - 'Header set X-Content-Type-Options: nosniff'
   - 'Header set X-Download-Options: noopen'


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3333.

Changes proposed in this pull request:

The addition of `Referrer-Policy "no-referrer"` meant that the CSRF tokens on the source interface did not validate due to the use of [WTF_CSRF_SSL_STRICT=True](https://flask-wtf.readthedocs.io/en/stable/config.html). Setting [`Referrer-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) to `"same-origin"` resolves. Note that [Tor Browser does not send Referers from onion services](https://trac.torproject.org/projects/tor/ticket/9623), so there are no negative privacy implications to this change.

## Testing

1. Generate and apply self-signed certs to the source interface running in a staging or prod application server VM. 
2. Ensure that you can successfully submit a document to the source interface.

## Deployment

Some sites have applied this change already in production. Their Apache configs will not automatically update to the latest, but the next time they re-run `securedrop-admin install` this change will mean that they do not regress to the faulty behavior produced by the use of `"no-referrer"` .

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

