### PR TITLE
added cron-apt logs to those pulled by admin command

### DIFF
--- a/install_files/ansible-base/securedrop-logs.yml
+++ b/install_files/ansible-base/securedrop-logs.yml
@@ -8,9 +8,11 @@
     log_paths_reference:
       app:
         - '/var/log/apt' # dir
+        - '/var/log/cron-apt' # dir
         - '/var/log/aptitude*'
       mon:
         - '/var/log/apt' # dir
+        - '/var/log/cron-apt' # dir
         - '/var/log/aptitude*'
         # syscheck contains the file integrity checking data store
         - '/var/ossec/queue/syscheck'


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4000 
The SecureDrop Application and Monitor Servers use `cron-apt` for scheduled daily updates, after the initial install via `apt`. This PR adds the logs under `var/log/cron-apt` to those captured by the `securedrop-admin logs` command, to make it easier to troubleshoot update errors.

## Testing

On an existing instance's Admin Workstation Tails USB:
1. checkout this branch in the `~/Persistent/securedrop` directory
1. set up the admin virtualenv and run the `logs` command:
```
./securedrop-admin setup
./securedrop-admin logs
```
1. Verify that the log tarballs for the app and mon server contain the `/var/log/cron-apt` directory and logs from both servers.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container
