### PR TITLE
journalist notifications: allow 30 minutes variance in reboot times

### DIFF
--- a/install_files/ansible-base/group_vars/staging.yml
+++ b/install_files/ansible-base/group_vars/staging.yml
@@ -64,3 +64,4 @@ install_local_packages: true
 # the Apache service is configured correctly.
 securedrop_app_install_from_repo: False
 
+daily_reboot_time: 4 # An integer between 0 and 23

--- a/install_files/ansible-base/roles/app/tasks/setup_cron.yml
+++ b/install_files/ansible-base/roles/app/tasks/setup_cron.yml
@@ -20,6 +20,7 @@
   cron:
     name: Update the number of submissions in the past 24h
     job: "{{ securedrop_code }}/manage.py were-there-submissions-today"
-    special_time: daily
+    # 0 -> 23, 1 -> 0, 2 -> 1, ... 23 -> 22
+    hour: "{{ (daily_reboot_time + 23) % 24 }}"
   tags:
     - cron

--- a/install_files/ansible-base/roles/ossec/files/process_submissions_today.sh
+++ b/install_files/ansible-base/roles/ossec/files/process_submissions_today.sh
@@ -17,8 +17,18 @@ function main() {
 function modified_in_the_past_24h() {
     local stamp
     stamp="$1"
+    #
+    # 24h is 1440 minutes but we subtract 30min to avoid the following race condition
+    #
+    # - machine reboots
+    # - notification sent
+    # - machine reboots 24h later but reboots 1 minute faster than the previous day
+    # - notification is sent 23h59 minutes after the last one and suppressed
+    #
+    local one_day
+    one_day=1410
     test -f "${stamp}" && \
-        find "${stamp}" -mtime -1 | \
+        find "${stamp}" -mmin "-${one_day}" | \
             grep --quiet "${stamp}"
 }
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes: #3478

The race condition goes as follows:

  - machine reboots
  - notification sent
  - machine reboots 24h later but reboots 1 minute faster than the previous day
  - notification is sent 23h59 minutes after the last one and suppressed

The notification will be sent the next day but the information it
contains will not reflect what happened in the past 24h because the cron job

   manage.py were-there-submissions-today

updates it daily, one hour before the machine reboots.

To resolve this race condition (or make it extremely unlikely) we
allow for notifications to be sent at most every 23h30.

Case 1: machine is slower to reboot the next day:

  - machine reboots
  - notification sent
  - machine reboots 24h later but reboots 5 minutes slower than the previous day
  - notification is processed 24h05 minutes after the last one, it is
    more tha 23h30 and therefore the notification is sent

Case 2: machine is faster to reboot the next day:

  - machine reboots
  - notification sent
  - machine reboots 24h later but reboots 8 minutes faster than the previous day
  - notification is processed 23h52 minutes after the last one, it is
    more tha 23h30 and therefore the notification is sent

## Testing

Testinfra tests changing the time of the app server are implemented. I do not think manual testing is possible for this race condition but I'm open to ideas.

## Deployment

* `./securedrop-admin install` must be run to fix the bug
* The cron job `ansible-base/roles/app/tasks/setup_cron.yml` updating the number of submissions in the past 24h will change to happen one hour before the reboot instead of midnight
* As a result it is possible that the journalist notification does not reflect the 

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
