### PR TITLE
Login throttling should be per-user

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -407,6 +407,7 @@ class Journalist(db.Model):
         login_attempt_period = datetime.datetime.utcnow() - \
             datetime.timedelta(seconds=cls._LOGIN_ATTEMPT_PERIOD)
         attempts_within_period = JournalistLoginAttempt.query.filter(
+            JournalistLoginAttempt.journalist_id == user.id).filter(
             JournalistLoginAttempt.timestamp > login_attempt_period).all()
         if len(attempts_within_period) > cls._MAX_LOGIN_ATTEMPTS_PER_PERIOD:
             raise LoginThrottledException(


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3563.

Changes proposed in this pull request:
 * Adds a regression test for bug in #3563 
 * Resolve #3563 bug by making the login throttling per-user

## Testing

- [ ] Reproduce original bug following STR in #3563
- [ ] Checkout the regression test without the fix (i.e. check out e128b04) and verify it fails
- [ ] Apply the fix in 369b472, the regression test should now pass and logging in as the second user in the STR should now result in success

## Deployment

To be deployed in `securedrop-app-code` deb package tomorrow

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR
