### PR TITLE
ci: move nightly jobs to 4 AM UTC / 8 PM PST

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 4 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Yesterday we had a pileup of jobs in CircleCI as we were trying to merge a bunch of PRs towards EOD Pacific time. The pileup was in part due to nightly jobs kicking off at 0 UTC which is 4pm PST, let's move them to 4am UTC / 8pm PST to avoid this in the future. 
 
## Testing

Confirm the job below should run at 4am UTC (needs merging to test)

## Deployment

CI only

## Checklist

N/A