### PR TITLE
Return current datetime if last_updated is None

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -118,13 +118,18 @@ class Source(db.Model):
     def to_json(self):
         docs_msg_count = self.documents_messages_count()
 
+        if self.last_updated:
+            last_updated = self.last_updated.isoformat() + 'Z'
+        else:
+            last_updated = datetime.datetime.utcnow().isoformat() + 'Z'
+
         json_source = {
             'uuid': self.uuid,
             'url': url_for('api.single_source', source_uuid=self.uuid),
             'journalist_designation': self.journalist_designation,
             'is_flagged': self.flagged,
             'is_starred': True if self.star else False,
-            'last_updated': self.last_updated.isoformat() + 'Z',
+            'last_updated': last_updated,
             'interaction_count': self.interaction_count,
             'key': {
               'type': 'PGP',


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3653 .

Due to recent changes in the model, last_updated is not set when the
source object is created. To avoid returning a null last_updated time,
the to_json method will now return the current time if the time is null.

## Testing

CI / Application tests should pass

## Deployment

None

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
