### PR TITLE
Adds --staging flag create-dev-data.py for tests

### DIFF
--- a/securedrop/create-dev-data.py
+++ b/securedrop/create-dev-data.py
@@ -3,6 +3,8 @@
 
 import datetime
 import os
+import sys
+import argparse
 from sqlalchemy.exc import IntegrityError
 
 os.environ["SECUREDROP_ENV"] = "dev"  # noqa
@@ -74,10 +76,19 @@ if __name__ == "__main__":  # pragma: no cover
     test_password = "correct horse battery staple profanity oil chewy"
     test_otp_secret = "JHCOGO7VCER3EJ4L"
 
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--staging", help="Adding user for staging tests.",
+                    action="store_true")
+    args = parser.parse_args()
     add_test_user("journalist",
                   test_password,
                   test_otp_secret,
                   is_admin=True)
+
+    # If staging, we only need the journalist user (admin)
+    if args.staging:
+        sys.exit(0)
+
     add_test_user("dellsberg",
                   test_password,
                   test_otp_secret,

--- a/securedrop/tests/functional/README.md
+++ b/securedrop/tests/functional/README.md
@@ -3,7 +3,7 @@
 - `sudo -u www-data bash`
 - `cd /var/wwww/securedrop/`
 - `./manage.py reset`    # This will clean the DB for testing
-- `./create-demo-user.py`  
+- `./create-dev-data.py --staging`
 
 Update this information to the `tests/functional/instance_information.json file.
 


### PR DESCRIPTION
We now have --staging flag to the create-dev-data.py script so
that we can easily create an user in the staging or prodcution test
and then use the functional tests to test the instance.

## Status

Ready for review.

## Description of Changes

Fixes #3671

Changes proposed in this pull request:

## Testing

On a staging or prod vm.

- `sudo -u www-data bash`
- `cd /var/wwww/securedrop/`
- `./manage.py reset`    # This will clean the DB for testing
- `./create-dev-data.py --staging`

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
