### PR TITLE
Control locale during Ansible runs

### DIFF
--- a/install_files/ansible-base/securedrop-backup.yml
+++ b/install_files/ansible-base/securedrop-backup.yml
@@ -3,6 +3,8 @@
   hosts: securedrop_application_server
   max_fail_percentage: 0
   any_errors_fatal: yes
+  environment:
+    LC_ALL: C
   roles:
     - role: backup
       tags: backup

--- a/install_files/ansible-base/securedrop-logs.yml
+++ b/install_files/ansible-base/securedrop-logs.yml
@@ -4,6 +4,8 @@
   become: yes
   max_fail_percentage: 0
   any_errors_fatal: yes
+  environment:
+    LC_ALL: C
   vars:
     log_paths_reference:
       app:

--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -2,6 +2,8 @@
 ---
 - name: Ensure validation is run before prod install
   hosts: localhost
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   connection: local
@@ -10,6 +12,8 @@
 
 - name: Prepare servers for installation
   hosts: securedrop
+  environment:
+    LC_ALL: C
   gather_facts: no
   max_fail_percentage: 0
   any_errors_fatal: yes
@@ -19,6 +23,8 @@
 
 - name: Add FPF apt repository and install base packages.
   hosts: securedrop
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   pre_tasks:
@@ -49,6 +55,8 @@
 
 - name: Configure OSSEC.
   hosts: securedrop
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   roles:
@@ -58,6 +66,8 @@
 
 - name: Configure mailing utilities.
   hosts: securedrop_monitor_server
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   roles:
@@ -67,6 +77,8 @@
 
 - name: Configure SecureDrop Application Server.
   hosts: securedrop_application_server
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   roles:
@@ -81,6 +93,8 @@
   # connection. After that point the admin will to proxy traffic over tor.
 - name: Lock down firewall configuration for Application and Monitor Servers.
   hosts: securedrop
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   roles:
@@ -89,6 +103,8 @@
 
 - name: Reboot Application and Monitor Servers.
   hosts: securedrop
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   vars:

--- a/install_files/ansible-base/securedrop-restore.yml
+++ b/install_files/ansible-base/securedrop-restore.yml
@@ -3,6 +3,8 @@
   hosts: securedrop_application_server
   max_fail_percentage: 0
   any_errors_fatal: yes
+  environment:
+    LC_ALL: C
   roles:
     - role: restore
       tags: restore

--- a/install_files/ansible-base/securedrop-staging.yml
+++ b/install_files/ansible-base/securedrop-staging.yml
@@ -2,6 +2,8 @@
 ---
 - name: Scrape build directory
   hosts: localhost
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   tasks:
@@ -23,6 +25,8 @@
 
 - name: Prepare servers for installation
   hosts: staging
+  environment:
+    LC_ALL: C
   gather_facts: no
   max_fail_percentage: 0
   any_errors_fatal: yes
@@ -32,6 +36,8 @@
 
 - name: Add FPF apt repository and install base packages.
   hosts: staging
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   roles:
@@ -47,6 +53,8 @@
 
 - name: Configure OSSEC.
   hosts: staging
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   roles:
@@ -56,6 +64,8 @@
 
 - name: Configure mailing utilities.
   hosts: mon-staging
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   roles:
@@ -65,6 +75,8 @@
 
 - name: Configure SecureDrop Application Server.
   hosts: app-staging
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   roles:
@@ -77,6 +89,8 @@
   # and default false in production environments, in order to force SSH traffic over Tor.
 - name: Configure host firewalls (with direct access for staging).
   hosts: staging
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   roles:
@@ -85,6 +99,8 @@
 
 - name: Reboot Application and Monitor Servers.
   hosts: staging
+  environment:
+    LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
   roles:

--- a/install_files/ansible-base/securedrop-tails.yml
+++ b/install_files/ansible-base/securedrop-tails.yml
@@ -8,6 +8,8 @@
   any_errors_fatal: yes
   connection: local
   gather_facts: yes
+  environment:
+    LC_ALL: C
   roles:
     - role: tails-config
       tags: tails-config

--- a/molecule/ansible-config/tests/test_play_configuration.py
+++ b/molecule/ansible-config/tests/test_play_configuration.py
@@ -78,3 +78,19 @@ def test_any_errors_fatal(host, playbook):
             assert 'any_errors_fatal' in play
             # Ansible coerces booleans, so bare assert is sufficient
             assert play['any_errors_fatal']
+
+
+@pytest.mark.parametrize('playbook', ['securedrop-prod.yml', 'securedrop-staging.yml'])
+def test_locale(host, playbook):
+    """
+    The securedrop-prod and securedrop-staging playbooks should
+    control the locale in the host environment by setting LC_ALL=C.
+
+    TODO: evaluate whether to do the same for the rest of the
+    playbooks.
+    """
+    with io.open(os.path.join(ANSIBLE_BASE, playbook), 'r') as f:
+        playbook_yaml = yaml.safe_load(f)
+        for play in playbook_yaml:
+            assert 'environment' in play
+            assert play['environment']['LC_ALL'] == 'C'

--- a/molecule/ansible-config/tests/test_play_configuration.py
+++ b/molecule/ansible-config/tests/test_play_configuration.py
@@ -80,14 +80,11 @@ def test_any_errors_fatal(host, playbook):
             assert play['any_errors_fatal']
 
 
-@pytest.mark.parametrize('playbook', ['securedrop-prod.yml', 'securedrop-staging.yml'])
+@pytest.mark.parametrize('playbook', find_ansible_playbooks())
 def test_locale(host, playbook):
     """
     The securedrop-prod and securedrop-staging playbooks should
     control the locale in the host environment by setting LC_ALL=C.
-
-    TODO: evaluate whether to do the same for the rest of the
-    playbooks.
     """
     with io.open(os.path.join(ANSIBLE_BASE, playbook), 'r') as f:
         playbook_yaml = yaml.safe_load(f)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

To avoid non-English system locales from breaking tasks that parse command output expecting English, set the environment variable LC_ALL=C in each play of securedrop-prod.yml.

Fixes #4219.

## Testing

Install app and mon with a non-English locale. Verify that running `securedrop-admin install` completes without errors. If it breaks on tasks in `install_tor.yml`, or anywhere else, this fix has not worked.

## Checklist

### If you made changes to `securedrop-admin`:

- [X] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR
