### PR TITLE
Fix unauthorized message deletion

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -212,8 +212,9 @@ def make_blueprint(config):
         history.
         """
 
-        query = Reply.query.filter(
-            Reply.filename == request.form['reply_filename'])
+        query = Reply.query.filter_by(
+            filename=request.form['reply_filename'],
+            source_id=g.source.id)
         reply = get_one_or_else(query, current_app.logger, abort)
         reply.deleted_by_source = True
         db.session.add(reply)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3892

Fixes a bug where a source X could delete a reply from a journalist to source Y by guessing the ID.

## Testing

See original ticket for the full description of the bug and manual steps to reproduce. There is a regression test for this so `make test` will cover this issue.

## Deployment

This will not affect deployment.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container