### PR TITLE
Avoid leaking information in GPG key creation and expiration dates

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -49,6 +49,10 @@ class CryptoUtil:
     # https://www.newyorker.com/news/news-desk/strongbox-and-aaron-swartz
     DEFAULT_KEY_CREATION_DATE = date(2013, 5, 14)
 
+    # '0' is the magic value that tells GPG's batch key generation not
+    # to set an expiration date.
+    DEFAULT_KEY_EXPIRATION_DATE = '0'
+
     def __init__(self,
                  scrypt_params,
                  scrypt_id_pepper,
@@ -178,9 +182,7 @@ class CryptoUtil:
             passphrase=secret,
             name_email=name,
             creation_date=self.DEFAULT_KEY_CREATION_DATE.isoformat(),
-            # "0" is the magic value that tells GPG's batch key generation not
-            # to set an expiration date.
-            expire_date="0"
+            expire_date=self.DEFAULT_KEY_EXPIRATION_DATE
         ))
 
     def delete_reply_keypair(self, source_filesystem_id):

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -9,6 +9,7 @@ import subprocess
 from random import SystemRandom
 
 from base64 import b32encode
+from datetime import date
 from flask import current_app
 from gnupg._util import _is_stream, _make_binary_stream
 
@@ -42,6 +43,11 @@ class CryptoUtil:
 
     GPG_KEY_TYPE = "RSA"
     DEFAULT_WORDS_IN_RANDOM_ID = 8
+
+    # All reply keypairs will be "created" on the same day SecureDrop (then
+    # Strongbox) was publicly released for the first time.
+    # https://www.newyorker.com/news/news-desk/strongbox-and-aaron-swartz
+    DEFAULT_KEY_CREATION_DATE = date(2013, 5, 14)
 
     def __init__(self,
                  scrypt_params,
@@ -170,7 +176,11 @@ class CryptoUtil:
             key_type=self.GPG_KEY_TYPE,
             key_length=self.__gpg_key_length,
             passphrase=secret,
-            name_email=name
+            name_email=name,
+            creation_date=self.DEFAULT_KEY_CREATION_DATE.isoformat(),
+            # "0" is the magic value that tells GPG's batch key generation not
+            # to set an expiration date.
+            expire_date="0"
         ))
 
     def delete_reply_keypair(self, source_filesystem_id):

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -230,7 +230,6 @@ def parse_gpg_date_string(date_string):
 
 
 def test_reply_keypair_creation_and_expiration_dates(source_app):
-    # TODO: setup copied from test_genkeypair. DRY?
     with source_app.app_context():
         codename = source_app.crypto_util.genrandomid()
         filesystem_id = source_app.crypto_util.hash_codename(codename)

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -208,6 +208,7 @@ def test_genkeypair(source_app):
 
         assert source_app.crypto_util.getkey(filesystem_id) is not None
 
+
 def parse_gpg_date_string(date_string):
     """Parse a date string returned from `gpg --with-colons --list-keys` into a
     datetime.
@@ -227,7 +228,8 @@ def parse_gpg_date_string(date_string):
         dt = datetime.utcfromtimestamp(int(date_string))
     return dt
 
-def test_genkeypair_should_use_obfuscated_creation_and_expiration_dates(source_app):
+
+def test_reply_keypair_creation_and_expiration_dates(source_app):
     # TODO: setup copied from test_genkeypair. DRY?
     with source_app.app_context():
         codename = source_app.crypto_util.genrandomid()
@@ -259,6 +261,7 @@ def test_genkeypair_should_use_obfuscated_creation_and_expiration_dates(source_a
         # Reply keypairs should not expire
         expire_date = new_key['expires']
         assert expire_date == ''
+
 
 def test_delete_reply_keypair(source_app, test_source):
     fid = test_source['filesystem_id']


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3912.

Changes proposed in this pull request:
1. Use a fixed date for the creation time of each source's GPG reply key, to avoid leaking the approximate date at which they first created a SecureDrop account, per discussion in https://github.com/freedomofpress/securedrop/issues/3912#issuecomment-447719726.
2. Reply keypairs should not expire, per discussion in https://github.com/freedomofpress/securedrop/issues/3912#issuecomment-447716901

## Testing

I added a unit test, `tests/test_crypto_util.py::test_genkeypair_should_use_obfuscated_creation_and_expiration_dates`. 

I confirmed the test fails on develop and passes with the changes made in this PR.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
Filed #3995 to address this issue.

2. New installs.
No special considerations that I can think of. I don't know of any places where we use the creation/expiration dates of the reply keys in SecureDrop, so I think this should be a fairly low-risk change.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

I was unable to run `make ci-lint` on macOS, got an error:
```
devops/scripts/dev-shell-ci run make --keep-going lint typelint
devops/scripts/dev-shell-ci: line 23: sha256sum: command not found
make: *** [ci-lint] Error 127
```
File #3996 to address this issue.