### PR TITLE
On NoScript XSS info page, add link back to submission page

### DIFF
--- a/securedrop/source_templates/disable-noscript-xss.html
+++ b/securedrop/source_templates/disable-noscript-xss.html
@@ -47,5 +47,6 @@
 
 <p>{{ gettext('Repeat steps 1-3 from above and re-check the setting. The setting has no effect while your Security Slider is set to "Safest", but we recommend enabling it during normal Tor usage.') }}</p>
 
+<p><a href="/lookup">« {{ gettext('Back to submission page') }}</a></p>
 
 {% endblock %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds a link back to the submission page at the bottom of the page explaining how to work around the NoScript cross-site sanitization upload problem.

Fixes #4208

## Testing

On the submission page, click the "Show me how" link to get to the instructions for working around the NoScript XSS upload problem. At the bottom of the page should be a "Back to submission page" link. Click it to verify that it takes you back to the source submission page.

## Checklist

### If you made changes to the server application code:

- [X] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
