### PR TITLE
added "filename" to reply creation api response

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -267,7 +267,8 @@ def make_blueprint(config):
                     raise e
 
             return jsonify({'message': 'Your reply has been stored',
-                            'uuid': reply.uuid}), 201
+                            'uuid': reply.uuid,
+                            'filename': reply.filename}), 201
 
     @api.route('/sources/<source_uuid>/replies/<reply_uuid>',
                methods=['GET', 'DELETE'])

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -652,6 +652,9 @@ def test_authorized_user_can_add_reply(journalist_app, journalist_api_token,
     reply = Reply.query.filter_by(uuid=str(reply_uuid)).one_or_none()
     assert reply is not None
 
+    # check that the filename is present and correct (#4047)
+    assert response.json['filename'] == reply.filename
+
     with journalist_app.app_context():  # Now verify everything was saved.
         assert reply.journalist_id == test_journo['id']
         assert reply.source_id == source_id


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4047

Adds the `filename` to the API response when creating a reply.

## Testing

```bash
make test TESTFILES=tests/test_journalist_api.py::test_authorized_user_can_add_reply
```
## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container