### PR TITLE
[xenial] Updated release-upgrades Prompt for Trusty, Xenial as appropriate

### DIFF
--- a/install_files/securedrop-config/DEBIAN/postinst
+++ b/install_files/securedrop-config/DEBIAN/postinst
@@ -4,10 +4,28 @@
 set -e
 set -x
 
-disable_upgrade_prompt() {
-    # Disable do-release-upgrade notification
-    sed -i 's/Prompt=.*/Prompt=never/' /etc/update-manager/release-upgrades || true
+
+# Issue #4104
+# Set Prompt=never on Xenial
+# Set Prompt=lts on Trusty
+update_release_prompt() {
+    set -e
+
+    declare -r upgrade_config='/etc/update-manager/release-upgrades'
+
+    declare -r release="$(lsb_release -sc)"
+    if [ "$?" -ne 0 ]; then
+        echo 'Unable to detect LSB codename' >&2
+        return 1
+    fi
+
+    if [[ "$release"  == trusty ]]; then
+        sed -i 's/Prompt=.*/Prompt=lts/' "$upgrade_config"
+    else
+        sed -i 's/Prompt=.*/Prompt=never/' "$upgrade_config"
+    fi
 }
+
 remove_2fa_tty_req() {
     # The goal here is to remove legacy 2FA req on TTY logins
     # Lets prevent this from bombing out the install though if it fails
@@ -70,7 +88,7 @@ case "$1" in
 
     manage_tor_repo_config
     remove_2fa_tty_req
-    disable_upgrade_prompt
+    update_release_prompt
 
     # Remove cron-apt action should occur after security upgrades to avoid breaking
     # automatic upgrades (see issue #4003)

--- a/install_files/securedrop-config/DEBIAN/postinst
+++ b/install_files/securedrop-config/DEBIAN/postinst
@@ -4,23 +4,32 @@
 set -e
 set -x
 
+update_release_available_script() {
+    # The script /etc/cron.weekly/update-notifier-common runs the command
+    # /usr/lib/ubuntu-release-upgrader/release-upgrade-motd which runs the command
+    # /usr/lib/ubuntu-release-upgrader/check-new-release whose output is written to the "stamp" file
+    # /var/lib/ubuntu-release-upgrader/release-upgrade-available which is picked up by OSSEC.
+    #
+    # To prevent the OSSEC alerts from from telling the user to run 'do-release-upgrade' which
+    # may break their system, we update both the script and the existing "stamp" file.
+
+    for file in /usr/lib/ubuntu-release-upgrader/check-new-release /var/lib/ubuntu-release-upgrader/release-upgrade-available; do
+        if [ -f $file ]; then
+            sed -i "s|Run 'do-release-upgrade' to upgrade to it\\.|Visit https://securedrop.org/xenial-upgrade for more information|" "$file"
+        fi
+    done
+}
 
 # Issue #4104
 # Set Prompt=never on Xenial
 # Set Prompt=lts on Trusty
 update_release_prompt() {
     set -e
+    upgrade_config='/etc/update-manager/release-upgrades'
 
-    declare -r upgrade_config='/etc/update-manager/release-upgrades'
-
-    declare -r release="$(lsb_release -sc)"
-    if [ "$?" -ne 0 ]; then
-        echo 'Unable to detect LSB codename' >&2
-        return 1
-    fi
-
-    if [[ "$release"  == trusty ]]; then
+    if [ "$(lsb_release -sc)" = trusty ]; then
         sed -i 's/Prompt=.*/Prompt=lts/' "$upgrade_config"
+        update_release_available_script
     else
         sed -i 's/Prompt=.*/Prompt=never/' "$upgrade_config"
     fi

--- a/install_files/securedrop-config/DEBIAN/postinst
+++ b/install_files/securedrop-config/DEBIAN/postinst
@@ -18,6 +18,11 @@ update_release_available_script() {
             sed -i "s|Run 'do-release-upgrade' to upgrade to it\\.|Visit https://securedrop.org/xenial-upgrade for more information|" "$file"
         fi
     done
+
+    # remove the file in case it's empty
+    rm -f /var/lib/ubuntu-release-upgrader/release-upgrade-available
+    # force re-run the update script to trigger an OSSEC alert
+    /usr/lib/ubuntu-release-upgrader/check-new-release -q > /var/lib/ubuntu-release-upgrader/release-upgrade-available &
 }
 
 revert_update_release_available_script() {

--- a/install_files/securedrop-config/DEBIAN/postinst
+++ b/install_files/securedrop-config/DEBIAN/postinst
@@ -20,6 +20,14 @@ update_release_available_script() {
     done
 }
 
+revert_update_release_available_script() {
+    for file in /usr/lib/ubuntu-release-upgrader/check-new-release /var/lib/ubuntu-release-upgrader/release-upgrade-available; do
+        if [ -f $file ]; then
+            sed -i "s|Visit https://securedrop\\.org/xenial-upgrade for more information|Run 'do-release-upgrade' to upgrade to it.|" "$file"
+        fi
+    done
+}
+
 # Issue #4104
 # Set Prompt=never on Xenial
 # Set Prompt=lts on Trusty
@@ -32,6 +40,7 @@ update_release_prompt() {
         update_release_available_script
     else
         sed -i 's/Prompt=.*/Prompt=never/' "$upgrade_config"
+        revert_update_release_available_script
     fi
 }
 

--- a/molecule/testinfra/staging/common/test_release_upgrades.py
+++ b/molecule/testinfra/staging/common/test_release_upgrades.py
@@ -1,0 +1,27 @@
+def test_release_manager_upgrade_channel(host):
+    """
+    Ensures that the `do-release-upgrade` command will honor
+    upgrades from Trusty to Xenial, but not suggest upgrades
+    from Xenial to Bionic (which is untested and unsupported.)
+    """
+    expected_channels = {
+        "trusty": "lts",
+        "xenial": "never",
+    }
+
+    config_path = "/etc/update-manager/release-upgrades"
+    assert host.file(config_path).is_file
+
+    raw_output = host.check_output("grep '^Prompt' {}".format(config_path))
+    _, channel = raw_output.split("=")
+
+    expected_channel = expected_channels[host.system_info.codename]
+    assert channel == expected_channel
+
+
+def test_do_release_upgrade_is_installed(host):
+    """
+    Ensure the `do-release-upgrade` command is present on target systems,
+    so that instance Admins can upgrade from Trusty to Xenial.
+    """
+    assert host.exists("do-release-upgrade")


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4104

Update the `Prompt` in the release manage file depending on system codename. Additionally, attempt to rewrite the OSSEC alerts to prevent admins from running `do-release-upgrade` and breaking everything.

## Testing

1. Trusty
    - Build trusty debs
    - Install on trusty box
    - Verify that `/etc/update-manager/release-upgrades` contains `Prompt=lts`
    - Verify that `/usr/lib/ubuntu-release-upgrader/check-new-release` contains "Visit https://securedrop.org/xenial-upgrade for more information" (and so does  `/var/lib/ubuntu-release-upgrader/release-upgrade-available` if it exits)
2. Xenial
    - Build xenial debs
    - Install on xenial box
    - Verify that `/etc/update-manager/release-upgrades` contains `Prompt=never`
    - Verify that `/usr/lib/ubuntu-release-upgrader/check-new-release` does not contain "Visit https://securedrop.org/xenial-upgrade for more information" (and neither does  `/var/lib/ubuntu-release-upgrader/release-upgrade-available` if it exits)

## Deployment

All installs on Trusty will have files modified to the state SD requires. All installs on Xenial will have their files reverted to the default state.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR