### PR TITLE
added source codename in dev

### DIFF
--- a/securedrop/create-dev-data.py
+++ b/securedrop/create-dev-data.py
@@ -97,9 +97,10 @@ def create_source_and_submissions(num_submissions=2, num_replies=2):
 
     db.session.commit()
 
-    print("Test source '{}' added with {} submissions "
-          "and {} replies".format(journalist_designation, num_submissions,
-                                  num_replies))
+    print(("Test source (codename: '{}', journalist designation '{}') "
+           "added with {} submissions and {} replies")
+          .format(codename, journalist_designation, num_submissions,
+                  num_replies))
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds a source's codename in the dev data to make it easier to quickly test UI changes.

## Testing

`make dev` and check that you can login with the printed codename.

## Deployment

These changes don't even make it to prod.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container