### PR TITLE
Update securedrop-app-code dependencies: Flask and Werkzeug

### DIFF
--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -6,7 +6,7 @@ Flask-Assets
 Flask-Babel
 Flask-SQLAlchemy
 Flask-WTF
-Flask
+Flask>0.12.2
 gnupg
 Jinja2
 jsmin
@@ -20,4 +20,4 @@ scrypt
 sh
 SQLAlchemy
 typing
-Werkzeug==0.12.2
+Werkzeug

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -17,7 +17,7 @@ flask-assets==0.12
 flask-babel==0.11.2
 flask-sqlalchemy==2.3.2
 flask-wtf==0.14.2
-flask==0.12.2
+flask==1.0.2
 gnupg==2.3.1
 idna==2.6                 # via cryptography
 ipaddress==1.0.22         # via cryptography
@@ -42,5 +42,5 @@ six==1.11.0               # via argon2-cffi, cryptography, python-dateutil, qrco
 sqlalchemy==1.2.0
 typing==3.6.4
 webassets==0.12.1         # via flask-assets
-werkzeug==0.12.2
+werkzeug==0.14.1
 wtforms==2.1              # via flask-wtf


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes CVE-2018-1000656

Towards #3740 (intentionally not using GitHub closing keywords here such that we keep the issue open until it is picked into the 0.9 release branch)

## Testing

Pending successful CI run

## Deployment

Deployed in `securedrop-app-code` package

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
