### PR TITLE
added filter against null last_updated columns

### DIFF
--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -62,6 +62,7 @@ def make_blueprint(config):
         # the Pocoo style guide, IMHO:
         # http://www.pocoo.org/internal/styleguide/
         sources = Source.query.filter_by(pending=False) \
+                              .filter(Source.last_updated.isnot(None)) \
                               .order_by(Source.last_updated.desc()) \
                               .all()
         for source in sources:

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1942,3 +1942,20 @@ def test_col_process_successfully_unstars_sources(journalist_app,
 
     source = Source.query.get(test_source['id'])
     assert not source.star.starred
+
+
+def test_source_with_null_last_updated(journalist_app,
+                                       test_journo,
+                                       test_files):
+    '''Regression test for issues #3862'''
+
+    source = test_files['source']
+    source.last_updated = None
+    db.session.add(source)
+    db.session.commit()
+
+    with journalist_app.test_client() as app:
+        _login_user(app, test_journo['username'], test_journo['password'],
+                    test_journo['otp_secret'])
+        resp = app.get(url_for('main.index'))
+        assert resp.status_code == 200


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3862

Add a hard filter of `source.last_updated IS NOT NULL` to the query for fetching sources for the journalist index page. Application logic *should* prevent this from ever happening, but if it does, it will cause the journalist index page to 500 for all users.

## Testing

- Remove the single line added in `main.py`
- `make test TESTFILES=tests/test_journalist.py::test_source_with_null_last_updated`
- See test failure
- Re-add the line to `main.py`
- Re-run above test command
- See test pass

## Deployment

This will not affect existing applications because we don't have support emails saying "hey why is the UI super busted"

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container