### PR TITLE
add uuid to reply endpoint

### DIFF
--- a/docs/development/journalist_api.rst
+++ b/docs/development/journalist_api.rst
@@ -363,7 +363,7 @@ source.
 
 with the reply in the request body:
 
-.. code:: sh
+.. code:: json
 
   {
    "reply": "-----BEGIN PGP MESSAGE-----[...]-----END PGP MESSAGE-----"
@@ -371,17 +371,21 @@ with the reply in the request body:
 
 Response 201 created (application/json):
 
-.. code:: sh
+.. code:: json
 
   {
-    "message": "Your reply has been stored"
+    "message": "Your reply has been stored",
+    "uuid": "0bc588dd-f613-4999-b21e-1cebbd9adc2c"
   }
+
+The returned ``uuid`` field is the UUID of the reply and can be used to
+reference this reply later.
 
 Replies that do not contain a GPG encrypted message will be rejected:
 
 Response 400 (application/json):
 
-.. code:: sh
+.. code:: json
 
   {
       "message": "You must encrypt replies client side"

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -244,7 +244,8 @@ def make_blueprint(config):
             db.session.add(reply)
             db.session.add(source)
             db.session.commit()
-            return jsonify({'message': 'Your reply has been stored'}), 201
+            return jsonify({'message': 'Your reply has been stored',
+                            'uuid': reply.uuid}), 201
 
     @api.route('/sources/<source_uuid>/replies/<reply_uuid>',
                methods=['GET', 'DELETE'])


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3915

Adds the `uuid` to the response when creating a reply so that the reply can be referenced later.

Somewhat related, should we really be sending `message` in the JSON? Because I feel like that human readable text doesn't need to be there if the HTTP codes are present. It also is confusing in this case. Is `message` related to what I posted? We have two fields, and `message` seems ambiguous / redundant.

## Testing

Post a reply, observe UUID present. Run tests.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container