### PR TITLE
Develop fix documentation broken reference

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -25,7 +25,7 @@ SecureDrop application environment consists of three dedicated computers:
    hidden service, to send messages and documents to the journalist. The
    journalist connects to the *Journalist Interface*, an `authenticated Tor
    hidden service
-   <https://gitweb.torproject.org/torspec.git/tree/rend-spec.txt#n851>`__, to
+   <https://gitweb.torproject.org/torspec.git/tree/rend-spec-v2.txt#n851>`__, to
    download encrypted documents and respond to sources.
 - *Monitor Server*: Ubuntu server that monitors the *Application Server*
    with `OSSEC <https://ossec.github.io/>`__ and sends email alerts.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

1. Fixing broken reference of "authenticated Tor hiddenservice" at [overview](https://docs.securedrop.org/en/latest/overview.html) section of the documentation.

~~2. Edit [vim](https://en.wikipedia.org/wiki/Vim_(text_editor)) generates **tags** files using [ctags](https://en.wikipedia.org/wiki/Ctags). [This functionality](http://vim.wikia.com/wiki/Single_tags_file_for_a_source_tree) helps to traverse to the definition of method, function or class. It is a meta file. Ignoring this file will solve the problem of mistakenly committing this file to the source.~~

## Steps to find broken reference at the documentation

1. Go to [Overview](https://docs.securedrop.org/en/latest/overview.html) of the documentation.
2. Find Sub section named [Technical Summary](https://docs.securedrop.org/en/latest/overview.html#technical-summary)
3. Go to the description of second point named **Application Server: Ubuntu server running ...**
4. Find reference of **authenticated Tor hidden service** at the beginning of second last line.
5. Click on that link, you will be redirected to a broken page.

## Checklist

### If you made changes to documentation:

- [ x ] Doc linting (`make docs-lint`) passed locally