### PR TITLE
Fix one major omission, three minor issues

### DIFF
--- a/docs/kernel_troubleshooting.rst
+++ b/docs/kernel_troubleshooting.rst
@@ -37,10 +37,9 @@ shut down the server.
 
 Once you hit a key, you will be able to interact with the menu with the
 up (⬆) and down (⬇) keys. Select “Ubuntu” as shown above, and press “e”
-to edit the boot options. In the line that begins “linux”, replace the
-word “quiet” with “single”. Note that the word "quiet" may be wrapped. Once you
-have performed the replacement, the output on your console should look similar to
-the screenshot below.
+to edit the boot options. In the line that begins with “linux”, add the word
+“single” at the end. When you are done, the output on your console should look
+similar to the screenshot below.
 
 |GRUB in edit mode|
 
@@ -146,7 +145,7 @@ This change still has to be applied to take effect on the next boot:
 
 .. code:: sh
 
-  sudo update-grub2
+  sudo update-grub
 
 Now you can reboot into the old, working kernel.
 
@@ -212,7 +211,7 @@ for details about kernel updates.
 You can test a kernel update without downtime for your instance by booting your
 *Monitor Server* with the new kernel. Log into your *Monitor Server* using
 the *Admin Workstation*. Shut down the server safely using the command
-``sudo shutdown -P now``. Ensure that the server is fully powered off.
+``sudo poweroff``. Ensure that the server is fully powered off.
 
 Attach required peripherals and power the server back up. After the GRUB bootloader
 appears, select **Advanced options for Ubuntu**, pictured below.
@@ -243,14 +242,22 @@ by issuing the following command:
 
 Make a backup of the file or take a note of the current value of
 ``GRUB_DEFAULT`` somewhere, so you can restore the previous behavior if needed.
-Change the line to ``GRUB_DEFAULT=0``. This will ensure that SecureDrop uses the
-most recent kernel version installed on your server.
+Change the line to ``GRUB_DEFAULT=0``. This configures the bootloader to default
+to loading the most recent kernel version installed on your server.
+
+This change still has to be applied to take effect on the next boot:
+
+.. code:: sh
+
+  sudo update-grub
 
 Safely shut down the *Monitor Server*, remove attached peripherals, and reboot
 it. Verify  that it is working correctly by logging in using your *Admin
 Workstation*. If everything is working as expected, you can make the same change
-to ``/etc/default/grub`` on your *Application Server* as well. You can do so
-from your *Admin Workstation* and reboot the server using the command
-``sudo shutdown -r now``.
+to ``/etc/default/grub`` on your *Application Server* as well. Remember to again
+run the command ``sudo update-grub`` when you are done.
+
+You can make the change on the *Application Server* from your *Admin Workstation*
+and reboot the server using the command ``sudo reboot``.
 
 Subsequent kernel updates will again be applied automatically.

--- a/docs/kernel_troubleshooting.rst
+++ b/docs/kernel_troubleshooting.rst
@@ -36,14 +36,14 @@ and reboot safely, provided you can log in. Do not unplug or forcibly
 shut down the server.
 
 Once you hit a key, you will be able to interact with the menu with the
-up (⬆) and down (⬇) keys. Select “Ubuntu” as shown above, and press “e”
-to edit the boot options. In the line that begins with “linux”, add the word
-“single” at the end. When you are done, the output on your console should look
+up (⬆) and down (⬇) keys. Select "Ubuntu" as shown above, and press "e"
+to edit the boot options. In the line that begins with "linux", add the word
+"single" at the end. When you are done, the output on your console should look
 similar to the screenshot below.
 
 |GRUB in edit mode|
 
-Press the “F10” key to boot.
+Press the "F10" key to boot.
 
 Test the New Kernel
 ~~~~~~~~~~~~~~~~~~~
@@ -130,10 +130,10 @@ setup, the line in ``/etc/default/grub`` would look like this:
 
 .. code:: sh
 
-  GRUB_DEFAULT=”1>2”
+  GRUB_DEFAULT="1>2"
 
-The “1” means the second entry of the main menu (“Advanced options”),
-the “2” means the third entry of the submenu. Again, update these
+The "1" means the second entry of the main menu ("Advanced options"),
+the "2" means the third entry of the submenu. Again, update these
 numbers consistent with your configuration. 
 
 
@@ -188,7 +188,7 @@ You can share ``server-facts.log``, ``syslog`` and ``dmesg`` with us as follows:
    and attach the files to it.
 -  Alternatively, email us at securedrop@freedom.press 
    (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__) 
-   with the subject “SecureDrop kernel facts” and the files attached.
+   with the subject "SecureDrop kernel facts" and the files attached.
 
 Once we get your information, we can try to provide assistance to
 resolve compatibility issues.


### PR DESCRIPTION
- Add reminder to run `update-grub` (!)
- Change `update-grub2` to `update-grub`
- Do not instruct users to replace `quiet` with `single`, as `quiet`
  may not be in the boot options
- Change `shutdown -r now` to `reboot` and `shutdown -P now` to
  `poweroff` for consistency and readability

Resolves #3558

## Status

Ready for review 

## Checklist
- [X] Doc linting (`make docs-lint`) passed locally
