### PR TITLE
use vim in update_version.sh

### DIFF
--- a/securedrop/dockerfiles/trusty/Dockerfile
+++ b/securedrop/dockerfiles/trusty/Dockerfile
@@ -6,7 +6,7 @@ ARG USER_ID
 ENV USER_ID ${USER_ID:-0}
 
 RUN apt-get update && \
-    apt-get install -y devscripts \
+    apt-get install -y devscripts vim \
                        python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
                        gettext paxctl x11vnc enchant libffi-dev sqlite3

--- a/securedrop/dockerfiles/xenial/Dockerfile
+++ b/securedrop/dockerfiles/xenial/Dockerfile
@@ -5,13 +5,16 @@ ENV USER_NAME ${USER_NAME:-root}
 ARG USER_ID
 ENV USER_ID ${USER_ID:-0}
 
+# If running grsecurity kernel on the host, Memprotect must be disabled on mono-sgen in the container
 RUN apt-get update && \
-    apt-get install -y devscripts vim \
+    apt-get install -y paxctl && \
+    { apt-get install -y libgtk2.0 || echo 'libgtk2.0 was not installed'; } && \
+    paxctl -cm /usr/bin/mono-sgen && dpkg-reconfigure mono-runtime-sgen
+
+RUN apt-get install -y devscripts vim \
                        python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
-                       gettext paxctl x11vnc enchant libffi-dev sqlite3 gettext sudo \
-                       libgtk2.0
-
+                       gettext paxctl x11vnc enchant libffi-dev sqlite3 gettext sudo
 
 ENV FIREFOX_CHECKSUM=88d25053306d33658580973b063cd459a56e3596a3a298c1fb8ab1d52171d860
 RUN curl -LO https://launchpad.net/~ubuntu-mozilla-security/+archive/ubuntu/ppa/+build/9727836/+files/firefox_46.0.1+build1-0ubuntu0.14.04.3_amd64.deb && \

--- a/securedrop/dockerfiles/xenial/Dockerfile
+++ b/securedrop/dockerfiles/xenial/Dockerfile
@@ -6,7 +6,7 @@ ARG USER_ID
 ENV USER_ID ${USER_ID:-0}
 
 RUN apt-get update && \
-    apt-get install -y devscripts \
+    apt-get install -y devscripts vim \
                        python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
                        gettext paxctl x11vnc enchant libffi-dev sqlite3 gettext sudo \

--- a/update_version.sh
+++ b/update_version.sh
@@ -21,6 +21,8 @@ fi
 
 readonly NEW_VERSION=$1
 
+export EDITOR=vim
+
 if [ -z "$NEW_VERSION" ]; then
   echo "You must specify the new version!"
   exit 1
@@ -64,7 +66,7 @@ fi
 
 # Update the changelog
 sed -i "s/\(## ${OLD_VERSION}\)/## ${NEW_VERSION}\n\n\n\n\1/g" changelog.md
-vi +5 changelog.md
+"$EDITOR" +5 changelog.md
 
 export DEBEMAIL="${DEBEMAIL:-securedrop@freedom.press}"
 export DEBFULLNAME="${DEBFULLNAME:-SecureDrop Team}"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Use `vim` instead of `vi` in `update_version.sh` because `vi` is so annoying to use in comparison.