### PR TITLE
Resolve deviation between dev/staging and prod

### DIFF
--- a/securedrop/requirements/develop-requirements.in
+++ b/securedrop/requirements/develop-requirements.in
@@ -19,7 +19,7 @@ pip-tools>=1.10
 pylint
 pytest-xdist
 python-vagrant
-safety
+safety>=1.8.4
 sphinx
 sphinx-autobuild
 sphinx_rtd_theme

--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -38,7 +38,7 @@ docker-py==1.10.6
 docker-pycreds==0.2.1     # via docker-py
 docopt==0.6.2             # via html-linter, template-remover
 docutils==0.14            # via botocore, sphinx
-dparse==0.2.1             # via safety
+dparse==0.4.1             # via safety
 enum34==1.1.6             # via astroid, cryptography, flake8
 execnet==1.4.1            # via pytest-xdist
 fasteners==0.14.1         # via python-gilt
@@ -93,7 +93,7 @@ pytz==2017.2              # via babel
 pyyaml==3.12              # via ansible, ansible-lint, bandit, dparse, molecule, python-gilt, sphinx-autobuild, watchdog, yamllint
 requests==2.18.3          # via cookiecutter, docker-py, safety, sphinx
 s3transfer==0.1.12        # via boto3
-safety==1.6.1
+safety==1.8.4
 sh==1.12.14               # via molecule, python-gilt
 singledispatch==3.4.0.3   # via astroid, pylint, tornado
 six==1.10.0               # via ansible-lint, astroid, bandit, bcrypt, click-completion, cryptography, docker-py, docker-pycreds, dparse, fasteners, git-url-parse, livereload, packaging, pip-tools, pylint, pynacl, python-dateutil, singledispatch, sphinx, stevedore, testinfra, websocket-client

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -11,7 +11,7 @@ click==6.7                # via flask, pip-tools
 coverage==4.4.2           # via pytest-cov
 first==2.0.1              # via pip-tools
 flask-testing==0.7.1
-flask==0.12.2             # via flask-testing
+flask==1.0.2              # via flask-testing
 funcsigs==1.0.2           # via mock, pytest
 itsdangerous==0.24        # via flask
 jinja2==2.10              # via flask
@@ -26,4 +26,4 @@ pytest-mock==1.7.1
 pytest==3.3.2
 selenium==2.53.6
 six==1.11.0               # via mock, pip-tools, pytest
-werkzeug==0.12.2          # via flask
+werkzeug==0.14.1          # via flask


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes

Fixes #3758 (this is the cause of deviation between dev/staging and prod).

During #3741, we updated Flask and Werkzeug in the 
`securedrop-app-code` package dependencies. However, these same 
dependencies were not updated in the test dependencies file, which include
Flask and Werkzeug (due to the `pip-compile` logic we have, which
pull in Flask and Werkzeug for Flask-testing). This
meant that in dev, the older versions of these deps were used.
Even in staging, the older versions of these deps was used due
to the fact that we install the test dependencies directly
in the staging VMs _after_ the `securedrop-app-code` package is
installed.

## Testing

1. Checkout `0.9.0-rc2`
2. Cherry pick in this commit
3. `make -C securedrop dev`
4. Reproduce defect #3758:

![screen shot 2018-08-31 at 5 28 48 pm](https://user-images.githubusercontent.com/7832803/44940444-58db9600-ad43-11e8-8cef-c4635df977ef.png)

This demonstrates that the source of divergence between dev and prod is resolved

## Deployment

None, effects dev/staging only

That said, this should be picked into `release/0.9` such that staging CI is running on the correct dependencies

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

