### PR TITLE
Adds instructions on verifying server locales before running install playbook

### DIFF
--- a/docs/upgrade/xenial_upgrade_in_place.rst
+++ b/docs/upgrade/xenial_upgrade_in_place.rst
@@ -246,6 +246,24 @@ stepping through the configuration using:
 
   ./securedrop-admin sdconfig
 
+Next, you may need to update your servers' default locale settings. This step is
+required if your servers were installed with language and locale settings that
+are incompatible with the SecureDrop installer's Ansible playbook. You can check
+your settings as follows:
+
+.. code:: sh
+ 
+  ssh app sudo locale | grep LANG=
+  ssh mon sudo locale | grep LANG=
+
+If the ``LANG`` variable is set to anything other than a blank value or an 
+English variant, you must change it using the following commands:
+
+.. code:: sh
+ 
+  ssh app sudo update-locale --reset LANG=  
+  ssh mon sudo update-locale --reset LANG=  
+
 Finally, install the Ubuntu 16.04 version of the server application code and
 configuration:
 

--- a/docs/upgrade/xenial_upgrade_in_place.rst
+++ b/docs/upgrade/xenial_upgrade_in_place.rst
@@ -257,12 +257,13 @@ your settings as follows:
   ssh mon sudo locale | grep LANG=
 
 If the ``LANG`` variable is set to anything other than a blank value or an 
-English variant, you must change it using the following commands:
+English variant, you must change your locale settings using the following 
+commands:
 
 .. code:: sh
  
-  ssh app sudo update-locale --reset LANG=  
-  ssh mon sudo update-locale --reset LANG=  
+  ssh app sudo update-locale --reset LC_ALL=C 
+  ssh mon sudo update-locale --reset LC_ALL=C
 
 Finally, install the Ubuntu 16.04 version of the server application code and
 configuration:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4242

Instructions added to upgrade-in-place docs, describing how to check and set server locales before running `./securedrop-admin install`

## Testing
- Docs-only PR - check for clarity and accuracy
- (optional) follow upgrade-in-place instructions on a system originally set up with a non-English language/locale and verify that the post-upgrade install run completes.

## Deployment

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
