### PR TITLE
[ci] move trusty app tests to nightly job and use circle ci branch filtering logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,6 @@ workflows:
   securedrop_ci:
     jobs:
       - lint
-      - trusty-app-tests
       - xenial-app-tests
       - admin-tests
       - updater-gui-tests
@@ -276,3 +275,4 @@ workflows:
     jobs:
       - static-analysis-and-no-known-cves
       - staging-test-with-rebase-xenial
+      - trusty-app-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,11 +257,27 @@ workflows:
   securedrop_ci:
     jobs:
       - lint
-      - xenial-app-tests
-      - admin-tests
-      - updater-gui-tests
+      - xenial-app-tests:
+          filters:
+            branches:
+              ignore:
+                - /docs-.*/
+      - admin-tests:
+          filters:
+            branches:
+              ignore:
+                - /docs-.*/
+      - updater-gui-tests:
+          filters:
+            branches:
+              ignore:
+                - /docs-.*/
       - static-analysis-and-no-known-cves
       - staging-test-with-rebase:
+          filters:
+            branches:
+              ignore:
+                - /docs-.*/
           requires:
             - lint
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ workflows:
               ignore:
                 - /docs-.*/
       - static-analysis-and-no-known-cves
-      - staging-test-with-rebase:
+      - staging-test-with-rebase-xenial:
           filters:
             branches:
               ignore:
@@ -290,5 +290,5 @@ workflows:
                 - develop
     jobs:
       - static-analysis-and-no-known-cves
-      - staging-test-with-rebase-xenial
+      - staging-test-with-rebase
       - trusty-app-tests

--- a/devops/gce-nested/ci-go.sh
+++ b/devops/gce-nested/ci-go.sh
@@ -16,11 +16,6 @@ set -o pipefail
 # Assume we're running against Trusty; Xenial also supported.
 target_platform="${1:-trusty}"
 
-# Skip full CI run on docs branches, since code shouldn't change.
-if [[ "${CIRCLE_BRANCH:-}" != docs-* ]]; then
-    ./devops/gce-nested/gce-start.sh
-    ./devops/gce-nested/gce-runner.sh "$target_platform"
-    ./devops/gce-nested/gce-stop.sh
-else
-    echo "Branch begins with 'docs-' prefix, skipping staging tests..."
-fi
+./devops/gce-nested/gce-start.sh
+./devops/gce-nested/gce-runner.sh "$target_platform"
+./devops/gce-nested/gce-stop.sh

--- a/devops/scripts/build-debs.sh
+++ b/devops/scripts/build-debs.sh
@@ -15,17 +15,12 @@ RUN_TESTS="${1:-test}"
 TARGET_PLATFORM="${2:-trusty}"
 SCENARIO_NAME="builder-${TARGET_PLATFORM}"
 
-if [[ "${CIRCLE_BRANCH:-}" != docs-* ]]; then
-    case "$RUN_TESTS" in
-        notest)
-            molecule_action=converge
-            ;;
-        test)
-            molecule_action=test
-            ;;
-    esac
-
-    molecule "${molecule_action}" -s "${SCENARIO_NAME}"
-else
-    echo Not running on docs branch...
-fi
+case "$RUN_TESTS" in
+    notest)
+        molecule_action=converge
+        ;;
+    test)
+        molecule_action=test
+        ;;
+esac
+molecule "${molecule_action}" -s "${SCENARIO_NAME}"

--- a/devops/scripts/combine-junit-test-results.sh
+++ b/devops/scripts/combine-junit-test-results.sh
@@ -7,10 +7,6 @@ set -e
 # but let's be certain.
 mkdir -p junit
 
-if [[ "${CIRCLE_BRANCH}" != docs-* ]]; then
-  # Combine tests for export as artifacts. There are at least two XML files,
-  # one from the application tests, and another from the config tests.
-  ./devops/scripts/combine-junit.py ./*results.xml > ./junit/junit.xml
-else
-  echo Not running on docs branch...
-fi
+# Combine tests for export as artifacts. There are at least two XML files,
+# one from the application tests, and another from the config tests.
+./devops/scripts/combine-junit.py ./*results.xml > ./junit/junit.xml


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR makes two improvements to reduce total CI time:
 - Beginning with 0.12.0, news organizations will be migrating to Xenial, and all new installs will be on Xenial. Thus, we should move the Trusty app test job to a nightly job, and monitor it for failures until Trusty is deprecated in the coming months. This reduces total CI time per PR, as the trusty job took 20+ minutes. Related to #4155.
 - It turns out that [CircleCI enables filtering by branches now](https://circleci.com/docs/2.0/configuration-reference/#branches), which we can use to replace our custom logic for avoiding unnecessary jobs on `docs-` branches, currently used for the staging job only. The app-tests were also being run for `docs-` branches, so we can use the same CircleCI branch filtering logic to easily exclude the staging/application test jobs run for `docs-` branches. Indeed, previously jobs would be kicked off and then would rapidly pass, but with the CircleCI branch filtering, jobs won't even get kicked off, so this should reduce build pileups. This _should_ also close #3699.

Note: We'll need to disable the trusty app test job as a required build to merge, holding off on that until we agree

# Testing

Verify that the test build [here](https://github.com/freedomofpress/securedrop/commits/docs-ci-reduce-jobs) (branch `docs-ci-reduce-jobs`) only ran two jobs:

<img width="1013" alt="screen shot 2019-02-19 at 11 1
0 54 pm" src="https://user-images.githubusercontent.com/7832803/53074718-52330d80-34a0-11e9-8c00-5fc0da3d3a08.png">

## Deployment

CI only

## Checklist

CI only