### PR TITLE
replace pycryptodome with pyca/cryptography 2.0.3

### DIFF
--- a/securedrop/Dockerfile
+++ b/securedrop/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install -y devscripts \
                        python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
-                       gettext paxctl x11vnc enchant
+                       gettext paxctl x11vnc enchant libffi-dev
 
 RUN gem install sass -v 3.4.23
 

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -6,9 +6,9 @@ import os
 import io
 import scrypt
 import subprocess
+from random import SystemRandom
 
 from base64 import b32encode
-from Cryptodome.Random import random
 from flask import current_app
 from gnupg._util import _is_stream, _make_binary_stream
 
@@ -23,6 +23,10 @@ if typing.TYPE_CHECKING:
 
 # to fix gpg error #78 on production
 os.environ['USERNAME'] = 'www-data'
+
+# SystemRandom sources from the system rand (e.g. urandom, CryptGenRandom, etc)
+# It supplies a CSPRNG but with an interface that supports methods like choice
+random = SystemRandom()
 
 
 class CryptoException(Exception):

--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -1,4 +1,4 @@
-cryptography
+cryptography==2.0.3
 cssmin
 Flask-Assets
 Flask-Babel

--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -1,3 +1,4 @@
+cryptography
 cssmin
 Flask-Assets
 Flask-Babel
@@ -8,7 +9,6 @@ gnupg
 Jinja2
 jsmin
 psutil
-pycryptodomex
 pyotp
 qrcode
 redis

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -4,8 +4,11 @@
 #
 #    pip-compile --output-file securedrop/requirements/securedrop-app-code-requirements.txt securedrop/requirements/securedrop-app-code-requirements.in
 #
+asn1crypto==0.24.0        # via cryptography
 babel==2.5.1              # via flask-babel
+cffi==1.11.5              # via cryptography
 click==6.7                # via flask, rq
+cryptography==2.2.2
 cssmin==0.2.0
 flask-assets==0.12
 flask-babel==0.11.2
@@ -13,19 +16,20 @@ flask-sqlalchemy==2.3.2
 flask-wtf==0.14.2
 flask==0.12.2
 gnupg==2.3.1
+idna==2.6                 # via cryptography
 itsdangerous==0.24        # via flask
 jinja2==2.10
 jsmin==2.2.2
 markupsafe==1.0           # via jinja2
 psutil==5.4.3
-pycryptodomex==3.4.7
+pycparser==2.18           # via cffi
 pyotp==2.2.6
 pytz==2017.3              # via babel
 qrcode==5.3
 redis==2.10.6
 rq==0.10.0
 scrypt==0.8.0
-six==1.11.0               # via qrcode
+six==1.11.0               # via cryptography, qrcode
 sqlalchemy==1.2.0
 typing==3.6.4
 webassets==0.12.1         # via flask-assets

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -8,8 +8,9 @@ asn1crypto==0.24.0        # via cryptography
 babel==2.5.1              # via flask-babel
 cffi==1.11.5              # via cryptography
 click==6.7                # via flask, rq
-cryptography==2.2.2
+cryptography==2.0.3
 cssmin==0.2.0
+enum34==1.1.6             # via cryptography
 flask-assets==0.12
 flask-babel==0.11.2
 flask-sqlalchemy==2.3.2
@@ -17,6 +18,7 @@ flask-wtf==0.14.2
 flask==0.12.2
 gnupg==2.3.1
 idna==2.6                 # via cryptography
+ipaddress==1.0.22         # via cryptography
 itsdangerous==0.24        # via flask
 jinja2==2.10
 jsmin==2.2.2

--- a/securedrop/secure_tempfile.py
+++ b/securedrop/secure_tempfile.py
@@ -118,11 +118,17 @@ class SecureTemporaryFile(_TemporaryFileWrapper, object):
             return self.decryptor.update(self.file.read())
 
     def close(self):
+        """The __del__ method in tempfile._TemporaryFileWrapper (which
+        SecureTemporaryFile class inherits from) calls close() when the
+        temporary file is deleted.
+        """
         try:
             self.decryptor.finalize()
         except AlreadyFinalized:
             pass
 
+        # Since tempfile._TemporaryFileWrapper.close() does other cleanup,
+        # (i.e. deleting the temp file on disk), we need to call it also.
         super(SecureTemporaryFile, self).close()
 
 

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -9,7 +9,6 @@ import time
 import traceback
 import requests
 
-from Cryptodome import Random
 from datetime import datetime
 from multiprocessing import Process
 from os.path import abspath, dirname, join, realpath
@@ -113,14 +112,6 @@ class FunctionalTest(object):
         self.journalist_app = journalist_app.create_app(config)
 
         def start_source_server(app):
-            # We call Random.atfork() here because we fork the source and
-            # journalist server from the main Python process we use to drive
-            # our browser with multiprocessing.Process() below. These child
-            # processes inherit the same RNG state as the parent process, which
-            # is a problem because they would produce identical output if we
-            # didn't re-seed them after forking.
-            Random.atfork()
-
             config.SESSION_EXPIRATION_MINUTES = self.session_expiration
 
             app.run(
@@ -130,7 +121,6 @@ class FunctionalTest(object):
                 threaded=True)
 
         def start_journalist_server(app):
-            Random.atfork()
             app.run(
                 port=journalist_port,
                 debug=True,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3399, remix of #3400

See #3441 for why cryptography 2.0.3 is what we'll need to install in 0.8.0

## Testing

The integration tests and the secure tempfile unit tests here do test this functionality. 

In addition, one can manually test by submitting a file that is greater than 512KB and ensuring that you can successfully decrypt it. 

## Deployment

It will install without issue on existing and new installs

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container