### PR TITLE
[0.9.1] Backport updater GUI fix

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -697,7 +697,8 @@ def update(args):
             try:
                 # We expect this to produce a non-zero exit code, which
                 # will produce a subprocess.CalledProcessError
-                subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+                subprocess.check_output(cmd, stderr=subprocess.STDOUT,
+                                        cwd=args.root)
                 sdlog.info("Signature verification failed.")
                 return 1
             except subprocess.CalledProcessError, e:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backports #3796 in prep for patch release

## Testing

Tested during review of #3796, but more testing doesn't hurt: 

1. checkout this branch
2. run updater GUI and click on Update Now
3. observe tag 0.9.0 checked out and verified

## Deployment

Will need a patch release and people will need to do the manual update flow (in the release notes) (or just run `securedrop-admin update`)

## Checklist

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
