### PR TITLE
Update builder image

### DIFF
--- a/molecule/builder/image_hash
+++ b/molecule/builder/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_10_23
-3aaef57ce8d5aa06d140a28eece17f1dbc7fb42431e3f7c2bf31869c77712201
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_11_28
+8824a304e0c2e77beb3a714ee3ca791b96ae420075e299405c61b31538a8698e


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3949 .

The builder image needed security updates. Followed instructions in maintenance guide to update the build container.: https://docs.securedrop.org/en/release-0.9/development/dockerbuildmaint.html

## Testing

`make build-debs` does not return an error.

## Deployment

Dev env only

## Checklist

### If you made changes to the system configuration:

- [X] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR