### PR TITLE
Remove 2FA from console logins for App + Mon servers

### DIFF
--- a/install_files/ansible-base/roles/restrict-direct-access/files/common-auth
+++ b/install_files/ansible-base/roles/restrict-direct-access/files/common-auth
@@ -1,4 +1,3 @@
-auth required pam_google_authenticator.so
 auth    [success=1 default=ignore]      pam_unix.so nullok_secure
 auth    requisite                       pam_deny.so
 auth    required                        pam_permit.so

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/ssh.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/ssh.yml
@@ -1,14 +1,4 @@
 ---
-- name: Install 2FA pam module.
-  apt:
-    name: libpam-google-authenticator
-    state: latest
-  tags:
-    - apt
-    - 2fa
-    - ssh
-    - pam
-
 - name: Copy SSH client config file.
   copy:
     src: ssh_config

--- a/install_files/securedrop-config/DEBIAN/postinst
+++ b/install_files/securedrop-config/DEBIAN/postinst
@@ -4,6 +4,13 @@
 set -e
 set -x
 
+remove_2fa_tty_req() {
+    # The goal here is to remove legacy 2FA req on TTY logins
+    # Lets prevent this from bombing out the install though if it fails
+    auth_file=/etc/pam.d/common-auth
+    sed -i "/^auth\ required\ pam_google.*/d" ${auth_file} || true
+}
+
 case "$1" in
     configure)
 
@@ -15,6 +22,7 @@ case "$1" in
     if [ -f "$apt_security_list" ]; then
         sed -i 's/deb\.torproject\.org\/torproject\.org/tor-apt.freedom.press/g' "$apt_security_list"
     fi
+    remove_2fa_tty_req
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/testinfra/common/test_system_hardening.py
+++ b/testinfra/common/test_system_hardening.py
@@ -76,3 +76,14 @@ def test_swap_disabled(Command):
     # Expect that ONLY the headers will be present in the output.
     rgx = re.compile("Filename\s*Type\s*Size\s*Used\s*Priority")
     assert re.search(rgx, c)
+
+
+def test_twofactor_disabled_on_tty(host):
+    """
+    Having 2FA on TTY logins is security theater on systems without encrypted drives.
+    Let's make sure this option is disabled!
+    """
+
+    pam_auth_file = host.file("/etc/pam.d/common-auth").content_string
+
+    assert "auth required pam_google_authenticator.so" not in pam_auth_file

--- a/testinfra/common/test_system_hardening.py
+++ b/testinfra/common/test_system_hardening.py
@@ -80,7 +80,7 @@ def test_swap_disabled(Command):
 
 def test_twofactor_disabled_on_tty(host):
     """
-    Having 2FA on TTY logins is security theater on systems without encrypted drives.
+    Having 2FA on TTY logins is cumbersome on systems without encrypted drives.
     Let's make sure this option is disabled!
     """
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3247 

Changes proposed in this pull request:

* Removes 2FA tty console requirements
* Adds a test to confirm the 2FA requirement is gone

## Testing

How should the reviewer test this PR?

### New Install

Run the vagrant staging scenario and confirm you CAN login via console using `vagrant` / `vagrant` credentials.

### Upgrade testing

 You need to be a Linux/KVM user for these instructions:

```bash
$ make build-debs # build new debian packages
$ molecule converge -s upgrade # fire up 0.7 instances
```
* Confirm you can NOT login via console with `vagrant` / `vagrant`

Now lets upgrade the systems with latest `securedrop-config` pkg:

```bash
$ molecule side-effect -s upgrade
```

* Confirm you CAN login via console with `vagrant` / `vagrant` (you might have to let it error out a few times. Ive noticed that when the screen refreshes on the console thats when it'll re-read the latest pam settings)

Want to run the test infra tests?

```bash
$ SECUREDROP_TESTINFRA_TARGET_HOST=app-staging pytest --hosts=app-staging --connection=ansible --ansible-inventory=/tmp/molecule/securedrop/upgrade/ansible_inventory.yml testinfra/common/test_system_hardening.py -k test_twofactor_disabled_on_tty 
$ SECUREDROP_TESTINFRA_TARGET_HOST=mon-staging pytest --hosts=mon-staging --connection=ansible --ansible-inventory=/tmp/molecule/securedrop/upgrade/ansible_inventory.yml testinfra/common/test_system_hardening.py -k test_twofactor_disabled_on_tty 
```


## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.   
The `securedrop-config` postinst hook should take care of this
2. New installs.
The `securedrop-config` postinst hook AND ansible should address this.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass