### PR TITLE
Remove unused sshd config options

### DIFF
--- a/install_files/ansible-base/roles/restrict-direct-access/templates/sshd_config
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/sshd_config
@@ -18,8 +18,7 @@ IgnoreRhosts yes
 RhostsRSAAuthentication no
 HostbasedAuthentication no
 PermitEmptyPasswords no
-# This is needed for libpam-google-authenticator package for 2fa SSH access.
-ChallengeResponseAuthentication yes
+ChallengeResponseAuthentication no
 KerberosAuthentication no
 KerberosGetAFSToken no
 GSSAPIAuthentication no
@@ -29,7 +28,7 @@ PrintMotd no
 PrintLastLog yes
 TCPKeepAlive yes
 AcceptEnv LANG LC_*
-UsePAM yes
+UsePAM no
 UseDNS no
 ClientAliveInterval 300
 ClientAliveCountMax 0
@@ -39,3 +38,4 @@ MACs hmac-sha2-256,hmac-sha2-512
 GatewayPorts no
 AllowGroups ssh
 AllowTcpForwarding no
+PasswordAuthentication no

--- a/install_files/securedrop-config/DEBIAN/postinst
+++ b/install_files/securedrop-config/DEBIAN/postinst
@@ -13,6 +13,12 @@ remove_2fa_tty_req() {
     # Lets prevent this from bombing out the install though if it fails
     auth_file=/etc/pam.d/common-auth
     sed -i "/^auth\ required\ pam_google.*/d" ${auth_file} || true
+    # Since we are removing the pam_google module, we must ensure password
+    # authentication for sshd is disabled to ensure only key authentication is used.
+    grep -qF "PasswordAuthentication no" /etc/ssh/sshd_config || echo "PasswordAuthentication no" >> /etc/ssh/sshd_config
+    sed -i "/^UsePAM\ /s/\ .*/\ no/" /etc/ssh/sshd_config
+    sed -i "/^ChallengeResponseAuthentication\ /s/\ .*/\ no/" /etc/ssh/sshd_config
+    service ssh restart
 }
 
 case "$1" in

--- a/molecule/builder/image_hash
+++ b/molecule/builder/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_12_05
-2cdb8993987d35b61f5db82fad3eb40ae360c46b0a3ffd426430c03478c85ce1
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2018_12_10
+3bc258546418c88bc970823ade4fd51959fa8550894b47c0ab6cbcf745b251cb

--- a/molecule/testinfra/staging/common/test_system_hardening.py
+++ b/molecule/testinfra/staging/common/test_system_hardening.py
@@ -88,3 +88,21 @@ def test_twofactor_disabled_on_tty(host):
     pam_auth_file = host.file("/etc/pam.d/common-auth").content_string
 
     assert "auth required pam_google_authenticator.so" not in pam_auth_file
+
+
+@pytest.mark.parametrize('sshd_opts', [
+  ('UsePAM', 'no'),
+  ('ChallengeResponseAuthentication', 'no'),
+  ('PasswordAuthentication', 'no'),
+  ('PubkeyAuthentication', 'yes'),
+  ('RSAAuthentication', 'yes'),
+])
+def test_sshd_config(host, sshd_opts):
+    """
+    Let's ensure sshd does not fall back to password-based authentication
+    """
+
+    sshd_config_file = host.file("/etc/ssh/sshd_config").content_string
+
+    line = "{} {}".format(sshd_opts[0], sshd_opts[1])
+    assert line in sshd_config_file


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3979 

Disables `ChallengeResponseAuthentication`, `UsePam`, and `PasswordAuthentication` in sshd config. 
Updates the builder hash (security updates were required for passing tests).


## Testing

#### Clean install scenario
- [ ] Ensure sshd configuration is as described (see tests)
- [ ] Ensure you can log in via ssh, through either tor or local network
- [ ] Ensure ssh access via Ansible works after reboot/bouncing sshd service (e.g. `./securedrop-admin backup`)

#### Upgrade install scenario
Use upgrade testing guide https://docs.securedrop.org/en/release-0.10.0/development/upgrade_testing.html or manually perform a clean install on 0.10.0 and install debs build from this branch. Confirm the following:
- [ ] Debs install successfully
- [ ] Ensure sshd configuration is as described (see tests, perform additional visual review of `/etc/ssh/sshd_config` to ensure is is identical to the one provisioned in clean installs of this branch.
- [ ] Ensure you can log in via ssh, through either tor or local network
- [ ] Ensure ssh access via Ansible works after reboot/bouncing sshd service (e.g. `./securedrop-admin backup`)

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.

Existing production will see their sshd configuration change by way of the `securedrop-config` package postinst script as part of the next SecureDrop release.

2. New installs.

Sshd config for new installs will be provisioned at install-time via Ansible.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

