### PR TITLE
Added passlib for more flexible password hashing

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -120,7 +120,7 @@ created by default when running ``make dev``. In addition, sources and
 submissions are present. The test users have the following credentials:
 
 * **Username:** ``journalist`` or ``dellsberg``
-* **Password:** ``WEjwn8ZyczDhQSK24YKM8C9a``
+* **Password:** ``correct horse battery staple profanity oil chewy``
 * **TOTP secret:** ``JHCO GO7V CER3 EJ4L``
 
 .. note:: The password and TOTP secret are the same for both accounts for

--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -38,6 +38,7 @@ appserver_dependencies:
   - apparmor-utils
   - redis-server
   - supervisor
+  - libpython2.7-dev
 
 tor_apt_repo_url: https://tor-apt.freedom.press
 

--- a/install_files/securedrop-app-code/DEBIAN/control
+++ b/install_files/securedrop-app-code/DEBIAN/control
@@ -6,5 +6,5 @@ Homepage: https://securedrop.org
 Package: securedrop-app-code
 Version: 0.9.0~rc1
 Architecture: amd64
-Depends: python-pip,apparmor-utils,gnupg2,haveged,python,secure-delete,sqlite3,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor,securedrop-keyring,securedrop-config
+Depends: python-pip,apparmor-utils,gnupg2,haveged,python,secure-delete,sqlite3,apache2-mpm-worker,libapache2-mod-wsgi,libapache2-mod-xsendfile,redis-server,supervisor,securedrop-keyring,securedrop-config,libpython2.7-dev
 Description: Packages the SecureDrop application code pip dependencies and apparmor profiles. This package will put the apparmor profiles in enforce mode. This package does use pip to install the pip wheelhouse

--- a/securedrop/alembic/versions/2d0ce3ee5bdc_added_passphrase_hash_column_to_.py
+++ b/securedrop/alembic/versions/2d0ce3ee5bdc_added_passphrase_hash_column_to_.py
@@ -1,0 +1,53 @@
+"""added passphrase_hash column to journalists table
+
+Revision ID: 2d0ce3ee5bdc
+Revises: faac8092c123
+Create Date: 2018-06-08 15:08:37.718268
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2d0ce3ee5bdc'
+down_revision = 'faac8092c123'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('journalists', sa.Column('passphrase_hash', sa.String(length=256), nullable=True))
+
+
+def downgrade():
+    # sqlite has no `drop column` command, so we recreate the original table
+    # then load it from a temp table
+
+    op.rename_table('journalists', 'journalists_tmp')
+
+    op.create_table('journalists',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('username', sa.String(length=255), nullable=False),
+        sa.Column('pw_salt', sa.Binary(), nullable=True),
+        sa.Column('pw_hash', sa.Binary(), nullable=True),
+        sa.Column('is_admin', sa.Boolean(), nullable=True),
+        sa.Column('otp_secret', sa.String(length=16), nullable=True),
+        sa.Column('is_totp', sa.Boolean(), nullable=True),
+        sa.Column('hotp_counter', sa.Integer(), nullable=True),
+        sa.Column('last_token', sa.String(length=6), nullable=True),
+        sa.Column('created_on', sa.DateTime(), nullable=True),
+        sa.Column('last_access', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('username')
+    )
+
+    conn = op.get_bind()
+    conn.execute('''
+        INSERT INTO journalists
+        SELECT id, username, pw_salt, pw_hash, is_admin, otp_secret, is_totp,
+               hotp_counter, last_token, created_on, last_access
+        FROM journalists_tmp
+    ''')
+    
+    op.drop_table('journalists_tmp')

--- a/securedrop/alembic/versions/2d0ce3ee5bdc_added_passphrase_hash_column_to_.py
+++ b/securedrop/alembic/versions/2d0ce3ee5bdc_added_passphrase_hash_column_to_.py
@@ -1,7 +1,7 @@
 """added passphrase_hash column to journalists table
 
 Revision ID: 2d0ce3ee5bdc
-Revises: faac8092c123
+Revises: fccf57ceef02 
 Create Date: 2018-06-08 15:08:37.718268
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '2d0ce3ee5bdc'
-down_revision = 'faac8092c123'
+down_revision = 'fccf57ceef02'
 branch_labels = None
 depends_on = None
 

