### PR TITLE
source: do not set last_updated default to now

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -49,7 +49,7 @@ class Source(db.Model):
     filesystem_id = Column(String(96), unique=True)
     journalist_designation = Column(String(255), nullable=False)
     flagged = Column(Boolean, default=False)
-    last_updated = Column(DateTime, default=datetime.datetime.utcnow)
+    last_updated = Column(DateTime)
     star = relationship("SourceStar", uselist=False, backref="source")
 
     # sources are "pending" and don't get displayed to journalists until they

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -2,6 +2,7 @@
 """Testing utilities that involve database (and often related
 filesystem) interaction.
 """
+import datetime
 import mock
 import os
 
@@ -143,6 +144,8 @@ def submit(source, num_submissions):
     :returns: A list of the :class:`models.Submission`s submitted.
     """
     assert num_submissions >= 1
+    source.last_updated = datetime.datetime.utcnow()
+    db.session.add(source)
     submissions = []
     for _ in range(num_submissions):
         source.interaction_count += 1


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #3635

The last_updated field is used to reflect:

* When a new submission is sent
* When the key of a flagged source is created (when the source is not flagged, the key is created at the same time the document is submitted)

It should not be set when the source record is created otherwise it
will be reported a an activity worthy of the journalist attention. But
when a new source is created (and before any submission is sent), the
source does not even show (it is pending) and the journalist cannot
notice any difference.


## Testing

Should be covered by the existing tests.

## Deployment

It will only change the `last_updated` field of new sources, not existing ones.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
