### PR TITLE
width of login input boxes in admin/journalist login pages increased to 550px to accomodate long passphrases

### DIFF
--- a/securedrop/journalist_templates/login.html
+++ b/securedrop/journalist_templates/login.html
@@ -5,12 +5,10 @@
 
 <form method="post" action="/login" autocomplete="off" class="login-form">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-  <p><input type="text" name="username" autocomplete="off" placeholder="{{ gettext('Username') }}" autofocus></p>
-  <p><input type="password" name="password" placeholder="{{ gettext('Password') }}"></p>
-  <p><input name="token" id="token" type="text" placeholder="{{ gettext('Two-factor Code') }}"></p>
-  <p class="pull-right">
-    <button class="sd-button" type="submit"><i class="far fa-arrow-alt-circle-right"></i> {{ gettext('LOG IN') }}</button>
-  </p>
+  <p><input class="login-username" type="text" name="username" autocomplete="off" placeholder="{{ gettext('Username') }}" autofocus></p>
+  <p><input class="login-password" type="password" name="password" placeholder="{{ gettext('Password') }}"></p>
+  <p><input class="login-token" name="token" id="token" type="text" placeholder="{{ gettext('Two-factor Code') }}"></p>
+  <p><button class="sd-button" type="submit"><i class="far fa-arrow-alt-circle-right"></i> {{ gettext('LOG IN') }}</button></p>
 </form>
 
 {% endblock %}

--- a/securedrop/sass/journalist.sass
+++ b/securedrop/sass/journalist.sass
@@ -92,7 +92,7 @@ button.small-danger, a.btn.small-danger, .btn.small-danger
     background-color: transparent
 
 .login-form
-  max-width: 445px
+  max-width: 550px
   input
     width: 100%
 

--- a/securedrop/sass/journalist.sass
+++ b/securedrop/sass/journalist.sass
@@ -93,8 +93,11 @@ button.small-danger, a.btn.small-danger, .btn.small-danger
 
 .login-form
   max-width: 550px
-  input
+  .login-username, .login-token
+    width: 33%
+  .login-password
     width: 100%
+
 
 .journalist-reply__input
   max-width: 700px


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Fixes #3711 

Changes proposed in this pull request:
increased size of login text boxes to 550px to accommodate the longer passphrases

## Testing

- Open the admin login panel, try to enter the long passphrase. 
- Passphrase fits in the input

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
