### PR TITLE
Update safety check and cryptography version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,33 +237,6 @@ jobs:
           name: Run static security testing on source code
           command: make bandit
 
-  staging-test-with-rebase-trusty:
-    machine:
-      enabled: true
-
-    working_directory: ~/sd
-    steps:
-      - checkout
-      - *rebaseontarget
-
-      - run:
-          name: Run Staging tests on GCE
-          command: make ci-go-trusty
-          no_output_timeout: 20m
-
-      - run:
-          name: Ensure environment torn down
-          # Always report true, since env should will destroyed already
-          # if all tests passed.
-          command: make ci-teardown || true
-          when: always
-
-      - store_test_results:
-          path: ~/sd/junit
-
-      - store_artifacts:
-          path: ~/sd/junit
-
   staging-test-with-rebase:
     machine:
       enabled: true
@@ -344,5 +317,4 @@ workflows:
                 - develop
     jobs:
       - static-analysis-and-no-known-cves
-      - staging-test-with-rebase-trusty
       - trusty-app-tests

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 	pip install --upgrade safety && \
 		for req_file in `find . -type f -name '*requirements.txt'`; do \
 			echo "Checking file $$req_file" \
-			&& safety check --ignore 36351 --full-report -r $$req_file \
+			&& safety check --full-report -r $$req_file \
 			&& echo -e '\n' \
 			|| exit 1; \
 		done

--- a/securedrop/dockerfiles/trusty/Dockerfile
+++ b/securedrop/dockerfiles/trusty/Dockerfile
@@ -30,7 +30,8 @@ RUN echo deb http://archive.ubuntu.com/ubuntu/ xenial main > /etc/apt/sources.li
     apt-get update
 
 COPY requirements requirements
-RUN pip install -r requirements/securedrop-app-code-requirements.txt && \
+RUN pip install -U setuptools==40.8.0 && \
+    pip install -r requirements/securedrop-app-code-requirements.txt && \
     pip install -r requirements/test-requirements.txt
 
 RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi

--- a/securedrop/dockerfiles/xenial/Dockerfile
+++ b/securedrop/dockerfiles/xenial/Dockerfile
@@ -26,7 +26,8 @@ RUN curl -LO https://launchpad.net/~ubuntu-mozilla-security/+archive/ubuntu/ppa/
 RUN gem install sass -v 3.4.23
 
 COPY requirements requirements
-RUN pip install -r requirements/securedrop-app-code-requirements.txt && \
+RUN pip install -U setuptools==40.8.0 && \
+    pip install -r requirements/securedrop-app-code-requirements.txt && \
     pip install -r requirements/test-requirements.txt
 
 # Fixes #4036 pybabel requires latest version of setuptools

--- a/securedrop/dockerfiles/xenial/Dockerfile
+++ b/securedrop/dockerfiles/xenial/Dockerfile
@@ -26,8 +26,8 @@ RUN curl -LO https://launchpad.net/~ubuntu-mozilla-security/+archive/ubuntu/ppa/
 RUN gem install sass -v 3.4.23
 
 COPY requirements requirements
-RUN pip install -U setuptools==40.8.0 && \
-    pip install -r requirements/securedrop-app-code-requirements.txt && \
+
+RUN pip install -r requirements/securedrop-app-code-requirements.txt && \
     pip install -r requirements/test-requirements.txt
 
 # Fixes #4036 pybabel requires latest version of setuptools

--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -1,15 +1,15 @@
 alembic
 argon2_cffi
-cryptography==2.0.3
+cryptography>2.3
 Flask-Assets
 Flask-Babel
 Flask-SQLAlchemy
 Flask-WTF
 Flask>0.12.2
-pretty-bad-protocol>=3.1.1
 Jinja2
 jsmin
 passlib
+pretty-bad-protocol>=3.1.1
 psutil
 pyotp
 qrcode

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -10,15 +10,13 @@ asn1crypto==0.24.0        # via cryptography
 babel==2.5.1              # via flask-babel
 cffi==1.11.5              # via argon2-cffi, cryptography
 click==6.7                # via flask, rq
-cryptography==2.0.3
+cryptography==2.6.1
 enum34==1.1.6             # via argon2-cffi, cryptography
 flask-assets==0.12
 flask-babel==0.11.2
 flask-sqlalchemy==2.3.2
 flask-wtf==0.14.2
 flask==1.0.2
-pretty-bad-protocol==3.1.1
-idna==2.6                 # via cryptography
 ipaddress==1.0.22         # via cryptography
 itsdangerous==0.24        # via flask
 jinja2==2.10
@@ -26,6 +24,7 @@ jsmin==2.2.2
 mako==1.0.7               # via alembic
 markupsafe==1.0           # via jinja2, mako
 passlib==1.7.1
+pretty-bad-protocol==3.1.1
 psutil==5.4.3
 pycparser==2.18           # via cffi
 pyotp==2.2.6


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3682

- Remove the rule ignoring the out of date version of `cryptography`
- Run the `make update-pip-requirements` script to bump cryptography and other dependencies

## Testing

CI should catch any incompatibilities in the libraries

## Deployment

No special considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container