### PR TITLE
New translation updates from weblate for 0.10.0

### DIFF
--- a/securedrop/translations/ar/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ar/LC_MESSAGES/messages.po
@@ -113,28 +113,28 @@ msgstr "اِختَر ملف."
 msgid "You can only upload PNG image files."
 msgstr "لا يمكن رفع ملفات غير PNG."
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr "حدث عطل غير متوقع. رجاء إبلاغ الإداري."
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "شكرا. لقد حُفظ ردُّك."
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "لم يتم اختيار أيّ مجموعة للتنزيل."
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "لم تُحدّد مجموعات لحذفها."
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "تم تغيير اسم المصدر '{original_name}' إلى '{new_name}'"
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "لا توجد رسائل غير مقروءة من هذا المصدر."
 
@@ -810,7 +810,7 @@ msgstr "لِج إلى حسابك للنفاذ إلى واجهة الصحافيي
 msgid "Password"
 msgstr "كلمة السر"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "لِج"
 
@@ -840,31 +840,31 @@ msgstr ""
 "تمت إعادة توجيهك إلى حسابك لأنّك والج إليه بالفعل. إنَ كنت تريد إنشاء حساب "
 "جديد فعليك الخروج من هذا الحساب أوّلا."
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr "يجب إدخال نصّ رسالة أو اختيار ملف لإيداعه."
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "شكرا! لقد تلقينا الرسالة."
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "شكرا! لقد تلقينا المستند."
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr "شكرا! لقد تلقينا الرسالة و&nbsp;المستند."
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "حُذِفَ الرد"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "حُذِفَت كُلّ الردود"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "عذرًا، لا يمكن التعرف على الاسم الرمزي."
 

--- a/securedrop/translations/de_DE/LC_MESSAGES/messages.po
+++ b/securedrop/translations/de_DE/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: SecureDrop \\'0.3.5\\'\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
 "POT-Creation-Date: 2017-09-02 07:28+0000\n"
-"PO-Revision-Date: 2018-08-28 14:00+0000\n"
+"PO-Revision-Date: 2018-09-04 19:23+0000\n"
 "Last-Translator: kwadronaut <kwadronaut@autistici.org>\n"
 "Language-Team: German <https://weblate.securedrop.club/projects/securedrop/"
 "securedrop/de/>\n"
@@ -113,30 +113,30 @@ msgstr "Datei erforderlich."
 msgid "You can only upload PNG image files."
 msgstr "Sie können nur PNG-Bilddateien hochladen."
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr ""
 "Ein unerwarteter Fehler ist aufgetreten! Bitte Informieren Sie Ihren "
 "Administrator."
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "Vielen Dank. Ihre Antwort wurde gespeichert."
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "Es sind keine Sammlungen zum Herunterladen ausgewählt."
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "Es sind keine Sammlungen zum Löschen ausgewählt."
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "Die Quelle wurde von '{original_name}' zu '{new_name}' umbenannt"
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "Keine ungelesenen Einreichungen für diese Quelle."
 
@@ -499,7 +499,7 @@ msgstr "Antworten"
 
 #: journalist_templates/col.html:41 journalist_templates/col.html:48
 msgid "Read"
-msgstr "Lesen"
+msgstr "Gelesen"
 
 #: journalist_templates/col.html:45
 msgid "Unread"
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Password"
 msgstr "Passwort"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "ANMELDEN"
 
@@ -851,32 +851,32 @@ msgstr ""
 "Sie wurden umgeleitet, weil Sie bereits angemeldet sind. Wenn Sie ein neues "
 "Konto erstellen möchten, müssen Sie sich zuerst abmelden."
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr ""
 "Sie müssen eine Nachricht eingeben oder eine Datei zum Versenden auswählen."
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "Danke! Wir haben Ihre Nachricht erhalten."
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "Danke! Wir haben Ihr Dokument erhalten."
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr "Danke! Wir haben Ihre Nachricht und Dokument erhalten."
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "Antwort gelöscht"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "Alle Antworten wurden gelöscht"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "Entschuldigung, das ist kein erkannter Deckname."
 

--- a/securedrop/translations/es_ES/LC_MESSAGES/messages.po
+++ b/securedrop/translations/es_ES/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: SecureDrop 0.3.12\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
 "POT-Creation-Date: 2017-09-02 07:28+0000\n"
-"PO-Revision-Date: 2018-09-04 02:25+0000\n"
+"PO-Revision-Date: 2018-09-04 19:23+0000\n"
 "Last-Translator: Pablo Di Noto <pdinoto@gmail.com>\n"
 "Language-Team: Spanish <https://weblate.securedrop.club/projects/securedrop/"
 "securedrop/es/>\n"
@@ -92,7 +92,7 @@ msgstr "Solo administradores pueden entrar a esta página."
 #: journalist_app/forms.py:19
 msgid "HOTP secrets are 40 characters long - you have entered {num_chars}."
 msgstr ""
-"Este campo debe ser de 40 caracteres de longitud, usted introdujo "
+"Los secretos de HOTP deben ser de 40 caracteres de longitud, usted introdujo "
 "{num_chars}."
 
 #: journalist_app/forms.py:30
@@ -118,28 +118,28 @@ msgstr "Archivo requerido."
 msgid "You can only upload PNG image files."
 msgstr "Solo puede subir archivos de imágenes PNG."
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr "¡Ocurrió un error inesperado! Por favor informe a su administrador."
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "Gracias. Su respuesta ha sido guardada."
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "No hay colecciones seleccionadas para descargar."
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "No hay colecciones seleccionadas para eliminar."
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "La fuente '{original_name}' ha sido renombrada a '{new_name}'"
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "No hay envíos sin leer para esta fuente."
 
@@ -216,7 +216,7 @@ msgstr ""
 
 #: journalist_app/utils.py:312
 msgid "No unread submissions in selected collections."
-msgstr "No hay envios sin leer en las colecciones seleccionadas."
+msgstr "No hay envíos sin leer en las colecciones seleccionadas."
 
 #: journalist_templates/_confirmation_modal.html:4
 msgid "Close"
@@ -278,7 +278,7 @@ msgstr ""
 "factores, siga las instrucciones de abajo para configurar FreeOTP. Una vez "
 "que haya agregado la entrada para su cuenta en la aplicación, introduzca uno "
 "de los códigos de 6 dígitos generados por la aplicación para confirmar que "
-"la autenticación de dos factores esta configura correctamente."
+"la autenticación de dos factores esta configurada correctamente."
 
 #: journalist_templates/account_new_two_factor.html:8
 #: journalist_templates/admin_new_user_two_factor.html:9
@@ -288,12 +288,12 @@ msgstr "Instale FreeOTP en su teléfono"
 #: journalist_templates/account_new_two_factor.html:9
 #: journalist_templates/admin_new_user_two_factor.html:10
 msgid "Open the FreeOTP app"
-msgstr "Abra la app FreeOTP"
+msgstr "Abra la aplicación FreeOTP"
 
 #: journalist_templates/account_new_two_factor.html:10
 #: journalist_templates/admin_new_user_two_factor.html:11
 msgid "Tap the QR code symbol at the top"
-msgstr "Toque el símbolo de código_QR en la parte superior"
+msgstr "Toque el símbolo de código QR en la parte superior"
 
 #: journalist_templates/account_new_two_factor.html:11
 #: journalist_templates/admin_new_user_two_factor.html:12
@@ -380,7 +380,7 @@ msgstr "Editar usuario {username}"
 
 #: journalist_templates/admin.html:29
 msgid "Delete user {username}"
-msgstr "Borrar usuario {username}"
+msgstr "Eliminar usuario {username}"
 
 #: journalist_templates/admin.html:35
 msgid "never"
@@ -437,14 +437,14 @@ msgstr "Admin"
 
 #: journalist_templates/base.html:28
 msgid "Log Out"
-msgstr "Cerrar Sessión"
+msgstr "Cerrar Sesión"
 
 #: journalist_templates/base.html:41
 msgid ""
 "Powered by <br> <img src=\"/static/i/securedrop_small.png\" alt=\"SecureDrop"
 "\">"
 msgstr ""
-"Con tecnología de  <br> <img src=\"/static/i/securedrop_small.png\" alt="
+"Con tecnología de <br> <img src=\"/static/i/securedrop_small.png\" alt="
 "\"SecureDrop\">"
 
 #: journalist_templates/base.html:56
@@ -482,7 +482,7 @@ msgid ""
 "The documents are stored encrypted for security. To read them, you will need "
 "to decrypt them using GPG."
 msgstr ""
-"Los documentos estan guardados y cifrados por seguridad. Para leerlos, usted "
+"Los documentos están guardados y cifrados por seguridad. Para leerlos, usted "
 "tendrá que descifrarlos usando GPG."
 
 #: journalist_templates/col.html:26
@@ -543,8 +543,8 @@ msgid ""
 "An encryption key will be generated for the source the next time they log "
 "in, after which you will be able to reply to the source here."
 msgstr ""
-"Una llave cifrada se generará para la fuente la próxima vez que ellos se "
-"conecten, después de lo cual usted podrá responder a la fuente desde aquí."
+"Una llave de cifrado se generará para la fuente la próxima vez que ésta se "
+"conecte, después de lo cual usted podrá responderle desde aquí."
 
 #: journalist_templates/col.html:105
 msgid "Click below if you would like to write a reply to this source."
@@ -562,11 +562,11 @@ msgid ""
 msgstr ""
 "Haga clic abajo para eliminar la colección de esta fuente. <em>Advertencia: "
 "Si hace esto, los archivos que se ven aquí serán irrecuperables y la fuente "
-"ya no podrá accesar usando su nombre clave anterior.</em>"
+"ya no podrá acceder usando su nombre clave anterior.</em>"
 
 #: journalist_templates/col.html:121
 msgid "DELETE SOURCE AND SUBMISSIONS"
-msgstr "ELIMINAR FUENTE Y ENVIOS"
+msgstr "ELIMINAR FUENTE Y ENVÍOS"
 
 #: journalist_templates/col.html:129
 msgid "Are you sure you want to delete this collection?"
@@ -636,7 +636,7 @@ msgstr "Editar usuario \"{user}\""
 
 #: journalist_templates/edit_account.html:8
 msgid "Change Username &amp; Admin Status"
-msgstr "Cambiar nombre de usuario &amp; Estado Admin"
+msgstr "Cambiar nombre de usuario y privilegio de administrador"
 
 #: journalist_templates/edit_account.html:12
 msgid "Change username"
@@ -694,7 +694,7 @@ msgstr "RESTABLECER CONTRASEÑA"
 
 #: journalist_templates/edit_account.html:58
 msgid "Reset Two-Factor Authentication"
-msgstr "Restablecer la Autenticación de Dos-Factores"
+msgstr "Restablecer la Autenticación de Dos Factores"
 
 #: journalist_templates/edit_account.html:61
 msgid ""
@@ -704,9 +704,9 @@ msgid ""
 "credentials. Otherwise, they will be locked out of their account."
 msgstr ""
 "Si un usuario ha perdido o comprometido las credenciales de autenticación de "
-"dos factores, puede restablecerlas aquí. <em> Si hace esto, asegúrese de que "
+"dos factores, puede restablecerlas aquí. <em>Si hace esto, asegúrese de que "
 "el usuario está presente y listo para configurar su dispositivo con las "
-"nuevas credenciales de dos-factores. De lo contrario, serán bloqueados de su "
+"nuevas credenciales de dos factores. De lo contrario, será bloqueado de su "
 "cuenta."
 
 #: journalist_templates/edit_account.html:63
@@ -718,9 +718,9 @@ msgid ""
 msgstr ""
 "Si sus credenciales de autenticación de dos factores se han perdido o se han "
 "comprometido, o si tiene un dispositivo nuevo, usted puede restablecer sus "
-"credenciales aquí. <em> Si hace esto, asegúrese de que está listo para "
+"credenciales aquí. <em>Si hace esto, asegúrese de estar listo para "
 "configurar su nuevo dispositivo, de lo contrario se le bloqueará de su "
-"cuenta. </em>"
+"cuenta.</em>"
 
 #: journalist_templates/edit_account.html:65
 msgid ""
@@ -750,10 +750,10 @@ msgid ""
 "appear under their collection of documents. You can use this box to write "
 "encrypted replies to them."
 msgstr ""
