### PR TITLE
docker ignore tox/venv

### DIFF
--- a/admin/.dockerignore
+++ b/admin/.dockerignore
@@ -1,0 +1,4 @@
+.tox
+.venv
+**/__pycache__
+**/*.pyc


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3550

Docker ignore generated resources.

## Testing

Run the tests, get a big tox directory, rebuild the container with `DOCKER_BUILD_VERBOSE=true`, see the following line:

```
Docker image build in progress Sending build context to Docker daemon  202.2kB
```