### PR TITLE
Smarter rebase on-top of github target logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ jobs:
       - run: apt-get install -y make
       - checkout
       - run:
-          name: Rebase on-top of latest develop
-          command: ./devops/scripts/rebase-develop.sh
+          name: Rebase on-top of github target
+          command: ./devops/scripts/rebase-ci.sh
       - setup_remote_docker
 
       - run: TAG=${CIRCLE_SHA1} make ci-lint-image
@@ -27,8 +27,8 @@ jobs:
       - run: apt-get install -y make
       - checkout
       - run:
-          name: Rebase on-top of latest develop
-          command: ./devops/scripts/rebase-develop.sh
+          name: Rebase on-top of github target
+          command: ./devops/scripts/rebase-ci.sh
       - setup_remote_docker
 
       - restore_cache:
@@ -133,8 +133,8 @@ jobs:
       - checkout
 
       - run:
-          name: Rebase on-top of latest develop
-          command: ./devops/scripts/rebase-develop.sh
+          name: Rebase on-top of github target
+          command: ./devops/scripts/rebase-ci.sh
 
       - run:
           name: Installation apt pre-reqs

--- a/devops/scripts/rebase-ci.sh
+++ b/devops/scripts/rebase-ci.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086
 #
 # To be utilized in CircleCI
 # Determine target branch from PR number and rebase against that

--- a/devops/scripts/rebase-ci.sh
+++ b/devops/scripts/rebase-ci.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
+#
+# To be utilized in CircleCI
+# Determine target branch from PR number and rebase against that
 
 set -e
+
+GITHUB_PR_URL="https://api.github.com/repos/freedomofpress/securedrop/pulls/${CIRCLE_PULL_REQUEST##*/}"
 
 # If current branch is not master or doesnt start with release...
 if [[ "$CIRCLE_BRANCH" != "master"  && "$CIRCLE_BRANCH" != release*  ]]; then
@@ -12,9 +17,14 @@ if [[ "$CIRCLE_BRANCH" != "master"  && "$CIRCLE_BRANCH" != release*  ]]; then
   # Ensure presensce of upstream remote
   git ls-remote --exit-code --quiet upstream 2>/dev/null || git remote add upstream https://github.com/freedomofpress/securedrop.git
 
+  # Determine target branch via API
+  #
+  # (We are togglin' between two upstream containers here - the constant is both have python3)
+  target_branch="$(curl -s ${GITHUB_PR_URL} | python3 -c 'import sys, json; print(json.load(sys.stdin)["base"]["ref"])')"
+
   # Fetch and rebase onto the latest in develop
-  git fetch upstream develop
-  git rebase upstream/develop
+  git fetch upstream "${target_branch}"
+  git rebase "upstream/${target_branch}"
 
   # Print out the current head for debugging potential CI issues
   git rev-parse HEAD


### PR DESCRIPTION
Ready for review


Fixes #2942

Changes proposed in this pull request:

* Modifies rebase script to pull from github API instead of hard-coding `develop`


How should the reviewer test this PR?

Start by populating the following env vars:
* `CIRCLE_PULL_REQUEST`
* `CIRCLE_BRANCH`  - Keep in mind that this looks like a full URL ala `https://github.com/freedomofpress/securedrop/pull/3556`. You might ask, why didnt @msheiny use `CIRCLE_PR_NUMBER` to just grab the number like @redshiftzero suggested!!? Well unfortunately that env var only applies to [forked PRs](https://circleci.com/docs/2.0/env-vars/).

Okay now run .. `devops/scripts/rebase-ci.sh`. Make sure stuff doesnt explode. If you have dangling git changes you should get errors about a rebase.


Any special considerations for deployment? Consider both:

Only affects CI. I did take note to look at the parameters from a forked PR on the github API and I'm convinced it'll work fine *famous last words*



- [x] I have written a test plan and validated it for this PR


Caveat -- One particular bit I am concerned about is Github API limits... its 60 per hour per host. Now I think we are safe here because we are executing on multiple builders which should change IP addresses.. but something to watch out for.