### PR TITLE
Bumps CI timeout on app tests 10m -> 20m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,7 @@ jobs:
       - run:
           name: Provision staging servers and run tests
           command: make ci-go
+          no_output_timeout: 20m
 
       - run:
           name: Ensure environment torn down


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #3779.

The default timeout option for a given CircleCI task is 10 minutes. If
no output is printed to stdout during that period, the build is
cancelled and marked as failed. Since we're running the app tests
via an Ansible wrapper, stdout is buffered, triggering the timeout.

Let's bump that value to 20m to give the tests a chance to report
results. See docs here:

https://circleci.com/docs/2.0/configuration-reference/

## Testing

CI should pass. That's it. 

## Deployment

No concerns, CI-only.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
