### PR TITLE
remove cssmin dependency

### DIFF
--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -1,7 +1,6 @@
 alembic
 argon2_cffi
 cryptography==2.0.3
-cssmin
 Flask-Assets
 Flask-Babel
 Flask-SQLAlchemy

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -11,7 +11,6 @@ babel==2.5.1              # via flask-babel
 cffi==1.11.5              # via argon2-cffi, cryptography
 click==6.7                # via flask, rq
 cryptography==2.0.3
-cssmin==0.2.0
 enum34==1.1.6             # via argon2-cffi, cryptography
 flask-assets==0.12
 flask-babel==0.11.2


### PR DESCRIPTION
## Status

Ready for review

/cc @rmol 

## Test Plan

* `make clean`
* `make build-debs`
* `make staging`
- [ ] Verify that CSS is delivered from staging instances by checking that the UI looks as expected
- [ ] Verify that CSS is minified by Sass by comparing file sizes

## Description of Changes

Fixes https://github.com/freedomofpress/securedrop/issues/2808

We can remove our `cssmin` dependency because we already use a ruby script that we tell to compress our css files at debian packaging time.

Changes proposed in this pull request:

* Remove `cssmin` dependency from `requirements.txt` and `requirements.in`

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
