### PR TITLE
Replace "administrator" with "admin"

### DIFF
--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -84,7 +84,7 @@ def make_blueprint(config):
                 else:
                     flash(gettext("An error occurred saving this user"
                                   " to the database."
-                                  " Please inform your administrator."),
+                                  " Please inform your admin."),
                           "error")
                     current_app.logger.error("Adding user "
                                              "'{}' failed: {}".format(

--- a/securedrop/journalist_app/decorators.py
+++ b/securedrop/journalist_app/decorators.py
@@ -12,7 +12,7 @@ def admin_required(func):
     def wrapper(*args, **kwargs):
         if logged_in() and g.user.is_admin:
             return func(*args, **kwargs)
-        flash(gettext("Only administrators can access this page."),
+        flash(gettext("Only admins can access this page."),
               "notification")
         return redirect(url_for('main.index'))
     return wrapper

--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -117,7 +117,7 @@ def make_blueprint(config):
         except Exception as exc:
             flash(gettext(
                 "An unexpected error occurred! Please "
-                "inform your administrator."), "error")
+                "inform your admin."), "error")
             # We take a cautious approach to logging here because we're dealing
             # with responses to sources. It's possible the exception message
             # could contain information we don't want to write to disk.

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -47,7 +47,7 @@ def commit_account_changes(user):
         except Exception as e:
             flash(gettext(
                 "An unexpected error occurred! Please "
-                  "inform your administrator."), "error")
+                  "inform your admin."), "error")
             current_app.logger.error("Account changes for '{}' failed: {}"
                                      .format(user, e))
             db.session.rollback()
@@ -137,7 +137,7 @@ def validate_hotp_secret(user, otp_secret):
         else:
             flash(gettext(
                 "An unexpected error occurred! "
-                "Please inform your administrator."), "error")
+                "Please inform your admin."), "error")
             current_app.logger.error(
                 "set_hotp_secret '{}' (id {}) failed: {}".format(
                     otp_secret, user.id, e))

--- a/securedrop/journalist_templates/admin_add_user.html
+++ b/securedrop/journalist_templates/admin_add_user.html
@@ -28,7 +28,7 @@
   <p>{{ gettext("The user's password will be:") }} <span class="password" id="password">{{ password }}</span></p>
   <p>
     {{ form.is_admin(id="is-admin") }}
-    <label for="is_admin">{{ gettext('Is Administrator') }}</label>
+    <label for="is_admin">{{ gettext('Is Admin') }}</label>
     <br>
     {% for error in form.is_admin.errors %}
       <span class="form-validation-error">{{ error }}</span>

--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -14,7 +14,7 @@
     </p>
     <p>
       <input name="is_admin" id="is-admin" type="checkbox" {% if user.is_admin %}checked{% endif %}>
-      <label for="is_admin">{{ gettext('Is Administrator') }}</label>
+      <label for="is_admin">{{ gettext('Is Admin') }}</label>
     </p>
     <button class="sd-button" type="submit" id="update">{{ gettext('UPDATE') }}</button>
   </form>

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -219,7 +219,7 @@ def _get_delete_confirmation(user):
 
 
 def delete_user(args):
-    """Deletes a journalist or administrator from the application."""
+    """Deletes a journalist or admin from the application."""
     with app_context():
         username = _get_username_to_delete()
         try:

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -377,7 +377,7 @@ class JournalistNavigationStepsMixin():
         # There's no field to change your username.
         with pytest.raises(NoSuchElementException):
             self.driver.find_element_by_css_selector('#username')
-        # There's no checkbox to change the administrator status of your
+        # There's no checkbox to change the admin status of your
         # account.
         with pytest.raises(NoSuchElementException):
             self.driver.find_element_by_css_selector('#is-admin')
@@ -410,7 +410,7 @@ class JournalistNavigationStepsMixin():
         # out with the user's username.
         username_field = self.driver.find_element_by_css_selector('#username')
         assert username_field.get_attribute('placeholder') == username
-        # There's a checkbox to change the administrator status of the user and
+        # There's a checkbox to change the admin status of the user and
         # it's already checked appropriately to reflect the current status of
         # our user.
         username_field = self.driver.find_element_by_css_selector('#is-admin')

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -120,7 +120,7 @@ def test_reply_error_flashed_message(journalist_app, test_journo, test_source):
 
             ins.assert_message_flashed(
                 'An unexpected error occurred! Please '
-                'inform your administrator.', 'error')
+                'inform your admin.', 'error')
 
 
 def test_empty_replies_are_rejected(journalist_app, test_journo, test_source):
@@ -772,7 +772,7 @@ def test_admin_resets_user_hotp_error(mocker,
             app.post(url_for('admin.reset_two_factor_hotp'),
                      data=dict(uid=test_journo['id'], otp_secret=bad_secret))
             ins.assert_message_flashed("An unexpected error occurred! "
-                                       "Please inform your administrator.",
+                                       "Please inform your admin.",
                                        "error")
 
     # Re-fetch journalist to get fresh DB instance
@@ -872,7 +872,7 @@ def test_user_resets_user_hotp_error(mocker,
                      data=dict(otp_secret=bad_secret))
             ins.assert_message_flashed(
                 "An unexpected error occurred! Please inform your "
-                "administrator.", "error")
+                "admin.", "error")
 
     # Re-fetch journalist to get fresh DB instance
     user = Journalist.query.get(test_journo['id'])
@@ -1140,7 +1140,7 @@ def test_admin_add_user_integrity_error(journalist_app, test_admin, mocker):
                                is_admin=None))
             ins.assert_message_flashed(
                 "An error occurred saving this user to the database."
-                " Please inform your administrator.",
+                " Please inform your admin.",
                 "error")
 
     log_event = mocked_error_logger.call_args[0][0]


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2332

Changes proposed in this pull request:

Replace instances of Administrator/administrator with Admin/admin

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
