### PR TITLE
3608 - Add admin checkbox clicks and test case for an admin to create…

### DIFF
--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -356,18 +356,11 @@ class JournalistNavigationStepsMixin():
             self.driver.find_element_by_id('link-admin-index')
 
     def _new_admin_user_can_log_in(self):
-        # Log out current admin user
-        self._logout()
+        # Test login with mocked token
+        self._check_login_with_otp('mocked')
 
-        self._login_user(self.new_user['username'],
-                         self.new_user['password'], 'mocked')
-
-        if not hasattr(self, 'accept_languages'):
-            # Test that the new user was logged in successfully
-            assert 'Sources' in self.driver.page_source
-
-        # New admin user should have admin interface link
-        assert 'link-admin-index' in self.driver.page_source
+        # Newly added user who is an admin can visit admin interface
+        self._admin_visits_admin_interface()
 
     def _edit_account(self):
         edit_account_link = self.driver.find_element_by_id(

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -234,13 +234,16 @@ class JournalistNavigationStepsMixin():
             hotp_secret.send_keys(hotp)
 
         if is_admin:
-            raise NotImplementedError("Admin's can't be added yet.")
+            is_admin_checkbox = self.driver.find_element_by_css_selector(
+                'input[name="is_admin"]'
+            )
+            is_admin_checkbox.click()
 
         submit_button = self.driver.find_element_by_css_selector(
             'button[type=submit]')
         submit_button.click()
 
-    def _admin_adds_a_user(self):
+    def _admin_adds_a_user(self, is_admin=False):
         add_user_btn = self.driver.find_element_by_css_selector(
             'button#add-user')
         add_user_btn.click()
@@ -257,7 +260,7 @@ class JournalistNavigationStepsMixin():
                 username='dellsberg',
                 password=password,
             )
-        self._add_user(self.new_user['username'])
+        self._add_user(self.new_user['username'], is_admin=is_admin)
 
         if not hasattr(self, 'accept_languages'):
             # Clicking submit on the add user form should redirect to
@@ -351,6 +354,20 @@ class JournalistNavigationStepsMixin():
         # interface link available
         with pytest.raises(NoSuchElementException):
             self.driver.find_element_by_id('link-admin-index')
+
+    def _new_admin_user_can_log_in(self):
+        # Log out current admin user
+        self._logout()
+
+        self._login_user(self.new_user['username'],
+                         self.new_user['password'], 'mocked')
+
+        if not hasattr(self, 'accept_languages'):
+            # Test that the new user was logged in successfully
+            assert 'Sources' in self.driver.page_source
+
+        # New admin user should have admin interface link
+        assert 'link-admin-index' in self.driver.page_source
 
     def _edit_account(self):
         edit_account_link = self.driver.find_element_by_id(

--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -38,3 +38,11 @@ class TestAdminInterface(
         self._admin_visits_admin_interface()
         self._admin_visits_system_config_page()
         self._admin_can_send_test_alert()
+
+    def test_admin_adds_admin_user(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        # Add an admin user
+        self._admin_adds_a_user(is_admin=True)
+        self._new_admin_user_can_log_in()
+        self._admin_can_edit_new_user()


### PR DESCRIPTION
… a new admin user and the new admin user to be able to login and have admin privileges

## Status
Ready for review

## Description of Changes
Add support for clicking admin checkbox in functional tests. 
Added a unit test to add a new admin user.

## Testing
Running of functional tests if necessary

## Deployment

Any special considerations for deployment? Consider both:

Its a test related change

## Checklist

### If you made changes to the server application code:

- N/A

### If you made changes to `securedrop-admin`:

- N/A

### If you made changes to the system configuration:

- - N/A

### If you made non-trivial code changes:

- N/A

### If you made changes to documentation:

- N/A