### PR TITLE
Bump paramiko version

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -5,8 +5,8 @@ ENV USER_NAME ${USER_NAME:-root}
 ARG USER_ID
 ENV USER_ID ${USER_ID:-0}
 
-RUN apt-get update
-RUN apt-get install -y python sudo lsb-release gnupg2 git
+RUN apt-get update && \
+    apt-get install -y python sudo lsb-release gnupg2 git
 RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi
 
 WORKDIR /opt

--- a/admin/requirements.txt
+++ b/admin/requirements.txt
@@ -118,9 +118,9 @@ markupsafe==1.0 \
 netaddr==0.7.19 \
     --hash=sha256:38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd \
     --hash=sha256:56b3558bd71f3f6999e4c52e349f38660e54a7a8a9943335f73dfc96883e08ca
-paramiko==2.4.0 \
-    --hash=sha256:486f637f0a33a4792e0e567be37426c287efaa8c4c4a45e3216f9ce7fd70b1fc \
-    --hash=sha256:8851e728e8b7590989e68e3936c48ee3ca4dad91d29e3d7ff0305b6c5fc582db \
+paramiko==2.4.1 \
+    --hash=sha256:24fb31c947de85fbdeca09e222d41206781581fb0bdf118d2ef18f6e414cd388 \
+    --hash=sha256:33e36775a6c71790ba7692a73f948b329cf9295a72b0102144b031114bd2a4f3 \
     # via ansible
 prompt-toolkit==1.0.15 \
     --hash=sha256:1df952620eccb399c53ebb359cc7d9a8d3a9538cb34c5a1344bdbeb29fbcc381 \

--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -65,7 +65,7 @@ molecule==2.13.1
 monotonic==1.4            # via fasteners
 netaddr==0.7.19
 packaging==16.8           # via dparse, safety
-paramiko==2.2.1           # via ansible
+paramiko==2.4.1           # via ansible
 pathspec==0.5.5           # via yamllint
 pathtools==0.1.2          # via sphinx-autobuild, watchdog
 pbr==3.0.1                # via git-url-parse, molecule, python-gilt, stevedore


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3632

Fix borked docker container build. Bump paramiko version to revolve CVE.

## Testing

CI should be fine and we don't even use paramiko anyway.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container