### PR TITLE
Rename Makefile targets, Xenial new default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - store_artifacts:
           path: ~/test-results
 
-  xenial-app-tests:
+  app-tests:
     machine:
       enabled: true
     environment:
@@ -296,7 +296,7 @@ workflows:
   securedrop_ci:
     jobs:
       - lint
-      - xenial-app-tests:
+      - app-tests:
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ jobs:
           name: Run static security testing on source code
           command: make bandit
 
-  staging-test-with-rebase:
+  staging-test-with-rebase-trusty:
     machine:
       enabled: true
 
@@ -248,7 +248,7 @@ jobs:
 
       - run:
           name: Run Staging tests on GCE
-          command: make ci-go
+          command: make ci-go-trusty
           no_output_timeout: 20m
 
       - run:
@@ -264,7 +264,7 @@ jobs:
       - store_artifacts:
           path: ~/sd/junit
 
-  staging-test-with-rebase-xenial:
+  staging-test-with-rebase:
     machine:
       enabled: true
 
@@ -275,7 +275,7 @@ jobs:
 
       - run:
           name: Run Staging tests on GCE (Xenial)
-          command: make ci-go-xenial
+          command: make ci-go
           no_output_timeout: 20m
 
       - run:
@@ -320,7 +320,7 @@ workflows:
               ignore:
                 - /docs-.*/
                 - /i18n-.*/
-      - staging-test-with-rebase-xenial:
+      - staging-test-with-rebase:
           filters:
             branches:
               ignore:
@@ -344,5 +344,5 @@ workflows:
                 - develop
     jobs:
       - static-analysis-and-no-known-cves
-      - staging-test-with-rebase
+      - staging-test-with-rebase-trusty
       - trusty-app-tests

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ STABLE_VER := $(shell cat molecule/shared/stable.ver)
 ci-go: ## Creates, provisions, tests, and destroys GCE host for testing staging environment.
 	./devops/gce-nested/ci-go.sh
 
-.PHONY: ci-go-xenial
-ci-go-xenial: ## Creates, provisions, tests, and destroys GCE host for testing staging environment under xenial.
-	./devops/gce-nested/ci-go.sh xenial
+.PHONY: ci-go-trusty
+ci-go-trusty: ## Creates, provisions, tests, and destroys GCE host for testing staging environment under trusty.
+	./devops/gce-nested/ci-go.sh trusty
 
 .PHONY: ci-teardown
 ci-teardown: ## Destroys GCE host for testing staging environment.
@@ -89,13 +89,13 @@ build-debs: ## Builds and tests debian packages
 build-debs-notest: ## Builds and tests debian packages (sans tests)
 	@./devops/scripts/build-debs.sh notest
 
-.PHONY: build-debs-xenial
-build-debs-xenial: ## Builds and tests debian packages (includes Xenial overrides, TESTING ONLY)
-	@./devops/scripts/build-debs.sh test xenial
+.PHONY: build-debs-trusty
+build-debs-trusty: ## Builds and tests debian packages (for Trusty)
+	@./devops/scripts/build-debs.sh test trusty
 
-.PHONY: build-debs-xenial-notest
-build-debs-xenial-notest: ## Builds and tests debian packages (includes Xenial overrides, sans tests, TESTING ONLY)
-	@./devops/scripts/build-debs.sh notest xenial
+.PHONY: build-debs-trusty-notest
+build-debs-trusty-notest: ## Builds and tests debian packages (for Trusty)
+	@./devops/scripts/build-debs.sh notest trusty
 
 .PHONY: build-gcloud-docker
 build-gcloud-docker: ## Build docker container for gcloud sdk
@@ -147,11 +147,11 @@ vagrant-package: ## Package up a vagrant box of the last stable SD release
 
 .PHONY: staging
 staging: ## Creates local staging environment in VM, autodetecting platform
-	@./devops/scripts/create-staging-env
-
-.PHONY: staging-xenial
-staging-xenial: ## Creates local staging VMs based on Xenial, autodetecting platform
 	@./devops/scripts/create-staging-env xenial
+
+.PHONY: staging-trusty
+staging-trusty: ## Creates local staging VMs based on Trusty, autodetecting platform
+	@./devops/scripts/create-staging-env
 
 .PHONY: clean
 clean: ## DANGER! Purges all site-specific info and developer files from project.

--- a/devops/gce-nested/ci-go.sh
+++ b/devops/gce-nested/ci-go.sh
@@ -13,8 +13,8 @@ set -u
 set -o pipefail
 
 
-# Assume we're running against Trusty; Xenial also supported.
-target_platform="${1:-trusty}"
+# Assume we're running against Xenial; Trusty also supported.
+target_platform="${1:-xenial}"
 
 ./devops/gce-nested/gce-start.sh
 ./devops/gce-nested/gce-runner.sh "$target_platform"

--- a/devops/gce-nested/gce-runner.sh
+++ b/devops/gce-nested/gce-runner.sh
@@ -16,8 +16,8 @@ REMOTE_IP="$(gcloud_call compute instances describe \
 SSH_TARGET="${SSH_USER_NAME}@${REMOTE_IP}"
 SSH_OPTS=(-i "$SSH_PRIVKEY" -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null")
 
-# Assume we're testing Trusty. Xenial is also supported
-target_platform="${1:-trusty}"
+# Assume we're testing Xenial. Trusty is also supported
+target_platform="${1:-xenial}"
 
 # Wrapper utility to run commands on remote GCE instance
 function ssh_gce {
@@ -55,8 +55,8 @@ function copy_securedrop_repo() {
 
 # Main logic
 copy_securedrop_repo
-if [[ "$target_platform" = "xenial" ]]; then
-    ssh_gce "make build-debs-xenial-notest"
+if [[ "$target_platform" = "trusty" ]]; then
+    ssh_gce "make build-debs-trusty-notest"
 else
     ssh_gce "make build-debs-notest"
 fi
@@ -65,10 +65,10 @@ fi
 # so register a trap to ensure the fetch always runs.
 trap fetch_junit_test_results EXIT
 
-# Run staging environment. If xenial is passed as an argument, run the
-# staging environment for xenial.
-if [[ "$target_platform" = "xenial" ]]; then
-    ssh_gce "make staging-xenial"
+# Run staging environment. If trusty is passed as an argument, run the
+# staging environment for trusty.
+if [[ "$target_platform" = "trusty" ]]; then
+    ssh_gce "make staging-trusty"
 else
     ssh_gce "make staging"
 fi

--- a/devops/scripts/build-debs.sh
+++ b/devops/scripts/build-debs.sh
@@ -12,7 +12,7 @@ set -o pipefail
 virtualenv_bootstrap
 
 RUN_TESTS="${1:-test}"
-TARGET_PLATFORM="${2:-trusty}"
+TARGET_PLATFORM="${2:-xenial}"
 SCENARIO_NAME="builder-${TARGET_PLATFORM}"
 
 case "$RUN_TESTS" in


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Towards #4155

:exclamation: CircleCI/GitHub configuration will need to be changed to require certain checks during CI. I propose the following tests should be required for merge:
* app-tests
* staging-test-with-rebase 
* static-analysis-and-no-known-cves
* lint


## Testing

- [ ] Ci should pass
- [ ] `make build-debs-trusty` should successfully Trusty debs
- [ ] `make staging-trusty` should successfully create a Trusty staging envireonment
- [ ] `make build-debs` should successfully create Xenial debs
- [ ] `make staging` should successfully create a Xenial staging envireonment
- [ ] `Makefile` targets no longer contain references to Xenial, Xenial is used by default.
## Deployment

Changes are scoped to dev environment only

## Checklist



### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR


