### PR TITLE
compile translations when setting up the docker development environment

### DIFF
--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -41,6 +41,7 @@ function reset_demo() {
     sudo chown -R "$(id -u)" /var/lib/securedrop
     cp ./tests/files/test_journalist_key.pub /var/lib/securedrop/keys
     gpg --homedir /var/lib/securedrop/keys --import /var/lib/securedrop/keys/test_journalist_key.pub >& /tmp/gpg.out || cat /tmp/gpg.out
+    ./i18n_tool.py translate-messages --compile
     ./manage.py reset
     ./create-dev-data.py
 }


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3395

## Testing

* git clone https://github.com/freedomofpress/securedrop/
* cd securedrop
* make -C securedrop dev
* firefox http://localhost:8080/?l=fr_FR
* check the display is french

## Deployment

N/A

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
