### PR TITLE
Improve error in form validation for logo upload: only PNGs allowed

### DIFF
--- a/securedrop/journalist_app/forms.py
+++ b/securedrop/journalist_app/forms.py
@@ -59,5 +59,5 @@ class LogoForm(FlaskForm):
     logo = FileField(validators=[
         FileRequired(message=gettext('File required.')),
         FileAllowed(['png'],
-                    message=gettext("Upload images only."))
+                    message=gettext("You can only upload PNG image files."))
     ])

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1042,9 +1042,9 @@ class TestJournalistApp(TestCase):
         resp = self.client.post(url_for('admin.manage_config'),
                                 data=form.data,
                                 follow_redirects=True)
-        self.assertMessageFlashed("Upload images only.",
+        self.assertMessageFlashed("You can only upload PNG image files.",
                                   "logo-error")
-        self.assertIn("Upload images only.", resp.data)
+        self.assertIn("You can only upload PNG image files.", resp.data)
 
     def test_logo_upload_with_empty_input_field_fails(self):
         self._login_admin()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Followup to #3379 (see [comments here](https://github.com/freedomofpress/securedrop/pull/3379#discussion_r186878612) pushing string change into 0.8.0 release)

Changes proposed in this pull request:
 * Makes the logo upload string clearer for end users.  

## Testing

Just determine whether or not you think the string is indeed an improvement and verify tests pass

## Deployment

None, minor string change in securedrop-app-code

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
