### PR TITLE
Update builder image hash

### DIFF
--- a/molecule/builder/image_hash
+++ b/molecule/builder/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_10_18
-c6d7ba22d2f66cf8a835981b1f60f08dea3800c8ed4ff29d7887e0fc55c221f4
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_10_23
+3aaef57ce8d5aa06d140a28eece17f1dbc7fb42431e3f7c2bf31869c77712201


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3898.

The builder image needed security updates. Followed instructions in maintenance guide to update the build container.: https://docs.securedrop.org/en/release-0.9/development/dockerbuildmaint.html

## Testing

`make build-debs` does not return an error.

## Deployment

Dev env only

## Checklist

### If you made changes to the system configuration:

- [X] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR