### PR TITLE
Revert "Add intel-microcode package"

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -54,4 +54,4 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 # If you bump this, also remember to bump in molecule/builder/tests/vars.yml
 securedrop_pkg_grsec:
   ver: "4.4.162"
-  depends: "intel-microcode,linux-image-4.4.144-grsec,linux-firmware-image-4.4.144-grsec,linux-image-4.4.162-grsec,linux-firmware-image-4.4.162-grsec"
+  depends: "linux-image-4.4.144-grsec,linux-firmware-image-4.4.144-grsec,linux-image-4.4.162-grsec,linux-firmware-image-4.4.162-grsec"

--- a/molecule/testinfra/staging/common/test_grsecurity.py
+++ b/molecule/testinfra/staging/common/test_grsecurity.py
@@ -19,7 +19,6 @@ def test_ssh_motd_disabled(File):
 @pytest.mark.skipif(os.environ.get('FPF_GRSEC', 'true') == "false",
                     reason="Need to skip in environment w/o grsec")
 @pytest.mark.parametrize("package", [
-    'intel-microcode',
     'linux-firmware-image-{}-grsec'.format(KERNEL_VERSION),
     'linux-image-{}-grsec'.format(KERNEL_VERSION),
     'paxctl',


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3954 
Reopens #3663 

Removes intel-microcode from the list of dependencies for securedrop-grsec:
intel-microcode is in trusty-security, however, the package on which in depends, iucode-tool is in trusty-multiverse. Because cron-apt will only pull in packages from trusty-security, iucode-tool cannot be installed, therefore intel-microcode cannot be installed, and securedrop-grsec is in a broken state.

## Testing
1. Checkout 0.10.0
2. vagrant up /staging/
3. Checkout this branch
4. make build-debs
5. vagrant provision /staging/
6. observe linux-{image,firmware}-4.4.162 are installed
7. securedrop-grsec-4.4.162 is properly installed

To confirm #3954  is properly fixed, the package will need to be put on apt-test to ensure the cron-apt job installs the packages correctly (sans intel-microcode)

## Deployment

Deployed via apt packages

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR