### PR TITLE
QA data loader: Set default multiplier at 25

### DIFF
--- a/securedrop/qa_loader.py
+++ b/securedrop/qa_loader.py
@@ -225,9 +225,9 @@ def arg_parser():
     parser = ArgumentParser(
         path.basename(__file__),
         description='Loads data into the database for testing upgrades')
-    parser.add_argument('-m', '--multiplier', type=positive_int, default=100,
+    parser.add_argument('-m', '--multiplier', type=positive_int, default=25,
                         help=('Factor to multiply the loaded data by '
-                              '(default 100)'))
+                              '(default 25)'))
     return parser
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3733. 

We can avoid making late game changes to the migrations in 0.9.0 provided that the migration is sufficiently fast for realistic amounts of data. This PR decreases the amount in the database used to QA - such that it is still realistic for testing/QA purposes (and it's still on the bigger side with 1000+ sources) - but should _not_ take an excessively long time to do the migration (as reported in #3733). 

## Testing

One should do an upgrade test from 0.8.0->0.9.0-rc1 to test this, and verify that the migration takes only a few minutes. 

I tested an upgrade with this test data (note: on a device with an SSD) and the migration was very fast (<5 mins). 

## Deployment

Note: we should backport this to the release branch in preparation for the next release, but for _this_ release, we should modify the test plan to specify that `./qa_loader.py -m 25` should be run prior to upgrade to 0.9.0. 

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

