### PR TITLE
[0.7.0] ossec: resolve journalist notification racing with reboots

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -75,6 +75,9 @@ worth checking the *Journalist Interface*. For this you will need:
           the GPG private key, it is not possible to specify multiple
           GPG keys.
 
+.. note:: The journalist notification is sent after the daily reboot
+          of the *Application Server*.
+
 You will have to copy the following required files to
 ``install_files/ansible-base``:
 

--- a/install_files/ansible-base/roles/ossec/files/process_submissions_today.sh
+++ b/install_files/ansible-base/roles/ossec/files/process_submissions_today.sh
@@ -29,7 +29,7 @@ function handle_notification() {
     stdin="$(< /dev/stdin)"
 
     local count
-    count=$(echo "$stdin" | perl -ne 'print scalar(<>) and exit if(/ossec: output/);')
+    count=$(echo "$stdin" | perl -ne "print scalar(<>) and exit if(m|ossec: output: 'head -1 /var/lib/securedrop/submissions_today.txt|);")
     if [[ "$count" =~ ^[0-9]+$ ]] ; then
         export SUBJECT="Submissions in the past 24h"
         #

--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -108,7 +108,7 @@
   <localfile>
     <log_format>full_command</log_format>
     <command>head -1 /var/lib/securedrop/submissions_today.txt | grep '^[0-9]*$'</command>
-    <frequency>86400</frequency>
+    <frequency>90000</frequency> <!-- 25 hours -->
   </localfile>
 
   <localfile>

--- a/testinfra/ossec/alert-journalist-one.txt
+++ b/testinfra/ossec/alert-journalist-one.txt
@@ -1,0 +1,14 @@
+OSSEC HIDS Notification.
+2018 May 06 20:18:24
+
+Received From: (app) 10.0.1.4->head -1 /var/lib/securedrop/submissions_today.txt | grep '^[0-9]*$'
+Rule: 400600 fired (level 1) -> "Boolean value indicating if there were submissions in the past 24h."
+Portion of the log(s):
+
+ossec: output: 'head -1 /var/lib/securedrop/submissions_today.txt | grep '^[0-9]*$'':
+0
+
+
+
+ --END OF NOTIFICATION
+ 

--- a/testinfra/ossec/alert-journalist-two.txt
+++ b/testinfra/ossec/alert-journalist-two.txt
@@ -1,0 +1,39 @@
+OSSEC HIDS Notification.
+2018 May 06 20:18:24
+
+Received From: (app) 10.0.1.4->netstat -tan |grep LISTEN |grep -v 127.0.0.1 | sort
+Rule: 533 fired (level 7) -> "Listened ports status (netstat) changed (new port opened or closed)."
+Portion of the log(s):
+
+ossec: output: 'netstat -tan |grep LISTEN |grep -v 127.0.0.1 | sort':
+tcp        0      0 0.0.0.0:111             0.0.0.0:*               LISTEN     
+tcp        0      0 0.0.0.0:37294           0.0.0.0:*               LISTEN     
+tcp6       0      0 :::111                  :::*                    LISTEN     
+tcp6       0      0 :::44352                :::*                    LISTEN     
+Previous output:
+ossec: output: 'netstat -tan |grep LISTEN |grep -v 127.0.0.1 | sort':
+tcp        0      0 0.0.0.0:111             0.0.0.0:*               LISTEN     
+tcp        0      0 0.0.0.0:48638           0.0.0.0:*               LISTEN     
+tcp6       0      0 :::111                  :::*                    LISTEN     
+tcp6       0      0 :::37312                :::*                    LISTEN     
+
+
+
+ --END OF NOTIFICATION
+
+
+
+OSSEC HIDS Notification.
+2018 May 06 20:18:24
+
+Received From: (app) 10.0.1.4->head -1 /var/lib/securedrop/submissions_today.txt | grep '^[0-9]*$'
+Rule: 400600 fired (level 1) -> "Boolean value indicating if there were submissions in the past 24h."
+Portion of the log(s):
+
+ossec: output: 'head -1 /var/lib/securedrop/submissions_today.txt | grep '^[0-9]*$'':
+0
+
+
+
+ --END OF NOTIFICATION
+ 

--- a/testinfra/ossec/alert-ossec.txt
+++ b/testinfra/ossec/alert-ossec.txt
@@ -1,0 +1,22 @@
+OSSEC HIDS Notification.
+2018 May 06 20:18:24
+
+Received From: (app) 10.0.1.4->netstat -tan |grep LISTEN |grep -v 127.0.0.1 | sort
+Rule: 533 fired (level 7) -> "Listened ports status (netstat) changed (new port opened or closed)."
+Portion of the log(s):
+
+ossec: output: 'netstat -tan |grep LISTEN |grep -v 127.0.0.1 | sort':
+tcp        0      0 0.0.0.0:111             0.0.0.0:*               LISTEN     
+tcp        0      0 0.0.0.0:37294           0.0.0.0:*               LISTEN     
+tcp6       0      0 :::111                  :::*                    LISTEN     
+tcp6       0      0 :::44352                :::*                    LISTEN     
+Previous output:
+ossec: output: 'netstat -tan |grep LISTEN |grep -v 127.0.0.1 | sort':
+tcp        0      0 0.0.0.0:111             0.0.0.0:*               LISTEN     
+tcp        0      0 0.0.0.0:48638           0.0.0.0:*               LISTEN     
+tcp6       0      0 :::111                  :::*                    LISTEN     
+tcp6       0      0 :::37312                :::*                    LISTEN     
+
+
+
+ --END OF NOTIFICATION

--- a/testinfra/ossec/test_journalist_mail.py
+++ b/testinfra/ossec/test_journalist_mail.py
@@ -116,8 +116,8 @@ class TestJournalistMail(TestBase):
         # encrypted mail to journalist or ossec contact
         #
         for (who, payload, expected) in (
-                ('journalist', 'ossec: output\n1', '1'),
-                ('ossec', 'MYGREATPAYLOAD', 'MYGREATPAYLOAD')):
+                ('journalist', 'JOURNALISTPAYLOAD', 'JOURNALISTPAYLOAD'),
+                ('ossec', 'OSSECPAYLOAD', 'OSSECPAYLOAD')):
             assert self.run(host, "postsuper -d ALL")
             trigger(who, payload)
             assert self.run(


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport #3374

Mitigates: #3368 

The app server is rebooted every 24h and will send a notification at
boot time. The ossec server is also rebooted and will immediately send
the email to the journalist, regardless of when the previous mail was
sent (mail frequency is not a feature of ossec-maild). Always running
the localfile command at boot time is an undocumented OSSEC behavior
https://github.com/ossec/ossec-hids/issues/1415 in 2.8.2 as well as
2.9.3.

This guarantees exactly one mail will be sent daily.

Setting the 25 hours frequency element is a safeguard:

* against the following race a) command runs because the 24h period
  expires, b) the server reboots shortly after because it reboots
  every 24h, c) command runs again after the server is rebooted,
  causing two notifications to be sent in a row

* in case the server does not reboot for some reason, the notification
  will still be sent every 25h

Fixes: https://github.com/freedomofpress/securedrop/issues/3367

## Testing

* Reboot the app server and verify the notification is sent

## Deployment

N/A

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
