### PR TITLE
Use absolute pathing in i18n testing

### DIFF
--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -30,6 +30,7 @@ import i18n_tool
 import journalist_app as journalist_app_module
 import pytest
 import source_app
+from utils.env import TESTS_DIR
 
 from sh import sed, pybabel
 
@@ -174,14 +175,14 @@ def test_i18n(journalist_app, config):
     del journalist_app
 
     sources = [
-        'tests/i18n/code.py',
-        'tests/i18n/template.html',
+        os.path.join(TESTS_DIR, 'i18n/code.py'),
+        os.path.join(TESTS_DIR, 'i18n/template.html'),
     ]
 
     i18n_tool.I18NTool().main([
         '--verbose',
         'translate-messages',
-        '--mapping', 'tests/i18n/babel.cfg',
+        '--mapping', os.path.join(TESTS_DIR, 'i18n/babel.cfg'),
         '--translations-dir', config.TEMP_DIR,
         '--sources', ",".join(sources),
         '--extract-update',

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -10,6 +10,7 @@ import i18n_tool
 import journalist_app
 import source_app
 import template_filters
+from utils.env import TESTS_DIR
 
 from sh import pybabel
 
@@ -98,9 +99,9 @@ def do_test(config, create_app):
     i18n_tool.I18NTool().main([
         '--verbose',
         'translate-messages',
-        '--mapping', 'tests/i18n/babel.cfg',
+        '--mapping', os.path.join(TESTS_DIR, 'i18n/babel.cfg'),
         '--translations-dir', config.TEMP_DIR,
-        '--sources', 'tests/i18n/code.py',
+        '--sources', os.path.join(TESTS_DIR, 'i18n/code.py'),
         '--extract-update',
         '--compile',
     ])

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -14,7 +14,8 @@ from sdconfig import config
 
 from db import db
 
-FILES_DIR = abspath(join(dirname(realpath(__file__)), '..', 'files'))
+TESTS_DIR = abspath(join(dirname(realpath(__file__)), '..'))
+FILES_DIR = join(TESTS_DIR, 'files')
 
 # The PID file for the redis worker is hard-coded below.  Ideally this
 # constant would be provided by a test harness.  It has been intentionally


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3660

Changes proposed in this pull request:

Uses absolute path references to elements located in the `securedrop/tests/i18n` directory. For some reason this branch was failing hard without these changes and throwing errors regarding inability to find specific files. 

## Testing

How should the reviewer test this PR?
Does the pass CI? Well then hop-diggity press the review button and press approve! :rocket: 

## Deployment

Any special considerations for deployment? Consider both:

Only affects tests

## Checklist

- [ ] Did you brush your teeth this morning?