### PR TITLE
add /var/lib/securedrop/tmp to the docker development environment

### DIFF
--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -37,7 +37,7 @@ function run_sass() {
 }
 
 function reset_demo() {
-    sudo mkdir -p /var/lib/securedrop/store /var/lib/securedrop/keys
+    sudo mkdir -p /var/lib/securedrop/{store,keys,tmp}
     sudo chown -R "$(id -u)" /var/lib/securedrop
     cp ./tests/files/test_journalist_key.pub /var/lib/securedrop/keys
     gpg --homedir /var/lib/securedrop/keys --import /var/lib/securedrop/keys/test_journalist_key.pub >& /tmp/gpg.out || cat /tmp/gpg.out


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Otherwise functions such as Download all will fail because it does not
exist

## Testing

Try to **Download all** from the journalist interface in `make dev`

## Deployment

N/A

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
