### PR TITLE
[0.7.0] Backports PR #3366

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ mon-ssh-aths
 *.csr
 *.pem
 *.crt
+*.ca
 
 # ignore ansible retry files
 *.retry

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,11 @@ libvirt-share: ## Configure ACLs to allow RWX for libvirt VM (e.g. Admin Worksta
 	@find "$(PWD)" -type d -and -user $$USER -exec setfacl -m u:libvirt-qemu:rwx {} +
 	@find "$(PWD)" -type f -and -user $$USER -exec setfacl -m u:libvirt-qemu:rw {} +
 
+.PHONY: self-signed-https-certs
+self-signed-https-certs: ## Generates self-signed certs for TESTING the HTTPS config
+	@echo "Generating self-signed HTTPS certs for testing..."
+	@./devops/generate-self-signed-https-certs.sh
+
 # Explaination of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" and any make targets that might appear between : and ##
 # 2. Use sed-like syntax to remove the make targets

--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -280,16 +280,16 @@ class SiteConfig(object):
              u'DNS server specified during installation',
              SiteConfig.ValidateNotEmpty(),
              None],
-            ['securedrop_app_https_on_source_interface', False, bool,
-             u'Whether HTTPS should be enabled on '
-             'Source Interface (requires EV cert)',
-             SiteConfig.ValidateYesNo(),
-             lambda x: x.lower() == 'yes'],
             ['securedrop_app_gpg_public_key', 'SecureDrop.asc', str,
              u'Local filepath to public key for '
              'SecureDrop Application GPG public key',
              SiteConfig.ValidatePath(self.args.ansible_path),
              None],
+            ['securedrop_app_https_on_source_interface', False, bool,
+             u'Whether HTTPS should be enabled on '
+             'Source Interface (requires EV cert)',
+             SiteConfig.ValidateYesNo(),
+             lambda x: x.lower() == 'yes'],
             ['securedrop_app_https_certificate_cert_src', '', str,
              u'Local filepath to HTTPS certificate '
              '(optional, only if using HTTPS on source interface)',

--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -290,6 +290,21 @@ class SiteConfig(object):
              'SecureDrop Application GPG public key',
              SiteConfig.ValidatePath(self.args.ansible_path),
              None],
+            ['securedrop_app_https_certificate_cert_src', '', str,
+             u'Local filepath to HTTPS certificate '
+             '(optional, only if using HTTPS on source interface)',
+             SiteConfig.ValidateOptionalPath(self.args.ansible_path),
+             None],
+            ['securedrop_app_https_certificate_key_src', '', str,
+             u'Local filepath to HTTPS certificate key '
+             '(optional, only if using HTTPS on source interface)',
+             SiteConfig.ValidateOptionalPath(self.args.ansible_path),
+             None],
+            ['securedrop_app_https_certificate_chain_src', '', str,
+             u'Local filepath to HTTPS certificate chain file '
+             '(optional, only if using HTTPS on source interface)',
+             SiteConfig.ValidateOptionalPath(self.args.ansible_path),
+             None],
             ['securedrop_app_gpg_fingerprint', '', str,
              u'Full fingerprint for the SecureDrop Application GPG Key',
              SiteConfig.ValidateFingerprint(),

--- a/admin/tests/files/ca.crt
+++ b/admin/tests/files/ca.crt
@@ -1,0 +1,1 @@
+TEST FILE ONLY

--- a/admin/tests/files/sd.crt
+++ b/admin/tests/files/sd.crt
@@ -1,0 +1,1 @@
+TEST FILE ONLY

--- a/admin/tests/files/sd.key
+++ b/admin/tests/files/sd.key
@@ -1,0 +1,1 @@
+TEST FILE ONLY

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -633,6 +633,12 @@ class TestSiteConfig(object):
         verify_desc_consistency_optional)
     verify_prompt_journalist_gpg_fpr = verify_prompt_fingerprint_optional
     verify_prompt_journalist_alert_email = verify_desc_consistency_optional
+    verify_prompt_securedrop_app_https_certificate_chain_src = (
+        verify_desc_consistency_optional)
+    verify_prompt_securedrop_app_https_certificate_key_src = (
+        verify_desc_consistency_optional)
+    verify_prompt_securedrop_app_https_certificate_cert_src = (
+        verify_desc_consistency_optional)
     verify_prompt_smtp_relay = verify_prompt_not_empty
     verify_prompt_smtp_relay_port = verify_desc_consistency
     verify_prompt_daily_reboot_time = verify_desc_consistency

