### PR TITLE
Implement logic to prevent checkout of branch when named the same as our signed tag

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -686,7 +686,18 @@ def update(args):
         if RELEASE_KEY in gpg_lines[1] and \
                 sig_result.count(good_sig_text) == 1 and \
                 bad_sig_text not in sig_result:
-            sdlog.info("Signature verification successful.")
+            # Finally, we check that there is no branch of the same name
+            # prior to reporting success.
+            cmd = ['git', 'show-ref', '--heads', '--verify', '--quiet',
+                   'refs/heads/{}'.format(latest_tag)]
+            try:
+                # We expect this to produce a non-zero exit code, which
+                # will produce a subprocess.CalledProcessError
+                subprocess.check_output(cmd)
+                sdlog.info("Signature verification failed.")
+                return 1
+            except subprocess.CalledProcessError:
+                sdlog.info("Signature verification successful.")
         else:  # If anything else happens, fail and exit 1
             sdlog.info("Signature verification failed.")
             return 1

--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -688,16 +688,21 @@ def update(args):
                 bad_sig_text not in sig_result:
             # Finally, we check that there is no branch of the same name
             # prior to reporting success.
-            cmd = ['git', 'show-ref', '--heads', '--verify', '--quiet',
+            cmd = ['git', 'show-ref', '--heads', '--verify',
                    'refs/heads/{}'.format(latest_tag)]
             try:
                 # We expect this to produce a non-zero exit code, which
                 # will produce a subprocess.CalledProcessError
-                subprocess.check_output(cmd)
+                subprocess.check_output(cmd, stderr=subprocess.STDOUT)
                 sdlog.info("Signature verification failed.")
                 return 1
-            except subprocess.CalledProcessError:
-                sdlog.info("Signature verification successful.")
+            except subprocess.CalledProcessError, e:
+                if 'not a valid ref' in e.output:
+                    # Then there is no duplicate branch.
+                    sdlog.info("Signature verification successful.")
+                else:  # If any other exception occurs, we bail.
+                    sdlog.info("Signature verification failed.")
+                    return 1
         else:  # If anything else happens, fail and exit 1
             sdlog.info("Signature verification failed.")
             return 1

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -538,7 +538,10 @@ class TestGitOperations:
                                     'securedrop/install_files/ansible-base')
         child = pexpect.spawn('coverage run {0} --root {1} update'.format(
                               cmd, ansible_base))
-        child.expect('Updated to SecureDrop', timeout=100)
+
+        output = child.read()
+        assert 'Updated to SecureDrop' in output
+        assert 'Signature verification successful' in output
 
         child.expect(pexpect.EOF, timeout=10)  # Wait for CLI to exit
         child.close()

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -574,3 +574,35 @@ class TestGitOperations:
         # Failures should eventually exit non-zero.
         assert child.exitstatus != 0
         assert child.signalstatus != 0
+
+    def test_update_with_duplicate_branch_and_tag(self,
+                                                  securedrop_git_repo):
+        gpgdir = os.path.join(os.path.expanduser('~'), '.gnupg')
+        set_reliable_keyserver(gpgdir)
+
+        github_url = 'https://api.github.com/repos/freedomofpress/securedrop/releases/latest'  # noqa: E501
+        latest_release = requests.get(github_url).json()
+        latest_tag = str(latest_release["tag_name"])
+
+        # Create a branch with the same name as a tag.
+        subprocess.check_call(['git', 'checkout', '-b', latest_tag])
+        # Checkout the older tag again in preparation for the update.
+        subprocess.check_call('git checkout 0.6'.split())
+
+        cmd = os.path.join(os.path.dirname(CURRENT_DIR),
+                           'securedrop_admin/__init__.py')
+        ansible_base = os.path.join(str(securedrop_git_repo),
+                                    'securedrop/install_files/ansible-base')
+
+        child = pexpect.spawn('coverage run {0} --root {1} update'.format(
+                              cmd, ansible_base))
+        output = child.read()
+        # Verify that we do not falsely check out a branch instead of a tag.
+        assert 'Switched to branch' not in output
+        assert 'Updated to SecureDrop' not in output
+        assert 'Signature verification failed' in output
+
+        child.expect(pexpect.EOF, timeout=10)  # Wait for CLI to exit
+        child.close()
+        assert child.exitstatus != 0
+        assert child.signalstatus != 0

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -208,6 +208,40 @@ class TestSecureDropAdmin(object):
             for patcher in patchers:
                 patcher.stop()
 
+    def test_update_unexpected_exception_git_refs(self, tmpdir, caplog):
+        git_repo_path = str(tmpdir)
+        args = argparse.Namespace(root=git_repo_path)
+
+        git_output = ('gpg: Signature made Tue 13 Mar 2018 01:14:11 AM UTC\n'
+                      'gpg:                using RSA key '
+                      '22245C81E3BAEB4138B36061310F561200F4AD77\n'
+                      'gpg: Good signature from "SecureDrop Release '
+                      'Signing Key" [unknown]\n')
+
+        patchers = [
+            mock.patch('securedrop_admin.check_for_updates',
+                       return_value=(True, "0.6.1")),
+            mock.patch('subprocess.check_call'),
+            mock.patch('subprocess.check_output',
+                       side_effect=[
+                           git_output,
+                           subprocess.CalledProcessError(1, 'cmd',
+                                                         'a random error')]),
+            ]
+
+        for patcher in patchers:
+            patcher.start()
+
+        try:
+            ret_code = securedrop_admin.update(args)
+            assert "Applying SecureDrop updates..." in caplog.text
+            assert "Signature verification successful." not in caplog.text
+            assert "Updated to SecureDrop" not in caplog.text
+            assert ret_code == 1
+        finally:
+            for patcher in patchers:
+                patcher.stop()
+
     def test_update_signature_does_not_verify(self, tmpdir, caplog):
         git_repo_path = str(tmpdir)
         args = argparse.Namespace(root=git_repo_path)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3567.

Changes proposed in this pull request:
 * Ensures that securedrop-admin update will not check out branch if it is named the same as our signed tag

## Testing

- [x] The regression test alone should fail: 55fd98e (`make -C admin test`)
- [x] After the fix in f86f380 and the test updates in d74ffb8 are applied, all tests should pass

### Manual testing

 - checkout the latest prod tag locally (`git checkout 0.7.0`)
 - make a branch of the same name (`git checkout -b 0.7.0`)
 - go to this branch (`git checkout logic-checkout-branch-tag`) and run `securedrop-admin update` manually - you should not successfully update to latest due to the duplicate tag/branch. Instead, you should see `Signature verification failed` (this should trigger the user to contact their admin/support)

## Deployment

Unfortunately, we should recommend users do the update on the command line, and they should apply the same logic in this PR manually

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
