### PR TITLE
Added auth to VNC in test container, for OS X compatibility.

### DIFF
--- a/devops/scripts/vnc-docker-connect.sh
+++ b/devops/scripts/vnc-docker-connect.sh
@@ -9,6 +9,11 @@ set -e
 # Bomb out if container not running
 docker inspect securedrop-dev >/dev/null 2>&1 || (echo "ERROR: SD container not running."; exit 1)
 
+# Maybe we are running macOS
+if [ "$(uname -s)" == "Darwin" ]; then
+    open "vnc://${USER}:freedom@127.0.0.1:5901" &
+    exit 0
+fi
 
 # Find our securedrop docker ip
 SD_DOCKER_IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' securedrop-dev)"
@@ -18,11 +23,7 @@ nc -w5 -z "$SD_DOCKER_IP" 5901 || (echo "ERROR: VNC server not found"; exit 1)
 
 # Are we running on gnome desktop?
 if [ "$(echo \"$XDG_DATA_DIRS\" | sed 's/.*\(gnome\).*/\1/')" == "gnome" ]; then
-    remote-viewer "vnc://${SD_DOCKER_IP}:5901" 2>/dev/null &
-
-# Maybe we are running macOS
-elif [ "$(uname -s)" == "Darwin" ]; then
-    open "vnc://${SD_DOCKER_IP}:5901" &
+    remote-viewer "vnc://${USER}:freedom@${SD_DOCKER_IP}:5901" 2>/dev/null &
 
 else
     echo "Not sure what the VNC terminal cli arguments are for your OS."

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -10,8 +10,13 @@ function run_redis() {
     setsid redis-server >& /tmp/redis.out || cat /tmp/redis.out
 }
 
+function setup_vncauth {
+    
+    echo "freedom" | vncpasswd -f > /tmp/vncpasswd
+}
+
 function run_x11vnc() {
-    setsid Xvnc -depth 24 -geometry 1024x768 -rfbport 5901 :1 >& /tmp/x11vnc.out || cat /tmp/x11vnc.out
+    setsid Xvnc -depth 24 -geometry 1024x768 -rfbauth /tmp/vncpasswd -rfbport 5901 :1 >& /tmp/x11vnc.out || cat /tmp/x11vnc.out
 }
 
 function urandom() {

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -20,6 +20,7 @@ function docker_image() {
 function docker_run() {
     find . \( -name '*.pyc' -o -name __pycache__ \) -delete
     docker run \
+           -p 127.0.0.1:5901:5901 \
 	   --rm \
 	   --user "${USER:-root}" \
 	   --volume "${TOPLEVEL}:${TOPLEVEL}" \

--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -5,6 +5,7 @@ set -euo pipefail
 
 source "${BASH_SOURCE%/*}/dev-deps"
 
+setup_vncauth
 run_redis &
 run_x11vnc &
 urandom


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updates #3721, adding OS X support. The built-in OS VNC client expects a password, so a file /tmp/vncpasswd is now created in the Docker test container and the VNC server and client commands have been updated according.

## Testing
On OS X and within the working copy:
```
make build-debs
cd securedrop ; ./bin/dev-shell ./bin/run-test tests/functional
```
Once the container is set up and functional tests are running, from another terminal and the same location, run `make func-vnc`

The OS X VNC client should start, connected to the Docker VNC server on 127.0.0.1:5901.

On Debian/Ubuntu:
Repeat the steps above. The system VNC client should start connected to the Docker VNC server on <docker_ip>:5901

## Deployment

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
