### PR TITLE
[xenial] Add documentation for Xenial upgrade

### DIFF
--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -318,8 +318,8 @@ before it can be used. We recommend:
     in a BIOS update. See these `release notes <https://downloadmirror.intel.com/26263/eng/RY_0359_ReleaseNotes.pdf>`__ (PDF) for more details.
 
 Later NUC revisions (the NUC7 and NUC8 series) typically include onboard WiFi
-and Bluetooth, and may use an Ethernet chipset not supported by the default Ubuntu 
-14.04.5 kernel. We are investigating workarounds for both issues. If you are 
+and Bluetooth, and may use an Ethernet chipset not supported by Securedrop's 
+custom kernel. We are investigating workarounds for both issues. If you are 
 having trouble sourcing the NUC5i5MYHE, please `contact us <https://securedrop.org/help/>`__
 for more information on how to safely configure and use more recent NUCs.  
 

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -318,7 +318,7 @@ before it can be used. We recommend:
     in a BIOS update. See these `release notes <https://downloadmirror.intel.com/26263/eng/RY_0359_ReleaseNotes.pdf>`__ (PDF) for more details.
 
 Later NUC revisions (the NUC7 and NUC8 series) typically include onboard WiFi
-and Bluetooth, and may use an Ethernet chipset not supported by Securedrop's 
+and Bluetooth, and may use an Ethernet chipset not supported by SecureDrop's
 custom kernel. We are investigating workarounds for both issues. If you are 
 having trouble sourcing the NUC5i5MYHE, please `contact us <https://securedrop.org/help/>`__
 for more information on how to safely configure and use more recent NUCs.  

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,6 +87,8 @@ anonymous sources.
    :maxdepth: 2
 
    upgrade/xenial_prep.rst
+   upgrade/xenial_upgrade_in_place.rst
+   upgrade/xenial_backup_install_restore.rst
    upgrade/0.10.0_to_0.11.0.rst
    upgrade/0.9.1_to_0.10.0.rst
    upgrade/0.8.0_to_0.9.1.rst

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -14,7 +14,7 @@ Install Ubuntu
   exactly as there are some "gotchas" that may cause your SecureDrop set up to break.
 
 The SecureDrop *Application Server* and *Monitor Server* run **Ubuntu Server
-16.04.5 LTS (Xenial Xerus)**. To install Ubuntu on the servers, you must first
+14.04.5 LTS (Trusty Tahr)**. To install Ubuntu on the servers, you must first
 download and verify the Ubuntu installation media. You should use the *Admin
 Workstation* to download and verify the Ubuntu installation media.
 
@@ -26,7 +26,7 @@ Download the Ubuntu Installation Media
 The installation media and the files required to verify it are available on the
 `Ubuntu Releases page`_. You will need to download the following files:
 
-* `ubuntu-16.04.5-server-amd64.iso`_
+* `ubuntu-14.04.5-server-amd64.iso`_
 * `SHA256SUMS`_
 * `SHA256SUMS.gpg`_
 
@@ -42,16 +42,16 @@ Alternatively, you can use the command line:
 .. code:: sh
 
    cd ~/Persistent
-   torify curl -OOO http://releases.ubuntu.com/16.04.5/{ubuntu-16.04.5-server-amd64.iso,SHA256SUMS{,.gpg}}
+   torify curl -OOO http://releases.ubuntu.com/14.04.5/{ubuntu-14.04.5-server-amd64.iso,SHA256SUMS{,.gpg}}
 
 .. note:: Downloading Ubuntu on the *Admin Workstation* can take a while
    because Tails does everything over Tor, and Tor is typically slow relative
    to the speed of your upstream Internet connection.
 
 .. _Ubuntu Releases page: http://releases.ubuntu.com/
-.. _ubuntu-16.04.5-server-amd64.iso: http://releases.ubuntu.com/16.04.5/ubuntu-16.04.5-server-amd64.iso
-.. _SHA256SUMS: http://releases.ubuntu.com/16.04.5/SHA256SUMS
-.. _SHA256SUMS.gpg: http://releases.ubuntu.com/16.04.5/SHA256SUMS.gpg
+.. _ubuntu-14.04.5-server-amd64.iso: http://releases.ubuntu.com/14.04.5/ubuntu-14.04.5-server-amd64.iso
+.. _SHA256SUMS: http://releases.ubuntu.com/14.04.5/SHA256SUMS
+.. _SHA256SUMS.gpg: http://releases.ubuntu.com/14.04.5/SHA256SUMS.gpg
 
 Verify the Ubuntu Installation Media
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -85,13 +85,13 @@ Verify the ``SHA256SUMS`` file and move on to the next step if you see
 
 The next and final step is to verify the Ubuntu image. ::
 
-    sha256sum -c <(grep ubuntu-16.04.5-server-amd64.iso SHA256SUMS)
+    sha256sum -c <(grep ubuntu-14.04.5-server-amd64.iso SHA256SUMS)
 
 
 If the final verification step is successful, you should see the
 following output in your terminal. ::
 
-    ubuntu-16.04.5-server-amd64.iso: OK
+    ubuntu-14.04.5-server-amd64.iso: OK
 
 .. caution:: If you do not see the line above it is not safe to proceed with the
              installation. If this happens, please contact us at
@@ -119,7 +119,7 @@ Ubuntu installer.
 If your USB is mapped to /dev/sdX and you are currently in the directory that
 contains the Ubuntu ISO, you would use dd like so: ::
 
-   sudo dd conv=fdatasync if=ubuntu-16.04.5-server-amd64.iso of=/dev/sdX
+   sudo dd conv=fdatasync if=ubuntu-14.04.5-server-amd64.iso of=/dev/sdX
 
 .. _install_ubuntu:
 
@@ -276,7 +276,7 @@ When the packages are finished installing, Ubuntu will automatically
 install the bootloader (GRUB). If it asks to install the bootloader to
 the Master Boot Record, choose **Yes**. When everything is done, reboot.
 
-.. |Ubuntu Server| image:: images/install/ubuntu_server.png 
+.. |Ubuntu Server| image:: images/install/ubuntu_server.png
 
 Save the Configurations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -14,7 +14,7 @@ Install Ubuntu
   exactly as there are some "gotchas" that may cause your SecureDrop set up to break.
 
 The SecureDrop *Application Server* and *Monitor Server* run **Ubuntu Server
-14.04.5 LTS (Trusty Tahr)**. To install Ubuntu on the servers, you must first
+16.04.5 LTS (Xenial Xerus)**. To install Ubuntu on the servers, you must first
 download and verify the Ubuntu installation media. You should use the *Admin
 Workstation* to download and verify the Ubuntu installation media.
 
@@ -26,7 +26,7 @@ Download the Ubuntu Installation Media
 The installation media and the files required to verify it are available on the
 `Ubuntu Releases page`_. You will need to download the following files:
 
-* `ubuntu-14.04.5-server-amd64.iso`_
+* `ubuntu-16.04.5-server-amd64.iso`_
 * `SHA256SUMS`_
 * `SHA256SUMS.gpg`_
 
@@ -42,16 +42,16 @@ Alternatively, you can use the command line:
 .. code:: sh
 
    cd ~/Persistent
-   torify curl -OOO http://releases.ubuntu.com/14.04.5/{ubuntu-14.04.5-server-amd64.iso,SHA256SUMS{,.gpg}}
+   torify curl -OOO http://releases.ubuntu.com/16.04.5/{ubuntu-16.04.5-server-amd64.iso,SHA256SUMS{,.gpg}}
 
 .. note:: Downloading Ubuntu on the *Admin Workstation* can take a while
    because Tails does everything over Tor, and Tor is typically slow relative
    to the speed of your upstream Internet connection.
 
 .. _Ubuntu Releases page: http://releases.ubuntu.com/
-.. _ubuntu-14.04.5-server-amd64.iso: http://releases.ubuntu.com/14.04.5/ubuntu-14.04.5-server-amd64.iso
-.. _SHA256SUMS: http://releases.ubuntu.com/14.04.5/SHA256SUMS
-.. _SHA256SUMS.gpg: http://releases.ubuntu.com/14.04.5/SHA256SUMS.gpg
+.. _ubuntu-16.04.5-server-amd64.iso: http://releases.ubuntu.com/16.04.5/ubuntu-16.04.5-server-amd64.iso
+.. _SHA256SUMS: http://releases.ubuntu.com/16.04.5/SHA256SUMS
+.. _SHA256SUMS.gpg: http://releases.ubuntu.com/16.04.5/SHA256SUMS.gpg
 
 Verify the Ubuntu Installation Media
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -85,13 +85,13 @@ Verify the ``SHA256SUMS`` file and move on to the next step if you see
 
 The next and final step is to verify the Ubuntu image. ::
 
-    sha256sum -c <(grep ubuntu-14.04.5-server-amd64.iso SHA256SUMS)
+    sha256sum -c <(grep ubuntu-16.04.5-server-amd64.iso SHA256SUMS)
 
 
 If the final verification step is successful, you should see the
 following output in your terminal. ::
 
