### PR TITLE
added instructions on using libvirt Vagrant provider in Ubuntu & Debian

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -141,6 +141,9 @@ can simply scan the following QR code:
 
 .. image:: ../images/devenv/test-users-totp-qrcode.png
 
+
+.. _multi_machine_environment:
+
 Setting Up a Multi-Machine Environment
 --------------------------------------
 

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -12,11 +12,6 @@ one.
 .. note:: If you plan to alter the configuration of any of these machines, make sure to
           review the :ref:`config_tests` documentation.
 
-.. note:: If you have errors with mounting shared folders in the Vagrant guest
-          machine, you should look at `GitHub #1381`_.
-
-.. _`GitHub #1381`: https://github.com/freedomofpress/securedrop/issues/1381
-
 .. note:: If you see test failures due to ``Too many levels of symbolic links``
           and you are using VirtualBox, try restarting VirtualBox.
 

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -131,12 +131,15 @@ under Linux uses QEMU/KVM, which cannot run simultaneously with Virtualbox.
 
 Instructions for both installation methods follow.
 
-Switch Vagrant provider to libvirt - Ubuntu 16.04
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
+Switch Vagrant provider to libvirt
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Make sure you've already installed Vagrant, as described
 in the :ref:`multi-machine setup docs <multi_machine_environment>`.
-Then install libvirt and QEMU:
+
+Ubuntu 16.04 setup
+^^^^^^^^^^^^^^^^^^
+
+Install libvirt and QEMU:
 
 .. code:: sh
 
@@ -151,14 +154,6 @@ Add your user to the libvirtd group:
    sudo addgroup libvirtd
    sudo usermod -a -g libvirtd $USER
 
-Log out, then log in again. Verify that libvirt is installed and KVM is
-available:
-
-.. code:: sh
-
-   libvirtd --version
-   kvm-ok
-
 Install Vagrant along with the required plugins for converting and using
 libvirt boxes:
 
@@ -169,29 +164,10 @@ libvirt boxes:
 
 .. note:: If Vagrant is already installed it may not recognize libvirt as a
    valid provider. In this case, remove Vagrant with ``sudo apt-get remove
-   vagrant`` and reinstall it as above
+   vagrant`` and reinstall it.
 
-Convert the bento/14.04 Vagrant box from ``virtualbox`` to ``libvirt`` format:
-
-.. code:: sh
-
-   vagrant box add --provider virtualbox bento/ubuntu-14.04
-   vagrant mutate bento/ubuntu-14.04 libvirt
-
-Set the default Vagrant provider to ``libvirt``:
-
-.. code:: sh
-
-   echo 'export VAGRANT_DEFAULT_PROVIDER=libvirt' >> ~/.bashrc
-   export VAGRANT_DEFAULT_PROVIDER=libvirt
-
-
-.. note:: To explicitly specify the ``libvirt``  provider below, use the command
-   ``vagrant up --provider=libvirt /prod/``
-
-
-Switch Vagrant provider to libvirt - Debian 9
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Debian 9 setup
+^^^^^^^^^^^^^^
 
 Install Vagrant, libvirt, QEMU, and their dependencies:
 
@@ -215,6 +191,9 @@ Add your user to the kvm group to give it permission to run KVM:
    sudo modprobe kvm_intel
 
 
+Validate libvirt config
+^^^^^^^^^^^^^^^^^^^^^^^
+
 Log out, then log in again. Verify that libvirt is installed and KVM is
 available:
 
@@ -223,13 +202,6 @@ available:
    libvirtd --version
    kvm-ok
 
-Convert the bento/14.04 Vagrant box from ``virtualbox`` to ``libvirt`` format:
-
-.. code:: sh
-
-   sudo apt-get install -y vagrant-mutate
-   vagrant box add --provider virtualbox bento/ubuntu-14.04
-   vagrant mutate bento/ubuntu-14.04 libvirt
 
 Set the default Vagrant provider to ``libvirt``:
 
@@ -238,9 +210,21 @@ Set the default Vagrant provider to ``libvirt``:
    echo 'export VAGRANT_DEFAULT_PROVIDER=libvirt' >> ~/.bashrc
    export VAGRANT_DEFAULT_PROVIDER=libvirt
 
-.. note:: To explicitly specify the ``libvirt``  provider, use the command
+
+.. note:: To explicitly specify the ``libvirt``  provider below, use the command
    ``vagrant up --provider=libvirt /prod/``
 
+Convert Vagrant boxes to libvirt
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Convert the bento/14.04 Vagrant box from ``virtualbox`` to ``libvirt`` format:
+
+.. code:: sh
+
+   vagrant box add --provider virtualbox bento/ubuntu-14.04
+   vagrant mutate bento/ubuntu-14.04 libvirt
+
+You can now use the libvirt-backed VM images to develop against
+the SecureDrop multi-machine environment.
 
 .. _prod_install_from_tails:
 

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -141,12 +141,11 @@ Instructions for both installation methods follow.
 Switch Vagrant provider to libvirt - Ubuntu 16.04
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Uninstall any exiting version of Vagrant. Install libvirt and QEMU:
+Install libvirt and QEMU:
 
 .. code:: sh
 
    sudo apt-get update
-   sudo apt-get remove vagrant
    sudo apt-get install libvirt-bin libvirt-dev qemu-utils qemu
    sudo /etc/init.d/libvirt-bin restart
 
@@ -165,7 +164,7 @@ available:
    libvirtd --version 
    kvm-ok
 
-Reinstall Vagrant and install the required plugins for converting and using 
+Install Vagrant along with the required plugins for converting and using 
 libvirt boxes:
 
 .. code:: sh
@@ -174,6 +173,10 @@ libvirt boxes:
    sudo dpkg -i vagrant_1.9.1_x86_64.deb
    vagrant plugin install vagrant-libvirt
    vagrant plugin install vagrant-mutate
+
+.. note:: If Vagrant is already installed it may not recognize libvirt as a 
+   valid provider. In this case, remove Vagrant with ``sudo apt-get remove 
+   vagrant`` and reinstall it as above 
 
 Convert the bento/14.04 Vagrant box from ``virtualbox`` to ``libvirt`` format:
 
@@ -203,19 +206,16 @@ Install Vagrant, libvirt, QEMU, and their dependencies:
 
    sudo apt-get update
    sudo apt-get install -y vagrant vagrant-libvirt libvirt-daemon-system qemu-kvm
-   sudo apt-get install -y nfs-common nfs-kernel-server ebtables dnsmasq
    sudo apt-get install -y ansible rsync
    vagrant plugin install vagrant-libvirt
-   sudo usermod -a -G libvirt debian
-   newgrp libvirt
+   sudo usermod -a -G libvirt $USER 
    sudo systemctl restart libvirtd                                                                    
                                                                                 
 Add your user to the kvm group to give it permission to run KVM:                                            
                                                                                 
 .. code:: sh
 
-   sudo usermod -a -G kvm debian
-   newgrp kvm
+   sudo usermod -a -G kvm $USER
    sudo rmmod kvm_intel
    sudo rmmod kvm
    sudo modprobe kvm

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -105,7 +105,7 @@ Vagrant host's ``install_files/ansible-base`` directory, named:
 
 For working on OSSEC monitoring rules with most system hardening active, update
 the OSSEC-related configuration in
-``install_files/ansible-base/staging-specific.yml`` so you receive the OSSEC
+``install_files/ansible-base/staging.yml`` so you receive the OSSEC
 alert emails.
 
 Direct SSH access is available via Vagrant for staging hosts, so you can use
@@ -131,12 +131,12 @@ under Linux uses QEMU/KVM, which cannot run simultaneously with Virtualbox.
 
 Instructions for both installation methods follow.
 
-.. _prod_install_from_tails:
-
 Switch Vagrant provider to libvirt - Ubuntu 16.04
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Install libvirt and QEMU:
+Make sure you've already installed Vagrant, as described
+in the :ref:`multi-machine setup docs <multi_machine_environment>`.
+Then install libvirt and QEMU:
 
 .. code:: sh
 
@@ -163,9 +163,7 @@ Install Vagrant along with the required plugins for converting and using
 libvirt boxes:
 
 .. code:: sh
-   
-   wget https://releases.hashicorp.com/vagrant/1.9.1/vagrant_1.9.1_x86_64.deb
-   sudo dpkg -i vagrant_1.9.1_x86_64.deb
+
    vagrant plugin install vagrant-libvirt
    vagrant plugin install vagrant-mutate
 
@@ -243,6 +241,8 @@ Set the default Vagrant provider to ``libvirt``:
 .. note:: To explicitly specify the ``libvirt``  provider, use the command      
    ``vagrant up --provider=libvirt /prod/``
    
+
+.. _prod_install_from_tails:
 
 Install from an Admin Workstation VM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -124,9 +124,9 @@ virtualized, rather than running on hardware. You will need to
 playbook from running with Vagrant-specific info.
 
 You can provision production VMs from an Admin Workstation (most realistic),
-or from your host. If your host OS is Linux-based and you plan to use an Admin 
-Workstation, you will need to switch Vagrant's default virtualization provider 
-from ``virtualbox`` to  ``libvirt``.  The Admin Workstation VM configuration 
+or from your host. If your host OS is Linux-based and you plan to use an Admin
+Workstation, you will need to switch Vagrant's default virtualization provider
+from ``virtualbox`` to  ``libvirt``.  The Admin Workstation VM configuration
 under Linux uses QEMU/KVM, which cannot run simultaneously with Virtualbox.
 
 Instructions for both installation methods follow.
@@ -156,10 +156,10 @@ available:
 
 .. code:: sh
 
-   libvirtd --version 
+   libvirtd --version
    kvm-ok
 
