### PR TITLE
securedrop-app-code: Remove extra python-pip in Depends field

### DIFF
--- a/install_files/securedrop-app-code/DEBIAN/control
+++ b/install_files/securedrop-app-code/DEBIAN/control
@@ -6,5 +6,5 @@ Homepage: https://securedrop.org
 Package: securedrop-app-code
 Version: 0.8.0~rc1
 Architecture: amd64
-Depends: python-pip,apparmor-utils,gnupg2,haveged,python,python-pip,secure-delete,sqlite,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor,securedrop-keyring,securedrop-config
+Depends: python-pip,apparmor-utils,gnupg2,haveged,python,secure-delete,sqlite,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor,securedrop-keyring,securedrop-config
 Description: Packages the SecureDrop application code pip dependencies and apparmor profiles. This package will put the apparmor profiles in enforce mode. This package does use pip to install the pip wheelhouse


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
* We have `python-pip` twice in the Depends field in the securedrop-app-code package, this is unnecessary

## Testing

Does CI pass?

## Deployment

There should be no deployment issues

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
