### PR TITLE
Add 'Getting Support' page to documentation

### DIFF
--- a/docs/getting_support.rst
+++ b/docs/getting_support.rst
@@ -1,0 +1,18 @@
+Getting Support
+===============
+
+There are a variety of support options available for people who need help installing SecureDrop, or are looking for help with their existing SecureDrop instance.
+
+Community Based Support
+-----------------------
+
+The `SecureDrop forum <https://forum.securedrop.club/>`_ is a great place to discuss SecureDrop and to get help from others. It is based on Discourse and creating an account is simple and easy.
+
+Additionally, the `SecureDrop Gitter channel <https://gitter.im/freedomofpress/securedrop>`_ is a great place to discuss SecureDrop in real-time chat. This is mostly a development focused channel, but occasionally support questions do come up from time to time.
+
+.. warning:: Remember that both the SecureDrop forum and the Gitter channel are public. **Do not post any sensitive information through public channels.**
+
+Priority Support and Training
+-----------------------------
+
+Freedom of the Press Foundation provides paid priority support and SecureDrop training to organizations. Visit the `Priority Support <https://securedrop.org/priority-support/>`_ and `Training <https://securedrop.org/training/>`_ pages on the SecureDrop website for more information.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,7 @@ anonymous sources.
    backup_and_restore
    backup_workstations
    kernel_troubleshooting
+   getting_support
 
 .. toctree::
    :caption: Upgrade SecureDrop


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2297.

The documentation lacks information on how to get support. We now have information on the SecureDrop website, and we should update our documentation to point to it.

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
