### PR TITLE
Removes uid-owner restriction from apt iptables rules

### DIFF
--- a/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
@@ -62,7 +62,7 @@
 -A INPUT -p udp --sport 123 --dport 123 -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "ntp"
 
 # apt rules can't be restricted by destination address because iptables will only resolve FQDNs once at startup
--A OUTPUT -p tcp --match multiport --dports 80,8080,443 -m owner --uid-owner root -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "apt updates"
+-A OUTPUT -p tcp --match multiport --dports 80,8080,443 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "apt updates"
 -A INPUT -p tcp --match multiport --sports 80,8080,443 -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "apt updates"
 
 {% if 'securedrop_application_server' in group_names %}

--- a/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
@@ -52,9 +52,9 @@
 -A OUTPUT -m owner --gid-owner ssh -j LOGNDROP -m comment --comment "Drop all other outbound traffic for ssh user"
 
 # DNS rules
--A OUTPUT -d {{ dns_server }} -p tcp --dport 53 -m owner --uid-owner root -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "tcp/udp dns"
+-A OUTPUT -d {{ dns_server }} -p tcp --dport 53 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "tcp/udp dns"
 -A INPUT -s {{ dns_server }} -p tcp --sport 53 -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "tcp/udp dns"
--A OUTPUT -d {{ dns_server }} -p udp --dport 53 -m owner --uid-owner root -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "tcp/udp dns"
+-A OUTPUT -d {{ dns_server }} -p udp --dport 53 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "tcp/udp dns"
 -A INPUT -s {{ dns_server }} -p udp --sport 53 -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "tcp/udp dns"
 
 # NTP rules

--- a/install_files/securedrop-config/DEBIAN/postinst
+++ b/install_files/securedrop-config/DEBIAN/postinst
@@ -31,6 +31,12 @@ allow_apt_user_in_iptables() {
         perl -npi -e \
             's/^.*--uid-owner root.*apt updates.*$/-A OUTPUT -p tcp --match multiport --dports 80,8080,443 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "apt updates"/' \
            "$rules_v4"
+
+        # Remove root restriction for general DNS calls. Using matching
+        # groups to preserve custom DNS settings via site-specific info.
+        perl -npi -e \
+            's/^(.*--dport 53) -m owner --uid-owner root(.*)$/$1$2/' \
+           "$rules_v4"
     fi
 }
 

--- a/install_files/securedrop-config/DEBIAN/postinst
+++ b/install_files/securedrop-config/DEBIAN/postinst
@@ -21,6 +21,19 @@ remove_2fa_tty_req() {
     service ssh restart
 }
 
+allow_apt_user_in_iptables() {
+    rules_v4="/etc/network/iptables/rules_v4"
+    # During initial install, file won't exist on disk, so skip.
+    if [ -f "$rules_v4" ]; then
+        # Find already configured apt allow line, targeting root uid, and
+        # subsitute entire line, dropping the uid targeting entirely,
+        # so both Trusty and Xenial continue to work well when invoking apt.
+        perl -npi -e \
+            's/^.*--uid-owner root.*apt updates.*$/-A OUTPUT -p tcp --match multiport --dports 80,8080,443 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "apt updates"/' \
+           "$rules_v4"
+    fi
+}
+
 case "$1" in
     configure)
 
@@ -34,11 +47,14 @@ case "$1" in
     fi
     remove_2fa_tty_req
     disable_upgrade_prompt
+
     # Remove cron-apt action should occur after security upgrades to avoid breaking
     # automatic upgrades (see issue #4003)
     if [ -f "/etc/cron-apt/action.d/1-remove" ]; then
         rm /etc/cron-apt/action.d/1-remove
     fi
+
+    allow_apt_user_in_iptables
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/molecule/testinfra/staging/app/iptables-app-staging.j2
+++ b/molecule/testinfra/staging/app/iptables-app-staging.j2
@@ -28,7 +28,7 @@
 -A OUTPUT -d {{ dns_server }}/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -d {{ dns_server }}/32 -p udp -m udp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
--A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
+-A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A OUTPUT -d {{ mon_ip }}/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
 -A OUTPUT -o eth0 -p tcp -m owner --uid-owner 0 -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
 -A OUTPUT -o lo -m comment --comment "Allow lo to lo traffic all protocols" -j ACCEPT

