### PR TITLE
Import okay

### DIFF
--- a/install_files/securedrop-app-code/debian/postinst
+++ b/install_files/securedrop-app-code/debian/postinst
@@ -119,7 +119,7 @@ case "$1" in
     # Migrate private keyring to gpg2.1 if needed
     if [ ! -d "/var/lib/securedrop/keys/private-keys-v1.d" ]; then
         # Then we should migrate the keyring
-        gpg2 --homedir=/var/lib/securedrop/keys --import < /var/lib/securedrop/keys/secring.gpg
+        gpg2 --homedir=/var/lib/securedrop/keys --batch --import < /var/lib/securedrop/keys/secring.gpg
     fi
 
     chown -R www-data:www-data /var/lib/securedrop /var/www/securedrop

--- a/install_files/securedrop-app-code/debian/postinst
+++ b/install_files/securedrop-app-code/debian/postinst
@@ -116,6 +116,12 @@ case "$1" in
         echo allow-loopback-pinentry > /var/lib/securedrop/keys/gpg-agent.conf
     fi
 
+    # Migrate private keyring to gpg2.1 if needed
+    if [ ! -d "/var/lib/securedrop/keys/private-keys-v1.d" ]; then
+        # Then we should migrate the keyring
+        gpg2 --homedir=/var/lib/securedrop/keys --import < /var/lib/securedrop/keys/secring.gpg
+    fi
+
     chown -R www-data:www-data /var/lib/securedrop /var/www/securedrop
 
     pip install --no-index --find-links=/var/securedrop/wheelhouse --upgrade \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4108 .

Changes proposed in this pull request:

## Testing

- [ ] Provision prod VMs
- [ ] Submit a document as a source
- [ ] Upgrade to xenial via `sudo do-release-upgrade` (some nice steps thanks to @zenmonkeykstop [here](https://github.com/freedomofpress/securedrop/issues/4057#issuecomment-460884539))
- [ ]  `make build-debs-xenial`
- [ ]  scp the securedrop-app-code deb into `app-staging` and install it (you have to install `paxctld` package before)
- [ ] Upgrade the app server to xenial via do-release-upgrade
- [ ] Submit another document as a source
- [ ] Ensure no gpg-related errors appear in /var/log/apache2/source-error.log



## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.

This should cause no errors in existing production instances. 



## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
