### PR TITLE
deps: Update urllib3 to 1.23 due to CVE-2018-20060

### DIFF
--- a/admin/requirements-dev.in
+++ b/admin/requirements-dev.in
@@ -9,3 +9,5 @@ pytest
 requests
 tox
 pexpect
+# Needed for requests. Minimum version due to CVE-2018-20060
+urllib3>=1.23

--- a/admin/requirements-dev.txt
+++ b/admin/requirements-dev.txt
@@ -179,10 +179,9 @@ six==1.11.0 \
 tox==2.9.1 \
     --hash=sha256:752f5ec561c6c08c5ecb167d3b20f4f4ffc158c0ab78855701a75f5cef05f4b8 \
     --hash=sha256:8af30fd835a11f3ff8e95176ccba5a4e60779df4d96a9dfefa1a1704af263225
-urllib3==1.22 \
-    --hash=sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b \
-    --hash=sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f \
-    # via requests
+urllib3==1.23 \
+    --hash=sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf \
+    --hash=sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5
 virtualenv==15.1.0 \
     --hash=sha256:02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a \
     --hash=sha256:39d88b533b422825d644087a21e78c45cf5af0ef7a99a1fc9fbb7b481e5c85b0 \

--- a/securedrop/requirements/develop-requirements.in
+++ b/securedrop/requirements/develop-requirements.in
@@ -24,4 +24,6 @@ sphinx
 sphinx-autobuild
 sphinx_rtd_theme
 testinfra
+# Needed for requests. Minimum version due to CVE-2018-20060
+urllib3>=1.23
 yamllint

--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -110,7 +110,7 @@ testinfra==1.16.0
 tornado==4.5.1            # via livereload, sphinx-autobuild
 tree-format==0.1.2        # via molecule
 typing==3.6.6             # via sphinx
-urllib3==1.22             # via requests
+urllib3==1.23
 watchdog==0.8.3           # via sphinx-autobuild
 websocket-client==0.44.0  # via docker-py
 whichcraft==0.4.1         # via cookiecutter


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3991.

Changes proposed in this pull request:

* We pull in urllib3 in thanks to `requests` in the dev env. This
commit specifies that urllib3 should be 1.23 or later [0].

[0] https://nvd.nist.gov/vuln/detail/CVE-2018-20060

## Testing

- [ ] Verify that urllib3 1.23 is not vulnerable to CVE-2018-20060 ([changelog](https://github.com/urllib3/urllib3/blob/master/CHANGES.rst#123-2018-06-04))
- [ ] Verify that urllib3 is updated in all places it should be
- [ ] Verify that CI passes and thus all is well with this change

## Deployment

Dev only!

## Checklist

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR - test plan above, but waiting on CI 🕙 
