### PR TITLE
More journalist pytest

### DIFF
--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1227,6 +1227,18 @@ def test_logo_upload_with_empty_input_field_fails(journalist_app, test_admin):
     assert 'File required.' in resp.data.decode('utf-8')
 
 
+def test_admin_page_restriction_http_gets(journalist_app, test_journo):
+    admin_urls = [url_for('admin.index'), url_for('admin.add_user'),
+                  url_for('admin.edit_user', user_id=test_journo['id'])]
+
+    with journalist_app.test_client() as app:
+        _login_user(app, test_journo['username'], test_journo['password'],
+                    test_journo['otp_secret'])
+        for admin_url in admin_urls:
+            resp = app.get(admin_url)
+            assert resp.status_code == 302
+
+
 class TestJournalistApp(TestCase):
 
     # A method required by flask_testing.TestCase
@@ -1260,15 +1272,6 @@ class TestJournalistApp(TestCase):
 
     def _login_user(self):
         self._ctx.g.user = self.user
-
-    def test_admin_page_restriction_http_gets(self):
-        admin_urls = [url_for('admin.index'), url_for('admin.add_user'),
-                      url_for('admin.edit_user', user_id=self.user.id)]
-
-        self._login_user()
-        for admin_url in admin_urls:
-            resp = self.client.get(admin_url)
-            self.assertStatus(resp, 302)
 
     def test_admin_page_restriction_http_posts(self):
         admin_urls = [url_for('admin.reset_two_factor_totp'),

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1209,6 +1209,24 @@ def test_creation_of_ossec_test_log_event(journalist_app, test_admin, mocker):
     )
 
 
+def test_logo_upload_with_empty_input_field_fails(journalist_app, test_admin):
+    with journalist_app.test_client() as app:
+        _login_user(app, test_admin['username'], test_admin['password'],
+                    test_admin['otp_secret'])
+
+        form = journalist_app_module.forms.LogoForm(
+            logo=(StringIO(''), '')
+        )
+
+        with InstrumentedApp(journalist_app) as ins:
+            resp = app.post(url_for('admin.manage_config'),
+                            data=form.data,
+                            follow_redirects=True)
+
+            ins.assert_message_flashed("File required.", "logo-error")
+    assert 'File required.' in resp.data.decode('utf-8')
+
+
 class TestJournalistApp(TestCase):
 
     # A method required by flask_testing.TestCase
@@ -1242,19 +1260,6 @@ class TestJournalistApp(TestCase):
 
     def _login_user(self):
         self._ctx.g.user = self.user
-
-    def test_logo_upload_with_empty_input_field_fails(self):
-        self._login_admin()
-
-        form = journalist_app_module.forms.LogoForm(
-            logo=(StringIO(''), '')
-        )
-        resp = self.client.post(url_for('admin.manage_config'),
-                                data=form.data,
-                                follow_redirects=True)
-
-        self.assertMessageFlashed("File required.", "logo-error")
-        self.assertIn('File required.', resp.data)
 
     def test_admin_page_restriction_http_gets(self):
         admin_urls = [url_for('admin.index'), url_for('admin.add_user'),

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1197,6 +1197,18 @@ def test_logo_upload_with_invalid_filetype_fails(journalist_app, test_admin):
         assert "You can only upload PNG image files." in text
 
 
+def test_creation_of_ossec_test_log_event(journalist_app, test_admin, mocker):
+    mocked_error_logger = mocker.patch('journalist.app.logger.error')
+    with journalist_app.test_client() as app:
+        _login_user(app, test_admin['username'], test_admin['password'],
+                    test_admin['otp_secret'])
+        app.get(url_for('admin.ossec_test'))
+
+    mocked_error_logger.assert_called_once_with(
+        "This is a test OSSEC alert"
+    )
+
+
 class TestJournalistApp(TestCase):
 
     # A method required by flask_testing.TestCase
@@ -1243,15 +1255,6 @@ class TestJournalistApp(TestCase):
 
         self.assertMessageFlashed("File required.", "logo-error")
         self.assertIn('File required.', resp.data)
-
-    @patch('journalist.app.logger.error')
-    def test_creation_of_ossec_test_log_event(self, mocked_error_logger):
-        self._login_admin()
-        self.client.get(url_for('admin.ossec_test'))
-
-        mocked_error_logger.assert_called_once_with(
-            "This is a test OSSEC alert"
-        )
 
     def test_admin_page_restriction_http_gets(self):
         admin_urls = [url_for('admin.index'), url_for('admin.add_user'),

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1239,6 +1239,23 @@ def test_admin_page_restriction_http_gets(journalist_app, test_journo):
             assert resp.status_code == 302
 
 
+def test_admin_page_restriction_http_posts(journalist_app, test_journo):
+    admin_urls = [url_for('admin.reset_two_factor_totp'),
+                  url_for('admin.reset_two_factor_hotp'),
+                  url_for('admin.add_user', user_id=test_journo['id']),
+                  url_for('admin.new_user_two_factor'),
+                  url_for('admin.reset_two_factor_totp'),
+                  url_for('admin.reset_two_factor_hotp'),
+                  url_for('admin.edit_user', user_id=test_journo['id']),
+                  url_for('admin.delete_user', user_id=test_journo['id'])]
+    with journalist_app.test_client() as app:
+        _login_user(app, test_journo['username'], test_journo['password'],
+                    test_journo['otp_secret'])
+        for admin_url in admin_urls:
+            resp = app.post(admin_url)
+            assert resp.status_code == 302
+
+
 class TestJournalistApp(TestCase):
 
     # A method required by flask_testing.TestCase
@@ -1272,20 +1289,6 @@ class TestJournalistApp(TestCase):
 
     def _login_user(self):
         self._ctx.g.user = self.user
-
-    def test_admin_page_restriction_http_posts(self):
-        admin_urls = [url_for('admin.reset_two_factor_totp'),
-                      url_for('admin.reset_two_factor_hotp'),
-                      url_for('admin.add_user', user_id=self.user.id),
-                      url_for('admin.new_user_two_factor'),
-                      url_for('admin.reset_two_factor_totp'),
-                      url_for('admin.reset_two_factor_hotp'),
-                      url_for('admin.edit_user', user_id=self.user.id),
-                      url_for('admin.delete_user', user_id=self.user.id)]
-        self._login_user()
-        for admin_url in admin_urls:
-            resp = self.client.post(admin_url)
-            self.assertStatus(resp, 302)
 
     def test_user_authorization_for_gets(self):
         urls = [url_for('main.index'), url_for('col.col', filesystem_id='1'),

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1268,6 +1268,23 @@ def test_user_authorization_for_gets(journalist_app):
             assert resp.status_code == 302
 
 
+def test_user_authorization_for_posts(journalist_app):
+    urls = [url_for('col.add_star', filesystem_id='1'),
+            url_for('col.remove_star', filesystem_id='1'),
+            url_for('col.process'),
+            url_for('col.delete_single', filesystem_id='1'),
+            url_for('main.reply'),
+            url_for('main.regenerate_code'),
+            url_for('main.bulk'),
+            url_for('account.new_two_factor'),
+            url_for('account.reset_two_factor_totp'),
+            url_for('account.reset_two_factor_hotp')]
+    with journalist_app.test_client() as app:
+        for url in urls:
+            resp = app.post(url)
+            assert resp.status_code == 302
+
+
 class TestJournalistApp(TestCase):
 
     # A method required by flask_testing.TestCase
@@ -1301,21 +1318,6 @@ class TestJournalistApp(TestCase):
 
     def _login_user(self):
         self._ctx.g.user = self.user
-
-    def test_user_authorization_for_posts(self):
-        urls = [url_for('col.add_star', filesystem_id='1'),
-                url_for('col.remove_star', filesystem_id='1'),
-                url_for('col.process'),
-                url_for('col.delete_single', filesystem_id='1'),
-                url_for('main.reply'),
-                url_for('main.regenerate_code'),
-                url_for('main.bulk'),
-                url_for('account.new_two_factor'),
-                url_for('account.reset_two_factor_totp'),
-                url_for('account.reset_two_factor_hotp')]
-        for url in urls:
-            res = self.client.post(url)
-            self.assertStatus(res, 302)
 
     def test_incorrect_current_password_change(self):
         self._login_user()

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1256,6 +1256,18 @@ def test_admin_page_restriction_http_posts(journalist_app, test_journo):
             assert resp.status_code == 302
 
 
+def test_user_authorization_for_gets(journalist_app):
+    urls = [url_for('main.index'), url_for('col.col', filesystem_id='1'),
+            url_for('col.download_single_submission',
+                    filesystem_id='1', fn='1'),
+            url_for('account.edit')]
+
+    with journalist_app.test_client() as app:
+        for url in urls:
+            resp = app.get(url)
+            assert resp.status_code == 302
+
+
 class TestJournalistApp(TestCase):
 
     # A method required by flask_testing.TestCase
@@ -1289,16 +1301,6 @@ class TestJournalistApp(TestCase):
 
     def _login_user(self):
         self._ctx.g.user = self.user
-
-    def test_user_authorization_for_gets(self):
-        urls = [url_for('main.index'), url_for('col.col', filesystem_id='1'),
-                url_for('col.download_single_submission',
-                        filesystem_id='1', fn='1'),
-                url_for('account.edit')]
-
-        for url in urls:
-            resp = self.client.get(url)
-            self.assertStatus(resp, 302)
 
     def test_user_authorization_for_posts(self):
         urls = [url_for('col.add_star', filesystem_id='1'),


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #2877 

Add pytest fixtures to some journalist app tests.

## Testing

```bash
make test TESTFILES=tests/test_journalist.py
```

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container