### PR TITLE
Update cwd for show-refs command

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -697,7 +697,8 @@ def update(args):
             try:
                 # We expect this to produce a non-zero exit code, which
                 # will produce a subprocess.CalledProcessError
-                subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+                subprocess.check_output(cmd, stderr=subprocess.STDOUT,
+                                        cwd=args.root)
                 sdlog.info("Signature verification failed.")
                 return 1
             except subprocess.CalledProcessError, e:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3795 

When executed in the context of the updater gui, the working directory for the securedrop-admin script was `/`, resulting in an error stating that the current working directory (or any of its parents) was a git repository.
This fix will ensure the SecureDrop updater GUI will not erroneously return a signature verification failure.

## Testing

1. checkout this branch
2. run updater GUI and click on `Update Now`
3. observe tag 0.9.0 checked out and verified

## Deployment

Deployed to admin workstations via git, will require admins to manually type `securedrop-admin update`

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
