### PR TITLE
Document release management i18n coordination

### DIFF
--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -297,6 +297,8 @@ Note that the new index will not be used right away, some workers may
 still have the old index open. Rebooting the machine is an option,
 waiting for a few hours is another option.
 
+.. _i18n_release:
+
 Release management
 ------------------
 

--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -92,9 +92,11 @@ Release Process
 ---------------
 
 1. If this is a regular release, work with the translation administrator
-   responsible for this release cycle to review and merge the final translations they
-   prepare. You *must* manually inspect each line in the diff to ensure no malicious
-   content is introduced.
+   responsible for this release cycle to review and merge the final translations
+   and screenshots (if necessary) they prepare. Refer to the 
+   :ref:`i18n documentation <i18n_release>` for more information about the i18n 
+   release process. Note that you *must* manually inspect each line in the diff 
+   to ensure no malicious content is introduced.
 2. Prepare the final release commit and tag. Do not push the tag file.
 3. Step through the signing ceremony for the tag file. If you do not have
    permissions to do so, coordinate with someone that does.


### PR DESCRIPTION
Added link in release management guide to the i18n release process and added mention of merging screenshots.

## Status

Ready for review

## Description of Changes

Release management guide: Add mention of screenshot and link to the i18n release management process.

## Testing

* The change in documentation should make sense
* The link should work
## Deployment

Docs only.

## Checklist


### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
