### PR TITLE
Journalist Interface: Localize tooltips

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -35,17 +35,17 @@
             {% if doc.filename.endswith('reply.gpg') %}
               {% if not doc.deleted_by_source %}
                 <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
-                <span title="Reply" class="icon"><i class="fa fa-reply pull right"></i></span>
+                <span title="{{ gettext('Reply') }}" class="icon"><i class="fa fa-reply pull right"></i></span>
               {% else %}
                 <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
-                <span title="Read" class="icon"><i class="fa fa-check"></i></span>
+                <span title="{{ gettext('Read') }}" class="icon"><i class="fa fa-check"></i></span>
               {% endif %}
             {% elif not doc.downloaded %}
               <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
-              <span title="Unread" class="icon"><i class="fa fa-envelope"></i></span>
+              <span title="{{ gettext('Unread') }}" class="icon"><i class="fa fa-envelope"></i></span>
             {% else %}
               <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
-              <span title="Read" class="icon"><i class="fa fa-envelope-open"></i></span>
+              <span title="{{ gettext('Read') }}" class="icon"><i class="fa fa-envelope-open"></i></span>
             {% endif %}
             <a class="file {% if not doc.downloaded and not doc.filename.endswith('reply.gpg') %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_file', filesystem_id=filesystem_id, fn=doc.filename) }}">
               <i class="fa fa-download"></i> <span class="filename">{{ doc.filename }}</span>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Noticed during resolution of #3734 

Changes proposed in this pull request:
 - Localize tooltips

## Testing

Make sure all tooltips modified in this PR are displayed in the Journalist Interface

## Deployment

Requires string changes

Since we have _no_ string changes as part of 0.9.0 so far we _could_ just merge this into `develop` and fix in 0.10.0. That said, we have a few days until string freeze, so now would be a good time to resolve if we want to get it into 0.9.0, which would be nice if possible. What do you think @kushaldas? 

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

