### PR TITLE
Update builder hash

### DIFF
--- a/molecule/builder/image_hash
+++ b/molecule/builder/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_07_25
-86cb12fa109798f01c86286cb168a21d5dfe3d676a8dba0c08127338b4dcf07a
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_08_23
+db17d3a734f6a714e57c0b9ce81dec36e51f2ec30a250902b839fb9050cb9d4f


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3729 : 

Updates builder hash, new image contains security updates. Updated using https://docs.securedrop.org/en/release-0.8/development/dockerbuildmaint.html#performing-container-updates

## Testing

Tests invoked as part of `make build-debs` target should pass.

## Deployment

Dev environment only