### PR TITLE
Fix source is_starred in journalist API

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -123,12 +123,17 @@ class Source(db.Model):
         else:
             last_updated = datetime.datetime.utcnow().isoformat() + 'Z'
 
+        if self.star and self.star.starred:
+            starred = True
+        else:
+            starred = False
+
         json_source = {
             'uuid': self.uuid,
             'url': url_for('api.single_source', source_uuid=self.uuid),
             'journalist_designation': self.journalist_designation,
             'is_flagged': self.flagged,
-            'is_starred': True if self.star else False,
+            'is_starred': starred,
             'last_updated': last_updated,
             'interaction_count': self.interaction_count,
             'key': {

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -306,6 +306,12 @@ def test_authorized_user_can_star_a_source(journalist_app, test_source,
         assert SourceStar.query.filter(
             SourceStar.source_id == source_id).one().starred
 
+        # API should also report is_starred is true
+        response = app.get(url_for('api.single_source', source_uuid=uuid),
+                           headers=get_api_headers(journalist_api_token))
+        json_response = json.loads(response.data)
+        assert json_response['is_starred'] is True
+
 
 def test_authorized_user_can_unstar_a_source(journalist_app, test_source,
                                              journalist_api_token):
@@ -323,6 +329,12 @@ def test_authorized_user_can_unstar_a_source(journalist_app, test_source,
         # Verify that the source is gone.
         assert SourceStar.query.filter(
             SourceStar.source_id == source_id).one().starred is False
+
+        # API should also report is_starred is false
+        response = app.get(url_for('api.single_source', source_uuid=uuid),
+                           headers=get_api_headers(journalist_api_token))
+        json_response = json.loads(response.data)
+        assert json_response['is_starred'] is False
 
 
 def test_disallowed_methods_produces_405(journalist_app, test_source,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3666.

Changes proposed in this pull request:
 - @kushaldas found a bug during QA of #3619 regarding incorrect `is_starred` results, this PR adds additional asserts in the tests for regression testing and fixes the bug

## Testing

Follow STR in #3666 and verify expected behavior occurs

OR 

checkout 92a4964, see tests fail. Checkout aae71df, see tests pass

## Deployment

Deployed in securedrop-app-code deb package

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
