### PR TITLE
[0.7.0] Fix mypy issue on develop: Use empty string instead of None in conftest.py

### DIFF
--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -31,7 +31,7 @@ gnupg_logger = logging.getLogger(gnupg.__name__)
 gnupg_logger.setLevel(logging.ERROR)
 valid_levels = {'INFO': logging.INFO, 'DEBUG': logging.DEBUG}
 gnupg_logger.setLevel(
-   valid_levels.get(os.environ.get('GNUPG_LOG_LEVEL', None), logging.ERROR)
+   valid_levels.get(os.environ.get('GNUPG_LOG_LEVEL', ""), logging.ERROR)
 )
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backports https://github.com/freedomofpress/securedrop/pull/3353 into 0.7 release branch.

## Testing

* Changes should be identical to those in #3353 
* CI should pass
## Deployment

Tests only

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
