### PR TITLE
added default value for remote_host_ref var in Qubes Molecule scenario

### DIFF
--- a/molecule/qubes-staging/qubes-vars.yml
+++ b/molecule/qubes-staging/qubes-vars.yml
@@ -18,6 +18,7 @@ remote_host_ref: >-
   {{ lookup('file', lookup('env', 'MOLECULE_INSTANCE_CONFIG'))
      | from_yaml
      | selectattr('instance', 'eq', ansible_host)
-     |map(attribute='address')
-     |first
+     | map(attribute='address')
+     | first
+     | default (ansible_host)
   }}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4019 

Update qubes-staging scenario's extra vars, to set a default value of `ansible_host` for `remote_host_ref`

## Testing
- set up Qubes SD staging environment as described here: https://docs.securedrop.org/en/release-0.11.0/development/qubes_staging.html - but do not run the `molecule test -s qubes-staging` step!
- instead, check out this branch and run `make staging`
