### PR TITLE
updated tmux note, fixed path error

### DIFF
--- a/docs/upgrade/xenial_backup_install_restore.rst
+++ b/docs/upgrade/xenial_backup_install_restore.rst
@@ -67,7 +67,7 @@ do so, run the following commands from the terminal:
   cd ~/Persistent/
   mkdir app_service
   cp securedrop/install_files/ansible-base/app-*ths app_service/
-  cp securedrop/install_files/ansible-base/site-specific app_service/
+  cp securedrop/install_files/ansible-base/group_vars/all/site-specific app_service/
 
 Once you have completed the backup process, you may shut down the *Admin
 Workstation* and move to the next step: installing a Xenial-based instance.

--- a/docs/upgrade/xenial_upgrade_in_place.rst
+++ b/docs/upgrade/xenial_upgrade_in_place.rst
@@ -76,9 +76,10 @@ prompts that follow:
 .. note:: The ``do-release-upgrade`` script displays some dialogs using
   ``ncurses``, a library for rendering GUI elements in text-only displays. It
   may display incorrectly within your terminal window. To force a redraw, adjust
-  the terminal window's size to approximately 150 columns by 40 rows, by
-  dragging the corners. If it still does not display correctly, make small
-  adjustments to the terminal size to force successive redraws.
+  the terminal window's size by toggling between the **Terminal > 80x43** and 
+  **Terminal > 132x43** items in the terminal window's menu bar. If the dialog 
+  still does not display correctly, try resizing the window by dragging the 
+  resize widget in the lower right corner.
 
 - Choose **OK** to close the Postfix information dialog
 - Choose **No Configuration** and **OK** on the "General type of mail


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes a path error and adds more robust way to mitigate tmux display errors

- [x] Doc linting (`make docs-lint`) passed locally
