### PR TITLE
Fix make ci-lint on macOS

### DIFF
--- a/devops/scripts/dev-shell-ci
+++ b/devops/scripts/dev-shell-ci
@@ -14,20 +14,27 @@ CHECKSUM_FILE=./.linting.checksum
 
 cd "${TOPLEVEL}"
 
+# sha256sum is not included with macOS, but we can achieve the same result by
+# aliasing it to shasum, which is included by default.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sha256sum="shasum -a 256"
+else
+    sha256sum="sha256sum"
+fi
 
 function gen_checksums() {
     rm "$CHECKSUM_FILE" 2> /dev/null || true
 
         # shellcheck disable=SC2013
     for file in $(cat $DOCKERFILE.deps); do
-        sha256sum "$file" >> "$CHECKSUM_FILE"
+        $sha256sum "$file" >> "$CHECKSUM_FILE"
     done
 
-    sha256sum "$DOCKERFILE" >> "$CHECKSUM_FILE"
+    $sha256sum "$DOCKERFILE" >> "$CHECKSUM_FILE"
 }
 
 function check_checksum {
-    sha256sum .linting.checksum | awk '{ print $1 }'
+    $sha256sum .linting.checksum | awk '{ print $1 }'
 }
 
 function docker_run() {


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3996.

Changes proposed in this pull request:
1. The ci-lint script chooses which tool to compute SHA256 sums depending on what the underlying platform provides by default. This allows it to work on more platforms, such as macOS. Using tools that are provided by default (rather than, for example, requiring macOS users to install `sha256sum`) minimizes the complexity of setting up the development environment.

## Testing

Run `make ci-lint` on macOS and Linux. It should work on both platforms.

## Deployment

Any special considerations for deployment?

No, because this is part of the developer workflow and is not exposed to end users.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
