### PR TITLE
Clarify docs re output of ssh hostname commands

### DIFF
--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -353,4 +353,6 @@ the below commands. You should not be prompted for a passphrase
     $ ssh <username>@<Monitor IP address> hostname
     mon
 
-If you have successfully connected to the app via SSH, the terminal output will be name of the app to which you have connected ('app' or 'mon') as shown above.
+If you have successfully connected to the server via SSH, the terminal
+output will be name of the server to which you have connected ('app'
+or 'mon') as shown above.

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -352,3 +352,5 @@ the below commands. You should not be prompted for a passphrase
     app
     $ ssh <username>@<Monitor IP address> hostname
     mon
+
+If you have successfully connected to the app via SSH, the terminal output will be name of the app to which you have connected ('app' or 'mon') as shown above.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3348. Supersedes #3417.

The codeblock at the end of the page "Set Up the Servers" is ambiguous to some people. We can make this less ambiguous by adding a brief line about what sort of output the admin should expect.

Long term solution may involve updating the style guide around how we do code blocks, or providing more clarification earlier in the document.

Special thanks to @kstohr for doing the vast majority of the work to fix #3348. We really appreciate it! 😁 

## Checklist

- [x] Doc linting (`make docs-lint`) passed locally
