### PR TITLE
Add API endpoints for replies

### DIFF
--- a/docs/development/journalist_api.rst
+++ b/docs/development/journalist_api.rst
@@ -92,10 +92,11 @@ Response 200 (application/json):
 .. code:: sh
 
   {
-    "current_user_url": "/api/v1/user/",
-    "sources_url": "/api/v1/sources/",
-    "submissions_url": "/api/v1/submissions/"
-    "token_url": "/api/v1/token/"
+    "current_user_url": "/api/v1/user",
+    "sources_url": "/api/v1/sources",
+    "submissions_url": "/api/v1/submissions",
+    "replies_url": "/api/v1/replies",
+    "token_url": "/api/v1/token"
   }
 
 Sources ``[/sources]``
@@ -132,7 +133,7 @@ Response 200 (application/json):
               "number_of_documents": 0,
               "number_of_messages": 2,
               "remove_star_url": "/api/v1/sources/9b6df7c9-a6b1-461d-91f0-5b715fc7a47a/remove_star",
-              "reply_url": "/api/v1/sources/9b6df7c9-a6b1-461d-91f0-5b715fc7a47a/reply",
+              "replies_url": "/api/v1/sources/9b6df7c9-a6b1-461d-91f0-5b715fc7a47a/replies",
               "submissions_url": "/api/v1/sources/9b6df7c9-a6b1-461d-91f0-5b715fc7a47a/submissions",
               "url": "/api/v1/sources/9b6df7c9-a6b1-461d-91f0-5b715fc7a47a",
               "uuid": "9b6df7c9-a6b1-461d-91f0-5b715fc7a47a"
@@ -151,7 +152,7 @@ Response 200 (application/json):
               "number_of_documents": 0,
               "number_of_messages": 2,
               "remove_star_url": "/api/v1/sources/f086bd03-1c89-49fb-82d5-00084c17b4ce/remove_star",
-              "reply_url": "/api/v1/sources/f086bd03-1c89-49fb-82d5-00084c17b4ce/reply",
+              "replies_url": "/api/v1/sources/f086bd03-1c89-49fb-82d5-00084c17b4ce/replies",
               "submissions_url": "/api/v1/sources/f086bd03-1c89-49fb-82d5-00084c17b4ce/submissions",
               "url": "/api/v1/sources/f086bd03-1c89-49fb-82d5-00084c17b4ce",
               "uuid": "f086bd03-1c89-49fb-82d5-00084c17b4ce"
@@ -184,7 +185,7 @@ Response 200 (application/json):
       "number_of_documents": 0,
       "number_of_messages": 2,
       "remove_star_url": "/api/v1/sources/9b6df7c9-a6b1-461d-91f0-5b715fc7a47a/remove_star",
-      "reply_url": "/api/v1/sources/9b6df7c9-a6b1-461d-91f0-5b715fc7a47a/reply",
+      "replies_url": "/api/v1/sources/9b6df7c9-a6b1-461d-91f0-5b715fc7a47a/replies",
       "submissions_url": "/api/v1/sources/9b6df7c9-a6b1-461d-91f0-5b715fc7a47a/submissions",
       "url": "/api/v1/sources/9b6df7c9-a6b1-461d-91f0-5b715fc7a47a",
       "uuid": "9b6df7c9-a6b1-461d-91f0-5b715fc7a47a"
@@ -247,6 +248,106 @@ Response 200 (application/json):
       "source_url": "/api/v1/sources/598b859c-72c7-4e53-a68c-b725eb514241",
       "submission_url": "/api/v1/sources/598b859c-72c7-4e53-a68c-b725eb514241/submissions/4c2e701c-70d2-4cb5-87c0-de59c2ebbc62",
       "uuid": "4c2e701c-70d2-4cb5-87c0-de59c2ebbc62"
