### PR TITLE
Rename Document Interface to Journalist Interface in Docker dev env

### DIFF
--- a/securedrop/management/run.py
+++ b/securedrop/management/run.py
@@ -170,7 +170,7 @@ def run(args):  # pragma: no cover
         lambda: DevServerProcess('Source Interface',
                                  ['python', 'source.py'],
                                  'blue'),
-        lambda: DevServerProcess('Document Interface',
+        lambda: DevServerProcess('Journalist Interface',
                                  ['python', 'journalist.py'],
                                  'cyan'),
         lambda: DevServerProcess('SASS Compiler',


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3396 via string change in dev env runner

## Testing

1. Run the dev env with `make dev` and observe that the string "Document Interface" shown on the console has been changed to "Journalist Interface"

## Deployment

N/A, dev env only

## Checklist

N/A