### PR TITLE
Clarify Delete button label

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -119,7 +119,7 @@
     <input type="hidden" name="filesystem_id" value="{{ filesystem_id }}">
     <input type="hidden" name="col_name" value="{{ source.journalist_designation }}">
     <a href="#delete-collection-confirmation-modal" id="delete-collection-link">
-      <button type="button" class="sd-button danger"><i class="far fa-trash-alt"></i> {{ gettext('DELETE COLLECTION') }}</button>
+      <button type="button" class="sd-button danger"><i class="far fa-trash-alt"></i> {{ gettext('DELETE SOURCE AND SUBMISSIONS') }}</button>
     </a>
 
     <!-- Confirmation modal for entire collection deletion -->


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2419.

Changes proposed in this pull request:

This pull request changes the label of this button:

<img width="824" alt="screen shot 2018-05-15 at 1 15 41 pm" src="https://user-images.githubusercontent.com/2976310/40072520-205dcbe6-5842-11e8-94fc-f8f5e8d90d15.png">

The original text was `DELETE COLLECTION`. The new text is `DELETE SOURCE AND SUBMISSIONS`. This text was proposed by @kushaldas in #2491 ([comment permalink](https://github.com/freedomofpress/securedrop/issues/2419#issuecomment-335828970)).

## Testing

1. Run app.
2. Look at button.

## Deployment

This will impact existing installs, but does not require any special procedures to deploy.

## Checklist

N/A