### PR TITLE
Bump libvirt upgrade testing SD boxes to 0.7

### DIFF
--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -12,7 +12,7 @@ platforms:
   - name: app-staging
     box: fpf/securedrop-app
     box_url: "../vagrant_packager/box_files/app_metadata.json"
-    box_version: "0.6"
+    box_version: "0.7"
     instance_raw_config_args:
       - "ssh.insert_key = false"
     provider_override_args:
@@ -27,7 +27,7 @@ platforms:
   - name: mon-staging
     box: fpf/securedrop-mon
     box_url: "../vagrant_packager/box_files/mon_metadata.json"
-    box_version: "0.6"
+    box_version: "0.7"
     instance_raw_config_args:
       - "ssh.insert_key = false"
     provider_override_args:

--- a/molecule/vagrant_packager/box_files/app_metadata.json
+++ b/molecule/vagrant_packager/box_files/app_metadata.json
@@ -3,35 +3,13 @@
   "description": "This box contains securedrop app server.",
   "versions": [
     {
-      "version": "0.5.2",
+      "version": "0.7",
       "providers": [
         {
           "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.5.2.box",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.7.box",
           "checksum_type": "sha256",
-          "checksum": "58f88fbb27b5c73f65340de78c49a0bc36b32408ab4b4cb97868d4ea7beb6743"
-        }
-      ]
-    },
-    {
-      "version": "0.5.2-1",
-      "providers": [
-        {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.5.2_1.box",
-          "checksum_type": "sha256",
-          "checksum": "a66128ea3c9212e7f9589f004652d88b003ba4554b5cceec66cd35b3870c9038"
-        }
-      ]
-    },
-    {
-      "version": "0.6",
-      "providers": [
-        {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.6.box",
-          "checksum_type": "sha256",
-          "checksum": "49486db31e66cfa815c2b80b3c41385064df6986ed12427f6627ac4ad400ba5b"
+          "checksum": "468923f1e77068b8de96808ed8f52dbe93db3ff0aba8647c37c2d2e83b8367e9"
         }
       ]
     }

--- a/molecule/vagrant_packager/box_files/mon_metadata.json
+++ b/molecule/vagrant_packager/box_files/mon_metadata.json
@@ -3,35 +3,13 @@
   "description": "This box contains securedrop monitor server.",
   "versions": [
     {
-      "version": "0.5.2",
+      "version": "0.7",
       "providers": [
         {
           "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.5.2.box",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.7.box",
           "checksum_type": "sha256",
-          "checksum": "d63744aed5e99922868e2eca6cefdc08d112624c222b48485a0bf91aecfb5b7c"
-        }
-      ]
-    },
-    {
-      "version": "0.5.2-1",
-      "providers": [
-        {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.5.2_1.box",
-          "checksum_type": "sha256",
-          "checksum": "cb362331753f56fd144b8512e2bf3fe2b1fde169475401f438ad9d0d15265912"
-        }
-      ]
-    },
-    {
-      "version": "0.6",
-      "providers": [
-        {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.6.box",
-          "checksum_type": "sha256",
-          "checksum": "6420493d0571163d284c9808ab6a995247732ae5ad62ee2e1018ead73054d0e9"
+          "checksum": "4358d2e31ee5dcfe4098fd2bedba3122967992de4c9b2dfb773805141d5ad633"
         }
       ]
     }

--- a/molecule/vagrant_packager/sd_clone.yml
+++ b/molecule/vagrant_packager/sd_clone.yml
@@ -16,5 +16,5 @@
         version: "release/{{ ORIG_SECUREDROP_VER }}"
         depth: 1
   vars:
-    ORIG_SECUREDROP_VER: 0.6
+    ORIG_SECUREDROP_VER: 0.7
     molecule_ephemeral_directory: "{{ playbook_dir }}/.molecule"


### PR DESCRIPTION
Ready for review


Fixes #3495

Changes proposed in this pull request:


From a box running libvirt:

* `$ molecule converge -s upgrade`. Ensure that it takes a whileeeeeeeee (should be pulling down 2GB+ of images
* At the end of the run you'll see a onion address displayed. Visit that address and confirm you are getting a 0.7 box coming up :)


None, only applicable to a subset of developers.