### PR TITLE
Update Docker builder image

### DIFF
--- a/molecule/builder/image_hash
+++ b/molecule/builder/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_06_12
-8d6dfd0b07e3bbd5b1e09bb6b560b36c924d387e19002b837d06a7769f39a7a2
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_06_13
+0a19a9183d02fc5b40dd8739a827e4653a060a902df0b54e3df273c3c8487300


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3522 

Updated builder image with latest fixes using [this guide](https://docs.securedrop.org/en/latest/development/dockerbuildmaint.html).

## Testing

`make build-debs` should complete without error.

## Deployment

None, build only.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
