### PR TITLE
Document requirement to compile translations.

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -119,6 +119,11 @@ can simply scan the following QR code:
 
 .. image:: ../images/devenv/test-users-totp-qrcode.png
 
+.. note:: Only the English language will be functional by default. To use other
+   languages in your development environment, you must
+   `compile the translations <i18n.html#compiling-translations>`__.
+
+
 Setting up a multi-machine environment
 --------------------------------------
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3433.

This PR adds the following text to the [Setting up the development environment](https://docs.securedrop.org/en/release-0.7/development/setup_development.html) doc:

> 
> #### Note
> 
> Only the English language will be functional by default. To use other languages in your development environment, you must [compile the translations](https://docs.securedrop.org/en/release-0.7/development/i18n.html#compiling-translations).
> 

## Testing

N/A; docs only.

## Deployment

N/A; docs only.

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