-"SecureDrop generará una clave de encriptación segura para esta fuente la "
-"próxima vez que inicien sesión. Una vez que la llave sea generada, un cuadro "
-"de respuesta aparecerá debajo de la colección de sus documentos. Puede "
-"utilizar este cuadro para escribir las respuestas encriptadas."
+"SecureDrop generará una clave de cifrado segura para esta fuente la próxima "
+"vez que inicien sesión. Una vez que la llave sea generada, un cuadro de "
+"respuesta aparecerá debajo de la colección de sus documentos. Puede utilizar "
+"este cuadro para escribir las respuestas cifradas."
 
 #: journalist_templates/flag.html:10
 msgid "Continue to the list of documents for {codename}..."
@@ -822,7 +822,7 @@ msgstr "Login para acceder la interfaz de periodista"
 msgid "Password"
 msgstr "Contraseña"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "INICIAR SESIÓN"
 
@@ -833,12 +833,13 @@ msgid ""
 "\"{url}\">Why is this dangerous?</a>"
 msgstr ""
 "<strong>ADVERTENCIA:&nbsp;</strong> Usted parece estar usando Tor2Web. Esto "
-"<strong>&nbsp; no &nbsp;</strong> proporciona anonimato. <a href=\"{url}\"> ¿"
-"Por qué esto es peligroso? </a>"
+"<strong>&nbsp; no &nbsp;</strong> proporciona anonimato. <a href=\"{url}\"> "
+"¿Por qué esto es peligroso? </a>"
 
 #: source_app/forms.py:15
 msgid "Field must be between 1 and {max_codename_len} characters long."
-msgstr "Esta campo debe tener de 1 a {max_codename_len} caracteres de longitud."
+msgstr ""
+"Esta campo debe tener de 1 a {max_codename_len} caracteres de longitud."
 
 #: source_app/forms.py:18
 msgid "Invalid input."
@@ -852,31 +853,31 @@ msgstr ""
 "Usted fue redirigido porque ya estaba en sesión. Si desea crear una cuenta "
 "nueva, debe cerrar la sesión primero."
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr "Debe escribir un mensaje o elegir un archivo para enviar."
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "¡Gracias! Recibimos su mensaje."
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "¡Gracias! Recibimos su documento."
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr "¡Gracias! Recibimos su mensaje y documento."
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "Respuesta eliminada"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "Todas las repuestas han sido eliminadas"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "Lo sentimos, ese nombre clave no es reconocido."
 
@@ -979,8 +980,8 @@ msgid ""
 "to Safest</a>, or ignore this warning to continue."
 msgstr ""
 "<strong> Se recomienda mover el control deslizante de seguridad a lo mas "
-"seguro para proteger su anonimato:</strong> <a id=\"disable-js\" href=\"\">"
-"Aprenda cómo establecerlo en el modo más seguro</a>, o ignore esta "
+"seguro para proteger su anonimato:</strong> <a id=\"disable-js\" href="
+"\"\">Aprenda cómo establecerlo en el modo más seguro</a>, o ignore esta "
 "advertencia para continuar."
 
 #: source_templates/index.html:18
@@ -990,8 +991,9 @@ msgid ""
 "install it</a>, or ignore this warning to continue."
 msgstr ""
 "<strong>Se recomienda que use el navegador Tor Browser para el acceder a "
-"SecureDrop: </strong><a id=\"recommend-tor\" href=\"{tor_browser_url}\">"
-"Aprenda a como instalarlo </a>, o ignore esta advertencia para continuar."
+"SecureDrop: </strong><a id=\"recommend-tor\" href="
+"\"{tor_browser_url}\">Aprenda a como instalarlo </a>, o ignore esta "
+"advertencia para continuar."
 
 #: source_templates/index.html:19
 msgid ""
@@ -1048,14 +1050,14 @@ msgstr ""
 
 #: source_templates/index.html:99
 msgid "Click <strong>Security Settings...</strong>"
-msgstr "Haga clic <strong>Configuración de Seguridad ...</strong>"
+msgstr "Haga clic <strong>Configuración de Seguridad...</strong>"
 
 #: source_templates/index.html:100
 msgid ""
 "Move the Slider to <strong>Safest</strong>, then click <strong>OK</strong>"
 msgstr ""
-"Mueva el control deslizante para<strong>Mas Seguro</strong>, luego haga clic "
-"en <strong>OK</strong>"
+"Mueva el control deslizante hacia <strong>Mas Seguro</strong>, luego haga "
+"clic en <strong>OK</strong>"
 
 #: source_templates/index.html:101
 msgid "<a href=\"/\">Click here</a> to refresh the page"
@@ -1067,7 +1069,7 @@ msgstr "Introduzca Nombre Clave"
 
 #: source_templates/login.html:12
 msgid "Enter your codename"
-msgstr "Entre su Nombre Clave"
+msgstr "Ingrese su Nombre Clave"
 
 #: source_templates/login.html:25 source_templates/lookup.html:47
 msgid "CANCEL"
@@ -1098,9 +1100,9 @@ msgid ""
 "visited. To err on the side of caution, we put a hold on sending all files "
 "and messages from that day through to our journalists."
 msgstr ""
-"Nuestros servidores experimentaron una oleada inusual de nueva actividad, "
-"cuando usted visitó por última vez. Por cautela, pusimos en espera todos los "
-"envíos de archivos y mensajes de ese día a nuestros periodistas."
+"Nuestros servidores experimentaron una oleada inusual de nueva actividad "
+"cuando usted nos visitó por última vez. Por precaución, pusimos en espera "
+"todos los envíos de archivos y mensajes de ese día a nuestros periodistas."
 
 #: source_templates/lookup.html:14
 msgid ""
@@ -1123,10 +1125,11 @@ msgid ""
 "and messages with our <a href=\"{url}\" class=\"text-link\">public key</a> "
 "before submission. Files are encrypted as they are received by SecureDrop."
 msgstr ""
