### PR TITLE
Runs fetch-tor-packages with pinned version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,6 +196,15 @@ jobs:
       - setup_remote_docker
       - run: cd admin ; make test
 
+  fetch-tor-debs:
+    docker:
+      - image: gcr.io/cloud-builders/docker
+    steps:
+      - run: apt-get install -y make virtualenv python-pip
+      - checkout
+      - setup_remote_docker
+      - run: make fetch-tor-packages
+
   updater-gui-tests:
     docker:
       - image: circleci/python:3.5
@@ -303,6 +312,12 @@ workflows:
                 - /docs-.*/
                 - /i18n-.*/
       - admin-tests:
+          filters:
+            branches:
+              ignore:
+                - /docs-.*/
+                - /i18n-.*/
+      - fetch-tor-debs:
           filters:
             branches:
               ignore:

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ upgrade-trusty-test-qa: ## Once an upgrade environment (Trusty) is running, forc
 
 .PHONY: fetch-tor-packages
 fetch-tor-packages: ## Retrieves the most recent Tor packages for Xenial, for apt repo
-	molecule test -s fetch-tor-packages
+	@./devops/scripts/fetch-tor-packages.sh
 
 # Explaination of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" and any make targets that might appear between : and ##

--- a/devops/scripts/fetch-tor-packages.sh
+++ b/devops/scripts/fetch-tor-packages.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# shellcheck disable=SC2209
+#
+# Wrapper around debian build logic to bootstrap virtualenv
+
+set -e
+set -u
+set -o pipefail
+
+. ./devops/scripts/boot-strap-venv.sh
+
+virtualenv_bootstrap
+
+molecule test -s fetch-tor-packages

--- a/molecule/fetch-tor-packages/playbook.yml
+++ b/molecule/fetch-tor-packages/playbook.yml
@@ -11,6 +11,8 @@
     tor_download_dest: "{{ sd_repo_root + '/build/' + ansible_distribution_release }}"
     tor_repo_pubkey: "{{ sd_repo_root + '/install_files/ansible-base/roles/tor-hidden-services/files/tor-signing-key.pub' }}"
     tor_repo_url: "deb https://deb.torproject.org/torproject.org {{ ansible_distribution_release }} main"
+    # Used to fetch a precise version; must also be updated in the test vars
+    tor_version: "0.3.5.8-1~xenial+1"
 
   tasks:
     - name: Add Tor apt repo pubkey
@@ -29,7 +31,7 @@
         path: "{{ tor_download_dir }}"
 
     - name: Download tor debs
-      command: apt-get download "{{ item }}"
+      command: apt-get download "{{ item }}={{ tor_version }}"
       args:
         chdir: "{{ tor_download_dir }}"
         # apt module doesn't support download, so silence warnings,


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Closes #4170.

Adds a `tor_version` var to the fetch-tor-packages logic. This is yet another point of update when we bump versions, but pinning will help us avoid surprises. To that end, we're also running the fetch action in CI now, to help us catch version mismatches earlier.

## Testing
* [ ] Confirm `make fetch-tor-packages` passes locally
* [ ] Confirm CI is passing

## Deployment

No concerns, dev env tooling only. There's a modest improvement in reliability in the release window, ensuring we fetch the same package version we've been testing.

## Checklist


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