+  }
+
+Get all replies associated with a source [``GET``]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Requires authentication.
+
+.. code:: sh
+
+  GET /api/v1/sources/<source_uuid>/replies
+
+Response 200 (application/json):
+
+.. code:: sh
+
+  {
+      "replies": [
+          {
+              "filename": "3-famished_sheep-reply.gpg",
+              "is_deleted_by_source": false,
+              "journalist_username": "journalist",
+              "journalist_uuid": "a2405127-1c9e-4a3a-80ea-95f6a71e5738",
+              "reply_url": "/api/v1/sources/f381dbb4-4bb5-451a-801a-e961461af6e5/replies/98cc4ed6-6ac5-4867-b144-f97d0497f2c1",
+              "size": 1116,
+              "source_url": "/api/v1/sources/f381dbb4-4bb5-451a-801a-e961461af6e5",
+              "uuid": "98cc4ed6-6ac5-4867-b144-f97d0497f2c1"
+          },
+          {
+              "filename": "4-famished_sheep-reply.gpg",
+              "is_deleted_by_source": false,
+              "journalist_username": "journalist",
+              "journalist_uuid": "a2405127-1c9e-4a3a-80ea-95f6a71e5738",
+              "reply_url": "/api/v1/sources/f381dbb4-4bb5-451a-801a-e961461af6e5/replies/2863e3ec-66c8-4b74-ba43-615c805be4da",
+              "size": 1116,
+              "source_url": "/api/v1/sources/f381dbb4-4bb5-451a-801a-e961461af6e5",
+              "uuid": "2863e3ec-66c8-4b74-ba43-615c805be4da"
+          }
+      ]
+  }
+
+Get a single reply associated with a source [``GET``]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Requires authentication.
+
+.. code:: sh
+
+  GET /api/v1/sources/<source_uuid>/replies/<reply_uuid>
+
+Response 200 (application/json):
+
+.. code:: sh
+
+  {
+      "filename": "3-famished_sheep-reply.gpg",
+      "is_deleted_by_source": false,
+      "journalist_username": "journalist",
+      "journalist_uuid": "a2405127-1c9e-4a3a-80ea-95f6a71e5738",
+      "reply_url": "/api/v1/sources/f381dbb4-4bb5-451a-801a-e961461af6e5/replies/98cc4ed6-6ac5-4867-b144-f97d0497f2c1",
+      "size": 1116,
+      "source_url": "/api/v1/sources/f381dbb4-4bb5-451a-801a-e961461af6e5",
+      "uuid": "98cc4ed6-6ac5-4867-b144-f97d0497f2c1"
+  }
+
+Download a reply [``GET``]
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Requires authentication.
+
+.. code:: sh
+
+  GET /api/v1/sources/<source_uuid>/replies/<reply_uuid>/download
+
+Response 200 will have ``Content-Type: application/pgp-encrypted`` and is the
+content of the PGP encrypted reply.
+
+An ETag header is also present containing the SHA256 hash of the response data:
+
+.. code:: sh
+
+  "sha256:c757c5aa263dc4a5a2bca8e7fe973367dbd2c1a6c780d19c0ba499e6b1b81efa"
+
+Note that these are not intended for cryptographic purposes and are present
+for clients to check that downloads are not corrupted.
+
+Delete a reply [``DELETE``]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Requires authentication.
+
+.. code:: sh
+
+  DELETE /api/v1/sources/<source_uuid>/replies/<reply_uuid>
+
+Response 200:
+
+.. code:: sh
+
+  {
+    "message": "Reply deleted"
   }
 
 Add a reply to a source [``POST``]
@@ -449,6 +550,67 @@ Response 200:
       ]
   }
 
+Reply ``[/replies]``
+--------------------
+
+Get all replies [``GET``]
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Requires authentication. This gets details of all replies across sources.
+
+.. code:: sh
+
+  GET /api/v1/replies
+
+Response 200:
+
+.. code:: sh
+
+  {
+      "replies": [
+          {
+              "filename": "3-famished_sheep-reply.gpg",
+              "is_deleted_by_source": false,
+              "journalist_username": "journalist",
+              "journalist_uuid": "a2405127-1c9e-4a3a-80ea-95f6a71e5738",
+              "reply_url": "/api/v1/sources/f381dbb4-4bb5-451a-801a-e961461af6e5/replies/98cc4ed6-6ac5-4867-b144-f97d0497f2c1",
+              "size": 1116,
+              "source_url": "/api/v1/sources/f381dbb4-4bb5-451a-801a-e961461af6e5",
+              "uuid": "98cc4ed6-6ac5-4867-b144-f97d0497f2c1"
+          },
+          {
+              "filename": "4-famished_sheep-reply.gpg",
+              "is_deleted_by_source": false,
+              "journalist_username": "journalist",
+              "journalist_uuid": "a2405127-1c9e-4a3a-80ea-95f6a71e5738",
+              "reply_url": "/api/v1/sources/f381dbb4-4bb5-451a-801a-e961461af6e5/replies/2863e3ec-66c8-4b74-ba43-615c805be4da",
+              "size": 1116,
+              "source_url": "/api/v1/sources/f381dbb4-4bb5-451a-801a-e961461af6e5",
+              "uuid": "2863e3ec-66c8-4b74-ba43-615c805be4da"
+          },
+          {
+              "filename": "3-intermittent_proline-reply.gpg",
+              "is_deleted_by_source": false,
+              "journalist_username": "journalist",
+              "journalist_uuid": "a2405127-1c9e-4a3a-80ea-95f6a71e5738",
+              "reply_url": "/api/v1/sources/06bfd5ba-ed6a-4850-b713-4e6940b74931/replies/33b35f6e-b43e-4ad5-a24b-37fd1916ad75",
+              "size": 1116,
+              "source_url": "/api/v1/sources/06bfd5ba-ed6a-4850-b713-4e6940b74931",
+              "uuid": "33b35f6e-b43e-4ad5-a24b-37fd1916ad75"
+          },
+          {
+              "filename": "4-intermittent_proline-reply.gpg",
+              "is_deleted_by_source": false,
+              "journalist_username": "journalist",
+              "journalist_uuid": "a2405127-1c9e-4a3a-80ea-95f6a71e5738",
+              "reply_url": "/api/v1/sources/06bfd5ba-ed6a-4850-b713-4e6940b74931/replies/6fad52dd-bc55-42aa-96da-4636644fb3e2",
+              "size": 1116,
+              "source_url": "/api/v1/sources/06bfd5ba-ed6a-4850-b713-4e6940b74931",
+              "uuid": "6fad52dd-bc55-42aa-96da-4636644fb3e2"
+          }
+      ]
+  }
+
 User ``[/user]``
 ----------------
 
@@ -468,5 +630,6 @@ Response 200:
   {
     "is_admin": true,
     "last_login": "2018-07-09T20:29:41.696782Z",
-    "username": "journalist"
+    "username": "journalist",
+    "uuid": "a2405127-1c9e-4a3a-80ea-95f6a71e5738"
   }

