### PR TITLE
Adds sorting of the released tags based on semver

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -36,6 +36,7 @@ import types
 import prompt_toolkit
 from prompt_toolkit.validation import Validator, ValidationError
 import yaml
+from pkg_resources import parse_version
 
 sdlog = logging.getLogger(__name__)
 RELEASE_KEY = '22245C81E3BAEB4138B36061310F561200F4AD77'
@@ -627,6 +628,9 @@ def check_for_updates(args):
 
     # Do not check out any release candidate tags
     all_prod_tags = [x for x in all_tags if 'rc' not in x]
+
+    # We want the tags to be sorted based on semver
+    all_prod_tags.sort(key=parse_version)
 
     latest_tag = all_prod_tags[-1]
 

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -66,6 +66,20 @@ class TestSecureDropAdmin(object):
                 assert update_status is True
                 assert tag == '0.6.1'
 
+    def test_check_for_updates_higher_version(self, tmpdir, caplog):
+        git_repo_path = str(tmpdir)
+        args = argparse.Namespace(root=git_repo_path)
+        current_tag = "0.6"
+        tags_available = "0.1\n0.10.0\n0.6.2\n0.6\n0.6-rc1\n0.9.0\n"
+
+        with mock.patch('subprocess.check_call'):
+            with mock.patch('subprocess.check_output',
+                            side_effect=[current_tag, tags_available]):
+                update_status, tag = securedrop_admin.check_for_updates(args)
+                assert "Update needed" in caplog.text
+                assert update_status is True
+                assert tag == '0.10.0'
+
     def test_check_for_updates_ensure_newline_stripped(self, tmpdir, caplog):
         """Regression test for #3426"""
         git_repo_path = str(tmpdir)


### PR DESCRIPTION
This is for
https://github.com/freedomofpress/securedrop/issues/3579

## Status

Ready for review

## Description of Changes

Fixes #3579

Now using the same logic `setuptools`  uses to sort package versions.

## Testing

```
cd admin
make test
```

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
