### PR TITLE
Added SD community CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,199 @@
+# SecureDrop Community Code of Conduct
+
+## Preamble
+
+Like the broader technical and activism communities as a whole, the SecureDrop
+community is made up of a mixture of staff and volunteers from all over the world,
+engaged in various activities—including operations, software
+development, mentorship, and building connections with great people and
+organizations.
+
+To work together effectively in a large, diverse and open community, we have a
+few ground rules that we expect everyone to adhere to, be it paid staff and
+board members, volunteers and event attendees; mentors, veterans, novices, or
+those seeking help and guidance.
+
+This isn't an exhaustive list of things that you cannot do. Rather, take it in
+the spirit in which it’s intended: a guide to make it easier to enrich all of
+us and the communities in which we participate.
+
+This code of conduct applies to all spaces and events under the responsibility of someone who belongs to the
+SecureDrop Community. This includes physical offices, GitHub repositories, online chat
+systems, the Support Forum, SecureDrop hosted or sponsored events, and any other
+forums created by the SecureDrop Community which are used for communication.
+In addition, we take violations of this code outside these spaces into account
+when determining a person's ability to participate within them.
+
+## Summary
+
+The SecureDrop Community should be a place where people feel safe and welcome.
+They should enjoy participating in discussions and contributing. To these ends,
+members of the community should:
+
+- Be friendly and patient
+- Assume good faith and good intentions
+- Be welcoming, considerate, and respectful
+- Be careful in the words they choose
+- Listen to each other, and communicate openly and honestly
+
+Members of the community should not:
+
+- Intimidate, harass, or insult each other
+- Follow the letter of this Code of Conduct while disregarding its spirit
+
+Members of the community should not hesitate to contact the Community Moderation
+and Safety Team ("Community Team") if they feel someone has violated this Code of
+Conduct, or if they have questions or concerns.
+
+## Behavioral Guidelines
+
+As a member of the community, you are expected to:
+
+- Be friendly and patient. Your work will be used by other people, and you in
+  turn will depend on the work of others. Any decision you take will affect
+  human beings, and you should take those consequences into account when making
+  decisions. Remember that our community is international, and that the people
+  you interact with may be communicating with you in a language that is not
+  their native tongue.
+
+- Assume good faith and good intentions. Disagreements — both social and
+  technical — happen all the time. Our diverse backgrounds give us the ability
+  to see things from many different perspectives, but they can also lead to
+  misunderstandings. It is important that we resolve disagreements
+  constructively, and that we do not jump to conclusions about each other's
+  motives.
+
+- Be welcoming, considerate, and respectful. We strive to be a community that
+  welcomes and supports people of all backgrounds and identities. This includes,
+  but is not limited to, members of any race, ethnicity, culture, national
+  origin, color, immigration status, social and economic class, educational
+  level, sex, sexual orientation, gender identity and expression, age, size,
+  family status, political belief, religion and mental and physical ability.
+
+- Be careful in the words you choose. Exclusionary behavior is absolutely
+  unacceptable. This includes, but is not limited to:
+
+  - Discriminatory (e.g., racist or sexist) jokes and language
+  - Inappropriate names for user accounts, servers, files, repositories, etc.
+  - Posting sexually explicit or violent material
+  - Personal insults
+  - Misgendering or deadnaming
+  - Unwelcome sexual attention
+  - Advocating for, or encouraging, any of the above behavior
+
+- Listen and communicate openly and honestly. Yield the floor to
+  others, and help to make sure that everyone gets heard. In other words, try to
+  be your best self. In doing so, you contribute the health and longevity of
+  this community.
+
+As a member of the SecureDrop Community, you are expected to never engage in the
+following behaviors:
+
+- Intimidation, harassments, or insults.  This includes but is not limited to:
+  - Physical intimidation or threats against someone's physical safety
+  - Obscene or intimidating gestures
+  - Stalking
+  - Demeaning another person
+  - Unwelcome following
+  - Enlisting the help of others, whether in person or online, in order to
+    target an individual
+  - Taking photographs, video, or audio recordings or recordings without consent
+  - Shouting
+  - Sustained disruption of talks and events
+  - Disruption of meetings
+  - Inappropriate physical contact
+  - Unwelcome sexual attention
+  - Posting (or threatening to post) other people's personally identifying
+    information ("doxing")
+  - Respect people's stated personal boundaries
+
+- Following the letter of this Code of Conduct while disregarding its spirit.
+  When judging whether certain behavior represents a violation of this code, we
+  will consider a violation in spirit (e.g., clearly behaving in a damaging or
+  obnoxious manner in a way not explicitly specified) to be no different from
+  any other violation of this code. That includes trolling and other forms of
+  consistently disruptive behavior.
+
+## Enforcement
+
+We do not tolerate unacceptable behavior from any community member, and there
+are no exceptions for those in positions of power such as maintainers,
+sponsors, funders, or other individuals with decision making authority.
+Further, people in positions of power can wield it to exacerbate the effects of
+harassment and to diminish the repercussions. For these reasons, those who are
+informal or formal leaders are held to a higher standard.
+
+Anyone asked by another community member to stop unacceptable behavior is
+expected to comply immediately. However, you should not step in on someone
+else's behalf without their consent.
+
+### How to get help
+
+The Community Team is made up established members of the community who
+assist with resolving conflicts within the community.
+
+Currently the Community Team consists of:
+
+- Jen Helsby (`@redshiftzero`) - Lead Engineer - [jen@freedom.press](mailto:jen@freedom.press)
+- Loic Dachary (`@dachary`) - Maintainer - [loic@dachary.org](mailto:loic@dachary.org)
+
+You can contact the whole Community Team or members individually.
+
+You should contact the Community Team if you have questions or concerns about
+the Code of Conduct (including improvements) or if you feel that you have
+witnessed a Code of Conduct violation. In the even of a violation either
+directed at yourself or someone else, please contact the Community Team as
+soon as possible through whatever analog or digital medium you are most
+comfortable with.
+
+Should your report be about any member of the Community Team or if there is a
+conflict of interest, that member will recuse themselves from the conflict
+resolution proceedings. They will not be involved with the discussion,
+documentation, communications, or decisions made by the rest of the Community
+Team with regards to the incident.
+
+## What the person reporting a violation can expect
+
+The Community Team will respond to reports as quickly as possible. When
+responding to a report, the Community Team will prioritize the safety of the
+person(s) who have been harmed or are at risk of harm and the reporter(s). No
+actions will be taken without the consent of the person who has been harmed or
+is at risk of harm except in cases where danger or harm are imminent.
+
+All reports to the Community Team, no matter how minor or severe, will be
+taken seriously and looked into.
+
+## How the Community Team responds to incidents
+
+The Community Team does not have a fixed of set responses to some enumerated
+set of incidents that may occur. The Community Team operates on a
+case-by-case basis taking into account past behavior; the relationship between
+the person(s) who were harmed and the person(s) causing the harm; the responses
+of the person(s) who caused harm; and the perceived threat of future harm.
+
+Actions the Community Team may take to mitigate harm include, but are not
+limited to:
+
+- A simple warning
+- Informal mediation
+- A temporary ban from email lists, chat channels, repositories, or other online
+  communication mediums
+- A temporary ban from events or community spaces
+- Permanent expulsion from the community
+
+Once the Community Team has reached a decision on how to mitigate the harm or
+risk of harm, the person(s) on the receiving end of the mitigation(s) may appeal
+the decision by writing or otherwise communicating with the Community Team.
+
+## License and Attribution
+
+Parts of this code of conduct are derived from or inspired by:
+
+- The Citizen Code of Conduct
+- The Django Code of Conduct
+- The Tor Project Code of Conduct
+- The OpenStack Foundation Community Code of Conduct
+- The Freedom of the Press Foundation Code of Conduct
+
+This Code of Conduct is shared under a Creative Commons CC-BY-SA 4.0 International
+license.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3251 

Adds the community CoC from [this commit in the staging repo](https://github.com/heartsucker/securedrop-community-coc/blob/f8dd24a22d3359ea1818a08a8a46dbfba0eb03a5/CoC.md). The source for acceptance and ratification by the community is [this thread](https://forum.securedrop.club/t/code-of-conduct-ratification/916/3).

## Testing

Please do **not** test this CoC. I will be very upset if you do. ಠ_ಠ