### PR TITLE
[0.8.0] Backport kernel docs, upgrade guide from #3545

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,6 +85,7 @@ anonymous sources.
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/0.7.x_to_0.8.rst
    upgrade/0.6.x_to_0.7.rst
    upgrade/0.5.x_to_0.6.rst
    upgrade/0.4.x_to_0.5.rst

--- a/docs/kernel_troubleshooting.rst
+++ b/docs/kernel_troubleshooting.rst
@@ -75,7 +75,7 @@ Compare the Behavior of the Old Kernel
 
 Reboot the server in a safe way with ``sudo reboot``. After the BIOS screen,
 you can select a different kernel from the GRUB boot menu by selecting
-**Advanced Options for Ubuntu**, pictured below.
+**Advanced options for Ubuntu**, pictured below.
 
 |GRUB with advanced options selected|
 
@@ -215,7 +215,7 @@ the *Admin Workstation*. Shut down the server safely using the command
 ``sudo shutdown -P now``. Ensure that the server is fully powered off.
 
 Attach required peripherals and power the server back up. After the GRUB bootloader
-appears, select **Advanced Options for Ubuntu**, pictured below.
+appears, select **Advanced options for Ubuntu**, pictured below.
 
 |GRUB with advanced options selected|
 

--- a/docs/kernel_troubleshooting.rst
+++ b/docs/kernel_troubleshooting.rst
@@ -161,6 +161,8 @@ additional confirmation of the kernel version, the command
 
 Please notify us of the compatibility issue so we can help you resolve it ASAP.
 
+.. _Report Compatibility Issues:
+
 Report Compatibility Issues
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -196,6 +198,8 @@ If you are not a member of our Support Portal, we also encourage you to request
 help in the `SecureDrop Community Forums <https://forum.securedrop.club/>`__.
 Choose carefully what information to disclose publicly. For example, raw logs
 may contain sensitive information useful to potential attackers.
+
+.. _Test and Enable an Updated Kernel:
 
 Test and Enable an Updated Kernel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/kernel_troubleshooting.rst
+++ b/docs/kernel_troubleshooting.rst
@@ -119,7 +119,7 @@ be third). Then edit the GRUB configuration:
 
 .. code:: sh
 
-  sudo vim /etc/default/grub
+  sudo nano /etc/default/grub
 
 Make a backup of the file or take a note of the current value of
 ``GRUB_DEFAULT`` somewhere, so you can restore the previous behavior easily at a
@@ -239,7 +239,7 @@ by issuing the following command:
 
 .. code:: sh
 
-  sudo vim /etc/default/grub
+  sudo nano /etc/default/grub
 
 Make a backup of the file or take a note of the current value of
 ``GRUB_DEFAULT`` somewhere, so you can restore the previous behavior if needed.

--- a/docs/kernel_troubleshooting.rst
+++ b/docs/kernel_troubleshooting.rst
@@ -196,3 +196,57 @@ If you are not a member of our Support Portal, we also encourage you to request
 help in the `SecureDrop Community Forums <https://forum.securedrop.club/>`__.
 Choose carefully what information to disclose publicly. For example, raw logs
 may contain sensitive information useful to potential attackers.
+
+Test and Enable an Updated Kernel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you have changed your default kernel, we urge you to test an updated kernel
+as soon as it becomes available in a future SecureDrop release. Note that an
+update may be enforced as part of a release to protect the security of your
+instance. Please consult the `release notes <https://securedrop.org/news/release-announcement/>`__
+for details about kernel updates.
+
+You can test a kernel update without downtime for you instance by booting your
+*Monitor Server* with the new kernel. Log into your *Monitor Server* using
+the *Admin Workstation*. Shut down the server safely using the command
+``sudo shutdown -P now``. Ensure that the server is fully powered off.
+
+Attach required peripherals and power the server back up. After the GRUB bootloader
+appears, select **Advanced Options for Ubuntu**, pictured below.
+
+|GRUB with advanced options selected|
+
+If a SecureDrop release with a kernel update has been installed on your system,
+the updated kernel version will be available in the list of options:
+
+|Selecting a specific kernel in GRUB|
+
+Select the new kernel (you do not need to use the version with recovery mode).
+If you do not know your admin account password, you can `boot into single user mode`_
+by editing the boot options. Otherwise, press enter to boot.
+
+Verify that you can boot successfully, and that you have network access
+(``sudo host freedom.press``). If you still encounter problems with the new
+kernel, please `report compatibility issues`_ at your earliest convenience, and
+reboot the server into the old kernel for now.
+
+If the update resolved compatibility issues with an earlier kernel version, you
+can make the new kernel the default. Edit the file ``/etc/default/grub``, e.g.,
+by issuing the following command:
+
+.. code:: sh
+
+  sudo vim /etc/default/grub
+
+Make a backup of the file or take a note of the current value of
+``GRUB_DEFAULT`` somewhere, so you can restore the previous behavior if needed.
+Change the line to ``GRUB_DEFAULT=0``. This will ensure that SecureDrop uses the
+most recent kernel version installed on your server.
+
+Safely shut down the *Monitor Server*, remove attached peripherals, and reboot
+it. Verify  that it is working correctly by logging in using your *Admin
+Workstation*. If everything is working as expected, you can make the same change
+to ``/etc/default/grub`` on your *Application Server* as well. You can do so
+from your *Admin Workstation* and reboot the server using the command
+``sudo shutdown -r now``.
+
+Subsequent kernel updates will again be applied automatically.

