### PR TITLE
[dev] some updates for making Xenial default env

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure("2") do |config|
       config.ssh.port = 22
     end
     staging.vm.hostname = "mon-staging"
-    staging.vm.box = "bento/ubuntu-14.04"
+    staging.vm.box = "bento/ubuntu-16.04"
     staging.vm.network "private_network", ip: "10.0.1.3"
     staging.vm.synced_folder './', '/vagrant', disabled: true
   end
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
       config.ssh.port = 22
     end
     staging.vm.hostname = "app-staging"
-    staging.vm.box = "bento/ubuntu-14.04"
+    staging.vm.box = "bento/ubuntu-16.04"
     staging.vm.network "private_network", ip: "10.0.1.2"
     staging.vm.synced_folder './', '/vagrant', disabled: true
     staging.vm.provider "virtualbox" do |v|
@@ -67,7 +67,7 @@ Vagrant.configure("2") do |config|
       config.ssh.port = 22
     end
     prod.vm.hostname = "mon-prod"
-    prod.vm.box = "bento/ubuntu-14.04"
+    prod.vm.box = "bento/ubuntu-16.04"
     prod.vm.network "private_network", ip: "10.0.1.5", virtualbox__intnet: internal_network_name
     prod.vm.synced_folder './', '/vagrant', disabled: true
   end
@@ -79,7 +79,7 @@ Vagrant.configure("2") do |config|
       config.ssh.port = 22
     end
     prod.vm.hostname = "app-prod"
-    prod.vm.box = "bento/ubuntu-14.04"
+    prod.vm.box = "bento/ubuntu-16.04"
     prod.vm.network "private_network", ip: "10.0.1.4", virtualbox__intnet: internal_network_name
     prod.vm.synced_folder './', '/vagrant', disabled: true
     prod.vm.provider "virtualbox" do |v|

--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -17,16 +17,16 @@ lint-full:  ## Run the python linter with nothing disabled
 	find . -name '*.py' | xargs pylint
 
 .PHONY: test
-test: ## Run the test suite in a Ubuntu 14.04 (Trusty) dockerized environment
+test: ## Run the test suite in a Ubuntu 16.04 (Xenial) dockerized environment
 	./bin/dev-shell ./bin/run-test -v $${TESTFILES:-tests}
 
-.PHONY: test-xenial
-test-xenial: ## Run the test suite in a Ubuntu 16.04 (Xenial) dockerized environment
-	BASE_OS=xenial ./bin/dev-shell ./bin/run-test -v $${TESTFILES:-tests}
+.PHONY: test-trusty
+test-trusty: ## Run the test suite in a Ubuntu 14.04 (Trusty) dockerized environment (to be removed April 30, 2019)
+	BASE_OS=trusty ./bin/dev-shell ./bin/run-test -v $${TESTFILES:-tests}
 
 .PHONY: translation-test
 translation-test: ## Run all pages-layout tests in all supported languages
-	BASE_OS=xenial ./bin/dev-shell ./bin/translation-test $${TESTFILES:-tests/pageslayout}
+	./bin/dev-shell ./bin/translation-test $${TESTFILES:-tests/pageslayout}
 
 .PHONY: dev
 dev: ## Run the dev server

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -10,8 +10,8 @@ TOPLEVEL=$(git rev-parse --show-toplevel)
 source "${BASH_SOURCE%/*}/../../devops/scripts/ticker"
 
 if ! test -n "${BASE_OS:-}" ; then
-    # If no base OS was specified, then we use Trusty
-    BASE_OS=trusty
+    # If no base OS was specified, then we use Xenial
+    BASE_OS=xenial
 fi
 
 function exit_if_not_supported_base_image() {


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Two more checkboxes in #4155, an easy merge

## Testing

- Check I got all the application-level references to the `make test*` targets in the application level makefile
- Check I got all the 14.04 references in the Vagrantfile

## Deployment

None, we're recommending Xenial in prod already
