### PR TITLE
Show password option for journalist and admin login

### DIFF
--- a/securedrop/journalist_templates/login.html
+++ b/securedrop/journalist_templates/login.html
@@ -6,9 +6,10 @@
 <form method="post" action="/login" autocomplete="off" class="login-form">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   <p><input class="login-username" type="text" name="username" autocomplete="off" placeholder="{{ gettext('Username') }}" autofocus></p>
-  <p><input class="login-password" type="password" name="password" placeholder="{{ gettext('Password') }}"></p>
+  <p><input class="login-password" id="login-form-password" type="password" name="password" placeholder="{{ gettext('Password') }}"></p>
+  <p class="show-password-checkbox-container"><label><input id="show-password-check" type="checkbox">Show password</label></p>
   <p><input class="login-token" name="token" id="token" type="text" placeholder="{{ gettext('Two-factor Code') }}"></p>
-  <p><button class="sd-button" type="submit"><i class="far fa-arrow-alt-circle-right"></i> {{ gettext('LOG IN') }}</button></p>
+  <button class="sd-button" type="submit"><i class="far fa-arrow-alt-circle-right"></i> {{ gettext('LOG IN') }}</button>
 </form>
 
 {% endblock %}

--- a/securedrop/sass/journalist.sass
+++ b/securedrop/sass/journalist.sass
@@ -107,3 +107,15 @@ button.small-danger, a.btn.small-danger, .btn.small-danger
   font-weight: normal
   letter-spacing: 0.5px
   padding-bottom: 4px
+
+#login-form-password
+  width: calc(100% - 30px)
+  display: inline-block
+
+#show-password-check
+  margin-right: 5px
+  vertical-align: middle
+  width: auto
+
+.show-password-checkbox-container
+  display: none

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -94,4 +94,17 @@ $(function () {
       return confirm(get_string("reset-user-mfa-confirm-string").supplant({ username: username }));
   });
 
+  // make show password checkbox visible if javascript enabled
+  $('.show-password-checkbox-container').css("display", "block");
+
+  // Set up listener for show password checkbox
+  $('#show-password-check').change(function(event) {
+    if(event.target.checked) {
+      $('#login-form-password').attr('type', 'text');
+    }
+    else {
+      $('#login-form-password').attr('type', 'password');
+    }
+  })
+
 });


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Fixes #3713 

Changes proposed in this pull request:
- added a checkbox which toggles the password to plaintext and vice-versa

## Testing
- open journalist/admin login page
- enter a passphrase
- toggle the checkbox to toggle between password 'asterisks' and plaintext.


## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
