### PR TITLE
ossec auth key gen. -> platform agnostic

### DIFF
--- a/install_files/ansible-base/roles/ossec/tasks/register.yml
+++ b/install_files/ansible-base/roles/ossec/tasks/register.yml
@@ -67,7 +67,7 @@
 # password file (see: https://github.com/ossec/ossec-hids/issues/1472)
 - name: Generate authd shared secret
   set_fact :
-    ossec_registration_secret: "{{ lookup('pipe', 'head -c 32 /dev/urandom | md5sum | tr -d \" -\" | sed \"$d\"') }}"
+    ossec_registration_secret: "{{ range(10000000,99999999999) | random | hash('md5') }}\n"
   delegate_to: localhost
   delegate_facts: True
   when:


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Fixes #3847 

Changes proposed in this pull request:

Modifies the OSSEC 3.0 registration passphrase generation logic (say that 4 times fast) so that it will be platform independent and use ansible/jinja native tools as opposed to calling pipe.

## Testing

How should the reviewer test this PR?
* Specifically test `make staging` against Mac OSX to ensure it passes thru completely
* Post install, log into the OSSEC server and run  `/var/ossec/bin/list_agents -c` to confirm agent connection

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.

Shouldn't affect upgrading scenarios due to the fact that this logic only runs on first registration

2. New installs.

Does OSSEC work and the install not bomb out!? :tada: 