### PR TITLE
source: do not set last_updated on key generation

### DIFF
--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -86,7 +86,6 @@ def async_genkey(crypto_util_, db_uri, filesystem_id, codename):
     try:
         source = session.query(Source).filter(
             Source.filesystem_id == filesystem_id).one()
-        source.last_updated = datetime.utcnow()
         session.commit()
     except Exception as e:
         logging.getLogger(__name__).error(


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3635 

The last_updated field is updated every time a submission is
sent. Also updating it when the source key is generated has a
different meaning and creates a problem.

A: there is enough entropy and the key is created when a message or
   document is submitted. The last_updated field is set twice, with
   the same value, give or take a few seconds.

B: there is not enough entropy and the key is created long after the
   initial document or message was submitted, when the source
   reconnects using the same passphrase. The last_updated is set and
   that confuses the manage.py::were_there_submissions_today which
   assumes the field is only set when a submission is received.

Since no code logic relies on the last_updated field being set when
the key is generated, the async_genkey is modified to no longer set
the last_updated field.

## Testing

TBD

## Deployment

Existing deployments will no longer set the `last_updated` field when a key is created. This has no consequence as this field is not exposed to admins and users.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
