### PR TITLE
Update test var for tor 0.3.5.8

### DIFF
--- a/molecule/fetch-tor-packages/tests/test_tor_packages.py
+++ b/molecule/fetch-tor-packages/tests/test_tor_packages.py
@@ -8,7 +8,7 @@ TOR_PACKAGES = [
     {"name": "tor", "arch": "amd64"},
     {"name": "tor-geoipdb", "arch": "all"},
 ]
-TOR_VERSION = "0.3.5.7-1~xenial+1"
+TOR_VERSION = "0.3.5.8-1~xenial+1"
 
 
 def test_tor_apt_repo(host):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #4170 

Changes proposed in this pull request:

## Testing

- [ ] `make fetch-tor-packages` should complete without error, all tests should pass
- [ ] Ensure 0.3.5.8 is the latest stable available for Xenial (https://blog.torproject.org/)
## Deployment
Dev env only

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

