### PR TITLE
[xenial] Target both Trusty and Xenial for staging tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,35 @@ jobs:
 
       - run:
           name: Run Staging tests on GCE
+          command: make ci-go
+
+      - run:
+          name: Ensure environment torn down
+          # Always report true, since env should will destroyed already
+          # if all tests passed.
+          command: make ci-teardown || true
+          when: always
+
+      - store_test_results:
+          path: ~/sd/junit
+
+      - store_artifacts:
+          path: ~/sd/junit
+
+  staging-test-with-rebase-xenial:
+    machine:
+      enabled: true
+
+    working_directory: ~/sd
+    steps:
+      - checkout
+
+      - run:
+          name: Rebase on-top of github target
+          command: ./devops/scripts/rebase-ci.sh
+
+      - run:
+          name: Run Staging tests on GCE
           command: make ci-xenial-go
 
       - run:
@@ -236,3 +265,14 @@ workflows:
       - staging-test-with-rebase:
           requires:
             - lint
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - static-analysis-and-no-known-cves
+      - staging-test-with-rebase-xenial

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
 
       - run:
           name: Run Staging tests on GCE
-          command: make ci-go
+          command: make ci-xenial-go
 
       - run:
           name: Ensure environment torn down

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,23 @@ ci-teardown: ## Destroys GCE host for testing staging environment.
 ci-run: ## Provisions GCE host for testing staging environment.
 	./devops/gce-nested/gce-runner.sh
 
+.PHONY: ci-run-xenial
+ci-run-xenial: ## Provisions GCE host for testing staging environment.
+	./devops/gce-nested/gce-runner.sh xenial
+
 .PHONY: ci-go
 ci-go: ## Creates, provisions, tests, and destroys GCE host for testing staging environment.
 	@if [[ "${CIRCLE_BRANCH}" != docs-* ]]; then \
 		make ci-spinup; \
 		make ci-run; \
+		make ci-teardown; \
+	fi
+
+.PHONY: ci-xenial-go
+ci-xenial-go: ## Creates, provisions, tests, and destroys GCE host for testing staging environment under xenial.
+	@if [[ "${CIRCLE_BRANCH}" != docs-* ]]; then \
+		make ci-spinup; \
+		make ci-run-xenial; \
 		make ci-teardown; \
 	fi
 
@@ -99,9 +111,7 @@ build-debs-notest: ## Builds and tests debian packages (sans tests)
 
 .PHONY: build-debs-xenial
 build-debs-xenial: ## Builds and tests debian packages (includes Xenial overrides, TESTING ONLY)
-	@if [[ "${CIRCLE_BRANCH}" != docs-* ]]; then \
-		molecule converge -s builder -- -e securedrop_build_xenial_support=True; \
-		else echo Not running on docs branch...; fi
+	@./devops/scripts/build-debs.sh xenial
 
 .PHONY: build-gcloud-docker
 build-gcloud-docker: ## Build docker container for gcloud sdk
@@ -157,7 +167,7 @@ staging: ## Creates local staging environment in VM, autodetecting platform
 
 .PHONY: staging-xenial
 staging-xenial: ## Creates local staging VMs based on Xenial, autodetecting platform
-	@./devops/create-staging-env xenial
+	@./devops/scripts/create-staging-env xenial
 
 .PHONY: clean
 clean: ## DANGER! Purges all site-specific info and developer files from project.

--- a/devops/gce-nested/gce-runner.sh
+++ b/devops/gce-nested/gce-runner.sh
@@ -53,12 +53,20 @@ function copy_securedrop_repo() {
 
 # Main logic
 copy_securedrop_repo
-
-ssh_gce "make build-debs-notest"
+if [[ "${1:-trusty}" = "xenial" ]]; then
+    ssh_gce "make build-debs-xenial"
+else
+    ssh_gce "make build-debs-notest"
+fi
 
 # The test results should be collected regardless of pass/fail,
 # so register a trap to ensure the fetch always runs.
 trap fetch_junit_test_results EXIT
 
-# Run staging environment
-ssh_gce "make staging"
+# Run staging environment. If xenial is passed as an argument, run the
+# staging environment for xenial.
+if [[ "${1:-trusty}" = "xenial" ]]; then
+    ssh_gce "make staging-xenial"
+else
+    ssh_gce "make staging"
+fi

--- a/devops/scripts/build-debs.sh
+++ b/devops/scripts/build-debs.sh
@@ -21,7 +21,12 @@ if [[ "${CIRCLE_BRANCH:-}" != docs-* ]]; then
             ;;
     esac
 
-    molecule "${molecule_action}" -s builder
+    if [[ "${1:-trusty}" = "xenial" ]]; then
+	molecule converge -s builder -- -e securedrop_build_xenial_support=True;
+    else
+    	molecule "${molecule_action}" -s builder
+    fi
+
 else
     echo Not running on docs branch...
 fi

--- a/molecule/libvirt-staging-xenial/molecule.yml
+++ b/molecule/libvirt-staging-xenial/molecule.yml
@@ -9,6 +9,8 @@ lint:
 platforms:
   - name: app-staging
     box: bento/ubuntu-16.04
+    raw_config_args:
+      - "cpu_mode = 'host-passthrough'"
     instance_raw_config_args:
       - "vm.synced_folder './', '/vagrant', disabled: true"
       - "vm.network 'private_network', ip: '10.0.1.2'"
@@ -22,6 +24,8 @@ platforms:
 
   - name: mon-staging
     box: bento/ubuntu-16.04
+    raw_config_args:
+      - "cpu_mode = 'host-passthrough'"
     instance_raw_config_args:
       - "vm.synced_folder './', '/vagrant', disabled: true"
       - "vm.network 'private_network', ip: '10.0.1.3'"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3966 

Introduces nightly staging xenial runs in CI for automated infra testing.

## Testing

- [ ] CI run with Xenial machines should occurs nightly at 0:00 UTC
- [ ] CI run completes without failure
- [ ] Other CI features are unaffected

## Deployment

1. Dev-env only

## Checklist


### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR


