### PR TITLE
[xenial] resolve gpg IMPORT_OK status code test failures

### DIFF
--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -77,7 +77,7 @@ def config(tmpdir):
     tmp = data.mkdir('tmp')
     sqlite = data.join('db.sqlite')
 
-    gpg = gnupg.GPG(homedir=str(keys))
+    gpg = gnupg.GPG('gpg2', homedir=str(keys))
     for ext in ['sec', 'pub']:
         with io.open(path.join(path.dirname(__file__),
                                'files',

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -411,7 +411,7 @@ def _can_decrypt_with_key(journalist_app, msg, key_fpr, passphrase=None):
     # to use it to test whether a message is decryptable with a specific
     # key.
     gpg_tmp_dir = tempfile.mkdtemp()
-    gpg = gnupg.GPG(homedir=gpg_tmp_dir)
+    gpg = gnupg.GPG('gpg2', homedir=gpg_tmp_dir)
 
     # Export the key of interest from the application's keyring
     pubkey = journalist_app.crypto_util.gpg.export_keys(key_fpr)

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -37,7 +37,7 @@ def init_gpg():
     """Initialize the GPG keyring and import the journalist key for
     testing.
     """
-    gpg = gnupg.GPG(homedir=config.GPG_KEY_DIR)
+    gpg = gnupg.GPG('gpg2', homedir=config.GPG_KEY_DIR)
     # Faster to import a pre-generated key than to gen a new one every time.
     for keyfile in (join(FILES_DIR, "test_journalist_key.pub"),
                     join(FILES_DIR, "test_journalist_key.sec")):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4038

After investigation, not specifying the gpg binary to be `gpg2` in test setup code was the source of the `IMPORT_OK` related test failures. This caused the divergence between test and dev/staging/prod, where we use `gpg2`. 

## Testing

There should be no `IMPORT_OK` related test failures in the xenial app test CI job. 

The test noted in the #4038 ticket (`tests/test_integration.py::test_submit_message`) should pass.

The only gpg-related failures in the test output (look at the integration tests) of the xenial job should be due to #4013 (`PINENTRY`)

## Deployment

This is a test only change, so no implications for deployment. 

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR