### PR TITLE
Explicitly declare onion services as v2 for existing installs

### DIFF
--- a/install_files/securedrop-config/DEBIAN/postinst
+++ b/install_files/securedrop-config/DEBIAN/postinst
@@ -39,6 +39,16 @@ allow_apt_user_in_iptables() {
            "$rules_v4"
     fi
 }
+# Tor 0.3.5.x series now defaults to v3 onion URLs, but SecureDrop currently
+# uses v2 onion URLs. We must explictly set this definition in torrc to avoid
+# breakage when upgrading from Tor 0.3.4.x to 0.3.5.x.
+set_v2_hidserv_in_torrc() {
+    if [ -f /etc/tor/torrc ]; then
+        if ! grep -q HiddenServiceVersion /etc/tor/torrc ; then
+            perl -pi -e 's/^(HiddenServiceDir.*)$/$1\nHiddenServiceVersion 2/' /etc/tor/torrc
+        fi
+    fi
+}
 
 case "$1" in
     configure)
@@ -61,6 +71,7 @@ case "$1" in
     fi
 
     allow_apt_user_in_iptables
+    set_v2_hidserv_in_torrc
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Towards #4031 , this is required to ensure torrc config is compatible with tor 0.3.5.x series. 
Modify the torrc file in place to explicitly declare current onion services as v2 onion services. Since securedrop-config is installed after tor hidden services are configured, it will also perform the modification (and be a no-op once #4080  is merged at install-time)

## Testing
- [ ] Do we actually need this? Ansible changes in #4080 will make these changes in the torrc configuration. If we require news orgs to run the playbook prior to Xenial upgrade, this addition might be superfluous.
- [ ] In both cases, ensure that the resulting configuration makes sense per the documentation (https://www.torproject.org/docs/tor-onion-service.html.en) and will not make it more difficult to make configuration changes when migrating to v3 onion services (#2951)

### Clean install

- Make debs and provision staging environment on this branch
- [ ] Hidden services configurations in `/etc/tor/torrc` on app and mon server specify version 2 for all hidden services
- [ ] Source, journalist and ssh interfaces are accessible

### Upgrade testing

- Build debs and provision existing SecureDrop 0.11.1 install with these debs
- [ ] Hidden services configurations in `/etc/tor/torrc` on app and mon server specify version 2 for all hidden services
- [ ] Source, journalist and ssh interfaces are accessible

## Deployment

These changes will be deployed to new and existing SecureDrop instances via `securedrop-config` deb package.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container


### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR


