### PR TITLE
Achieves clean install against Xenial

### DIFF
--- a/docs/development/xenial_support.rst
+++ b/docs/development/xenial_support.rst
@@ -38,10 +38,6 @@ Known bugs with Xenial support
 Below is a high-level overview of known problems to be addressed
 for delivering Xenial compatibility.
 
-Ansible provisioning
-    Changes required to support the "xenial" apt sources throughout
-    config logic, particularly in templates.
-
 Packaging
     Dependencies for the ``securedrop-app-code`` deb package have changed;
     ``apache2`` should be explicitly required; ``apache2-mpm-worker``
@@ -61,9 +57,9 @@ PAM logic
     resolves. More research required.
 
 Config tests
-    The testinfra config test suite expects Trusty throughout. We'll need
-    to update that logic to refer to LSB codename instead, and assert
-    that the target platform is one of either Trusty or Xenial.
+    The testinfra config test suite runs slightly different checks for
+    Trusty and Xenial where appropriate. Care should be taken to preserve
+    functionality of the config tests against both distros.
 
 More detailed research notes on evaluating Xenial support can be found
 in the following GitHub issues:

--- a/install_files/ansible-base/roles/app-test/files/xvfb-systemd
+++ b/install_files/ansible-base/roles/app-test/files/xvfb-systemd
@@ -1,0 +1,9 @@
+[Unit]
+Description=X Virtual Frame Buffer Service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/Xvfb :1 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
+
+[Install]
+WantedBy=multi-user.target

--- a/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/dev_setup_xvfb_for_functional_tests.yml
@@ -13,21 +13,45 @@
   tags:
     - apt
 
-- name: Copy xvfb init script.
+- name: Copy xvfb init script (Trusty)
   copy:
     src: xvfb
     dest: /etc/init.d/xvfb
     owner: root
     mode: "0700"
+  # Trusty uses upstart/sysv-style init scripts
+  when: ansible_distribution_release == "trusty"
   tags:
     - xvfb
     - permissions
 
-- name: Update rc.d to run xvfb at boot.
+- name: Update rc.d to run xvfb at boot (Trusty)
   command: update-rc.d xvfb defaults
   register: xvfb_setup
   changed_when: "'System start/stop links for /etc/init.d/xvfb already exist' not in xvfb_setup.stdout"
+  when: ansible_distribution_release == "trusty"
   notify: start xvfb
+  tags:
+    - xvfb
+
+- name: Copy xvfb init script (Xenial)
+  copy:
+    src: xvfb-systemd
+    dest: /etc/systemd/system/xvfb.service
+    owner: root
+    mode: "0644"
+  # Xenial uses systemd, so upstart/sysv init scripts won't work
+  when: ansible_distribution_release == "xenial"
+  notify: start xvfb
+  tags:
+    - xvfb
+    - permissions
+
+- name: Update xvfb service to run at boot (Xenial)
+  service:
+    name: xvfb
+    enabled: yes
+  when: ansible_distribution_release == "xenial"
   tags:
     - xvfb
 

--- a/install_files/ansible-base/roles/app-test/tasks/modern_gettext.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/modern_gettext.yml
@@ -8,6 +8,7 @@
     repo: deb http://archive.ubuntu.com/ubuntu/ xenial main
     state: present
     update_cache: yes
+  when: ansible_distribution_release != "xenial"
   tags:
     - apt
 
@@ -23,5 +24,6 @@
     repo: deb http://archive.ubuntu.com/ubuntu/ xenial main
     state: absent
     update_cache: yes
+  when: ansible_distribution_release != "xenial"
   tags:
     - apt

--- a/install_files/ansible-base/roles/app/defaults/main.yml
+++ b/install_files/ansible-base/roles/app/defaults/main.yml
@@ -45,11 +45,9 @@ securedrop_app_https_ssl_ciphers:
   - ECDHE-ECDSA-AES128-SHA256
   - ECDHE-RSA-AES128-SHA256
 
-# Apt packages for configuring Apache service.
-apache_packages:
-  - apache2-mpm-worker
-  - libapache2-mod-wsgi
-  - libapache2-mod-xsendfile
+# Distro-specific vars to be included dynamically for
+# Trusty and Xenial support.
+apache_packages: []
 
 apache_templates:
   - ports.conf

--- a/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
+++ b/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
@@ -1,4 +1,7 @@
 ---
+- name: Import apache packages vars for distro.
+  include_vars: "{{ ansible_distribution+'_'+ansible_distribution_release }}.yml"
+
 - name: Install apache packages.
   apt:
     pkg: "{{ item }}"

--- a/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
+++ b/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
@@ -60,6 +60,7 @@
   apache2_module:
     state: absent
     name: "{{ item }}"
+    force: yes
   with_items: "{{ apache_disabled_modules }}"
   notify:
     - restart apache2

--- a/install_files/ansible-base/roles/app/vars/Ubuntu_trusty.yml
+++ b/install_files/ansible-base/roles/app/vars/Ubuntu_trusty.yml
@@ -1,0 +1,5 @@
+---
+apache_packages:
+  - apache2-mpm-worker
+  - libapache2-mod-wsgi
+  - libapache2-mod-xsendfile

--- a/install_files/ansible-base/roles/app/vars/Ubuntu_xenial.yml
+++ b/install_files/ansible-base/roles/app/vars/Ubuntu_xenial.yml
@@ -1,0 +1,5 @@
+---
+apache_packages:
+  - apache2
+  - libapache2-mod-wsgi
+  - libapache2-mod-xsendfile

--- a/molecule/testinfra/staging/app/apache/test_apache_system_config.py
+++ b/molecule/testinfra/staging/app/apache/test_apache_system_config.py
@@ -6,7 +6,6 @@ securedrop_test_vars = pytest.securedrop_test_vars
 
 
 @pytest.mark.parametrize("package", [
-    "apache2-mpm-worker",
     "libapache2-mod-wsgi",
     "libapache2-mod-xsendfile",
 ])
@@ -15,6 +14,17 @@ def test_apache_apt_packages(Package, package):
     Ensure required Apache packages are installed.
     """
     assert Package(package).is_installed
+
+
+def test_apache_apt_packages_trusty(Package, SystemInfo):
+    """
+    Ensure required Apache packages are installed. Only checks Trusty-specific
+    packages; other tests handle more general apt dependencies for Apache.
+    """
+    # Skip if testing against Xenial
+    if SystemInfo.release != "trusty":
+        return True
+    assert Package("apache2-mpm-worker").is_installed
 
 
 def test_apache_security_config_deprecated(File):

--- a/molecule/testinfra/staging/app/iptables-app-staging.j2
+++ b/molecule/testinfra/staging/app/iptables-app-staging.j2
@@ -24,7 +24,7 @@
 -A OUTPUT -o lo -p tcp -m tcp --sport 8080 -m owner --uid-owner {{ securedrop_user_id }} -m state --state RELATED,ESTABLISHED -m comment --comment "Restrict the apache user outbound connections" -j ACCEPT
 -A OUTPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -o lo -p tcp -m owner --uid-owner {{ securedrop_user_id }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "for redis worker all application user local loopback user" -j ACCEPT
 -A OUTPUT -m owner --uid-owner {{ securedrop_user_id }} -m comment --comment "Drop all other traffic by the securedrop user" -j LOGNDROP
--A OUTPUT -m owner --gid-owner 108 -m comment --comment "Drop all other outbound traffic for ssh user" -j LOGNDROP
+-A OUTPUT -m owner --gid-owner {{ ssh_group_gid }} -m comment --comment "Drop all other outbound traffic for ssh user" -j LOGNDROP
 -A OUTPUT -d {{ dns_server }}/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -d {{ dns_server }}/32 -p udp -m udp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT

--- a/molecule/testinfra/staging/common/test_platform.py
+++ b/molecule/testinfra/staging/common/test_platform.py
@@ -1,3 +1,9 @@
+# We expect Ubuntu, either Trusty or Xenial, the two LTSes
+# currently targeted for support.
+SUPPORTED_CODENAMES = ('trusty', 'xenial')
+SUPPORTED_RELEASES = ('14.04', '16.04')
+
+
 def test_ansible_version(host):
     """
     Check that a supported version of Ansible is being used.
@@ -11,14 +17,14 @@ def test_ansible_version(host):
     assert c.startswith("ansible 2.")
 
 
-def test_platform(SystemInfo):
+def test_platform(host):
     """
     SecureDrop requires Ubuntu Trusty 14.04 LTS. The shelf life
     of that release means we'll need to migrate to Xenial LTS
     at some point; until then, require hosts to be running
     Ubuntu.
     """
-    assert SystemInfo.type == "linux"
-    assert SystemInfo.distribution == "ubuntu"
-    assert SystemInfo.codename == "trusty"
-    assert SystemInfo.release == "14.04"
+    assert host.system_info.type == "linux"
+    assert host.system_info.distribution == "ubuntu"
+    assert host.system_info.codename in SUPPORTED_CODENAMES
+    assert host.system_info.release in SUPPORTED_RELEASES

--- a/molecule/testinfra/staging/common/test_system_hardening.py
+++ b/molecule/testinfra/staging/common/test_system_hardening.py
@@ -74,7 +74,9 @@ def test_swap_disabled(Command):
         assert not re.search("^/", c, re.M)
         # Expect that ONLY the headers will be present in the output.
         rgx = re.compile("Filename\s*Type\s*Size\s*Used\s*Priority")
-        assert re.search(rgx, c)
+        # On Xenial, swapon 2.27.1 shows blank output, with no headers, so
+        # check for empty output as confirmation of no swap.
+        assert any((re.search(rgx, c), c == ""))
 
 
 def test_twofactor_disabled_on_tty(host):


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #3825. Updates the Ansible logic, as well as the config test suite, to verify Xenial configuration. The clean install flow now passes without error, as does the entire config test suite.

## Testing
1. Run `make build-debs-xenial` to create Xenial-specific deb packages (see #3728 for details).
2. Run `make staging-xenial` to create Xenial-based VMs and install against them.
3. Run `molecule verify -s libvirt-staging-xenial` and confirm all config tests pass.

We must also ensure that there are no side-effects for the Trusty flow. Having CI pass should be sufficient there, but running the above steps with the `-xenial` suffix removed would be grand, as well. 

## Deployment

Careful attention should be given to avoid side effects on the Trusty config. No concerns for the Xenial config, since that's still coming together, and isn't used in the wild yet.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
