### PR TITLE
CI: Add back static analysis and checking Python dependencies for CVEs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,19 @@ jobs:
             cd journalist_gui
             xvfb-run -a pipenv run python3 test_gui.py
 
+  static-analysis-and-no-known-cves:
+    machine:
+      enabled: true
+    steps:
+      - checkout
+      - run:
+          name: Check Python dependencies for CVEs
+          command: make safety
+
+      - run:
+          name: Run static security testing on source code
+          command: make bandit
+
   staging-test-with-rebase:
     machine:
       enabled: true
@@ -149,6 +162,7 @@ workflows:
       - tests
       - admin-tests
       - updater-gui-tests
+      - static-analysis-and-no-known-cves
       - staging-test-with-rebase:
           requires:
             - lint


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4033

Changes proposed in this pull request:
 - Returns static analysis and checking for CVEs in Python dependencies to CI (now in a separate Circle job)

## Testing

CI job `static-analysis-and-no-known-cves` should run and be green 💚 

## Deployment

CI only

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
