### PR TITLE
CI: Resolve flakiness by having xvfb-run pick a free display

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
           name: Run tests
           command: |
             cd journalist_gui
-            xvfb-run pipenv run python3 test_gui.py
+            xvfb-run -a pipenv run python3 test_gui.py
 
   staging-test-with-rebase:
     docker:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3665

Changes proposed in this pull request:
  * Upon investigation this wasn’t due to a specific test, and instead was due to the way we’re running the tests in CI. The complaint when a failure occurred was that Xvfb could not get a display. I’ve added the `-a` option for `xvfb-run` which will try another display number if the default (`:99`) is unavailable 

## Testing

To test I reran this CI job a bunch of times (it's a super fast (~1 min) CI job):

https://circleci.com/gh/freedomofpress/securedrop/17745
https://circleci.com/gh/freedomofpress/securedrop/17761
https://circleci.com/gh/freedomofpress/securedrop/17764
https://circleci.com/gh/freedomofpress/securedrop/17765
https://circleci.com/gh/freedomofpress/securedrop/17766
https://circleci.com/gh/freedomofpress/securedrop/17767
https://circleci.com/gh/freedomofpress/securedrop/17768
https://circleci.com/gh/freedomofpress/securedrop/17769
https://circleci.com/gh/freedomofpress/securedrop/17770
https://circleci.com/gh/freedomofpress/securedrop/17771

You can alternatively SSH in to a CircleCI box and run the test command in the diff in a loop (I did this also and hit no issues)

If that all checks out, I suggest that we merge this and reopen #3665 if the issue pops up again

## Deployment

CI only

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
