### PR TITLE
CI on release branch: Remove customization of Tor apt sources

### DIFF
--- a/molecule/aws/tor_apt_test.yml
+++ b/molecule/aws/tor_apt_test.yml
@@ -4,19 +4,6 @@
     data: "{{ lookup('file','securedrop_test.pub') }}"
     state: present
 
-- name: Temporary fix for GH issue 2938
-  file:
-    state: absent
-    path: "/etc/apt/sources.list.d/tor_apt_freedom_press.list"
-
-- name: Switch apt repo URLs to staging.
-  replace:
-    dest: "/etc/apt/sources.list.d/tor.apt.freedom.press.list"
-    replace: "tor-apt-test.freedom.press"
-    regexp: '//tor-apt\.freedom\.press'
-  ignore_errors: "yes"
-  notify: update tor
-
 - name: Force possible tor update
   meta: flush_handlers
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Ports changes in #3785 (already closed) to release branch for 0.9.

## Testing

1. Verify this commit is the same presented in #3785.
2. Confirm CI is passing.

## Deployment

No concerns, CI-only.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
