### PR TITLE
Remove common-auth pam customizations

### DIFF
--- a/install_files/ansible-base/roles/restrict-direct-access/files/common-auth
+++ b/install_files/ansible-base/roles/restrict-direct-access/files/common-auth
@@ -1,4 +1,26 @@
-auth    [success=1 default=ignore]      pam_unix.so nullok_secure
-auth    requisite                       pam_deny.so
-auth    required                        pam_permit.so
-auth    optional                        pam_ecryptfs.so unwrap
+#
+# /etc/pam.d/common-auth - authentication settings common to all services
+#
+# This file is included from other service-specific PAM config files,
+# and should contain a list of the authentication modules that define
+# the central authentication scheme for use on the system
+# (e.g., /etc/shadow, LDAP, Kerberos, etc.).  The default is to use the
+# traditional Unix authentication mechanisms.
+#
+# As of pam 1.0.1-6, this file is managed by pam-auth-update by default.
+# To take advantage of this, it is recommended that you configure any
+# local modules either before or after the default block, and use
+# pam-auth-update to manage selection of other modules.  See
+# pam-auth-update(8) for details.
+
+# here are the per-package modules (the "Primary" block)
+auth	[success=1 default=ignore]	pam_unix.so nullok_secure
+# here's the fallback if no module succeeds
+auth	requisite			pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth	required			pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+auth	optional			pam_cap.so
+# end of pam-auth-update config


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes
PAM customizations were necessary to allow 2FA for console logins. Since, these configurations are no longer necessary due to the phasing out of 2FA for console logins and `/var/log/auth.log` in trusty and `syslog` in xenial, (encryptfs.so), let's replace the FPF-configuredpam.d/common-auth file with the upstream-maintained common-auth.

Closes #3963 for new installs or installs on which `./securedrop-admin install` is run. 

## Testing
- [ ]  Ensure `/etc/pam.d/common-auth` provided by this PR is consistent with the upstream version(s) in Ubuntu 14.04 and 16.04.

#### Clean install
- [ ] Provision a Trusty staging environment (e.g. `molecule converge -s libvirt-staging`) and ensure SSH access is preserved on app and mon servers.
- [ ] Provision a Xenial staging environment (e.g. `molecule converge -s libvirt-staging-xenial`) and ensure SSH access is preserved on app and mon servers.
- [ ] Error message `/lib/security/pam_encryptfs.so: cannot open shared object file: No such file or directory` does not appear in `/var/log/auth.log` (Trusty) or `journalctl -e` (Xenial) does not contain after running the playbooks.

#### Upgrade testing
- `git checkout develop`
- Provision a Prod environment on `develop` (using`./securedrop-admin install`)
- Check out this branch and re-run `./securedrop-admin install`
- [ ] Ensure ssh access is preserved on app and mon servers.
- [ ] Error message `/lib/security/pam_encryptfs.so: cannot open shared object file: No such file or directory` does not appear in `/var/log/auth.log` (Trusty) or `journalctl -e` (Xenial) does not contain after running the playbooks.

## Deployment

Since there is no negative impact on running instances (Trusty or Xenial) other than errors in the logs, let's minimize the risk to automatically patch the file on running instances via postinst, and instead only ship this change via Ansible:

1. Existing production installs will be updated via Ansible
2. New installs via Ansible.

## Checklist

### If you made changes to the system configuration:

- [X] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR
