### PR TITLE
avoid accidentally exporting all pub keys

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -205,7 +205,10 @@ class CryptoUtil:
 
     def export_pubkey(self, name):
         fingerprint = self.getkey(name)
-        return self.gpg.export_keys(fingerprint)
+        if fingerprint:
+            return self.gpg.export_keys(fingerprint)
+        else:
+            return None
 
     def encrypt(self, plaintext, fingerprints, output=None):
         # Verify the output path

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -278,3 +278,19 @@ def test_delete_reply_keypair_no_key(source_app):
 def test_getkey(source_app, test_source):
     assert (source_app.crypto_util.getkey(test_source['filesystem_id'])
             is not None)
+
+    # check that a non-existent key returns None
+    assert source_app.crypto_util.getkey('x' * 50) is None
+
+
+def test_export_pubkey(source_app, test_source):
+    begin_pgp = '-----BEGIN PGP PUBLIC KEY BLOCK----'
+
+    # check that a filesystem_id exports the pubkey
+    exported = source_app.crypto_util.export_pubkey(
+        test_source['filesystem_id'])
+    assert exported.startswith(begin_pgp)
+
+    # check that a non-existent identifer exports None
+    exported = source_app.crypto_util.export_pubkey('x' * 50)
+    assert exported is None


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4005

Avoids exporting all keys when a fingerprint is `None`.

## Testing

```
make test
```

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container