### PR TITLE
Make unread status on submissions and sources clearer

### DIFF
--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -1,18 +1,22 @@
 {% set docs = source.documents_messages_count()['documents'] %}
 {% set msgs = source.documents_messages_count()['messages'] %}
-<li class="source" data-source-designation="{{ source.journalist_designation|lower }}">
+<li class="source {% if source.num_unread != 0 %}unread{% else %}read{% endif %}" data-source-designation="{{ source.journalist_designation|lower }}">
   <time class="date" title="{{ source.last_updated|rel_datetime_format }}" datetime="{{ source.last_updated|rel_datetime_format(fmt="%Y-%m-%d %H:%M:%S%Z") }}">{{ source.last_updated|rel_datetime_format(relative=True) }}</time>
   <div class="designation">
     {% if source.star.starred %}
       <button class="button-star starred" type="submit"
               formaction="{{ url_for('col.remove_star', filesystem_id=source.filesystem_id) }}"><i class="fa fa-star"></i></button>
       <input id="checkbox" type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}">
-      <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="starred-source-link-{{ loop_index }}">{{ source.journalist_designation }}</a></span>
+      <a href="/col/{{ source.filesystem_id }}" id="starred-source-link-{{ loop_index }}" class="code-name {% if source.num_unread != 0 %}unread{% else %}read{% endif %}">
+        {{ source.journalist_designation }}
+      </a>
     {% else %}
       <button class="button-star un-starred" type="submit"
         formaction="{{ url_for('col.add_star', filesystem_id=source.filesystem_id) }}"><i class="fa fa-star"></i></button>
       <input id="checkbox" type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}">
-      <span class="code-name"><a href="/col/{{ source.filesystem_id }}" id="un-starred-source-link-{{ loop_index }}">{{ source.journalist_designation }}</a></span>
+      <a href="/col/{{ source.filesystem_id }}" id="un-starred-source-link-{{ loop_index }}" class="code-name {% if source.num_unread != 0 %}unread{% else %}read{% endif %}">
+        {{ source.journalist_designation }}
+      </a>
     {% endif %}
   </div>
   <div class="submission-count">

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -31,7 +31,7 @@
 
       <ul id="submissions" class="plain submissions">
         {% for doc in source.collection %}
-          <li class="submission">
+          <li class="submission {% if not doc.downloaded %}unread{% endif %}">
             {% if not doc.filename.endswith('reply.gpg') %}
               {% if not doc.downloaded %}
                 <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
@@ -48,9 +48,9 @@
               <span class="file reply"><span class="filename">{{ doc.filename }}</span></span>
               <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat() }}</span></span>
             {% else %}
-            <span class="file">
-                <a class="btn small" href="{{ url_for('col.download_single_submission', filesystem_id=filesystem_id, fn=doc.filename) }}">
-                    <i class="fa fa-download"></i> <span class="filename">{{ doc.filename }}</span></a></span>
+              <a class="file {% if not doc.downloaded %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_submission', filesystem_id=filesystem_id, fn=doc.filename) }}">
+                <i class="fa fa-download"></i> <span class="filename">{{ doc.filename }}</span>
+              </a>
               <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat() }}</span></span>
             {% endif %}
             {% if doc.filename.endswith('-doc.gz.gpg') %}

--- a/securedrop/sass/journalist.sass
+++ b/securedrop/sass/journalist.sass
@@ -89,7 +89,7 @@ button.small-danger, a.btn.small-danger, .btn.small-danger
 
 #cols li.source
   .button-star
-    background-color: $color_grey_light
+    background-color: transparent
 
 .login-form
   max-width: 445px

--- a/securedrop/sass/modules/_cols.sass
+++ b/securedrop/sass/modules/_cols.sass
@@ -3,16 +3,21 @@
     padding: 0
 
     li.source
-      background: $color_grey_xlight
       border-bottom: 1px solid #ddd
       padding: 6px
       text-align: left
+      
+      &.unread
+        background: white
+      
+      &.read
+        background: $color_grey_xlight
 
       &:dir(rtl)
         text-align: right
 
-      &:last-child
-        border-bottom: none
+      &:first-child
+        border-top: 1px solid #ddd
 
       .date
         float: right
@@ -34,6 +39,14 @@
           font-weight: bold
           margin: 5px
           display: inline-block
+
+      .code-name
+        text-decoration: none
+        &.read
+          font-weight: normal
+          color: #444
+        &.unread
+          font-weight: bold
 
       .submission-count
         display: inline-block

--- a/securedrop/sass/modules/_submission.sass
+++ b/securedrop/sass/modules/_submission.sass
@@ -8,12 +8,20 @@
     &:dir(rtl)
       text-align: right
 
-    &:last-child
-      border-bottom: none
+    &:first-child
+      border-top: 1px solid #ddd
 
     .file
       min-width: 300px
       display: inline-block
+      color: inherit
+      text-decoration: none
+      
+      &.unread
+        font-weight: bold
+      
+      &.read
+        color: #444
 
       &.reply
         font-size: small
@@ -21,3 +29,6 @@
     .info
       font-size: 12px
       color: #666666
+    
+    &.unread
+      background: white


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3159.

Changes proposed in this pull request:

* Alter the appearance of the submission list to make a clearer distinction between read and unread documents

## Testing

In the journalist interface, from the source list view, observe that sources with unread documents look different, like so:

![screen shot 2018-05-08 at 1 58 08 pm](https://user-images.githubusercontent.com/296631/39774125-f854011c-52c7-11e8-8227-2ee74f75e7b0.png)

Visit a source and observe that read/unread files look different, like so:

![screen shot 2018-05-08 at 10 56 20 am](https://user-images.githubusercontent.com/296631/39764839-78be07fe-52ae-11e8-883b-9dcb4bd2bb2a.png)

To change a file from read to unread state, download it. You will need to refresh the page.

## Deployment

No deployment considerations
