### PR TITLE
[0.7.0] Backport fix #3429

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -588,7 +588,8 @@ def check_for_updates(args):
     sdlog.info("Checking for SecureDrop updates...")
 
     # Determine what branch we are on
-    current_tag = subprocess.check_output(['git', 'describe'], cwd=args.root)
+    current_tag = subprocess.check_output(['git', 'describe'],
+                                          cwd=args.root).rstrip('\n')
 
     # Fetch all branches
     git_fetch_cmd = ['git', 'fetch', '--all']

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -66,6 +66,21 @@ class TestSecureDropAdmin(object):
                 assert update_status is True
                 assert tag == '0.6.1'
 
+    def test_check_for_updates_ensure_newline_stripped(self, tmpdir, caplog):
+        """Regression test for #3426"""
+        git_repo_path = str(tmpdir)
+        args = argparse.Namespace(root=git_repo_path)
+        current_tag = "0.6.1\n"
+        tags_available = "0.6\n0.6-rc1\n0.6.1\n"
+
+        with mock.patch('subprocess.check_call'):
+            with mock.patch('subprocess.check_output',
+                            side_effect=[current_tag, tags_available]):
+                update_status, tag = securedrop_admin.check_for_updates(args)
+                assert "All updates applied" in caplog.text
+                assert update_status is False
+                assert tag == '0.6.1'
+
     def test_check_for_updates_update_not_needed(self, tmpdir, caplog):
         git_repo_path = str(tmpdir)
         args = argparse.Namespace(root=git_repo_path)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
 * Backport fix in #3429

## Testing

If you're bored, run through test instructions in #3429 again ;-) 

## Deployment

Part of workstation code release in 0.7.0

## Checklist

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