--- a/securedrop/create-dev-data.py
+++ b/securedrop/create-dev-data.py
@@ -14,15 +14,12 @@ from models import Journalist, Source, Submission
 def add_test_user(username, password, otp_secret, is_admin=False):
     context = journalist_app.create_app(config).app_context()
     context.push()
-    valid_password = "correct horse battery staple profanity oil chewy"
 
     try:
         user = Journalist(username=username,
-                          password=valid_password,
+                          password=password,
                           is_admin=is_admin)
         user.otp_secret = otp_secret
-        user.pw_salt = user._gen_salt()
-        user.pw_hash = user._scrypt_hash(password, user.pw_salt)
         db.session.add(user)
         db.session.commit()
         print('Test user successfully added: '
@@ -72,7 +69,7 @@ def create_source_and_submissions(num_submissions=2):
 
 if __name__ == "__main__":  # pragma: no cover
     # Add two test users
-    test_password = "WEjwn8ZyczDhQSK24YKM8C9a"
+    test_password = "correct horse battery staple profanity oil chewy"
     test_otp_secret = "JHCOGO7VCER3EJ4L"
 
     add_test_user("journalist",

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -325,12 +325,10 @@ class Journalist(db.Model):
     def _gen_salt(self, salt_bytes=32):
         return os.urandom(salt_bytes)
 
-    _SCRYPT_PARAMS = dict(N=2**14, r=8, p=1)
+    _LEGACY_SCRYPT_PARAMS = dict(N=2**14, r=8, p=1)
 
-    def _scrypt_hash(self, password, salt, params=None):
-        if not params:
-            params = self._SCRYPT_PARAMS
-        return scrypt.hash(str(password), salt, **params)
+    def _scrypt_hash(self, password, salt):
+        return scrypt.hash(str(password), salt, **self._LEGACY_SCRYPT_PARAMS)
 
     MAX_PASSWORD_LEN = 128
     MIN_PASSWORD_LEN = 14

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -31,9 +31,8 @@ from db import db
 LOGIN_HARDENING = True
 if os.environ.get('SECUREDROP_ENV') == 'test':
     LOGIN_HARDENING = False
-    ARGON2_PARAMS = dict(memory_cost=2**3, rounds=1, parallelism=1)
-else:
-    ARGON2_PARAMS = dict(memory_cost=2**16, rounds=4, parallelism=2)
+
+ARGON2_PARAMS = dict(memory_cost=2**16, rounds=4, parallelism=2)
 
 
 def get_one_or_else(query, logger, failure_method):
@@ -342,6 +341,8 @@ class Journalist(db.Model):
         if not self.passphrase_hash:
             self.passphrase_hash = \
                 argon2.using(**ARGON2_PARAMS).hash(passphrase)
+            # passlib creates one merged field that embeds randomly generated
+            # salt in the output like $alg$salt$hash
             self.pw_hash = None
             self.pw_salt = None
 

--- a/securedrop/qa_loader.py
+++ b/securedrop/qa_loader.py
@@ -64,6 +64,12 @@ def new_journalist():
                                          nullable=False),
                             pw,
                             random_bool())
+    if random_bool():
+        # to add legacy passwords back in
+        journalist.passphrase_hash = None
+        journalist.pw_salt = random_chars(32, nullable=False)
+        journalist.pw_hash = random_chars(64, nullable=False)
+
     journalist.is_admin = bool_or_none()
 
     journalist.is_totp = bool_or_none()

--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -1,4 +1,5 @@
 alembic
+argon2_cffi
 cryptography==2.0.3
 cssmin
 Flask-Assets
@@ -9,6 +10,7 @@ Flask
 gnupg
 Jinja2
 jsmin
+passlib
 psutil
 pyotp
 qrcode

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -5,13 +5,14 @@
 #    pip-compile --output-file securedrop/requirements/securedrop-app-code-requirements.txt securedrop/requirements/securedrop-app-code-requirements.in
 #
 alembic==0.9.9
+argon2-cffi==18.1.0
 asn1crypto==0.24.0        # via cryptography
 babel==2.5.1              # via flask-babel
-cffi==1.11.5              # via cryptography
+cffi==1.11.5              # via argon2-cffi, cryptography
 click==6.7                # via flask, rq
 cryptography==2.0.3
 cssmin==0.2.0
-enum34==1.1.6             # via cryptography
+enum34==1.1.6             # via argon2-cffi, cryptography
 flask-assets==0.12
 flask-babel==0.11.2
 flask-sqlalchemy==2.3.2
