### PR TITLE
Modify template to allow journalist to download own replies

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -31,28 +31,21 @@
 
       <ul id="submissions" class="plain submissions">
         {% for doc in source.collection %}
-          <li class="submission {% if not doc.downloaded %}unread{% endif %}">
-            {% if not doc.filename.endswith('reply.gpg') %}
-              {% if not doc.downloaded %}
+          <li class="submission {% if not doc.downloaded and not doc.filename.endswith('reply.gpg') %}unread{% endif %}">
+              {% if doc.filename.endswith('reply.gpg') %}
+                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
+                <span title="Reply" class="icon"><i class="fa fa-reply pull right"></i></span>
+              {% elif not doc.downloaded %}
                 <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
                 <span title="Unread" class="icon"><i class="fa fa-envelope"></i></span>
               {% else %}
-                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
-                <span class="icon"><i class="fa fa-envelope-open"></i></span>
+                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
+                <span title="Read" class="icon"><i class="fa fa-envelope-open"></i></span>
               {% endif %}
-            {% elif doc.filename.endswith('reply.gpg') %}
-                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
-                <span class="icon"></span>
-            {% endif %}
-            {% if doc.filename.endswith('reply.gpg') %}
-              <span class="file reply"><span class="filename">{{ doc.filename }}</span></span>
-              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat() }}</span></span>
-            {% else %}
-              <a class="file {% if not doc.downloaded %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_submission', filesystem_id=filesystem_id, fn=doc.filename) }}">
-                <i class="fa fa-download"></i> <span class="filename">{{ doc.filename }}</span>
-              </a>
-              <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat() }}</span></span>
-            {% endif %}
+            <a class="file {% if not doc.downloaded and not doc.filename.endswith('reply.gpg') %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_submission', filesystem_id=filesystem_id, fn=doc.filename) }}">
+              <i class="fa fa-download"></i> <span class="filename">{{ doc.filename }}</span>
+            </a>
+            <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat() }}</span></span>
             {% if doc.filename.endswith('-doc.gz.gpg') %}
               <i title="{{ gettext('Uploaded Document') }}" class="far fa-file-archive pull-right"></i>
             {% elif doc.filename.endswith('-reply.gpg') %}

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -42,7 +42,7 @@
                 <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
                 <span title="Read" class="icon"><i class="fa fa-envelope-open"></i></span>
               {% endif %}
-            <a class="file {% if not doc.downloaded and not doc.filename.endswith('reply.gpg') %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_submission', filesystem_id=filesystem_id, fn=doc.filename) }}">
+            <a class="file {% if not doc.downloaded and not doc.filename.endswith('reply.gpg') %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_file', filesystem_id=filesystem_id, fn=doc.filename) }}">
               <i class="fa fa-download"></i> <span class="filename">{{ doc.filename }}</span>
             </a>
             <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat() }}</span></span>

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1259,7 +1259,7 @@ def test_admin_page_restriction_http_posts(journalist_app, test_journo):
 
 def test_user_authorization_for_gets(journalist_app):
     urls = [url_for('main.index'), url_for('col.col', filesystem_id='1'),
-            url_for('col.download_single_submission',
+            url_for('col.download_single_file',
                     filesystem_id='1', fn='1'),
             url_for('account.edit')]
 
@@ -1342,6 +1342,26 @@ def test_passphrase_migration_on_reset(journalist_app):
 
     # check that that a verification post-migration works
     assert journalist.valid_password(VALID_PASSWORD)
+
+
+def test_journalist_reply_view(journalist_app, test_source, test_journo):
+    source, _ = utils.db_helper.init_source()
+    journalist, _ = utils.db_helper.init_journalist()
+    submissions = utils.db_helper.submit(source, 1)
+    replies = utils.db_helper.reply(journalist, source, 1)
+
+    subm_url = url_for('col.download_single_file',
+                       filesystem_id=submissions[0].source.filesystem_id,
+                       fn=submissions[0].filename)
+    reply_url = url_for('col.download_single_file',
+                        filesystem_id=replies[0].source.filesystem_id,
+                        fn=replies[0].filename)
+
+    with journalist_app.test_client() as app:
+        resp = app.get(subm_url)
+        assert resp.status_code == 302
+        resp = app.get(reply_url)
+        assert resp.status_code == 302
 
 
 class TestJournalistApp(TestCase):


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Fixes #3674 

Journalists can now download their replies encrypted to the submission
key. They are automatically marked as read in the interface and have a
reply icon to avoid confusion with sources messages and unread count.

## Testing

* Submit document/message as source
* Log into journalist account
* Reply to source
* Journalist must be able to download reply
* The reply in the conversation thread must not be confusing
## Deployment

This will be deployed in the SecureDrop app code deb package.

Since this is a journalist-facing change, we should inform users of this in the release notes.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
