### PR TITLE
only save basename of filename for a reply on API requests

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -1,9 +1,10 @@
-from datetime import datetime, timedelta
-from functools import wraps
 import json
-from werkzeug.exceptions import default_exceptions  # type: ignore
 
+from datetime import datetime, timedelta
 from flask import abort, Blueprint, current_app, jsonify, request
+from functools import wraps
+from os import path
+from werkzeug.exceptions import default_exceptions  # type: ignore
 
 from db import db
 from journalist_app import utils
@@ -238,9 +239,10 @@ def make_blueprint(config):
                 return jsonify(
                     {'message': 'You must encrypt replies client side'}), 400
 
-            reply = Reply(user, source,
-                          current_app.storage.path(source.filesystem_id,
-                                                   filename))
+            # issue #3918
+            filename = path.basename(filename)
+
+            reply = Reply(user, source, filename)
             db.session.add(reply)
             db.session.add(source)
             db.session.commit()

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -648,6 +648,9 @@ def test_authorized_user_can_add_reply(journalist_app, journalist_api_token,
         assert reply.journalist_id == test_journo['id']
         assert reply.source_id == source_id
 
+        # regression test for #3918
+        assert '/' not in reply.filename
+
         source = Source.query.get(source_id)
 
         expected_filename = '{}-{}-reply.gpg'.format(


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3918 

Replies created via the API are currently being saved in the DB with a filename as `/var/lib/securedrop/data/$filesystem_id/$filename`. This fixes that.

## Testing

- `make dev`
- Send reply via API
- In the container `sudo sqlite3 /var/lib/securedrop/db.sqlite 'select filename from replies'`
- See that `/var/lib/...` is not in any of the returned rows

## Deployment

We may need a db migration to ensure that instances that had rows inserted in this manner are cleared otherwise they may broken in way that requires admin intervention. This could be done with a one-way `alembic` migration. The reviewer should consider this case before approving this PR.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container