### PR TITLE
[xenial] Restart haveged and apparmor

### DIFF
--- a/install_files/ansible-base/roles/app/handlers/main.yml
+++ b/install_files/ansible-base/roles/app/handlers/main.yml
@@ -19,6 +19,13 @@
     name: securedrop_worker
     state: present
 
+## Here, we list apparmor before haveged to ensure the correct AppArmor
+## profile is loaded prior to restarting haveged
+- name: restart apparmor
+  service:
+    name: apparmor
+    state: restarted
+
 - name: restart haveged
   service:
     name: haveged

--- a/install_files/ansible-base/roles/app/tasks/configure_haveged.yml
+++ b/install_files/ansible-base/roles/app/tasks/configure_haveged.yml
@@ -75,6 +75,9 @@
     line: "After=apparmor.service systemd-random-seed.service"
     backrefs: yes
   when: haveged_apparmor.stat.exists
+  notify:
+    - restart apparmor
+    - restart haveged
   tags:
     - haveged
     - hardening


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In the Xenial upgrade scenario, restarting will ensure the AppArmor profiles are correctly loaded so that it can be properly enforced, prior to rebooting.

Fixes #4200 

## Testing
- Install 0.12.0-rc3 on Trusty
- Upgrade to Xenial 
- [ ] ssh into app, and run` sudo aa-status`, observe that haveged is unconfined
- run installer on this branch
- [ ] observe  haveged restart handler running *after* apparmor restart handler
- [ ] run `sudo aa-status` and observe that /usr/sbin/haveged is in enforce mode
- [ ] to validate idempotency, run installer again, observe the apparmor handler not running

## Deployment

Any special considerations for deployment? Consider both:

1. Ansible via ./securedrop-admin install
2. Ansible via ./securedrop-admin install

## Checklist
### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
