### PR TITLE
Extract VNC changes from Tor Browser functional test branch

### DIFF
--- a/devops/scripts/vnc-docker-connect.sh
+++ b/devops/scripts/vnc-docker-connect.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# shellcheck disable=SC2086
+#
+#
+# Connect to a docker test instance's VNC session
+
+set -e
+
+# Bomb out if container not running
+docker inspect securedrop-dev >/dev/null 2>&1 || (echo "ERROR: SD container not running."; exit 1)
+
+
+# Find our securedrop docker ip
+SD_DOCKER_IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' securedrop-dev)"
+
+# Quit if the VNC port not found
+nc -w5 -z "$SD_DOCKER_IP" 5901 || (echo "ERROR: VNC server not found"; exit 1)
+
+# Are we running on gnome desktop?
+if [ "$(echo \"$XDG_DATA_DIRS\" | sed 's/.*\(gnome\).*/\1/')" == "gnome" ]; then
+    remote-viewer "vnc://${SD_DOCKER_IP}:5901" 2>/dev/null &
+
+# Maybe we are running macOS
+elif [ "$(uname -s)" == "Darwin" ]; then
+    open "vnc://${SD_DOCKER_IP}:5901" &
+
+else
+    echo "Not sure what the VNC terminal cli arguments are for your OS."
+    echo "Please add to $0 and make a pull-request"
+fi

--- a/devops/scripts/vnc-docker-connect.sh
+++ b/devops/scripts/vnc-docker-connect.sh
@@ -9,6 +9,11 @@ set -e
 # Bomb out if container not running
 docker inspect securedrop-dev >/dev/null 2>&1 || (echo "ERROR: SD container not running."; exit 1)
 
+# Maybe we are running macOS
+if [ "$(uname -s)" == "Darwin" ]; then
+    open "vnc://${USER}:freedom@127.0.0.1:5901" &
+    exit 0
+fi
 
 # Find our securedrop docker ip
 SD_DOCKER_IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' securedrop-dev)"
@@ -18,11 +23,7 @@ nc -w5 -z "$SD_DOCKER_IP" 5901 || (echo "ERROR: VNC server not found"; exit 1)
 
 # Are we running on gnome desktop?
 if [ "$(echo \"$XDG_DATA_DIRS\" | sed 's/.*\(gnome\).*/\1/')" == "gnome" ]; then
-    remote-viewer "vnc://${SD_DOCKER_IP}:5901" 2>/dev/null &
-
-# Maybe we are running macOS
-elif [ "$(uname -s)" == "Darwin" ]; then
-    open "vnc://${SD_DOCKER_IP}:5901" &
+    remote-viewer "vnc://${USER}:freedom@${SD_DOCKER_IP}:5901" 2>/dev/null &
 
 else
     echo "Not sure what the VNC terminal cli arguments are for your OS."

--- a/devops/scripts/vnc-docker-connect.sh
+++ b/devops/scripts/vnc-docker-connect.sh
@@ -21,13 +21,13 @@ SD_DOCKER_IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddre
 # Quit if the VNC port not found
 nc -w5 -z "$SD_DOCKER_IP" 5901 || (echo "ERROR: VNC server not found"; exit 1)
 
-if [ ! $(which remote-viewer) ]
+if [ ! "$(which remote-viewer)" ]
 then
     printf "\nError: We use the remote-viewer utility to reach Docker via VNC,\n"
     printf "and it is not installed. On Debian or Ubuntu, install it with\n"
     printf "'sudo apt install virt-viewer', or if you use another VNC client,\n"
     printf "consider adding it to this script:\n"
-    printf "\n$(realpath $0)\n\n"
+    printf "\n%s\n\n" "$(realpath $0)"
     printf "and submitting a pull request.\n\n"
     exit 1
 fi

--- a/devops/scripts/vnc-docker-connect.sh
+++ b/devops/scripts/vnc-docker-connect.sh
@@ -22,9 +22,12 @@ SD_DOCKER_IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddre
 nc -w5 -z "$SD_DOCKER_IP" 5901 || (echo "ERROR: VNC server not found"; exit 1)
 
 # Are we running on gnome desktop?
-if [ "$(echo \"$XDG_DATA_DIRS\" | sed 's/.*\(gnome\).*/\1/')" == "gnome" ]; then
-    remote-viewer "vnc://${USER}:freedom@${SD_DOCKER_IP}:5901" 2>/dev/null &
-
+if [ "$(echo \"$XDG_DATA_DIRS\" | sed 's/.*\(gnome\).*/\1/')" = "gnome" ]; then
+    echo -e "[virt-viewer]\ntype=vnc\nhost=${SD_DOCKER_IP}\nport=5901\npassword=freedom" > /tmp/func-vnc.ini
+    remote-viewer /tmp/func-vnc.ini 2>/dev/null &
+elif [ "$(echo \"$XDG_DATA_DIRS\" | sed 's/.*\(ubuntu\).*/\1/')" = "ubuntu" ]; then
+    echo -e "[virt-viewer]\ntype=vnc\nhost=${SD_DOCKER_IP}\nport=5901\npassword=freedom" > /tmp/func-vnc.ini
+    remote-viewer /tmp/func-vnc.ini 2>/dev/null &
 else
     echo "Not sure what the VNC terminal cli arguments are for your OS."
     echo "Please add to $0 and make a pull-request"

--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -57,6 +57,10 @@ translate: ## Update POT translation files from sources
 	./bin/dev-shell ./i18n_tool.py translate-messages --extract-update
 	./bin/dev-shell ./i18n_tool.py translate-desktop --extract-update
 
