### PR TITLE
Fixes #3758 checks file value before accessing it

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -124,7 +124,9 @@ def make_blueprint(config):
     @login_required
     def submit():
         msg = request.form['msg']
-        fh = request.files['fh']
+        fh = None
+        if 'fh' in request.files:
+            fh = request.files['fh']
 
         # Don't submit anything if it was an "empty" submission. #878
         if not (msg or fh):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3758 

Now we check if there is any uploaded file in the request
object before accessing it. This was causing error if the
'fh' key was missing in the request.files.

## Testing

Try to submit only message, and then only upload a file,
and finally upload both message and a file at the same time
using source interface.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
