### PR TITLE
Fix check_for_updates

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -588,7 +588,8 @@ def check_for_updates(args):
     sdlog.info("Checking for SecureDrop updates...")
 
     # Determine what branch we are on
-    current_tag = subprocess.check_output(['git', 'describe'], cwd=args.root)
+    current_tag = subprocess.check_output(['git', 'describe'],
+                                          cwd=args.root).rstrip('\n')
 
     # Fetch all branches
     git_fetch_cmd = ['git', 'fetch', '--all']

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -66,6 +66,21 @@ class TestSecureDropAdmin(object):
                 assert update_status is True
                 assert tag == '0.6.1'
 
+    def test_check_for_updates_ensure_newline_stripped(self, tmpdir, caplog):
+        """Regression test for #3426"""
+        git_repo_path = str(tmpdir)
+        args = argparse.Namespace(root=git_repo_path)
+        current_tag = "0.6.1\n"
+        tags_available = "0.6\n0.6-rc1\n0.6.1\n"
+
+        with mock.patch('subprocess.check_call'):
+            with mock.patch('subprocess.check_output',
+                            side_effect=[current_tag, tags_available]):
+                update_status, tag = securedrop_admin.check_for_updates(args)
+                assert "All updates applied" in caplog.text
+                assert update_status is False
+                assert tag == '0.6.1'
+
     def test_check_for_updates_update_not_needed(self, tmpdir, caplog):
         git_repo_path = str(tmpdir)
         args = argparse.Namespace(root=git_repo_path)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3426.

Changes proposed in this pull request:
 * Strips newline from `current_tag` in `securedrop-admin check_for_updates` 

## Test plan

All of the following should be done in Tails.

### No updates needed case

0. Check out 0.6
1. Apply the diff in `admin/securedrop_admin/__init__.py` to 0.6
2. Run `./securedrop-admin check_for_updates`

You should see that updates are not needed: `INFO: All updates applied`

### Updates needed case

0. Check out a random branch that is not this one
1. Add a new tag locally that has a higher version number than the current prod version of SecureDrop, e.g. 0.7.0
2. Switch back to this branch
3. Run `./securedrop-admin check_for_updates`

You should see that updates are needed: `INFO: Update needed`

## Deployment

Will go out in workstation update

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container