--- a/devops/generate-self-signed-https-certs.sh
+++ b/devops/generate-self-signed-https-certs.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Quick-and-dirty self-signed HTTPS cert generation. Reuses the cert as the CA
+# as a shortcut. Only appropriate for testing; certs will absolutely throw a
+# warning in Tor Browser.
+set -e
+set -u
+set -o pipefail
+
+
+# Decide where to write the files and what to call them.
+# Should match with the defaults configured by sdconfig.
+keyfile_basename="securedrop_source_onion"
+keyfile_dest_dir="install_files/ansible-base"
+
+function generate-test-https-certs {
+    openssl genrsa -out "${keyfile_dest_dir}/${keyfile_basename}.key" 2048
+    openssl rsa -in "${keyfile_dest_dir}/${keyfile_basename}.key" -out "${keyfile_dest_dir}/${keyfile_basename}.key"
+    openssl req -sha256 -new -key "${keyfile_dest_dir}/${keyfile_basename}.key" -out "${keyfile_dest_dir}/${keyfile_basename}.csr" -subj '/CN=localhost'
+    openssl x509 -req -sha256 -days 365 -in "${keyfile_dest_dir}/${keyfile_basename}.csr" -signkey "${keyfile_dest_dir}/${keyfile_basename}.key" -out "${keyfile_dest_dir}/${keyfile_basename}.crt"
+}
+
+# Run it.
+generate-test-https-certs
+
+# Pretend we have a real CA in the mix.
+cp "${keyfile_dest_dir}/${keyfile_basename}.crt" "${keyfile_dest_dir}/${keyfile_basename}.ca"
+
+# Not need to preserve the CSR.
+rm -f "${keyfile_dest_dir}/${keyfile_basename}.csr"

--- a/devops/generate-self-signed-https-certs.sh
+++ b/devops/generate-self-signed-https-certs.sh
@@ -12,8 +12,10 @@ set -o pipefail
 keyfile_basename="securedrop_source_onion"
 keyfile_dest_dir="install_files/ansible-base"
 
+echo "WARNING: These certs should only be used in a test or development environment!"
+
 function generate-test-https-certs {
-    openssl genrsa -out "${keyfile_dest_dir}/${keyfile_basename}.key" 2048
+    openssl genrsa -out "${keyfile_dest_dir}/${keyfile_basename}.key" 4096
     openssl rsa -in "${keyfile_dest_dir}/${keyfile_basename}.key" -out "${keyfile_dest_dir}/${keyfile_basename}.key"
     openssl req -sha256 -new -key "${keyfile_dest_dir}/${keyfile_basename}.key" -out "${keyfile_dest_dir}/${keyfile_basename}.csr" -subj '/CN=localhost'
     openssl x509 -req -sha256 -days 365 -in "${keyfile_dest_dir}/${keyfile_basename}.csr" -signkey "${keyfile_dest_dir}/${keyfile_basename}.key" -out "${keyfile_dest_dir}/${keyfile_basename}.crt"

--- a/docs/https_source_interface.rst
+++ b/docs/https_source_interface.rst
@@ -111,12 +111,12 @@ on your admin workstation:
 
   ./securedrop-admin sdconfig
 
-This command will prompt you for the following variables::
+This command will prompt you for the following information::
 
-    securedrop_app_https_on_source_interface: yes
-    securedrop_app_https_certificate_cert_src: sd.crt
-    securedrop_app_https_certificate_key_src: sd.key
-    securedrop_app_https_certificate_chain_src: ca.crt
+  Whether HTTPS should be enabled on Source Interface (requires EV cert): yes
+  Local filepath to HTTPS certificate (optional, only if using HTTPS on source interface): sd.crt
+  Local filepath to HTTPS certificate key (optional, only if using HTTPS on source interface): sd.key
+  Local filepath to HTTPS certificate chain file (optional, only if using HTTPS on source interface): ca.crt
 
 The filenames should match the names of the files provided to you by DigiCert,
 and should be saved inside the ``install_files/ansible-base/`` directory. You'll


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
* Brings in HTTPS sdconfig updates into #3366 

## Testing

Verify commits same as in #3366

## Deployment

See #3366

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
