### PR TITLE
Update code ownership responsibilities

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,18 @@
 # application code
-/securedrop/ @redshiftzero @heartsucker @dachary
+/securedrop/ @redshiftzero @heartsucker @kushaldas
+
+# updater GUI
+/journalist_gui/ @redshiftzero @kushaldas
+
+# admin CLI
+/admin/ @redshiftzero @kushaldas @emkll @heartsucker @msheiny
+
+# docs
+/docs/ @redshiftzero @kushaldas @emkll
 
 # ansible / deployment
-/build/         @conorsch @msheiny
-/devops/        @conorsch @msheiny
-/install_files/ @conorsch @msheiny
-/molecule/      @conorsch @msheiny
-/testinfra/     @conorsch @msheiny
-/tails_files/   @conorsch @msheiny
+/devops/        @conorsch @msheiny @kushaldas @emkll
+/install_files/ @conorsch @msheiny @kushaldas @emkll
+/molecule/      @conorsch @msheiny @kushaldas @emkll
+/testinfra/     @conorsch @msheiny @kushaldas @emkll
+/tails_files/   @conorsch @msheiny @kushaldas @emkll


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR updates the code ownership responsibilities since @emkll and @kushaldas became SecureDrop maintainers

## Testing

Are you happy with the code ownership here? Let me know if you would prefer not to be listed for a particular directory

Note: code owners must have write access to the repo, so for `/docs/` we should feel free to request review from others without write access as needed

## Deployment

None, dev only

## Checklist

N/A