### PR TITLE
Fix release branch specific CI issues

### DIFF
--- a/molecule/aws/tor_apt_test.yml
+++ b/molecule/aws/tor_apt_test.yml
@@ -4,19 +4,6 @@
     data: "{{ lookup('file','securedrop_test.pub') }}"
     state: present
 
-- name: Temporary fix for GH issue 2938
-  file:
-    state: absent
-    path: "/etc/apt/sources.list.d/tor_apt_freedom_press.list"
-
-- name: Switch apt repo URLs to staging.
-  replace:
-    dest: "/etc/apt/sources.list.d/tor.apt.freedom.press.list"
-    replace: "tor-apt-test.freedom.press"
-    regexp: '//tor-apt\.freedom\.press'
-  ignore_errors: "yes"
-  notify: update tor
-
 - name: Force possible tor update
   meta: flush_handlers
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3768. This should be backported into `release/0.9` after this is merged such that we have green CI for the release tomorrow.  

Changes proposed in this pull request:
 - Remove now no longer necessary task removing duplicate apt repo resolved in #3189
 - Remove customizations for the tor-apt test repo that we are not using (instead we're using `apt-test.freedom.press` which we are already using in staging environment)

## Testing

Confirm this build testing this logic is passing: https://circleci.com/gh/freedomofpress/securedrop/17551

Check tor version artifact to make sure the upcoming Tor version (0.3.3.9, see #3625) to be sent to instances is installed: https://17551-3156820-gh.circle-artifacts.com/0/root/sd/.tor_version

## Deployment

CI only

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

