### PR TITLE
Updates builder image hash

### DIFF
--- a/molecule/builder/image_hash
+++ b/molecule/builder/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_08_31
-d4b3ebe38954c8843c62881c97212a4935feb3da1ae374d3740b318fbd4ab703
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_10_03
+09a53b68318d4ab52c32aacdf0320527d70010f018877e6b32df322c9bd797b4


### PR DESCRIPTION
## Status

Ready for review . 

## Description of Changes
Standard process to update the builder container image hash to remove build failures during local development, following docs at https://docs.securedrop.org/en/release-0.9/development/dockerbuildmaint.html

## Testing
1. `unset FPF_CI`
2. `make build-debs`
3. Confirm no errors.

## Deployment

No, standard process to update the build image. Applies new security updates, which will be used during build process for upcoming 0.10.0 release.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
