### PR TITLE
Fix staging environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,16 +44,12 @@ Vagrant.configure("2") do |config|
     end
     staging.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/securedrop-staging.yml"
+      ansible.inventory_path = "install_files/ansible-base/inventory-staging"
       ansible.verbose = 'v'
       # Taken from the parallel execution tips and tricks
       # https://docs.vagrantup.com/v2/provisioning/ansible.html
       ansible.limit = 'all,localhost'
       ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
-      ansible.groups = {
-        'securedrop_application_server' => %w(app-staging),
-        'securedrop_monitor_server' => %w(mon-staging),
-        'staging:children' => %w(securedrop_application_server securedrop_monitor_server),
-      }
     end
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,8 @@ Vagrant.configure("2") do |config|
       config.ssh.host = find_ssh_aths("mon-ssh-aths")
       config.ssh.proxy_command = tor_ssh_proxy_command
       config.ssh.port = 22
+    elsif ARGV[0] == "ssh"
+      config.ssh.host = "10.0.1.3"
     end
     staging.vm.hostname = "mon-staging"
     staging.vm.box = "bento/ubuntu-14.04"
@@ -31,6 +33,8 @@ Vagrant.configure("2") do |config|
       config.ssh.host = find_ssh_aths("app-ssh-aths")
       config.ssh.proxy_command = tor_ssh_proxy_command
       config.ssh.port = 22
+    elsif ARGV[0] == "ssh"
+      config.ssh.host = "10.0.1.2"
     end
     staging.vm.hostname = "app-staging"
     staging.vm.box = "bento/ubuntu-14.04"

--- a/install_files/ansible-base/group_vars/staging.yml
+++ b/install_files/ansible-base/group_vars/staging.yml
@@ -5,12 +5,9 @@ dns_server: "8.8.8.8"
 ### Used by the common role ###
 ssh_users: "vagrant"
 
-# Vagrant reserves eth0 for host gateway at 10.0.2.15; use eth1 for internal IPs.
-# In production, the IPs are hardcoded, and must also be set in the firewall config.
-primary_network_iface: eth1
-monitor_ip: "{{ hostvars['mon-staging']['ansible_'+primary_network_iface].ipv4.address }}"
+monitor_ip: 10.0.1.3
 monitor_hostname: "{{ hostvars['mon-staging'].ansible_hostname }}"
-app_ip: "{{ hostvars['app-staging']['ansible_'+primary_network_iface].ipv4.address }}"
+app_ip: 10.0.1.2
 app_hostname: "{{ hostvars['app-staging'].ansible_hostname }}"
 
 ### Used by the app role ###

--- a/install_files/ansible-base/inventory-staging
+++ b/install_files/ansible-base/inventory-staging
@@ -1,0 +1,9 @@
+[securedrop_application_server]
+app-staging ansible_host=10.0.1.2
+
+[securedrop_monitor_server]
+mon-staging ansible_host=10.0.1.3
+
+[staging:children]
+securedrop_monitor_server
+securedrop_application_server

--- a/install_files/ansible-base/roles/restrict-direct-access/defaults/main.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/defaults/main.yml
@@ -10,3 +10,14 @@ ssh_listening_address: "{{ '127.0.0.1' if enable_ssh_over_tor else '0.0.0.0' }}"
 # in separate plays, so declaring it within the context of iptables role, so
 # the hostname files can be fetched back to the Admin Workstation.
 tor_hidden_services_parent_dir: /var/lib/tor/services
+
+
+# Platform specific command for inferring the local interface utilized
+# to route to a specific IP host
+admin_net_int:
+  Linux:
+    cmd: "/bin/ip r get "
+    rgx: "(?<=dev )\\w+"
+  Darwin:
+    cmd: "/sbin/route -n get "
+    rgx: "(?<=interface: )\\w+"

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/iptables.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/iptables.yml
@@ -15,6 +15,13 @@
   # The process should be re-designed so the iptables rules are not applied in
   # bulk. When that is done this issue will be avoided.
 
+- name: Gather localhost facts first
+  setup:
+  become: no
+  delegate_to: localhost
+  delegate_facts: True
+  run_once: True
+
 - name: Copy load_iptables if-up script.
   copy:
     src: load_iptables
@@ -36,22 +43,16 @@
     - iptables
     - permissions
 
-- name: Determine admin network - first find admin net dev
+- name: Determine local platform specific routing info
   set_fact:
-    admin_dev: "{{ lookup('pipe','/bin/ip r get '+ssh_ip)|regex_search('(?<=dev )\\w+') }}"
+    admin_route_map: "{{ admin_net_int[hostvars['localhost']['ansible_system']] }}"
+
+- name: Record admin network interface
+  set_fact:
+    admin_dev: "{{ lookup('pipe',admin_route_map.cmd+ssh_ip)|regex_search(admin_route_map.rgx) }}"
   when: not enable_ssh_over_tor
-  tags:
-    - iptables
-    - permissions
 
-- name: Gather localhost facts first
-  setup:
-  become: no
-  delegate_to: localhost
-  delegate_facts: True
-  run_once: True
-
-- name: Determine admin network - next compute admin network cidr
+- name: Compute admin network CIDR
   set_fact:
     admin_net_cidr: "{{ '/'.join([hostvars['localhost']['ansible_'+admin_dev].ipv4.network,
                         hostvars['localhost']['ansible_'+admin_dev].ipv4.netmask]

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/iptables.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/iptables.yml
@@ -28,9 +28,6 @@
     dest: /etc/network/if-up.d/load_iptables
     owner: root
     mode: "0744"
-  tags:
-    - iptables
-    - permissions
 
 - name: Create iptables directory.
   file:
@@ -39,9 +36,6 @@
     owner: root
     group: root
     dest: /etc/network/iptables
-  tags:
-    - iptables
-    - permissions
 
 - name: Determine local platform specific routing info
   set_fact:
@@ -59,9 +53,6 @@
                         )|ipaddr('cidr') }}"
   delegate_to: localhost
   when: not enable_ssh_over_tor
-  tags:
-    - iptables
-    - permissions
 
 - name: Copy IPv4 iptables rules.
   template:
@@ -70,9 +61,6 @@
     owner: root
     mode: "0644"
   notify: drop flag for reboot
-  tags:
-    - iptables
-    - permissions
 
 - name: Copy IPv6 iptables rules.
   copy:
@@ -80,6 +68,3 @@
     dest: /etc/network/iptables/rules_v6
     owner: root
     mode: "0644"
-  tags:
-    - iptables
-    - permissions

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/main.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/main.yml
@@ -6,3 +6,6 @@
 - include: ssh.yml
 
 - include: iptables.yml
+  tags:
+    - iptables
+    - permissions

--- a/molecule/aws/aws-vars.yml
+++ b/molecule/aws/aws-vars.yml
@@ -1,6 +1,8 @@
 ---
 install_local_packages: true
 primary_network_iface: eth0
+app_ip: "{{ hostvars['app-staging']['ansible_'+primary_network_iface].ipv4.address }}"
+monitor_ip: "{{ hostvars['mon-staging'][].ipv4.address }}"
 ssh_users: sdrop
 enable_ssh_over_tor: false
 ssh_net_in_override: 0.0.0.0/0

--- a/molecule/vagrant_packager/ansible-override-vars.yml
+++ b/molecule/vagrant_packager/ansible-override-vars.yml
@@ -5,3 +5,5 @@ ssh_users: vagrant
 securedrop_app_install_from_repo: true
 allow_direct_access: true
 ssh_listening_address: 0.0.0.0
+app_ip: "{{ hostvars['app-staging']['ansible_'+primary_network_iface].ipv4.address }}"
+monitor_ip: "{{ hostvars['mon-staging'][].ipv4.address }}"


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #3318  

Changes proposed in this pull request:

* Pushes the wacky `primary_network_iface` variable to the depths of CI/AWS usage
* Enforces vagrant to tell ansible to connect over the static IPs we just setup
* With that ^^^ change, made a hacky work-around to tell vagrant to use those same static IPs for ssh usage. See the comments for a little bit of background for why I needed to do that.

I really wanted to go all out and move this under molecule and kill the staging/prod distinction here butttt this was faster :+1: 

## Testing

How should the reviewer test this PR?

* Be a Mac user (i need some Mac user specific feedback for the routing commands)
* Go through the developer docs and make sure you have virtualbox/kvm + vagrant setup and are in a virtualenv with dev python deps installed
* run `vagrant up /staging/` - confirm no errors
* confirm you can run `vagrant ssh app-staging` / `vagrant ssh mon-staging`
* confirm CI is passing
* confirm that you've seen `Dumb and Dumber`


## Deployment

Any special considerations for deployment? Consider both:

Nope only affects developers
