### PR TITLE
docs: add missing directory in developper instructions

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -78,7 +78,7 @@ To get started, you can try the following:
 
 .. code:: sh
 
-   cd securedrop
+   cd securedrop/securedrop
    make dev                                    # run development servers
    make test                                   # run tests
    bin/dev-shell bin/run-test tests/functional # functional tests only


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Contributes to #3403

The instructions in the previous chapter recommend to clone, meaning
the user is not at the root of the securedrop directory. If they
just cd securedrop as recommended, they won't be in the directory
which is valid to run the following commands.

## Testing

Follow the instructions in the docs/development/setup_development.rst to the letter

## Deployment

N/A

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
