### PR TITLE
Replace shell=True / sh calls with sh package (Issue #3071)

### DIFF
--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -4,7 +4,12 @@ IMAGE = securedrop
 
 .PHONY: lint
 lint: ## Run the python linter with the project's default error settings
-	find . -name '*.py' | xargs pylint --reports=no --errors-only --disable=import-error
+	find . -name '*.py' | xargs pylint --reports=no --errors-only \
+	   --disable=import-error \
+	   --disable=no-name-in-module \
+	   --disable=unexpected-keyword-arg \
+	   --disable=too-many-function-args \
+	   --disable=import-error
 
 .PHONY: lint-full
 lint-full:  ## Run the python linter with nothing disabled

--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -244,19 +244,17 @@ class I18NTool(object):
 
             def need_update(p):
                 exists = os.path.exists(join(args.root, p))
-                sh("""
-                set -ex
-                cd {r}
-                git checkout i18n/i18n -- {p}
-                git reset HEAD -- {p}
-                """.format(r=args.root, p=p))
+                k = {'_cwd': args.root}
+                git.checkout('i18n/i18n', '--', p, **k)
+                git.reset('HEAD', '--', p, **k)
                 if not exists:
                     return True
                 else:
                     return self.file_is_modified(join(args.root, p))
 
             def add(p):
-                sh("git -C {r} add {p}".format(r=args.root, p=p))
+                git('-C', args.root, 'add', p)
+
             updated = False
             #
             # Update messages

--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -347,6 +347,7 @@ class I18NTool(object):
 
     def setup_verbosity(self, args):
         if args.verbose:
+            logging.getLogger('sh.command').setLevel(logging.INFO)
             log.setLevel(logging.DEBUG)
         else:
             log.setLevel(logging.INFO)

--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -14,50 +14,10 @@ import version
 
 from os.path import dirname, join, realpath
 
+from sh import git, pybabel, sed, msgmerge, xgettext, msgfmt
+
 logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s')
 log = logging.getLogger(__name__)
-
-
-def sh(command, input=None):
-    """Run the *command* which must be a shell snippet. The stdin is
-    either /dev/null or the *input* argument string.
-
-    The stderr/stdout of the snippet are captured and logged via
-    logging.debug(), one line at a time.
-    """
-    log.debug(":sh: " + command)
-    if input is None:
-        stdin = None
-    else:
-        stdin = subprocess.PIPE
-    proc = subprocess.Popen(
-        args=command,
-        stdin=stdin,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        shell=True,
-        bufsize=1)
-    if stdin is not None:
-        proc.stdin.write(input)
-        proc.stdin.close()
-    lines_of_command_output = []
-    loggable_line_list = []
-    with proc.stdout:
-        for line in iter(proc.stdout.readline, b''):
-            line = line.decode('utf-8')
-            lines_of_command_output.append(line)
-            loggable_line = line.strip().encode('ascii', 'ignore')
-            log.debug(loggable_line)
-            loggable_line_list.append(loggable_line)
-    if proc.wait() != 0:
-        if log.getEffectiveLevel() > logging.DEBUG:
-            for loggable_line in loggable_line_list:
-                log.error(loggable_line)
-        raise subprocess.CalledProcessError(
-            returncode=proc.returncode,
-            cmd=command
-        )
-    return "".join(lines_of_command_output)
 
 
 class I18NTool(object):

--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -213,16 +213,13 @@ class I18NTool(object):
         io.open(l10n_txt, mode='w').write(l10n_content)
         self.require_git_email_name(includes)
         if self.file_is_modified(l10n_txt):
-            sh("""
-            set -ex
-            cd {includes}
-            git add l10n.txt
-            git commit \
-              -m 'docs: update the list of supported languages' \
-              l10n.txt
-            """.format(includes=includes))
+            k = {'_cwd': includes}
+            git.add('l10n.txt', **k)
+            msg = 'docs: update the list of supported languages'
+            git.commit('-m', msg, 'l10n.txt', **k)
             log.warning(l10n_txt + " updated")
-            log.warning(sh("cd " + includes + "; git show"))
+            git_show_out = git.show(**k)
+            log.warning(git_show_out)
         else:
             log.warning(l10n_txt + " already up to date")
 

--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -52,15 +52,10 @@ class I18NTool(object):
         return subprocess.call(['git', '-C', dir, 'diff', '--quiet', path])
 
     def ensure_i18n_remote(self, args):
-        sh("""
-        set -ex
-        cd {root}
-        if ! git remote | grep --quiet i18n ; then
-           git remote add i18n {url}
-        fi
-        git fetch i18n
-        """.format(root=args.root,
-                   url=args.url))
+        k = {'_cwd': args.root}
+        if 'i18n' not in git.remote(**k).stdout:
+            git.remote.add('i18n', args.url, **k)
+        git.fetch('i18n', **k)
 
     def translate_messages(self, args):
         messages_file = os.path.join(args.translations_dir, 'messages.pot')

--- a/securedrop/requirements/develop-requirements.in
+++ b/securedrop/requirements/develop-requirements.in
@@ -8,7 +8,7 @@ dnspython
 flake8
 html-linter
 molecule>2.13
-# Needed for ansible network filte
+# Needed for ansible network filter
 # http://docs.ansible.com/ansible/latest/playbooks_filters_ipaddr.html
 netaddr
 pip-tools>=1.10

--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -15,6 +15,7 @@ qrcode
 redis
 rq
 scrypt
+sh
 SQLAlchemy
 typing
 Werkzeug==0.12.2

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -35,6 +35,7 @@ qrcode==5.3
 redis==2.10.6
 rq==0.10.0
 scrypt==0.8.0
+sh==1.12.14
 six==1.11.0               # via cryptography, python-dateutil, qrcode
 sqlalchemy==1.2.0
 typing==3.6.4

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -31,6 +31,8 @@ import journalist_app as journalist_app_module
 import pytest
 import source_app
 
+from sh import sed, pybabel
+
 
 def verify_i18n(app):
     not_translated = 'code hello i18n'

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -187,29 +187,19 @@ def test_i18n(journalist_app, config):
         '--extract-update',
     ])
 
-    i18n_tool.sh("""
-    pybabel init -i {d}/messages.pot -d {d} -l en_US
+    pot = os.path.join(config.TEMP_DIR, 'messages.pot')
+    pybabel('init', '-i', pot, '-d', config.TEMP_DIR, '-l', 'en_US')
 
-    pybabel init -i {d}/messages.pot -d {d} -l fr_FR
-    sed -i -e '/code hello i18n/,+1s/msgstr ""/msgstr "code bonjour"/' \
-          {d}/fr_FR/LC_MESSAGES/messages.po
-
-    pybabel init -i {d}/messages.pot -d {d} -l zh_Hans_CN
-    sed -i -e '/code hello i18n/,+1s/msgstr ""/msgstr "code chinese"/' \
-          {d}/zh_Hans_CN/LC_MESSAGES/messages.po
-
-    pybabel init -i {d}/messages.pot -d {d} -l ar
-    sed -i -e '/code hello i18n/,+1s/msgstr ""/msgstr "code arabic"/' \
-          {d}/ar/LC_MESSAGES/messages.po
-
-    pybabel init -i {d}/messages.pot -d {d} -l nb_NO
-    sed -i -e '/code hello i18n/,+1s/msgstr ""/msgstr "code norwegian"/' \
-          {d}/nb_NO/LC_MESSAGES/messages.po
-
-    pybabel init -i {d}/messages.pot -d {d} -l es_ES
-    sed -i -e '/code hello i18n/,+1s/msgstr ""/msgstr "code spanish"/' \
-          {d}/es_ES/LC_MESSAGES/messages.po
-    """.format(d=config.TEMP_DIR))
+    for (l, s) in (('fr_FR', 'code bonjour'),
+                   ('zh_Hans_CN', 'code chinese'),
+                   ('ar', 'code arabic'),
+                   ('nb_NO', 'code norwegian'),
+                   ('es_ES', 'code spanish')):
+        pybabel('init', '-i', pot, '-d', config.TEMP_DIR, '-l', l)
+        po = os.path.join(config.TEMP_DIR, l, 'LC_MESSAGES/messages.po')
+        sed('-i', '-e',
+            '/code hello i18n/,+1s/msgstr ""/msgstr "{}"/'.format(s),
+            po)
 
     i18n_tool.I18NTool().main([
         '--verbose',

--- a/securedrop/tests/test_i18n_tool.py
+++ b/securedrop/tests/test_i18n_tool.py
@@ -90,17 +90,15 @@ class TestI18NTool(object):
 
         locale = 'fr_FR'
         po_file = join(str(tmpdir), locale + ".po")
-        i18n_tool.sh("""
-        msginit  --no-translator \
-                 --locale {locale} \
-                 --output {po_file} \
-                 --input {messages_file}
-        sed -i -e '/{source}/,+1s/msgstr ""/msgstr "SOURCE FR"/' \
-                 {po_file}
-        """.format(source='SecureDrop Source Interfaces',
-                   messages_file=messages_file,
-                   po_file=po_file,
-                   locale=locale))
+        msginit(
+            '--no-translator',
+            '--locale', locale,
+            '--output', po_file,
+            '--input', messages_file)
+        source = 'SecureDrop Source Interfaces'
+        sed('-i', '-e',
+            '/{}/,+1s/msgstr ""/msgstr "SOURCE FR"/'.format(source),
+            po_file)
         assert exists(po_file)
 
         #

--- a/securedrop/tests/test_i18n_tool.py
+++ b/securedrop/tests/test_i18n_tool.py
@@ -147,11 +147,7 @@ class TestI18NTool(object):
 
         locale = 'en_US'
         locale_dir = join(str(tmpdir), locale)
-        i18n_tool.sh("pybabel init -i {} -d {} -l {}".format(
-            messages_file,
-            str(tmpdir),
-            locale,
-        ))
+        pybabel('init', '-i', messages_file, '-d', str(tmpdir), '-l', locale)
         mo_file = join(locale_dir, 'LC_MESSAGES/messages.mo')
         assert not exists(mo_file)
         i18n_tool.I18NTool().main(args)
@@ -181,11 +177,7 @@ class TestI18NTool(object):
         locale = 'en_US'
         locale_dir = join(str(tmpdir), locale)
         po_file = join(locale_dir, 'LC_MESSAGES/messages.po')
-        i18n_tool.sh("pybabel init -i {} -d {} -l {}".format(
-            messages_file,
-            str(tmpdir),
-            locale,
-        ))
+        pybabel(['init', '-i', messages_file, '-d', str(tmpdir), '-l', locale])
         assert exists(po_file)
         # pretend this happened a few seconds ago
         few_seconds_ago = time.time() - 60

--- a/securedrop/tests/test_i18n_tool.py
+++ b/securedrop/tests/test_i18n_tool.py
@@ -10,8 +10,9 @@ from mock import patch
 import pytest
 import shutil
 import signal
-import subprocess
 import time
+
+from sh import sed, msginit, pybabel, git, touch
 
 
 class TestI18NTool(object):
@@ -368,39 +369,3 @@ class TestI18NTool(object):
         message = i18n_tool.sh("git -C {d}/securedrop show".format(d=d))
         assert "Someone Else" in message
         assert u"Loïc" not in message
-
-
-class TestSh(object):
-
-    def test_sh(self):
-        assert 'A' == i18n_tool.sh("echo -n A")
-        with pytest.raises(Exception) as excinfo:
-            i18n_tool.sh("exit 123")
-        assert excinfo.value.returncode == 123
-
-    def test_sh_progress(self, caplog):
-        i18n_tool.sh("echo AB ; sleep 5 ; echo C")
-        records = caplog.records
-        assert ':sh: ' in records[0].message
-        assert records[0].levelname == 'DEBUG'
-        assert 'AB' == records[1].message
-        assert records[1].levelname == 'DEBUG'
-        assert 'C' == records[2].message
-        assert records[2].levelname == 'DEBUG'
-
-    def test_sh_input(self, caplog):
-        assert 'abc' == i18n_tool.sh("cat", 'abc')
-
-    def test_sh_fail(self, caplog):
-        level = i18n_tool.log.getEffectiveLevel()
-        i18n_tool.log.setLevel(logging.INFO)
-        assert i18n_tool.log.getEffectiveLevel() == logging.INFO
-        with pytest.raises(subprocess.CalledProcessError) as excinfo:
-            i18n_tool.sh("echo AB ; echo C ; exit 111")
-        i18n_tool.log.setLevel(level)
-        assert excinfo.value.returncode == 111
-        records = caplog.records
-        assert 'AB' == records[0].message
-        assert records[0].levelname == 'ERROR'
-        assert 'C' == records[1].message
-        assert records[1].levelname == 'ERROR'

--- a/securedrop/tests/test_i18n_tool.py
+++ b/securedrop/tests/test_i18n_tool.py
@@ -4,7 +4,6 @@ import io
 import os
 from os.path import abspath, dirname, exists, getmtime, join, realpath
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-import logging
 import i18n_tool
 from mock import patch
 import pytest
@@ -32,21 +31,6 @@ class TestI18NTool(object):
                 'translate-messages',
                 '--translations-dir', str(tmpdir)
             ]) == signal.SIGINT
