### PR TITLE
[0.7.0] Resolve HTTPS CSRF validation failure due to Referrer-Policy on source interface

### DIFF
--- a/install_files/ansible-base/roles/app/templates/sites-available/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/source.conf
@@ -47,7 +47,7 @@ XSendFile        Off
 
 Header edit Set-Cookie ^(.*)$ $1;HttpOnly
 Header always append X-Frame-Options: DENY
-Header set Referrer-Policy "no-referrer"
+Header set Referrer-Policy "same-origin"
 Header set X-XSS-Protection: "1; mode=block"
 Header set X-Content-Type-Options: nosniff
 Header set X-Content-Security-Policy: "default-src 'self'"

--- a/testinfra/app/apache/test_apache_source_interface.py
+++ b/testinfra/app/apache/test_apache_source_interface.py
@@ -27,7 +27,7 @@ def test_apache_headers_source_interface(File, header):
     'WSGIProcessGroup source',
     'WSGIScriptAlias / /var/www/source.wsgi',
     'Header set Cache-Control "no-store"',
-    'Header set Referrer-Policy "no-referrer"',
+    'Header set Referrer-Policy "same-origin"',
     "Alias /static {}/static".format(securedrop_test_vars.securedrop_code),
     """
 <Directory {}/static>

--- a/testinfra/vars/app-staging.yml
+++ b/testinfra/vars/app-staging.yml
@@ -3,7 +3,7 @@
 wanted_apache_headers:
   - 'Header edit Set-Cookie ^(.*)$ $1;HttpOnly'
   - 'Header always append X-Frame-Options: DENY'
-  - 'Header set Referrer-Policy "no-referrer"'
+  - 'Header set Referrer-Policy "same-origin"'
   - 'Header set X-XSS-Protection: "1; mode=block"'
   - 'Header set X-Content-Type-Options: nosniff'
   - 'Header set X-Download-Options: noopen'


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backports #3351 to 0.7 release branch.

## Testing

Changes introduced should be identical to #3351 (a29c9f2ce95eef63df5a4ae3c6e072886d600dd0 and 4fc204ad1daef55af8e8de2ec33c6d0b15ef921b)

