### PR TITLE
Fixes #4038 python-gnupg works with gpg binary

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -5,6 +5,7 @@ import gnupg
 import os
 import io
 import scrypt
+import platform
 import subprocess
 from random import SystemRandom
 
@@ -79,7 +80,11 @@ class CryptoUtil:
 
         self.do_runtime_tests()
 
-        self.gpg = gnupg.GPG(binary='gpg2', homedir=gpg_key_dir)
+        os_details = platform.linux_distribution()
+        if os_details[1] == "16.04":
+            self.gpg = gnupg.GPG(binary='gpg', homedir=gpg_key_dir)
+        else:
+            self.gpg = gnupg.GPG(binary='gpg2', homedir=gpg_key_dir)
 
         # map code for a given language to a localized wordlist
         self.__language2words = {}  # type: Dict[Text, List[str]]


### PR DESCRIPTION
## Status

DO NOT MERGE

## Description of Changes

Fixes #4038 

For the python-gnupg to work properly on Xenial, we should
call `gpg` binary instead of `gpg2` (which we use in Trusty).

## Testing

To view the effected 2fa tests: `$ BASE_OS=xenial securedrop/bin/dev-shell bin/run-test -v tests/test_2fa.py`

`make test-xenial`

## Deployment

We will have to verify in the upgrade story.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
