### PR TITLE
Adds "upgrade" boxes for 0.12.1

### DIFF
--- a/molecule/vagrant-packager/box_files/app_trusty_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_trusty_metadata.json
@@ -1,72 +1,83 @@
 {
-  "name": "fpf/securedrop-app-trusty",
   "description": "This box contains securedrop app server.",
+  "name": "fpf/securedrop-app-trusty",
   "versions": [
     {
-      "version": "0.7.0",
       "providers": [
         {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.7.box",
+          "checksum": "468923f1e77068b8de96808ed8f52dbe93db3ff0aba8647c37c2d2e83b8367e9",
           "checksum_type": "sha256",
-          "checksum": "468923f1e77068b8de96808ed8f52dbe93db3ff0aba8647c37c2d2e83b8367e9"
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.7.box"
         }
-      ]
+      ],
+      "version": "0.7.0"
     },
     {
-      "version": "0.8.0",
       "providers": [
         {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.8.box",
+          "checksum": "524056caec12a170132ed02f3b8727056d1aeb3ce7050c074be34f259dc6beed",
           "checksum_type": "sha256",
-          "checksum": "524056caec12a170132ed02f3b8727056d1aeb3ce7050c074be34f259dc6beed"
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.8.box"
         }
-      ]
+      ],
+      "version": "0.8.0"
     },
     {
-      "version": "0.9.1",
       "providers": [
         {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.9.1.box",
+          "checksum": "6fb8c12821b902b0905f967d7405c620443f4f4345b18d05b59005f798a08e50",
           "checksum_type": "sha256",
-          "checksum": "6fb8c12821b902b0905f967d7405c620443f4f4345b18d05b59005f798a08e50"
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.9.1.box"
         }
-      ]
+      ],
+      "version": "0.9.1"
     },
     {
-      "version": "0.11.0",
       "providers": [
         {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.11.0.box",
+          "checksum": "cf2c4c8ac89bd132d3f75ee77e2d97b68c562e1ee36aa059bb1d4e6b37499f62",
           "checksum_type": "sha256",
-          "checksum": "cf2c4c8ac89bd132d3f75ee77e2d97b68c562e1ee36aa059bb1d4e6b37499f62"
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.11.0.box"
         }
-      ]
+      ],
+      "version": "0.11.0"
     },
     {
-      "version": "0.11.1",
       "providers": [
         {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.11.1.box",
+          "checksum": "e832c4940ef10e8d999033271454f7220c85f4b0a89f378906895d4a82478eee",
           "checksum_type": "sha256",
-          "checksum": "e832c4940ef10e8d999033271454f7220c85f4b0a89f378906895d4a82478eee"
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging_0.11.1.box"
         }
-      ]
+      ],
+      "version": "0.11.1"
     },
     {
-      "version": "0.12.0",
       "providers": [
         {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging-trusty_0.12.0.box",
+          "checksum": "db9f077d0b9f960c5d36a8a804a791151271009c7490fe3a4c715b71998afcd8",
           "checksum_type": "sha256",
-          "checksum": "db9f077d0b9f960c5d36a8a804a791151271009c7490fe3a4c715b71998afcd8"
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging-trusty_0.12.0.box"
         }
-      ]
+      ],
+      "version": "0.12.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "4c668f06619a532293409d8bc64f69ee66697a2122f2a9a461a15ad57869a6b5",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging-trusty_0.12.1.box"
+        }
+      ],
+      "version": "0.12.1"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -12,6 +12,17 @@
         }
       ],
       "version": "0.12.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "a59ffff93660460b0653d429031deb033819ccac30b8872d8efa9f7f5b57f6f3",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/app-staging-xenial_0.12.1.box"
+        }
+      ],
+      "version": "0.12.1"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_trusty_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_trusty_metadata.json
@@ -1,72 +1,83 @@
 {
-  "name": "fpf/securedrop-mon-trusty",
   "description": "This box contains securedrop monitor server.",
+  "name": "fpf/securedrop-mon-trusty",
   "versions": [
     {
-      "version": "0.7.0",
       "providers": [
         {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.7.box",
+          "checksum": "4358d2e31ee5dcfe4098fd2bedba3122967992de4c9b2dfb773805141d5ad633",
           "checksum_type": "sha256",
-          "checksum": "4358d2e31ee5dcfe4098fd2bedba3122967992de4c9b2dfb773805141d5ad633"
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.7.box"
         }
-      ]
+      ],
+      "version": "0.7.0"
     },
     {
-      "version": "0.8.0",
       "providers": [
         {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.8.box",
+          "checksum": "c18fe9dddf28cc70b858b878550c5ae202e4a2c752119528ab7d2062dab15842",
           "checksum_type": "sha256",
-          "checksum": "c18fe9dddf28cc70b858b878550c5ae202e4a2c752119528ab7d2062dab15842"
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.8.box"
         }
-      ]
+      ],
+      "version": "0.8.0"
     },
     {
-      "version": "0.9.1",
       "providers": [
         {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.9.1.box",
+          "checksum": "9891c88aa7148129f2f91638d7dfed1e7815eb980bba1de8a9c075f14ae0ddeb",
           "checksum_type": "sha256",
-          "checksum": "9891c88aa7148129f2f91638d7dfed1e7815eb980bba1de8a9c075f14ae0ddeb"
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.9.1.box"
         }
-      ]
+      ],
+      "version": "0.9.1"
     },
     {
-      "version": "0.11.0",
       "providers": [
         {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.11.0.box",
+          "checksum": "baba21e8799fe2093d902b332b45d7a8342adf019fa195382011fbdfa54cd1d5",
           "checksum_type": "sha256",
-          "checksum": "baba21e8799fe2093d902b332b45d7a8342adf019fa195382011fbdfa54cd1d5"
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.11.0.box"
         }
-      ]
+      ],
+      "version": "0.11.0"
     },
     {
-      "version": "0.11.1",
       "providers": [
         {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.11.1.box",
+          "checksum": "bbc8ed55fab20ed96c3b090126b69baabbd41e95faa60676dff72bc69af67376",
           "checksum_type": "sha256",
-          "checksum": "bbc8ed55fab20ed96c3b090126b69baabbd41e95faa60676dff72bc69af67376"
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging_0.11.1.box"
         }
-      ]
+      ],
+      "version": "0.11.1"
     },
     {
-      "version": "0.12.0",
       "providers": [
         {
-          "name": "libvirt",
-          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging-trusty_0.12.0.box",
+          "checksum": "0ac7538f52b3450a1791a06b8a02fe81b65637da92bb00a61b669beccef87f8d",
           "checksum_type": "sha256",
-          "checksum": "0ac7538f52b3450a1791a06b8a02fe81b65637da92bb00a61b669beccef87f8d"
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging-trusty_0.12.0.box"
         }
-      ]
+      ],
+      "version": "0.12.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "56d1fee8e1b5f27e69a6aa2159e38340dbb3b33326977428cf43af0fc74ae0ba",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging-trusty_0.12.1.box"
+        }
+      ],
+      "version": "0.12.1"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -12,6 +12,17 @@
         }
       ],
       "version": "0.12.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "e38864cc63bf26c4423c45986ab06f16c5638615b5850f00c69153b456cbb3a9",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://s3.amazonaws.com/securedrop-vagrant/mon-staging-xenial_0.12.1.box"
+        }
+      ],
+      "version": "0.12.1"
     }
   ]
 }


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Post-release task documented in #4260.

Changes proposed in this pull request:

Includes both Trusty & Xenial boxes. Note that the documented procedure of running `git checkout 0.12.1` was *not* performed here, as the logic for building multiple platform boxes was not included in the point release (it had previously been merged into `develop`).

So, I manually set `molecule/shared/stable.ver` to "0.12.1" and ran the logic from the develop branch. Given that the Ansible changes were included in the point release, these boxes should still serve as accurate testing for future upgrades.

The diff on the Trusty JSON metadata file is uniquely large because this is the first time we're using the automatically-update-JSON logic on that box. The Trusty boxes were last updated _manually_ in #4215, and the Xenial boxes were last updated in #4253, which included the automatically-update-JSON logic. Going forward, these JSON files will continue to be machine-generated, eliminating any extraneous diffs, as well as minimizing the likelihood of user error during build.

## Testing

You must edit the target "stable version" to review, since we haven't finished backporting the release changes (so the feature branch has "0.12.0" as the stable ver still). Given that the boxes can take a long time to fetch, I recommend splitting review between Trusty/Xenial between two reviewers.

### Xenial
- [ ] Run `echo "0.12.1" > molecule/shared/stable.ver`
- [ ] Run `rm -rf build/*` to clear out any local debs.
- [ ] Run `make build-debs` to build only Xenial debs
- [ ] Run `make upgrade-start`
- [ ] Confirm boxes pull successfully
- [ ] Confirm boxes are running 0.12.1. 
- [ ] Confirm boxes are running Ubuntu 16.04


### Trusty

- [ ] Confirm that the _only_ substantive change to the JSON is the new 0.12.1 box; all other changes are simply formatting.
- [ ] Run `echo "0.12.1" > molecule/shared/stable.ver`
- [ ] Run `rm -rf build/*` to clear out any local debs.
- [ ] Run `make build-debs-trusty` to build only Trusty debs
- [ ] Run `make upgrade-trusty-start`
- [ ] Confirm boxes pull successfully
- [ ] Confirm boxes are running 0.12.1. 
- [ ] Confirm boxes are running Ubuntu 14.04


## Deployment

No concerns, changes affect dev env only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
