### PR TITLE
Install Tor browser and geckodriver

### DIFF
--- a/install_files/ansible-base/roles/app-test/defaults/main.yml
+++ b/install_files/ansible-base/roles/app-test/defaults/main.yml
@@ -14,3 +14,17 @@ test_apt_dependencies:
 
 # Additional Python dependencies required for running the application tests.
 test_pip_requirements: "{{ securedrop_code }}/requirements/test-requirements.txt"
+
+# Specify TBB version to download and install
+tbb_release: 7.5.4
+tbb_locale: en-US
+tbb_arch: 64
+tbb_directory: "/home/{{ ansible_user|default(ansible_ssh_user|default(lookup('env', 'USER'))) }}/.local/tbb"
+tbb_signing_key: EF6E286DDA85EA2A4BA7DE684E2C6E8793298290
+keyserver: "hkp://ipv4.pool.sks-keyservers.net"
+tbb_apt_dependencies:
+  - libasound2
+  - libdbus-glib-1-2
+  - libfontconfig1
+  - libgtk2.0-0
+  - libxrender1

--- a/install_files/ansible-base/roles/app-test/tasks/install_tbb.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/install_tbb.yml
@@ -1,0 +1,71 @@
+---
+- name: Install TBB apt dependencies.
+  sudo: true
+  apt:
+    name: "{{ item }}"
+    state: latest
+    update_cache: yes
+    cache_valid_time: 3600
+  with_items: "{{ tbb_apt_dependencies }}"
+
+- name: Create tbb directory.
+  sudo: true
+  file:
+    path: "{{ tbb_directory }}"
+    state: directory
+    owner: "{{ securedrop_user }}"
+    group: "{{ securedrop_user }}"
+    mode: "0770"
+
+- name: Download TBB {{ tbb_release }} tarball and signature.
+  get_url:
+    url: "{{ item }}"
+    dest: "{{ tbb_directory }}/{{ item|basename }}"
+  with_items:
+    - https://dist.torproject.org/torbrowser/{{ tbb_release }}/tor-browser-linux{{ tbb_arch }}-{{ tbb_release }}_{{ tbb_locale }}.tar.xz
+    - https://dist.torproject.org/torbrowser/{{ tbb_release }}/tor-browser-linux{{ tbb_arch }}-{{ tbb_release }}_{{ tbb_locale }}.tar.xz.asc
+
+- name: Install gnupg-curl
+  sudo: true
+  apt:
+    name: gnupg-curl
+    state: present
+
+- name: Download TBB {{ tbb_release }} signing key.
+  sudo: true
+  command: gpg --keyserver {{ keyserver }} --recv-key {{ tbb_signing_key }}
+  register: gpg_import_tor_browser_devs_key_result
+  changed_when: "'imported: 1' in gpg_import_tor_browser_devs_key_result.stderr"
+
+- name: Verify TBB {{ tbb_release }} signature.
+  command: >
+    gpg --verify
+    tor-browser-linux{{ tbb_arch }}-{{ tbb_release }}_{{ tbb_locale }}.tar.xz.asc
+    tor-browser-linux{{ tbb_arch }}-{{ tbb_release }}_{{ tbb_locale }}.tar.xz
+  register: gpg_verify_result
+  changed_when: false
+  args:
+    chdir: "{{ tbb_directory }}"
+
+- name: Extract TBB {{ fpsd_crawler_tbb_release }} archive.
+  unarchive:
+    copy: no
+    src: "{{ tbb_directory }}/tor-browser-linux{{ tbb_arch }}-{{ tbb_release }}_{{ tbb_locale }}.tar.xz"
+    dest: "{{ tbb_directory }}"
+    owner: "{{ securedrop_user }}"
+    group: "{{ securedrop_user }}"
+    mode: "0770"
+
+- name: Download geckodriver for compatibility with Tor
+  get_url:
+    dest: "/opt/geckodriver-v0.17.0-linux64.tar.gz"
+    url: https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz
+    sha256sum: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+  tags:
+    - apt
+
+- name: install geckodriver
+  shell: |
+    cd /bin
+    tar -zxvf /opt/geckodriver-v0.17.0-linux64.tar.gz
+    chmod +x geckodriver

--- a/install_files/ansible-base/roles/app-test/tasks/main.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/main.yml
@@ -16,3 +16,5 @@
 - include: disable_mprotect_ff_plugin_container.yml
 
 - include: modern_gettext.yml
+
+- include: install_tbb.yml


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #3485

Installs Tor browser and geckodriver. I think the ansible logic can be improved.



## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