--- a/docs/kernel_troubleshooting.rst
+++ b/docs/kernel_troubleshooting.rst
@@ -209,7 +209,7 @@ update may be enforced as part of a release to protect the security of your
 instance. Please consult the `release notes <https://securedrop.org/news/release-announcement/>`__
 for details about kernel updates.
 
-You can test a kernel update without downtime for you instance by booting your
+You can test a kernel update without downtime for your instance by booting your
 *Monitor Server* with the new kernel. Log into your *Monitor Server* using
 the *Admin Workstation*. Shut down the server safely using the command
 ``sudo shutdown -P now``. Ensure that the server is fully powered off.

--- a/docs/upgrade/0.7.x_to_0.8.rst
+++ b/docs/upgrade/0.7.x_to_0.8.rst
@@ -14,6 +14,7 @@ workstations. This does *not* update the Tails operating system. The graphical
 updater was introduced in SecureDrop 0.7.0. It looks like this:
 
 .. |SecureDrop updater| image:: ../images/0.6.x_to_0.7/securedrop-updater.png
+
 |SecureDrop updater|
 
 Click "Update Now" to perform the update on each workstation where this prompt

--- a/docs/upgrade/0.7.x_to_0.8.rst
+++ b/docs/upgrade/0.7.x_to_0.8.rst
@@ -1,0 +1,97 @@
+Upgrade from 0.7.0 to 0.8.x
+===========================
+
+Updating the Tails Workstations
+-------------------------------
+
+We recommend that you update all Tails drives to version 3.8, which is scheduled
+to be released concurrently with SecureDrop 0.8.0 on June 26, 2018. Follow the
+graphical prompts on your workstations to perform this upgrade.
+
+For the *Journalist Workstations* and the *Admin Workstation*, the graphical
+SecureDrop updater will also prompt you to update the SecureDrop code on your
+workstations. This does *not* update the Tails operating system. The graphical
+updater was introduced in SecureDrop 0.7.0. It looks like this:
+
+.. |SecureDrop updater| image:: ../images/0.6.x_to_0.7/securedrop-updater.png
+|SecureDrop updater|
+
+Click "Update Now" to perform the update on each workstation where this prompt
+appears.
+
+Removal of Two-Factor Authentication for Keyboard Login
+-------------------------------------------------------
+
+SecureDrop 0.8.0 removes the requirement for two-factor authentication when
+logging into your server using an attached physical keyboard. This feature
+provided no real security benefit, as it could easily be bypassed using single
+user mode.
+
+To ensure that you can login as the admin user using a physical keyboard, you may
+wish to use this opportunity to cycle the admin user password on your SecureDrop
+servers.
+
+To do so, log into each SecureDrop server via SSH using your *Admin Workstation*.
+Become the root user by typing ``sudo su``, then change the password for the
+admin user by typing ``passwd <username>``, e.g., if your admin user account was
+called ``alice``, you would type ``passwd alice``.
+
+Enter a secure password and store it in the KeePassX password manager on your
+*Admin Workstation*.
+
+Troubleshooting Kernel Issues
+-----------------------------
+
+SecureDrop 0.8.0 ships with an update of the Linux kernel running on your
+*Application* and *Monitor Servers*, from version 4.4.115 to version 4.4.135.
+If you have not previously changed your default kernel, your server will
+boot into the new kernel automatically on its next reboot.
+
+We have tested this kernel extensively against :ref:`recommended hardware <Specific Hardware Recommendations>`
+and other common configurations. Compared with the previous kernel, it ships with
+additional hardware support. If you are experiencing an outage after the update,
+it may be due to differences between the two kernel versions relevant to your
+specific configuration.
+
+Please consult our :doc:`kernel troubleshooting guide <../kernel_troubleshooting>`
+for instructions on how to compare the differences between kernel versions and
+how to roll back to an earlier version if necessary.
+
+.. important::
+
+  It is of critical importance for the security and stability of your instance
+  that you :ref:`report kernel compatibility issues <Report Compatibility Issues>`
+  to us as soon as you become aware of them.
+
+Enabling the New Kernel After a Downgrade
+-----------------------------------------
+
+If you have previously downgraded your kernel to the 3.14.x series due to
+compatibility issues with the kernel that shipped with SecureDrop 0.7.0
+(version 4.4.115), we urge you to test the new kernel (version 4.4.135). The new
+kernel ships with expanded hardware support and is intended to address the
+hardware compatibility issues that we are aware of.
+
+You can test the new kernel without downtime by following
+:ref:`our instructions for testing and enabling a new kernel after a downgrade
+<Test and Enable an Updated Kernel>`. Please note that this is *only* necessary
+if you have manually downgraded the kernel; otherwise, the new kernel will be
+enabled automatically.
+
+If the new kernel does not address compatibility issues on your hardware, please
+let us know as soon as you can by following :ref:`our instructions for reporting
+compatibility issues <Report Compatibility Issues>`. We intend to remove support
+for kernel series 3.14.x in a future release, once all major compatibility
+issues we are aware of have been resolved.
+
+Getting Support
+---------------
+
+Should you require further support with your SecureDrop installation or upgrade,
+we are happy to help!
+
+-  Community support is available at https://forum.securedrop.club
+-  The Freedom of the Press Foundation offers training and priority support
+   services. See https://securedrop.org/priority-support/ for more information.
+   If you are already a member of our support portal, please don't hesitate to
+   open a ticket there.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
 * Backport changes in #3545 into the release branch

## Testing

Verify same commits as in #3545

## Deployment

Docs only

## Checklist

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
