### PR TITLE
Bump SecureDrop kernel to 4.4.177

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -52,5 +52,5 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder/tests/vars.yml
 securedrop_pkg_grsec:
-  ver: "4.4.167"
-  depends: "linux-image-4.4.162-grsec,linux-firmware-image-4.4.162-grsec,linux-image-4.4.167-grsec,linux-firmware-image-4.4.167-grsec"
+  ver: "4.4.177"
+  depends: "linux-image-4.4.167-grsec,linux-firmware-image-4.4.167-grsec,linux-image-4.4.177-grsec,linux-firmware-image-4.4.177-grsec"

--- a/molecule/builder-trusty/tests/vars.yml
+++ b/molecule/builder-trusty/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "0.13.0~rc1"
 ossec_version: "3.0.0"
 keyring_version: "0.1.2"
 config_version: "0.1.3"
-grsec_version: "4.4.167"
+grsec_version: "4.4.177"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/staging/vars/staging.yml
+++ b/molecule/testinfra/staging/vars/staging.yml
@@ -163,4 +163,4 @@ log_events_with_ossec_alerts:
     rule_id: "400503"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
-grsec_version: "4.4.167"
+grsec_version: "4.4.177"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #4024 
Simply bumps strings for grsec kernel, the kernel work was done by @zenmonkeykstop in https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/46

Changes proposed in this pull request:

## Test Plan

First:
- [x] Metapackage and kernel images uploaded to apt-test (Thanks @rmol !)

To validate the functionality of these kernels:

- [ ] Clean install using apt-test.freedom.press is successful
- [ ] intel e1000e NIC is functional using the 4.4.177-grsec kernel provided
- [ ] CI passes

## Deployment

New and existing installs will be upgraded via apt

## Checklist


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

