### PR TITLE
Use `--batch` option for refreshing release key to resolve graphical updater issues

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -642,7 +642,8 @@ def check_for_updates(args):
 
 
 def get_release_key_from_keyserver(args, keyserver=None, timeout=45):
-    gpg_recv = ['timeout', str(timeout), 'gpg', '--recv-key']
+    gpg_recv = ['timeout', str(timeout), 'gpg', '--batch', '--no-tty',
+            '--recv-key']
     release_key = [RELEASE_KEY]
 
     # We construct the gpg --recv-key command based on optional keyserver arg.

--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -643,7 +643,7 @@ def check_for_updates(args):
 
 def get_release_key_from_keyserver(args, keyserver=None, timeout=45):
     gpg_recv = ['timeout', str(timeout), 'gpg', '--batch', '--no-tty',
-            '--recv-key']
+                '--recv-key']
     release_key = [RELEASE_KEY]
 
     # We construct the gpg --recv-key command based on optional keyserver arg.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4100 

Changes proposed in this pull request:

By using --batch for refreshing the release key, there's no tty, and the described error will not happen and you can update the key and workstation without manual intervention.

## Testing

It's imperative to launch the gui-updater *not* from a terminal, since this is a known work-around. I've tested with a 0.11 workstation, tried to update with an up-to-date Tails by using the gui.

## Deployment

Should improve updates and upgrades. Not aware of any effects to fresh installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

I find the setup process burden a bit too high for a random passer-by, I don't have a admin development container, sorry.

### Trivial code change:

I looked at admin/tests/ but it looks like they're all launched with a TTY available.