### PR TITLE
[xenial] run haveged process confined by AppArmor

### DIFF
--- a/install_files/ansible-base/roles/app/tasks/configure_haveged.yml
+++ b/install_files/ansible-base/roles/app/tasks/configure_haveged.yml
@@ -38,3 +38,31 @@
   tags:
     - haveged
     - hardening
+
+# The following two tasks resolve haveged AppArmor issues described in
+# https://github.com/freedomofpress/securedrop/issues/4098.
+
+# This temporary fix ensures that the pid file haveged uses is whitelisted
+# by AppArmor.
+# Upstream bug: https://bugs.launchpad.net/ubuntu/+source/haveged/+bug/1708674
+- name: Whitelist haveged pid file in its AppArmor profile.
+  lineinfile:
+    dest: /etc/apparmor.d/usr.sbin.haveged
+    insertafter: "  #include <abstractions/base>"
+    line: "  /run/haveged.pid rw,"
+  tags:
+    - haveged
+    - hardening
+
+# This temporary fix resolves a race condition where havaged would start
+# prior to AppArmor, in which case haveged would be running unconfined.
+# Bug described in: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=824179
+- name: Start apparmor prior to haveged process.
+  lineinfile:
+    dest: /lib/systemd/system/haveged.service
+    regexp: "^After=systemd-random-seed.service"
+    line: "After=apparmor.service systemd-random-seed.service"
+    backrefs: yes
+  tags:
+    - haveged
+    - hardening

--- a/install_files/ansible-base/roles/app/tasks/configure_haveged.yml
+++ b/install_files/ansible-base/roles/app/tasks/configure_haveged.yml
@@ -39,8 +39,18 @@
     - haveged
     - hardening
 
-# The following two tasks resolve haveged AppArmor issues described in
+# The following three tasks resolve haveged AppArmor issues on Xenial described in
 # https://github.com/freedomofpress/securedrop/issues/4098.
+
+- name: Check whether haveged AppArmor profile exists in expected location for Xenial.
+  stat:
+    path: "/etc/apparmor.d/usr.sbin.haveged"
+  register: haveged_apparmor
+  # Do not report changed, this task does not modify state.
+  changed_when: false
+  tags:
+    - haveged
+    - hardening
 
 # This temporary fix ensures that the pid file haveged uses is whitelisted
 # by AppArmor.
@@ -50,11 +60,12 @@
     dest: /etc/apparmor.d/usr.sbin.haveged
     insertafter: "  #include <abstractions/base>"
     line: "  /run/haveged.pid rw,"
+  when: haveged_apparmor.stat.exists
   tags:
     - haveged
     - hardening
 
-# This temporary fix resolves a race condition where havaged would start
+# This temporary fix resolves a race condition where haveged would start
 # prior to AppArmor, in which case haveged would be running unconfined.
 # Bug described in: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=824179
 - name: Start apparmor prior to haveged process.
@@ -63,6 +74,7 @@
     regexp: "^After=systemd-random-seed.service"
     line: "After=apparmor.service systemd-random-seed.service"
     backrefs: yes
+  when: haveged_apparmor.stat.exists
   tags:
     - haveged
     - hardening

--- a/molecule/testinfra/staging/app/test_apparmor.py
+++ b/molecule/testinfra/staging/app/test_apparmor.py
@@ -116,12 +116,8 @@ def test_aastatus_unconfined(host):
     """ Ensure that there are no processes that are unconfined but have
         a profile """
 
-    # Trusty should show 0 unconfined processes. In Xenial, haveged
-    # is unconfined by default, due to introduction of a new profile.
-    # We should consider enforcing that, too.
+    # Trusty and Xenial should show 0 unconfined processes.
     expected_unconfined = 0
-    if host.system_info.codename == "xenial":
-        expected_unconfined = 1
 
     unconfined_chk = str("{} processes are unconfined but have"
                          " a profile defined".format(expected_unconfined))


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4098.

Changes proposed in this pull request:
 - fix AppArmor profile for haveged (enable rw to its pid file)
 - ensure that AppArmor service starts prior to haveged so haveged runs confined on boot

## Testing

(the trusty CI staging job and the testinfra test modified in this PR should sufficiently test for trusty)

### Xenial

- [ ] `make staging-xenial` completes without error
- [ ] `sudo aa-status` reports 0 processes running unconfined

## Deployment

Enforcing this via ansible playbook since they will be ran as part of the Xenial upgrade

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
