### PR TITLE
Journalist API - Validate json before routing request

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -65,6 +65,21 @@ def make_blueprint(config):
                      'auth_token_url': '/api/v1/token'}
         return jsonify(endpoints), 200
 
+    # Before every post, we validate the payload before processing the request
+    @api.before_request
+    def validate_data():
+        if request.method == 'POST':
+            # flag and star can have empty payloads
+            if not request.data:
+                if ('flag' not in request.path and 'star' not in request.path):
+                    return abort(400, 'malformed request')
+            # other requests must have valid JSON payload
+            else:
+                try:
+                    json.loads(request.data)
+                except (ValueError):
+                    return abort(400, 'malformed request')
+
     @api.route('/token', methods=['POST'])
     def get_token():
         creds = json.loads(request.data)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes
Validates JSON before reaching the endpoints as part of `before_request`.

Fixes #3651.


## Testing

* [ ] All tests should pass
* [ ] Requests with invalid JSON should return error 400
* [ ] Requests with no JSON payload should also 400, with the exception of starring and flagging functionality.

## Deployment

Part of application code that is deployed through debian packages.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
