### PR TITLE
added warnings stressing the importance of protecting ATHS files.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -156,7 +156,7 @@ Service will be available in the following files under
 
 - ``app-source-ths`` contains the ``.onion`` address of the *Source
   Interface*.
-- ``app-journalcontainst-aths`` contains the ``HidServAuth``
+- ``app-journalist-aths`` contains the ``HidServAuth``
   configuration line for the *Journalist Interface*. During a later
   step, this will be automatically added to your Tor configuration
   file in order to exclusively limit connections to the hidden
@@ -165,6 +165,13 @@ Service will be available in the following files under
   *Application Server*.
 - ``mon-ssh-aths`` contains the ``HidServAuth`` for SSH access to the
   *Monitor Server*.
+
+.. warning:: The ``app-journalist-aths``, ``app-ssh-aths``, and 
+             ``mon-ssh-aths`` files contain passwords for their corresponding 
+             authenticated hidden services. They should not be shared with 
+             third parties or copied from the *Admin Workstation* for any 
+             reason other than well-defined administrative tasks such as 
+             onboarding new users or performing backups.
 
 The dynamic inventory file will automatically read the Onion URLs
 from the ``app-ssh-aths`` and ``mon-ssh-aths`` files and use them to connect

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -76,6 +76,12 @@ to access the servers over SSH.
              and only the *Admin Workstation* should have shell access to the
              servers.
 
+.. warning:: The ``app-journalist-aths`` file contains a password for the 
+             authenticated hidden service used by the *Journalist Interface*, 
+             and should not be shared except through the onboarding process. 
+             Make sure to securely delete it from the Transfer Device once 
+             onboarding is complete.  
+
 Since you need will the Tails setup scripts (``securedrop/tails_files``) that
 you used to :doc:`Configure the *Admin Workstation* Post-Install
 <configure_admin_workstation_post_install>`, clone (and verify) the SecureDrop

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -69,7 +69,9 @@ to access the servers over SSH.
          the *Admin Workstation* via the Transfer Device. Place these files
          in ``~/Persistent/securedrop/install_files/ansible-base`` on the
          *Journalist Workstation*, and the ``./securedrop-admin tailsconfig``
-         tool will automatically use them.
+         tool will automatically use them. Don't forget to securely delete 
+         these files from the *Transfer Device* when you're done, by 
+         right-clicking them in the file manager and selecting **Wipe**.
 
 .. warning:: Do **not** copy the files ``app-ssh-aths`` and ``mon-ssh-aths``
              to the *Journalist Workstation*. Those files grant access via SSH,
@@ -79,8 +81,6 @@ to access the servers over SSH.
 .. warning:: The ``app-journalist-aths`` file contains a password for the 
              authenticated hidden service used by the *Journalist Interface*, 
              and should not be shared except through the onboarding process. 
-             Make sure to securely delete it from the Transfer Device once 
-             onboarding is complete.  
 
 Since you need will the Tails setup scripts (``securedrop/tails_files``) that
 you used to :doc:`Configure the *Admin Workstation* Post-Install


### PR DESCRIPTION
## Status

Ready for review. 

## Description of Changes

Fixes #2761 

Warnings added in the installation and onboarding docs to highlight the fact that ATHS files contain authentication info and should be protected.

## Testing

- `make docs-lint` (passes locally) 
- Review docs changes, see if they're consistent.

## Deployment
No special instructions

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
