### PR TITLE
Apache AppArmor: Whitelist new source template screensaver.html

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -214,6 +214,7 @@
   /var/www/securedrop/source_templates/lookup.html r,
   /var/www/securedrop/source_templates/next_submission_flashed_message.html r,
   /var/www/securedrop/source_templates/notfound.html r,
+  /var/www/securedrop/source_templates/screensaver.html r,
   /var/www/securedrop/source_templates/session_timeout.html r,
   /var/www/securedrop/source_templates/tor2web-warning.html r,
   /var/www/securedrop/source_templates/use-tor-browser.html r,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3454.

Changes proposed in this pull request:
* Whitelist new source template screensaver.html

## Testing

1. Provision staging.
2. Verify you can navigate to the source interface in Tor Browser and you do not get a 500

## Deployment

Deployed in `securedrop-app-code` package

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
