### PR TITLE
Never set session cookies for API requests

### DIFF
--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -16,7 +16,8 @@ import version
 from crypto_util import CryptoUtil
 from db import db
 from journalist_app import account, admin, api, main, col
-from journalist_app.utils import get_source, logged_in
+from journalist_app.utils import (get_source, logged_in,
+                                  JournalistInterfaceSessionInterface)
 from models import Journalist
 from store import Storage
 
@@ -40,6 +41,7 @@ def create_app(config):
 
     app.config.from_object(config.JournalistInterfaceFlaskConfig)
     app.sdconfig = config
+    app.session_interface = JournalistInterfaceSessionInterface()
 
     csrf = CSRFProtect(app)
     Environment(app)

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1959,3 +1959,12 @@ def test_source_with_null_last_updated(journalist_app,
                     test_journo['otp_secret'])
         resp = app.get(url_for('main.index'))
         assert resp.status_code == 200
+
+
+def test_does_set_cookie_headers(journalist_app, test_journo):
+    with journalist_app.test_client() as app:
+        response = app.get(url_for('main.login'))
+
+        observed_headers = response.headers
+        assert 'Set-Cookie' in observed_headers.keys()
+        assert 'Cookie' in observed_headers['Vary']

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -850,3 +850,13 @@ def test_set_reply_uuid(journalist_app, journalist_api_token, test_source):
                         data=json.dumps(req_data),
                         headers=get_api_headers(journalist_api_token))
         assert resp.status_code == 400
+
+
+def test_api_does_not_set_cookie_headers(journalist_app, test_journo):
+    with journalist_app.test_client() as app:
+        response = app.get(url_for('api.get_endpoints'))
+
+        observed_headers = response.headers
+        assert 'Set-Cookie' not in observed_headers.keys()
+        if 'Vary' in observed_headers.keys():
+            assert 'Cookie' not in observed_headers['Vary']


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3876.

Changes proposed in this pull request:

Implement a custom session interface that never sets session cookies
on API requests

## Testing

How should the reviewer test this PR?

- curl -v localhost:8081/admin/
    - You should see a Set-cookie header

- curl -v localhost:8081/api/v1/
    - You should not see any Set-cookie header

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
