### PR TITLE
docs: remove both .venv and admin/.venv

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,8 +19,9 @@ on network speed and computing power.
 
  .. note :: Occasionally this command times out due to network latency issues.
     You should be able to re-run the command and complete the setup. If you run
-    into a problem, try removing the ``~/Persistent/securedrop/.venv/``
-    directory and running the command again. The command should only be run as
+    into a problem, try removing the ``~/Persistent/securedrop/admin/.venv/``
+    directory and the ``~/Persistent/securedrop/.venv`` symbolic link
+    and running the command again. The command should only be run as
     the ``amnesia`` user.
 
 .. _configure_securedrop:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes: #3200 

The tip must remove the symlink and the actual directory containing
the dependencies, otherwise it is not effective.

## Testing

Follow the steps described in the modified tip and verify ./securedrop-admin setup && ./securedrop-admin install works.

## Deployment

N/A

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
