### PR TITLE
Try harder to attach to an existing tmux session

### DIFF
--- a/install_files/ansible-base/group_vars/securedrop_application_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_application_server.yml
@@ -7,7 +7,7 @@ ip_info:
 ### Used by the install_local_deb_pkgs role ###
 local_deb_packages:
   - "securedrop-keyring-0.1.2+{{ securedrop_app_code_version }}-amd64.deb"
-  - "securedrop-config-0.1.2+{{ securedrop_app_code_version }}-amd64.deb"
+  - "securedrop-config-0.1.3+{{ securedrop_app_code_version }}-amd64.deb"
   - "securedrop-ossec-agent-3.0.0+{{ securedrop_app_code_version }}-amd64.deb"
   - "{{ securedrop_app_code_deb }}.deb"
   - "ossec-agent-3.0.0-amd64.deb"

--- a/install_files/ansible-base/group_vars/securedrop_monitor_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_monitor_server.yml
@@ -7,7 +7,7 @@ ip_info:
 ### Used by the install_local_deb_pkgs role ###
 local_deb_packages:
   - "securedrop-keyring-0.1.2+{{ securedrop_app_code_version }}-amd64.deb"
-  - "securedrop-config-0.1.2+{{ securedrop_app_code_version }}-amd64.deb"
+  - "securedrop-config-0.1.3+{{ securedrop_app_code_version }}-amd64.deb"
   - "securedrop-ossec-server-3.0.0+{{ securedrop_app_code_version }}-amd64.deb"
   - ossec-server-3.0.0-amd64.deb
 

--- a/install_files/ansible-base/roles/common/files/bashrc_securedrop_additions
+++ b/install_files/ansible-base/roles/common/files/bashrc_securedrop_additions
@@ -1,9 +1,0 @@
-# If not running interactively, do not do anything
-[[ $- != *i* ]] && return
-
-# Auto-launch tmux on login
-# https://wiki.archlinux.org/index.php/Tmux#Start_tmux_on_every_shell_login
-if which tmux >/dev/null 2>&1; then
-    #if not inside a tmux session, and if no session is started, start a new session
-    test -z "$TMUX" && (tmux attach || tmux new-session)
-fi

--- a/install_files/ansible-base/roles/common/tasks/create_users.yml
+++ b/install_files/ansible-base/roles/common/tasks/create_users.yml
@@ -23,17 +23,6 @@
     - users
     - sudoers
 
-- name: Set SecureDrop bash profile additions.
-  copy:
-    src: bashrc_securedrop_additions
-    dest: /etc/profile.d/securedrop_additions.sh
-    owner: root
-    group: root
-    mode: "0644"
-  tags:
-    - users
-    - environment
-
 # Backwards-compatibility. Previously, the SecureDrop bashrc additions
 # for forcing a terminal multiplexer during interactive login sessions were
 # added to ~/.bashrc for each admin user account. It's cleaner to add the

--- a/install_files/securedrop-config/DEBIAN/control
+++ b/install_files/securedrop-config/DEBIAN/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
 Homepage: https://securedrop.org
 Package: securedrop-config
-Version: 0.1.2+0.13.0~rc1
+Version: 0.1.3+0.13.0~rc1
 Architecture: all
 Description: Establishes baseline system state for running SecureDrop.
  Configures apt repositories.

--- a/install_files/securedrop-config/etc/profile.d/securedrop_additions.sh
+++ b/install_files/securedrop-config/etc/profile.d/securedrop_additions.sh
@@ -2,7 +2,12 @@
 
 which tmux >/dev/null 2>&1 || return
 
-function tmux_attach_via_proc() {
+tmux_attach_via_proc() {
+    # If the tmux package is upgraded during the lifetime of a
+    # session, attaching with the new binary can fail due to different
+    # protocol versions. This function attaches using the reference to
+    # the old executable found in the /proc tree of an existing
+    # session.
     pid=$(pgrep --newest tmux)
     if test -n "$pid"
     then

--- a/install_files/securedrop-config/etc/profile.d/securedrop_additions.sh
+++ b/install_files/securedrop-config/etc/profile.d/securedrop_additions.sh
@@ -1,0 +1,17 @@
+[[ $- != *i* ]] && return
+
+which tmux >/dev/null 2>&1 || return
+
+function tmux_attach_via_proc() {
+    pid=$(pgrep --newest tmux)
+    if test -n "$pid"
+    then
+        /proc/$pid/exe attach
+    fi
+    return 1
+}
+
+if test -z "$TMUX"
+then
+    (tmux attach || tmux_attach_via_proc || tmux new-session)
+fi

--- a/molecule/builder-trusty/tests/vars.yml
+++ b/molecule/builder-trusty/tests/vars.yml
@@ -2,7 +2,7 @@
 securedrop_version: "0.13.0~rc1"
 ossec_version: "3.0.0"
 keyring_version: "0.1.2"
-config_version: "0.1.2"
+config_version: "0.1.3"
 grsec_version: "4.4.167"
 
 # These values will be interpolated with values populated above


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

If in the course of an ssh/tmux session the tmux package is upgraded and the ssh connection broken, the next ssh attempt will encounter an error because of the tmux protocol version mismatch.

The old tmux can be used to reattach by searching for the tmux process under /proc and using its reference to the old tmux executable. This change attempts to do that automatically if a first "tmux attach" attempt fails, but we can see that a previous session still exists.

Fixes #4221.

## Testing

This is not deterministically reproducible, but I've had it happen on at least one of the servers during each upgrade from Trusty to Xenial, provided they are set up to use SSH over Tor. It seems more likely to occur on the app server, so try running `securedrop-admin install` with this branch, then execute `sudo do-release-upgrade` on the app server first. When you reconnect after libssl et al. are upgraded and Tor restarted, you should automatically resume the tmux session. If instead you get an error about the protocol mismatch, the fix hasn't worked.

## Checklist

### If you made changes to the system configuration:

- [X] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR
