### PR TITLE
Remove .close in modals.

### DIFF
--- a/securedrop/journalist_templates/_confirmation_modal.html
+++ b/securedrop/journalist_templates/_confirmation_modal.html
@@ -1,7 +1,6 @@
 <div id="{{ modal_data.modal_id }}" class="modal-dialog">
   <a href="#close" class="external"></a>
   <div>
-    <a href="#close" title="{{ gettext('Close') }}" class="close">X</a>
     <h2>{{ modal_data.modal_header }}</h2>
     <p>{{ modal_data.modal_body }}</p>
     <a href="#close" id="{{ modal_data.cancel_id }}" title="{{ gettext('Cancel') }}" class="btn sd-button">{{ gettext('Cancel') }}</a>

--- a/securedrop/sass/modules/_confirm-modal.sass
+++ b/securedrop/sass/modules/_confirm-modal.sass
@@ -30,21 +30,5 @@
     border-radius: 10px
     background: white
 
-  .close
-    background: $color_grey_medium
-    color: white
-    line-height: 25px
-    position: absolute
-    right: -12px
-    text-align: center
-    top: -10px
-    width: 24px
-    text-decoration: none
-    font-weight: bold
-    -moz-border-radius: 12px
-    border-radius: 12px
-    -moz-box-shadow: 1px 1px 3px #000
-    box-shadow: 1px 1px 3px #000
-
     &:hover
       background: $color_purple_medium


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes
Removal of the X .close in modal dialogs. 

All modal dialogs have a **cancel**/**don't do that thing** button. The **cancel**/**don't do that thing** button serves the purpose of cancelling the intended action much better. The button provides the user a clear action to cancel this action.

That means the X (a.close) is not needed.

Fixes #.

Changes proposed in this pull request:

## Testing

How should the reviewer test this PR?

1. Choose an individual file/msg or collection to be deleted
2. Click "Delete" button to delete the individual/collection of files/msgs in the SecureDrop journalist interface
3. When the modal is displayed, the X that shows [in this image](https://imgur.com/YFo4m75) should not be seen.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

None.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
