### PR TITLE
update name of models.py to db.py since it changed

### DIFF
--- a/docs/development/client.rst
+++ b/docs/development/client.rst
@@ -64,7 +64,7 @@ way:
 
 * ``app.py`` - starts and configures the application.
 * ``logic.py`` - contains the application logic, encapsulated in the ``Client`` class.
-* ``models.py`` - holds all the `SQLAlchemy ORM model definitions <https://www.sqlalchemy.org/>`_ for interacting with the local Sqlite database.
+* ``db.py`` - holds all the `SQLAlchemy ORM model definitions <https://www.sqlalchemy.org/>`_ for interacting with the local Sqlite database.
 * ``storage.py`` - contains the functions needed for interacting with a remote SecureDrop API and the local database.
 * ``utils.py`` - generic utility functions needed throughout the application.
 * ``gui`` - this namespace contains two modules: ``main.py`` (containing the ``Window`` class through which all interactions with the user interface should happen) and ``widgets.py`` (containing all the custom widgets used by the ``Window`` class to draw the user interface).


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes
The current version of the securedrop-client no longer has a models.py. It has been renamed to db.py and the docs should reflect that change (it was introduced in commit 7b0c560004 over in the securedrop-client repo)

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
