### PR TITLE
Allow DELETE HTTP method for journalist interface

### DIFF
--- a/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
@@ -36,13 +36,6 @@ Header unset Etag
 # Limit the max submitted size of requests.
 LimitRequestBody 524288000
 
-#Redirect error pages to ensure headers are sent
-ErrorDocument 400 /notfound
-ErrorDocument 401 /notfound
-ErrorDocument 403 /notfound
-ErrorDocument 404 /notfound
-ErrorDocument 500 /error
-
 <Directory />
   Options None
   AllowOverride None

--- a/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
@@ -53,11 +53,11 @@ ErrorDocument 500 /error
 <Directory /var/www/>
   Options {{ apache_dir_options | default('None') }}
   AllowOverride None
-  <Limit GET POST HEAD>
+  <Limit GET POST HEAD DELETE>
     Order allow,deny
     allow from {{ securedrop_app_apache_allow_from }}
   </Limit>
-  <LimitExcept GET POST HEAD>
+  <LimitExcept GET POST HEAD DELETE>
     Order deny,allow
     Deny from all
   </LimitExcept>
@@ -66,11 +66,11 @@ ErrorDocument 500 /error
 <Directory /var/www/securedrop>
   Options {{ apache_dir_options | default('None') }}
   AllowOverride None
-  <Limit GET POST HEAD>
+  <Limit GET POST HEAD DELETE>
     Order allow,deny
     allow from {{ securedrop_app_apache_allow_from }}
   </Limit>
-  <LimitExcept GET POST HEAD>
+  <LimitExcept GET POST HEAD DELETE>
     Order deny,allow
     Deny from all
   </LimitExcept>

--- a/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
@@ -31,7 +31,6 @@ Header set X-Content-Type-Options: nosniff
 Header set X-Download-Options: noopen
 Header set X-Content-Security-Policy: "default-src 'self'"
 Header set Content-Security-Policy: "default-src 'self'"
-Header unset Etag
 
 # Limit the max submitted size of requests.
 LimitRequestBody 524288000

--- a/molecule/testinfra/staging/app/apache/test_apache_journalist_interface.py
+++ b/molecule/testinfra/staging/app/apache/test_apache_journalist_interface.py
@@ -16,7 +16,6 @@ wanted_apache_headers = [
   "Header set X-Content-Security-Policy: \"default-src 'self'\"",
   "Header set Content-Security-Policy: \"default-src 'self'\"",
   'Header set Referrer-Policy "no-referrer"',
-  'Header unset Etag',
 ]
 
 

--- a/molecule/testinfra/staging/app/apache/test_apache_journalist_interface.py
+++ b/molecule/testinfra/staging/app/apache/test_apache_journalist_interface.py
@@ -51,11 +51,11 @@ common_apache2_directory_declarations = """
 <Directory /var/www/>
   Options None
   AllowOverride None
-  <Limit GET POST HEAD>
+  <Limit GET POST HEAD DELETE>
     Order allow,deny
     allow from {apache_allow_from}
   </Limit>
-  <LimitExcept GET POST HEAD>
+  <LimitExcept GET POST HEAD DELETE>
     Order deny,allow
     Deny from all
   </LimitExcept>
@@ -64,11 +64,11 @@ common_apache2_directory_declarations = """
 <Directory {securedrop_code}>
   Options None
   AllowOverride None
-  <Limit GET POST HEAD>
+  <Limit GET POST HEAD DELETE>
     Order allow,deny
     allow from {apache_allow_from}
   </Limit>
-  <LimitExcept GET POST HEAD>
+  <LimitExcept GET POST HEAD DELETE>
     Order deny,allow
     Deny from all
   </LimitExcept>

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -309,7 +309,7 @@ def make_blueprint(config):
         user = get_user_object(request)
         return jsonify(user.to_json()), 200
 
-    def _handle_http_exception(error):
+    def _handle_api_http_exception(error):
         # Workaround for no blueprint-level 404/5 error handlers, see:
         # https://github.com/pallets/flask/issues/503#issuecomment-71383286
         response = jsonify({'error': error.name,
@@ -318,6 +318,6 @@ def make_blueprint(config):
         return response, error.code
 
     for code in default_exceptions:
-        api.errorhandler(code)(_handle_http_exception)
+        api.errorhandler(code)(_handle_api_http_exception)
 
     return api

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -2024,3 +2024,9 @@ def test_does_set_cookie_headers(journalist_app, test_journo):
         observed_headers = response.headers
         assert 'Set-Cookie' in observed_headers.keys()
         assert 'Cookie' in observed_headers['Vary']
+
+
+def test_app_error_handlers_defined(journalist_app):
+    for status_code in [400, 401, 403, 404, 500]:
+        # This will raise KeyError if an app-wide error handler is not defined
+        assert journalist_app.error_handler_spec[None][status_code]

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -244,7 +244,16 @@ def test_user_without_token_cannot_post_protected_endpoints(journalist_app,
             assert response.status_code == 403
 
 
-def test_api_404(journalist_app, journalist_api_token):
+def test_api_error_handlers_defined(journalist_app):
+    """Ensure the expected error handler is defined in the API blueprint"""
+    for status_code in [400, 401, 403, 404, 500]:
+        result = journalist_app.error_handler_spec['api'][status_code]
+
+        expected_error_handler = '_handle_api_http_exception'
+        assert result.values()[0].__name__ == expected_error_handler
+
+
+def test_api_error_handler_404(journalist_app, journalist_api_token):
     with journalist_app.test_client() as app:
         response = app.get('/api/v1/invalidendpoint',
                            headers=get_api_headers(journalist_api_token))


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Fixes #3977 , #3877 

Certain Journalist API operations require DELETE (e.g. delete or unstar a source). This will ensure that Apache allows the DELETE operation for new installs (or existing installs after an Ansible run).

Furthermore, this will disable Apache stripping Etag headers on the journalist interface in order to receive Etag information from the API (containing sha256 sum of file for integrity). Currently all Etag headers should be `sha256sum:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` due to a bug tracked in #4032 .

From the test plan below, it is very clear that we need some integration tests in order to validate these configurations (tracked #4030)
## Testing

#### Clean install scenario
- Check out this branch
- ./securedrop-admin install
- [ ] install completed without error
- [ ] `/etc/apache2/sites-enabled/journalist.conf` contains expected changes (or run testinfra suite)
- Create admin user for the app
- Navigate to the source interface and submit a document/message
- Attempt to delete source via API (see below for example commands)
- [ ] The deletion was successful, DELETE method was allowed by Apache.
#### Upgrade scenario

- Install SecureDrop 0.12.1
- Check out this branch
- ./securedrop-admin install
- [ ] install completed without error
- [ ] `/etc/apache2/sites-enabled/journalist.conf` contains expected changes (or run testinfra suite)
- Create admin user for the app
- Navigate to the source interface and submit a document/message
- Attempt to delete source via API

#### Example test commands for api (curl)
0. Ensure aths token is in torrc
1.  Get auth token:
```
torify curl -X POST \
  http://$JOURNALIST_INTERFACE.onion/api/v1/token \
  -H 'Content-Type: application/json' \
  -d '{
    "username": "$USERNAME", 
    "passphrase": "$PASSPHRASE", 
    "one_time_code": "$TOTP"
}'
```
2. Use the above token to get list of sources (to obtain `source_uuid`):
```
torify curl -X GET \
  http://$JOURNALIST_INTERFACE.onion/api/v1/sources \
  -H 'Authorization: Bearer $YOUR_TOKEN_GOES_HERE' \
  -H 'Content-Type: application/json' 
```
3. Get the source based on `source_uuid` obtained above:
```
torify curl -X GET \
  http://$JOURNALIST_INTERFACE.onion/api/v1/sources/$SOURCE_UUID \
  -H 'Authorization: Bearer $YOUR_TOKEN_GOES_HERE' \
  -H 'Content-Type: application/json' 
```
4. Get the download URL of a file from the`source_uuid` :
```
torify curl -O \
  http://$JOURNALIST_INTERFACE.onion/api/v1/sources/$SOURCE_UUID/submissions/$SUBMISSION_UUID/download \
  -H 'Authorization: Bearer $YOUR_TOKEN_GOES_HERE' \
  -H 'Content-Type: application/json' 
```
5. Get the headers/Etag value :
```
torify curl -I \
  http://$JOURNALIST_INTERFACE.onion/api/v1/sources/$SOURCE_UUID/submissions/$SUBMISSION_UUID/download \
  -H 'Authorization: Bearer $YOUR_TOKEN_GOES_HERE' \
  -H 'Content-Type: application/json' 
```
Should return the expected Etag value in the headers:
```
HTTP/1.1 200 OK
Date: Mon, 14 Jan 2019 19:22:02 GMT
Server: Apache
Content-Disposition: attachment; filename=1-better_wrap-msg.gpg
Cache-Control: public, max-age=43200
Expires: Tue, 15 Jan 2019 07:22:02 GMT
X-Frame-Options: DENY
Etag: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
Cache-Control: no-store
Referrer-Policy: no-referrer
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Content-Security-Policy: default-src 'self'
Content-Security-Policy: default-src 'self'
Last-Modified: Mon, 14 Jan 2019 18:54:00 GMT
Content-Length: 592
Content-Type: application/pgp-encrypted
```
6. Delete the source:
```
curl -X DELETE \
  http://$JOURNALIST_INTERFACE.onion/api/v1/sources/$SOURCE_UUID \
  -H 'Authorization: Bearer $YOUR_TOKEN_GOES_HERE' \
  -H 'Content-Type: application/json' 
```
7. Ensure the source is deleted:
```
curl -X GET \
  http://$JOURNALIST_INTERFACE.onion/api/v1/sources \
  -H 'Authorization: Bearer $YOUR_TOKEN_GOES_HERE' \
  -H 'Content-Type: application/json' 
```
## Deployment
Due to the risks associated with modifying the Apache configuration and due to this change being opt-in for users of the SecureDrop Workstation, this change will initially require an Ansible run to be applied.

1. New installs: Via Ansible / securedrop-admin install
2. Existing installs/upgrades: Via Ansible / securedrop-admin install
## Checklist


### If you made changes to the system configuration:

- [X] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR
