### PR TITLE
Always force the use latest kernel by default

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -53,5 +53,5 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder/tests/vars.yml
 securedrop_pkg_grsec:
-  ver: "4.4.144"
+  ver: "4.4.144-1"
   depends: "linux-image-3.14.79-grsec,linux-image-4.4.135-grsec,linux-firmware-image-4.4.135-grsec,linux-image-4.4.144-grsec,linux-firmware-image-4.4.144-grsec"

--- a/install_files/securedrop-grsec/DEBIAN/postinst
+++ b/install_files/securedrop-grsec/DEBIAN/postinst
@@ -19,16 +19,11 @@ set -x
 case "$1" in
     configure)
 
-    # If the SecureDrop instance is running a rolled-back kernel, this will
-    # preserve the kernel boot priority specfied in its ordinal form by the
-    # canonical form. (In this specific case, 1>2 as GRUB_DEFAULT in
-    # /etc/default/grub indicates the instance is running 3.14.79-grsec)
-    # In any other case, we want to run the latest 4.4 series kernel.
-    if grep -qE "^GRUB_DEFAULT=[\"\' ]*1>2[\"\' ]*$" /etc/default/grub; then
-        sed -i "s/^\(GRUB_DEFAULT=\)[\"\' ]*1>2[\"\' ]*$/\1\"Advanced options for Ubuntu>Ubuntu, with Linux 3.14.79-grsec\"/" /etc/default/grub
-        # update grub to set the new default
-        update-grub2
-    fi
+    # Replace the default GRUB boot option with 0, which defaults to the
+    # highest kernel version. Any kernel provided by apt.freedom.press must
+    # suprecede the ones provided by Ubuntu.
+    sed -i '/^GRUB_DEFAULT=/s/=.*/=0/' /etc/default/grub
+    update-grub
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/molecule/builder/tests/vars.yml
+++ b/molecule/builder/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "0.10.0~rc1"
 ossec_version: "3.0.0"
 keyring_version: "0.1.2"
 config_version: "0.1.1"
-grsec_version: "4.4.144"
+grsec_version: "4.4.144-1"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3842.

- Bumps kernel metapackage version to 4.4.144-1 so that the version is higher than currently installed version
- Change postinst to force latest kernel to boot by default

## Testing

* Install 0.9.0 on virtual machines or hardware
* roll back to 3.14.79 per instructions here: https://docs.securedrop.org/en/release-0.9/kernel_troubleshooting.html
* checkout this branch and make build-debs and use securedrop-grsec-4.4.144-1-amd64.deb
* install securedrop-grsec-4.4.144-1-amd64.deb on machines that have been rolled back
* sudo apt-get autoremove (necessary for local testing only: when using apt servers, this will be done by cron-apt)

Confirm that: 
- [ ] The app and mon servers boot into kernel 4.4.144-grsec (`uname -r`)
- [ ] `apt list --installed | grep grsec` still includes 3.14.79
- [ ] `/etc/default/grub` contains `GRUB_DEFAULT=0`

## Deployment

All changes will be deployed as part with the securedrop-grsec package.
Setting the version string to 4.4.144-1 (because we are not shipping a kernel as part of 0.10.0, see #3838 ). We will be removing 3.14.79 kernel at a later date, see #3643 
## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
