### PR TITLE
Securedrop-admin CLI: Return 1 should eventually exit non-zero

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -807,8 +807,10 @@ def main(argv):
         except Exception as e:
             raise SystemExit(
                 'ERROR (run with -v for more): {msg}'.format(msg=e))
-        else:
-            sys.exit(EXIT_SUCCESS)
+    if return_code == 0:
+        sys.exit(EXIT_SUCCESS)
+    else:
+        sys.exit(EXIT_SUBPROCESS_ERROR)
 
 
 if __name__ == "__main__":

--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -537,6 +537,7 @@ def setup_logger(verbose=False):
 def sdconfig(args):
     """Configure SD site settings"""
     SiteConfig(args).load_and_update_config()
+    return 0
 
 
 def install_securedrop(args):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3533.

Changes proposed in this pull request:
 * Return 1 should eventually exit non-zero

## Testing

Running securedrop-admin CLI commands interactively is a good way to test (as we have integration test coverage for only sdconfig merged in right now): the expected behavior is that keyboard interrupts and errors produce non-zero exit codes, and clean exits produce zero exit codes. 

### securedrop-admin tailsconfig

If you enter sudo password incorrectly, it should exit non-zero. Else it should exit 0

### securedrop-admin sdconfig

Keyboard interrupt should produce non-zero exit code. Else it should exit 0

## Deployment

When users update to the latest signed tag in the workstation, this code will be updated. 

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR