### PR TITLE
Upgrade ansible to 2.7.2

### DIFF
--- a/admin/requirements-ansible.in
+++ b/admin/requirements-ansible.in
@@ -1,3 +1,3 @@
-ansible>2.4<2.5
+ansible>2.7<2.8
 cryptography>=2.3
 netaddr

--- a/admin/requirements.txt
+++ b/admin/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --generate-hashes --output-file requirements.txt requirements.in requirements-ansible.in
 #
-ansible==2.4.2 \
-    --hash=sha256:315f1580b20bbc2c2f1104f8b5e548c6b4cac943b88711639c5e0d4dfc4d7658
+ansible==2.7.2 \
+    --hash=sha256:a00d79531e4e0268321e431b1810286369ecf791dbebc1aecb28d453d4ea1ee0
 asn1crypto==0.24.0 \
     --hash=sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87 \
     --hash=sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49 \

--- a/install_files/ansible-base/callback_plugins/ansible_version_check.py
+++ b/install_files/ansible-base/callback_plugins/ansible_version_check.py
@@ -21,7 +21,7 @@ class CallbackModule(CallbackBase):
     def __init__(self):
         # Can't use `on_X` because this isn't forwards compatible
         # with Ansible 2.0+
-        required_version = '2.4.2'  # Keep synchronized with requirements files
+        required_version = '2.7.2'  # Keep synchronized with requirements files
         if not ansible.__version__.startswith(required_version):
             print_red_bold(
                 "SecureDrop restriction: only Ansible {version}.*"

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/ssh.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/ssh.yml
@@ -35,6 +35,6 @@
 - name: Ensure sshd is running.
   service:
     name: ssh
-    state: running
+    state: started
   tags:
     - ssh

--- a/install_files/ansible-base/roles/tor-hidden-services/tasks/configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/tasks/configure_tor_hidden_services.yml
@@ -40,6 +40,6 @@
 - name: Ensure tor is running.
   service:
     name: tor
-    state: running
+    state: started
   tags:
     - tor

--- a/molecule/builder/playbook.yml
+++ b/molecule/builder/playbook.yml
@@ -2,7 +2,7 @@
 - name: Build SecureDrop application Debian package from local repository.
   hosts: builders
   # Build as fast as possible with each host going individually
-  strategy: free
+  strategy: linear
   become: yes
   tasks:
     - name: Update apt-cache for our security checker

--- a/molecule/upgrade/playbook.yml
+++ b/molecule/upgrade/playbook.yml
@@ -41,14 +41,14 @@
     - name: Ensure tor is running
       service:
         name: tor
-        state: running
+        state: started
         enabled: yes
       tags: always
 
     - name: Ensure supervisor is running
       service:
         name: supervisor
-        state: running
+        state: started
       delegate_to: app-staging
       runonce: yes
       tags: always

--- a/securedrop/requirements/ansible.in
+++ b/securedrop/requirements/ansible.in
@@ -1,1 +1,1 @@
-ansible>2.4<2.5
+ansible>2.7<2.8

--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.10         # via sphinx
 ansible-lint==3.4.21      # via molecule
-ansible==2.4.2
+ansible==2.7.2
 anyconfig==0.9.4          # via molecule
 apipkg==1.4               # via execnet
 argh==0.26.2              # via sphinx-autobuild, watchdog


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Fixes #3891 .

Upgrades Ansible to 2.7.2 for SecureDrop admin tools. There is currently an issue where builders can't be run concurrently to due timeout of `get_mount_facts`

The workaround is to use a linear build of packages, which slows down the process. Setting `gather_timeout` to a value greater than 10 (seconds) does not seem to have effect locally.

## Testing

- [ ] Install the dependencies listed in `develop-requirements.txt` to upgrade your local ansible version
- [ ] Clean install
- [ ] Hash for ansible version (in `admin/requirements.txt`) is correct
- [ ] `./securedrop-admin backup` and `./securedrop-admin restore` should be functional 

## Deployment

1. For SecureDrop instances, it is deployed to admin workstations via `./securedrop-admin update`
2. Dev env will need to be updated by installing the requirements in `securedrop/requirements/develop-requirements.txt`

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

