### PR TITLE
Update Admin Guide with how to configure locales

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -413,7 +413,7 @@ languages:
 
 .. include:: includes/l10n.txt
 
-At any time during and after initial setup, you can chose from a list of
+At any time during and after initial setup, you can choose from a list of
 supported languages to display using the codes shown in parentheses.
 
 .. note:: With a *Source Interface* displayed in French (for example), sources
@@ -431,7 +431,8 @@ codes. For example: ::
 
     Space separated list of additional locales to support (ru nl pt_BR fr_FR tr it_IT zh_Hant sv hi ar en_US de_DE es_ES nb_NO): nl fr_FR es_ES
 
-Locales will be applied after the next reboot.
+You'll need to list all languages you now want to support, adding or removing
+languages as needed. Locale changes will be applied after the next reboot.
 
 Frequently Asked Questions
 --------------------------

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -351,6 +351,8 @@ You should see a message appear indicating the change was a success:
 Updating System Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. _update-system-configuration:
+
 If you want to update the system configuration, you should use the
 ``securedrop-admin`` tool on the *Admin Workstation*. From
 ``~/Persistent/securedrop``, run:
@@ -402,6 +404,34 @@ by monitoring OSSEC alerts. (Please note that while an OSSEC alert can notify yo
 occurrence of an update to the server, it may not reveal the content of the change.) Another
 management option would be SSHing into the server and manually inspecting the configuration to
 identify any discrepancies.
+
+Configuring Localization for the *Source Interface* and the *Journalist Interface*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The *Source Interface* and *Journalist Interface* are translated in the following
+languages:
+
+.. include:: includes/l10n.txt
+
+At any time during and after initial setup, you can chose from a list of
+supported languages to display using the codes shown in parentheses.
+
+.. note:: With a *Source Interface* displayed in French (for example), sources
+          submitting documents are likely to expect a journalist fluent in
+          French to be available to read the documents and follow up in that
+          language.
+
+To add or remove locales from your instance, you'll need to :ref:`update your
+system configuration <update-system-configuration>` as outlined above.
+
+When you reach the prompt starting with "Space separated list of additional
+locales to support", you will see a list of languages currently supported.
+Refer to the list above to see which languages correspond to which language
+codes. For example: ::
+
+    Space separated list of additional locales to support (ru nl pt_BR fr_FR tr it_IT zh_Hant sv hi ar en_US de_DE es_ES nb_NO): nl fr_FR es_ES
+
+Locales will be applied after the next reboot.
 
 Frequently Asked Questions
 --------------------------


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Resolves #3846.

Documentation on how to add additional locales was easily available for new instances. However, existing admins would likely not find these docs, creating a pain point for support. In the interest of DRYing support a bit, adding a section on how to add locales explicitly will make it easier for SecureDrop admins in the short term.

## Testing

A reviewer should compare this to the documentation in the [Install Guide](https://docs.securedrop.org/en/latest/install.html#localization-of-the-source-interface-and-journalist-interface). Additionally, they should follow the instructions to configure locales on a (non-production) SecureDrop environment.

## Checklist

- [x] Doc linting (`make docs-lint`) passed locally