-
-        assert tool.main([
-            'translate-messages',
-            '--translations-dir', str(tmpdir),
-            '--extract-update'
-        ]) is None
-        assert 'pybabel extract' not in caplog.text
-
-        assert tool.main([
-            '--verbose',
-            'translate-messages',
-            '--translations-dir', str(tmpdir),
-            '--extract-update'
-        ]) is None
-        assert 'pybabel extract' in caplog.text
 
     def test_translate_desktop_l10n(self, tmpdir):
         in_files = {}

--- a/securedrop/tests/test_i18n_tool.py
+++ b/securedrop/tests/test_i18n_tool.py
@@ -230,17 +230,15 @@ class TestI18NTool(object):
         assert i18n_tool.I18NTool.require_git_email_name(str(tmpdir))
 
     def test_update_docs(self, tmpdir, caplog):
-        os.makedirs(join(str(tmpdir), 'includes'))
-        i18n_tool.sh("""
-        cd {dir}
-        git init
-        git config user.email "you@example.com"
-        git config user.name "Your Name"
-        mkdir includes
-        touch includes/l10n.txt
-        git add includes/l10n.txt
-        git commit -m 'init'
-        """.format(dir=str(tmpdir)))
+        k = {'_cwd': str(tmpdir)}
+        git.init(**k)
+        git.config('user.email', "you@example.com", **k)
+        git.config('user.name', "Your Name", **k)
+        os.mkdir(join(str(tmpdir), 'includes'))
+        touch('includes/l10n.txt', **k)
+        git.add('includes/l10n.txt', **k)
+        git.commit('-m', 'init', **k)
+
         i18n_tool.I18NTool().main([
             '--verbose',
             'update-docs',

--- a/securedrop/tests/test_i18n_tool.py
+++ b/securedrop/tests/test_i18n_tool.py
@@ -199,18 +199,14 @@ class TestI18NTool(object):
             assert 'template hello i18n' not in mo
 
     def test_require_git_email_name(self, tmpdir):
-        i18n_tool.sh("""
-        cd {dir}
-        git init
-        """.format(dir=str(tmpdir)))
+        k = {'_cwd': str(tmpdir)}
+        git('init', **k)
         with pytest.raises(Exception) as excinfo:
             i18n_tool.I18NTool.require_git_email_name(str(tmpdir))
         assert 'please set name' in excinfo.value.message
-        i18n_tool.sh("""
-        cd {dir}
-        git config user.email "you@example.com"
-        git config user.name "Your Name"
-        """.format(dir=str(tmpdir)))
+
+        git.config('user.email', "you@example.com", **k)
+        git.config('user.name', "Your Name", **k)
         assert i18n_tool.I18NTool.require_git_email_name(str(tmpdir))
 
     def test_update_docs(self, tmpdir, caplog):

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -105,10 +105,9 @@ def do_test(config, create_app):
         '--compile',
     ])
 
