### PR TITLE
Preserve conversation history only for journalists

### DIFF
--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -75,7 +75,7 @@ Journalist Interface <yubikey_setup>`.)
 
 Reset Passphrase or Two-factor Authentication Token
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If necessary journalists may reset their user passphrase or two-factor authentication token in their user profile. To navigate to your user profile, log in to the *Journalist Interface* and click on the link in the upper right of the screen where it says **Logged on as <your user name>.** 
+If necessary journalists may reset their user passphrase or two-factor authentication token in their user profile. To navigate to your user profile, log in to the *Journalist Interface* and click on the link in the upper right of the screen where it says **Logged on as <your user name>.**
 
 If you have lost or forgotten your passphrase or two-factor authentication device, you will need to contact your SecureDrop admin for assistance.
 
@@ -130,15 +130,23 @@ field and click **Submit**.
 Once your reply has been successfully submitted, you will be returned
 to the source page and see a message confirming that the reply was
 stored. The source will see your reply the next time they log in with
-their unique codename. To minimize sensitive data retention, the
-source interface encourages the source to delete the reply after
-reading it. If you notice one or more replies disappear from the list
-of documents, you may infer that the source read and deleted them. You
-may also delete replies if you change your mind after sending them.
+their unique codename. To minimize the impact of a source codename
+being compromised, the source interface encourages the source to delete
+the reply after reading it. Once a source has read your reply and deleted
+it from their inbox, a checkmark will appear next to the reply in the interface.
+
+.. note:: Prior to SecureDrop 0.9.0, replies when deleted from the source inbox
+  would also disappear from the journalist inbox. As such, if there are older
+  conversations, there may be discontinuities in the conversation.
+
+You may also delete replies if you change your mind after sending them.
 
 Documents and messages are encrypted to the SecureDrop installation's
 GPG public key. In order to read the messages or look at the documents
-you will need to transfer them to the *Secure Viewing Station*.
+you will need to transfer them to the *Secure Viewing Station*. To recall
+the conversation history between your organization and sources, you can also
+download replies and transfer them to the *Secure Viewing Station* for
+decryption.
 
 Flag for Reply
 ~~~~~~~~~~~~~~

--- a/securedrop/alembic/versions/e0a525cbab83_add_column_to_track_source_deletion_of_.py
+++ b/securedrop/alembic/versions/e0a525cbab83_add_column_to_track_source_deletion_of_.py
@@ -1,0 +1,66 @@
+"""add column to track source deletion of replies
+
+Revision ID: e0a525cbab83
+Revises: 2d0ce3ee5bdc
+Create Date: 2018-08-02 00:07:59.242510
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e0a525cbab83'
+down_revision = '2d0ce3ee5bdc'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Schema migration
+    op.rename_table('replies', 'replies_tmp')
+
+    # Add new column.
+    op.add_column('replies_tmp',
+                  sa.Column('deleted_by_source', sa.Boolean()))
+
+    # Populate deleted_by_source column in replies_tmp table.
+    conn = op.get_bind()
+    replies = conn.execute(
+        sa.text("SELECT * FROM replies_tmp")).fetchall()
+
+    for reply in replies:
+        id = reply.id
+        conn.execute(
+            sa.text("""UPDATE replies_tmp
+                       SET deleted_by_source=('0')
+                       WHERE id={}""".format(id)))
+
+    # Now create new table with not null constraint applied to
+    # deleted_by_source.
+    op.create_table('replies',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('journalist_id', sa.Integer(), nullable=True),
+        sa.Column('source_id', sa.Integer(), nullable=True),
+        sa.Column('filename', sa.String(length=255), nullable=False),
+        sa.Column('size', sa.Integer(), nullable=False),
+        sa.Column('deleted_by_source', sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(['journalist_id'], ['journalists.id'], ),
+        sa.ForeignKeyConstraint(['source_id'], ['sources.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    # Data Migration: move all replies into the new table.
+    conn.execute('''
+        INSERT INTO replies
+        SELECT id, journalist_id, source_id, filename, size, deleted_by_source
+        FROM replies_tmp
+    ''')
+
+    # Now delete the old table.
+    op.drop_table('replies_tmp')
+
+
+def downgrade():
+    with op.batch_alter_table('replies', schema=None) as batch_op:
+        batch_op.drop_column('deleted_by_source')

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -32,20 +32,26 @@
       <ul id="submissions" class="plain submissions">
         {% for doc in source.collection %}
           <li class="submission {% if not doc.downloaded and not doc.filename.endswith('reply.gpg') %}unread{% endif %}">
-              {% if doc.filename.endswith('reply.gpg') %}
+            {% if doc.filename.endswith('reply.gpg') %}
+              {% if not doc.deleted_by_source %}
                 <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
                 <span title="Reply" class="icon"><i class="fa fa-reply pull right"></i></span>
-              {% elif not doc.downloaded %}
-                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
-                <span title="Unread" class="icon"><i class="fa fa-envelope"></i></span>
               {% else %}
-                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
-                <span title="Read" class="icon"><i class="fa fa-envelope-open"></i></span>
+                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
+                <span class="icon"><i class="fa fa-check"></i></span>
               {% endif %}
+            {% elif not doc.downloaded %}
+              <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
+              <span title="Unread" class="icon"><i class="fa fa-envelope"></i></span>
+            {% else %}
+              <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
+              <span title="Read" class="icon"><i class="fa fa-envelope-open"></i></span>
+            {% endif %}
             <a class="file {% if not doc.downloaded and not doc.filename.endswith('reply.gpg') %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_file', filesystem_id=filesystem_id, fn=doc.filename) }}">
               <i class="fa fa-download"></i> <span class="filename">{{ doc.filename }}</span>
             </a>
             <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat() }}</span></span>
+
             {% if doc.filename.endswith('-doc.gz.gpg') %}
               <i title="{{ gettext('Uploaded Document') }}" class="far fa-file-archive pull-right"></i>
             {% elif doc.filename.endswith('-reply.gpg') %}

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -217,6 +217,8 @@ class Reply(db.Model):
     filename = Column(String(255), nullable=False)
     size = Column(Integer, nullable=False)
 
+    deleted_by_source = Column(Boolean, default=False, nullable=False)
+
     def __init__(self, journalist, source, filename):
         self.journalist_id = journalist.id
         self.source_id = source.id

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -77,7 +77,7 @@ def make_blueprint(config):
     def lookup():
         replies = []
         source_inbox = Reply.query.filter(Reply.source_id == g.source.id) \
-                                  .filter(Reply.source_deleted == False).all()  # noqa
+                                  .filter(Reply.deleted_by_source == False).all()  # noqa
 
         for reply in source_inbox:
             reply_path = current_app.storage.path(
@@ -214,7 +214,7 @@ def make_blueprint(config):
         query = Reply.query.filter(
             Reply.filename == request.form['reply_filename'])
         reply = get_one_or_else(query, current_app.logger, abort)
-        reply.source_deleted = True
+        reply.deleted_by_source = True
         db.session.add(reply)
         db.session.commit()
 

--- a/securedrop/tests/migrations/migration_e0a525cbab83.py
+++ b/securedrop/tests/migrations/migration_e0a525cbab83.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+
+import random
+import string
+import uuid
+
+from sqlalchemy import text
+from sqlalchemy.exc import NoSuchColumnError
+
+from db import db
+from journalist_app import create_app
+from .helpers import (random_bool, random_bytes, random_chars, random_datetime,
+                      random_username, bool_or_none)
+
+random.seed('ᕕ( ᐛ )ᕗ')
+
+
+def add_source():
+    filesystem_id = random_chars(96) if random_bool() else None
+    params = {
+        'uuid': str(uuid.uuid4()),
+        'filesystem_id': filesystem_id,
+        'journalist_designation': random_chars(50),
+        'flagged': bool_or_none(),
+        'last_updated': random_datetime(nullable=True),
+        'pending': bool_or_none(),
+        'interaction_count': random.randint(0, 1000),
+    }
+    sql = '''INSERT INTO sources (uuid, filesystem_id,
+                journalist_designation, flagged, last_updated, pending,
+                interaction_count)
+             VALUES (:uuid, :filesystem_id, :journalist_designation,
+                :flagged, :last_updated, :pending, :interaction_count)
+          '''
+    db.engine.execute(text(sql), **params)
+
+
+def add_journalist():
+    if random_bool():
+        otp_secret = random_chars(16, string.ascii_uppercase + '234567')
+    else:
+        otp_secret = None
+
+    is_totp = random_bool()
+    if is_totp:
+        hotp_counter = 0 if random_bool() else None
+    else:
+        hotp_counter = random.randint(0, 10000) if random_bool() else None
+
+    last_token = random_chars(6, string.digits) if random_bool() else None
+
+    params = {
+        'username': random_username(),
+        'pw_salt': random_bytes(1, 64, nullable=True),
+        'pw_hash': random_bytes(32, 64, nullable=True),
+        'is_admin': bool_or_none(),
+        'otp_secret': otp_secret,
+        'is_totp': is_totp,
+        'hotp_counter': hotp_counter,
+        'last_token': last_token,
+        'created_on': random_datetime(nullable=True),
+        'last_access': random_datetime(nullable=True),
+        'passphrase_hash': random_bytes(32, 64, nullable=True)
+    }
+    sql = '''INSERT INTO journalists (username, pw_salt, pw_hash,
+                is_admin, otp_secret, is_totp, hotp_counter, last_token,
+                created_on, last_access, passphrase_hash)
+             VALUES (:username, :pw_salt, :pw_hash, :is_admin,
+                :otp_secret, :is_totp, :hotp_counter, :last_token,
+                :created_on, :last_access, :passphrase_hash);
+          '''
+    db.engine.execute(text(sql), **params)
+
+
+class UpgradeTester():
+
+    '''This migration verifies that the deleted_by_source column now exists,
+    and that the data migration completed successfully.
+    '''
+
+    SOURCE_NUM = 200
+    JOURNO_NUM = 20
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            for _ in range(self.JOURNO_NUM):
+                add_journalist()
+
+            add_source()
+
+            for jid in range(1, self.JOURNO_NUM):
+                self.add_reply(jid, 1)
+
+            db.session.commit()
+
+    @staticmethod
+    def add_reply(journalist_id, source_id):
+        params = {
+            'journalist_id': journalist_id,
+            'source_id': source_id,
+            'filename': random_chars(50),
+            'size': random.randint(0, 1024 * 1024 * 500),
+        }
+        sql = '''INSERT INTO replies (journalist_id, source_id, filename,
+                    size)
+                 VALUES (:journalist_id, :source_id, :filename, :size)
+              '''
+        db.engine.execute(text(sql), **params)
+
+    def check_upgrade(self):
+        with self.app.app_context():
+            replies = db.engine.execute(
+                text('SELECT * FROM replies')).fetchall()
+            assert len(replies) == self.JOURNO_NUM - 1
+
+            for reply in replies:
+                assert reply.deleted_by_source == False  # noqa
+
+
+class DowngradeTester():
+
+    SOURCE_NUM = 200
+    JOURNO_NUM = 20
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            for _ in range(self.JOURNO_NUM):
+                add_journalist()
+
+            add_source()
+
+            for jid in range(1, self.JOURNO_NUM):
+                self.add_reply(jid, 1)
+
+            db.session.commit()
+
+    @staticmethod
+    def add_reply(journalist_id, source_id):
+        params = {
+            'journalist_id': journalist_id,
+            'source_id': source_id,
+            'filename': random_chars(50),
+            'size': random.randint(0, 1024 * 1024 * 500),
+            'deleted_by_source': False,
+        }
+        sql = '''INSERT INTO replies (journalist_id, source_id, filename,
+                    size, deleted_by_source)
+                 VALUES (:journalist_id, :source_id, :filename, :size,
+                    :deleted_by_source)
+              '''
+        db.engine.execute(text(sql), **params)
+
+    def check_downgrade(self):
+        '''Verify that the deleted_by_source column is now gone, and
+        otherwise the table has the expected number of rows.
+        '''
+        with self.app.app_context():
+            sql = "SELECT * FROM replies"
+            replies = db.engine.execute(text(sql)).fetchall()
+
+            for reply in replies:
+                try:
+                    # This should produce an exception, as the column (should)
+                    # be gone.
+                    assert reply['deleted_by_source'] is None
+                except NoSuchColumnError:
+                    pass
+
+            assert len(replies) == self.JOURNO_NUM - 1

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -441,11 +441,6 @@ class TestIntegration(unittest.TestCase):
                 self.assertEqual(resp.status_code, 200)
                 self.assertIn("Reply deleted", resp.data)
 
-                # Make sure the reply is deleted from the filesystem
-                utils.async.wait_for_assertion(
-                    lambda: self.assertFalse(os.path.exists(
-                        current_app.storage.path(filesystem_id, msgid))))
-
             app.get('/logout')
 
     @patch('source_app.main.async_genkey')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3675

Changes proposed in this pull request:
 - Adds new column to track which replies should appear in the source inbox
 - Preserves (encrypted) conversation history for journalists (from the source's perspective, no changes will occur)

## Testing

1. Submit document as source
2. Submit reply as journalist
3. Verify that the reply is displayed without a checkmark, e.g. see last row here:

<img width="484" alt="screen shot 2018-08-03 at 11 23 24 am" src="https://user-images.githubusercontent.com/7832803/43659301-7470c15e-9710-11e8-847d-9fbd5c12de26.png">

4. Delete reply as source
5. Verify that the reply still exists on the journalist side, can be downloaded and decrypted, and a checkmark now appears next to it, e.g. see last row here:

<img width="602" alt="screen shot 2018-08-03 at 11 24 22 am" src="https://user-images.githubusercontent.com/7832803/43659321-7f7cdb8c-9710-11e8-9060-30179d87f2f6.png">

## Deployment

Deployed in securedrop-app-code package, significant change on journalist side so needs to be described in pre-release announcement and release notes

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

