### PR TITLE
[xenial] gpg 2.1+ compliance + fix decryption of journalist replies

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -105,6 +105,7 @@
   /var/lib/securedrop/db.sqlite-journal w,
   /var/lib/securedrop/keys/* rwl,
   /var/lib/securedrop/keys/*.app-staging.* w,
+  /var/lib/securedrop/keys/gpg-agent.conf r,
   /var/lib/securedrop/keys/private-keys-v1.d/* rw,
   /var/lib/securedrop/keys/openpgp-revocs.d/* rw,
   /var/lib/securedrop/keys/pubring.gpg r,

--- a/install_files/securedrop-app-code/debian/postinst
+++ b/install_files/securedrop-app-code/debian/postinst
@@ -84,6 +84,19 @@ case "$1" in
       chmod 0700 "$dir"
     done
 
+    # Ensure required gpg-agent.conf is in place, see #4013.
+    if [ -e "/var/lib/securedrop/keys/gpg-agent.conf" ]; then
+
+        # gpg-agent.conf does exist, update it if needed.
+        if ! grep -qE '^allow-loopback-pinentry$' /var/lib/securedrop/keys/gpg-agent.conf; then
+            echo allow-loopback-pinentry >> /var/lib/securedrop/keys/gpg-agent.conf
+        fi
+
+    else
+        # gpg-agent.conf does not yet exist, create it.
+        echo allow-loopback-pinentry > /var/lib/securedrop/keys/gpg-agent.conf
+    fi
+
     chown -R www-data:www-data /var/lib/securedrop /var/www/securedrop
 
     pip install --no-index --find-links=/var/securedrop/wheelhouse --upgrade \

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -46,8 +46,8 @@ function reset_demo() {
     # Create gpg-agent.conf
     echo allow-loopback-pinentry > /var/lib/securedrop/keys/gpg-agent.conf
 
-    # Kill gpg-agent(s) so it picks up the new config on restart.
-    pkill -f gpg-agent
+    # Kill gpg-agent(s) if they exist so it picks up the new config on restart.
+    pkill -f gpg-agent || true
     # Note that we should avoid `gpgconf --kill gpg-agent` since the pkill command will
     # handle killing multiple gpg-agent processes if they exist (this is what we want).
 

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -37,10 +37,30 @@ function run_sass() {
 }
 
 function reset_demo() {
+    # Set up gpg keys directory structure.
     sudo mkdir -p /var/lib/securedrop/{store,keys,tmp}
     sudo chown -R "$(id -u)" /var/lib/securedrop
     cp ./tests/files/test_journalist_key.pub /var/lib/securedrop/keys
-    gpg --homedir /var/lib/securedrop/keys --import /var/lib/securedrop/keys/test_journalist_key.pub >& /tmp/gpg.out || cat /tmp/gpg.out
+    gpg2 --homedir /var/lib/securedrop/keys --import /var/lib/securedrop/keys/test_journalist_key.pub >& /tmp/gpg.out || cat /tmp/gpg.out
+
+    # Create gpg-agent.conf
+    echo allow-loopback-pinentry > /var/lib/securedrop/keys/gpg-agent.conf
+
+    # Kill gpg-agent(s) so it picks up the new config on restart.
+    pkill -f gpg-agent
+    # Note that we should avoid `gpgconf --kill gpg-agent` since the pkill command will
+    # handle killing multiple gpg-agent processes if they exist (this is what we want).
+
+    # Set permissions on gpg-related directories/files.
+    sudo chown -R "$(id -gn)" /var/lib/securedrop/keys
+    chmod 700 /var/lib/securedrop/keys
+    chmod 600 /var/lib/securedrop/keys/*
+
+    # If the following directories exist, make sure they have the proper permissions.
+    chmod -f 700 /var/lib/securedrop/keys/private-keys-v1.d || true
+    chmod -f 700 /var/lib/securedrop/keys/openpgp-revocs.d || true
+
+    # Generate translated strings
     ./i18n_tool.py translate-messages --compile
 
     # remove previously uploaded custom logos
@@ -50,5 +70,8 @@ function reset_demo() {
     sqlite3 /var/lib/securedrop/db.sqlite .databases &> /dev/null
 
     ./manage.py reset
+
+    gpg2 --homedir /var/lib/securedrop/keys --import /var/lib/securedrop/keys/test_journalist_key.pub
+
     ./create-dev-data.py
 }

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -82,7 +82,8 @@ class CryptoUtil:
 
         # --pinentry-mode, required for SecureDrop on gpg 2.1.x+, was
         # added in gpg 2.1.
-        gpg_binary = gnupg.GPG(binary='gpg2', homedir=gpg_key_dir)
+        self.gpg_key_dir = gpg_key_dir
+        gpg_binary = gnupg.GPG(binary='gpg2', homedir=self.gpg_key_dir)
         if StrictVersion(gpg_binary.binary_version) >= StrictVersion('2.1'):
             self.gpg = gnupg.GPG(binary='gpg2',
                                  homedir=gpg_key_dir,
@@ -202,8 +203,11 @@ class CryptoUtil:
         if not key:
             return
 
+        # Always delete keys without invoking pinentry-mode = loopback
+        # see: https://lists.gnupg.org/pipermail/gnupg-users/2016-May/055965.html
+        temp_gpg = gnupg.GPG(binary='gpg2', homedir=self.gpg_key_dir)
         # The subkeys keyword argument deletes both secret and public keys.
-        self.gpg.delete_keys(key, secret=True, subkeys=True)
+        temp_gpg.delete_keys(key, secret=True, subkeys=True)
 
     def getkey(self, name):
         for key in self.gpg.list_keys():

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import gnupg
+import pretty_bad_protocol as gnupg
 import os
 import io
 import scrypt
@@ -11,7 +11,7 @@ from random import SystemRandom
 from base64 import b32encode
 from datetime import date
 from flask import current_app
-from gnupg._util import _is_stream, _make_binary_stream
+from pretty_bad_protocol._util import _is_stream, _make_binary_stream
 
 import typing
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
@@ -79,7 +79,9 @@ class CryptoUtil:
 
         self.do_runtime_tests()
 
-        self.gpg = gnupg.GPG(binary='gpg2', homedir=gpg_key_dir)
+        self.gpg = gnupg.GPG(binary='gpg2',
+                             homedir=gpg_key_dir,
+                             options=['--pinentry-mode loopback'])
 
         # map code for a given language to a localized wordlist
         self.__language2words = {}  # type: Dict[Text, List[str]]
@@ -176,7 +178,7 @@ class CryptoUtil:
         """
         name = clean(name)
         secret = self.hash_codename(secret, salt=self.scrypt_gpg_pepper)
-        return self.gpg.gen_key(self.gpg.gen_key_input(
+        genkey_obj = self.gpg.gen_key(self.gpg.gen_key_input(
             key_type=self.GPG_KEY_TYPE,
             key_length=self.__gpg_key_length,
             passphrase=secret,
@@ -184,6 +186,7 @@ class CryptoUtil:
             creation_date=self.DEFAULT_KEY_CREATION_DATE.isoformat(),
             expire_date=self.DEFAULT_KEY_EXPIRATION_DATE
         ))
+        return genkey_obj
 
     def delete_reply_keypair(self, source_filesystem_id):
         key = self.getkey(source_filesystem_id)

--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -7,7 +7,7 @@ Flask-Babel
 Flask-SQLAlchemy
 Flask-WTF
 Flask>0.12.2
-gnupg
+pretty-bad-protocol>=3.1.1
 Jinja2
 jsmin
 passlib

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -18,7 +18,7 @@ flask-babel==0.11.2
 flask-sqlalchemy==2.3.2
 flask-wtf==0.14.2
 flask==1.0.2
-gnupg==2.3.1
+pretty-bad-protocol==3.1.1
 idna==2.6                 # via cryptography
 ipaddress==1.0.22         # via cryptography
 itsdangerous==0.24        # via flask

--- a/securedrop/secure_tempfile.py
+++ b/securedrop/secure_tempfile.py
@@ -4,7 +4,7 @@ import os
 import io
 from tempfile import _TemporaryFileWrapper
 
-from gnupg._util import _STREAMLIKE_TYPES
+from pretty_bad_protocol._util import _STREAMLIKE_TYPES
 from cryptography.exceptions import AlreadyFinalized
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers.algorithms import AES

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -86,9 +86,8 @@ def make_blueprint(config):
             try:
                 with io.open(reply_path, "rb") as f:
                     contents = f.read()
-                reply.decrypted = current_app.crypto_util.decrypt(
-                    g.codename,
-                    contents).decode('utf-8')
+                reply_obj = current_app.crypto_util.decrypt(g.codename, contents)
+                reply.decrypted = reply_obj.decode('utf-8')
             except UnicodeDecodeError:
                 current_app.logger.error("Could not decode reply %s" %
                                          reply.filename)

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import gnupg
+import pretty_bad_protocol as gnupg
 import logging
 import os
 import io

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -89,6 +89,11 @@ def config(tmpdir):
     tmp = data.mkdir('tmp')
     sqlite = data.join('db.sqlite')
 
+    # gpg 2.1+ requires gpg-agent, see #4013
+    gpg_agent_config = str(keys.join('gpg-agent.conf'))
+    with open(gpg_agent_config, 'w+') as f:
+        f.write('allow-loopback-pinentry')
+
     gpg = gnupg.GPG('gpg2', homedir=str(keys))
     for ext in ['sec', 'pub']:
         with io.open(path.join(path.dirname(__file__),

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import gnupg
+import pretty_bad_protocol as gnupg
 import gzip
 import os
 import random

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1586,12 +1586,15 @@ def test_render_locales(config, journalist_app, test_journo, test_source):
     assert url_end + '?l=en_US' in text, text
 
 
-def test_render_xenial_positive(config, journalist_app, test_journo):
+def test_render_xenial_positive(config, journalist_app, test_journo, mocker):
     yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
     journalist_app.config.update(
         XENIAL_WARNING_DATE=yesterday,
         XENIAL_VER='16.04'
     )
+
+    mocked_error_platform = mocker.patch('platform.linux_distribution')
+    mocked_error_platform.return_value = ('Ubuntu', '14.04', 'trusty')
 
     with journalist_app.test_client() as app:
         _login_user(app, test_journo['username'], test_journo['password'],
@@ -1603,12 +1606,15 @@ def test_render_xenial_positive(config, journalist_app, test_journo):
     assert "critical-skull" in text, text
 
 
-def test_render_xenial_negative_version(config, journalist_app, test_journo):
+def test_render_xenial_negative_version(config, journalist_app, test_journo, mocker):
     yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
     journalist_app.config.update(
         XENIAL_WARNING_DATE=yesterday,
-        XENIAL_VER='14.04'
+        XENIAL_VER='16.04'
     )
+
+    mocked_error_platform = mocker.patch('platform.linux_distribution')
+    mocked_error_platform.return_value = ('Ubuntu', '16.04', 'xenial')
 
     with journalist_app.test_client() as app:
         _login_user(app, test_journo['username'], test_journo['password'],

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -3,7 +3,7 @@ import io
 import os
 import pytest
 
-from gnupg._util import _is_stream
+from pretty_bad_protocol._util import _is_stream
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 from secure_tempfile import SecureTemporaryFile

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Testing utilities related to setup and teardown of test environment.
 """
-import gnupg
+import pretty_bad_protocol as gnupg
 import os
 import io
 import shutil


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3622 
Fixes #4013

Changes proposed in this pull request:
 - This PR makes SecureDrop work with gpg 2.1, while preserving functionality for earlier versions of gpg used on trusty (the gpg config options passed to the gpg binary will now vary based on the version of gpg that is used on the server). gpg 2.1 introduced some other significant changes, the most important of which is now requiring the use of gpg-agent. 

thoughts welcome on this as I had to sidestep some API weirdness / bugs on the gpg side which I note in the commit messages

## Testing

- [ ] All xenial app test should now pass (and after this PR is merged we will make that a required CI job)
- [ ] All trusty app tests should also still pass
- [ ] In the xenial staging environment, a source should now be able to decrypt journalist replies
- [ ] In the xenial dev environment (`BASE_OS=xenial make dev`), a source should now be able to decrypt journalist replies
- [ ] In the trusty dev environment (`make dev`), a source should still be able to decrypt journalist replies
- [ ] In the trusty staging environment, a source should still be able to decrypt journalist replies

## Deployment

New installs and upgrades both will have the now required gpg-agent conf (for gpg 2.1+) written to disk via `postinst` of `securedrop-app-code`. A reboot will then occur.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
