### PR TITLE
Set reply UUID

### DIFF
--- a/docs/development/journalist_api.rst
+++ b/docs/development/journalist_api.rst
@@ -357,6 +357,9 @@ Requires authentication. Clients are expected to encrypt replies prior to
 submission to the server. Replies should be encrypted to the public key of the
 source.
 
+Including the ``uuid`` field in the request is optional. Clients may want to
+pre-set the ``uuid`` so they can track in-flight messages.
+
 .. code:: sh
 
   POST /api/v1/sources/<source_uuid>/replies
@@ -366,6 +369,7 @@ with the reply in the request body:
 .. code:: json
 
   {
+   "uuid": "0bc588dd-f613-4999-b21e-1cebbd9adc2c",
    "reply": "-----BEGIN PGP MESSAGE-----[...]-----END PGP MESSAGE-----"
   }
 
@@ -379,7 +383,8 @@ Response 201 created (application/json):
   }
 
 The returned ``uuid`` field is the UUID of the reply and can be used to
-reference this reply later.
+reference this reply later. If the client set the ``uuid`` in the request,
+this will have the same value.
 
 Replies that do not contain a GPG encrypted message will be rejected:
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3957

Allow API consumer to set the `Reply.uuid` in the request to allow clients to easily track in-flight message in their own cache/db.

## Testing

```bash
make test TESTFILES=tests/test_journalist_api.py::test_set_reply_uuid
```

Also play with the api some?

## Deployment

This is a non-breaking change to the API.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container