### PR TITLE
added fn to prevent multiple GUI updater instances

### DIFF
--- a/journalist_gui/Pipfile
+++ b/journalist_gui/Pipfile
@@ -11,3 +11,4 @@ python_version = "3.5"
 [packages]
 "pyqt5" = "*"
 pexpect = "*"
+pytest = "*"

--- a/journalist_gui/SecureDropUpdater
+++ b/journalist_gui/SecureDropUpdater
@@ -1,16 +1,34 @@
 #!/usr/bin/python
-from PyQt5 import QtWidgets
+from PyQt5.QtWidgets import QApplication, QMessageBox
 import sys
+import socket
 
 from journalist_gui.SecureDropUpdater import UpdaterApp
 
+def prevent_second_instance(app: QApplication) -> None:
+
+    # Null byte triggers abstract namespace
+    IDENTIFIER = '\0' + "Securedrop Updater"
+    ALREADY_BOUND_ERRNO = 98
+
+    app.instance_binding = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    try:
+        app.instance_binding.bind(IDENTIFIER)
+    except OSError as e:
+        if e.errno == ALREADY_BOUND_ERRNO:
+            err_dialog = QMessageBox()
+            err_dialog.setText('SecureDrop Updater is already running.')
+            err_dialog.exec()
+            sys.exit()
+        else:
+            raise
 
 def main():
-    app = QtWidgets.QApplication(sys.argv)
+    app = QApplication(sys.argv)
+    prevent_second_instance(app)
     form = UpdaterApp()
     form.show()
     app.exec_()
-
 
 if __name__ == '__main__':
     main()

--- a/journalist_gui/SecureDropUpdater
+++ b/journalist_gui/SecureDropUpdater
@@ -1,31 +1,12 @@
 #!/usr/bin/python
-from PyQt5.QtWidgets import QApplication, QMessageBox
+from PyQt5 import QtWidgets
 import sys
-import socket
 
-from journalist_gui.SecureDropUpdater import UpdaterApp
-
-def prevent_second_instance(app: QApplication) -> None:
-
-    # Null byte triggers abstract namespace
-    IDENTIFIER = '\0' + "Securedrop Updater"
-    ALREADY_BOUND_ERRNO = 98
-
-    app.instance_binding = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-    try:
-        app.instance_binding.bind(IDENTIFIER)
-    except OSError as e:
-        if e.errno == ALREADY_BOUND_ERRNO:
-            err_dialog = QMessageBox()
-            err_dialog.setText('SecureDrop Updater is already running.')
-            err_dialog.exec()
-            sys.exit()
-        else:
-            raise
+from journalist_gui.SecureDropUpdater import UpdaterApp, prevent_second_instance
 
 def main():
-    app = QApplication(sys.argv)
-    prevent_second_instance(app)
+    app = QtWidgets.QApplication(sys.argv)
+    prevent_second_instance(app, "Securedrop Workstation Updater")
     form = UpdaterApp()
     form.show()
     app.exec_()

--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -5,12 +5,33 @@ import subprocess
 import os
 import re
 import pexpect
+import socket
+import sys
 
 from journalist_gui import updaterUI, strings, resources_rc  # noqa
 
 
 FLAG_LOCATION = "/home/amnesia/Persistent/.securedrop/securedrop_update.flag"  # noqa
 ESCAPE_POD = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
+
+
+def prevent_second_instance(app: QtWidgets.QApplication, name: str) -> None:  # noqa
+
+    # Null byte triggers abstract namespace
+    IDENTIFIER = '\0' + name
+    ALREADY_BOUND_ERRNO = 98
+
+    app.instance_binding = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    try:
+        app.instance_binding.bind(IDENTIFIER)
+    except OSError as e:
+        if e.errno == ALREADY_BOUND_ERRNO:
+            err_dialog = QtWidgets.QMessageBox()
+            err_dialog.setText(name + ' is already running.')
+            err_dialog.exec()
+            sys.exit()
+        else:
+            raise
 
 
 class SetupThread(QThread):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3999.

Changes proposed in this pull request:

Adds a function based on the one in securedrop-client as per @redshiftzero's [recommendation](https://github.com/freedomofpress/securedrop/issues/3999#issuecomment-448674976), to prevent multiple running instances of the GUI updater.

## Testing

In a Tails Admin or Journalist workstation:

1.  Check out this branch in the `~/Persistent/securedrop` application directory:
```
cd ~/Persistent/securedrop
git checkout 3999-singleton-gui-updater
```
2. Disable existing Tails network connections and re-enable them 1 by 1. (If the Tails workstation only has one network connection, disable and enable it repeatedly, allowing a minute or two for the Tor connection and networkmanager hook to run between each toggle.) The first network connection should spawn a SecureDrop GUI updater window. Second and subsequent runs should pop up an alert dialog saying "SecureDrop Updater is already running." No other updater windows should spawn.
3. In the SecureDrop GUI updater window, complete the update and verify that it finishes successfully.


## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR