### PR TITLE
Adds upgrade testing boxes for 0.11.1

### DIFF
--- a/molecule/vagrant_packager/box_files/app_metadata.json
+++ b/molecule/vagrant_packager/box_files/app_metadata.json
@@ -45,6 +45,17 @@
           "checksum": "cf2c4c8ac89bd132d3f75ee77e2d97b68c562e1ee36aa059bb1d4e6b37499f62"
         }
       ]
+    },
+    {
+      "version": "0.11.1",
+      "providers": [
+        {
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.11.1.box",
+          "checksum_type": "sha256",
+          "checksum": "e832c4940ef10e8d999033271454f7220c85f4b0a89f378906895d4a82478eee"
+        }
+      ]
     }
   ]
 }

--- a/molecule/vagrant_packager/box_files/mon_metadata.json
+++ b/molecule/vagrant_packager/box_files/mon_metadata.json
@@ -45,6 +45,17 @@
           "checksum": "baba21e8799fe2093d902b332b45d7a8342adf019fa195382011fbdfa54cd1d5"
         }
       ]
+    },
+    {
+      "version": "0.11.1",
+      "providers": [
+        {
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.11.1.box",
+          "checksum_type": "sha256",
+          "checksum": "bbc8ed55fab20ed96c3b090126b69baabbd41e95faa60676dff72bc69af67376"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION

## Status

Ready for review.

## Description of Changes

Checks the final box on, and therefore closes, #4060.

Standard procedure to update the base boxes used for the "upgrade" Molecule
scenario. Used the recently updated dev docs on maintenance of these
boxes to validate the documented procedure.

Changes proposed in this pull request:

* New base images for the "upgrade" scenario posted to S3
* New corresponding metadata for base images

It's worth pointing out that #4080 changes the storage paths for the debs, and as such, perhaps slight updates to the `upgrade/` scenario logic will be required after merge of #4080. This PR is likely to get in first, so would prefer to follow up separately, to keep diffs small. 

## Testing

* [ ] Run `rm -rf build/* && make build-debs` to ensure you have clean debs (especially important given pending review of #4080)
* [ ] `make upgrade-start` ; first run will take a while to fetch the images, then future runs will be snappy
* [ ] `make upgrade-test-local` ; confirm no errors
* [ ] Manually verify that the Source Interface shows 0.12.0~rc1

## Deployment
No, dev env only.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
