### PR TITLE
Set last_updated for sources in create_dev_data.py

### DIFF
--- a/securedrop/create-dev-data.py
+++ b/securedrop/create-dev-data.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import datetime
 import os
 from sqlalchemy.exc import IntegrityError
 
@@ -58,6 +59,7 @@ def create_source_and_submissions(num_submissions=2):
                 source.journalist_filename,
                 'test submission!'
             )
+            source.last_updated = datetime.datetime.utcnow()
             submission = Submission(source, fpath)
             db.session.add(submission)
 


### PR DESCRIPTION
## Status

Ready for review. Failing safety check will require a rebase once https://github.com/freedomofpress/securedrop/pull/3679 is merged.

## Description of Changes

Fixes #3680, manually sets `source.last_updated` for sources in `create_dev_data.py`.
## Testing

How should the reviewer test this PR?
1. checkout this branch
2. make dev
3. login to the journalist interface

## Deployment

Development environment only.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
