### PR TITLE
Transitions lint container to Debian Stretch

### DIFF
--- a/devops/docker/Dockerfile.linting
+++ b/devops/docker/Dockerfile.linting
@@ -1,6 +1,6 @@
 FROM koalaman/shellcheck:v0.4.7 as shellcheck
 
-FROM gcr.io/google-containers/python:2.7.11-slim
+FROM python:2.7.16-slim-stretch
 LABEL MAINTAINER="Freedom of the Press Foundation"
 LABEL APP="SDLinter"
 


### PR DESCRIPTION


## Status

Work in progress

## Description of Changes

Reusing the same container image we've pegged for the Admin Workstation
test suite, for simplicity's sake. The old linting container was based
on Debian Jessie, and appears to be unmaintained, with the last update
on 2016-03-20 [0].

[0] https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/python

Changes proposed in this pull request:

## Testing

Don't yet, still WIP :innocent:

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
