### PR TITLE
Ensure CI staging run reports errors accurately

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,8 +236,8 @@ jobs:
           command: ./devops/scripts/rebase-ci.sh
 
       - run:
-          name: Run Staging tests on GCE
-          command: make ci-xenial-go
+          name: Run Staging tests on GCE (Xenial)
+          command: make ci-go-xenial
 
       - run:
           name: Ensure environment torn down

--- a/Makefile
+++ b/Makefile
@@ -5,37 +5,17 @@ PWD := $(shell pwd)
 TAG ?= $(shell git rev-parse HEAD)
 STABLE_VER := $(shell cat molecule/shared/stable.ver)
 
-.PHONY: ci-spinup
-ci-spinup: ## Creates GCE host for testing staging environment.
-	./devops/gce-nested/gce-start.sh
+.PHONY: ci-go
+ci-go: ## Creates, provisions, tests, and destroys GCE host for testing staging environment.
+	./devops/gce-nested/ci-go.sh
+
+.PHONY: ci-go-xenial
+ci-go-xenial: ## Creates, provisions, tests, and destroys GCE host for testing staging environment under xenial.
+	./devops/gce-nested/ci-go.sh xenial
 
 .PHONY: ci-teardown
 ci-teardown: ## Destroys GCE host for testing staging environment.
 	./devops/gce-nested/gce-stop.sh
-
-.PHONY: ci-run
-ci-run: ## Provisions GCE host for testing staging environment.
-	./devops/gce-nested/gce-runner.sh
-
-.PHONY: ci-run-xenial
-ci-run-xenial: ## Provisions GCE host for testing staging environment.
-	./devops/gce-nested/gce-runner.sh xenial
-
-.PHONY: ci-go
-ci-go: ## Creates, provisions, tests, and destroys GCE host for testing staging environment.
-	@if [[ "${CIRCLE_BRANCH}" != docs-* ]]; then \
-		make ci-spinup; \
-		make ci-run; \
-		make ci-teardown; \
-	fi
-
-.PHONY: ci-xenial-go
-ci-xenial-go: ## Creates, provisions, tests, and destroys GCE host for testing staging environment under xenial.
-	@if [[ "${CIRCLE_BRANCH}" != docs-* ]]; then \
-		make ci-spinup; \
-		make ci-run-xenial; \
-		make ci-teardown; \
-	fi
 
 .PHONY: ci-lint
 ci-lint: ## Runs linting in linting container.

--- a/devops/gce-nested/ci-go.sh
+++ b/devops/gce-nested/ci-go.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Wrapper script to managed GCE-based CI runs, specifically:
+#
+#   * create GCE host
+#   * provision staging VMs within GCE host
+#   * clean up GCE host
+#
+# We're using a wrapper script for this functionality to ensure
+# that errors propagate up to the CI runner, so that any non-zero
+# exit aborts the run and the CI job is marked as failing.
+set -e
+set -u
+set -o pipefail
+
+
+# Assume we're running against Trusty; Xenial also supported.
+target_platform="${1:trusty}"
+
+# Skip full CI run on docs branches, since code shouldn't change.
+if [[ "${CIRCLE_BRANCH:-}" != docs-* ]]; then
+    ./devops/gce-nested/gce-start.sh
+    ./devops/gce-nested/gce-runner.sh "$target_platform"
+    ./devops/gce-nested/gce-stop.sh
+else
+    echo "Branch begins with 'docs-' prefix, skipping staging tests..."
+fi

--- a/devops/gce-nested/ci-go.sh
+++ b/devops/gce-nested/ci-go.sh
@@ -14,7 +14,7 @@ set -o pipefail
 
 
 # Assume we're running against Trusty; Xenial also supported.
-target_platform="${1:trusty}"
+target_platform="${1:-trusty}"
 
 # Skip full CI run on docs branches, since code shouldn't change.
 if [[ "${CIRCLE_BRANCH:-}" != docs-* ]]; then

--- a/devops/gce-nested/gce-runner.sh
+++ b/devops/gce-nested/gce-runner.sh
@@ -16,6 +16,8 @@ REMOTE_IP="$(gcloud_call compute instances describe \
 SSH_TARGET="${SSH_USER_NAME}@${REMOTE_IP}"
 SSH_OPTS=(-i "$SSH_PRIVKEY" -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null")
 
+# Assume we're testing Trusty. Xenial is also supported
+target_platform="${1:-trusty}"
 
 # Wrapper utility to run commands on remote GCE instance
 function ssh_gce {
@@ -53,7 +55,7 @@ function copy_securedrop_repo() {
 
 # Main logic
 copy_securedrop_repo
-if [[ "${1:-trusty}" = "xenial" ]]; then
+if [[ "$target_platform" = "xenial" ]]; then
     ssh_gce "make build-debs-xenial"
 else
     ssh_gce "make build-debs-notest"
@@ -65,7 +67,7 @@ trap fetch_junit_test_results EXIT
 
 # Run staging environment. If xenial is passed as an argument, run the
 # staging environment for xenial.
-if [[ "${1:-trusty}" = "xenial" ]]; then
+if [[ "$target_platform" = "xenial" ]]; then
     ssh_gce "make staging-xenial"
 else
     ssh_gce "make staging"

--- a/docs/development/testing_continuous_integration.rst
+++ b/docs/development/testing_continuous_integration.rst
@@ -89,9 +89,8 @@ Run ``make help`` to see the full list of CI commands in the Makefile:
     Makefile for developing and testing SecureDrop.
     Subcommands:
         ci-go                      Creates, provisions, tests, and destroys GCE host for testing staging environment.
+        ci-go-xenial               Creates, provisions, tests, and destroys GCE host for testing staging environment under xenial.
         ci-lint                    Runs linting in linting container.
-        ci-run                     Provisions GCE host for testing staging environment.
-        ci-spinup                  Creates GCE host for testing staging environment.
         ci-teardown                Destroys GCE host for testing staging environment.
 
 To run the tests locally:
@@ -100,6 +99,6 @@ To run the tests locally:
 
     make ci-go
 
-You can use ``make ci-run`` to provision the remote hosts while making changes,
-including rebuilding the Debian packages used in the Staging environment.
-See :doc:`virtual_environments` for more information.
+You can use ``./devops/gce-nested/ci-runner.sh`` to provision the remote hosts
+while making changes, including rebuilding the Debian packages used in the
+Staging environment. See :doc:`virtual_environments` for more information.


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #4066 

The `make ci-go` target was always exiting zero, due to the in-line bash
if statement, causing failed CI runs to report as successful. Moved the
logic into a wrapper script. Also trimmed out from of the extraneous
Makefile targets related to CI (and corresponding docs), to remove a bit
of the indirection and make maintenance more straightforward for the
team.

## Testing
We'll have to make temporary commits on the WIP PR to confirm that an error in e.g. the provisioning flow results in failed CI. Rough checklist is below. **All reports should include URLs to the corresponding CI run satisfying the requested check.**

* [ ] observe passing CI on this branch with base changes
* [ ] append a temporary commit designed to trigger failure in CI (e.g. an Ansible `fail` task); confirm observation of failure in CI
* [ ] revert temporary commit, observe CI passing
* [ ] rebase to remove temporary commits

It's possibly we've been missing CI-specific problems such as connection timeouts, so we may need to add retries or :scream: sleeps in order to stabilize. 

## Deployment

None, CI only.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
