### PR TITLE
Fixes #4036 Updates setuptools for ci

### DIFF
--- a/securedrop/dockerfiles/xenial/Dockerfile
+++ b/securedrop/dockerfiles/xenial/Dockerfile
@@ -24,6 +24,9 @@ COPY requirements requirements
 RUN pip install -r requirements/securedrop-app-code-requirements.txt && \
     pip install -r requirements/test-requirements.txt
 
+# Fixes #4036 pybabel requires latest version of setuptools
+RUN pip install --upgrade setuptools
+
 RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi
 
 STOPSIGNAL SIGKILL


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

Fixes #4036 

With the upgraded setuptools package, the errors
in the issue gets fixed.

## Testing

To see only the effected tests: `$ BASE_OS=xenial securedrop/bin/dev-shell bin/run-test -v tests/test_i18n_tool.py tests/test_i18n.py`

`make test-xenial`

## Deployment

None yet.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
