### PR TITLE
Apply database migration on backup restore

### DIFF
--- a/install_files/ansible-base/roles/restore/files/restore.py
+++ b/install_files/ansible-base/roles/restore/files/restore.py
@@ -45,6 +45,8 @@ def main():
     # If the process exits with a non-zero return code, raises an exception.
     subprocess.check_call(['service', 'apache2', 'restart'])
     subprocess.check_call(['service', 'tor', 'reload'])
+    # Apply database migrations (if backed-up version < version to restore)
+    subprocess.check_call(['dpkg-reconfigure', 'securedrop-app-code'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3732 .

Apply migrations as part of backup restore script.

## Testing

1. Install SecureDrop version < 0.9.0
2. `./securedrop-admin backup`
3. Upgrade SecureDrop to 0.9.0-rc1
4. Grab filename from backup tarball that was written to `install_files/ansible-base/`
5. `./securedrop-admin restore <filename>`
6. Go to the source interface and submit a document
7. Validate that the document can be retrieved on the journalist interface
8. Inspect the database to ensure the migrations have been successful, and that the following tables have UUIDs (`sqlite3 /var/lib/securedrop/db.sqlite`):
    a. replies
    b. submissions
    c. sources
    d. journalists

## Deployment

This will be used when restoring from backup. Code will be updated via SecureDrop Updater GUI.

## Checklist


### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
