### PR TITLE
Adds Upgrade scenario boxes for 0.12.0 (Trusty)

### DIFF
--- a/devops/scripts/vagrant_package.sh
+++ b/devops/scripts/vagrant_package.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
+# Wrapper script to create Vagrant boxes for use with the "upgrade"
+# scenario.
 
 molecule test -s vagrant_packager && \
 # Unfortunately since we need to prompt the user for sudo creds..
 # I had to break the actual vagrant package logic outside of molecule
 molecule/vagrant_packager/package.py && \
 molecule destroy -s vagrant_packager
+
+

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -10,8 +10,8 @@ lint:
 
 platforms:
   - name: app-staging
-    box: fpf/securedrop-app
-    box_url: "../vagrant_packager/box_files/app_metadata.json"
+    box: fpf/securedrop-app-trusty
+    box_url: "../vagrant_packager/box_files/app_trusty_metadata.json"
     instance_raw_config_args:
       - "ssh.insert_key = false"
     provider_override_args:
@@ -24,8 +24,8 @@ platforms:
       - staging
 
   - name: mon-staging
-    box: fpf/securedrop-mon
-    box_url: "../vagrant_packager/box_files/mon_metadata.json"
+    box: fpf/securedrop-mon-trusty
+    box_url: "../vagrant_packager/box_files/mon_trusty_metadata.json"
     instance_raw_config_args:
       - "ssh.insert_key = false"
     provider_override_args:

--- a/molecule/vagrant_packager/box_files/app_trusty_metadata.json
+++ b/molecule/vagrant_packager/box_files/app_trusty_metadata.json
@@ -56,6 +56,17 @@
           "checksum": "e832c4940ef10e8d999033271454f7220c85f4b0a89f378906895d4a82478eee"
         }
       ]
+    },
+    {
+      "version": "0.12.0",
+      "providers": [
+        {
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging-trusty_0.12.0.box",
+          "checksum_type": "sha256",
+          "checksum": "db9f077d0b9f960c5d36a8a804a791151271009c7490fe3a4c715b71998afcd8"
+        }
+      ]
     }
   ]
 }

--- a/molecule/vagrant_packager/box_files/app_trusty_metadata.json
+++ b/molecule/vagrant_packager/box_files/app_trusty_metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "fpf/securedrop-app",
+  "name": "fpf/securedrop-app-trusty",
   "description": "This box contains securedrop app server.",
   "versions": [
     {

--- a/molecule/vagrant_packager/box_files/mon_trusty_metadata.json
+++ b/molecule/vagrant_packager/box_files/mon_trusty_metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "fpf/securedrop-mon",
+  "name": "fpf/securedrop-mon-trusty",
   "description": "This box contains securedrop monitor server.",
   "versions": [
     {

--- a/molecule/vagrant_packager/box_files/mon_trusty_metadata.json
+++ b/molecule/vagrant_packager/box_files/mon_trusty_metadata.json
@@ -56,6 +56,17 @@
           "checksum": "bbc8ed55fab20ed96c3b090126b69baabbd41e95faa60676dff72bc69af67376"
         }
       ]
+    },
+    {
+      "version": "0.12.0",
+      "providers": [
+        {
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging-trusty_0.12.0.box",
+          "checksum_type": "sha256",
+          "checksum": "0ac7538f52b3450a1791a06b8a02fe81b65637da92bb00a61b669beccef87f8d"
+        }
+      ]
     }
   ]
 }

--- a/molecule/vagrant_packager/package.py
+++ b/molecule/vagrant_packager/package.py
@@ -120,6 +120,14 @@ def main():
     SCENARIO_PATH = os.path.dirname(os.path.realpath(__file__))
     BOX_PATH = join(SCENARIO_PATH, "build")
     EPHEMERAL_DIRS = {}
+    TARGET_VERSION_FILE = os.path.join(SCENARIO_PATH, os.path.pardir, "shared", "stable.ver")
+    with open(TARGET_VERSION_FILE, 'r') as f:
+        TARGET_VERSION = f.read().strip()
+    try:
+        TARGET_PLATFORM = os.environ['SECUREDROP_TARGET_PLATFORM']
+    except KeyError:
+        msg = "Set SECUREDROP_TARGET_PLATFORM env var to 'trusty' or 'xenial'"
+        raise Exception(msg)
 
     for srv in ["app-staging", "mon-staging"]:
 
@@ -174,7 +182,7 @@ def main():
                         join(EPHEMERAL_DIRS['build'], 'Vagrantfile'))
 
         print("Creating tar file")
-        box_file = join(BOX_PATH, srv+".box")
+        box_file = join(BOX_PATH, "{}-{}_{}.box".format(srv, TARGET_PLATFORM, TARGET_VERSION))
         with tarfile.open(box_file, "w|gz") as tar:
             for boxfile in ["box.img", "Vagrantfile", "metadata.json"]:
                 tar.add(join(EPHEMERAL_DIRS["build"], boxfile),

--- a/molecule/vagrant_packager/playbook.yml
+++ b/molecule/vagrant_packager/playbook.yml
@@ -1,4 +1,13 @@
 ---
+- name: Prepare servers for installation
+  hosts: securedrop
+  gather_facts: no
+  max_fail_percentage: 0
+  any_errors_fatal: yes
+  become: yes
+  roles:
+    - { role: prepare-servers }
+
 - name: Add FPF apt repository and install base packages.
   hosts: securedrop
   max_fail_percentage: 0


### PR DESCRIPTION
## Status

Work in progress.

## Description of Changes

Built new Trusty 0.12.0 boxes for upgrade scenario. They're uploaded, but I haven't tested them yet. Further changes will be required to prepare and upload Xenial-based 0.12.0 boxes. Would prefer to handle those changes in a separate PR.

Changes proposed in this pull request:

* Created and pushed (to S3) new base boxes for the "upgrade" testing scenario (so far Trusty only)
* Reorganized the path/metadata logic in the box building somewhat, to accommodate for different platforms

**Prior to merge, these changes should be rebased on top of latest develop.** Note that as specified in the box maintenance docs (https://docs.securedrop.org/en/release-0.12.0/development/upgrade_testing.html#updating-the-base-boxes-used-for-upgrade-testing) I checked out the `0.12.0` tag in order to build these boxes, but I branched from that tag in order to write these commits, for the per-platform logic. Technically the `mv` operations documented in the manual steps are no longer required, and can be removed. The manual JSON updates _are_ still required, although I'd prefer to automate those at a later date, as well.

## Testing
1. Run `make upgrade-start`
2. Confirm boxes pull successfully
3. Confirm boxes are running 0.12.0. 



## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
