### PR TITLE
Update builder image

### DIFF
--- a/molecule/builder/Dockerfile
+++ b/molecule/builder/Dockerfile
@@ -1,5 +1,5 @@
-# April 28th, 2018 ubuntu:trusty
-FROM ubuntu@sha256:b8855dc848e2622653ab557d1ce2f4c34218a9380cceaa51ced85c5f3c8eb201
+# ubuntu:trusty-20180531
+FROM ubuntu@sha256:885bb6705b01d99544ddb98cbe4e4555d1efe1d052cef90832e72a0688ac6b37
 
 # additional meta-data makes it easier to clean up, find
 LABEL org="Freedom of the Press"

--- a/molecule/builder/image_hash
+++ b/molecule/builder/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_06_11
-f3ff196b95b92900cce1751e241c7cd7254ef379b3533110584dee11d18138d2
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_06_12
+8d6dfd0b07e3bbd5b1e09bb6b560b36c924d387e19002b837d06a7769f39a7a2


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3516 .

Updated builder image using [builder maintenance docs](https://docs.securedrop.org/en/latest/development/dockerbuildmaint.html).
* Updated Ubuntu Trusty base image.
* Rebuilt sd-builder image to get latest package updates.

## Testing

* `make build-debs` should be successful.
* Ubuntu base image hash should be valid (trusty-20180531).

## Deployment

Local builds only.
## Checklist

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
