### PR TITLE
remove task that removes tmux from bashrc

### DIFF
--- a/install_files/ansible-base/roles/common/tasks/create_users.yml
+++ b/install_files/ansible-base/roles/common/tasks/create_users.yml
@@ -33,19 +33,3 @@
   tags:
     - users
     - environment
-
-# Backwards-compatibility. Previously, the SecureDrop bashrc additions
-# for forcing a terminal multiplexer during interactive login sessions were
-# added to ~/.bashrc for each admin user account. It's cleaner to add the
-# config lines to /etc/profile.d, so all accounts get them by default.
-# Post 0.4, we can remove this task, which is here to clean up the local
-# bashrc files so that the additions are only sourced once.
-- name: Clean up local bashrc config for admin accounts.
-  lineinfile:
-    dest: /home/{{ item }}/.bashrc
-    line: '. /etc/bashrc.securedrop_additions'
-    state: absent
-  with_items: "{{ ssh_users }}"
-  tags:
-    - users
-    - environment


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #3609

(see title)

## Testing

`make staging`

## Deployment

This might need a double check from the ops team, but this change has been here long enough that there shouldn't be any instances left that retain this line.