--- a/securedrop/alembic/versions/3d91d6948753_create_source_uuid_column.py
+++ b/securedrop/alembic/versions/3d91d6948753_create_source_uuid_column.py
@@ -30,11 +30,11 @@ def upgrade():
     sources = conn.execute(sa.text("SELECT * FROM sources_tmp")).fetchall()
 
     for source in sources:
-        id = source.id
-        source_uuid = str(uuid.uuid4())
         conn.execute(
-            sa.text("UPDATE sources_tmp SET uuid=('{}') WHERE id={}".format(
-                source_uuid, id)))
+            sa.text("""UPDATE sources_tmp SET uuid=:source_uuid WHERE
+                       id=:id""").bindparams(source_uuid=str(uuid.uuid4()),
+                                             id=source.id)
+            )
 
     # Now create new table with unique constraint applied.
     op.create_table(quoted_name('sources', quote=False),

--- a/securedrop/alembic/versions/6db892e17271_add_reply_uuid.py
+++ b/securedrop/alembic/versions/6db892e17271_add_reply_uuid.py
@@ -30,12 +30,11 @@ def upgrade():
         sa.text("SELECT * FROM replies_tmp")).fetchall()
 
     for reply in replies:
-        id = reply.id
-        reply_uuid = str(uuid.uuid4())
         conn.execute(
-            sa.text("""UPDATE replies_tmp
-                       SET uuid=('{}')
-                       WHERE id={}""".format(reply_uuid, id)))
+            sa.text("""UPDATE replies_tmp SET uuid=:reply_uuid WHERE
+                       id=:id""").bindparams(reply_uuid=str(uuid.uuid4()),
+                                             id=reply.id)
+            )
 
     # Now create new table with constraints applied to UUID column.
     op.create_table('replies',

--- a/securedrop/alembic/versions/6db892e17271_add_reply_uuid.py
+++ b/securedrop/alembic/versions/6db892e17271_add_reply_uuid.py
@@ -1,0 +1,71 @@
+"""add reply UUID
+
+Revision ID: 6db892e17271
+Revises: e0a525cbab83
+Create Date: 2018-08-06 20:31:50.035066
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+import uuid
+
+# revision identifiers, used by Alembic.
+revision = '6db892e17271'
+down_revision = 'e0a525cbab83'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Schema migration
+    op.rename_table('replies', 'replies_tmp')
+
+    # Add new column.
+    op.add_column('replies_tmp', sa.Column('uuid', sa.String(length=36)))
+
+    # Populate new column in replies_tmp table.
+    conn = op.get_bind()
+    replies = conn.execute(
+        sa.text("SELECT * FROM replies_tmp")).fetchall()
+
+    for reply in replies:
+        id = reply.id
+        reply_uuid = str(uuid.uuid4())
+        conn.execute(
+            sa.text("""UPDATE replies_tmp
+                       SET uuid=('{}')
+                       WHERE id={}""".format(reply_uuid, id)))
+
+    # Now create new table with constraints applied to UUID column.
+    op.create_table('replies',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('uuid', sa.String(length=36), nullable=False),
+        sa.Column('journalist_id', sa.Integer(), nullable=True),
+        sa.Column('source_id', sa.Integer(), nullable=True),
+        sa.Column('filename', sa.String(length=255), nullable=False),
+        sa.Column('size', sa.Integer(), nullable=False),
+        sa.Column('deleted_by_source', sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(['journalist_id'], ['journalists.id'], ),
+        sa.ForeignKeyConstraint(['source_id'], ['sources.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('uuid'),
+    )
+
+    # Data Migration: move all replies into the new table.
+    conn.execute('''
+        INSERT INTO replies
+        SELECT id, uuid, journalist_id, source_id, filename, size,
+            deleted_by_source
+        FROM replies_tmp
+    ''')
+
+    # Now delete the old table.
+    op.drop_table('replies_tmp')
+
+
+def downgrade():
+    with op.batch_alter_table('replies', schema=None) as batch_op:
+        batch_op.drop_column('uuid')
+
+    # ### end Alembic commands ###

--- a/securedrop/alembic/versions/e0a525cbab83_add_column_to_track_source_deletion_of_.py
+++ b/securedrop/alembic/versions/e0a525cbab83_add_column_to_track_source_deletion_of_.py
@@ -30,11 +30,10 @@ def upgrade():
         sa.text("SELECT * FROM replies_tmp")).fetchall()
 
     for reply in replies:
-        id = reply.id
         conn.execute(
-            sa.text("""UPDATE replies_tmp
-                       SET deleted_by_source=('0')
-                       WHERE id={}""".format(id)))
+            sa.text("""UPDATE replies_tmp SET deleted_by_source=0 WHERE
+                       id=:id""").bindparams(id=reply.id)
+            )
 
     # Now create new table with not null constraint applied to
     # deleted_by_source.

--- a/securedrop/alembic/versions/f2833ac34bb6_add_uuid_column_for_users_table.py
+++ b/securedrop/alembic/versions/f2833ac34bb6_add_uuid_column_for_users_table.py
@@ -30,12 +30,11 @@ def upgrade():
         sa.text("SELECT * FROM journalists_tmp")).fetchall()
 
     for journalist in journalists:
-        id = journalist.id
-        journalist_uuid = str(uuid.uuid4())
         conn.execute(
-            sa.text("""UPDATE journalists_tmp
-                       SET uuid=('{}')
-                       WHERE id={}""".format(journalist_uuid, id)))
+            sa.text("""UPDATE journalists_tmp SET uuid=:journalist_uuid WHERE
+                       id=:id""").bindparams(journalist_uuid=str(uuid.uuid4()),
+                                             id=journalist.id)
+            )
 
     # Now create new table with unique constraint applied.
     op.create_table('journalists',

--- a/securedrop/alembic/versions/f2833ac34bb6_add_uuid_column_for_users_table.py
+++ b/securedrop/alembic/versions/f2833ac34bb6_add_uuid_column_for_users_table.py
@@ -1,0 +1,75 @@
+"""add UUID column for users table
+
+Revision ID: f2833ac34bb6
+Revises: 6db892e17271
+Create Date: 2018-08-13 18:10:19.914274
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import uuid
+
+
+# revision identifiers, used by Alembic.
+revision = 'f2833ac34bb6'
+down_revision = '6db892e17271'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Save existing journalist table.
+    op.rename_table('journalists', 'journalists_tmp')
+
+    # Add UUID column.
+    op.add_column('journalists_tmp', sa.Column('uuid', sa.String(length=36)))
+
+    # Add UUIDs to journalists_tmp table.
+    conn = op.get_bind()
+    journalists = conn.execute(
+        sa.text("SELECT * FROM journalists_tmp")).fetchall()
+
+    for journalist in journalists:
+        id = journalist.id
+        journalist_uuid = str(uuid.uuid4())
+        conn.execute(
+            sa.text("""UPDATE journalists_tmp
+                       SET uuid=('{}')
+                       WHERE id={}""".format(journalist_uuid, id)))
+
+    # Now create new table with unique constraint applied.
+    op.create_table('journalists',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('uuid', sa.String(length=36), nullable=False),
+        sa.Column('username', sa.String(length=255), nullable=False),
+        sa.Column('pw_salt', sa.Binary(), nullable=True),
+        sa.Column('pw_hash', sa.Binary(), nullable=True),
+        sa.Column('passphrase_hash', sa.String(length=256), nullable=True),
+        sa.Column('is_admin', sa.Boolean(), nullable=True),
+        sa.Column('otp_secret', sa.String(length=16), nullable=True),
+        sa.Column('is_totp', sa.Boolean(), nullable=True),
+        sa.Column('hotp_counter', sa.Integer(), nullable=True),
+        sa.Column('last_token', sa.String(length=6), nullable=True),
+        sa.Column('created_on', sa.DateTime(), nullable=True),
+        sa.Column('last_access', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('username'),
+        sa.UniqueConstraint('uuid')
+    )
+
+    conn = op.get_bind()
+    conn.execute('''
+        INSERT INTO journalists
+        SELECT id, uuid, username, pw_salt, pw_hash, passphrase_hash,
+               is_admin, otp_secret, is_totp, hotp_counter, last_token,
+               created_on, last_access
+        FROM journalists_tmp
+    ''')
+
+    # Now delete the old table.
+    op.drop_table('journalists_tmp')
+
+
+def downgrade():
+    with op.batch_alter_table('journalists', schema=None) as batch_op:
+        batch_op.drop_column('uuid')

--- a/securedrop/alembic/versions/fccf57ceef02_create_submission_uuid_column.py
+++ b/securedrop/alembic/versions/fccf57ceef02_create_submission_uuid_column.py
@@ -30,12 +30,11 @@ def upgrade():
         sa.text("SELECT * FROM submissions_tmp")).fetchall()
 
     for submission in submissions:
-        id = submission.id
-        submission_uuid = str(uuid.uuid4())
         conn.execute(
-            sa.text("""UPDATE submissions_tmp
-                       SET uuid=('{}')
-                       WHERE id={}""".format(submission_uuid, id)))
+            sa.text("""UPDATE submissions_tmp SET uuid=:submission_uuid WHERE
+                       id=:id""").bindparams(submission_uuid=str(uuid.uuid4()),
+                                             id=submission.id)
+            )
 
     # Now create new table with unique constraint applied.
     op.create_table('submissions',

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -62,6 +62,7 @@ def make_blueprint(config):
         endpoints = {'sources_url': '/api/v1/sources',
                      'current_user_url': '/api/v1/user',
                      'submissions_url': '/api/v1/submissions',
+                     'replies_url': '/api/v1/replies',
                      'auth_token_url': '/api/v1/token'}
         return jsonify(endpoints), 200
 
@@ -204,40 +205,54 @@ def make_blueprint(config):
                               submission)
             return jsonify({'message': 'Submission deleted'}), 200
 
-    @api.route('/sources/<source_uuid>/reply', methods=['POST'])
+    @api.route('/sources/<source_uuid>/replies', methods=['GET', 'POST'])
     @token_required
-    def post_reply(source_uuid):
-        source = get_or_404(Source, source_uuid,
-                            column=Source.uuid)
-        if request.json is None:
-            abort(400, 'please send requests in valid JSON')
-
-        if 'reply' not in request.json:
-            abort(400, 'reply not found in request body')
-
-        user = get_user_object(request)
-
-        data = json.loads(request.data)
-        if not data['reply']:
-            abort(400, 'reply should not be empty')
-
-        source.interaction_count += 1
-        try:
-            filename = current_app.storage.save_pre_encrypted_reply(
-                source.filesystem_id,
-                source.interaction_count,
-                source.journalist_filename,
-                data['reply'])
-        except NotEncrypted:
+    def all_source_replies(source_uuid):
+        if request.method == 'GET':
+            source = get_or_404(Source, source_uuid, column=Source.uuid)
             return jsonify(
-                {'message': 'You must encrypt replies client side'}), 400
+                {'replies': [reply.to_json() for
+                             reply in source.replies]}), 200
+        elif request.method == 'POST':
+            source = get_or_404(Source, source_uuid,
+                                column=Source.uuid)
+            if request.json is None:
+                abort(400, 'please send requests in valid JSON')
 
-        reply = Reply(user, source,
-                      current_app.storage.path(source.filesystem_id, filename))
-        db.session.add(reply)
-        db.session.add(source)
-        db.session.commit()
-        return jsonify({'message': 'Your reply has been stored'}), 201
+            if 'reply' not in request.json:
+                abort(400, 'reply not found in request body')
+
+            user = get_user_object(request)
+
+            data = json.loads(request.data)
+            if not data['reply']:
+                abort(400, 'reply should not be empty')
+
+            source.interaction_count += 1
+            try:
+                filename = current_app.storage.save_pre_encrypted_reply(
+                    source.filesystem_id,
+                    source.interaction_count,
+                    source.journalist_filename,
+                    data['reply'])
+            except NotEncrypted:
+                return jsonify(
+                    {'message': 'You must encrypt replies client side'}), 400
+
+            reply = Reply(user, source,
+                          current_app.storage.path(source.filesystem_id,
+                                                   filename))
+            db.session.add(reply)
+            db.session.add(source)
+            db.session.commit()
+            return jsonify({'message': 'Your reply has been stored'}), 201
+
+    @api.route('/sources/<source_uuid>/replies/<reply_uuid>', methods=['GET'])
+    @token_required
+    def single_reply(source_uuid, reply_uuid):
+        get_or_404(Source, source_uuid, column=Source.uuid)
+        reply = get_or_404(Reply, reply_uuid, column=Reply.uuid)
+        return jsonify(reply.to_json()), 200
 
     @api.route('/submissions', methods=['GET'])
     @token_required
@@ -245,6 +260,13 @@ def make_blueprint(config):
         submissions = Submission.query.all()
         return jsonify({'submissions': [submission.to_json() for
                                         submission in submissions]}), 200
+
+    @api.route('/replies', methods=['GET'])
+    @token_required
+    def get_all_replies():
+        replies = Reply.query.all()
+        return jsonify(
+            {'replies': [reply.to_json() for reply in replies]}), 200
 
     @api.route('/user', methods=['GET'])
     @token_required

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -247,12 +247,18 @@ def make_blueprint(config):
             db.session.commit()
             return jsonify({'message': 'Your reply has been stored'}), 201
 
-    @api.route('/sources/<source_uuid>/replies/<reply_uuid>', methods=['GET'])
+    @api.route('/sources/<source_uuid>/replies/<reply_uuid>',
+               methods=['GET', 'DELETE'])
     @token_required
     def single_reply(source_uuid, reply_uuid):
-        get_or_404(Source, source_uuid, column=Source.uuid)
+        source = get_or_404(Source, source_uuid, column=Source.uuid)
         reply = get_or_404(Reply, reply_uuid, column=Reply.uuid)
-        return jsonify(reply.to_json()), 200
+        if request.method == 'GET':
+            return jsonify(reply.to_json()), 200
+        elif request.method == 'DELETE':
+            utils.delete_file(source.filesystem_id, reply.filename,
+                              reply)
+            return jsonify({'message': 'Reply deleted'}), 200
 
     @api.route('/submissions', methods=['GET'])
     @token_required

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -192,6 +192,7 @@ def make_blueprint(config):
     @token_required
     def single_submission(source_uuid, submission_uuid):
         if request.method == 'GET':
+            source = get_or_404(Source, source_uuid, column=Source.uuid)
             submission = get_or_404(Submission, submission_uuid,
                                     column=Submission.uuid)
             return jsonify(submission.to_json()), 200

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -573,7 +573,8 @@ class Journalist(db.Model):
         json_user = {
             'username': self.username,
             'last_login': self.last_access.isoformat() + 'Z',
-            'is_admin': self.is_admin
+            'is_admin': self.is_admin,
+            'uuid': self.uuid
         }
         return json_user
 

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -150,7 +150,8 @@ class Source(db.Model):
             'add_star_url': url_for('api.add_star', source_uuid=self.uuid),
             'remove_star_url': url_for('api.remove_star',
                                        source_uuid=self.uuid),
-            'reply_url': url_for('api.post_reply', source_uuid=self.uuid)
+            'replies_url': url_for('api.all_source_replies',
+                                   source_uuid=self.uuid)
             }
         return json_source
 
@@ -230,6 +231,21 @@ class Reply(db.Model):
 
     def __repr__(self):
         return '<Reply %r>' % (self.filename)
+
+    def to_json(self):
+        json_submission = {
+            'source_url': url_for('api.single_source',
+                                  source_uuid=self.source.uuid),
+            'reply_url': url_for('api.single_reply',
+                                 source_uuid=self.source.uuid,
+                                 reply_uuid=self.uuid),
+            'filename': self.filename,
+            'size': self.size,
+            'journalist_username': self.journalist.username,
+            'uuid': self.uuid,
+            'is_deleted_by_source': self.deleted_by_source,
+        }
+        return json_submission
 
 
 class SourceStar(db.Model):

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -200,6 +200,7 @@ class Submission(db.Model):
 class Reply(db.Model):
     __tablename__ = "replies"
     id = Column(Integer, primary_key=True)
+    uuid = Column(String(36), unique=True, nullable=False)
 
     journalist_id = Column(Integer, ForeignKey('journalists.id'))
     journalist = relationship(
@@ -222,6 +223,7 @@ class Reply(db.Model):
     def __init__(self, journalist, source, filename):
         self.journalist_id = journalist.id
         self.source_id = source.id
+        self.uuid = str(uuid.uuid4())
         self.filename = filename
         self.size = os.stat(current_app.storage.path(source.filesystem_id,
                                                      filename)).st_size

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -242,6 +242,7 @@ class Reply(db.Model):
             'filename': self.filename,
             'size': self.size,
             'journalist_username': self.journalist.username,
+            'journalist_uuid': self.journalist.uuid,
             'uuid': self.uuid,
             'is_deleted_by_source': self.deleted_by_source,
         }
@@ -318,6 +319,7 @@ class NonDicewarePassword(PasswordError):
 class Journalist(db.Model):
     __tablename__ = "journalists"
     id = Column(Integer, primary_key=True)
+    uuid = Column(String(36), unique=True, nullable=False)
     username = Column(String(255), nullable=False, unique=True)
     pw_salt = Column(Binary(32))
     pw_hash = Column(Binary(256))
@@ -342,6 +344,7 @@ class Journalist(db.Model):
         self.username = username
         self.set_password(password)
         self.is_admin = is_admin
+        self.uuid = str(uuid.uuid4())
 
         if otp_secret:
             self.set_hotp_secret(otp_secret)

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -182,6 +182,20 @@ def test_submissions(journalist_app):
 
 
 @pytest.fixture(scope='function')
+def test_files(journalist_app, test_journo):
+    with journalist_app.app_context():
+        source, codename = utils.db_helper.init_source()
+        utils.db_helper.submit(source, 2)
+        utils.db_helper.reply(test_journo['journalist'], source, 1)
+        return {'source': source,
+                'codename': codename,
+                'filesystem_id': source.filesystem_id,
+                'uuid': source.uuid,
+                'submissions': source.submissions,
+                'replies': source.replies}
+
+
+@pytest.fixture(scope='function')
 def journalist_api_token(journalist_app, test_journo):
     with journalist_app.test_client() as app:
         valid_token = TOTP(test_journo['otp_secret']).now()

--- a/securedrop/tests/migrations/migration_6db892e17271.py
+++ b/securedrop/tests/migrations/migration_6db892e17271.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+
+import random
+import string
+import uuid
+
+from sqlalchemy import text
+from sqlalchemy.exc import NoSuchColumnError
+
+from db import db
+from journalist_app import create_app
+from .helpers import (random_bool, random_bytes, random_chars, random_datetime,
+                      random_username, bool_or_none)
+
+random.seed('ᕕ( ᐛ )ᕗ')
+
+
+def add_source():
+    filesystem_id = random_chars(96) if random_bool() else None
+    params = {
+        'uuid': str(uuid.uuid4()),
+        'filesystem_id': filesystem_id,
+        'journalist_designation': random_chars(50),
+        'flagged': bool_or_none(),
+        'last_updated': random_datetime(nullable=True),
+        'pending': bool_or_none(),
+        'interaction_count': random.randint(0, 1000),
+    }
+    sql = '''INSERT INTO sources (uuid, filesystem_id,
+                journalist_designation, flagged, last_updated, pending,
+                interaction_count)
+             VALUES (:uuid, :filesystem_id, :journalist_designation,
+                :flagged, :last_updated, :pending, :interaction_count)
+          '''
+    db.engine.execute(text(sql), **params)
+
+
+def add_journalist():
+    if random_bool():
+        otp_secret = random_chars(16, string.ascii_uppercase + '234567')
+    else:
+        otp_secret = None
+
+    is_totp = random_bool()
+    if is_totp:
+        hotp_counter = 0 if random_bool() else None
+    else:
+        hotp_counter = random.randint(0, 10000) if random_bool() else None
+
+    last_token = random_chars(6, string.digits) if random_bool() else None
+
+    params = {
+        'username': random_username(),
+        'pw_salt': random_bytes(1, 64, nullable=True),
+        'pw_hash': random_bytes(32, 64, nullable=True),
+        'is_admin': bool_or_none(),
+        'otp_secret': otp_secret,
+        'is_totp': is_totp,
+        'hotp_counter': hotp_counter,
+        'last_token': last_token,
+        'created_on': random_datetime(nullable=True),
+        'last_access': random_datetime(nullable=True),
+        'passphrase_hash': random_bytes(32, 64, nullable=True)
+    }
+    sql = '''INSERT INTO journalists (username, pw_salt, pw_hash,
+                is_admin, otp_secret, is_totp, hotp_counter, last_token,
+                created_on, last_access, passphrase_hash)
+             VALUES (:username, :pw_salt, :pw_hash, :is_admin,
+                :otp_secret, :is_totp, :hotp_counter, :last_token,
+                :created_on, :last_access, :passphrase_hash);
+          '''
+    db.engine.execute(text(sql), **params)
+
+
+class UpgradeTester():
+
+    '''This migration verifies that the deleted_by_source column now exists,
+    and that the data migration completed successfully.
+    '''
+
+    SOURCE_NUM = 200
+    JOURNO_NUM = 20
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            for _ in range(self.JOURNO_NUM):
+                add_journalist()
+
+            add_source()
+
+            for jid in range(1, self.JOURNO_NUM):
+                self.add_reply(jid, 1)
+
+            db.session.commit()
+
+    @staticmethod
+    def add_reply(journalist_id, source_id):
+        params = {
+            'journalist_id': journalist_id,
+            'source_id': source_id,
+            'filename': random_chars(50),
+            'size': random.randint(0, 1024 * 1024 * 500),
+            'deleted_by_source': False,
+        }
+        sql = '''INSERT INTO replies (journalist_id, source_id, filename,
+                    size, deleted_by_source)
+                 VALUES (:journalist_id, :source_id, :filename, :size,
+                         :deleted_by_source)
+              '''
+        db.engine.execute(text(sql), **params)
+
+    def check_upgrade(self):
+        with self.app.app_context():
+            replies = db.engine.execute(
+                text('SELECT * FROM replies')).fetchall()
+            assert len(replies) == self.JOURNO_NUM - 1
+
+            for reply in replies:
+                assert reply.uuid is not None
+
+
+class DowngradeTester():
+
+    SOURCE_NUM = 200
+    JOURNO_NUM = 20
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            for _ in range(self.JOURNO_NUM):
+                add_journalist()
+
+            add_source()
+
+            for jid in range(1, self.JOURNO_NUM):
+                self.add_reply(jid, 1)
+
+            db.session.commit()
+
+    @staticmethod
+    def add_reply(journalist_id, source_id):
+        params = {
+            'journalist_id': journalist_id,
+            'source_id': source_id,
+            'uuid': str(uuid.uuid4()),
+            'filename': random_chars(50),
+            'size': random.randint(0, 1024 * 1024 * 500),
+            'deleted_by_source': False,
+        }
+        sql = '''INSERT INTO replies (journalist_id, source_id, uuid, filename,
+                    size, deleted_by_source)
+                 VALUES (:journalist_id, :source_id, :uuid, :filename, :size,
+                    :deleted_by_source)
+              '''
+        db.engine.execute(text(sql), **params)
+
+    def check_downgrade(self):
+        '''Verify that the deleted_by_source column is now gone, and
+        otherwise the table has the expected number of rows.
+        '''
+        with self.app.app_context():
+            sql = "SELECT * FROM replies"
+            replies = db.engine.execute(text(sql)).fetchall()
+
+            for reply in replies:
+                try:
+                    # This should produce an exception, as the column (should)
+                    # be gone.
+                    assert reply['uuid'] is None
+                except NoSuchColumnError:
+                    pass
+
+            assert len(replies) == self.JOURNO_NUM - 1

--- a/securedrop/tests/migrations/migration_f2833ac34bb6.py
+++ b/securedrop/tests/migrations/migration_f2833ac34bb6.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+
+import random
+import string
+import uuid
+
+from sqlalchemy import text
+from sqlalchemy.exc import NoSuchColumnError
+
+from db import db
+from journalist_app import create_app
+from .helpers import (random_bool, random_bytes, random_chars, random_datetime,
+                      random_username, bool_or_none)
+
+random.seed('ᕕ( ᐛ )ᕗ')
+
+
+class UpgradeTester():
+
+    '''This migration verifies that the UUID column now exists, and that
+    the data migration completed successfully.
+    '''
+
+    JOURNO_NUM = 20
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            for _ in range(self.JOURNO_NUM):
+                self.add_journalist()
+            db.session.commit()
+
+    @staticmethod
+    def add_journalist():
+        if random_bool():
+            otp_secret = random_chars(16, string.ascii_uppercase + '234567')
+        else:
+            otp_secret = None
+
+        is_totp = random_bool()
+        if is_totp:
+            hotp_counter = 0 if random_bool() else None
+        else:
+            hotp_counter = random.randint(0, 10000) if random_bool() else None
+
+        last_token = random_chars(6, string.digits) if random_bool() else None
+
+        params = {
+            'username': random_username(),
+            'pw_salt': random_bytes(1, 64, nullable=True),
+            'pw_hash': random_bytes(32, 64, nullable=True),
+            'is_admin': bool_or_none(),
+            'otp_secret': otp_secret,
+            'is_totp': is_totp,
+            'hotp_counter': hotp_counter,
+            'last_token': last_token,
+            'created_on': random_datetime(nullable=True),
+            'last_access': random_datetime(nullable=True),
+            'passphrase_hash': random_bytes(32, 64, nullable=True)
+        }
+        sql = '''INSERT INTO journalists (username, pw_salt, pw_hash,
+                    is_admin, otp_secret, is_totp, hotp_counter, last_token,
+                    created_on, last_access, passphrase_hash)
+                 VALUES (:username, :pw_salt, :pw_hash, :is_admin,
+                    :otp_secret, :is_totp, :hotp_counter, :last_token,
+                    :created_on, :last_access, :passphrase_hash);
+              '''
+        db.engine.execute(text(sql), **params)
+
+    def check_upgrade(self):
+        with self.app.app_context():
+            journalists = db.engine.execute(
+                text('SELECT * FROM journalists')).fetchall()
+
+            for journalist in journalists:
+                assert journalist.uuid is not None
+
+
+class DowngradeTester():
+
+    JOURNO_NUM = 20
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            for _ in range(self.JOURNO_NUM):
+                self.add_journalist()
+            db.session.commit()
+
+    @staticmethod
+    def add_journalist():
+        if random_bool():
+            otp_secret = random_chars(16, string.ascii_uppercase + '234567')
+        else:
+            otp_secret = None
+
+        is_totp = random_bool()
+        if is_totp:
+            hotp_counter = 0 if random_bool() else None
+        else:
+            hotp_counter = random.randint(0, 10000) if random_bool() else None
+
+        last_token = random_chars(6, string.digits) if random_bool() else None
+
+        params = {
+            'username': random_username(),
+            'uuid': str(uuid.uuid4()),
+            'pw_salt': random_bytes(1, 64, nullable=True),
+            'pw_hash': random_bytes(32, 64, nullable=True),
+            'is_admin': bool_or_none(),
+            'otp_secret': otp_secret,
+            'is_totp': is_totp,
+            'hotp_counter': hotp_counter,
+            'last_token': last_token,
+            'created_on': random_datetime(nullable=True),
+            'last_access': random_datetime(nullable=True),
+            'passphrase_hash': random_bytes(32, 64, nullable=True)
+        }
+        sql = '''INSERT INTO journalists (username, uuid, pw_salt, pw_hash,
+                    is_admin, otp_secret, is_totp, hotp_counter, last_token,
+                    created_on, last_access, passphrase_hash)
+                 VALUES (:username, :uuid, :pw_salt, :pw_hash, :is_admin,
+                    :otp_secret, :is_totp, :hotp_counter, :last_token,
+                    :created_on, :last_access, :passphrase_hash);
+              '''
+        db.engine.execute(text(sql), **params)
+
+    def check_downgrade(self):
+        '''Verify that the UUID column is now gone, but otherwise the table
+        has the expected number of rows.
+        '''
+        with self.app.app_context():
+            sql = "SELECT * FROM journalists"
+            journalists = db.engine.execute(text(sql)).fetchall()
+
+            for journalist in journalists:
+                try:
+                    # This should produce an exception, as the column (should)
+                    # be gone.
+                    assert journalist['uuid'] is None
+                except NoSuchColumnError:
+                    pass

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -495,6 +495,22 @@ def test_authorized_user_can_delete_single_submission(journalist_app,
             Submission.uuid == submission_uuid).all() == []
 
 
+def test_authorized_user_can_delete_single_reply(journalist_app, test_files,
+                                                 journalist_api_token):
+    with journalist_app.test_client() as app:
+        reply_uuid = test_files['source'].replies[0].uuid
+        uuid = test_files['source'].uuid
+        response = app.delete(url_for('api.single_reply',
+                                      source_uuid=uuid,
+                                      reply_uuid=reply_uuid),
+                              headers=get_api_headers(journalist_api_token))
+
+        assert response.status_code == 200
+
+        # Reply should now be gone.
+        assert Reply.query.filter(Reply.uuid == reply_uuid).all() == []
+
+
 def test_authorized_user_can_delete_source_collection(journalist_app,
                                                       test_source,
                                                       journalist_api_token):

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -552,6 +552,27 @@ def test_authorized_user_can_download_submission(journalist_app,
             hashlib.sha256(response.data).hexdigest())
 
 
+def test_authorized_user_can_download_reply(journalist_app, test_files,
+                                            journalist_api_token):
+    with journalist_app.test_client() as app:
+        reply_uuid = test_files['source'].replies[0].uuid
+        uuid = test_files['source'].uuid
+
+        response = app.get(url_for('api.download_reply',
+                                   source_uuid=uuid,
+                                   reply_uuid=reply_uuid),
+                           headers=get_api_headers(journalist_api_token))
+
+        assert response.status_code == 200
+
+        # Response should be a PGP encrypted download
+        assert response.mimetype == 'application/pgp-encrypted'
+
+        # Response should have Etag field with hash
+        assert response.headers['ETag'] == '"sha256:{}"'.format(
+            hashlib.sha256(response.data).hexdigest())
+
+
 def test_authorized_user_can_get_current_user_endpoint(journalist_app,
                                                        test_journo,
                                                        journalist_api_token):

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -586,6 +586,7 @@ def test_authorized_user_can_get_current_user_endpoint(journalist_app,
         json_response = json.loads(response.data)
         assert json_response['is_admin'] is False
         assert json_response['username'] == test_journo['username']
+        assert json_response['uuid'] == test_journo['journalist'].uuid
 
 
 def test_request_with_missing_auth_header_triggers_403(journalist_app):

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -470,6 +470,8 @@ def test_authorized_user_can_get_single_reply(journalist_app, test_files,
         assert json_response['uuid'] == reply_uuid
         assert json_response['journalist_username'] == \
             reply.journalist.username
+        assert json_response['journalist_uuid'] == \
+            reply.journalist.uuid
         assert json_response['is_deleted_by_source'] is False
         assert json_response['filename'] == \
             test_files['source'].replies[0].filename


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #3676 

Changes proposed in this pull request:
 * Adds API endpoints for getting, deleting and downloading replies to sources

## Testing

0. Provision staging VM on `develop`, add test data (at least 1 user and 1 reply)
1.  `make build-debs`
2. `vagrant provision /staging/`
3. Ensure that API responses contain UUIDs for reply and user

## Deployment

Deployed in securedrop-app-code package

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
