### PR TITLE
Update builder image hash

### DIFF
--- a/molecule/builder/image_hash
+++ b/molecule/builder/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_06_21
-b3a6a29e84407928511cb9f8ebdc9e62205abf02bfd9a6b9ccb02d52d814afe0
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_06_26
+f1e82d828a0edc99d7669f32f4357605abd63ec3a713bbdd725960d2d0338737


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updated builder image using [builder maintenance docs](https://docs.securedrop.org/en/latest/development/dockerbuildmaint.html).
* Rebuilt sd-builder image to get latest package updates.

## Testing

* `make build-debs` should be successful.
* Image should be the same as the one merged in the 0.8 release branch https://github.com/freedomofpress/securedrop/commit/d9c3445d3b383f2ffc955ca70ee60093f9158758

## Deployment

Local builds only.
## Checklist

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
