### PR TITLE
[dev] Test replies: encrypt a string instead of 1 random byte

### DIFF
--- a/securedrop/create-dev-data.py
+++ b/securedrop/create-dev-data.py
@@ -86,7 +86,7 @@ def create_source_and_submissions(num_submissions=2, num_replies=2):
         fname = "{}-{}-reply.gpg".format(source.interaction_count,
                                          source.journalist_filename)
         current_app.crypto_util.encrypt(
-            str(os.urandom(1)),
+            'this is a test reply!',
             [current_app.crypto_util.getkey(source.filesystem_id),
              config.JOURNALIST_KEY],
             current_app.storage.path(source.filesystem_id, fname))


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
 - Replaces the 1 random byte message with a nice test reply string
 - This was the source of confusion over in https://github.com/freedomofpress/securedrop-client/pull/114

## Testing

`make -C securedrop dev`

## Deployment

Dev environment only

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
