### PR TITLE
Fixes #4036 #4037 #4038 Fixes gnupg and setuptools related errors

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -5,6 +5,7 @@ import gnupg
 import os
 import io
 import scrypt
+import platform
 import subprocess
 from random import SystemRandom
 
@@ -79,7 +80,11 @@ class CryptoUtil:
 
         self.do_runtime_tests()
 
-        self.gpg = gnupg.GPG(binary='gpg2', homedir=gpg_key_dir)
+        os_details = platform.linux_distribution()
+        if os_details[1] == "16.04":
+            self.gpg = gnupg.GPG(binary='gpg', homedir=gpg_key_dir)
+        else:
+            self.gpg = gnupg.GPG(binary='gpg2', homedir=gpg_key_dir)
 
         # map code for a given language to a localized wordlist
         self.__language2words = {}  # type: Dict[Text, List[str]]

--- a/securedrop/dockerfiles/xenial/Dockerfile
+++ b/securedrop/dockerfiles/xenial/Dockerfile
@@ -24,6 +24,8 @@ COPY requirements requirements
 RUN pip install -r requirements/securedrop-app-code-requirements.txt && \
     pip install -r requirements/test-requirements.txt
 
+RUN pip install --upgrade setuptools
+
 RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi
 
 STOPSIGNAL SIGKILL


### PR DESCRIPTION
## Status

DO NOT MERGE

## Description of Changes

Fixes #4036 #4037 #4038 

With the upgraded setuptools package, the errors
in first two issues get fixed, 

For the python-gnupg to work properly on Xenial, we should
call `gpg` binary instead of `gpg2` (which we use in Trusty).

## Testing

Minimal testing `BASE_OS=xenial securedrop/bin/dev-shell bin/run-test -v tests/test_i18n_tool.py tests/test_i18n.py tests/test_integration.py tests/test_2fa.py`

and `make test-xenial`.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.

We have to verify that everything works fine.

2. New installs.

No changes here.
## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
