### PR TITLE
Update builder hash

### DIFF
--- a/molecule/builder/image_hash
+++ b/molecule/builder/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_08_30
-c6d16f15b5c6f12e202ee01afe221be7f2f72991d6f1e2c5aad0dc88688919e5
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_08_31
+d4b3ebe38954c8843c62881c97212a4935feb3da1ae374d3740b318fbd4ab703


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3765 , updates securedrop buillder image with latest packages
## Testing

`make build-debs` should complete without error.

## Deployment

Dev only
