### PR TITLE
Update ansible to 2.6.8

### DIFF
--- a/admin/requirements-ansible.in
+++ b/admin/requirements-ansible.in
@@ -1,3 +1,3 @@
-ansible>2.4<2.5
+ansible>2.6<2.7
 cryptography>=2.3
 netaddr

--- a/admin/requirements.txt
+++ b/admin/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --generate-hashes --output-file requirements.txt requirements.in requirements-ansible.in
 #
-ansible==2.4.2 \
-    --hash=sha256:315f1580b20bbc2c2f1104f8b5e548c6b4cac943b88711639c5e0d4dfc4d7658
+ansible==2.6.8 \
+    --hash=sha256:012649806427e630ef8e8b71d42483af882bc39ade3b19e1f369b14c0afd5b87
 asn1crypto==0.24.0 \
     --hash=sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87 \
     --hash=sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49 \

--- a/install_files/ansible-base/callback_plugins/ansible_version_check.py
+++ b/install_files/ansible-base/callback_plugins/ansible_version_check.py
@@ -21,7 +21,7 @@ class CallbackModule(CallbackBase):
     def __init__(self):
         # Can't use `on_X` because this isn't forwards compatible
         # with Ansible 2.0+
-        required_version = '2.4.2'  # Keep synchronized with requirements files
+        required_version = '2.6.8'  # Keep synchronized with requirements files
         if not ansible.__version__.startswith(required_version):
             print_red_bold(
                 "SecureDrop restriction: only Ansible {version}.*"

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/ssh.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/ssh.yml
@@ -35,6 +35,6 @@
 - name: Ensure sshd is running.
   service:
     name: ssh
-    state: running
+    state: started
   tags:
     - ssh

--- a/install_files/ansible-base/roles/tor-hidden-services/tasks/configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/tasks/configure_tor_hidden_services.yml
@@ -40,6 +40,6 @@
 - name: Ensure tor is running.
   service:
     name: tor
-    state: running
+    state: started
   tags:
     - tor

--- a/molecule/upgrade/playbook.yml
+++ b/molecule/upgrade/playbook.yml
@@ -41,14 +41,14 @@
     - name: Ensure tor is running
       service:
         name: tor
-        state: running
+        state: started
         enabled: yes
       tags: always
 
     - name: Ensure supervisor is running
       service:
         name: supervisor
-        state: running
+        state: started
       delegate_to: app-staging
       runonce: yes
       tags: always

--- a/securedrop/requirements/ansible.in
+++ b/securedrop/requirements/ansible.in
@@ -1,1 +1,1 @@
-ansible>2.4<2.5
+ansible>2.6<2.7

--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -5,9 +5,9 @@
 #    pip-compile --output-file securedrop/requirements/develop-requirements.txt admin/requirements-ansible.in securedrop/requirements/develop-requirements.in
 #
 alabaster==0.7.10         # via sphinx
-ansible-lint==3.4.21      # via molecule
-ansible==2.4.2
-anyconfig==0.9.4          # via molecule
+ansible-lint==3.4.23      # via molecule
+ansible==2.6.8
+anyconfig==0.9.7          # via molecule
 apipkg==1.4               # via execnet
 argh==0.26.2              # via sphinx-autobuild, watchdog
 arrow==0.10.0             # via jinja2-time
@@ -23,7 +23,7 @@ binaryornot==0.4.4        # via cookiecutter
 boto3==1.5.24
 boto==2.48.0
 botocore==1.8.38          # via boto3, s3transfer
-cerberus==1.1             # via molecule
+cerberus==1.2             # via molecule
 certifi==2017.7.27.1      # via requests, tornado
 cffi==1.10.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via binaryornot, requests
@@ -61,19 +61,19 @@ lazy-object-proxy==1.3.1  # via astroid
 livereload==2.5.1         # via sphinx-autobuild
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8, pylint
-molecule==2.13.1
+molecule==2.19.0
 monotonic==1.4            # via fasteners
 netaddr==0.7.19
 packaging==16.8           # via dparse, safety
 paramiko==2.4.2           # via ansible
 pathspec==0.5.5           # via yamllint
 pathtools==0.1.2          # via sphinx-autobuild, watchdog
-pbr==3.0.1                # via git-url-parse, molecule, python-gilt, stevedore
-pexpect==4.2.1            # via molecule
+pbr==4.1.0                # via git-url-parse, molecule, python-gilt, stevedore
+pexpect==4.6.0            # via molecule
 pip-tools==1.10.1
 port-for==0.3.1           # via sphinx-autobuild
 poyo==0.4.1               # via cookiecutter
-psutil==5.2.2             # via molecule
+psutil==5.4.6             # via molecule
 ptyprocess==0.5.2         # via pexpect
 py==1.4.34                # via pytest
 pyasn1==0.3.1             # via paramiko
@@ -90,13 +90,13 @@ python-dateutil==2.6.1    # via arrow, botocore
 python-gilt==1.2.1        # via molecule
 python-vagrant==0.5.15
 pytz==2017.2              # via babel
-pyyaml==3.12              # via ansible, ansible-lint, bandit, dparse, molecule, python-gilt, sphinx-autobuild, watchdog, yamllint
+pyyaml==3.13              # via ansible, ansible-lint, bandit, dparse, molecule, python-gilt, sphinx-autobuild, watchdog, yamllint
 requests==2.20.0          # via cookiecutter, docker-py, safety, sphinx
 s3transfer==0.1.12        # via boto3
 safety==1.8.4
 sh==1.12.14               # via molecule, python-gilt
 singledispatch==3.4.0.3   # via astroid, pylint, tornado
-six==1.10.0               # via ansible-lint, astroid, bandit, bcrypt, click-completion, cryptography, docker-py, docker-pycreds, dparse, fasteners, git-url-parse, livereload, packaging, pip-tools, pylint, pynacl, python-dateutil, singledispatch, sphinx, stevedore, testinfra, websocket-client
+six==1.11.0               # via ansible-lint, astroid, bandit, bcrypt, click-completion, cryptography, docker-py, docker-pycreds, dparse, fasteners, git-url-parse, livereload, molecule, packaging, pip-tools, pylint, pynacl, python-dateutil, singledispatch, sphinx, stevedore, testinfra, websocket-client
 smmap2==2.0.3             # via gitdb2
 snowballstemmer==1.2.1    # via sphinx
 sphinx-autobuild==0.7.1
@@ -106,7 +106,7 @@ sphinxcontrib-websupport==1.0.1  # via sphinx
 stevedore==1.28.0         # via bandit
 tabulate==0.8.2           # via molecule
 template-remover==0.1.9   # via html-linter
-testinfra==1.12.0
+testinfra==1.16.0
 tornado==4.5.1            # via livereload, sphinx-autobuild
 tree-format==0.1.2        # via molecule
 typing==3.6.6             # via sphinx


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Fixes #3891 .

Upgrades Ansible to 2.6.8 for SecureDrop admin tools. There is currently an issue with Ansible 2.7 series where builders can't be run concurrently to due timeout of `get_mount_facts`. Let's update to 2.6.x since it's still fully supported (bugs and security fixes), since the window for 0.11.0 is rapidly closing.

## Testing

- [ ] CI should pass
- [ ] Install the dependencies listed in `develop-requirements.txt` to upgrade your local ansible version
- [ ] `make build-debs` completes without error (except the builder image updates)
- [ ] Clean install
- [ ] Hash for ansible version (in `admin/requirements.txt`) is correct
- [ ] `./securedrop-admin backup` and `./securedrop-admin restore` should be functional 

## Deployment

1. For SecureDrop instances, it is deployed to admin workstations via `./securedrop-admin update`
2. Dev env will need to be updated by installing the requirements in `securedrop/requirements/develop-requirements.txt`

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

