### PR TITLE
makefile: fix typo to path of create-staging-env script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ staging: ## Creates local staging environment in VM, autodetecting platform
 
 .PHONY: staging-xenial
 staging-xenial: ## Creates local staging VMs based on Xenial, autodetecting platform
-	@./devops/create-staging-env xenial
+	@./devops/scripts/create-staging-env xenial
 
 .PHONY: clean
 clean: ## DANGER! Purges all site-specific info and developer files from project.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:
 * Fixes typo in makefile

## Testing

`make staging-xenial` should not complain about path not found

## Deployment

dev only

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
