### PR TITLE
prevent 500 errors when parsing malformed auth token

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -37,7 +37,10 @@ def token_required(f):
             return abort(403, 'API token not found in Authorization header.')
 
         if auth_header:
-            auth_token = auth_header.split(" ")[1]
+            split = auth_header.split(" ")
+            if len(split) != 2 or split[0] != 'Token':
+                abort(403, 'Malformed authorization header.')
+            auth_token = split[1]
         else:
             auth_token = ''
         if not Journalist.validate_api_token_and_get_user(auth_token):

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -860,3 +860,24 @@ def test_api_does_not_set_cookie_headers(journalist_app, test_journo):
         assert 'Set-Cookie' not in observed_headers.keys()
         if 'Vary' in observed_headers.keys():
             assert 'Cookie' not in observed_headers['Vary']
+
+
+# regression test for #4053
+def test_malformed_auth_token(journalist_app, journalist_api_token):
+    with journalist_app.app_context():
+        # we know this endpoint requires an auth header
+        url = url_for('api.get_all_sources')
+
+    with journalist_app.test_client() as app:
+        # precondition to ensure token is even valid
+        resp = app.get(url, headers={'Authorization': 'Token {}'.format(journalist_api_token)})
+        assert resp.status_code == 200
+
+        resp = app.get(url, headers={'Authorization': 'not-token {}'.format(journalist_api_token)})
+        assert resp.status_code == 403
+
+        resp = app.get(url, headers={'Authorization': journalist_api_token})
+        assert resp.status_code == 403
+
+        resp = app.get(url, headers={'Authorization': 'too many {}'.format(journalist_api_token)})
+        assert resp.status_code == 403


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4053

Adds a check on the length of a split token to prevent index errors when parsing.

## Testing

```bash
make test TESTFILES=tests/test_journalist_api.py
```

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container