### PR TITLE
Update Tor Browser User Agent for 8.0

### DIFF
--- a/securedrop/static/js/source.js
+++ b/securedrop/static/js/source.js
@@ -1,4 +1,4 @@
-var TBB_UA_REGEX = /Mozilla\/5\.0 \(Windows NT 6\.1; rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/;
+var TBB_UA_REGEX = /Mozilla\/5\.0 \((Windows NT 6\.1|X11; Linux x86_64|Macintosh; Intel Mac OS X 10\.13|Windows NT 6\.1; Win64; x64); rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/;
 var ORFOX_UA_REGEX = /Mozilla\/5\.0 \(Android; Mobile; rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/;
 
 function is_likely_tor_browser() {


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes
Tor Browser's user agent now contains platform/OS due to changes in upstream Firefox (see https://trac.torproject.org/projects/tor/ticket/26146). We should explicitly list all platforms (instead of relaxing the regex to avoid matching `Android; Mobile`, Orfox's UA string.

We should also follow the discussion in that ticket, and revert/change the string as required.

Fixes #3788

## Testing

Navigate to the source interface and verify you do not see the get tor banner with the following Browser/OS combinations:
- Tor Browser 8.0a10 on Windows
- Tor Browser 8.0a10 on Linux (eg, Tails 3.9)
- Tor Browser 8.0a10 on MacOS
- Tor Browser 7.4 on any platform

## Deployment

This file will be shipped as part of the securedrop-app-code deb package 

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR