### PR TITLE
Broaden apache snippet to disable logging on landing page

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -262,7 +262,7 @@ logging. However you still need to make sure no other assets get logged!
 
 ::
 
-    SetEnvIf Request_URI "^/securedrop(/.*)$" dontlog
+    SetEnvIf Request_URI "^/securedrop($|(\/.*))" dontlog
     CustomLog logs/access_log common env=!dontlog
 
 In nginx, logging can be disabled like so:

--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -258,11 +258,11 @@ that includes a file integrity monitor. More information can be found
 **Don't log access to the *Landing Page* in the webserver**
 
 Here's an Apache example that would exclude the *Landing Page* from
-logging:
+logging. However you still need to make sure no other assets get logged!
 
 ::
 
-    SetEnvIf Request_URI "^/securedrop$" dontlog
+    SetEnvIf Request_URI "^/securedrop(/.*)$" dontlog
     CustomLog logs/access_log common env=!dontlog
 
 In nginx, logging can be disabled like so:


### PR DESCRIPTION
The suggestion to not log the landing page, might still for example
get such files or assets CSS logged:

… "GET /securedrop/style.min.css?ver=1479378239672 HTTP/1.1" 200 …

Feel free to change to yet someting else, maybe this would exclude
certain logs that people would still like.

## Status

Ready for review

## Description of Changes

Fixes #.

Changes documentation and stresses the other assets too. This snippet will not log urls like: example.com/securedrop/fancylogo.jpg or example.com/securedrop?style.min.css

## Testing

You can setup a demo instance, test this adapted apache configuration.

## Deployment

1. Upgrading existing production instances.
It'd be good if admins checked their instances if nothing gets logged that shouldn't be logged. It's good practice to check this anyway once in a while.

## Checklist

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
A pull request should tick this box^