### PR TITLE
Update update_version.sh

### DIFF
--- a/update_version.sh
+++ b/update_version.sh
@@ -70,8 +70,8 @@ export DEBEMAIL="${DEBEMAIL:-securedrop@freedom.press}"
 export DEBFULLNAME="${DEBFULLNAME:-SecureDrop Team}"
 
 # Update the changelog in the Debian package
-dch -b -v "${NEW_VERSION}-trusty" -D trusty -c install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/changelog-trusty
-dch -b -v "${NEW_VERSION}-xenial" -D xenial -c install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/changelog-xenial
+dch -b -v "${NEW_VERSION}+trusty" -D trusty -c install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/changelog-trusty
+dch -b -v "${NEW_VERSION}+xenial" -D xenial -c install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/changelog-xenial
 # Commit the change
 # Due to `set -e`, providing an empty commit message here will cause the script to abort early.
 git commit -a


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Fixes #4144


## Testing

You can bump the version correctly using the release management guide, securedrop-app-code deb package name is separated with a `+` instead of a `-`

## Deployment
Dev env only
