### PR TITLE
Updating weblate reference codes.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,6 @@ See the [introduction for contributors](https://docs.securedrop.org/en/latest/de
 Check out our [Development Roadmap](https://github.com/freedomofpress/securedrop/wiki/Development-Roadmap) to see our plans and priorities for upcoming releases.
 
 For translators, see the [Translator Guide](https://docs.securedrop.org/en/stable/development/l10n.html) to learn how to get started with SecureDrop translations
-in our [translation portal](https://weblate.securedrop.club/).
+in our [translation portal](https://weblate.securedrop.org/).
 
 We also have a public [Gitter channel](https://gitter.im/freedomofpress/securedrop) and a [public Discourse forum](https://forum.securedrop.org/) where you can discuss SecureDrop and ask questions.

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ The wordlist we use to generate source passphrases come from various sources:
 
 A huge thank you to all SecureDrop contributors! You can see just
 code and documentation contributors in the ["Contributors"](https://github.com/freedomofpress/securedrop/graphs/contributors)
-tab on GitHub, and you can see code, documentation and translation contributors together [here](https://lab.securedrop.club/bot/securedrop/graphs/i18n).
+tab on GitHub, and you can see code, documentation and translation contributors together [here](https://github.com/freedomofpress/securedrop-i18n).

--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -26,7 +26,7 @@ class I18NTool(object):
     #
     # The database of support language, indexed by the language code
     # used by weblate (i.e. whatever shows as CODE in
-    # https://weblate.securedrop.club/projects/securedrop/securedrop/CODE/
+    # https://weblate.securedrop.org/projects/securedrop/securedrop/CODE/
     # is the index of the SUPPORTED_LANGUAGES database below.
     #
     # name: English name of the language to the documentation, not for
@@ -324,7 +324,7 @@ class I18NTool(object):
             default=root,
             help=('root of the SecureDrop git repository'
                   ' (default {})'.format(root)))
-        url = 'https://lab.securedrop.club/bot/securedrop.git'
+        url = 'https://github.com/freedomofpress/securedrop-i18n'
         parser.add_argument(
             '--url',
             default=url,


### PR DESCRIPTION
Update docs to account for [Weblate](http://weblate.securedrop.org)

## Status

Completed

## Description of Changes

Partially fixes #3929 

## Testing

* Go through all the changed documents. Verify that they are pointing to correct reference.
* URLs are not broken

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
