### PR TITLE
More integration tests for securedrop-admin

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -6,7 +6,7 @@ ARG USER_ID
 ENV USER_ID ${USER_ID:-0}
 
 RUN apt-get update
-RUN apt-get install -y python sudo lsb-release gnupg2
+RUN apt-get install -y python sudo lsb-release gnupg2 git
 RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi
 
 WORKDIR /opt

--- a/admin/requirements-dev.in
+++ b/admin/requirements-dev.in
@@ -6,5 +6,6 @@ pbr
 pip-tools>2.0.0
 pylint
 pytest
+requests
 tox
 pexpect

--- a/admin/requirements-dev.txt
+++ b/admin/requirements-dev.txt
@@ -16,6 +16,14 @@ backports.functools-lru-cache==1.4 \
     --hash=sha256:31f235852f88edc1558d428d890663c49eb4514ffec9f3650e7f3c9e4a12e36f \
     --hash=sha256:4ba998e881f285c1d1b73f5b6e3766539b4e162320f9589334400c5ddc35198c \
     # via astroid, pylint
+certifi==2018.4.16 \
+    --hash=sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7 \
+    --hash=sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0 \
+    # via requests
+chardet==3.0.4 \
+    --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
+    --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
+    # via requests
 click==6.7 \
     --hash=sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d \
     --hash=sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b \
@@ -75,6 +83,10 @@ funcsigs==1.0.2 \
     --hash=sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca \
     --hash=sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50 \
     # via mock, pytest
+idna==2.6 \
+    --hash=sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f \
+    --hash=sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4 \
+    # via requests
 isort==4.2.15 \
     --hash=sha256:79f46172d3a4e2e53e7016e663cc7a8b538bec525c36675fcfd2767df30b3983 \
     --hash=sha256:cd5d3fc2c16006b567a17193edf4ed9830d9454cbeb5a42ac80b36ea00c23db4 \
@@ -153,6 +165,9 @@ pylint==1.8.1 \
 pytest==3.3.1 \
     --hash=sha256:ae4a2d0bae1098bbe938ecd6c20a526d5d47a94dc42ad7331c9ad06d0efe4962 \
     --hash=sha256:cf8436dc59d8695346fcd3ab296de46425ecab00d64096cebe79fb51ecb2eb93
+requests==2.18.4 \
+    --hash=sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b \
+    --hash=sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e
 singledispatch==3.4.0.3 \
     --hash=sha256:5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c \
     --hash=sha256:833b46966687b3de7f438c761ac475213e53b306740f1abfaa86e1d1aae56aa8 \
@@ -164,6 +179,10 @@ six==1.11.0 \
 tox==2.9.1 \
     --hash=sha256:752f5ec561c6c08c5ecb167d3b20f4f4ffc158c0ab78855701a75f5cef05f4b8 \
     --hash=sha256:8af30fd835a11f3ff8e95176ccba5a4e60779df4d96a9dfefa1a1704af263225
+urllib3==1.22 \
+    --hash=sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b \
+    --hash=sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f \
+    # via requests
 virtualenv==15.1.0 \
     --hash=sha256:02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a \
     --hash=sha256:39d88b533b422825d644087a21e78c45cf5af0ef7a99a1fc9fbb7b481e5c85b0 \

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -490,6 +490,11 @@ class TestGitOperations:
         child = pexpect.spawn(fullcmd)
         child.expect('Update needed', timeout=20)
 
+        child.expect(pexpect.EOF, timeout=10)  # Wait for CLI to exit
+        child.close()
+        assert child.exitstatus == 0
+        assert child.signalstatus is None
+
     def test_update(self):
         cmd = os.path.join(os.path.dirname(CURRENT_DIR),
                            'securedrop_admin/__init__.py')
@@ -498,3 +503,8 @@ class TestGitOperations:
         child = pexpect.spawn('python {0} --root {1} update'.format(
                               cmd, ansible_base))
         child.expect('Updated to SecureDrop', timeout=20)
+
+        child.expect(pexpect.EOF, timeout=10)  # Wait for CLI to exit
+        child.close()
+        assert child.exitstatus == 0
+        assert child.signalstatus is None

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -459,9 +459,13 @@ class TestGitOperations:
     def setup_method(self, method):
         global NEW_TMP_DIR
         NEW_TMP_DIR = tempfile.mkdtemp()
-        cmd = ['cp', '-r', '../', NEW_TMP_DIR]
+
+        # Clone the SecureDrop repository into a temp directory and move there.
+        cmd = ['git', 'clone',
+               'https://github.com/freedomofpress/securedrop.git']
         subprocess.check_call(cmd)
-        os.chdir(os.path.join(NEW_TMP_DIR, 'admin'))
+        subprocess.check_call(["mv", "securedrop", NEW_TMP_DIR])
+        os.chdir(os.path.join(NEW_TMP_DIR, 'securedrop/admin'))
         subprocess.check_call('git reset --hard'.split())
         # Now we will put in our own git configuration
         with io.open('../.git/config', 'w') as fobj:
@@ -479,17 +483,18 @@ class TestGitOperations:
     def test_check_for_update(self):
         cmd = os.path.join(os.path.dirname(CURRENT_DIR),
                            'securedrop_admin/__init__.py')
