### PR TITLE
Documents dev env setup in Qubes

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -45,6 +45,23 @@ Install Docker_.
 .. _Docker: https://store.docker.com/editions/community/docker-ce-desktop-mac
 
 
+Qubes
+~~~~~
+
+Create a StandaloneVM based on Debian 9, called ``sd-dev``.
+You can use the **Q** menu to configure a new VM, or run
+the following in ``dom0``:
+
+.. code:: sh
+
+   qvm-clone --class StandaloneVM debian-9 sd-dev
+   qvm-start sd-dev
+   qvm-sync-appmenus sd-dev
+
+The commands above will created a new StandaloneVM, boot it, then update
+the Qubes menus with applications within that VM. Open a terminal in
+``sd-dev``, and proceed with installing `Docker CE for Debian`_.
+
 Fork & Clone the Repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes https://github.com/freedomofpress/securedrop-workstation/issues/106.

Straightforward, mostly the same as the existing Debian 9 install docs,
with a few dom0 commands, as is to be expected in Qubes. We recommend a
StandaloneVM in Qubes, because otherwise the developer must:

  * manage a custom template for the dev AppVM, or
  * reinstall docker on every boot (no, thanks)

The compromise here is additional overhead for the StandaloneVM, but
that's well worth it for a smooth dev experience.

## Testing

**Qubes machine required to test.** Recommended testing procedure (feel free to copy/paste into comments below): 

* [ ] Follow the new docs to set up a VM for use on SD development.
* [ ] Proceed with the "Using the Docker Environment" section of the docs (unchanged by this PR)
* [ ] Confirm you can build and run the SD dev env container setup
* [ ] Confirm you can view the SD Source Interface in a browser within the `sd-dev` VM.

That should be sufficient for merge. If anything's unclear, don't hesitate to comment. A separate PR will provide much more verbose documentation around getting the staging setup working in Qubes, and this work is required for that work to make sense.

## Deployment
None, dev-env only.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
