### PR TITLE
Update kernels to 4.4.167 and remove wireless support

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -53,5 +53,5 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder/tests/vars.yml
 securedrop_pkg_grsec:
-  ver: "4.4.162"
-  depends: "linux-image-4.4.144-grsec,linux-firmware-image-4.4.144-grsec,linux-image-4.4.162-grsec,linux-firmware-image-4.4.162-grsec"
+  ver: "4.4.167"
+  depends: "linux-image-4.4.162-grsec,linux-firmware-image-4.4.162-grsec,linux-image-4.4.167-grsec,linux-firmware-image-4.4.167-grsec"

--- a/molecule/builder/tests/vars.yml
+++ b/molecule/builder/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "0.12.0~rc1"
 ossec_version: "3.0.0"
 keyring_version: "0.1.2"
 config_version: "0.1.1"
-grsec_version: "4.4.162"
+grsec_version: "4.4.167"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/staging/common/test_grsecurity.py
+++ b/molecule/testinfra/staging/common/test_grsecurity.py
@@ -170,3 +170,26 @@ def test_pax_flags(Command, File, binary):
     # the "p" and "m" flags.
     assert "PAGEEXEC is disabled" not in c.stdout
     assert "MPROTECT is disabled" not in c.stdout
+
+
+@pytest.mark.parametrize('kernel_opts', [
+  'WLAN',
+  'NFC',
+  'WIMAX',
+  'WIRELESS',
+  'HAMRADIO',
+  'IRDA',
+  'BT',
+])
+def test_wireless_disabled_in_kernel_config(host, kernel_opts):
+    """
+    Kernel modules for wireless are blacklisted, but we go one step further and
+    remove wireless support from the kernel. Let's make sure wireless is
+    disabled in the running kernel config!
+    """
+
+    kernel_config_path = "/boot/config-{}-grsec".format(KERNEL_VERSION)
+    kernel_config = host.file(kernel_config_path).content_string
+
+    line = "# CONFIG_{} is not set".format(kernel_opts)
+    assert line in kernel_config

--- a/molecule/testinfra/staging/vars/staging.yml
+++ b/molecule/testinfra/staging/vars/staging.yml
@@ -169,4 +169,4 @@ log_events_with_ossec_alerts:
     rule_id: "400503"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
-grsec_version: "4.4.162"
+grsec_version: "4.4.167"


### PR DESCRIPTION
## Status

Ready for review

:exclamation: Before merge, please review the following PR (contains the config of the 4.4.167 SecureDrop kernel):

- [x] Review https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/42 and ensure the configuration is valid 
- [x] Upload to apt-test.freedom.press (DONE )

## Description of Changes

Fixes #2726 .

Removes wireless support from the kernel, bumps version to 4.4.167. Adds tests to ensure the configuration is properly applied.

## Testing

0. Review kernel configuration in https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/42
1. Provision staging and run infra tests, and observe no failures:
```
    ======== 446 passed, 13 skipped, 8 xfailed, 2 xpassed in 135.22 seconds ========
```
2. Syslog should not contain any error messages
3. If testing on hardware, please report findings on this ticket (I have tested on NUC 5PYH and the Kernel works as expected).
4. Ensure test coverage for configuration is adequate
## Deployment

New and existing installs will be handled by the deb packages hosted on the apt server.

## Checklist

- [X] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR
