### PR TITLE
Link directly to i18n repo contributors list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ The wordlist we use to generate source passphrases come from various sources:
 
 A huge thank you to all SecureDrop contributors! You can see just
 code and documentation contributors in the ["Contributors"](https://github.com/freedomofpress/securedrop/graphs/contributors)
-tab on GitHub, and you can see code, documentation and translation contributors together [here](https://github.com/freedomofpress/securedrop-i18n).
+tab on GitHub, and you can see code, documentation and translation contributors together [here](https://github.com/freedomofpress/securedrop-i18n/graphs/contributors).


### PR DESCRIPTION
The intention is to make the names of all i18n contributors more
discoverable. We separately prepare a list of contributors to the
i18n for each release as part of the release notes.

## Status

Ready for review