### PR TITLE
Add explanatory text to screensaver.

### DIFF
--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -5,53 +5,67 @@
 
 +base_rules
 
-@keyframes fadein
+@keyframes screensaver-stop
   from
-    opacity: 0
+    height: 100%
 
   to
-    opacity: 1
+    height: 0
 
 
-@-webkit-keyframes fadein
+@-webkit-keyframes screensaver-stop
   from
-    opacity: 0
+    height: 100%
 
   to
-    opacity: 1
+    height: 0
 
 
-@keyframes fadeout
+@keyframes screensaver-start
   0%
-    opacity: 1
+    height: 0
 
   98%
-    opacity: 1
+    height: 0
 
   100%
-    opacity: 0
+    height: 100%
 
 
-@-webkit-keyframes fadeout
+@-webkit-keyframes screensaver-start
   0%
-    opacity: 1
+    height: 0
 
   98%
-    opacity: 1
+    height: 0
 
   100%
-    opacity: 0
+    height: 100%
 
 
-html
-  animation: fadeout 120s
-  -webkit-animation: fadeout 120s
-  opacity: 0
+#screensaver
+  animation: screensaver-start 120s
+  -webkit-animation: screensaver-start 120s
+  animation-fill-mode: forwards
+  position: fixed
+  width: 100%
+  height: 0
+  top: 0
+  left: 0
+  z-index: 1000
+  overflow: hidden
+  color: $color_grey_medium
+  background-color: #fff
+  /* center contents vertically and horizontally */
+  display: flex
+  justify-content: center
+  flex-direction: column
+  text-align: center
 
-  &:hover
+  html:hover &
     animation: none
     -webkit-animation: none
-    opacity: 1
+    height: 0
 
 +source_index_rules
 

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -40,6 +40,8 @@
         </div>
       </div>
 
+      {% include 'screensaver.html' %}
+
       {% block footer %}
       <footer>
         {{ gettext('Like all software, SecureDrop may contain security bugs. Use at your own risk.') }} <br>{{ gettext('Powered by') }} SecureDrop {{ version }}.

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -81,6 +81,9 @@
       <div id="index-locales" class="center">
         {% include 'locales.html' %}
       </div>
+
+      {% include 'screensaver.html' %}
+
       <footer>
         {{ gettext('Like all software, SecureDrop may contain security bugs. Use at your own risk.') }}<br>{{ gettext('Powered by') }} SecureDrop {{ version }}.
       </footer>

--- a/securedrop/source_templates/screensaver.html
+++ b/securedrop/source_templates/screensaver.html
@@ -1,0 +1,3 @@
+      <div id="screensaver">
+        <p>{{ gettext('Interface hidden. Move your mouse here to show.') }}</p>
+      </div>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1975.

This PR adds an explanatory message to the ["screen saver"](https://github.com/freedomofpress/securedrop/issues/447) in the source interface. The message reads `Interface hidden. Move your mouse here to show.`, and looks like this:

<img width="530" src="https://user-images.githubusercontent.com/2976310/40139149-f2087b02-591c-11e8-87d4-03a03db663db.png">

### Implementation detail

The screen saver originally used a CSS animation to set `opacity: 0` on the `<html>` element. Since all page contents should be inside this element and we want to display text on the screensaver, I had to change the approach.

This PR uses a CSS animation to show a full-page `<div>` with a white background over the page contents.

### Possible improvements / discussion

I've gone with the minimal implementation to make this easier to review/merge. However, it seems reasonable to consider some further enhancements. If these sound valuable, I'd be happy to open follow-up issue(s) and/or PR's. Feedback appreciated.

- **Activate even if mouse is over the window**
    The screen saver only activates if the mouse is left outside of the window. If the source leaves their cursor over the window, it will never activate. Not sure if this can be achieved without JS, but it could be a progressive enhancement.

- **"Boss Key"**
    #1975 also suggests adding a [Boss Key](https://en.wikipedia.org/wiki/Boss_key). This would also require JS, but might be a useful way to allow a source to obfuscate the interface when an adversary is present.

- **Replace page title and favicon**
    When the screensaver and/or boss mode is active, we could remove the favicon, and replace the title with something generic (eg. `Interface Hidden`). This also requires JS, but it might be a useful enhancement.

## Testing

1. Open the Source interface in a browser.
2. Move your cursor outside of the window.
3. Wait two minutes for screen saver to appear.

## Deployment

Nothing special AFAIK.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
