### PR TITLE
[ci] run page layout tests in all supported languages for i18n-* branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,46 @@
 ---
+common-steps:
+  - &createcachedir
+    run:
+      name: Ensure cache dir exists and permissions are good
+      command: |
+        sudo mkdir -p /caches && sudo chown circleci: -R /caches
+
+  - &restorecache
+    restore_cache:
+      key: v1-sd-layers-{{ checksum "securedrop/dockerfiles/xenial/Dockerfile" }}
+      paths:
+        - /caches/layers.tar.gz
+
+  - &loadimagelayers
+    run:
+      name: Load image layer cache
+      command: |
+        set +o pipefail
+        docker load -i /caches/layers.tar |true
+
+  - &dockerimagebuild
+    run:
+      name: Build Docker images
+      command: |
+        set +o pipefail
+        docker images
+        fromtag=$(docker images |grep securedrop-test-xenial |head -n1 |awk '{print $2}')
+        cd securedrop && DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial:${fromtag:-latest}" ./bin/dev-shell true
+
+  - &saveimagelayers
+    run:
+      name: Save Docker image layer cache
+      command: |
+        docker images
+        docker save -o /caches/layers.tar securedrop-test-xenial:latest
+
+  - &savecache
+    save_cache:
+      key: v1-sd-layers-{{ checksum "securedrop/dockerfiles/xenial/Dockerfile" }}
+      paths:
+        - /caches/layers.tar
+
 version: 2
 jobs:
   lint:
@@ -91,40 +133,12 @@ jobs:
           name: Rebase on-top of github target
           command: ./devops/scripts/rebase-ci.sh
 
-      - run:
-          name: Ensure cache dir exists and permissions are good
-          command: |
-            sudo mkdir -p /caches && sudo chown circleci: -R /caches
-
-      - restore_cache:
-          key: v1-sd-layers-{{ checksum "securedrop/dockerfiles/xenial/Dockerfile" }}
-          paths:
-            - /caches/layers.tar.gz
-
-      - run:
-          name: Load image layer cache
-          command: |
-            set +o pipefail
-            docker load -i /caches/layers.tar |true
-
-      - run:
-          name: Build Docker images
-          command: |
-            set +o pipefail
-            docker images
-            fromtag=$(docker images |grep securedrop-test-xenial |head -n1 |awk '{print $2}')
-            cd securedrop && DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial:${fromtag:-latest}" ./bin/dev-shell true
-
-      - run:
-          name: Save Docker image layer cache
-          command: |
-            docker images
-            docker save -o /caches/layers.tar securedrop-test-xenial:latest
-
-      - save_cache:
-          key: v1-sd-layers-{{ checksum "securedrop/dockerfiles/xenial/Dockerfile" }}
-          paths:
-            - /caches/layers.tar
+      - *createcachedir
+      - *restorecache
+      - *loadimagelayers
+      - *dockerimagebuild
+      - *saveimagelayers
+      - *savecache
 
       - run:
           name: Make test results directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,24 @@ jobs:
       - store_artifacts:
           path: ~/test-results
 
+  translation-tests:
+    machine:
+      enabled: true
+    environment:
+      DOCKER_API_VERSION: 1.23
+      BASE_OS: xenial
+    parallelism: 3
+    steps:
+      - checkout
+      - run:
+          name: Rebase ontop of github target
+          command: ./devops/scripts/rebase-ci.sh
+
+      - run:
+          name: Run tests
+          command: |
+            cd securedrop && make translation-test
+
   admin-tests:
     docker:
       - image: gcr.io/cloud-builders/docker
@@ -262,24 +280,39 @@ workflows:
             branches:
               ignore:
                 - /docs-.*/
+                - /i18n-.*/
       - admin-tests:
           filters:
             branches:
               ignore:
                 - /docs-.*/
+                - /i18n-.*/
       - updater-gui-tests:
           filters:
             branches:
               ignore:
                 - /docs-.*/
-      - static-analysis-and-no-known-cves
+                - /i18n-.*/
+      - static-analysis-and-no-known-cves:
+          filters:
+            branches:
+              ignore:
+                - /docs-.*/
+                - /i18n-.*/
       - staging-test-with-rebase-xenial:
           filters:
             branches:
               ignore:
                 - /docs-.*/
+                - /i18n-.*/
           requires:
             - lint
+      - translation-tests:
+          filters:
+            branches:
+              ignore:
+                - /docs-.*/
+
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,8 +324,8 @@ workflows:
       - translation-tests:
           filters:
             branches:
-              ignore:
-                - /docs-.*/
+              only:
+                - /i18n-.*/
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
     environment:
       DOCKER_API_VERSION: 1.23
       BASE_OS: xenial
-    parallelism: 3
+    parallelism: 2
     steps:
       - checkout
       - *rebaseontarget
@@ -173,11 +173,19 @@ jobs:
       - *savecache
 
       - run:
+          name: Make test results directory
+          command: mkdir -p ~/test-results
+
+      - run:
           name: Run tests
           command: |
+            export TESTFILES=$(cd securedrop; circleci tests glob 'tests/pageslayout/test*py' |circleci tests split --split-by=timings |xargs echo)
             docker rm -f securedrop-test-xenial || true
             fromtag=$(docker images |grep securedrop-test-xenial |head -n1 |awk '{print $2}')
             cd securedrop && DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial:${fromtag:-latest}" make translation-test
+
+      - store_test_results:
+          path: ~/test-results
 
   admin-tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,10 +171,19 @@ jobs:
           name: Rebase ontop of github target
           command: ./devops/scripts/rebase-ci.sh
 
+      - *createcachedir
+      - *restorecache
+      - *loadimagelayers
+      - *dockerimagebuild
+      - *saveimagelayers
+      - *savecache
+
       - run:
           name: Run tests
           command: |
-            cd securedrop && make translation-test
+            docker rm -f securedrop-test-xenial || true
+            fromtag=$(docker images |grep securedrop-test-xenial |head -n1 |awk '{print $2}')
+            cd securedrop && DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial:${fromtag:-latest}" make translation-test
 
   admin-tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 ---
 common-steps:
+  - &rebaseontarget
+    run:
+      name: Rebase on top of GitHub target branch
+      command: ./devops/scripts/rebase-ci.sh
+
   - &createcachedir
     run:
       name: Ensure cache dir exists and permissions are good
@@ -48,10 +53,7 @@ jobs:
       enabled: true
     steps:
       - checkout
-      - run:
-          name: Rebase on-top of github target
-          command: ./devops/scripts/rebase-ci.sh
-
+      - *rebaseontarget
       - run: make ci-lint
 
   trusty-app-tests:
@@ -63,9 +65,7 @@ jobs:
     parallelism: 3
     steps:
       - checkout
-      - run:
-          name: Rebase on-top of github target
-          command: ./devops/scripts/rebase-ci.sh
+      - *rebaseontarget
 
       - run:
           name: Ensure cache dir exists and permissions are good
@@ -129,10 +129,7 @@ jobs:
     parallelism: 3
     steps:
       - checkout
-      - run:
-          name: Rebase on-top of github target
-          command: ./devops/scripts/rebase-ci.sh
-
+      - *rebaseontarget
       - *createcachedir
       - *restorecache
       - *loadimagelayers
@@ -167,10 +164,7 @@ jobs:
     parallelism: 3
     steps:
       - checkout
-      - run:
-          name: Rebase ontop of github target
-          command: ./devops/scripts/rebase-ci.sh
-
+      - *rebaseontarget
       - *createcachedir
       - *restorecache
       - *loadimagelayers
@@ -242,10 +236,7 @@ jobs:
     working_directory: ~/sd
     steps:
       - checkout
-
-      - run:
-          name: Rebase on-top of github target
-          command: ./devops/scripts/rebase-ci.sh
+      - *rebaseontarget
 
       - run:
           name: Run Staging tests on GCE
@@ -271,10 +262,7 @@ jobs:
     working_directory: ~/sd
     steps:
       - checkout
-
-      - run:
-          name: Rebase on-top of github target
-          command: ./devops/scripts/rebase-ci.sh
+      - *rebaseontarget
 
       - run:
           name: Run Staging tests on GCE (Xenial)

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -155,10 +155,12 @@ Merging Translations Back to Develop
 ------------------------------------
 
 `Weblate`_ automatically pushes the translations done via the web