+.PHONY: func-vnc
+func-vnc: ## Open up a VNC connection to a running docker instance
+	../devops/scripts/vnc-docker-connect.sh
+
 # For an explanation of this shell magic, see the Makefile in the root of the repository
 .PHONY: help
 help: ## Print this message and exit.

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -11,7 +11,7 @@ function run_redis() {
 }
 
 function run_x11vnc() {
-    setsid x11vnc -display :1 -autoport 5901 -shared >& /tmp/x11vnc.out || cat /tmp/x11vnc.out
+    setsid Xvnc -depth 24 -geometry 1024x768 -rfbport 5901 :1 >& /tmp/x11vnc.out || cat /tmp/x11vnc.out
 }
 
 function urandom() {

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -6,7 +6,7 @@ function run_xvfb() {
     (setsid Xvfb :1 -screen 0 1024x768x24 -ac +extension GLX +render -noreset >& /tmp/xvfb.out || cat /tmp/xvfb.out) &
 
     # give it time to start
-    for i in {1..10}
+    for _ in {1..10}
     do
         xdpyinfo -display :1 >/dev/null 2>&1 && return 0
         sleep 1

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -3,7 +3,15 @@
 export DISPLAY=:1
 
 function run_xvfb() {
-    setsid Xvfb :1 -screen 0 1024x768x24 -ac +extension GLX +render -noreset >& /tmp/xvfb.out || cat /tmp/xvfb.out
+    (setsid Xvfb :1 -screen 0 1024x768x24 -ac +extension GLX +render -noreset >& /tmp/xvfb.out || cat /tmp/xvfb.out) &
+
+    # give it time to start
+    for i in {1..10}
+    do
+        xdpyinfo -display :1 >/dev/null 2>&1 && return 0
+        sleep 1
+    done
+    xdpyinfo -display :1 >/dev/null 2>&1 || (echo "Xvfb is not available"; exit 1)
 }
 
 function run_redis() {

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -10,8 +10,18 @@ function run_redis() {
     setsid redis-server >& /tmp/redis.out || cat /tmp/redis.out
 }
 
-function setup_vncauth {
+function write_vncpw {
     echo "freedom" | vncpasswd -f > /tmp/vncpasswd
+}
+
+function setup_vncauth {
+    # vncpasswd can seg fault, so we'll retry a few times if necessary
+    tries=0
+    while [ $tries -lt 10 ]
+    do
+        write_vncpw && return 0
+        echo "Retrying write of VNC credentials"
+    done
 }
 
 function run_x11vnc() {

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -10,22 +10,12 @@ function run_redis() {
     setsid redis-server >& /tmp/redis.out || cat /tmp/redis.out
 }
 
-function write_vncpw {
-    echo "freedom" | vncpasswd -f > /tmp/vncpasswd
-}
-
 function setup_vncauth {
-    # vncpasswd can seg fault, so we'll retry a few times if necessary
-    tries=0
-    while [ $tries -lt 10 ]
-    do
-        write_vncpw && return 0
-        echo "Retrying write of VNC credentials"
-    done
+    x11vnc -storepasswd freedom /tmp/vncpasswd
 }
 
 function run_x11vnc() {
-    setsid Xvnc -depth 24 -geometry 1024x768 -rfbauth /tmp/vncpasswd -rfbport 5901 :1 >& /tmp/x11vnc.out || cat /tmp/x11vnc.out
+    setsid x11vnc -display :1 -geometry 1024x768 -rfbauth /tmp/vncpasswd -rfbport 5901 -shared >& /tmp/x11vnc.out || cat /tmp/x11vnc.out
 }
 
 function urandom() {

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -10,8 +10,12 @@ function run_redis() {
     setsid redis-server >& /tmp/redis.out || cat /tmp/redis.out
 }
 
+function setup_vncauth {
+    echo "freedom" | vncpasswd -f > /tmp/vncpasswd
+}
+
 function run_x11vnc() {
-    setsid Xvnc -depth 24 -geometry 1024x768 -rfbport 5901 :1 >& /tmp/x11vnc.out || cat /tmp/x11vnc.out
+    setsid Xvnc -depth 24 -geometry 1024x768 -rfbauth /tmp/vncpasswd -rfbport 5901 :1 >& /tmp/x11vnc.out || cat /tmp/x11vnc.out
 }
 
 function urandom() {

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -28,8 +28,8 @@ function docker_image() {
 
     docker build \
            ${DOCKER_BUILD_ARGUMENTS:-} \
-	   --build-arg=USER_ID="$(id -u)" \
-	   --build-arg=USER_NAME="${USER:-root}" \
+       --build-arg=USER_ID="$(id -u)" \
+       --build-arg=USER_NAME="${USER:-root}" \
            -t "securedrop-test-${1}" \
        --file "${TOPLEVEL}/securedrop/dockerfiles/${1}/Dockerfile" \
        "${TOPLEVEL}/securedrop"
@@ -40,12 +40,13 @@ function docker_run() {
 
     find . \( -name '*.pyc' -o -name __pycache__ \) -delete
     docker run \
-	   --rm \
+       --rm \
        -e NUM_SOURCES \
-	   --user "${USER:-root}" \
-	   --volume "${TOPLEVEL}:${TOPLEVEL}" \
-	   --workdir "${TOPLEVEL}/securedrop" \
-	   -ti ${DOCKER_RUN_ARGUMENTS:-} "securedrop-test-${1}" "${@:2}"
+       --user "${USER:-root}" \
+       --volume "${TOPLEVEL}:${TOPLEVEL}" \
+       --workdir "${TOPLEVEL}/securedrop" \
+       --name securedrop-dev
+       -ti ${DOCKER_RUN_ARGUMENTS:-} "securedrop-test-${1}" "${@:2}"
 }
 
 if test -n "${CIRCLE_SHA1:-}" ; then

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -40,6 +40,7 @@ function docker_run() {
 
     find . \( -name '*.pyc' -o -name __pycache__ \) -delete
     docker run \
+       -p 127.0.0.1:5901:5901 \
        --rm \
        -e NUM_SOURCES \
        --user "${USER:-root}" \

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -46,7 +46,7 @@ function docker_run() {
        --user "${USER:-root}" \
        --volume "${TOPLEVEL}:${TOPLEVEL}" \
        --workdir "${TOPLEVEL}/securedrop" \
-       --name securedrop-dev
+       --name securedrop-dev \
        -ti ${DOCKER_RUN_ARGUMENTS:-} "securedrop-test-${1}" "${@:2}"
 }
 

--- a/securedrop/bin/run
+++ b/securedrop/bin/run
@@ -7,7 +7,6 @@ source "${BASH_SOURCE%/*}/dev-deps"
 
 run_xvfb &
 run_redis &
-run_x11vnc &
 urandom
 run_sass --watch &
 maybe_create_config_py

--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -7,6 +7,7 @@ source "${BASH_SOURCE%/*}/dev-deps"
 
 run_xvfb &
 run_redis &
+run_x11vnc &
 urandom
 run_sass --force --update
 maybe_create_config_py

--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -5,7 +5,7 @@ set -euo pipefail
 
 source "${BASH_SOURCE%/*}/dev-deps"
 
-run_xvfb &
+setup_vncauth
 run_redis &
 run_x11vnc &
 urandom

--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -7,6 +7,7 @@ source "${BASH_SOURCE%/*}/dev-deps"
 
 setup_vncauth
 run_redis &
+run_xvfb &
 run_x11vnc &
 urandom
 run_sass --force --update

--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -5,9 +5,9 @@ set -euo pipefail
 
 source "${BASH_SOURCE%/*}/dev-deps"
 
-setup_vncauth
+run_xvfb
 run_redis &
-run_xvfb &
+setup_vncauth
 run_x11vnc &
 urandom
 run_sass --force --update

--- a/securedrop/dockerfiles/trusty/Dockerfile
+++ b/securedrop/dockerfiles/trusty/Dockerfile
@@ -1,5 +1,5 @@
-# ubuntu:14.04 as of 2019-01-22
-FROM ubuntu@sha256:cac55e5d97fad634d954d00a5c2a56d80576a08dcc01036011f26b88263f1578
+# ubuntu 14.04 image from 2019-03-12
+FROM ubuntu@sha256:6612de24437f6f01d6a2988ed9a36b3603df06e8d2c0493678f3ee696bc4bb2d
 ARG USER_NAME
 ENV USER_NAME ${USER_NAME:-root}
 ARG USER_ID
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install -y devscripts vim \
                        python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
-                       gettext paxctl tightvncserver enchant libffi-dev sqlite3
+                       gettext paxctl x11vnc enchant libffi-dev sqlite3
 
 RUN gem install sass -v 3.4.23
 

--- a/securedrop/dockerfiles/trusty/Dockerfile
+++ b/securedrop/dockerfiles/trusty/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install -y devscripts vim \
                        python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
-                       gettext paxctl x11vnc enchant libffi-dev sqlite3
+                       gettext paxctl tightvncserver enchant libffi-dev sqlite3
 
 RUN gem install sass -v 3.4.23
 

--- a/securedrop/dockerfiles/xenial/Dockerfile
+++ b/securedrop/dockerfiles/xenial/Dockerfile
@@ -1,5 +1,5 @@
-# ubuntu 16.04 image - 2019-01-22
-FROM ubuntu@sha256:e4a134999bea4abb4a27bc437e6118fdddfb172e1b9d683129b74d254af51675
+# ubuntu 16.04 image from 2019-03-12
+FROM ubuntu@sha256:58d0da8bc2f434983c6ca4713b08be00ff5586eb5cdff47bcde4b2e88fd40f88
 ARG USER_NAME
 ENV USER_NAME ${USER_NAME:-root}
 ARG USER_ID
@@ -14,7 +14,7 @@ RUN apt-get update && \
 RUN apt-get install -y devscripts vim \
                        python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
-                       gettext paxctl tightvncserver enchant libffi-dev sqlite3 gettext sudo \
+                       gettext paxctl x11vnc enchant libffi-dev sqlite3 gettext sudo \
                        libgtk2.0
 
 ENV FIREFOX_CHECKSUM=88d25053306d33658580973b063cd459a56e3596a3a298c1fb8ab1d52171d860

--- a/securedrop/dockerfiles/xenial/Dockerfile
+++ b/securedrop/dockerfiles/xenial/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update && \
 RUN apt-get install -y devscripts vim \
                        python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
-                       gettext paxctl x11vnc enchant libffi-dev sqlite3 gettext sudo
+                       gettext paxctl tightvncserver enchant libffi-dev sqlite3 gettext sudo \
+                       libgtk2.0
 
 ENV FIREFOX_CHECKSUM=88d25053306d33658580973b063cd459a56e3596a3a298c1fb8ab1d52171d860
 RUN curl -LO https://launchpad.net/~ubuntu-mozilla-security/+archive/ubuntu/ppa/+build/9727836/+files/firefox_46.0.1+build1-0ubuntu0.14.04.3_amd64.deb && \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

These changes were cherry-picked from the tbb-0.12.0 branch. The VNC server used in the functional test container is switched to tightvncserver, and scripts are changed to ensure that it can be reached on both Mac and Linux developer machines.

Fixes #4287.

## Testing

Run the functional tests with `securedrop/bin/dev-shell bin/run-test -v tests/functional`. In another local shell, run `make -C securedrop func-vnc` to verify that you can connect to the test container with VNC and watch the functional tests run.

## Checklist

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR
