### PR TITLE
Add an example with TLS 1.3 support in nginx

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -227,6 +227,7 @@ Here's a similar example for nginx:
 
 Here's a similar example for nginx if the system supports TLS 1.3:
 ::
+
     add_header Strict-Transport-Security max-age=16070400;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;

--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -226,6 +226,7 @@ Here's a similar example for nginx:
     ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
 
 Here's a similar example for nginx if the system supports TLS 1.3:
+
 ::
 
     add_header Strict-Transport-Security max-age=16070400;

--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -228,7 +228,7 @@ Here's a similar example for nginx:
 Here's a similar example for nginx if the system supports TLS 1.3:
 ::
     add_header Strict-Transport-Security max-age=16070400;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+    ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;
     ssl_ciphers "TLS-CHACHA20-POLY1305-SHA256:TLS-AES-256-GCM-SHA384:TLS-AES-128-GCM-SHA256:EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
 

--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -225,6 +225,13 @@ Here's a similar example for nginx:
     ssl_prefer_server_ciphers on;
     ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
 
+Here's a similar example for nginx if the system supports TLS 1.3:
+::
+    add_header Strict-Transport-Security max-age=16070400;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers "TLS-CHACHA20-POLY1305-SHA256:TLS-AES-256-GCM-SHA384:TLS-AES-128-GCM-SHA256:EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+
 .. note:: We have prioritized security in selecting these cipher suites, so if
           you choose to use them then your site might not be compatible with
           legacy or outdated browsers and operating systems. For a good


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Add an example of using TLS 1.3 with nginx. TLS 1.3 in nginx has been supported since pril 2017. TLS 1.3 brings an "encrypted handshake" which is better than what is currently being done in previous versions of TLS.

Fixes #.

Changes proposed in this pull request:

Add an example with TLS 1.3 support in nginx
## Testing

How should the reviewer test this PR?
Setup a server with nginx enabled with tls 1.3 and proper OpenSSL (1.1.1).

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
Will require proper OpenSSL & nginx buid.

2. New installs.
Will require proper OpenSSL & nginx buid.


