### PR TITLE
Transitions lint container to Debian Stretch

### DIFF
--- a/devops/docker/Dockerfile.linting
+++ b/devops/docker/Dockerfile.linting
@@ -1,6 +1,6 @@
 FROM koalaman/shellcheck:v0.4.7 as shellcheck
 
-FROM gcr.io/google-containers/python:2.7.11-slim
+FROM python:2.7.16-slim-stretch
 LABEL MAINTAINER="Freedom of the Press Foundation"
 LABEL APP="SDLinter"
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #4301.

Transitions lint container to Debian Stretch
    
Switching to a Stretch-based container for linting tasks, given that Jessie is EOL and has started throwing errors on apt list updates. Furthermore, the previous Jessie-based container appears unmaintained, with the last update on 2016-03-20 [0].

The new container was suggested by @cji, docs at [1] & [2]
    
[0] https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/python
[1] https://hub.docker.com/_/python
[2] https://github.com/docker-library/python/blob/636e02777ea417851942e6e826fe5a6b4dee6f74/2.7/stretch/slim/Dockerfile

## Testing
* [ ] `make ci-lint` passes locally
* [ ] CI is passing

## Deployment
No concerns, dev env & CI only.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
