### PR TITLE
Pytest 2 electric boogaloo

### DIFF
--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -166,7 +166,8 @@ def test_source(journalist_app):
         return {'source': source,
                 'codename': codename,
                 'filesystem_id': source.filesystem_id,
-                'uuid': source.uuid}
+                'uuid': source.uuid,
+                'id': source.id}
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Toward #2877.

More use of pytest fixtures.

## Testing

`make test TESTFILES=tests/test_journalist.py`

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container