-    ubuntu-14.04.5-server-amd64.iso: OK
+    ubuntu-16.04.5-server-amd64.iso: OK
 
 .. caution:: If you do not see the line above it is not safe to proceed with the
              installation. If this happens, please contact us at
@@ -119,7 +119,7 @@ Ubuntu installer.
 If your USB is mapped to /dev/sdX and you are currently in the directory that
 contains the Ubuntu ISO, you would use dd like so: ::
 
-   sudo dd conv=fdatasync if=ubuntu-14.04.5-server-amd64.iso of=/dev/sdX
+   sudo dd conv=fdatasync if=ubuntu-16.04.5-server-amd64.iso of=/dev/sdX
 
 .. _install_ubuntu:
 

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -276,7 +276,7 @@ When the packages are finished installing, Ubuntu will automatically
 install the bootloader (GRUB). If it asks to install the bootloader to
 the Master Boot Record, choose **Yes**. When everything is done, reboot.
 
-.. |Ubuntu Server| image:: images/install/ubuntu_server.png
+.. |Ubuntu Server| image:: images/install/ubuntu_server.png 
 
 Save the Configurations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/upgrade/xenial_backup_install_restore.rst
+++ b/docs/upgrade/xenial_backup_install_restore.rst
@@ -1,0 +1,57 @@
+Ubuntu 16.04 LTS (Xenial) -  back up, install, restore
+======================================================
+
+One way to upgrade your instance to Xenial is to take a backup of your existing 
+instance, install a new Xenial-based instance on new hardware, and then cut over to and validate the new instance. 
+
+This approach has the following benefits
+
+[ list here ]
+
+However, some downsides include:
+
+[ list here ]
+
+This method may also be used to restore an instance that has become unusable due to an upgrade or hardware failure.
+
+
+Communicating with users before the change
+------------------------------------------
+
+[ blurb here ]
+
+ - You should coordinate the timing of the upgrade with the people responsible for checking for submissions. If they have ongoing conversations with sources, or are expecting submissions, it may be necessary to reschedule the upgrade.
+ - You should also consider communicating the downtime downtime and reason for it on your instance's landing page.
+ 
+
+Step 1: back up your instance
+-----------------------------
+
+[ refer to existing backup docs - some additional detail ] 
+
+
+Step 2: install using Xenial
+----------------------------
+
+[ refer to existing installation notes ]
+
+
+Step 3: Restore your instance data and config from backup
+---------------------------------------------------------
+
+[ refer to backup/restore docs ]
+
+Step 4: Cut over to the new instance
+------------------------------------
+
+[ describe process of cutting over to new instance - collision between hidden services etc ]
+
+Step 5: Test the instance connectivity and configuration
+--------------------------------------------------------
+
+[ TBD - either a bunch of shell commands that check installed versions and stuff like grsec and Apparmor, or a single script provided with the release to do basic server tests ]
+
+[ Also a checklist for basic functionality - connectivity to the 4 services, and a run through the submission-to-decryption workflow ]
+
+[ Anything else? ]
+

--- a/docs/upgrade/xenial_backup_install_restore.rst
+++ b/docs/upgrade/xenial_backup_install_restore.rst
@@ -1,27 +1,47 @@
-Ubuntu 16.04 LTS (Xenial) -  back up, install, restore
+Ubuntu 16.04 LTS (Xenial) -  Back Up, Install, Restore
 ======================================================
 
-One way to upgrade your instance to Xenial is to take a backup of your existing 
-instance, install a new Xenial-based instance on new or existing hardware, and then cut over to and validate the new instance. 
+One way to upgrade your instance to Ubuntu 16.04 (Xenial) is to create a backup
+of your existing Ubuntu 14.04 (Trusty) instance, install a new instance based on
+Xenial, and restore the data from the backup to the Xenial-based installation.
 
-With the use of separate hardware, this method minimizes the downtime required for the upgrade, and allows you to validate the instance before permanently cutting over. However, it does require physical access to the servers to complete the installation. If you do not have physical access to the servers, you should consider using the upgrade-in-place method to upgrade to Xenial, which can be completed from the *Admin Workstation* over Tor. 
+You can follow this procedure on your existing hardware (causing significant
+downtime), or you can install using redundant hardware and perform a cut-over
+once you have validated that the new installation is working (minimizing
+downtime).
+
+.. note ::
+  This procedure requires physical access to the servers and firewall
+  to complete the installation. If you do not have physical access to the
+  hardware, consider using the method documented in :doc:`xenial_upgrade_in_place`,
+  which can be completed from the *Admin Workstation* over Tor.
 
 
 Before you begin
 ----------------
 
-Before you get started, make sure that you have completed the :doc:`preparatory steps for the Xenial upgrade <xenial_prep>`. As you will be installing onto new hardware, you wil lneed physical access to the servers and firewall, and you will need a monitor and keyboard to connect to the servers during the OS installation.
+Before you get started, make sure that you have completed the :doc:`preparatory
+steps for the Xenial upgrade <xenial_prep>`. You will need physical access to
+the servers and firewall, and you will need a monitor and keyboard to connect to
+the servers during the OS installation.
 
-If you are planning to install the Xenial instance on new hardware, make sure that you have all the necessary hardware to hand and configured. This guide assumes that you are either using the existing hardware firewall, or a new firewall preconfigured with the same settings as your existing one. 
+If you are planning to install the Xenial instance on new hardware, make sure
+that you have all the necessary hardware to hand and configured. This guide
+assumes that you are either using the existing hardware firewall, or a new
+firewall configured with the same settings as your existing one.
 
-Although downtime should be minimal, you should coordinate the timing of the upgrade with the people responsible for checking for submissions. If they have ongoing conversations with sources, or are expecting submissions, it may be necessary to reschedule the upgrade. You should also consider communicating the planned downtime and the reason for it on your instance's landing page.
+Although downtime should be minimal, you should coordinate the timing of the
+upgrade with the people responsible for checking for submissions. If they have
+ongoing conversations with sources, or are expecting submissions, it may be
+necessary to reschedule the upgrade. Consider communicating the planned downtime
+and the reason for it on your instance's *Landing Page*.
 
- 
-
-Step 1: back up your instance
+Step 1: Back up your instance
 -----------------------------
 
-First, you should back up your instance. Start up the *Admin Workstation* with persistence enabled and an administration password set. Then, once you are connected to the Tor network, open a terminal and run the following commands:
+Start up the *Admin Workstation* with persistence enabled and an administration
+password set. Then, once you are connected to the Tor network, open a terminal
+and run the following commands:
 
 .. code:: sh
 
@@ -29,50 +49,73 @@ First, you should back up your instance. Start up the *Admin Workstation* with p
  ./securedrop-admin setup
  ./securedrop-admin backup
 
-This will create a backup named ``sd-backup-<date>.tar.gz`` in the ``~/Persistent/securedrop/install_files/ansible-base`` directory. Make a note of the exact name, as you'll need it later.
+This will create a backup named ``sd-backup-<date>.tar.gz`` in the
+``~/Persistent/securedrop/install_files/ansible-base`` directory. Make a note of
+the exact name, as you'll need it later.
 
-You should also make a copy of the configuration files that allow the *Admin Workstation* to connect to the hidden services on the *Application Server*. To do so, run the following commands from the terminal:
+You should also make a copy of the configuration files that allow the *Admin
+Workstation* to connect to the hidden services on the *Application Server*. To
+do so, run the following commands from the terminal:
 
-.. code:: sh 
+.. code:: sh
 
   cd ~/Persistent/
   mkdir app_service
   cp securedrop/install_files/ansible-base/app-*ths app_service/
   cp securedrop/install_files/ansible-base/site-specific app_service/
 
-Once you have completed the backup process, you may shut down the *Admin Workstation* and move to the next step: installing a Xenial-based instance. (You will need physical access to the servers and firewall for this step.) 
+Once you have completed the backup process, you may shut down the *Admin
+Workstation* and move to the next step: installing a Xenial-based instance.
 
-Step 2: install Xenial
+Step 2: Install Xenial
 ----------------------
 
-Assuming that you are using your existing firewall, or that you've already set up your new firewall following the instructions in :doc:`../network_firewall`, the next step is to connect your candidate *Application* and *Monitor* servers to it and install the Xenial base OS. 
+Assuming that you are using your existing firewall, or that you've already set
+up your new firewall following the instructions in :doc:`../network_firewall`,
+the next step is to connect your candidate *Application* and *Monitor* servers
+to it and install the Xenial base OS.
 
 .. caution::
- If you're reusing your existing servers, their storage will be wiped by this step, so make sure your backups are available!
+ If you're reusing your existing servers, their storage will be wiped by this
+ step, so make sure your backups are available!
 
-With the servers connected to the firewall, follow the instructions in :doc:`../servers` to install Xenial, overwriting the existing Trusty installation. You should use the same network settings and administrator shell account name as for your previous installation. 
+With the servers connected to the firewall, follow the instructions in
+:doc:`../servers` to install Xenial, overwriting the existing Trusty
+installation. You should use the same network settings and administrator shell
+account name as for your previous installation.
 
 .. note::
- 
- if you do not have the network settings or shell username recorded, you'll find them listed in the ``~/Persistent/app_service/site-specific`` file on the  *Admin Workstation*
+
+ If you do not have the network settings (including your server IP addresses) or
+ shell username recorded, you'll find them listed in the
+ ``~/Persistent/app_service/site-specific`` file on the *Admin Workstation*.
 
 Step 3: Set up SSH access to the servers
 ----------------------------------------
 
-Once you have installed Xenial on the servers, you'll need to configure key-based SSH access to the servers from the *Admin Workstation*.
+Once you have installed Xenial on the servers, you'll need to configure
+key-based SSH access to the servers from the *Admin Workstation*.
 
-First, connect the *Admin Workstation* directly to the firewall via Ethernet, and start up the *Admin Workstation* with persistence enabled and an administration password set. You may need to update the network settings in Tails to use the static IP that was set up during the firewall configuration for the *Admin Workstation*.
+First, connect the *Admin Workstation* directly to the firewall via Ethernet,
+and start up the *Admin Workstation* with persistence enabled and an
+administration password set. You may need to update the network settings in
+Tails to use the static IP that was set up during the firewall configuration for
+the *Admin Workstation*.
 
-Then, remove the previous instance's connection config from the *Admin Workstation*, by opening a terminal and running the following commands:
+Then, remove the previous instance's connection configuration from the *Admin
+Workstation*, by opening a terminal and running the following commands:
 
 .. code:: sh
- 
+
  rm ~/.ssh/{config,known_hosts}
  rm ~/Persistent/securedrop/install_files/ansible-base/app-source-ths
  rm ~/Persistent/securedrop/install_files/ansible-base/app-*-aths
  rm ~/Persistent/securedrop/install_files/ansible-base/mon-*-aths
 
-Next, copy the *Admin Workstation*'s SSH public key to the new servers. To do so, you will need the IP addresses of the servers, and the username and password of the administrator account created during the OS installation. The commands below use the default values, but make sure to substitute your own:
+Next, copy the *Admin Workstation*'s SSH public key to the new servers. To do
+so, you will need the IP addresses of the servers, and the username and password
+of the administrator account created during the OS installation. The commands
+below use the default values, but make sure to substitute your own:
 
 .. code:: sh
 
@@ -81,25 +124,29 @@ Next, copy the *Admin Workstation*'s SSH public key to the new servers. To do so
 
  # copy key to mon
  ssh-copy-id sdadmin@10.20.3.2
- 
+
 You will be prompted by both commands for the shell account password.
 
 To confirm that key-based SSH access is working, run the following commands:
 
 .. code:: sh
-  
+
   ssh sdadmin@10.20.2.2 hostname
   ssh sdadmin@10.20.3.2 hostname
 
-In both cases, the commands should return the hostname of the remote server, without requiring a password.
+In both cases, the commands should return the hostname of the remote server,
+without requiring a password.
 
 
 Step 4: Install SecureDrop
 --------------------------
 
-Once you have set up SSH access, it's time to install SecureDrop. As most of the application settings are preserved on the *Admin Workstation* from your previous instance, this process will be simpler than your first installation.
+Once you have set up SSH access, it's time to install SecureDrop. As most of the
+application settings are preserved on the *Admin Workstation* from your previous
+instance, this process will be simpler than your first installation.
 
-First, you'll need make sure your *Admin Workstation*'s SecureDrop application code is up-to-date and validated. From a terminal, run the following commands:
+First, you'll need make sure your *Admin Workstation*'s SecureDrop application
+code is up-to-date and validated. From a terminal, run the following commands:
 
 .. code:: sh
 
@@ -107,11 +154,15 @@ First, you'll need make sure your *Admin Workstation*'s SecureDrop application c
  git checkout 0.12.0
  git tag -v 0.12.0
 
-You should see ``Good signature from "SecureDrop Release Signing Key"`` in the output of that last command, along with the fingerprint ``"2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"``
+You should see ``Good signature from "SecureDrop Release Signing Key"`` in the
+output of that last command, along with the fingerprint ``"2224 5C81 E3BA EB41
+38B3 6061 310F 5612 00F4 AD77"``
 
 .. caution::
 
- If you do not, signature verification has failed and you should not proceed with the installation. If this happens, please contact us at securedrop@freedom.press.
+ If you do not, signature verification has failed and you should not proceed
+ with the installation. If this happens, please contact us at
+ securedrop@freedom.press.
 
 If the command above returns the expected value, you may proceed with the installation.
 
@@ -121,83 +172,113 @@ First, run the following command to set up the SecureDrop administration environ
 
   ./securedrop-admin setup
 
-This command may take several minutes to complete and may fail due to Tor network timeouts. If it does fail, try running it again. If it fails repeatedly, :ref:`contact us. <bir_contact_us>` 
+This command may take several minutes to complete and may fail due to Tor
+network timeouts. If it does fail, try running it again. If it fails repeatedly,
+:ref:`contact us. <bir_contact_us>`
 
-Next, step through the SecureDrop application settings to verify that their values are correct. You should not need to change anything - run the following command and press Enter when prompted with the current values:
+Next, step through the SecureDrop application settings to verify that their
+values are correct. You should not need to change anything - run the following
+command and press Enter when prompted with the current values:
 
 .. code:: sh
 
  ./securedrop-admin sdconfig
 
-If the configuration values are correct, you may proceed with the installation using the following command:
+If the configuration values are correct, you may proceed with the installation
+using the following command:
 
 .. code:: sh
 
  ./securedrop-admin install
 
-This command will take several minutes to complete, and will reboot the *Application* and *Monitor* servers as part of the process. If it fails, try running it again. If it fails repeatedly, :ref:`contact us. <bir_contact_us>`
+This command will take several minutes to complete, and will reboot the
+*Application* and *Monitor* servers as part of the process. If it fails, try
+running it again. If it fails repeatedly, :ref:`contact us. <bir_contact_us>`
 
-When the server installation completes successfully, you should set up the *Admin Workstation* to connect to the new servers over Tor. To do so, run the following command:
+When the server installation completes successfully, you should set up the
+*Admin Workstation* to connect to the new servers over Tor. To do so, run the
+following command:
 
 .. code:: sh
 
  ./securedrop-admin tailsconfig
 
-This will update desktop shortcuts and SSH configuration files on the *Admin Workstation*. Once it is complete, you may move on to the next step: restoring the old instance configuration and data from the backup.
+This will update desktop shortcuts and SSH configuration files on the *Admin
+Workstation*. Once it is complete, you may move on to the next step: restoring
+the old instance configuration and data from the backup.
 
-Step 5: Restore your instance data and config from backup
----------------------------------------------------------
+Step 5: Restore your instance data and configuration from backup
+----------------------------------------------------------------
 
-Before beginning the restore procedure, you should stop and start the Tails network connection using the panel widget in the upper-right corner of the screen. This will force the Tails Tor proxy to load the config changes made by the ``./securedrop-admin tailsconfig`` command. Once Tor has reconnected, you're ready to restore the backup.
+Before beginning the restore procedure, you should stop and start the Tails
+network connection using the panel widget in the upper-right corner of the
+screen. This will force the Tails Tor proxy to load the config changes made by
+the ``./securedrop-admin tailsconfig`` command. Once Tor has reconnected, you're
+ready to restore the backup.
 
-To restore from backup, run the following commands in a terminal, substituting the name of the backup file that you created earlier for `sd-backup-<date>.tar.gz`:
+To restore from backup, run the following commands in a terminal, substituting
+the name of the backup file that you created earlier for
+`sd-backup-<date>.tar.gz`:
 
 .. code:: sh
 
  cd ~/Persistent/securedrop
  ./securedrop-admin restore sd-backup-<date>.tar.gz
 
-Once the restore process is complete, the previous instance's *Application Server* ATHS and THS files should be copied into place on the *Admin Workstation*. From a terminal, run the following commands:
+Once the restore process is complete, the previous instance's *Application
+Server* ATHS and THS files should be copied into place on the *Admin
+Workstation*. From a terminal, run the following commands:
 
 .. code:: sh
 
  cd ~/Persistent
  cp app_services/app*ths securedrop/install_files/ansible-base/
 
-Finally, run the ``tailsconfig`` command again to update the *Admin Workstation*'s SSH configuration and desktop shortcuts:
+Finally, run the ``tailsconfig`` command again to update the *Admin
+Workstation*'s SSH configuration and desktop shortcuts:
 
 .. code:: sh
 
  cd ~/Persistent/securedrop
  ./securedrop-admin tailsconfig
 
-Once the command completes, stop and restart the network connection again to force the Tails Tor proxy to pick up on the configuration changes.
+Once the command completes, stop and restart the network connection again to
+force the Tails Tor proxy to pick up on the configuration changes.
 
 Step 6: Cut over to the new instance
 ------------------------------------
 
-If you used your existing instance's hardware for the Xenial installation, your new instance is now available, with unchanged Onion URLs. If you installed onto new hardware, you should now power down your old instance hardware and reboot your new instance's servers. Once the reboot is complete, move on to Step 7.
+If you used your existing instance's hardware for the Xenial installation, your
+new instance is now available, with unchanged Onion URLs. If you installed onto
+new hardware, you should now power down your old instance hardware and reboot
+your new instance's servers. Once the reboot is complete, move on to Step 7.
 
 Step 7: Test the instance connectivity
 --------------------------------------
 
-Your Xenial-based instance should now be up and running, with the *Journalist* and *Source* interfaces available under their original Onion URLs. To confirm this, use the desktop shortcuts on the *Admin Workstation* to connect to each interface, and log into the *Journalist Interface* using your existing credentials. You should also verify SSH connectivity to the *Application* and *Monitor* servers from a terminal, using the commands ``ssh app`` and ``ssh mon`` respectively.
+Your Xenial-based instance should now be up and running, with the *Journalist*
+and *Source* interfaces available under their original Onion URLs. To confirm
+this, use the desktop shortcuts on the *Admin Workstation* to connect to each
+interface, and log into the *Journalist Interface* using your existing
+credentials. You should also verify SSH connectivity to the *Application* and
+*Monitor* servers from a terminal, using the commands ``ssh app`` and ``ssh
+mon`` respectively.
 
 .. _bir_contact_us:
 
 Contact us
 ----------
 
-If you have questions or comments regarding this process, or if you             
-encounter any issues, you can always contact us by the following means:         
-                                                                                
+If you have questions or comments regarding this process, or if you
+encounter any issues, you can always contact us by the following means:
+
 - via our `Support Portal <https://support.freedom.press>`_, if you are a member
-  (membership is approved on a case-by-case basis);                             
-- via securedrop@freedom.press                                                  
+  (membership is approved on a case-by-case basis);
+- via securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__)
-  for sensitive security issues (please use judiciously);                       
-- via our `community forums <https://forum.securedrop.org>`_.                   
-                                                                                
+  for sensitive security issues (please use judiciously);
+- via our `community forums <https://forum.securedrop.org>`_.
+
 If you encounter problems that are not security-sensitive, we also encourage you
-to `file an issue <https://github.com/freedomofpress/securedrop/issues/new/>`   
-in our public GitHub repository.       
+to `file an issue <https://github.com/freedomofpress/securedrop/issues/new/>`
+in our public GitHub repository.

--- a/docs/upgrade/xenial_backup_install_restore.rst
+++ b/docs/upgrade/xenial_backup_install_restore.rst
@@ -291,7 +291,7 @@ encounter any issues, you can always contact us by the following means:
 - via our `community forums <https://forum.securedrop.org>`_.
 
 If you encounter problems that are not security-sensitive, we also encourage you
-to `file an issue <https://github.com/freedomofpress/securedrop/issues/new/>`
+to `file an issue <https://github.com/freedomofpress/securedrop/issues/new/>`_
 in our public GitHub repository.
 
 .. caution:: 

--- a/docs/upgrade/xenial_backup_install_restore.rst
+++ b/docs/upgrade/xenial_backup_install_restore.rst
@@ -2,56 +2,202 @@ Ubuntu 16.04 LTS (Xenial) -  back up, install, restore
 ======================================================
 
 One way to upgrade your instance to Xenial is to take a backup of your existing 
-instance, install a new Xenial-based instance on new hardware, and then cut over to and validate the new instance. 
+instance, install a new Xenial-based instance on new or existing hardware, and then cut over to and validate the new instance. 
 
-This approach has the following benefits
-
-[ list here ]
-
-However, some downsides include:
-
-[ list here ]
-
-This method may also be used to restore an instance that has become unusable due to an upgrade or hardware failure.
+With the use of separate hardware, this method minimizes the downtime required for the upgrade, and allows you to validate the instance before permanently cutting over. However, it does require physical access to the servers to complete the installation. If you do not have physical access to the servers, you should consider using the upgrade-in-place method to upgrade to Xenial, which can be completed from the *Admin Workstation* over Tor. 
 
 
-Communicating with users before the change
-------------------------------------------
+Before you begin
+----------------
 
-[ blurb here ]
+Before you get started, make sure that you have completed the :doc:`preparatory steps for the Xenial upgrade <xenial_prep>`. As you will be installing onto new hardware, you wil lneed physical access to the servers and firewall, and you will need a monitor and keyboard to connect to the servers during the OS installation.
 
- - You should coordinate the timing of the upgrade with the people responsible for checking for submissions. If they have ongoing conversations with sources, or are expecting submissions, it may be necessary to reschedule the upgrade.
- - You should also consider communicating the downtime downtime and reason for it on your instance's landing page.
+If you are planning to install the Xenial instance on new hardware, make sure that you have all the necessary hardware to hand and configured. This guide assumes that you are either using the existing hardware firewall, or a new firewall preconfigured with the same settings as your existing one. 
+
+Although downtime should be minimal, you should coordinate the timing of the upgrade with the people responsible for checking for submissions. If they have ongoing conversations with sources, or are expecting submissions, it may be necessary to reschedule the upgrade. You should also consider communicating the planned downtime and the reason for it on your instance's landing page.
+
  
 
 Step 1: back up your instance
 -----------------------------
 
-[ refer to existing backup docs - some additional detail ] 
+First, you should back up your instance. Start up the *Admin Workstation* with persistence enabled and an administration password set. Then, once you are connected to the Tor network, open a terminal and run the following commands:
+
+.. code:: sh
+
+ cd ~/Persistent/securedrop
+ ./securedrop-admin setup
+ ./securedrop-admin backup
+
+This will create a backup named ``sd-backup-<date>.tar.gz`` in the ``~/Persistent/securedrop/install_files/ansible-base`` directory. Make a note of the exact name, as you'll need it later.
+
+You should also make a copy of the configuration files that allow the *Admin Workstation* to connect to the hidden services on the *Application Server*. To do so, run the following commands from the terminal:
+
+.. code:: sh 
+
+  cd ~/Persistent/
+  mkdir app_service
+  cp securedrop/install_files/ansible-base/app-*ths app_service/
+  cp securedrop/install_files/ansible-base/site-specific app_service/
+
+Once you have completed the backup process, you may shut down the *Admin Workstation* and move to the next step: installing a Xenial-based instance. (You will need physical access to the servers and firewall for this step.) 
+
+Step 2: install Xenial
+----------------------
+
+Assuming that you are using your existing firewall, or that you've already set up your new firewall following the instructions in :doc:`../network_firewall`, the next step is to connect your candidate *Application* and *Monitor* servers to it and install the Xenial base OS. 
+
+.. caution::
+ If you're reusing your existing servers, their storage will be wiped by this step, so make sure your backups are available!
+
+With the servers connected to the firewall, follow the instructions in :doc:`../servers` to install Xenial, overwriting the existing Trusty installation. You should use the same network settings and administrator shell account name as for your previous installation. 
+
+.. note::
+ 
+ if you do not have the network settings or shell username recorded, you'll find them listed in the ``~/Persistent/app_service/site-specific`` file on the  *Admin Workstation*
+
+Step 3: Set up SSH access to the servers
+----------------------------------------
+
+Once you have installed Xenial on the servers, you'll need to configure key-based SSH access to the servers from the *Admin Workstation*.
+
+First, connect the *Admin Workstation* directly to the firewall via Ethernet, and start up the *Admin Workstation* with persistence enabled and an administration password set. You may need to update the network settings in Tails to use the static IP that was set up during the firewall configuration for the *Admin Workstation*.
+
+Then, remove the previous instance's connection config from the *Admin Workstation*, by opening a terminal and running the following commands:
+
+.. code:: sh
+ 
+ rm ~/.ssh/{config,known_hosts}
+ rm ~/Persistent/securedrop/install_files/ansible-base/app-source-ths
+ rm ~/Persistent/securedrop/install_files/ansible-base/app-*-aths
+ rm ~/Persistent/securedrop/install_files/ansible-base/mon-*-aths
+
+Next, copy the *Admin Workstation*'s SSH public key to the new servers. To do so, you will need the IP addresses of the servers, and the username and password of the administrator account created during the OS installation. The commands below use the default values, but make sure to substitute your own:
+
+.. code:: sh
+
+ # copy key to app
+ ssh-copy-id sdadmin@10.20.2.2
+
+ # copy key to mon
+ ssh-copy-id sdadmin@10.20.3.2
+ 
+You will be prompted by both commands for the shell account password.
+
+To confirm that key-based SSH access is working, run the following commands:
+
+.. code:: sh
+  
+  ssh sdadmin@10.20.2.2 hostname
+  ssh sdadmin@10.20.3.2 hostname
+
+In both cases, the commands should return the hostname of the remote server, without requiring a password.
 
 
-Step 2: install using Xenial
-----------------------------
+Step 4: Install SecureDrop
+--------------------------
 
-[ refer to existing installation notes ]
+Once you have set up SSH access, it's time to install SecureDrop. As most of the application settings are preserved on the *Admin Workstation* from your previous instance, this process will be simpler than your first installation.
 
+First, you'll need make sure your *Admin Workstation*'s SecureDrop application code is up-to-date and validated. From a terminal, run the following commands:
 
-Step 3: Restore your instance data and config from backup
+.. code:: sh
+
+ cd ~/Persistent/securedrop
+ git checkout 0.12.0
+ git tag -v 0.12.0
+
+You should see ``Good signature from "SecureDrop Release Signing Key"`` in the output of that last command, along with the fingerprint ``"2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"``
+
+.. caution::
+
+ If you do not, signature verification has failed and you should not proceed with the installation. If this happens, please contact us at securedrop@freedom.press.
+
+If the command above returns the expected value, you may proceed with the installation.
+
+First, run the following command to set up the SecureDrop administration environment:
+
+.. code:: sh
+
+  ./securedrop-admin setup
+
+This command may take several minutes to complete and may fail due to Tor network timeouts. If it does fail, try running it again. If it fails repeatedly, :ref:`contact us. <bir_contact_us>` 
+
+Next, step through the SecureDrop application settings to verify that their values are correct. You should not need to change anything - run the following command and press Enter when prompted with the current values:
+
+.. code:: sh
+
+ ./securedrop-admin sdconfig
+
+If the configuration values are correct, you may proceed with the installation using the following command:
+
+.. code:: sh
+
+ ./securedrop-admin install
+
+This command will take several minutes to complete, and will reboot the *Application* and *Monitor* servers as part of the process. If it fails, try running it again. If it fails repeatedly, :ref:`contact us. <bir_contact_us>`
+
+When the server installation completes successfully, you should set up the *Admin Workstation* to connect to the new servers over Tor. To do so, run the following command:
+
+.. code:: sh
+
+ ./securedrop-admin tailsconfig
+
+This will update desktop shortcuts and SSH configuration files on the *Admin Workstation*. Once it is complete, you may move on to the next step: restoring the old instance configuration and data from the backup.
+
+Step 5: Restore your instance data and config from backup
 ---------------------------------------------------------
 
-[ refer to backup/restore docs ]
+Before beginning the restore procedure, you should stop and start the Tails network connection using the panel widget in the upper-right corner of the screen. This will force the Tails Tor proxy to load the config changes made by the ``./securedrop-admin tailsconfig`` command. Once Tor has reconnected, you're ready to restore the backup.
 
-Step 4: Cut over to the new instance
+To restore from backup, run the following commands in a terminal, substituting the name of the backup file that you created earlier for `sd-backup-<date>.tar.gz`:
+
+.. code:: sh
+
+ cd ~/Persistent/securedrop
+ ./securedrop-admin restore sd-backup-<date>.tar.gz
+
+Once the restore process is complete, the previous instance's *Application Server* ATHS and THS files should be copied into place on the *Admin Workstation*. From a terminal, run the following commands:
+
+.. code:: sh
+
+ cd ~/Persistent
+ cp app_services/app*ths securedrop/install_files/ansible-base/
+
+Finally, run the ``tailsconfig`` command again to update the *Admin Workstation*'s SSH configuration and desktop shortcuts:
+
+.. code:: sh
+
+ cd ~/Persistent/securedrop
+ ./securedrop-admin tailsconfig
+
+Once the command completes, stop and restart the network connection again to force the Tails Tor proxy to pick up on the configuration changes.
+
+Step 6: Cut over to the new instance
 ------------------------------------
 
-[ describe process of cutting over to new instance - collision between hidden services etc ]
+If you used your existing instance's hardware for the Xenial installation, your new instance is now available, with unchanged Onion URLs. If you installed onto new hardware, you should now power down your old instance hardware and reboot your new instance's servers. Once the reboot is complete, move on to Step 7.
 
-Step 5: Test the instance connectivity and configuration
---------------------------------------------------------
+Step 7: Test the instance connectivity
+--------------------------------------
 
-[ TBD - either a bunch of shell commands that check installed versions and stuff like grsec and Apparmor, or a single script provided with the release to do basic server tests ]
+Your Xenial-based instance should now be up and running, with the *Journalist* and *Source* interfaces available under their original Onion URLs. To confirm this, use the desktop shortcuts on the *Admin Workstation* to connect to each interface, and log into the *Journalist Interface* using your existing credentials. You should also verify SSH connectivity to the *Application* and *Monitor* servers from a terminal, using the commands ``ssh app`` and ``ssh mon`` respectively.
 
-[ Also a checklist for basic functionality - connectivity to the 4 services, and a run through the submission-to-decryption workflow ]
+.. _bir_contact_us:
 
-[ Anything else? ]
+Contact us
+----------
 
+If you have questions or comments regarding this process, or if you             
+encounter any issues, you can always contact us by the following means:         
+                                                                                
+- via our `Support Portal <https://support.freedom.press>`_, if you are a member
+  (membership is approved on a case-by-case basis);                             
+- via securedrop@freedom.press                                                  
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__)
+  for sensitive security issues (please use judiciously);                       
+- via our `community forums <https://forum.securedrop.org>`_.                   
+                                                                                
+If you encounter problems that are not security-sensitive, we also encourage you
+to `file an issue <https://github.com/freedomofpress/securedrop/issues/new/>`   
+in our public GitHub repository.       

