### PR TITLE
dev: customize number of test sources via NUM_SOURCES env var

### DIFF
--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -41,6 +41,7 @@ function docker_run() {
     find . \( -name '*.pyc' -o -name __pycache__ \) -delete
     docker run \
 	   --rm \
+       -e NUM_SOURCES \
 	   --user "${USER:-root}" \
 	   --volume "${TOPLEVEL}:${TOPLEVEL}" \
 	   --workdir "${TOPLEVEL}/securedrop" \

--- a/securedrop/create-dev-data.py
+++ b/securedrop/create-dev-data.py
@@ -32,7 +32,7 @@ def main():
                       is_admin=False)
 
         # Add test sources and submissions
-        num_sources = 2
+        num_sources = int(os.getenv('NUM_SOURCES', 2))
         for _ in range(num_sources):
             create_source_and_submissions()
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This is for https://github.com/freedomofpress/securedrop-sdk/pull/59 - I want to be able to run tests that are doing destructive actions like deleting sources (i.e. when I call an SDK method that hits DELETE API endpoints) without restarting the container (for speed). This PR is a minimal way to enable this (i.e. by making sure there are plenty of test sources).

Changes proposed in this pull request:
 - Enable a dev to pass the number of test sources to be created in the dev container

## Testing

- [ ] `make -C securedrop dev` creates 2 test sources as always
- [ ] `NUM_SOURCES=10 make -C securedrop dev` creates 10 test sources

## Deployment

Dev only

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

