### PR TITLE
Fine-tunes conditional logic in iptables template

### DIFF
--- a/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
@@ -96,7 +96,7 @@
 # Allowed for staging and optionally for production (disables ssh over tor)
 {% if not enable_ssh_over_tor %}
   {%- for interface in ansible_interfaces -%}
-    {%- if  hostvars[inventory_hostname]['ansible_'+interface].ipv4 -%}
+    {%- if 'ipv4' in hostvars[inventory_hostname]['ansible_'+interface] -%}
         {%- set int_details = hostvars[inventory_hostname]['ansible_'+interface].ipv4 -%}
         {%- set net_string = '/'.join([int_details.network,int_details.netmask]) -%}
         {%- if ssh_ip|ipaddr(net_string) -%}


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

The conditional logic checking for whether the 'ipv4' attribute was
defined wasn't properly structured: it assumed the attribute was present
in order to check it. Slight tweak to the syntax to make a more graceful
evaluation to False.

Closes #3555.

## Testing
Fresh install should pass on pass with `enable_ssh_over_tor=True` _and_ `enable_ssh_over_tor=False`. Since we're in the QA period, I suggest merging absent this testing, so that we can cut a new rc and confirm resolved there. 

## Deployment
Yes, affects playbook runs. Given discussion in #3555, the proposed fix appears to resolve errors encountered when `enable_ssh_over_tor=false`; we previously resolved errors when `enable_ssh_over_tor=true` (the default).

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