-"Si usted esta familiarizado con GPG, puede opcionalmente cifrar sus archivos "
-"y mensajes con nuestra <a href=\"{url}\" class=\"text-link\">llave publica</"
-"a> antes de enviarlos. Ya sea que usted encifre sus mensajes con GPG o no, "
-"todos los archivos son cifrados tan pronto son recibidos por SecureDrop."
+"Si usted esta familiarizado con GPG, puede cifrar sus archivos y mensajes de "
+"forma opcional con nuestra <a href=\"{url}\" class=\"text-link\">llave "
+"publica</a> antes de enviarlos. Sin importar si usted ha cifrado sus "
+"mensajes con GPG o no, todos los archivos son cifrados tan pronto son "
+"recibidos por SecureDrop."
 
 #: source_templates/lookup.html:22
 msgid "<a href=\"{url}\" class=\"text-link\">Learn more</a>."
@@ -1146,7 +1149,7 @@ msgstr "Escriba un mensaje."
 
 #: source_templates/lookup.html:53
 msgid "Read Replies"
-msgstr "Leer Respustas"
+msgstr "Leer Respuestas"
 
 #: source_templates/lookup.html:58
 msgid ""
@@ -1158,8 +1161,8 @@ msgstr ""
 "Usted ha recibido una respuesta. Para proteger su identidad en el improbable "
 "caso de que alguien aprenda su nombre clave, por favor, borre todas las "
 "respuestas cuando haya terminado con ellas. Esto también nos permite saber "
-"que usted es consciente de nuestra respuesta. Usted puede responder enviando "
-"nuevos archivos y mensaje arriba."
+"que usted es ha recibido nuestra respuesta. Usted puede responder enviando "
+"nuevos archivos y mensajes arriba."
 
 #: source_templates/lookup.html:71
 msgid "Delete this reply?"
@@ -1183,7 +1186,7 @@ msgstr "SI, ELIMINE TODAS LAS RESPUESTAS"
 
 #: source_templates/lookup.html:87
 msgid "NO, NOT YET"
-msgstr "NO, TODAVIA NO"
+msgstr "NO, TODAVÍA NO"
 
 #: source_templates/lookup.html:91
 msgid "There are no replies at this time."
@@ -1247,7 +1250,7 @@ msgid ""
 "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject."
 "org/projects/torbrowser.html\">Tor browser</a> instead."
 msgstr ""
-"Nosotros<strong>recomendamos encarecidamente</strong> que use <a href=\"www."
+"Nosotros <strong>recomendamos encarecidamente</strong> que use <a href=\"www."
 "torproject.org/projects/torbrowser.html\">Tor Browser</a> en su lugar."
 
 #: source_templates/use-tor-browser.html:3
@@ -1267,9 +1270,9 @@ msgid ""
 "you</strong> to install Tor Browser and use it to access our site safely and "
 "anonymously."
 msgstr ""
-"Si usted quiere enviar información a SecureDrop, nosotros <strong> "
-"encarecidamente le recomendamos </strong> que instale el Tor Browser y lo "
-"use para entrar a nuestro sitio anónimamente."
+"Si usted quiere enviar información a SecureDrop, nosotros "
+"<strong>encarecidamente le recomendamos</strong> que instale el Tor Browser "
+"y lo use para entrar a nuestro sitio de forma anónima."
 
 #: source_templates/use-tor-browser.html:6
 msgid ""
@@ -1285,10 +1288,10 @@ msgid ""
 "mail provider is less likely to be monitored, you can send a mail to "
 "<pre>gettor@torproject.org</pre> and a bot will answer with instructions."
 msgstr ""
-"Si existe la posibilidad de que descargar Tor Browser levante sospechas y es "
-"menos probable que su proveedor de correos sea supervisado, puede enviar un "
-"correo a <pre>gettor@torproject.org</pre> y un bot responderá con "
-"instrucciones."
+"Si existe la posibilidad de que levante sospechas al descargar Tor Browser y "
+"es menos probable que su proveedor de correos sea supervisado, puede enviar "
+"un correo a <pre>gettor@torproject.org</pre> y un sistema automático "
+"responderá con instrucciones."
 
 #: source_templates/why-journalist-key.html:3
 msgid "Why download the journalist's public key?"
@@ -1300,18 +1303,17 @@ msgid ""
 "messages and files before submission can provide an extra layer of security "
 "before your data reaches the SecureDrop server."
 msgstr ""
-"SecureDrop encripta archivos y mensajes después de haber sido enviados. "
-"Encriptar mensajes y archivos antes de enviarlos puede proveer una capa "
-"extra de seguridad a su información antes de que llegue al servidor de "
-"SecureDrop."
+"SecureDrop cifra archivos y mensajes después de haber sido enviados. Cifrar "
+"los mensajes y archivos antes de enviarlos puede proveer una capa extra de "
+"seguridad a su información antes de que llegue al servidor de SecureDrop."
 
 #: source_templates/why-journalist-key.html:5
 msgid ""
 "If you are already familiar with the GPG encryption software, you may wish "
 "to encrypt your submissions yourself. To do so:"
 msgstr ""
-"Si usted ya esta familiarizado encriptando con el software GPG, es posible "
-"que desee encriptar sus envios usted mismo. Para hacer eso:"
+"Si usted ya esta familiarizado con el cifrado utilizando GPG, es posible que "
+"desee cifrar sus envíos usted mismo. Para hacer eso:"
 
 #: source_templates/why-journalist-key.html:7
 msgid ""
@@ -1345,7 +1347,7 @@ msgstr ""
 
 #: source_templates/why-journalist-key.html:14
 msgid "Encrypt your submission."
-msgstr "Encripte su envío."
+msgstr "Cifre su envío."
 
 #: source_templates/why-journalist-key.html:16
 msgid ""
@@ -1365,7 +1367,7 @@ msgid ""
 "recipient &lt;user ID&gt; --encrypt roswell_photos.pdf</code>"
 msgstr ""
 "En todos los sistemas, abra la Terminal y use este commando de GPG: "
-"<code>gpg --recipient &lt; user ID&gt; --encrypt roswell_photos.pdf</code>"
+"<code>gpg --recipient &lt;user ID&gt; --encrypt roswell_photos.pdf</code>"
 
 #: source_templates/why-journalist-key.html:20
 msgid ""
@@ -1373,8 +1375,8 @@ msgid ""
 "unencrypted file, with .gpg at the end (e.g. <code>roswell_photos.pdf.gpg</"
 "code>)"
 msgstr ""
-"Suba su envío encriptado. Este va tener el mismo nombre de archivo como el "
-"archivo que no esta encriptado, con .gpg al final (por "
+"Suba su envío cifrado. Este va tener el mismo nombre de archivo como el "
+"archivo que no esta cifrado, con .gpg al final (por "
 "ejemplo<code>roswell_photos.pdf.gpg</code>)"
 
 #: source_templates/why-journalist-key.html:23
@@ -1383,10 +1385,9 @@ msgid ""
 "strong> use GPG to sign the encrypted file (with the <code>--sign</code> or "
 "<code>-s</code> flag) as this will reveal your GPG identity to us."
 msgstr ""
-"<strong>Tip:</strong> Si usted desea permanecer anónimo,<strong>no </strong> "
-"use GPG para firmar el archivo encriptado (con el <code> --sign</code> or "
-"<code> -s</code> marca) ya que esto va revelar su identidad de GPG a "
-"nosotros."
+"<strong>Sugerencia:</strong> Si usted desea permanecer anónimo, <strong>no</"
+"strong> firme con GPG el archivo cifrado (usando las opciones <code>--sign</"
+"code> o <code>-s</code>) ya que esto va revelaría su identidad."
 
 #: source_templates/why-journalist-key.html:25
 msgid "Back to submission page"

--- a/securedrop/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/securedrop/translations/fr_FR/LC_MESSAGES/messages.po
@@ -119,30 +119,30 @@ msgstr "Un fichier est exigé."
 msgid "You can only upload PNG image files."
 msgstr "Vous ne pouvez téléverser que des fichiers images PNG."
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr ""
 "Une erreur inattendue est survenue ! Veuillez la signaler à votre "
 "administrateur."
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "Merci. Votre réponse a été enregistrée."
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "Aucune collection n’a été sélectionnée pour être téléchargée."
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "Aucune collection n’a été sélectionnée pour être supprimée."
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "La source '{original_name}' a été renommée '{new_name}'"
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "Aucun envoi non lu pour cette source."
 
@@ -830,7 +830,7 @@ msgstr "Connectez-vous pour accéder à l'interface des journalistes"
 msgid "Password"
 msgstr "Mot de passe"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "CONNEXION"
 
@@ -860,31 +860,31 @@ msgstr ""
 "Vous avez été redirigé, car vous êtes déjà connecté. Si vous souhaitez créer "
 "un nouveau compte, vous devriez d’abord vous déconnecter."
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr "Vous devez saisir un message ou sélectionner un fichier à envoyer."
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "Merci ! Nous avons reçu votre message."
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "Merci ! Nous avons reçu votre document."
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr "Merci ! Nous avons reçu vos document et message."
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "La réponse a été supprimée"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "Toutes les réponses ont été supprimées"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "Désolé, ce nom de code n’est pas reconnu."
 

--- a/securedrop/translations/hi/LC_MESSAGES/messages.po
+++ b/securedrop/translations/hi/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: SecureDrop 0.6~rc2\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
-"PO-Revision-Date: 2018-09-03 17:28+0000\n"
+"PO-Revision-Date: 2018-09-04 19:23+0000\n"
 "Last-Translator: Drashti <drashtipandya37@gmail.com>\n"
 "Language-Team: Hindi <https://weblate.securedrop.club/projects/securedrop/"
 "securedrop/hi/>\n"
@@ -110,28 +110,28 @@ msgstr "आवश्यक फाइल।"
 msgid "You can only upload PNG image files."
 msgstr "आप केवल PNG छवि फ़ाइलों को अपलोड कर सकते हैं।"
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr "एक अप्रत्याशित त्रुटि हुई है ! कृपया अपने व्यवस्थापक को सूचित करें।"
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "धन्यवाद। आपका उत्तर संग्रहीत किया गया है।"
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "डाउनलोड के लिए कोई संग्रह नहीं चुना गया।"
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "हटाए जाने के लिए कोई संग्रह नहीं चुना गया।"
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "स्रोत '{original_name}' का नाम बदलकर '{new_name}' कर दिया गया है"
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "इस स्रोत के लिए कोई अपठित सबमिशन नहीं है |"
 
@@ -474,7 +474,7 @@ msgstr "जवाब दें"
 
 #: journalist_templates/col.html:41 journalist_templates/col.html:48
 msgid "Read"
-msgstr "વાંચો"
+msgstr "पठित"
 
 #: journalist_templates/col.html:45
 msgid "Unread"
@@ -781,7 +781,7 @@ msgstr "पत्रकार इंटरफेस प्रवेशने क
 msgid "Password"
 msgstr "पासवर्ड"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "लॉग इन"
 
@@ -811,31 +811,31 @@ msgstr ""
 "आपको पुनर्निर्देशित किया गया था क्योंकि आप पहले ही लॉग इन हैं। यदि आप एक नया खाता "
 "बनाना चाहते हैं, तो आपको पहले लॉग आउट करना चाहिए।"
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr "सबमिट करने के लिए आपको कोई संदेश दर्ज करना होगा या एक फ़ाइल चुनें |"
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "धन्यवाद! हमें आपका संदेशा मिला|"
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "धन्यवाद! हमें आपका दस्तावेज़ मिला।"
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr "धन्यवाद! हमें आपका संदेशा और दस्तावेज़ मिला।"
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "जवाब हटा दिया गया"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "सभी उत्तर हटा दिए गए हैं"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "क्षमा करें, वह एक मान्यता प्राप्त कोडनाम नहीं है |"
 

--- a/securedrop/translations/it_IT/LC_MESSAGES/messages.po
+++ b/securedrop/translations/it_IT/LC_MESSAGES/messages.po
@@ -121,29 +121,29 @@ msgstr "File obbligatorio."
 msgid "You can only upload PNG image files."
 msgstr "Possono essere caricate solo immagini PNG."
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr ""
 "Si è verificato un errore inatteso. Informare il proprio amministratore."
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "Grazie. La tua risposta è stata archiviata."
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "Nessun archivio è stato selezionato per essere scaricato."
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "Nessun archivio è stato selezionato per essere eliminato."
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "La fonte \"{original_name}\" è stata rinominata in \"{new_name}\""
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "Non ci sono invii non letti per questa fonte."
 
@@ -818,7 +818,7 @@ msgstr "Accedere per utilizzare l'interfaccia giornalista"
 msgid "Password"
 msgstr "Password"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "ACCEDI"
 
@@ -850,31 +850,31 @@ msgstr ""
 "l'accesso. Per creare un nuovo account bisogna prima terminare la sessione "
 "corrente."
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr "È necessario inserire un messaggio o scegliere un file da inviare."
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "Grazie! Abbiamo ricevuto il tuo messaggio."
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "Grazie! Abbiamo ricevuto il tuo documento."
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr "Grazie! Abbiamo ricevuto il tuo messaggio e il documento."
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "Risposta eliminata"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "Tutte le risposte sono state eliminate"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "Questo nome in codice non è riconosciuto."
 

--- a/securedrop/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/securedrop/translations/nb_NO/LC_MESSAGES/messages.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: SecureDrop 0.3.12\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
 "POT-Creation-Date: 2017-09-02 07:28+0000\n"
-"PO-Revision-Date: 2018-08-28 09:18+0000\n"
-"Last-Translator: Øyvind Bye Skille <oyvind@byeskille.net>\n"
+"PO-Revision-Date: 2018-09-04 19:23+0000\n"
+"Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://weblate.securedrop.club/projects/"
 "securedrop/securedrop/nb_NO/>\n"
 "Language: nb_NO\n"
@@ -113,30 +113,30 @@ msgstr "Fil påkrevd."
 msgid "You can only upload PNG image files."
 msgstr "Du kan kun laste opp PNG-bildefiler."
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr ""
 "En uventet feil oppstod! Gi administrator for din SecureDrop beskjed om at "
 "det skjedde."
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "Takk. Svaret ditt har blitt lagret."
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "Ingen kildedata valgt for nedlasting."
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "Ingen kildeoppføringer valgt for sletting."
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "Kilden '{original_name}' har endret navn til '{new_name}'"
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "Ingen uleste bidrag fra denne kilden."
 
@@ -230,7 +230,7 @@ msgstr[1] "{msg_num} meldinger"
 #: journalist_templates/_source_row.html:27
 msgid "1 unread"
 msgid_plural "{num_unread} unread"
-msgstr[0] "1 ulest"
+msgstr[0] "Én ulest"
 msgstr[1] "{num_unread} uleste"
 
 #: journalist_templates/account_edit_hotp_secret.html:6
@@ -550,7 +550,7 @@ msgstr ""
 
 #: journalist_templates/col.html:121
 msgid "DELETE SOURCE AND SUBMISSIONS"
-msgstr "SLETT KILDEDATA OG INNSENDT INFO"
+msgstr "SLETT KILDEDATA OG INNSENDELSER"
 
 #: journalist_templates/col.html:129
 msgid "Are you sure you want to delete this collection?"
@@ -798,7 +798,7 @@ msgstr "Logg inn for å få tilgang til journalist-portalen"
 msgid "Password"
 msgstr "Passord"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "LOGG INN"
 
@@ -828,31 +828,31 @@ msgstr ""
 "Du ble omdirigert fordi du allerede er logget inn. Om du ønsker å lage en ny "
 "konto må du først logge ut."
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr "Du må skrive inn en melding eller velge ei fil å sende inn."
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "Takk! Vi mottok meldingen din."
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "Takk! Vi har mottatt dokumentet ditt."
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr "Takk! Vi mottok meldingen og dokumentet ditt."
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "Svar slettet"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "Alle svar har blitt slettet"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "Beklager, det er ikke et gjenkjent kodenavn."
 
@@ -949,10 +949,10 @@ msgid ""
 "your anonymity:</strong> <a id=\"disable-js\" href=\"\">Learn how to set it "
 "to Safest</a>, or ignore this warning to continue."
 msgstr ""
-"<strong>Det er anbefalt at sikkerhetsglidebryteren settes til \"Safest\" for "
-"å sikre din anonymitet:</strong><a id=\"disable-js\" href=\"\">Lær hvordan "
-"du setter den til \"Safest\"</a>, eller se bort fra denne advarselen for å "
-"fortsette uten."
+"<strong>Det er anbefalt at sikkerhetsglidebryteren settes til \"Tryggest\" "
+"for å sikre din anonymitet:</strong><a id=\"disable-js\" href=\"\">Lær "
+"hvordan du setter den til \"Tryggest\"</a>, eller se bort fra denne "
+"advarselen for å fortsette uten."
 
 #: source_templates/index.html:18
 msgid ""
@@ -1180,7 +1180,7 @@ msgstr "Beklager, men vi kunne ikke finne det du ba om."
 
 #: source_templates/screensaver.html:2
 msgid "Interface hidden. Move your cursor here to show."
-msgstr "Skjult grensesnitt. Beveg musepekeren for å vise."
+msgstr "Grensesnitt skjult. Beveg musepekeren for å vise."
 
 #: source_templates/session_timeout.html:6
 msgid ""
@@ -1256,9 +1256,9 @@ msgid ""
 "mail provider is less likely to be monitored, you can send a mail to "
 "<pre>gettor@torproject.org</pre> and a bot will answer with instructions."
 msgstr ""
-"Det er mulig at det å laste ned Tor-nettleseren hever mistanke og at e-"
+"Hvis det er mulig at det å laste ned Tor-nettleseren hever mistanke, og at e-"
 "posttilbyderen din mindre sannsynlig er overvåket, du kan sende en e-post "
-"til <pre>gettor@otrproject.org</pre>og en robot vil svare med instruksjoner."
+"til <pre>gettor@otrproject.org</pre> og en robot vil svare med instruksjoner."
 
 #: source_templates/why-journalist-key.html:3
 msgid "Why download the journalist's public key?"

--- a/securedrop/translations/nl/LC_MESSAGES/messages.po
+++ b/securedrop/translations/nl/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: SecureDrop 0.3.12\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
 "POT-Creation-Date: 2017-09-02 07:28+0000\n"
-"PO-Revision-Date: 2018-08-28 13:59+0000\n"
+"PO-Revision-Date: 2018-09-04 19:23+0000\n"
 "Last-Translator: kwadronaut <kwadronaut@autistici.org>\n"
 "Language-Team: Dutch <https://weblate.securedrop.club/projects/securedrop/"
 "securedrop/nl/>\n"
@@ -116,28 +116,28 @@ msgstr "Bestand verplicht."
 msgid "You can only upload PNG image files."
 msgstr "U kunt alleen PNG-afbeeldingen uploaden."
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr "Er trad een onverwachte fout op! Neem contact op met uw beheerder."
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "Bedankt. Uw reactie is opgeslagen."
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "Geen collecties geselecteerd om te downloaden."
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "Geen collecties geselecteerd om te verwijderen."
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "De bron '{original_name}' is hernoemd naar '{new_name}'"
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "Geen ongelezen inzendingen van deze bron."
 
@@ -492,7 +492,7 @@ msgstr "Reageren"
 
 #: journalist_templates/col.html:41 journalist_templates/col.html:48
 msgid "Read"
-msgstr "Lees"
+msgstr "Gelezen"
 
 #: journalist_templates/col.html:45
 msgid "Unread"
@@ -809,7 +809,7 @@ msgstr "Inloggen om de interface voor journalisten te openen"
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "INLOGGEN"
 
@@ -839,31 +839,31 @@ msgstr ""
 "U bent omgeleid omdat u al ingelogd bent. Indien u een nieuw account wilt "
 "aanmaken, moet u eerst uitloggen."
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr "U moet een bericht invoeren of een bestand selecteren om te versturen."
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "Bedankt! We hebben uw bericht ontvangen."
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "Bedankt! We hebben uw document ontvangen."
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr "Bedankt! We hebben uw bericht en document ontvangen."
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "Reactie verwijderd"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "Alle reacties zijn verwijderd"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "Helaas is dit een onbekende codenaam."
 

--- a/securedrop/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/securedrop/translations/pt_BR/LC_MESSAGES/messages.po
@@ -116,28 +116,28 @@ msgstr "Arquivo obrigatório."
 msgid "You can only upload PNG image files."
 msgstr "Você pode carregar somente documentos de imagem PNG."
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr "Ocorreu um erro inesperado! Por favor, informe o administrador."
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "Agradecemos pela contribuição. Sua resposta foi registrada."
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "Nenhuma coleção selecionada para download."
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "Nenhuma coleção selecionada para ser apagada."
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "A fonte '{original_name}' foi renomeada como '{new_name}'"
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "Esta fonte não tem nenhum envio não lido."
 
@@ -811,7 +811,7 @@ msgstr "Faça login para acessar a interface para jornalistas"
 msgid "Password"
 msgstr "Senha"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "ENTRAR"
 
@@ -840,32 +840,32 @@ msgid ""
 msgstr ""
 "Sessão já iniciada. Para criar uma nova conta, é preciso encerrar a sessão."
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr "É preciso escrever uma mensagem ou escolher um arquivo para enviar."
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "Agradecemos a contribuição. Recebemos a sua mensagem."
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "Agradecemos a contribuição. Recebemos o seu documento."
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr ""
 "Agradecemos sua contribuição. Recebemos a sua mensagem e o seu documento."
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "Resposta apagada"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "Todas as respostas foram apagadas"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "Desculpe, este codinome não foi reconhecido."
 

--- a/securedrop/translations/ru/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ru/LC_MESSAGES/messages.po
@@ -15,8 +15,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
-"4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 2.20\n"
 "Generated-By: Babel 2.4.0\n"
 
@@ -115,28 +115,28 @@ msgstr "Файл обязателен."
 msgid "You can only upload PNG image files."
 msgstr "Вы можете загружать изображения только в формате PNG."
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr "Произошла непредвиденная ошибка! Сообщите об этом администратору."
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "Спасибо. Ваш ответ сохранен."
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "Коллекции для скачивания не выбраны."
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "Не выбраны коллекции для удаления."
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "Источник '{original_name}' был переименован в '{new_name}'"
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "Нет непрочитанных материалов для этого источника."
 
@@ -821,7 +821,7 @@ msgstr "Войдите, чтобы получить доступ к панели
 msgid "Password"
 msgstr "Пароль"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "Войти"
 
@@ -851,31 +851,31 @@ msgstr ""
 "Вы были перенаправлены, так как уже выполнили вход в систему. Если вы хотите "
 "создать новый аккаунт, то сначала нужно выйти из системы."
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr "Вы должны ввести сообщение или выбрать файл для отправки."
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "Спасибо! Мы получили ваше сообщение."
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "Спасибо! Мы получили ваш документ."
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr "Спасибо! Мы получили ваше сообщение и документ."
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "Ответ удален"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "Все ответы были удалены"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "К сожалению, это кодовое имя не распознано."
 

--- a/securedrop/translations/sv/LC_MESSAGES/messages.po
+++ b/securedrop/translations/sv/LC_MESSAGES/messages.po
@@ -113,28 +113,28 @@ msgstr "Fil krävs."
 msgid "You can only upload PNG image files."
 msgstr "Du kan endast ladda upp PNG-bildfiler."
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr "Ett oväntat fel uppstod! Informera din administratör."
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "Tack. Ditt svar har sparats."
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "Inga samlingar valda för nedladdning."
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "Inga samlingar har markerats för radering."
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "Källan '{original_name}' har döpts om till '{new_name}'"
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "Det finns inga olästa inlämningar från denna källa."
 
@@ -793,7 +793,7 @@ msgstr "Logga in för att få tillgång till journalistgränssnittet"
 msgid "Password"
 msgstr "Lösenord"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "LOGGA IN"
 
@@ -823,31 +823,31 @@ msgstr ""
 "Du omdirigerades eftersom du redan är inloggad. Ifall du vill skapa ett nytt "
 "konto, logga ut först."
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr "Du måste ange ett meddelande eller välja en fil att lämna in."
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "Tack! Vi har tagit emot ditt meddelande."
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "Tack! Vi har tagit emot ditt dokument."
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr "Tack! Vi har tagit emot ditt meddelande och dokument."
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "Svaret har tagits bort"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "Alla svar har tagits bort"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "Tyvärr, detta kodnamn är okänt."
 

--- a/securedrop/translations/tr/LC_MESSAGES/messages.po
+++ b/securedrop/translations/tr/LC_MESSAGES/messages.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: SecureDrop 0.5-rc4\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
-"PO-Revision-Date: 2018-08-30 21:18+0000\n"
-"Last-Translator: tekrei <tekrei@gmail.com>\n"
+"PO-Revision-Date: 2018-09-04 19:23+0000\n"
+"Last-Translator: erinm <erinm@benespace.org>\n"
 "Language-Team: Turkish <https://weblate.securedrop.club/projects/securedrop/"
 "securedrop/tr/>\n"
 "Language: tr\n"
@@ -117,28 +117,28 @@ msgstr "Dosya gerekli."
 msgid "You can only upload PNG image files."
 msgstr "Yalnızca PNG resim dosyalarını yükleyebilirsiniz."
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr "Beklenmeyen bir hata oluştu! Lütfen sistem yöneticinize haber verin."
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "Teşekkürler. Yanıtınız saklandı."
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "İndirmek için herhangi bir derleme seçilmedi."
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "Silmek için herhangi bir derleme seçilmedi."
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "'{original_name}' kaynağının ismi '{new_name}' şeklinde değiştirildi"
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "Bu kaynağın okunmamış gönderimi yok."
 
@@ -487,11 +487,11 @@ msgstr "Yanıtla"
 
 #: journalist_templates/col.html:41 journalist_templates/col.html:48
 msgid "Read"
-msgstr "Oku"
+msgstr "Okunmuş"
 
 #: journalist_templates/col.html:45
 msgid "Unread"
-msgstr "1 Okunmamış"
+msgstr "Okunmamış"
 
 #: journalist_templates/col.html:56
 msgid "Uploaded Document"
@@ -805,7 +805,7 @@ msgstr "Gazeteci arayüzüne erişmek için oturum açın"
 msgid "Password"
 msgstr "Parola"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "OTURUM AÇ"
 
@@ -835,31 +835,31 @@ msgstr ""
 "Zaten oturumunuz açık olduğu için buraya yönlendirildiniz. Yeni bir hesap "
 "açmak istiyorsanız, önce oturumu kapatmalısınız."
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr "Bir ileti girmeli veya gönderecek bir dosya seçmelisiniz."
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "Teşekkürler! İletiniz alındı."
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "Teşekkürler! Belgeniz alındı."
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr "Teşekkürler! İletiniz ve belgeniz alındı."
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "Yanıt silindi"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "Bütün yanıtlar silindi"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "Üzgünüz, kod adı bilinmiyor."
 

--- a/securedrop/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/securedrop/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -109,28 +109,28 @@ msgstr "檔案欄為必要。"
 msgid "You can only upload PNG image files."
 msgstr "僅可上傳 PNG 格式的圖片檔。"
 
-#: journalist_app/main.py:117 journalist_app/utils.py:48
+#: journalist_app/main.py:118 journalist_app/utils.py:48
 #: journalist_app/utils.py:138
 msgid "An unexpected error occurred! Please inform your administrator."
 msgstr "發生預期之外的錯誤！請通知系統管理員。"
 
-#: journalist_app/main.py:128
+#: journalist_app/main.py:129
 msgid "Thanks. Your reply has been stored."
 msgstr "謝謝，我們已儲存您的回覆。"
 
-#: journalist_app/main.py:149
+#: journalist_app/main.py:150
 msgid "No collections selected for download."
 msgstr "未選擇要下載的集件。"
 
-#: journalist_app/main.py:152 journalist_app/utils.py:236
+#: journalist_app/main.py:153 journalist_app/utils.py:236
 msgid "No collections selected for deletion."
 msgstr "未選擇要刪除的集件。"
 
-#: journalist_app/main.py:178
+#: journalist_app/main.py:179
 msgid "The source '{original_name}' has been renamed to '{new_name}'"
 msgstr "線人 {original_name} 已重新命名為 {new_name}"
 
-#: journalist_app/main.py:193
+#: journalist_app/main.py:194
 msgid "No unread submissions for this source."
 msgstr "此位線人無未讀的提交。"
 
@@ -747,7 +747,7 @@ msgstr "登入記者使用介面"
 msgid "Password"
 msgstr "密碼"
 
-#: journalist_templates/login.html:12
+#: journalist_templates/login.html:11
 msgid "LOG IN"
 msgstr "登錄"
 
@@ -774,31 +774,31 @@ msgid ""
 "a new account, you should log out first."
 msgstr "你被重定向了， 因為已在登錄狀態。如果想創建一個新帳戶，請先登出。"
 
-#: source_app/main.py:131
+#: source_app/main.py:133
 msgid "You must enter a message or choose a file to submit."
 msgstr "你必须輸入一則訊息，或是選擇一個文件來提交。"
 
-#: source_app/main.py:164
+#: source_app/main.py:166
 msgid "Thanks! We received your message."
 msgstr "謝謝！我們已收到你的訊息。"
 
-#: source_app/main.py:166
+#: source_app/main.py:168
 msgid "Thanks! We received your document."
 msgstr "謝謝！我們已收到你的文件。"
 
-#: source_app/main.py:168
+#: source_app/main.py:170
 msgid "Thanks! We received your message and document."
 msgstr "謝謝！我們已收到你的訊息和文件。"
 
-#: source_app/main.py:220
+#: source_app/main.py:222
 msgid "Reply deleted"
 msgstr "回覆已刪除"
 
-#: source_app/main.py:238
+#: source_app/main.py:240
 msgid "All replies have been deleted"
 msgstr "所有的回覆都已被删除"
 
-#: source_app/main.py:252
+#: source_app/main.py:254
 msgid "Sorry, that is not a recognized codename."
 msgstr "對不起，無法識別這個代號。"
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

These are the new translation updates from weblate for ``0.10.0``.

## Testing

These are new translations files (covered by a generic apparmor inclusion) and updates that can be verified if you speak the language by switching to the corresponding language using the menu. Ensuring there is no breakage because of placeholders incorrectly copied over can be done with:


1. Run the following:

```
bin/dev-shell bash
source bin/dev-deps
run_xvfb & run_redis & run_x11vnc & run_sass --watch & urandom & maybe_create_config_py
./i18n_tool.py translate-messages --compile
```

2. Set config.py line `SUPPORTED_LOCALES = ['ar','de_DE','es_ES','fr_FR','nb_NO','nl','pt_BR','zh_Hant','en_US','it_IT','tr', 'hi', 'ru', 'sv']`


3. Now finally run the tests:
```
$ PAGE_LAYOUT_LOCALES='ar,de_DE,es_ES,fr_FR,nb_NO,nl,pt_BR,zh_Hant,it_IT,tr,hi,ru,sv' pytest -v --page-layout tests/pageslayout
```



## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
