### PR TITLE
ossec: set permissions on gpg homedir and contents

### DIFF
--- a/install_files/ansible-base/roles/ossec/defaults/main.yml
+++ b/install_files/ansible-base/roles/ossec/defaults/main.yml
@@ -21,3 +21,9 @@ ossec_is_client: False
 journalist_alert_gpg_public_key: ""
 journalist_gpg_fpr: ""
 journalist_alert_email: ""
+
+# These files should be created once an OSSEC key is imported.
+gpg_keyring_files:
+  - pubring.gpg
+  - secring.gpg
+  - trustdb.gpg

--- a/install_files/ansible-base/roles/ossec/tasks/configure_server.yml
+++ b/install_files/ansible-base/roles/ossec/tasks/configure_server.yml
@@ -20,6 +20,44 @@
   tags:
     - gpg
 
+- name: Check if GPG homedir already exists.
+  stat:
+    path: /var/ossec/.gnupg
+  register: gpg_homedir_status
+  tags:
+    - gpg
+
+- name: Ensure correct permissions on OSSEC GPG homedir if it exists.
+  file:
+    state: directory
+    path: /var/ossec/.gnupg
+    mode: "0700"
+    owner: ossec
+    group: "{{ ossec_group }}"
+  when: gpg_homedir_status.stat.exists
+  tags:
+    - gpg
+
+- name: Check if .gpg files have been created yet in the GPG homedir.
+  stat:
+    path: "/var/ossec/.gnupg/{{ item }}"
+  with_items: "{{ gpg_keyring_files }}"
+  register: gpg_keyring_status
+  tags:
+    - gpg
+
+- name: Ensure correct permissions on contents of OSSEC GPG homedir.
+  file:
+    state: file
+    path: "/var/ossec/.gnupg/{{ item.item }}"
+    mode: "0600"
+    owner: ossec
+    group: "{{ ossec_group }}"
+  with_items: "{{ gpg_keyring_status.results }}"
+  when: item.stat.exists
+  tags:
+    - gpg
+
 - name: Add the OSSEC GPG public key to the OSSEC manager keyring.
   # multiline format for command module, since this is a long command
   command: >


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In bug #3928, problems with the permissions on the OSSEC gpg
keyring resulted in an error when attempting to import the OSSEC
public key.

This commit adds Ansible tasks to set the expected permissions
on the gpg homedir and its contents prior to attempting to import
the key

Fixes #3928.

note: some of this syntax i.e. `with_items` will need to get changed as part of #3891 

## Testing

0. Follow STR in #3928 and ensure the error does not occur

1. Test that fresh installs continue to work with this change 

2. Verify that the permissions I claim to be "the expected permissions" are indeed the right permissions

## Deployment

People are hitting this bug in prod when running `securedrop-admin install`, this will resolve as part of the workstation update in 0.11

## Checklist

[heads up did not get a chance to run tests locally, relying on CI and manual testing]

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR
