### PR TITLE
[0.12.0] Ensure version of tor installed is from FPF repo

### DIFF
--- a/install_files/ansible-base/roles/tor-hidden-services/tasks/install_tor.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/tasks/install_tor.yml
@@ -37,7 +37,15 @@
     apt-cache policy tor | sed -e 's/^\s*Installed:\ \(\S*\)/\1/g;tx;d;:x'
   changed_when: false
   register: extract_tor_version
-  when: "'amazon' in ansible_product_version"
+
+# Ubuntu upstream repositories serve a version of tor that is very old. Since
+# FPF apt servers host this same package, let's ensure that the FPF-provided
+# Tor package is installed by checking we are using a recent version.
+
+- name: Ensure correct Tor version installed.
+  assert:
+    that: extract_tor_version.stdout is version('0.3.4.9', '>=')
+    fail_msg: "Tor package was not found on FPF apt server."
 
 - name: Dump Tor version to file (for reporting)
   copy:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

From https://github.com/freedomofpress/securedrop/pull/4169

Ubuntu upstream uses older versions:
- 0.2.4.27 (Trusty)
- 0.2.9.14 (Xenial)

(cherry picked from commit 2ef9dd1657c6716b6438ff6c9b886f7727e43d1f)

## Testing

Verify that the changes are example same and from the right comit.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