-interface as a series of commit to the ``i18n`` branch in the `Weblate
+interface as a series of commits to the ``i18n`` branch in the `Weblate
 SecureDrop branch`_ which is a fork of the ``develop`` branch of the
 `SecureDrop git repository`_. These translations need to be submitted
 to the ``develop`` branch via pull requests for merge on a regular basis.
+Branches to merge translations should be prefixed with ``i18n-`` so that
+the translation tests will run in CircleCI.
 
 SecureDrop only supports a subset of all the languages being worked on
 in `Weblate`_: some of them are partially translated or not fully
@@ -172,12 +174,12 @@ file must be manually edited to add this new language to the
 
       $ git clone https://github.com/freedomofpress/securedrop
       $ cd securedrop
-      $ git checkout -b wip-i18n origin/develop
+      $ git checkout -b i18n-merge origin/develop
       $ securedrop/bin/dev-shell ./i18n_tool.py --verbose update-from-weblate
       $ securedrop/bin/dev-shell ./i18n_tool.py --verbose translate-desktop --compile
       $ securedrop/bin/dev-shell ./i18n_tool.py --verbose update-docs
       $ git commit -m 'l10n: compile desktop files' translations # if needed
-      $ git push wip-i18n # and make a pull request from the branch
+      $ git push i18n-merge # and make a pull request from the branch
 
 .. warning::
 
@@ -205,6 +207,9 @@ Verify the translations are not broken:
       $ securedrop/bin/dev-shell ./i18n_tool.py --verbose translate-messages --compile
       $ PAGE_LAYOUT_LOCALES=$(echo $sm | tr ' ' ',') \
           pytest -v --page-layout tests/pageslayout
+
+.. note:: The CI job ``translation-tests`` will run the above page layout tests
+          in all supported languages on branches named with the prefix ``i18n-``.
 
 Go to https://github.com/freedomofpress/securedrop and propose a pull request.
 

--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -24,6 +24,10 @@ test: ## Run the test suite in a Ubuntu 14.04 (Trusty) dockerized environment
 test-xenial: ## Run the test suite in a Ubuntu 16.04 (Xenial) dockerized environment
 	BASE_OS=xenial ./bin/dev-shell ./bin/run-test -v $${TESTFILES:-tests}
 
+.PHONY: translation-test
+translation-test: ## Run all pages-layout tests in all supported languages
+	BASE_OS=xenial ./bin/dev-shell ./bin/translation-test
+
 .PHONY: dev
 dev: ## Run the dev server
 	 DOCKER_RUN_ARGUMENTS='-p127.0.0.1:8080:8080 -p127.0.0.1:8081:8081 -p127.0.0.1:5901:5901' ./bin/dev-shell ./bin/run

--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -26,7 +26,7 @@ test-xenial: ## Run the test suite in a Ubuntu 16.04 (Xenial) dockerized environ
 
 .PHONY: translation-test
 translation-test: ## Run all pages-layout tests in all supported languages
-	BASE_OS=xenial ./bin/dev-shell ./bin/translation-test
+	BASE_OS=xenial ./bin/dev-shell ./bin/translation-test $${TESTFILES:-tests/pageslayout}
 
 .PHONY: dev
 dev: ## Run the dev server

--- a/securedrop/bin/translation-test
+++ b/securedrop/bin/translation-test
@@ -1,0 +1,26 @@
+#!/bin/bash
+# shellcheck disable=SC1090
+
+set -euo pipefail
+
+source "${BASH_SOURCE%/*}/dev-deps"
+
+run_xvfb &
+run_redis &
+urandom
+run_sass --force --update
+maybe_create_config_py
+./i18n_tool.py translate-messages --compile
+
+mkdir -p "/tmp/test-results/logs"
+
+: "${PAGE_LAYOUT_LOCALES:=ar,de_DE,es_ES,fr_FR,nb_NO,nl,pt_BR,zh_Hant,it_IT,tr,hi,ru,sv}"
+export PAGE_LAYOUT_LOCALES
+
+pytest \
+  -v \
+  --page-layout \
+  --durations 10 \
+  --junitxml=/tmp/test-results/junit.xml \
+  tests/pageslayout
+  "$@"

--- a/securedrop/bin/translation-test
+++ b/securedrop/bin/translation-test
@@ -14,13 +14,14 @@ maybe_create_config_py
 
 mkdir -p "/tmp/test-results/logs"
 
-: "${PAGE_LAYOUT_LOCALES:=ar,de_DE,es_ES,fr_FR,nb_NO,nl,pt_BR,zh_Hant,it_IT,tr,hi,ru,sv}"
-export PAGE_LAYOUT_LOCALES
-
-pytest \
-  -v \
-  --page-layout \
-  --durations 10 \
-  --junitxml=/tmp/test-results/junit.xml \
-  tests/pageslayout
-  "$@"
+# Taking screenshots for consumes a lot of memory
+# and can result in OOM errors in CI. Running each locale
+# separately avoids this.
+for locale in ar de_DE es_ES fr_FR nb_NO nl pt_BR zh_Hant it_IT tr hi ru sv
+do
+  PAGE_LAYOUT_LOCALES=$locale pytest \
+    -v \
+    --page-layout \
+    --durations 10 \
+    "$@"
+done


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #4183

## Testing

- [ ] Ensure the workflow kicked off by this branch has only two jobs: `translation-tests` and `lint`. This is because this branch is prefixed with `i18n-`.
- [ ] The above two jobs should pass.
- [ ] Ensure the workflow kicked off by `normal-ci-jobs-should-run` contains the normal CI jobs - this branch is identical to this one except for an additional dummy commit (added otherwise CircleCI will display the CI job results in the checks for this PR since they are tracked by commit hash and not branch name).

## Deployment

This is CI only for developer/release agility

## Checklist

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
