### PR TITLE
[docs] Make it clearer that key generation must be done on the SVS

### DIFF
--- a/docs/generate_securedrop_application_key.rst
+++ b/docs/generate_securedrop_application_key.rst
@@ -7,7 +7,16 @@ of this key is only stored on the *Secure Viewing Station* which is never
 connected to the Internet. SecureDrop submissions can only be decrypted and
 read on the *Secure Viewing Station*.
 
-We will now generate the *SecureDrop Submission Key*.
+We will now generate the *SecureDrop Submission Key*. If you aren't still
+logged into your *Secure Viewing Station* from the previous step, boot it using
+its Tails USB stick, with persistence enabled.
+
+.. important:: Do not follow these steps before you have fully configured the
+  *Secure Viewing Station* according to the :doc:`instructions <set_up_svs>`.
+  The private key you will generate in the following steps is one of the most
+  important secrets associated with your SecureDrop installation. This procedure
+  is intended to ensure that the private key is protected by the air-gap
+  throughout its lifetime.
 
 Create the Key
 --------------


### PR DESCRIPTION
Resolves #4076

## Status

Ready for review

## Checklist

- [x] Doc linting (`make docs-lint`) passed locally
