### PR TITLE
Added journalist password change API

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -578,7 +578,8 @@ class Journalist(db.Model):
             'username': self.username,
             'last_login': self.last_access.isoformat() + 'Z',
             'is_admin': self.is_admin,
-            'uuid': self.uuid
+            'uuid': self.uuid,
+            'new_passphrase_url': url_for('api.set_passphrase')
         }
         return json_user
 

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -314,6 +314,9 @@ class NonDicewarePassword(PasswordError):
 
     """Raised when attempting to validate a password that is not diceware-like
     """
+    def __str__(self):
+        return ("Password needs to be a passphrase of at least "
+                "{} words.").format(Journalist.MIN_PASSWORD_WORDS)
 
 
 class Journalist(db.Model):
@@ -361,6 +364,7 @@ class Journalist(db.Model):
 
     MAX_PASSWORD_LEN = 128
     MIN_PASSWORD_LEN = 14
+    MIN_PASSWORD_WORDS = 7
 
     def set_password(self, passphrase):
         self.check_password_acceptable(passphrase)
@@ -398,7 +402,7 @@ class Journalist(db.Model):
             raise InvalidPasswordLength(password)
 
         # Ensure all passwords are "diceware-like"
-        if len(password.split()) < 7:
+        if len(password.split()) < cls.MIN_PASSWORD_WORDS:
             raise NonDicewarePassword()
 
     def valid_password(self, passphrase):


### PR DESCRIPTION
## Status

Ready for review / Work in progress

This is only the API call for password changes. I haven't done 2FA yet.

Unit tests are included.

## Description of Changes

Changes are in response to #3869

## Testing

API endpoint is /api/v1/user/new-passphrase

The new password is specified in the "new_passphrase" attribute in the JSON data.