--- a/docs/upgrade/xenial_upgrade_in_place.rst
+++ b/docs/upgrade/xenial_upgrade_in_place.rst
@@ -1,0 +1,149 @@
+Ubuntu 16.04 LTS (Xenial) - upgrading in place
+==============================================
+
+If some instance downtime during the Xenial upgrade is acceptable, or if no backup hardware is available to allow for the no-downtime backup->install->restore upgrade procedure, it is possible to upgrade your SecureDrop instance in place. The upgrade-in place procedure requires no additional hardware, and is described below. 
+
+
+Communicating with users before the change
+------------------------------------------
+
+The process of upgrading in place will result in downtime for your instance. Our testing indicates that the upgrade may take up to 8 hours, assuming no issues. As a result, we recommend that you plan for 2 days work, during which the instance will be unavailable. You should also consider having a communications plan in place both for journalist and sources.
+
+ - You should coordinate the timing of the upgrade with the people responsible for checking for submissions. If they have ongoing conversations with sources, or are expecting submissions, it may be necessary to reschedule the upgrade.
+ - You should also consider communicating the downtime downtime and reason for it on your instance's landing page.
+ 
+
+Preparatory steps
+-----------------
+
+ - take a backup of the instance using usual methods
+ - make sure Admin Stick is updated to 0.12.0 (or later)
+ - make sure that your instance is also upgraded to 0.12.0+ (ED: needed for changes in postints to iptables etc - probably best to check deployed deb versions via ssh commands)
+
+Upgrade and validate the Monitor Server 
+---------------------------------------
+
+First, open a terminal by selecting **Applications > Favorites > Terminal**. Then connect to the Monitor Server with the command ``ssh mon``.
+
+Before running the ``do-release-upgrade`` command, you must edit the ``/etc/update-manager/release-upgrades``, changing `Prompt=never` to `Prompt=lts`. ED - this won't be necessary when #4104 lands
+
+The OS upgrade process for the Monitor Server will take from 30-60 minutes based on your server specifications and available bandwidth, and should not be interrupted once begun. To begin  the process, run the command below and then supply the answers listed below to the prompts that follow:
+
+
+.. code:: sh
+
+  sudo do-release-upgrade
+
+.. note:: The prompt answers below have been tested on the recommended hardware for SecureDrop. If your instance uses non-standard hardware, you may be see different or additional prompts. In general, when responding to these prompts you should preserve existing configuration files whenever possible.
+    
+- Run ``sudo do-release-upgrade`` to start the upgrade process
+- Press Enter after the "Some third party entries..." message
+- Type 'y' and press Enter to continue after the "Installing the upgrade..." message
+- Type 'y' and press Enter to continue after the "Fetching and installing..." message
+
+.. note:: The ``do-release-upgrade`` script displays some dialogs using ``ncurses``, a library for rendering GUI elements in text-only displays. It may display incorrectly within your terminal window. To force a redraw, adjust the terminal's size to approximately 150 columns by 40 rows. If it still does not display correctly, make small adjustments to the terminal size to force successive redraws.
+  
+- Choose OK to close the *Postfix* information dialog
+- Choose **No Configuration** and **OK** on the *General type of mail configuration* dialog
+- Choose **Yes** on the *Configuring libssl.0.0:amd64* dialog - when you do so, the ``sshd`` and ``tor`` daemons will restart, breaking your connection to the Monitor Server
+- Close the terminal window, open a new one, and reconnect with the command ``ssh mon``
+- Choose **No** to overriding local changes, on the *PAM configuration* dialog
+- Choose the default action (keep local version)  when prompted about ``blacklist.conf`` changes
+- Choose **Keep the local version currently installed** on the `Configuring grub-efi-amd64` dialog
+- Choose default (keep current version) when prompted about ``/etc/ssh/moduli`` changes
+- Choose default (keep current version) when prompted about ``/etc/ssh/ssh_config`` changes
+- Choose default (keep current version) when prompted about ``/etc/pam.d/sshd`` changes
+- Choose **keep local version currently installed** and **OK** on the *Configuring unattended-upgrades* dialog
+- Type 'y' and press Enter to remove obsolete packages when prompted
+- Type 'y' and press Enter to restart the system and complete the update
+
+The Monitor Server will now reboot - this may take several minutes. In order to reconnect via ``ssh mon``, you must stop and restart the Admin Workstation's Internet connection,  using the upper-righthand control in the Tails menubar. 
+
+To confirm that the upgrade succeeded, connect from a terminal using the command ``ssh mon`` and run the following command to display the installed OS version:
+
+.. code:: sh
+  
+  sudo lsb_release -a
+
+Exit the SSH session to the Monitor server. Next, you will upgrade the Application Server using a a similar procedure
+
+Upgrade and validate the Application Server
+-------------------------------------------
+
+First, open a terminal by selecting **Applications > Favorites > Terminal**. Then connect to the Application Server with the command ``ssh app``.
+
+Before running the ``do-release-upgrade`` command, you must edit the ``/etc/update-manager/release-upgrades``, changing `Prompt=never` to `Prompt=lts`. ED - this won't be necessary when #4104 lands
+
+The OS upgrade process for the Application Server will take from 30-60 minutes based on your server specifications and available bandwidth, and should not be interrupted once begun. To begin  the process, run the command below and then supply the answers listed below to the prompts that follow:
+
+
+.. code:: sh
+
+  sudo do-release-upgrade
+
+.. note:: The prompt answers below have been tested on the recommended hardware for SecureDrop. If your instance uses non-standard hardware, you may be see different or additional prompts. In general, when responding to these prompts you should preserve existing configuration files whenever possible.
+    
+- Run ``sudo do-release-upgrade`` to start the upgrade process
+- Press Enter after the "Some third party entries..." message
+- Type 'y' and press Enter to continue after the "Installing the upgrade..." message
+- Type 'y' and press Enter to continue after the "Fetching and installing..." message
+
+.. note:: The ``do-release-upgrade`` script displays some dialogs using ``ncurses``, a library for rendering GUI elements in text-only displays. It may display incorrectly within your terminal window. To force a redraw, adjust the terminal's size to approximately 150 columns by 40 rows. If it still does not display correctly, make small adjustments to the terminal size to force successive redraws.
+  
+- Choose OK to close the *Postfix* information dialog
+- Choose **No Configuration** and **OK** on the *General type of mail configuration* dialog
+- Choose **Yes** on the *Configuring libssl.0.0:amd64* dialog - when you do so, the ``sshd`` and ``tor`` daemons will restart, breaking your connection to the Application Server
+- Close the terminal window, open a new one, and reconnect with the command ``ssh app``
+- Choose **No** to overriding local changes, on the *PAM configuration* dialog
+- Choose the default action (keep local version)  when prompted about ``blacklist.conf`` changes
+- Choose **Keep the local version currently installed** on the `Configuring grub-efi-amd64` dialog
+- Choose default (keep current version) when prompted about ``/etc/ssh/moduli`` changes
+- Choose default (keep current version) when prompted about ``/etc/ssh/ssh_config`` changes
+- Choose default (keep current version) when prompted about ``/etc/pam.d/sshd`` changes
+- Choose **keep local version currently installed** and **OK** on the *Configuring unattended-upgrades* dialog
+- Type 'y' and press Enter to remove obsolete packages when prompted
+- Type 'y' and press Enter to restart the system and complete the update
+
+The Application Server will now reboot - this may take several minutes. In order to reconnect via ``ssh app``, you must stop and restart the Admin Workstation's Internet connection,  using the upper-righthand control in the Tails menubar. 
+
+To confirm that the upgrade succeeded, connect from a terminal using the command ``ssh app`` and run the following command to display the installed OS version:
+
+.. code:: sh
+  
+  sudo lsb_release -a
+
+Disconnect the SSH session to the Application Server. You are now ready to move on to the next step: updating to the Xenial version of the application code and config using ``./securedrop-admin install``
+
+Reinstall the SecureDrop application
+------------------------------------
+
+Open a new Terminal, and run the following commands to set up the SecureDrop admin environment:
+
+.. code:: sh
+
+  cd ~/Persistent/securedrop
+  ./securedrop-admin setup
+
+Next, verify that the SecureDrop configuration matches expected values, by stepping through the configuration using:
+
+.. code:: sh
+
+  ./securedrop-admin sdconfig
+
+Finally, install the Xenial version of the server application code and config:
+
+.. code:: sh
+
+  ./securedrop-admin sdconfig
+  
+You will be prompted for the admin user's password on the servers. Type it in and press Enter.
+
+Test the instance after upgrading
+---------------------------------
+
+[ TBD - either a bunch of shell commands that check installed versions and stuff like grsec and Apparmor, or a single script provided with the release to do basic server tests ]
+
+[ Also a checklist for basic functionality - connectivity to the 4 services, and a run through the submission-to-decryption workflow ]
+
+[ Anything else? ]
+

--- a/docs/upgrade/xenial_upgrade_in_place.rst
+++ b/docs/upgrade/xenial_upgrade_in_place.rst
@@ -1,118 +1,191 @@
-Ubuntu 16.04 LTS (Xenial) - upgrading in place
+Ubuntu 16.04 LTS (Xenial) - Upgrading in Place
 ==============================================
 
-If some instance downtime during the Xenial upgrade is acceptable, or if no backup hardware is available to allow for the no-downtime backup->install->restore upgrade procedure, it is possible to upgrade your SecureDrop instance in place. The upgrade-in place procedure requires no additional hardware, and is described below. 
+.. caution::
+  You can perform an upgrade from Ubuntu 14.04 to Ubuntu 16.04 in place, but
+  please be advised that this may result in prolonged downtime of your SecureDrop
+  instance, especially in the event of problems during the upgrade process.
 
+  If you have access to backup hardware, we recommend following the procedure
+  described in :doc:`xenial_backup_install_restore` instead.
 
 Communicating with users before the change
 ------------------------------------------
 
-The process of upgrading in place will result in downtime for your instance. Our testing indicates that the upgrade may take up to 8 hours, assuming no issues. As a result, we recommend that you plan for 2 days work, during which the instance will be unavailable. You should also consider having a communications plan in place both for journalist and sources.
+The process of upgrading in place will result in downtime for your instance. Our
+testing indicates that the upgrade may take up to 8 hours, assuming no issues.
+We recommend that you plan for 2 days of work, during which the instance will be
+unavailable.
 
- - You should coordinate the timing of the upgrade with the people responsible for checking for submissions. If they have ongoing conversations with sources, or are expecting submissions, it may be necessary to reschedule the upgrade.
- - You should also consider communicating the downtime downtime and reason for it on your instance's landing page.
- 
+In addition to placing a maintenance notice on your instance's *Landing Page*,
+we recommend coordinating the upgrade schedule with the internal users of the
+system responsible for checking for submissions. If they have ongoing
+conversations with sources, or are expecting submissions, it may be necessary to
+reschedule the upgrade.
+
 
 Preparatory steps
 -----------------
+Before performing the upgrade, please perform all the steps outlined in
+:doc:`xenial_prep`.
 
- - take a backup of the instance using usual methods
- - make sure Admin Stick is updated to 0.12.0 (or later)
- - make sure that your instance is also upgraded to 0.12.0+ (ED: needed for changes in postints to iptables etc - probably best to check deployed deb versions via ssh commands)
+.. warning::
+  In order to successfully upgrade your SecureDrop instance, it is of critical
+  importance that your *Admin Workstation* and your servers use SecureDrop
+  0.12.0. Older releases of SecureDrop do not not support Ubuntu 16.04.
 
-Upgrade and validate the Monitor Server 
----------------------------------------
+Upgrade and validate the *Monitor Server*
+-----------------------------------------
 
-First, open a terminal by selecting **Applications > Favorites > Terminal**. Then connect to the Monitor Server with the command ``ssh mon``.
+On your *Admin Workstation*, open a terminal by selecting
+**Applications > Favorites > Terminal**. Then connect to the *Monitor Server*
+with the command ``ssh mon``.
 
-Before running the ``do-release-upgrade`` command, you must edit the ``/etc/update-manager/release-upgrades``, changing `Prompt=never` to `Prompt=lts`. ED - this won't be necessary when #4104 lands
+Before running the ``do-release-upgrade`` command, you must edit the
+``/etc/update-manager/release-upgrades``, changing `Prompt=never` to
+`Prompt=lts`. **[ED - this won't be necessary when #4104 lands]**
 
-The OS upgrade process for the Monitor Server will take from 30-60 minutes based on your server specifications and available bandwidth, and should not be interrupted once begun. To begin  the process, run the command below and then supply the answers listed below to the prompts that follow:
-
-
-.. code:: sh
-
-  sudo do-release-upgrade
-
-.. note:: The prompt answers below have been tested on the recommended hardware for SecureDrop. If your instance uses non-standard hardware, you may be see different or additional prompts. In general, when responding to these prompts you should preserve existing configuration files whenever possible.
-    
-- Run ``sudo do-release-upgrade`` to start the upgrade process
-- Press Enter after the "Some third party entries..." message
-- Type 'y' and press Enter to continue after the "Installing the upgrade..." message
-- Type 'y' and press Enter to continue after the "Fetching and installing..." message
-
-.. note:: The ``do-release-upgrade`` script displays some dialogs using ``ncurses``, a library for rendering GUI elements in text-only displays. It may display incorrectly within your terminal window. To force a redraw, adjust the terminal's size to approximately 150 columns by 40 rows. If it still does not display correctly, make small adjustments to the terminal size to force successive redraws.
-  
-- Choose OK to close the *Postfix* information dialog
-- Choose **No Configuration** and **OK** on the *General type of mail configuration* dialog
-- Choose **Yes** on the *Configuring libssl.0.0:amd64* dialog - when you do so, the ``sshd`` and ``tor`` daemons will restart, breaking your connection to the Monitor Server
-- Close the terminal window, open a new one, and reconnect with the command ``ssh mon``
-- Choose **No** to overriding local changes, on the *PAM configuration* dialog
-- Choose the default action (keep local version)  when prompted about ``blacklist.conf`` changes
-- Choose **Keep the local version currently installed** on the `Configuring grub-efi-amd64` dialog
-- Choose default (keep current version) when prompted about ``/etc/ssh/moduli`` changes
-- Choose default (keep current version) when prompted about ``/etc/ssh/ssh_config`` changes
-- Choose default (keep current version) when prompted about ``/etc/pam.d/sshd`` changes
-- Choose **keep local version currently installed** and **OK** on the *Configuring unattended-upgrades* dialog
-- Type 'y' and press Enter to remove obsolete packages when prompted
-- Type 'y' and press Enter to restart the system and complete the update
-
-The Monitor Server will now reboot - this may take several minutes. In order to reconnect via ``ssh mon``, you must stop and restart the Admin Workstation's Internet connection,  using the upper-righthand control in the Tails menubar. 
-
-To confirm that the upgrade succeeded, connect from a terminal using the command ``ssh mon`` and run the following command to display the installed OS version:
-
-.. code:: sh
-  
-  sudo lsb_release -a
-
-Exit the SSH session to the Monitor server. Next, you will upgrade the Application Server using a a similar procedure
-
-Upgrade and validate the Application Server
--------------------------------------------
-
-First, open a terminal by selecting **Applications > Favorites > Terminal**. Then connect to the Application Server with the command ``ssh app``.
-
-Before running the ``do-release-upgrade`` command, you must edit the ``/etc/update-manager/release-upgrades``, changing `Prompt=never` to `Prompt=lts`. ED - this won't be necessary when #4104 lands
-
-The OS upgrade process for the Application Server will take from 30-60 minutes based on your server specifications and available bandwidth, and should not be interrupted once begun. To begin  the process, run the command below and then supply the answers listed below to the prompts that follow:
-
+The operating system upgrade process for the *Monitor Server* will take
+approximately 30-60 minutes, depending on your server specifications and
+available bandwidth, and should not be interrupted once begun. To begin the
+process, run the command below and then supply the answers listed below to the
+prompts that follow:
 
 .. code:: sh
 
   sudo do-release-upgrade
 
-.. note:: The prompt answers below have been tested on the recommended hardware for SecureDrop. If your instance uses non-standard hardware, you may be see different or additional prompts. In general, when responding to these prompts you should preserve existing configuration files whenever possible.
-    
+.. note:: The prompt answers below have been tested on the
+  :ref:`recommended hardware <Specific Hardware Recommendations>` for
+  SecureDrop. If your instance uses non-standard hardware, you may see different
+  or additional prompts. In general, when responding to these prompts, you
+  should choose to preserve existing configuration files whenever possible.
+
 - Run ``sudo do-release-upgrade`` to start the upgrade process
 - Press Enter after the "Some third party entries..." message
-- Type 'y' and press Enter to continue after the "Installing the upgrade..." message
-- Type 'y' and press Enter to continue after the "Fetching and installing..." message
+- Type 'y' and press Enter to continue after the "Installing the upgrade..."
+  message
+- Type 'y' and press Enter to continue after the "Fetching and installing..."
+  message
 
-.. note:: The ``do-release-upgrade`` script displays some dialogs using ``ncurses``, a library for rendering GUI elements in text-only displays. It may display incorrectly within your terminal window. To force a redraw, adjust the terminal's size to approximately 150 columns by 40 rows. If it still does not display correctly, make small adjustments to the terminal size to force successive redraws.
-  
-- Choose OK to close the *Postfix* information dialog
-- Choose **No Configuration** and **OK** on the *General type of mail configuration* dialog
-- Choose **Yes** on the *Configuring libssl.0.0:amd64* dialog - when you do so, the ``sshd`` and ``tor`` daemons will restart, breaking your connection to the Application Server
-- Close the terminal window, open a new one, and reconnect with the command ``ssh app``
-- Choose **No** to overriding local changes, on the *PAM configuration* dialog
-- Choose the default action (keep local version)  when prompted about ``blacklist.conf`` changes
-- Choose **Keep the local version currently installed** on the `Configuring grub-efi-amd64` dialog
-- Choose default (keep current version) when prompted about ``/etc/ssh/moduli`` changes
-- Choose default (keep current version) when prompted about ``/etc/ssh/ssh_config`` changes
-- Choose default (keep current version) when prompted about ``/etc/pam.d/sshd`` changes
-- Choose **keep local version currently installed** and **OK** on the *Configuring unattended-upgrades* dialog
+.. note:: The ``do-release-upgrade`` script displays some dialogs using
+  ``ncurses``, a library for rendering GUI elements in text-only displays. It
+  may display incorrectly within your terminal window. To force a redraw, adjust
+  the terminal's size to approximately 150 columns by 40 rows. If it still does
+  not display correctly, make small adjustments to the terminal size to force
+  successive redraws.
+
+- Choose **OK** to close the Postfix information dialog
+- Choose **No Configuration** and **OK** on the "General type of mail
+  configuration" dialog
+- Choose **Yes** on the "Configuring libssl.0.0:amd64" dialog - when you do so,
+  the ``sshd`` and ``tor`` daemons will restart, breaking your connection to the
+  *Monitor Server*
+- Close the terminal window, open a new one, and reconnect with the command
+  ``ssh mon``
+- Choose **No** to overriding local changes on the "PAM configuration" dialog
+- Choose the default action (keep local version) when prompted about
+  ``blacklist.conf`` changes
+- Choose **Keep the local version currently installed** on the
+  "Configuring grub-efi-amd64" dialog
+- Choose default (keep current version) when prompted about ``/etc/ssh/moduli``
+  changes
+- Choose default (keep current version) when prompted about
+  ``/etc/ssh/ssh_config`` changes
+- Choose default (keep current version) when prompted about ``/etc/pam.d/sshd``
+  changes
+- Choose **keep local version currently installed** and **OK** on the
+  "Configuring unattended-upgrades" dialog
 - Type 'y' and press Enter to remove obsolete packages when prompted
 - Type 'y' and press Enter to restart the system and complete the update
 
-The Application Server will now reboot - this may take several minutes. In order to reconnect via ``ssh app``, you must stop and restart the Admin Workstation's Internet connection,  using the upper-righthand control in the Tails menubar. 
+The *Monitor Server* will now reboot - this may take several minutes. In order
+to reconnect via ``ssh mon``, you must stop and restart the
+*Admin Workstation's* Internet connection, using the upper-right-hand control in
+the Tails menu bar.
 
-To confirm that the upgrade succeeded, connect from a terminal using the command ``ssh app`` and run the following command to display the installed OS version:
+To confirm that the upgrade succeeded, connect from a terminal using the command
+``ssh mon`` and run the following command to display the installed OS version:
 
 .. code:: sh
-  
+
   sudo lsb_release -a
 
-Disconnect the SSH session to the Application Server. You are now ready to move on to the next step: updating to the Xenial version of the application code and config using ``./securedrop-admin install``
+Exit the SSH session to the *Monitor Server*. Next, you will upgrade the
+*Application Server* using a a similar procedure.
+
+Upgrade and validate the *Application Server*
+---------------------------------------------
+On your *Admin Workstation*, open a terminal by selecting
+**Applications > Favorites > Terminal**. Then connect to the
+*Application Server* with the command ``ssh app``.
+
+First, open a terminal by selecting **Applications > Favorites > Terminal**.
+Then connect to the Application Server with the command ``ssh app``.
+
+Before running the ``do-release-upgrade`` command, you must edit the
+``/etc/update-manager/release-upgrades``, changing `Prompt=never` to
+`Prompt=lts`. **[ED - this won't be necessary when #4104 lands]**
+
+The operating system upgrade process should take a similar amount of time as
+the upgrade of the *Monitor Server*, and should not be interrupted once begun.
+
+To begin the process, run the command below and then supply the answers listed
+below to the prompts that follow.
+
+.. code:: sh
+
+  sudo do-release-upgrade
+
+.. note:: As with the *Monitor Server*, the exact prompts may vary based on your
+  hardware, and you should choose to preserve existing configuration files
+  whenever possible.
+
+- Run ``sudo do-release-upgrade`` to start the upgrade process
+- Press Enter after the "Some third party entries..." message
+- Type 'y' and press Enter to continue after the "Installing the upgrade..."
+  message
+- Type 'y' and press Enter to continue after the "Fetching and installing..."
+  message
+- Choose **OK** to close the Postfix information dialog
+- Choose **No Configuration** and **OK** on the "General type of mail
+  configuration" dialog
+- Choose **Yes** on the "Configuring libssl.0.0:amd64" dialog - when you do so,
+  the ``sshd`` and ``tor`` daemons will restart, breaking your connection to the
+  *Application Server*
+- Close the terminal window, open a new one, and reconnect with the command
+  ``ssh app``
+- Choose **No** to overriding local changes on the "PAM configuration" dialog
+- Choose the default action (keep local version) when prompted about
+  ``blacklist.conf`` changes
+- Choose **Keep the local version currently installed** on the
+  "Configuring grub-efi-amd64" dialog
+- Choose default (keep current version) when prompted about ``/etc/ssh/moduli``
+  changes
+- Choose default (keep current version) when prompted about
+  ``/etc/ssh/ssh_config`` changes
+- Choose default (keep current version) when prompted about ``/etc/pam.d/sshd``
+  changes
+- Choose **keep local version currently installed** and **OK** on the
+  "Configuring unattended-upgrades" dialog
+- Type 'y' and press Enter to remove obsolete packages when prompted
+- Type 'y' and press Enter to restart the system and complete the update
+
+The *Application Server* will now reboot - this may take several minutes. In
+order to reconnect via ``ssh app``, you must stop and restart the
+*Admin Workstation's* Internet connection,  using the upper-right-hand control
+in the Tails menu bar.
+
+To confirm that the upgrade succeeded, connect from a terminal using the command
+``ssh app`` and run the following command to display the installed OS version:
+
+.. code:: sh
+
+  sudo lsb_release -a
+
+Disconnect the SSH session to the Application Server. You are now ready to move
+on to the next step: updating to the Ubuntu 16.04 version of the application
+code and configuration using ``./securedrop-admin install``
 
 Reinstall the SecureDrop application
 ------------------------------------
@@ -130,20 +203,24 @@ Next, verify that the SecureDrop configuration matches expected values, by stepp
 
   ./securedrop-admin sdconfig
 
-Finally, install the Xenial version of the server application code and config:
+Finally, install the Ubuntu 16.04 version of the server application code and
+configuration:
 
 .. code:: sh
 
-  ./securedrop-admin sdconfig
-  
-You will be prompted for the admin user's password on the servers. Type it in and press Enter.
+  ./securedrop-admin install
+
+You will be prompted for the admin user's passphrase on the servers. Type it in
+and press Enter.
 
 Test the instance after upgrading
 ---------------------------------
 
-[ TBD - either a bunch of shell commands that check installed versions and stuff like grsec and Apparmor, or a single script provided with the release to do basic server tests ]
+[ TBD - either a bunch of shell commands that check installed versions and stuff
+like grsec and Apparmor, or a single script provided with the release to do
+basic server tests ]
 
-[ Also a checklist for basic functionality - connectivity to the 4 services, and a run through the submission-to-decryption workflow ]
+[ Also a checklist for basic functionality - connectivity to the 4 services, and
+a run through the submission-to-decryption workflow ]
 
 [ Anything else? ]
-

--- a/docs/upgrade/xenial_upgrade_in_place.rst
+++ b/docs/upgrade/xenial_upgrade_in_place.rst
@@ -71,9 +71,9 @@ prompts that follow:
 .. note:: The ``do-release-upgrade`` script displays some dialogs using
   ``ncurses``, a library for rendering GUI elements in text-only displays. It
   may display incorrectly within your terminal window. To force a redraw, adjust
-  the terminal's size to approximately 150 columns by 40 rows. If it still does
-  not display correctly, make small adjustments to the terminal size to force
-  successive redraws.
+  the terminal window's size to approximately 150 columns by 40 rows, by
+  dragging the corners. If it still does not display correctly, make small
+  adjustments to the terminal size to force successive redraws.
 
 - Choose **OK** to close the Postfix information dialog
 - Choose **No Configuration** and **OK** on the "General type of mail
@@ -110,6 +110,8 @@ To confirm that the upgrade succeeded, connect from a terminal using the command
 .. code:: sh
 
   sudo lsb_release -a
+
+The output should include the text "Ubuntu 16.04.5 LTS".
 
 Exit the SSH session to the *Monitor Server*. Next, you will upgrade the
 *Application Server* using a a similar procedure.
@@ -183,6 +185,8 @@ To confirm that the upgrade succeeded, connect from a terminal using the command
 
   sudo lsb_release -a
 
+The output should include the text "Ubuntu 16.04.5 LTS".
+
 Disconnect the SSH session to the Application Server. You are now ready to move
 on to the next step: updating to the Ubuntu 16.04 version of the application
 code and configuration using ``./securedrop-admin install``
@@ -213,14 +217,77 @@ configuration:
 You will be prompted for the admin user's passphrase on the servers. Type it in
 and press Enter.
 
-Test the instance after upgrading
----------------------------------
+Perform additional tests
+------------------------
+While we have extensively tested the upgrade on recommended hardware, we
+recommend performing the following tests yourself to identify potential issues
+specific to your system configuration.
 
-[ TBD - either a bunch of shell commands that check installed versions and stuff
-like grsec and Apparmor, or a single script provided with the release to do
-basic server tests ]
+Validate the kernel version
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Ensure you are logged out, and then type the commands ``ssh app uname -r`` and
+``ssh mon uname -r`` in your terminal window.
 
-[ Also a checklist for basic functionality - connectivity to the 4 services, and
-a run through the submission-to-decryption workflow ]
+The output for both commands should be ``4.4.167-grsec``, which indicates that
+the latest available kernel for SecureDrop is installed on your *Application
+Server* and your *Monitor Server*.
 
-[ Anything else? ]
+Validate the application version
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To confirm that you are running SecureDrop 0.12.0 for Xenial, on the Tails
+desktop, you should find a shortcut called **SecureDrop Source Interface**.
+Double-click it to launch the Tor browser.
+
+After the *Source Interface* loads, add the path ``/metadata`` to the URL in
+your address bar. If your *Source Interface* can be found at
+``examplenot4real.onion``, then the address you should visit is
+``examplenot4real.onion/metadata``. That page should show you key/value pairs,
+including ``0.12.0`` for ``sd_version`` and ``16.04`` for ``server_os``.
+
+End-to-end test
+^^^^^^^^^^^^^^^
+We recommend an end-to-end test of document submission, reply and decryption.
+First, confirm that you can log into the *Journalist Interface*. On the Tails
+desktop, you should find a shortcut called **SecureDrop Journalist Interface**.
+Double-click it to launch the Tor browser.
+
+Once the page has finished loading, sign in using your SecureDrop login
+credentials. Confirm that you can view the list of submissions as expected.
+
+Keep the browser window open, and launch the **SecureDrop Source Interface**
+using its shortcut on the Tails desktop. The *Source Interface* should load in
+another browser tab.
+
+Once the page has finished loading, click **Submit Documents**. On the subsequent
+page, click **Submit Documents** again (you may want to write down your codename
+in case you need it for further testing).On the following screen, choose a
+simple file to upload, and enter a message to go along with it, then press
+**Submit**.
+
+Switch to the tab with the *Journalist Interface*, reload it, and confirm that
+you can see your new submission. Write a reply, and switch back to the
+*Source Interface*. Reload it, and confirm that you can see the reply.
+
+Now, from the *Journalist Interface*, download the submission you just made.
+Copy it to your *Transfer Device* and boot into your *Secure Viewing Station*.
+Confirm that you can open the encrypted document.
+
+Just in case you picked the wrong submission, we strongly recommend following
+standard precautions, e.g., do not open the document directly from the *Transfer
+Device* but copy it onto the *Secure Viewing Station* first.
+
+Contact us
+==========
+If you have questions or comments regarding this process, or if you
+encounter any issues, you can always contact us by the following means:
+
+- via our `Support Portal <https://support.freedom.press>`_, if you are a member
+  (membership is approved on a case-by-case basis);
+- via securedrop@freedom.press
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__)
+  for sensitive security issues (please use judiciously);
+- via our `community forums <https://forum.securedrop.org>`_.
+
+If you encounter problems that are not security-sensitive, we also encourage you
+to `file an issue <https://github.com/freedomofpress/securedrop/issues/new/>`
+in our public GitHub repository.

--- a/docs/upgrade/xenial_upgrade_in_place.rst
+++ b/docs/upgrade/xenial_upgrade_in_place.rst
@@ -277,7 +277,7 @@ standard precautions, e.g., do not open the document directly from the *Transfer
 Device* but copy it onto the *Secure Viewing Station* first.
 
 Contact us
-==========
+----------
 If you have questions or comments regarding this process, or if you
 encounter any issues, you can always contact us by the following means:
 


### PR DESCRIPTION
This PR adds instructions for 
- performing an upgrade to Ubuntu 16.04 in-place
- re-installing from a backup (on existing or new hardware)

(The bulk of the work here was done by @zenmonkeykstop with copyediting by yours truly.)

Resolves #4057.

## How to test

A tester should follow the instructions as closely as possible, against supported hardware.

## Status

Ready for review

- [x] `make docs-lint` passes