### PR TITLE
Remove alert type in ossec email subject line

### DIFF
--- a/install_files/securedrop-ossec-server/var/ossec/etc/local_internal_options.conf
+++ b/install_files/securedrop-ossec-server/var/ossec/etc/local_internal_options.conf
@@ -1,0 +1,10 @@
+# local_internal_options.conf
+#
+# This file should be handled with care. It contains
+# run time modifications that can affect the use
+# of OSSEC. Only change it if you know what you
+# are doing. Look first at ossec.conf
+# for most of the things you want to change.
+#
+# This file will not be overwritten during upgrades.
+maild.full_subject=1


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3882 .

Setting maild.full_subject=1 for ossec >= 3.0.0 will ensure alert does not appear in the email subject line (and thus unencrypted as it is sent to the admin).

Setting it in local_internal_options will ensure that it is not squashed by changes in internal_options that is shipped as part of the ossec-server package.

It appears the logic was inverted in 3.0.0 (via https://github.com/ossec/ossec-hids/commit/f4cf191d06752983679d739ec2f13e91320a829f)

Thanks @zenmonkeykstop for finding the bug and pointing me towards the `maild.full_subject` configuration option!

## Testing

`make build-debs` and install securedrop-ossec-server-3.0.0+0.10.0(~rcX).deb produced by this branch.
Observe the emails do not contain the alert type in subject line.

## Deployment

Upgrades and new installs will be ensured by securedrop-ossec-server deb package.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
