### PR TITLE
CI docs: Explain rebase behavior for maintainers

### DIFF
--- a/docs/development/testing_continuous_integration.rst
+++ b/docs/development/testing_continuous_integration.rst
@@ -23,6 +23,16 @@ machines and run the :ref:`tests <config_tests>` against them.
   ``docs-``. These checks are enforced in different parts of the configuration,
   mainly within the ``Makefile``.
 
+.. warning:: In CI, we rebase branches in PRs on HEAD of the target branch.
+  This rebase does not occur for branches that are not in PRs.
+  When a branch is pushed to the shared ``freedomofpress`` remote, CI will run,
+  a rebase will not occur, and since opening a
+  `PR does not trigger a re-build <https://discuss.circleci.com/t/pull-requests-not-triggering-build/1213>`_,
+  the CI build results are not shown rebased on the latest of the target branch.
+  This is important to maintain awareness of if your branch is behind the target
+  branch. Once your branch is in a PR, you can rebuild, push an additional
+  commit, or manually rebase your branch to update the CI results.
+
 Limitations of the CI Staging Environment
 -----------------------------------------
 Our CI staging environment is currently directly provisioned to Xen-based


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #3773

Changes proposed in this pull request:
 - Due to a limitation with CircleCI (see ticket for full details), the PR branch may not be rebased on latest of the target branch when a PR is submitted. This can result in confusion, as in #3771. This documents that behavior for those that can push to the shared remote.

## Testing

Lint job on this branch prior to me opening a PR: https://circleci.com/gh/freedomofpress/securedrop/17844

Lint job on this branch _after_ submitting a PR and rebasing and force pushing to the branch: https://circleci.com/gh/freedomofpress/securedrop/17847

Inspect the "Rebase on-top of github target" run step, and see that in the first case the rebase does not occur, and in the second it does. 

## Deployment

CI only

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
