### PR TITLE
return user id when creating auth token

### DIFF
--- a/docs/development/journalist_api.rst
+++ b/docs/development/journalist_api.rst
@@ -44,7 +44,8 @@ This will produce a response with your Authorization token:
 
   {
       "expiration": "2018-07-10T04:29:41.696321Z",
-      "token": "eyJhbGciOiJIUzI1NiIsImV4cCI6MTUzMTE5Njk4MSwiaWF0IjoxNTMxMTY4MTgxfQ.eyJpZCI6MX0.TBSvfrICMxtvWgpVZzqTl6wHYNQuGPOaZpuAKwwIXXo"
+      "token": "eyJhbGciOiJIUzI1NiIsImV4cCI6MTUzMTE5Njk4MSwiaWF0IjoxNTMxMTY4MTgxfQ.eyJpZCI6MX0.TBSvfrICMxtvWgpVZzqTl6wHYNQuGPOaZpuAKwwIXXo",
+      "journalist_uuid": "54d81dae-9d94-4145-8a57-4c804a04cfe0"
   }
 
 Thereafter in order to authenticate to protected endpoints, send the token in

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -105,9 +105,12 @@ def make_blueprint(config):
             journalist = Journalist.login(username, passphrase, one_time_code)
             token_expiry = datetime.utcnow() + timedelta(
                 seconds=TOKEN_EXPIRATION_MINS * 60)
-            response = jsonify({'token': journalist.generate_api_token(
-                 expiration=TOKEN_EXPIRATION_MINS * 60),
-                 'expiration': token_expiry.isoformat() + 'Z'})
+
+            response = jsonify({
+                'token': journalist.generate_api_token(expiration=TOKEN_EXPIRATION_MINS * 60),
+                'expiration': token_expiry.isoformat() + 'Z',
+                'journalist_uuid': journalist.uuid,
+            })
 
             # Update access metadata
             journalist.last_access = datetime.utcnow()

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -155,7 +155,8 @@ def test_journo(journalist_app):
                 'username': username,
                 'password': password,
                 'otp_secret': otp_secret,
-                'id': user.id}
+                'id': user.id,
+                'uuid': user.uuid}
 
 
 @pytest.fixture(scope='function')

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -41,6 +41,7 @@ def test_valid_user_can_get_an_api_token(journalist_app, test_journo):
                             headers=get_api_headers())
         observed_response = json.loads(response.data)
 
+        assert observed_response['journalist_uuid'] == test_journo['uuid']
         assert isinstance(Journalist.validate_api_token_and_get_user(
             observed_response['token']), Journalist) is True
         assert response.status_code == 200


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #4081

Return the journalist's UUID when they create an auth token.

## Testing
- Verify the name `journalist_uuid` is a reasonable name for this field
- `make test` like usual

## Deployment

This is a backwards compatible API change.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally