### PR TITLE
 ansible: rules_v4 does not need to inspect unused ipv4 details

### DIFF
--- a/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
@@ -94,21 +94,21 @@
 
 # Permit direct SSH access.
 # Allowed for staging and optionally for production (disables ssh over tor)
-          {%- if not enable_ssh_over_tor -%}
-{% for interface in ansible_interfaces -%}
-  {%- if  hostvars[inventory_hostname]['ansible_'+interface].ipv4 -%}
-      {%- set int_details = hostvars[inventory_hostname]['ansible_'+interface].ipv4 -%}
-      {%- set net_string = '/'.join([int_details.network,int_details.netmask]) -%}
-      {%- if ssh_ip|ipaddr(net_string) -%}
-        {%- set ssh_int = interface -%}
+{%- if not enable_ssh_over_tor -%}
+  {% for interface in ansible_interfaces -%}
+    {%- if  hostvars[inventory_hostname]['ansible_'+interface].ipv4 -%}
+        {%- set int_details = hostvars[inventory_hostname]['ansible_'+interface].ipv4 -%}
+        {%- set net_string = '/'.join([int_details.network,int_details.netmask]) -%}
+        {%- if ssh_ip|ipaddr(net_string) -%}
+          {%- set ssh_int = interface -%}
 -A INPUT -s {{ adjacent_sd_ip }} -p tcp --dport 22 -j DROP -m comment --comment "Block explicitly SSH from the adjacent SD component"
 -A INPUT -i {{ ssh_int }} -s {{ ssh_net_in_override|default(admin_net_cidr) }} -p tcp --dport 22 -m state --state NEW -m limit --limit 3/min --limit-burst 3 -j ACCEPT -m comment --comment "Rate limit incoming ssh traffic"
 -A INPUT -i {{ ssh_int }} -s {{ ssh_net_in_override|default(admin_net_cidr) }} -p tcp --dport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
 -A OUTPUT -o {{ ssh_int }} -p tcp -m owner --uid-owner root --sport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
-      {%- endif %}
-  {%- endif %}
-{% endfor %}
-          {%- endif %}
+       {%- endif %}
+    {%- endif %}
+  {% endfor %}
+{%- endif %}
 
 # Allow generic loopback connections
 -A INPUT -i lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"

--- a/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
@@ -94,21 +94,21 @@
 
 # Permit direct SSH access.
 # Allowed for staging and optionally for production (disables ssh over tor)
+          {%- if not enable_ssh_over_tor -%}
 {% for interface in ansible_interfaces -%}
   {%- if  hostvars[inventory_hostname]['ansible_'+interface].ipv4 -%}
       {%- set int_details = hostvars[inventory_hostname]['ansible_'+interface].ipv4 -%}
       {%- set net_string = '/'.join([int_details.network,int_details.netmask]) -%}
       {%- if ssh_ip|ipaddr(net_string) -%}
         {%- set ssh_int = interface -%}
-          {%- if not enable_ssh_over_tor -%}
 -A INPUT -s {{ adjacent_sd_ip }} -p tcp --dport 22 -j DROP -m comment --comment "Block explicitly SSH from the adjacent SD component"
 -A INPUT -i {{ ssh_int }} -s {{ ssh_net_in_override|default(admin_net_cidr) }} -p tcp --dport 22 -m state --state NEW -m limit --limit 3/min --limit-burst 3 -j ACCEPT -m comment --comment "Rate limit incoming ssh traffic"
 -A INPUT -i {{ ssh_int }} -s {{ ssh_net_in_override|default(admin_net_cidr) }} -p tcp --dport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
 -A OUTPUT -o {{ ssh_int }} -p tcp -m owner --uid-owner root --sport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
-          {%- endif %}
       {%- endif %}
   {%- endif %}
 {% endfor %}
+          {%- endif %}
 
 # Allow generic loopback connections
 -A INPUT -i lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"

--- a/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
@@ -94,8 +94,8 @@
 
 # Permit direct SSH access.
 # Allowed for staging and optionally for production (disables ssh over tor)
-{%- if not enable_ssh_over_tor -%}
-  {% for interface in ansible_interfaces -%}
+{% if not enable_ssh_over_tor %}
+  {%- for interface in ansible_interfaces -%}
     {%- if  hostvars[inventory_hostname]['ansible_'+interface].ipv4 -%}
         {%- set int_details = hostvars[inventory_hostname]['ansible_'+interface].ipv4 -%}
         {%- set net_string = '/'.join([int_details.network,int_details.netmask]) -%}
@@ -107,8 +107,8 @@
 -A OUTPUT -o {{ ssh_int }} -p tcp -m owner --uid-owner root --sport 22 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
        {%- endif %}
     {%- endif %}
-  {% endfor %}
-{%- endif %}
+  {%- endfor %}
+{% endif %}
 
 # Allow generic loopback connections
 -A INPUT -i lo -p all -j ACCEPT -m comment --comment "Allow lo to lo traffic all protocols"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3465 

The iptables rules are only used when enable_ssh_over_tor is not
set. Save ansible the trouble of examining the details of the ipv4
address and interface when the result is not going to be used.

The main benefit is also to workaround a border case which is not
properly handled by ipaddr:

   ipaddr('184.20.18.54/255.255.255.255')

although valid fails with

   AnsibleFilterError: ipaddr: unknown filter type

This border case may be found in colocations where IP addresses are
distributed individually as /32 instead of being part of an allocated
subnet. It is however unlikely to be found in test environments or in
setups where the machines are allocated IPs in a private subnet.

## Comment

The [first commit](https://github.com/freedomofpress/securedrop/pull/3466/commits/8279b85ec97a3ab847bd04dcc81e50d275cd3f42) contains the change and the [second commit](https://github.com/freedomofpress/securedrop/pull/3466/commits/c2910305ea76b556da30f4986531be288a48a2e1) is whitespace only changes to facilitate review.

## Testing

[Install SecureDrop](https://docs.securedrop.org/en/latest/install.html) with and without **enable_ssh_over_tor** to verify it works as it did before the change. This seems really overkill and I wonder if there is a simpler way of checking the same?

## Deployment

N/A
