### PR TITLE
[0.11.0] Add 0.10.0 to 0.11.0 upgrade guide to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ anonymous sources.
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/0.10.0_to_0.11.0.rst
    upgrade/0.9.1_to_0.10.0.rst
    upgrade/0.8.0_to_0.9.1.rst
    upgrade/0.7.x_to_0.8.rst

--- a/docs/upgrade/0.10.0_to_0.11.0.rst
+++ b/docs/upgrade/0.10.0_to_0.11.0.rst
@@ -1,0 +1,92 @@
+Upgrade from 0.10.0 to 0.11.0
+=============================
+
+Updating the Tails Workstations
+-------------------------------
+
+We recommend that you update all Tails drives to version 3.11, which was released
+concurrently with SecureDrop 0.11.0 on December 11, 2018. Follow the Tails
+graphical prompts on your workstations to perform this upgrade.
+
+On a subsequent boot of your SecureDrop *Journalist* and *Admin Workstations*,
+the *SecureDrop Workstation Updater* will alert you to workstation updates.
+Choose "Update Now" on each of the workstations:
+
+.. image:: ../images/0.6.x_to_0.7/securedrop-updater.png
+
+Please note that this only updates the SecureDrop code on your Tails
+workstations. Tails upgrades must be performed separately.
+
+If you don't see a graphical updater, you may be running an older
+version of the SecureDrop code on your workstation (earlier than
+0.7.0). You can update as follows: ::
+
+    cd ~/Persistent/securedrop
+    git fetch --tags
+    gpg --recv-key "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
+    git tag -v 0.11.0
+
+The output should include the following two lines: ::
+
+    gpg:                using RSA key 22245C81E3BAEB4138B36061310F561200F4AD77
+    gpg: Good signature from "SecureDrop Release Signing Key"
+
+Please verify that each character of the fingerprint above matches what
+on the screen of your workstation. If it does, you can check out the
+new release: ::
+
+    git checkout 0.11.0
+
+.. important:: If you do see the warning "refname '0.11.0' is ambiguous" in the
+  output, we recommend that you contact us immediately at securedrop@freedom.press
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
+
+Finally, run the following commands: ::
+
+  ./securedrop-admin setup
+  ./securedrop-admin tailsconfig
+
+.. important:: 
+        If you haven't already updated your workstations when SecureDrop
+        0.9.1 was released, you'll need to update your workstations
+        manually. Due to a bug in the graphical SecureDrop updater that was
+        fixed in SecureDrop 0.9.1 (released on September 6, 2018),
+        attempting an update of your SecureDrop workstation code on your
+        *Journalist* or *Admin Workstations* using the graphical updater
+        may fail with an error message: "WARNING: Signature verification failed."
+
+        Should you encounter this message, follow the instructions in the
+        :doc:`Upgrade from 0.8.0 to 0.9.1<0.8.0_to_0.9.1>` guide.
+
+
+Troubleshooting Kernel Issues
+-----------------------------
+
+If you have previously downgraded your kernel, as part of the the upgrade
+process to SecureDrop 0.11.0, the default Linux kernel will change to the
+latest released kernel (version 4.4.162).
+
+We have tested this kernel extensively against :ref:`recommended hardware <Specific Hardware Recommendations>`
+and other common configurations. Please consult our :doc:`kernel troubleshooting guide <../kernel_troubleshooting>`
+for instructions on how to compare the differences between kernel versions and
+how to roll back to an earlier version if necessary.
+ 
+.. important::
+
+  The 3.14.x series kernel will be removed as part of the upgrade to SecureDrop
+  release 0.11.0. Your system will boot to the latest kernel by default (version
+  4.4.162). If you experience issues after the upgrade, please
+  :ref:`report kernel compatibility issues <Report Compatibility Issues>` as soon
+  as possible.
+
+Getting Support
+---------------
+
+Should you require further support with your SecureDrop installation or upgrade,
+we are happy to help!
+
+-  Community support is available at https://forum.securedrop.org
+-  The Freedom of the Press Foundation offers training and priority support
+   services. See https://securedrop.org/priority-support/ for more information.
+   If you are already a member of our support portal, please don't hesitate to
+   open a ticket there.


### PR DESCRIPTION
Resolves #3982.

A new release means new upgrade documentation. Main changes include:
    * Update references to latest Tails release
    * Mention that SD servers default to latest 4.4.162 kernel
    * Update warning re 3.14.x kernel to mention that it is now removed
      (If this is the case, the admin is instructed to contact us.)

Kept the documentation regarding updating SD Tails admin code from very
old (<0.7.0) versions since occasionally admins might have not updated
for some time. We can revisit this in a future release.

(cherry picked from commit 0a40b9a26a85ee4e0ff2cf0bd36c9fa7b5cebb8f)

## Status

Ready for review / Work in progress

## Description of Changes

Fixes  #3982.

Changes proposed in this pull request:

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
