### PR TITLE
[Do not merge] Run manage.py were-there-submissions today on notification install

### DIFF
--- a/install_files/ansible-base/roles/app/tasks/main.yml
+++ b/install_files/ansible-base/roles/app/tasks/main.yml
@@ -20,3 +20,16 @@
 - include: setup_cron.yml
 
 - include: configure_haveged.yml
+
+# ./manage.py were-there-submissions-today runs every night as a cron. If the
+# instance is rebooted prior to the cron running a first time, a SecureDrop
+# Submissions error is sent to the admin.
+# (see https://github.com/freedomofpress/securedrop/issues/3393)
+- include: run_were_there_submissions_today.yml
+  when:
+    - journalist_gpg_fpr is defined
+    - journalist_gpg_fpr != ""
+    - journalist_alert_gpg_public_key is defined
+    - journalist_alert_gpg_public_key != ""
+    - journalist_alert_email is defined
+    - journalist_alert_email != ""

--- a/install_files/ansible-base/roles/app/tasks/run_were_there_submissions_today.yml
+++ b/install_files/ansible-base/roles/app/tasks/run_were_there_submissions_today.yml
@@ -1,0 +1,13 @@
+- name: Check submissions_today
+  stat: path=/var/lib/securedrop/submissions_today.txt
+  register: submission_file
+  become: yes
+  tags:
+    - journalist-notifications
+
+- name: Run ./manage.py were-there-submissions-today to initialize flag
+  shell: "python /var/www/securedrop/manage.py were-there-submissions-today"
+  when: not submission_file.stat.exists
+  become: yes
+  tags:
+    - journalist-notifications


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes
Install logic will run `./manage.py were-there-submissions-today` thus populating `/var/lib/securedrop/submissions_today.txt` if and only if:
- Jounalist notifications are enabled (email, gpg key and gpg fpr are defined)
- `/var/lib/securedrop/submissions_today.txt` does not exist

Fixes #3393

Changes proposed in this pull request:

## Testing

1. Reproduce bug in #3393 on `develop` branch or `0.7.0~rc4` tag:
- Install SecureDrop with notifications enabled
- Install SecureDrop again to enable SSH over local
- Observe SecureDrop notifications error email sent to admin
2. Validate the fix by doing the above with this branch
- Run `./securedrop-admin install` again and ensure `./manage.py` is not run again if the text file is present.

## Deployment

This affects new provisioning functionality so there are no deployment considerations.

## Checklist

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