-Install Vagrant along with the required plugins for converting and using 
+Install Vagrant along with the required plugins for converting and using
 libvirt boxes:
 
 .. code:: sh
@@ -167,9 +167,9 @@ libvirt boxes:
    vagrant plugin install vagrant-libvirt
    vagrant plugin install vagrant-mutate
 
-.. note:: If Vagrant is already installed it may not recognize libvirt as a 
-   valid provider. In this case, remove Vagrant with ``sudo apt-get remove 
-   vagrant`` and reinstall it as above 
+.. note:: If Vagrant is already installed it may not recognize libvirt as a
+   valid provider. In this case, remove Vagrant with ``sudo apt-get remove
+   vagrant`` and reinstall it as above
 
 Convert the bento/14.04 Vagrant box from ``virtualbox`` to ``libvirt`` format:
 
@@ -186,26 +186,26 @@ Set the default Vagrant provider to ``libvirt``:
    export VAGRANT_DEFAULT_PROVIDER=libvirt
 
 
-.. note:: To explicitly specify the ``libvirt``  provider below, use the command 
+.. note:: To explicitly specify the ``libvirt``  provider below, use the command
    ``vagrant up --provider=libvirt /prod/``
 
 
 Switch Vagrant provider to libvirt - Debian 9
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                                                                                
+
 Install Vagrant, libvirt, QEMU, and their dependencies:
-                                                                                
+
 .. code:: sh
 
    sudo apt-get update
    sudo apt-get install -y vagrant vagrant-libvirt libvirt-daemon-system qemu-kvm
    sudo apt-get install -y ansible rsync
    vagrant plugin install vagrant-libvirt
-   sudo usermod -a -G libvirt $USER 
-   sudo systemctl restart libvirtd                                                                    
-                                                                                
-Add your user to the kvm group to give it permission to run KVM:                                            
-                                                                                
+   sudo usermod -a -G libvirt $USER
+   sudo systemctl restart libvirtd
+
+Add your user to the kvm group to give it permission to run KVM:
+
 .. code:: sh
 
    sudo usermod -a -G kvm $USER
@@ -213,34 +213,34 @@ Add your user to the kvm group to give it permission to run KVM:
    sudo rmmod kvm
    sudo modprobe kvm
    sudo modprobe kvm_intel
-                                                                    
-                                                                                
-Log out, then log in again. Verify that libvirt is installed and KVM is         
-available:                                                                      
-                                                                                
-.. code:: sh                                                                    
-                                                                                
-   libvirtd --version                                                           
-   kvm-ok                                                                       
-                                                                                
-Convert the bento/14.04 Vagrant box from ``virtualbox`` to ``libvirt`` format:  
-                                                                                
-.. code:: sh                                                                    
-                                              
-   sudo apt-get install -y vagrant-mutate                                  
-   vagrant box add --provider virtualbox bento/ubuntu-14.04                     
-   vagrant mutate bento/ubuntu-14.04 libvirt                                    
-                                                                                
-Set the default Vagrant provider to ``libvirt``:                                
-                                                                                
-.. code:: sh                                                                    
-                                                                                
-   echo 'export VAGRANT_DEFAULT_PROVIDER=libvirt' >> ~/.bashrc                  
-   export VAGRANT_DEFAULT_PROVIDER=libvirt                                      
-                                                                                
-.. note:: To explicitly specify the ``libvirt``  provider, use the command      
+
+
+Log out, then log in again. Verify that libvirt is installed and KVM is
+available:
+
+.. code:: sh
+
+   libvirtd --version
+   kvm-ok
+
+Convert the bento/14.04 Vagrant box from ``virtualbox`` to ``libvirt`` format:
+
+.. code:: sh
+
+   sudo apt-get install -y vagrant-mutate
+   vagrant box add --provider virtualbox bento/ubuntu-14.04
+   vagrant mutate bento/ubuntu-14.04 libvirt
+
+Set the default Vagrant provider to ``libvirt``:
+
+.. code:: sh
+
+   echo 'export VAGRANT_DEFAULT_PROVIDER=libvirt' >> ~/.bashrc
+   export VAGRANT_DEFAULT_PROVIDER=libvirt
+
+.. note:: To explicitly specify the ``libvirt``  provider, use the command
    ``vagrant up --provider=libvirt /prod/``
-   
+
 
 .. _prod_install_from_tails:
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #3630

Docs-only PR that adds instructions on setting up and using the libvirt Vagrant provider. Instructions are provided for Ubuntu 16.04 and Debian 9, drawing heavily from Loic Dachary's HOWTO: <https://blog.dachary.org/2017/08/15/howto-vagrant-libvirt-provider-on-debian-gnulinux-stretch9/>

Changes proposed in this pull request: updates to docs/development/ virtual_environments.rst

## Testing

Review instructions for clarity and accuracy. Optionally, perform described procedure on fresh Xenial and Stretch 9 installs.

## Deployment
n/a, docs only

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
