### PR TITLE
journalist: ngettext around unread as it may be singular or plural

### DIFF
--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -24,7 +24,7 @@
     <span><i class="far fa-file-alt"></i> {{ ngettext('1 message', '{msg_num} messages', msgs).format(msg_num=msgs) }}</span>
     {% if source.num_unread > 0 %}
       <span class="unread">
-        <a class="btn small" href="/download_unread/{{ source.filesystem_id }}"><i class="fa fa-download"></i> {{ gettext('{num_unread} unread').format(num_unread=source.num_unread) }}</a>
+        <a class="btn small" href="/download_unread/{{ source.filesystem_id }}"><i class="fa fa-download"></i> {{ ngettext('1 unread', '{num_unread} unread', source.num_unread).format(num_unread=source.num_unread) }}</a>
       </span>
     {% endif %}
   </div>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

ngettext around unread as it may be singular or plural

## Testing

* make dev
* firefox https://localhost:8080
* navigate to the list of documents
* see 2 unread
* read one document
* see 1 unread

It does not show a difference because it English there is none. But it shows ngettext gets the two cases right and there is no formatting error introduced.
 

## Deployment

N/A

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

