### PR TITLE
Fix improper reference link in logging.rst

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -240,6 +240,8 @@ Rebooting the Servers
 
   sudo reboot
 
+.. _investigating_logs:
+
 Investigating Logs
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -1,7 +1,7 @@
 Useful Logs
 ===========
 
-For tips on collecting these logs, see `Admin Guide > Investigating Logs <https://docs.securedrop.org/en/stable/admin.html#investigating-logs>`__
+For tips on collecting these logs, see the :ref:`admin guide <investigating_logs>`.
 
 Both servers
 ------------


### PR DESCRIPTION
Ready for review

- [x] Doc linting (`make docs-lint`) passed locally
