### PR TITLE
Bump grsecurity kernel to 4.4.144

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -52,5 +52,5 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder/tests/vars.yml
 securedrop_pkg_grsec:
-  ver: "4.4.135"
-  depends: "linux-image-3.14.79-grsec,linux-image-4.4.115-grsec,linux-image-4.4.135-grsec,linux-firmware-image-4.4.135-grsec"
+  ver: "4.4.144"
+  depends: "linux-image-3.14.79-grsec,linux-image-4.4.135-grsec,linux-firmware-image-4.4.135-grsec,linux-image-4.4.144-grsec,linux-firmware-image-4.4.144-grsec"

--- a/molecule/builder/tests/vars.yml
+++ b/molecule/builder/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "0.9.0~rc1"
 ossec_version: "2.8.2"
 keyring_version: "0.1.1"
 config_version: "0.1.1"
-grsec_version: "4.4.135"
+grsec_version: "4.4.144"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/testinfra/common/test_grsecurity.py
+++ b/testinfra/common/test_grsecurity.py
@@ -76,7 +76,7 @@ def test_grsecurity_kernel_is_running(Command):
     """
     c = Command('uname -r')
     assert c.stdout.endswith('-grsec')
-    assert c.stdout == '4.4.135-grsec'
+    assert c.stdout == '4.4.144-grsec'
 
 
 @pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Fixes #3646 

* Adds linux-{firmware, image}-4.4.144 to list of dependencies for
securedrop-grsec metapackage.
* Remove linux-image-4.4.115.

## Testing

Staging vms will automatically use this kernel version as they rely on apt-test.
For hardware testing, setting the apt server to apt-test.freedom.press should upgrade the server's kernel version. 

## Deployment
1. securedrop-grsec-4.4.144, linux-firmware-4.4.144 and linux-image 4.4.144 have already been uploaded to apt-test.freedom.press.

2. securedrop-grsec-4.4.144, linux-firmware-4.4.144 and linux-image 4.4.144 will need to be uploaded to apt.freedom.press as part of the 0.9 release.

For hardware testing, please upgrade the testing table below
## Checklist

Test | VMs  | Clean install- NUC | PowerEdge R620 | Clean install - Mac Mini | Upgrade - Mac mini | Upgrade - NUC w/ 3.14| HP Proliant DL385 G7
| ------------ | :---: | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| Boots | :heavy_check_mark: |  |  | | :heavy_check_mark: | |  |
| paxtest blackhat |:heavy_check_mark: |  |  | | :heavy_check_mark: | |  |
| [Spectre/Meltdown test](https://meltdown.ovh) |:heavy_check_mark: |  |  | | :heavy_check_mark: | |  |
| End-to-end  | :heavy_check_mark: |  |  | | :heavy_check_mark: | |  |
| Testinfra tests | :heavy_check_mark: | N/A | N/A | N/A | N/A | N/A | N/A|
| No errors/grsec denies in logs after 24+h  | :heavy_check_mark: |  |  | | :heavy_check_mark: | |  |
| No (unusual) ossec alerts after 24+h  |:heavy_check_mark: |  |  | | :heavy_check_mark: | |  |

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

