### PR TITLE
Ensure version of tor installed is from FPF repo

### DIFF
--- a/install_files/ansible-base/roles/tor-hidden-services/tasks/install_tor.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/tasks/install_tor.yml
@@ -37,7 +37,15 @@
     apt-cache policy tor | sed -e 's/^\s*Installed:\ \(\S*\)/\1/g;tx;d;:x'
   changed_when: false
   register: extract_tor_version
-  when: "'amazon' in ansible_product_version"
+
+# Ubuntu upstream repositories serve a version of tor that is very old. Since
+# FPF apt servers host this same package, let's ensure that the FPF-provided
+# Tor package is installed by checking we are using a recent version.
+
+- name: Ensure correct Tor version installed.
+  assert:
+    that: extract_tor_version.stdout is version('0.3.4.9', '>=')
+    fail_msg: "Tor package was not found on FPF apt server."
 
 - name: Dump Tor version to file (for reporting)
   copy:


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #4162 . 

Because we don't want to couple Tor versions with SecureDrop releases, and that we probably won't go back in Tor versions, specifying  `>=` the current Tor version seems like a sensible approach, given the versions being served in Ubuntu Trusty and Xenial apt repos:
- 0.2.4.27 (Trusty)
- 0.2.9.14 (Xenial)

Changes proposed in this pull request:

## Testing
- [ ] The test/assertion introduced make sense, we don't want to pin specific tor versions to SecureDrop releases.
- [ ] Using prod VMs or hardware, check out this branch and attempt installing against prod apt servers. This should fail because it will be installing Tor from Ubuntu's repos, as apt-tor.freedom.press was removed.
- [ ] Using prod VMs or hardware, check out this branch and attempt installing against test apt server (apt-test.freedom.press). This should succeed because Tor packages are served by the test apt server.

CI/staging scenarios are not an accurate test as they also include apt-test in their source list (for kernel tests).

## Deployment

This change only affects new installs, and will be provided via the Ansible install logic.

## Checklist

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR

