### PR TITLE
SecureDrop 0.9.1 changelog into develop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,12 @@
 
 ## 0.10.0~rc1
 
+## 0.9.1
 
+* Bugfix: Resolve error in SecureDrop Updater due to incorrect working directory (#3796)
+
+The issues for this release were tracked in the 0.9.1 milestone on GitHub:
+https://github.com/freedomofpress/securedrop/milestone/47
 
 ## 0.9.0
 

--- a/install_files/securedrop-app-code/usr/share/doc/securedrop-app-code/changelog.Debian
+++ b/install_files/securedrop-app-code/usr/share/doc/securedrop-app-code/changelog.Debian
@@ -4,6 +4,12 @@ securedrop-app-code (0.10.0~rc1) trusty; urgency=medium
 
  -- SecureDrop Team <securedrop@freedom.press>  Wed, 05 Sep 2018 23:39:46 +0000
 
+ securedrop-app-code (0.9.1) trusty; urgency=medium
+
+   * See changelog.md
+
+  -- SecureDrop Team <securedrop@freedom.press>  Thu, 06 Sep 2018 17:57:36 +0000
+
 securedrop-app-code (0.9.0) trusty; urgency=medium
 
   * See changelog.md


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Cherry pick 0.9.1 changelog into develop

Changes proposed in this pull request:

## Testing

CI should pass 

## Deployment

Already live as part of 0.9.1 release

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR
