### PR TITLE
Add 0.9.1 to 0.10.0 upgrade guide to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ anonymous sources.
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/0.9.1_to_0.10.0.rst
    upgrade/0.8.0_to_0.9.1.rst
    upgrade/0.7.x_to_0.8.rst
    upgrade/0.6.x_to_0.7.rst

--- a/docs/upgrade/0.8.0_to_0.9.1.rst
+++ b/docs/upgrade/0.8.0_to_0.9.1.rst
@@ -36,6 +36,8 @@ where "<version>" is your current installed version.
 If the workstation code is at version 0.7.0 or earlier:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. _update_workstation_code_from_070:
+
 Update the workstation code to version 0.8.0 (not 0.9.0 or 0.9.1) manually
 before proceeding:
 

--- a/docs/upgrade/0.9.1_to_0.10.0.rst
+++ b/docs/upgrade/0.9.1_to_0.10.0.rst
@@ -1,0 +1,50 @@
+Upgrade from 0.9.1 to 0.10.0
+============================
+
+Updating the Tails Workstations
+-------------------------------
+
+We recommend that you update all Tails drives to version 3.10, which was released
+concurrently with SecureDrop 0.9.0 on October 23, 2018. Follow the Tails
+graphical prompts on your workstations to perform this upgrade.
+
+Due to a bug in the graphical SecureDrop updater that was fixed in SecureDrop
+0.9.1 (released on September 6, 2018), attempting an update of your SecureDrop
+workstation code on your *Journalist* or *Admin Workstations* using the
+graphical updater will fail with an error message: "WARNING: Signature
+verification failed."
+
+If you haven't already updated your workstations
+when SecureDrop 0.9.1 was released, you'll need to update your workstations
+manually. To do so, follow the instructions in the
+:doc:`Upgrade from 0.8.0 to 0.9.1<0.8.0_to_0.9.1>` guide.
+
+Troubleshooting Kernel Issues
+-----------------------------
+
+If you have previously downgraded your kernel, as part of the the upgrade
+process to SecureDrop 0.10.0, the default Linux kernel will change to the
+latest released kernel (version 4.4.144). 
+
+We have tested this kernel extensively against :ref:`recommended hardware <Specific Hardware Recommendations>`
+and other common configurations. Please consult our :doc:`kernel troubleshooting guide <../kernel_troubleshooting>`
+for instructions on how to compare the differences between kernel versions and
+how to roll back to an earlier version if necessary.
+
+.. important::
+
+  The 3.14.x series kernel will be removed with release 0.11.0 (scheduled
+  for December 11). Please :ref:`report kernel compatibility issues <Report Compatibility Issues>`
+  immediately to avoid extended downtime.
+
+Getting Support
+---------------
+
+Should you require further support with your SecureDrop installation or upgrade,
+we are happy to help!
+
+-  Community support is available at https://forum.securedrop.org
+-  The Freedom of the Press Foundation offers training and priority support
+   services. See https://securedrop.org/priority-support/ for more information.
+   If you are already a member of our support portal, please don't hesitate to
+   open a ticket there.

--- a/docs/upgrade/0.9.1_to_0.10.0.rst
+++ b/docs/upgrade/0.9.1_to_0.10.0.rst
@@ -24,7 +24,7 @@ version of the SecureDrop code on your workstation (earlier than
     cd ~/Persistent/securedrop
     git fetch --tags
     gpg --recv-key "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
-    git tag -V 0.10.0
+    git tag -v 0.10.0
 
 The output should include the following two lines: ::
 
@@ -44,7 +44,7 @@ new release: ::
 Finally, run the following commands: ::
 
   ./securedrop-admin setup
-  ./securedrop-admin tails-config
+  ./securedrop-admin tailsconfig
 
 .. important:: 
         If you haven't already updated your workstations when SecureDrop

--- a/docs/upgrade/0.9.1_to_0.10.0.rst
+++ b/docs/upgrade/0.9.1_to_0.10.0.rst
@@ -5,19 +5,33 @@ Updating the Tails Workstations
 -------------------------------
 
 We recommend that you update all Tails drives to version 3.10, which was released
-concurrently with SecureDrop 0.9.0 on October 23, 2018. Follow the Tails
+concurrently with SecureDrop 0.10.0 on October 23, 2018. Follow the Tails
 graphical prompts on your workstations to perform this upgrade.
 
-Due to a bug in the graphical SecureDrop updater that was fixed in SecureDrop
-0.9.1 (released on September 6, 2018), attempting an update of your SecureDrop
-workstation code on your *Journalist* or *Admin Workstations* using the
-graphical updater will fail with an error message: "WARNING: Signature
-verification failed."
+For the *Journalist Workstation* and *Admin Workstation*, the graphical
+SecureDrop updater will also prompt you to update the SecureDrop code
+on your workstation. The updater was introduced in SecureDrop 0.7.0. It
+looks like this:
 
-If you haven't already updated your workstations
-when SecureDrop 0.9.1 was released, you'll need to update your workstations
-manually. To do so, follow the instructions in the
-:doc:`Upgrade from 0.8.0 to 0.9.1<0.8.0_to_0.9.1>` guide.
+.. image:: ../images/0.6.x_to_0.7/securedrop-updater.png
+
+If you don't see a graphical updater, you may be running an older
+version of the SecureDrop code on your workstation (earlier than
+0.7.0). If that is the case, refer to :ref:`this guide <update_workstation_code_from_070>`
+to get onto the latest workstation code.
+
+.. important:: 
+        If you haven't already updated your workstations when SecureDrop
+        0.9.1 was released, you'll need to update your workstations
+        manually. Due to a bug in the graphical SecureDrop updater that was
+        fixed in SecureDrop 0.9.1 (released on September 6, 2018),
+        attempting an update of your SecureDrop workstation code on your
+        *Journalist* or *Admin Workstations* using the graphical updater
+        may fail with an error message: "WARNING: Signature verification failed."
+
+        Should you encounter this message, follow the instructions in the
+        :doc:`Upgrade from 0.8.0 to 0.9.1<0.8.0_to_0.9.1>` guide.
+
 
 Troubleshooting Kernel Issues
 -----------------------------
@@ -30,7 +44,7 @@ We have tested this kernel extensively against :ref:`recommended hardware <Speci
 and other common configurations. Please consult our :doc:`kernel troubleshooting guide <../kernel_troubleshooting>`
 for instructions on how to compare the differences between kernel versions and
 how to roll back to an earlier version if necessary.
-
+ 
 .. important::
 
   The 3.14.x series kernel will be removed with release 0.11.0 (scheduled

--- a/docs/upgrade/0.9.1_to_0.10.0.rst
+++ b/docs/upgrade/0.9.1_to_0.10.0.rst
@@ -8,17 +8,43 @@ We recommend that you update all Tails drives to version 3.10, which was release
 concurrently with SecureDrop 0.10.0 on October 23, 2018. Follow the Tails
 graphical prompts on your workstations to perform this upgrade.
 
-For the *Journalist Workstation* and *Admin Workstation*, the graphical
-SecureDrop updater will also prompt you to update the SecureDrop code
-on your workstation. The updater was introduced in SecureDrop 0.7.0. It
-looks like this:
+On a subsequent boot of your SecureDrop *Journalist* and *Admin Workstations*,
+the *SecureDrop Workstation Updater* will alert you to workstation updates.
+Choose "Update Now" on each of the workstations:
 
 .. image:: ../images/0.6.x_to_0.7/securedrop-updater.png
 
+Please note that this only updates the SecureDrop code on your Tails
+workstations. Tails upgrades must be performed separately.
+
 If you don't see a graphical updater, you may be running an older
 version of the SecureDrop code on your workstation (earlier than
-0.7.0). If that is the case, refer to :ref:`this guide <update_workstation_code_from_070>`
-to get onto the latest workstation code.
+0.7.0). You can update as follows: ::
+
+    cd ~/Persistent/securedrop
+    git fetch --tags
+    gpg --recv-key "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
+    git tag -V 0.10.0
+
+The output should include the following two lines: ::
+
+    gpg:                using RSA key 22245C81E3BAEB4138B36061310F561200F4AD77
+    gpg: Good signature from "SecureDrop Release Signing Key"
+
+Please verify that each character of the fingerprint above matches what
+on the screen of your workstation. If it does, you can check out the
+new release: ::
+
+    git checkout 0.10.0
+
+.. important:: If you do see the warning "refname '0.10.0' is ambiguous" in the
+  output, we recommend that you contact us immediately at securedrop@freedom.press
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
+
+Finally, run the following commands: ::
+
+  ./securedrop-admin setup
+  ./securedrop-admin tails-config
 
 .. important:: 
         If you haven't already updated your workstations when SecureDrop


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3881.

SecureDrop release 0.10.0 is coming soon! This will add some documentation on how to upgrade from 0.9.1 to 0.10.0. In particular, we stress that the 3.14.x kernel will be removed in release 0.11.0.

## Testing

Reviewing for typos and running `make docs-lint` locally should suffice.

## Checklist

- [x] Doc linting (`make docs-lint`) passed locally