@@ -25,6 +26,7 @@ jinja2==2.10
 jsmin==2.2.2
 mako==1.0.7               # via alembic
 markupsafe==1.0           # via jinja2, mako
+passlib==1.7.1
 psutil==5.4.3
 pycparser==2.18           # via cffi
 pyotp==2.2.6
@@ -36,7 +38,7 @@ redis==2.10.6
 rq==0.10.0
 scrypt==0.8.0
 sh==1.12.14
-six==1.11.0               # via cryptography, python-dateutil, qrcode
+six==1.11.0               # via argon2-cffi, cryptography, python-dateutil, qrcode
 sqlalchemy==1.2.0
 typing==3.6.4
 webassets==0.12.1         # via flask-assets

--- a/securedrop/tests/migrations/migration_2d0ce3ee5bdc.py
+++ b/securedrop/tests/migrations/migration_2d0ce3ee5bdc.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+
+import random
+import string
+
+from sqlalchemy import text
+
+from db import db
+from journalist_app import create_app
+from .helpers import (random_bool, random_chars, random_username, random_bytes,
+                      random_datetime, bool_or_none)
+
+random.seed('ᕕ( ᐛ )ᕗ')
+
+
+class Helper():
+
+    @staticmethod
+    def add_source():
+        filesystem_id = random_chars(96) if random_bool() else None
+        params = {
+            'filesystem_id': filesystem_id,
+            'journalist_designation': random_chars(50),
+            'flagged': bool_or_none(),
+            'last_updated': random_datetime(nullable=True),
+            'pending': bool_or_none(),
+            'interaction_count': random.randint(0, 1000),
+        }
+        sql = '''INSERT INTO sources (filesystem_id, journalist_designation,
+                    flagged, last_updated, pending, interaction_count)
+                 VALUES (:filesystem_id, :journalist_designation, :flagged,
+                    :last_updated, :pending, :interaction_count)
+              '''
+        db.engine.execute(text(sql), **params)
+
+    @staticmethod
+    def add_journalist_login_attempt(journalist_id):
+        params = {
+            'timestamp': random_datetime(nullable=True),
+            'journalist_id': journalist_id,
+        }
+        sql = '''INSERT INTO journalist_login_attempt (timestamp,
+                    journalist_id)
+                 VALUES (:timestamp, :journalist_id)
+              '''
+        db.engine.execute(text(sql), **params)
+
+    @staticmethod
+    def add_reply(journalist_id, source_id):
+        params = {
+            'journalist_id': journalist_id,
+            'source_id': source_id,
+            'filename': random_chars(50),
+            'size': random.randint(0, 1024 * 1024 * 500),
+        }
+        sql = '''INSERT INTO replies (journalist_id, source_id, filename,
+                    size)
+                 VALUES (:journalist_id, :source_id, :filename, :size)
+              '''
+        db.engine.execute(text(sql), **params)
+
+    @staticmethod
+    def extract(app):
+        with app.app_context():
+            sql = '''SELECT j.id, count(distinct a.id), count(distinct r.id)
+                     FROM journalists AS j
+                     LEFT OUTER JOIN journalist_login_attempt AS a
+                     ON a.journalist_id = j.id
+                     LEFT OUTER JOIN replies AS r
+                     ON r.journalist_id = j.id
+                     GROUP BY j.id
+                     ORDER BY j.id
+                  '''
+            res = list(db.session.execute(text(sql)))
+        return res
+
+
+class UpgradeTester(Helper):
+
+    JOURNO_NUM = 100
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+        self.initial_data = None
+
+    def load_data(self):
+        with self.app.app_context():
+            for _ in range(self.JOURNO_NUM):
+                self.add_journalist()
+
+            self.add_source()
+
+            for jid in range(1, self.JOURNO_NUM):
+                for _ in range(random.randint(1, 3)):
+                    self.add_journalist_login_attempt(jid)
+
+            for jid in range(1, self.JOURNO_NUM):
+                self.add_reply(jid, 1)
+
+            db.session.commit()
+            self.initial_data = self.extract(self.app)
+
+    def check_upgrade(self):
+        extracted = self.extract(self.app)
+        assert len(extracted) == self.JOURNO_NUM
+        assert extracted == self.initial_data
+
+    @staticmethod
+    def add_journalist():
+        if random_bool():
+            otp_secret = random_chars(16, string.ascii_uppercase + '234567')
+        else:
+            otp_secret = None
+
+        is_totp = random_bool()
+        if is_totp:
+            hotp_counter = 0 if random_bool() else None
+        else:
+            hotp_counter = random.randint(0, 10000) if random_bool() else None
+
+        last_token = random_chars(6, string.digits) if random_bool() else None
+
+        params = {
+            'username': random_username(),
+            'pw_salt': random_bytes(1, 64, nullable=True),
+            'pw_hash': random_bytes(32, 64, nullable=True),
+            'is_admin': bool_or_none(),
+            'otp_secret': otp_secret,
+            'is_totp': is_totp,
+            'hotp_counter': hotp_counter,
+            'last_token': last_token,
+            'created_on': random_datetime(nullable=True),
+            'last_access': random_datetime(nullable=True),
+            'passphrase_hash': random_bytes(32, 64, nullable=True)
+        }
+        sql = '''INSERT INTO journalists (username, pw_salt, pw_hash,
+                    is_admin, otp_secret, is_totp, hotp_counter, last_token,
+                    created_on, last_access, passphrase_hash)
+                 VALUES (:username, :pw_salt, :pw_hash, :is_admin,
+                    :otp_secret, :is_totp, :hotp_counter, :last_token,
+                    :created_on, :last_access, :passphrase_hash);
+              '''
+        db.engine.execute(text(sql), **params)
+
+
+class DowngradeTester(Helper):
+
+    JOURNO_NUM = 100
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+        self.initial_data = None
+
+    def load_data(self):
+        with self.app.app_context():
+            for _ in range(self.JOURNO_NUM):
+                self.add_journalist()
+
+            self.add_source()
+
+            for jid in range(1, self.JOURNO_NUM):
+                for _ in range(random.randint(1, 3)):
+                    self.add_journalist_login_attempt(jid)
+
+            for jid in range(1, self.JOURNO_NUM):
+                self.add_reply(jid, 1)
+
+            db.session.commit()
+            self.initial_data = self.extract(self.app)
+
+    def check_downgrade(self):
+        extracted = self.extract(self.app)
+        assert len(extracted) == self.JOURNO_NUM
+        assert extracted == self.initial_data
+
+    @staticmethod
+    def add_journalist():
+        if random_bool():
+            otp_secret = random_chars(16, string.ascii_uppercase + '234567')
+        else:
+            otp_secret = None
+
+        is_totp = random_bool()
+        if is_totp:
+            hotp_counter = 0 if random_bool() else None
+        else:
+            hotp_counter = random.randint(0, 10000) if random_bool() else None
+
+        last_token = random_chars(6, string.digits) if random_bool() else None
+
+        params = {
+            'username': random_username(),
+            'pw_salt': random_bytes(1, 64, nullable=True),
+            'pw_hash': random_bytes(32, 64, nullable=True),
+            'is_admin': bool_or_none(),
+            'otp_secret': otp_secret,
+            'is_totp': is_totp,
+            'hotp_counter': hotp_counter,
+            'last_token': last_token,
+            'created_on': random_datetime(nullable=True),
+            'last_access': random_datetime(nullable=True),
+        }
+        sql = '''INSERT INTO journalists (username, pw_salt, pw_hash,
+                    is_admin, otp_secret, is_totp, hotp_counter, last_token,
+                    created_on, last_access)
+                 VALUES (:username, :pw_salt, :pw_hash, :is_admin,
+                    :otp_secret, :is_totp, :hotp_counter, :last_token,
+                    :created_on, :last_access);
+              '''
+        db.engine.execute(text(sql), **params)

--- a/securedrop/tests/migrations/migration_2d0ce3ee5bdc.py
+++ b/securedrop/tests/migrations/migration_2d0ce3ee5bdc.py
@@ -4,6 +4,7 @@ import random
 import string
 
 from sqlalchemy import text
+from uuid import uuid4
 
 from db import db
 from journalist_app import create_app
@@ -19,6 +20,7 @@ class Helper():
     def add_source():
         filesystem_id = random_chars(96) if random_bool() else None
         params = {
+            'uuid': str(uuid4()),
             'filesystem_id': filesystem_id,
             'journalist_designation': random_chars(50),
             'flagged': bool_or_none(),
@@ -26,10 +28,11 @@ class Helper():
             'pending': bool_or_none(),
             'interaction_count': random.randint(0, 1000),
         }
-        sql = '''INSERT INTO sources (filesystem_id, journalist_designation,
-                    flagged, last_updated, pending, interaction_count)
-                 VALUES (:filesystem_id, :journalist_designation, :flagged,
-                    :last_updated, :pending, :interaction_count)
+        sql = '''INSERT INTO sources (uuid, filesystem_id,
+                    journalist_designation, flagged, last_updated, pending,
+                    interaction_count)
+                 VALUES (:uuid, :filesystem_id, :journalist_designation,
+                    :flagged, :last_updated, :pending, :interaction_count)
               '''
         db.engine.execute(text(sql), **params)
 
@@ -132,14 +135,13 @@ class UpgradeTester(Helper):
             'last_token': last_token,
             'created_on': random_datetime(nullable=True),
             'last_access': random_datetime(nullable=True),
-            'passphrase_hash': random_bytes(32, 64, nullable=True)
         }
         sql = '''INSERT INTO journalists (username, pw_salt, pw_hash,
                     is_admin, otp_secret, is_totp, hotp_counter, last_token,
-                    created_on, last_access, passphrase_hash)
+                    created_on, last_access)
                  VALUES (:username, :pw_salt, :pw_hash, :is_admin,
                     :otp_secret, :is_totp, :hotp_counter, :last_token,
-                    :created_on, :last_access, :passphrase_hash);
+                    :created_on, :last_access);
               '''
         db.engine.execute(text(sql), **params)
 
@@ -201,12 +203,13 @@ class DowngradeTester(Helper):
             'last_token': last_token,
             'created_on': random_datetime(nullable=True),
             'last_access': random_datetime(nullable=True),
+            'passphrase_hash': random_bytes(32, 64, nullable=True)
         }
         sql = '''INSERT INTO journalists (username, pw_salt, pw_hash,
                     is_admin, otp_secret, is_totp, hotp_counter, last_token,
-                    created_on, last_access)
+                    created_on, last_access, passphrase_hash)
                  VALUES (:username, :pw_salt, :pw_hash, :is_admin,
                     :otp_secret, :is_totp, :hotp_counter, :last_token,
-                    :created_on, :last_access);
+                    :created_on, :last_access, :passphrase_hash);
               '''
         db.engine.execute(text(sql), **params)

--- a/securedrop/tests/test_alembic.py
+++ b/securedrop/tests/test_alembic.py
@@ -2,6 +2,7 @@
 
 import os
 import pytest
+import re
 import subprocess
 
 from alembic.config import Config as AlembicConfig
@@ -19,6 +20,8 @@ MIGRATION_PATH = path.join(path.dirname(__file__), '..', 'alembic', 'versions')
 ALL_MIGRATIONS = [x.split('.')[0].split('_')[0]
                   for x in os.listdir(MIGRATION_PATH)
                   if x.endswith('.py')]
+
+WHITESPACE_REGEX = re.compile('\s*')
 
 
 def list_migrations(cfg_path, head):
@@ -83,12 +86,12 @@ def ddl_equal(left, right):
     if left is None and right is None:
         return True
 
-    left = [x for x in left.split('\n') if x]
-    right = [x for x in right.split('\n') if x]
+    left = [x for x in WHITESPACE_REGEX.split(left) if x]
+    right = [x for x in WHITESPACE_REGEX.split(right) if x]
 
-    # Strip commas, whitespace, quotes
-    left = [x.replace("\"", "").replace(",", "").strip() for x in left]
-    right = [x.replace("\"", "").replace(",", "").strip() for x in right]
+    # Strip commas and quotes
+    left = [x.replace("\"", "").replace(",", "") for x in left]
+    right = [x.replace("\"", "").replace(",", "") for x in right]
 
     return sorted(left) == sorted(right)
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2918

- Adds `passlib` library for handing password hashing and verification
- Replace `scrypt` with `argon2` 
- Adds database column & migration for new hashes

> Note: This shouldn't be merged until after the 0.8.0 release is branched off `develop`

## Testing

Check the manual tests.

```
make test
```

Do a manual test

```
git checkout develop
make build-debs
vagrant up /staging/

# add a user, login

git checkout passlib
make build-debs
vagrant provision /staging/

# check can still login
# add new user
```

## Deployment

This includes legacy support for old password hashing schemes, so old journalists accounts will still be able to log in. This adds a new apt dependency, but it's in the security lists so we won't error out.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
