### PR TITLE
Update grsecurity kernels to 4.4.162

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -54,4 +54,4 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 # If you bump this, also remember to bump in molecule/builder/tests/vars.yml
 securedrop_pkg_grsec:
   ver: "4.4.144-1"
-  depends: "linux-image-4.4.135-grsec,linux-firmware-image-4.4.135-grsec,linux-image-4.4.144-grsec,linux-firmware-image-4.4.144-grsec"
+  depends: "intel-microcode,linux-image-4.4.135-grsec,linux-firmware-image-4.4.135-grsec,linux-image-4.4.144-grsec,linux-firmware-image-4.4.144-grsec"

--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -54,4 +54,4 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 # If you bump this, also remember to bump in molecule/builder/tests/vars.yml
 securedrop_pkg_grsec:
   ver: "4.4.144-1"
-  depends: "linux-image-3.14.79-grsec,linux-image-4.4.135-grsec,linux-firmware-image-4.4.135-grsec,linux-image-4.4.144-grsec,linux-firmware-image-4.4.144-grsec"
+  depends: "linux-image-4.4.135-grsec,linux-firmware-image-4.4.135-grsec,linux-image-4.4.144-grsec,linux-firmware-image-4.4.144-grsec"

--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -53,5 +53,5 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder/tests/vars.yml
 securedrop_pkg_grsec:
-  ver: "4.4.144-1"
-  depends: "intel-microcode,linux-image-4.4.135-grsec,linux-firmware-image-4.4.135-grsec,linux-image-4.4.144-grsec,linux-firmware-image-4.4.144-grsec"
+  ver: "4.4.162"
+  depends: "intel-microcode,linux-image-4.4.144-grsec,linux-firmware-image-4.4.144-grsec,linux-image-4.4.162-grsec,linux-firmware-image-4.4.162-grsec"

--- a/molecule/builder/tests/vars.yml
+++ b/molecule/builder/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "0.11.0~rc1"
 ossec_version: "3.0.0"
 keyring_version: "0.1.2"
 config_version: "0.1.1"
-grsec_version: "4.4.144-1"
+grsec_version: "4.4.162"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/staging/common/test_grsecurity.py
+++ b/molecule/testinfra/staging/common/test_grsecurity.py
@@ -3,7 +3,7 @@ import os
 import re
 
 
-KERNEL_VERSION = "4.4.162"
+KERNEL_VERSION = pytest.securedrop_test_vars.grsec_version
 
 
 def test_ssh_motd_disabled(File):

--- a/molecule/testinfra/staging/common/test_grsecurity.py
+++ b/molecule/testinfra/staging/common/test_grsecurity.py
@@ -76,7 +76,7 @@ def test_grsecurity_kernel_is_running(Command):
     """
     c = Command('uname -r')
     assert c.stdout.endswith('-grsec')
-    assert c.stdout == '4.4.144-grsec'
+    assert c.stdout == '4.4.162-grsec'
 
 
 @pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",

--- a/molecule/testinfra/staging/common/test_grsecurity.py
+++ b/molecule/testinfra/staging/common/test_grsecurity.py
@@ -3,6 +3,9 @@ import os
 import re
 
 
+KERNEL_VERSION = "4.4.162"
+
+
 def test_ssh_motd_disabled(File):
     """
     Ensure the SSH MOTD (Message of the Day) is disabled.
@@ -16,6 +19,9 @@ def test_ssh_motd_disabled(File):
 @pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",
                     reason="Need to skip in environment w/o grsec")
 @pytest.mark.parametrize("package", [
+    'intel-microcode',
+    'linux-firmware-image-{}-grsec'.format(KERNEL_VERSION),
+    'linux-image-{}-grsec'.format(KERNEL_VERSION),
     'paxctl',
     'securedrop-grsec',
 ])
@@ -76,7 +82,7 @@ def test_grsecurity_kernel_is_running(Command):
     """
     c = Command('uname -r')
     assert c.stdout.endswith('-grsec')
-    assert c.stdout == '4.4.162-grsec'
+    assert c.stdout == '{}-grsec'.format(KERNEL_VERSION)
 
 
 @pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",

--- a/molecule/testinfra/staging/vars/staging.yml
+++ b/molecule/testinfra/staging/vars/staging.yml
@@ -169,3 +169,4 @@ log_events_with_ossec_alerts:
     rule_id: "400503"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
+grsec_version: "4.4.162"


### PR DESCRIPTION
## Status
Ready for review

4.4.162 kernel packages have already been uploaded to apt-test.freedom.press. Fixes #3838 


## Description of Changes

* Bump kernels to 4.4.162 (linux-image and linux-firmware-image)
* Adds intel-microcode package
* Add linux-firmware-image for hardware compatibility
* Remove 3.14.79 and 4.4.115 kernels.

## Testing
- [ ] Ensure `apt-test.freedom.press` is in apt-sources.
- [ ] If using staging VMs, just `vagrant up /staging/`, and testinfra tests pass
- [ ] Else, add apt-test.freedom.press to apt sources and run `cron-apt -i -s`, and reboot
- [ ] The server comes back up, and `uname -r` returns `4.4.162-grsec`
- [ ] `paxtest blackhat` kills all the things

### Hardware-specific testing

I have tested this in VMs, NUCs and Mac Minis, and seem to work properly. If you have any other hardware

## Deployment

Packages are live on apt-test.freedom.press for testing.

For the 0.11.0 release, kernel debs (both the `securedrop-grsec` metapackage and `linux-image-4.4.162-grsec_4.4.162-grsec-1_amd64` need to be uploaded to the apt server).


If the instances fail to boot, instructions in https://docs.securedrop.org/en/stable/upgrade/0.5.x_to_0.6.html are still valid.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
