### PR TITLE
updated docs and molecule vars to use Xenial for qubes staging env

### DIFF
--- a/molecule/qubes-staging/qubes-vars.yml
+++ b/molecule/qubes-staging/qubes-vars.yml
@@ -22,3 +22,5 @@ remote_host_ref: >-
      | first
      | default (ansible_host)
   }}
+
+securedrop_staging_install_target_distro: xenial


### PR DESCRIPTION
## Status
Work in progress

## Description of Changes

Updates the qubes-staging molecule scenario and docs to use Xenial.

This is a WIP - for some reason the grsec kernel renames the `eth0` interface, requiring a manual intervention after first boot to edit `/etc/network/interfaces` before  provisioning can continue. However, as it stands the process described produces a working  Xenial staging environment in Qubes

## Testing

- follow the Qubes staging provisioning documentation 
- verify that the resulting `sd-app` and `sd-mon` servers are running 16.04
- verify that the source and journalist interfaces are available with a > 0.12.0 version number

## Checklist
### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
