### PR TITLE
Update UI language referencing Tor button

### DIFF
--- a/securedrop/source_templates/logout_flashed_message.html
+++ b/securedrop/source_templates/logout_flashed_message.html
@@ -2,5 +2,5 @@
   <img src="{{ url_for('static', filename='i/hand_with_fingerprint.png') }}">
 </div>
 <div class="message"><strong>{{ gettext('Important!') }}</strong><br>
-  <p>{{ gettext('Thank you for exiting your session! Please select "New Identity" from the green onion button in the Tor browser to clear all history of your SecureDrop usage from this device.') }}</p>
+  <p>{{ gettext('Thank you for exiting your session! Please select "New Identity" from the onion button in the Tor browser\'s toolbar to clear all history of your SecureDrop usage from this device.') }}</p>
 </div>

--- a/securedrop/source_templates/session_timeout.html
+++ b/securedrop/source_templates/session_timeout.html
@@ -3,6 +3,6 @@
     <img src="{{ url_for('static', filename='i/hand_with_fingerprint.png') }}">
   </div>
   <div class="message"><strong>{{ gettext('Important!') }}</strong><br>
-  <p>{{ gettext('Your session timed out due to inactivity. Please login again if you want to continue using SecureDrop, or select "New Identity" from the green onion button in the Tor browser to clear all history of your SecureDrop usage from this device. If you are not using Tor Browser, restart your browser.') }}</p>
+  <p>{{ gettext('Your session timed out due to inactivity. Please login again if you want to continue using SecureDrop, or select "New Identity" from the onion button in the Tor browser\'s toolbar to clear all history of your SecureDrop usage from this device. If you are not using Tor Browser, restart your browser.') }}</p>
   </div>
 </div>


### PR DESCRIPTION
There is a still a friendly little green button, but it's now used for getting a new circuit. To get a new identity, you have to use the friendly little grey button.

Resolves #4131

## Status

Ready for review

## Additional notes

If it looks good, we should port it to the release branch as this is confusing behavior from the source's point of view - but needs to be done before string freeze.

## Testing

String change only, visual inspection of the PR should be sufficient.

- [X] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container