### PR TITLE
vagrantfile: Fix error in 2.1.2 and standardize on vagrant 2.1.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Workaround for URL breakage, see #2970.
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
+Vagrant.require_version ">= 2.1.2"
 
 Vagrant.configure("2") do |config|
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #3350

Changes proposed in this pull request:
- I've been removing this `Vagrant::DEFAULT_SERVER_URL.replace` line for months locally on Vagrant 2.1.2 with VirtualBox (for testing staging and prod VMs). 

- Since testers on other OSes report no issues in #3350 on Vagrant 2.1.2,
let's standardize all developers on this more recent version.

## Testing

I think this has got a lot of testing already in #3350, so I think we can safely merge this. 

## Deployment

Developer environment only

## Checklist

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR
