### PR TITLE
Fix mypy issue on develop: Use empty string instead of None in conftest.py

### DIFF
--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -31,7 +31,7 @@ gnupg_logger = logging.getLogger(gnupg.__name__)
 gnupg_logger.setLevel(logging.ERROR)
 valid_levels = {'INFO': logging.INFO, 'DEBUG': logging.DEBUG}
 gnupg_logger.setLevel(
-   valid_levels.get(os.environ.get('GNUPG_LOG_LEVEL', None), logging.ERROR)
+   valid_levels.get(os.environ.get('GNUPG_LOG_LEVEL', ""), logging.ERROR)
 )
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3352.

Changes proposed in this pull request:
 * Will also pick this one into 0.7.0 for harmonious builds over there

## Testing

Does the CI lint job pass?

## Deployment

Test only

## Checklist

- [x] Linting (`make ci-lint`) passes in the development container!