-    i18n_tool.sh("""
-    pybabel init -i {d}/messages.pot -d {d} -l en_US
-    pybabel init -i {d}/messages.pot -d {d} -l fr_FR
-    """.format(d=config.TEMP_DIR))
+    for l in ('en_US', 'fr_FR'):
+        pot = os.path.join(config.TEMP_DIR, 'messages.pot')
+        pybabel('init', '-i', pot, '-d', config.TEMP_DIR, '-l', l)
 
     app = create_app(config)
 

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -11,6 +11,8 @@ import journalist_app
 import source_app
 import template_filters
 
+from sh import pybabel
+
 
 def verify_rel_datetime_format(app):
     with app.test_client() as c:


### PR DESCRIPTION
## Status

**Work in progress**

## Description of Changes

Fixes #3071  .

Changes proposed in this pull request:

### What

Replacing the `sh` call in `i18n_tool` with a package called `sh`
and re-writing all bash commands.

### Why

There is a potential internal vulnerability from translation files.
Running `shell=True` would allow a malicious translator to potentially
inject a shell script when running the tool.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

- `make -C securedrop translate` and verify the modifications are relevant (i18n is merged once per release, this is expected)
- `securedrop/bin/dev-shell ./i18n_tool.py --verbose update-docs` and verify nothing changes
- `make build-debs` 
  - vagrant up /staging/
  - add `SUPPORTED_LOCALES = ['en_US', 'fr_FR']`  to /var/www/securedrop/config.py
  - tor-browser $(cat install_files/ansible-base/app-source-ths 
  - switch languages 
-  manually check the .mo files are accounted for in the `build/securedrop-app-code-0.8.0~rc1-amd64.deb` package

## Deployment

N/A

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