--- a/molecule/testinfra/staging/app/iptables-app-staging.j2
+++ b/molecule/testinfra/staging/app/iptables-app-staging.j2
@@ -25,8 +25,8 @@
 -A OUTPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -o lo -p tcp -m owner --uid-owner {{ securedrop_user_id }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "for redis worker all application user local loopback user" -j ACCEPT
 -A OUTPUT -m owner --uid-owner {{ securedrop_user_id }} -m comment --comment "Drop all other traffic by the securedrop user" -j LOGNDROP
 -A OUTPUT -m owner --gid-owner {{ ssh_group_gid }} -m comment --comment "Drop all other outbound traffic for ssh user" -j LOGNDROP
--A OUTPUT -d {{ dns_server }}/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
--A OUTPUT -d {{ dns_server }}/32 -p udp -m udp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
+-A OUTPUT -d {{ dns_server }}/32 -p tcp -m tcp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
+-A OUTPUT -d {{ dns_server }}/32 -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A OUTPUT -d {{ mon_ip }}/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT

--- a/molecule/testinfra/staging/mon/iptables-mon-staging.j2
+++ b/molecule/testinfra/staging/mon/iptables-mon-staging.j2
@@ -24,7 +24,7 @@
 -A OUTPUT -d {{ dns_server }}/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -d {{ dns_server }}/32 -p udp -m udp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
--A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
+-A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A OUTPUT -d {{ app_ip }}/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "Allow OSSEC agent to monitor" -j ACCEPT
 -A OUTPUT -d {{ dns_server }}/32 -p tcp -m tcp --dport 53 -m owner --uid-owner {{ postfix_user_id }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "postfix dns rule" -j ACCEPT
 -A OUTPUT -d {{ dns_server }}/32 -p udp -m udp --dport 53 -m owner --uid-owner {{ postfix_user_id }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "postfix dns rule" -j ACCEPT

--- a/molecule/testinfra/staging/mon/iptables-mon-staging.j2
+++ b/molecule/testinfra/staging/mon/iptables-mon-staging.j2
@@ -21,8 +21,8 @@
 -A OUTPUT -p tcp -m owner --uid-owner {{ tor_user_id }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor outbound" -j ACCEPT
 -A OUTPUT -m owner --uid-owner {{ tor_user_id }} -m comment --comment "Drop all other traffic for tor" -j LOGNDROP
 -A OUTPUT -m owner --gid-owner {{ ssh_group_gid }} -m comment --comment "Drop all other outbound traffic for ssh user" -j LOGNDROP
--A OUTPUT -d {{ dns_server }}/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
--A OUTPUT -d {{ dns_server }}/32 -p udp -m udp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
+-A OUTPUT -d {{ dns_server }}/32 -p tcp -m tcp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
+-A OUTPUT -d {{ dns_server }}/32 -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A OUTPUT -d {{ app_ip }}/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "Allow OSSEC agent to monitor" -j ACCEPT


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #3952.

Under Trusty, apt calls run as the root user. Under Xenial, however, apt
calls run as the `_apt` user. We must ensure that the firewall rules
permit apt updates on both systems, before and after the upgrade from
Trusty to Xenial. We cannot add references to `_apt` under Trusty, since
the user doesn't exist in the passwd file, causing the iptables-restore
action to fail.

Let's simply remove the uid-owner restriction on the apt-specific
iptables rule. By this point in the iptables logic, non-whitelisted traffic
from both the `debian-tor` and `www-data` users hsa been dropped (via
jump to the LOGNDROP chain). As such, it's fine to loosen the
specificity of the iptables rules somewhat, in order to ensure a smooth
transition.

## Testing

We need to cover a few different scenarios here for full coverage:

* [ ] Clean install of Trusty
* [ ] Clean install of Xenial
* [ ] Trusty -> Xenial upgrade

In all cases, the following should be true:

* [ ] Config tests pass (modulo #3916 if running locally)
* [ ] `sudo apt update` works on both hosts

Note that `sudo host apt.freedom.press` can still pass whereas `sudo apt update` would be broken, so it's important to use the apt-update command during testing. 

I haven't tested all these scenarios yet myself, but opening PR to invite more feedback and increase the changes we find something to fix early. 

## Deployment

Yes, we must make sure this change lands in prod *prior* to the Xenial upgrade, otherwise we run the risk of breaking future automatic updates.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
