### PR TITLE
[0.7.0] Backport #3379

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -332,7 +332,7 @@ Simply click the **Update Instance Config** button:
 
 |System Config Page|
 
-And on the instance configuration page, select and upload the image you prefer.
+And on the instance configuration page, select and upload the PNG image you prefer.
 You should see a message appear indicating the change was a success:
 
 |Logo Update|

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -65,7 +65,7 @@ To update these screenshots automatically you can run:
 
 .. code:: sh
 
-   make -C securedrop images update-user-guides
+   make -C securedrop update-user-guides
 
 This will generate screenshots for each page in the web application and copy
 them to the folder under ``docs/images/manual/screenshots`` where they will

--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -30,7 +30,6 @@ development_dependencies:
   - devscripts # for dch
   - gdb # for gcore in TestSubmissionNotInMemory
   - paxctl
-  - libjpeg-dev
 
 # These profiles are referenced by multiple machines, such as Application Server
 # for direct copying at install time, and the build machine for including them
@@ -53,7 +52,6 @@ appserver_dependencies:
   - apparmor-utils
   - redis-server
   - supervisor
-  - libjpeg-dev
 
 tor_apt_repo_url: https://tor-apt.freedom.press
 

--- a/install_files/securedrop-app-code/DEBIAN/control
+++ b/install_files/securedrop-app-code/DEBIAN/control
@@ -6,5 +6,5 @@ Homepage: https://securedrop.org
 Package: securedrop-app-code
 Version: 0.7.0~rc3
 Architecture: amd64
-Depends: python-pip,apparmor-utils,gnupg2,haveged,python,python-pip,secure-delete,sqlite,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor,securedrop-keyring,securedrop-config,libjpeg-dev
+Depends: python-pip,apparmor-utils,gnupg2,haveged,python,python-pip,secure-delete,sqlite,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor,securedrop-keyring,securedrop-config
 Description: Packages the SecureDrop application code pip dependencies and apparmor profiles. This package will put the apparmor profiles in enforce mode. This package does use pip to install the pip wheelhouse

--- a/securedrop/Dockerfile
+++ b/securedrop/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install -y devscripts \
                        python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
-                       gettext paxctl x11vnc enchant libjpeg-dev
+                       gettext paxctl x11vnc enchant
 
 RUN gem install sass -v 3.4.23
 

--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from PIL import Image
-
 import os
 
 from flask import (Blueprint, render_template, request, url_for, redirect, g,
@@ -33,19 +31,16 @@ def make_blueprint(config):
         form = LogoForm()
         if form.validate_on_submit():
             f = form.logo.data
-            custom_logo_filepath = os.path.join(config.SECUREDROP_ROOT,
-                                                "static/i/custom_logo.png")
+            custom_logo_filepath = os.path.join(current_app.static_folder, 'i',
+                                                'custom_logo.png')
             try:
-                with Image.open(f) as im:
-                    im.thumbnail((500, 450), resample=3)
-                    im.save(custom_logo_filepath, "PNG")
+                f.save(custom_logo_filepath)
                 flash(gettext("Image updated."), "logo-success")
             except Exception:
                 flash("Unable to process the image file."
                       " Try another one.", "logo-error")
             finally:
                 return redirect(url_for("admin.manage_config"))
-
         else:
             for field, errors in form.errors.items():
                 for error in errors:

--- a/securedrop/journalist_app/forms.py
+++ b/securedrop/journalist_app/forms.py
@@ -58,7 +58,6 @@ class ReplyForm(FlaskForm):
 class LogoForm(FlaskForm):
     logo = FileField(validators=[
         FileRequired(message=gettext('File required.')),
-        FileAllowed(['jpg', 'png', 'jpeg'],
-                    message=gettext("You can only upload JPG/JPEG"
-                                    " or PNG image files."))
+        FileAllowed(['png'],
+                    message=gettext("Upload images only."))
     ])

--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -17,4 +17,3 @@ scrypt
 SQLAlchemy
 typing
 Werkzeug==0.12.2
-Pillow

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -17,7 +17,6 @@ itsdangerous==0.24        # via flask
 jinja2==2.10
 jsmin==2.2.2
 markupsafe==1.0           # via jinja2
-pillow==5.0.0
 psutil==5.4.3
 pycryptodomex==3.4.7
 pyotp==2.2.6

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1042,10 +1042,9 @@ class TestJournalistApp(TestCase):
         resp = self.client.post(url_for('admin.manage_config'),
                                 data=form.data,
                                 follow_redirects=True)
-        self.assertMessageFlashed("You can only upload JPG/JPEG"
-                                  " or PNG image files.", "logo-error")
-        self.assertIn("You can only upload JPG/JPEG"
-                      " or PNG image files.", resp.data)
+        self.assertMessageFlashed("Upload images only.",
+                                  "logo-error")
+        self.assertIn("Upload images only.", resp.data)
 
     def test_logo_upload_with_empty_input_field_fails(self):
         self._login_admin()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
 * Backports #3379

## Testing

These should be the same commits as #3379

## Deployment

Resolves issues with upgrades of `securedrop-app-code` deb package

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
