### PR TITLE
Temporarily ignore safety check for pyca/cryptography

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ build-debs: ## Builds and tests debian packages
 safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 	@for req_file in `find . -type f -name '*requirements.txt'`; do \
 		echo "Checking file $$req_file" \
-		&& safety check --full-report -r $$req_file \
+		&& safety check --ignore 36351 --full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \
 	done


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

NOTE: These changes should be reverted one SecureDrop app code is updated, this is tracked in #3682

Partially fixes #3677 and resolves current CI failures. 

This ignores the safety check failure for CVE-2018-10903. As the flaw is in AES-GCM (SecureDrop app server does not make use of AES-GCM), and that updating the dependency may require updating to Xenial or potentially introducing further risk, let's set safety to (temporarily) ignore this vulnerability. See issue #3677 for more information.

Update of the admin workstation environment are tracked in https://github.com/freedomofpress/securedrop/pull/3679 (which will need to be rebased)

## Testing
0. Make sure SecureDrop does not use AES-GCM and as such is not affected by CVE-2018-10903
1. CI should pass

## Deployment

Dev/CI env only
