### PR TITLE
bump max line length from 79 to 100

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+max-line-length = 100
 exclude =
     config.py,
     .venv/,

--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -9,7 +9,8 @@ lint: ## Run the python linter with the project's default error settings
 	   --disable=no-name-in-module \
 	   --disable=unexpected-keyword-arg \
 	   --disable=too-many-function-args \
-	   --disable=import-error
+	   --disable=import-error \
+	   --max-line-length=100
 
 .PHONY: lint-full
 lint-full:  ## Run the python linter with nothing disabled


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4006 

Changes `flake8` and `pylint` to set the max line length to 100 characters.

## Testing

Make a line with 100 characters and verify that the lints don't fail.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container