### PR TITLE
Add docs for secure workstation update as part of 0.7->0.8 update

### DIFF
--- a/docs/upgrade/0.7.x_to_0.8.rst
+++ b/docs/upgrade/0.7.x_to_0.8.rst
@@ -1,24 +1,70 @@
-Upgrade from 0.7.0 to 0.8.x
+Upgrade from 0.7.0 to 0.8.0
 ===========================
 
 Updating the Tails Workstations
 -------------------------------
 
-We recommend that you update all Tails drives to version 3.8, which is scheduled
-to be released concurrently with SecureDrop 0.8.0 on June 26, 2018. Follow the
+We recommend that you update all Tails drives to version 3.8, which was released
+concurrently with SecureDrop 0.8.0 on June 26, 2018. Follow the
 graphical prompts on your workstations to perform this upgrade.
 
 For the *Journalist Workstations* and the *Admin Workstation*, the graphical
 SecureDrop updater will also prompt you to update the SecureDrop code on your
-workstations. This does *not* update the Tails operating system. The graphical
-updater was introduced in SecureDrop 0.7.0. It looks like this:
+workstations. The updater was introduced in SecureDrop 0.7.0. It looks like
+this:
 
 .. |SecureDrop updater| image:: ../images/0.6.x_to_0.7/securedrop-updater.png
 
 |SecureDrop updater|
 
-Click "Update Now" to perform the update on each workstation where this prompt
-appears.
+Due to `bug 3567 <https://github.com/freedomofpress/securedrop/issues/3567>`__,
+if this update is performed using the graphical updater, a branch containing
+unsigned code could take precedence over a release tag, if they have the same
+name. The likelihood of an exploit is low, as it would require accidental or
+deliberate branch creation, or compromise of GitHub and/or the communication
+flow between the workstation and Github.
+
+To completely eliminate this risk, we recommend that you select "Update Later"
+and perform the update manually by issuing the following commands on each
+workstation:
+
+.. code:: sh
+
+   cd ~/Persistent/securedrop
+   git fetch --tags
+   gpg --recv-key "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
+   git tag -v 0.8.0
+
+The output should include the following two lines:
+
+.. code:: sh
+
+   gpg:                using RSA key 22245C81E3BAEB4138B36061310F561200F4AD77
+   gpg: Good signature from "SecureDrop Release Signing Key"
+
+Please verify that each character of the fingerprint above matches what you see
+on the screen of your workstation. If it does, you can check out the new
+release:
+
+.. code:: sh
+
+  git checkout 0.8.0
+
+Please verify that the output of this command does not contain
+the text "warning: refname '0.8.0' is ambiguous".
+
+.. important:: If you do see the warning "refname '0.8.0' is ambiguous" in the
+  output, we recommend that you contact us immediately at securedrop@freedom.press
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
+
+Finally, run the following command:
+
+.. code:: sh
+
+  ./securedrop-admin setup
+
+Please note that this only updates the SecureDrop code on the workstation.
+Tails upgrades still have to be performed separately.
 
 Removal of Two-Factor Authentication for Keyboard Login
 -------------------------------------------------------


### PR DESCRIPTION
Resolves #3581

## Status

Ready for review

## Checklist

- [X] Doc linting (`make docs-lint`) passed locally