### PR TITLE
Fixes functional tests for #4039

### DIFF
--- a/securedrop/dockerfiles/xenial/Dockerfile
+++ b/securedrop/dockerfiles/xenial/Dockerfile
@@ -9,12 +9,14 @@ RUN apt-get update && \
     apt-get install -y devscripts \
                        python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
-                       gettext paxctl x11vnc enchant libffi-dev sqlite3 gettext sudo
+                       gettext paxctl x11vnc enchant libffi-dev sqlite3 gettext sudo \
+                       libgtk2.0
 
-ENV FIREFOX_CHECKSUM=179647c2d47e2acf2cf3596f21c8cbea8eda4b271d4d09d7b18be55553751912
-RUN curl -LO https://launchpad.net/~ubuntu-mozilla-security/+archive/ubuntu/ppa/+build/11952510/+files/firefox-locale-en_51.0.1+build2-0ubuntu0.16.04.2_amd64.deb && \
+
+ENV FIREFOX_CHECKSUM=88d25053306d33658580973b063cd459a56e3596a3a298c1fb8ab1d52171d860
+RUN curl -LO https://launchpad.net/~ubuntu-mozilla-security/+archive/ubuntu/ppa/+build/9727836/+files/firefox_46.0.1+build1-0ubuntu0.14.04.3_amd64.deb && \
     shasum -a 256 firefox*deb && \
-    echo "${FIREFOX_CHECKSUM}  firefox-locale-en_51.0.1+build2-0ubuntu0.16.04.2_amd64.deb" | shasum -a 256 -c - && \
+    echo "${FIREFOX_CHECKSUM}  firefox_46.0.1+build1-0ubuntu0.14.04.3_amd64.deb" | shasum -a 256 -c - && \
     dpkg -i firefox*deb && apt-get install -f && \
     paxctl -cm /usr/lib/firefox/firefox
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4039

We are getting back Firefox 46 and in future we will move
to Tor Browser based tests for the functional test cases.

## Testing

This will fix the functional tests for now in `Xenial`.

`BASE_OS=xenial ./bin/dev-shell ./bin/run-test -v tests/functional/` is the command to run only functional tests part.

## Deployment

No, dev-only change.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