+        ansible_base = os.path.join(NEW_TMP_DIR,
+                                    'securedrop/install_files/ansible-base')
         fullcmd = 'python {0} --root {1} check_for_updates'.format(
-                  cmd, os.path.join(NEW_TMP_DIR,
-                                    'install_files/ansible-base '))
+                  cmd, ansible_base)
         child = pexpect.spawn(fullcmd)
         child.expect('Update needed', timeout=20)
 
     def test_update(self):
         cmd = os.path.join(os.path.dirname(CURRENT_DIR),
                            'securedrop_admin/__init__.py')
+        ansible_base = os.path.join(NEW_TMP_DIR,
+                                    'securedrop/install_files/ansible-base')
         child = pexpect.spawn('python {0} --root {1} update'.format(
-                              cmd, os.path.join(
-                                                NEW_TMP_DIR,
-                                                'install_files/ansible-base')))
+                              cmd, ansible_base))
         child.expect('Updated to SecureDrop', timeout=20)

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -484,3 +484,12 @@ class TestGitOperations:
                                     'install_files/ansible-base '))
         child = pexpect.spawn(fullcmd)
         child.expect('Update needed', timeout=20)
+
+    def test_update(self):
+        cmd = os.path.join(os.path.dirname(CURRENT_DIR),
+                           'securedrop_admin/__init__.py')
+        child = pexpect.spawn('python {0} --root {1} update'.format(
+                              cmd, os.path.join(
+                                                NEW_TMP_DIR,
+                                                'install_files/ansible-base')))
+        child.expect('Updated to SecureDrop', timeout=20)

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -466,6 +466,14 @@ def securedrop_git_repo(tmpdir):
     subprocess.check_call('git checkout 0.6'.split())
     yield tmpdir
 
+    # Save coverage information in same directory as unit test coverage
+    test_name = str(tmpdir).split('/')[-1]
+    subprocess.check_call(['cp',
+                           '{}/securedrop/admin/.coverage'.format(
+                               str(tmpdir)),
+                           '{}/../.coverage.{}'.format(CURRENT_DIR,
+                                                       test_name)])
+
 
 # This class is to test all the git related operations.
 class TestGitOperations:
@@ -474,7 +482,7 @@ class TestGitOperations:
                            'securedrop_admin/__init__.py')
         ansible_base = os.path.join(str(securedrop_git_repo),
                                     'securedrop/install_files/ansible-base')
-        fullcmd = 'python {0} --root {1} check_for_updates'.format(
+        fullcmd = 'coverage run {0} --root {1} check_for_updates'.format(
                   cmd, ansible_base)
         child = pexpect.spawn(fullcmd)
         child.expect('Update needed', timeout=20)
@@ -497,7 +505,7 @@ class TestGitOperations:
                            'securedrop_admin/__init__.py')
         ansible_base = os.path.join(str(securedrop_git_repo),
                                     'securedrop/install_files/ansible-base')
-        fullcmd = 'python {0} --root {1} check_for_updates'.format(
+        fullcmd = 'coverage run {0} --root {1} check_for_updates'.format(
                   cmd, ansible_base)
         child = pexpect.spawn(fullcmd)
         child.expect('All updates applied', timeout=20)
@@ -525,7 +533,7 @@ class TestGitOperations:
                            'securedrop_admin/__init__.py')
         ansible_base = os.path.join(str(securedrop_git_repo),
                                     'securedrop/install_files/ansible-base')
-        child = pexpect.spawn('python {0} --root {1} update'.format(
+        child = pexpect.spawn('coverage run {0} --root {1} update'.format(
                               cmd, ansible_base))
         child.expect('Updated to SecureDrop', timeout=100)
 

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -519,6 +519,19 @@ class TestGitOperations:
         assert child.signalstatus is None
 
     def test_update(self):
+        gpgdir = os.path.join(os.path.expanduser('~'), '.gnupg')
+
+        # If gpg.conf doesn't exist, create it and set a reliable default
+        # keyserver for the tests.
+        gpgconf_path = os.path.join(gpgdir, 'gpg.conf')
+        if not os.path.exists(gpgconf_path):
+            os.mkdir(gpgdir)
+            with open(gpgconf_path, 'a') as f:
+                f.write('keyserver hkp://ipv4.pool.sks-keyservers.net')
+
+            # Ensure correct permissions on .gnupg home directory.
+            os.chmod(gpgdir, 0700)
+
         cmd = os.path.join(os.path.dirname(CURRENT_DIR),
                            'securedrop_admin/__init__.py')
         ansible_base = os.path.join(NEW_TMP_DIR,

--- a/admin/tox.ini
+++ b/admin/tox.ini
@@ -10,6 +10,7 @@ whitelist_externals = *
 commands = env \
          {envbindir}/coverage run --source=securedrop_admin,bootstrap \
          {envbindir}/py.test -v {posargs:tests}
+         {envbindir}/coverage combine --append
          {envbindir}/coverage report --omit=*test*,*tox* --show-missing
 
 [testenv:flake8]


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3459  and #3460 

We now have two tests to check `update` and `check_for_update` subcommands of `securedrop-admin`.
This work is on top of #3472.

## Testing

```
make -C admin test
```


## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
