### PR TITLE
Add staging-specific creation of test data

### DIFF
--- a/molecule/upgrade/side_effect.yml
+++ b/molecule/upgrade/side_effect.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Perform apt upgrades
   hosts: securedrop
   become: yes
@@ -8,3 +7,29 @@
       apt:
         update_cache: yes
         upgrade: yes
+
+- name: Lay out app testing deps
+  hosts: securedrop_application_server
+  max_fail_percentage: 0
+  any_errors_fatal: yes
+  roles:
+    - role: app-test
+      tags: app-test
+
+  tasks:
+    - name: Reset database
+      command: ./manage.py reset
+      args:
+        chdir: /var/www/securedrop
+
+    - name: Slap in latest create-dev-data script
+      copy:
+          src: ../../securedrop/create-dev-data.py
+          dest: /var/www/securedrop/create-dev-data.py
+          mode: 0555
+
+    - name: Insert journalist test user
+      command: /var/www/securedrop/create-dev-data.py --staging
+      args:
+        chdir: /var/www/securedrop
+  become: yes

--- a/securedrop/create-dev-data.py
+++ b/securedrop/create-dev-data.py
@@ -3,6 +3,7 @@
 
 import datetime
 import os
+import argparse
 
 from flask import current_app
 from sqlalchemy.exc import IntegrityError
@@ -15,7 +16,7 @@ from db import db
 from models import Journalist, Reply, Source, Submission
 
 
-def main():
+def main(staging=False):
     app = journalist_app.create_app(config)
     with app.app_context():
         # Add two test users
@@ -26,6 +27,10 @@ def main():
                       test_password,
                       test_otp_secret,
                       is_admin=True)
+
+        if staging:
+            return
+
         add_test_user("dellsberg",
                       test_password,
                       test_otp_secret,
@@ -104,4 +109,9 @@ def create_source_and_submissions(num_submissions=2, num_replies=2):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--staging", help="Adding user for staging tests.",
+                        action="store_true")
+    args = parser.parse_args()
+
+    main(args.staging)

--- a/securedrop/tests/functional/README.md
+++ b/securedrop/tests/functional/README.md
@@ -1,0 +1,33 @@
+### To test in prod vms
+
+- `sudo -u www-data bash`
+- `cd /var/wwww/securedrop/`
+- `./manage.py reset`    # This will clean the DB for testing
+- `./create-dev-data.py --staging`
+
+Update this information to the `tests/functional/instance_information.json file.
+
+The content of the file looks like below.
+
+```
+{
+    "hidserv_token": "asfjsdfag",
+    "journalist_location": "http://thejournalistfqb.onion",
+    "source_location": "http://thesourceadsfa.onion",
+    "sleep_time": 10,
+    "user": {
+        "name": "journalist",
+        "password": "WEjwn8ZyczDhQSK24YKM8C9a",
+        "secret": "JHCOGO7VCER3EJ4L"
+    }
+}
+```
+
+### Run the tests
+
+```
+cd securedrop
+./bin/dev-shell ./bin/run-test -v tests/functional/
+```
+You may wish to append a pipe to less (i.e. `| less`), as a failure may generate
+many pages of output, making it difficult to scroll back.

--- a/securedrop/tests/functional/README.md
+++ b/securedrop/tests/functional/README.md
@@ -1,7 +1,7 @@
 ### To test in prod vms
 
 - `sudo -u www-data bash`
-- `cd /var/wwww/securedrop/`
+- `cd /var/www/securedrop/`
 - `./manage.py reset`    # This will clean the DB for testing
 - `./create-dev-data.py --staging`
 

--- a/securedrop/tests/functional/README.md
+++ b/securedrop/tests/functional/README.md
@@ -5,7 +5,7 @@
 - `./manage.py reset`    # This will clean the DB for testing
 - `./create-dev-data.py --staging`
 
-Update this information to the `tests/functional/instance_information.json file.
+Update this information to the `tests/functional/instance_information.json` file.
 
 The content of the file looks like below.
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR cherry-picks a few commits from tbb-0.12.0 to add a `--staging` argument to the `create-dev-data.py` script, which skips creation of the second journalist and all source accounts.

Fixes #4286.

## Testing

As in `securedrop/tests/functional/README.md`:

- `sudo -u www-data bash`
- `cd /var/www/securedrop/`
- `./manage.py reset`    # This will clean the DB for testing
- `./create-dev-data.py --staging`

Verify that only the first journalist account was added to the database:

- `cd /var/lib/securedrop`
- `sqlite3 db.sqlite`
- `select * from journalists;`

## Checklist

### If you made changes to the server application code:

- [X] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR
