### PR TITLE
docs: fix incorrect POST reply API endpoint

### DIFF
--- a/docs/development/journalist_api.rst
+++ b/docs/development/journalist_api.rst
@@ -359,7 +359,7 @@ source.
 
 .. code:: sh
 
-  POST /api/v1/sources/<source_uuid>/reply
+  POST /api/v1/sources/<source_uuid>/replies
 
 with the reply in the request body:
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Changes proposed in this pull request:
 - fix inaccurate docs noticed by @joshuathayer during the hackathon

## Testing

Check that my change below is correct (looking at https://github.com/freedomofpress/securedrop/blob/develop/securedrop/journalist_app/api.py#L208)

## Deployment

Docs only

## Checklist

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
