### PR TITLE
better clean up of files in on removal/purge

### DIFF
--- a/install_files/securedrop-app-code/DEBIAN/postrm
+++ b/install_files/securedrop-app-code/DEBIAN/postrm
@@ -20,7 +20,8 @@ set -e
 . /usr/share/debconf/confmodule
 
 clean_pyc() {
-    find /var/www/securedrop/alembic -name '*.pyc' -delete
+    find /var/www/securedrop/ -name '*.pyc' -delete
+    find /var/www/securedrop/ -name __pycache__ -delete
 }
 
 case "$1" in
@@ -32,11 +33,7 @@ case "$1" in
     ;;
 
     purge)
-        for dir in securedrop/ securedrop/tmp securedrop/keys securedrop/store; do
-          full_path="/var/lib/$dir"
-          rm -rf "$full_path"
-        done 
-        clean_pyc
+        rm -rf /var/lib/securedrop/ /var/www/securedrop
     ;;
 
     *)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3238

Changes the remove/purge logic to actually completely remove the package.

## Testing

```
make build-debs
vagrant up /staging/
vagrant ssh app-staging
sudo apt purge -y securedrop-app-code
```

Then check that `/var/{lib,www}/securedrop` are not present.