### PR TITLE
extend staging timeout for long ansible tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,7 @@ jobs:
       - run:
           name: Run Staging tests on GCE
           command: make ci-go
+          no_output_timeout: 20m
 
       - run:
           name: Ensure environment torn down

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,6 +276,7 @@ jobs:
       - run:
           name: Run Staging tests on GCE (Xenial)
           command: make ci-go-xenial
+          no_output_timeout: 20m
 
       - run:
           name: Ensure environment torn down


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes timeout errors in CI, closes #4220 

## Testing

Does CI pass? In particular this Ansible step:

```
Perform safe upgrade to ensure all the packages are updated
```

## Deployment

CI only.