### PR TITLE
Updates builder container image hash

### DIFF
--- a/molecule/builder/image_hash
+++ b/molecule/builder/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_06_26
-f1e82d828a0edc99d7669f32f4357605abd63ec3a713bbdd725960d2d0338737
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_07_25
+86cb12fa109798f01c86286cb168a21d5dfe3d676a8dba0c08127338b4dcf07a


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #3657.

Changes proposed in this pull request:

## Testing

1. Make sure you're not overriding the CI env var locally (to get passing builds): `unset FPF_CI`
2. Build debs locally via `make build-debs`.
3. Confirm zero errors.

That's it! Recall that CI doesn't fail on these tests, so the best path to approval is running the builds locally. 

## Deployment

No concerns, does have impact, though: these dependency updates will be used for generating deb packages that get distributed to instances—but we'll probably update several times between now and the nxt release.

## Checklist
Requesting manual review by humans (as well as expecting CI to pass entirely).