### PR TITLE
Remove unused wireless packages

### DIFF
--- a/install_files/ansible-base/roles/common/defaults/main.yml
+++ b/install_files/ansible-base/roles/common/defaults/main.yml
@@ -44,3 +44,8 @@ sysctl_flags:
     value: "1"
   - name: "net.ipv6.conf.lo.disable_ipv6"
     value: "1"
+
+unused_packages:
+  - libiw30
+  - wireless-tools
+  - wpasupplicant

--- a/install_files/ansible-base/roles/common/tasks/main.yml
+++ b/install_files/ansible-base/roles/common/tasks/main.yml
@@ -22,3 +22,5 @@
 - include: disable_swap.yml
 
 - include: remove_kernel_modules.yml
+
+- include: remove_unused_packages.yml

--- a/install_files/ansible-base/roles/common/tasks/remove_unused_packages.yml
+++ b/install_files/ansible-base/roles/common/tasks/remove_unused_packages.yml
@@ -1,0 +1,16 @@
+---
+- name: Remove unused packages
+  apt:
+    name: "{{ item }}"
+    state: absent
+  with_items: "{{ unused_packages }}"
+  tags:
+    - apt
+    - hardening
+
+- name: Remove dependencies that are no longer required
+  apt:
+    autoremove: yes
+  tags:
+    - apt
+    - hardening

--- a/molecule/testinfra/staging/common/test_system_hardening.py
+++ b/molecule/testinfra/staging/common/test_system_hardening.py
@@ -1,6 +1,8 @@
 import pytest
 import re
 
+testinfra_hosts = ["app", "app-staging", "mon", "mon-staging"]
+
 
 @pytest.mark.parametrize('sysctl_opt', [
   ('net.ipv4.conf.all.accept_redirects', 0),
@@ -133,3 +135,13 @@ def test_no_ecrypt_messages_in_logs(host, logfile):
         # string to make it into syslog as a side-effect of the testinfra
         # invocation, causing subsequent test runs to report failure.
         assert error_message not in f.content_string
+
+
+@pytest.mark.parametrize('package', [
+    'libiw30',
+    'wpasupplicant',
+    'wireless-tools',
+])
+def test_unused_packages_are_removed(host, package):
+    """ Check if unused package is present """
+    assert host.package(package).is_installed is False


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4163

## Testing
#### Clean install scenario:
- [ ] Xenial staging tests pass
- [ ] Nightly Trusty tests pass

#### Upgrade testing scenario (requires prod VMs or hardware)
- [ ] Install on 0.12.0 (on 0.12.0 tag)
- [ ] Upgrade to Xenial
- [ ] Run install on this branch
- [ ] Observe wireless packages are removed

## Deployment

This change to the Ansible logic will be deployed via GitHub, and deployed to server when an admin installs.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR