### PR TITLE
[0.11.0] Update builder image

### DIFF
--- a/molecule/builder/image_hash
+++ b/molecule/builder/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_10_23
-3aaef57ce8d5aa06d140a28eece17f1dbc7fb42431e3f7c2bf31869c77712201
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_11_28
+8824a304e0c2e77beb3a714ee3ca791b96ae420075e299405c61b31538a8698e


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backports https://github.com/freedomofpress/securedrop/pull/3950 into 0.11.0 release branch.

## Testing

- [ ] https://github.com/freedomofpress/securedrop/pull/3950 is merged into develop
- [ ] Changes are identical to those in https://github.com/freedomofpress/securedrop/pull/3950

## Deployment

Dev env only

## Checklist

### If you made changes to the server application code:
- [x] Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
