### PR TITLE
Update default staging target to Xenial

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -25,7 +25,7 @@ apparmor_profiles:
   - usr.sbin.apache2
 
 # Installing the securedrop-app-code.deb package
-securedrop_staging_install_target_distro: trusty
+securedrop_staging_install_target_distro: xenial
 securedrop_app_code_deb: "securedrop-app-code_{{ securedrop_app_code_version }}+{{ securedrop_staging_install_target_distro }}_amd64" # do not enter .deb extension
 
 # Apt package dependencies for running the SecureDrop application.

--- a/molecule/libvirt-staging-xenial/ansible-override-vars.yml
+++ b/molecule/libvirt-staging-xenial/ansible-override-vars.yml
@@ -5,5 +5,3 @@ ssh_net_in_override: 0.0.0.0/0
 # In libvirt, we want to connect over eth0, not eth1 which is used for
 # inter-VM communication for OSSEC.
 ssh_ip: "{{ ansible_default_ipv4.address }}"
-
-securedrop_staging_install_target_distro: xenial

--- a/molecule/libvirt-staging/ansible-override-vars.yml
+++ b/molecule/libvirt-staging/ansible-override-vars.yml
@@ -5,3 +5,6 @@ ssh_net_in_override: 0.0.0.0/0
 # In libvirt, we want to connect over eth0, not eth1 which is used for
 # inter-VM communication for OSSEC.
 ssh_ip: "{{ ansible_default_ipv4.address }}"
+
+# Default staging target is Xenial, so force use of Trusty
+securedrop_staging_install_target_distro: trusty

--- a/molecule/virtualbox-staging-xenial/ansible-override-vars.yml
+++ b/molecule/virtualbox-staging-xenial/ansible-override-vars.yml
@@ -5,5 +5,3 @@ ssh_net_in_override: 0.0.0.0/0
 # In libvirt, we want to connect over eth0, not eth1 which is used for
 # inter-VM communication for OSSEC.
 ssh_ip: "{{ ansible_default_ipv4.address }}"
-
-securedrop_staging_install_target_distro: xenial

--- a/molecule/virtualbox-staging/ansible-override-vars.yml
+++ b/molecule/virtualbox-staging/ansible-override-vars.yml
@@ -1,3 +1,6 @@
 ---
 # Permit direct access via SSH
 ssh_net_in_override: 0.0.0.0/0
+
+# Default staging target is Xenial, so force use of Trusty
+securedrop_staging_install_target_distro: trusty


### PR DESCRIPTION
Resolves #4310

## Status

Ready for review

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

(Staging VMs are provisioned and working, but testinfra tests are failing locally for me - most likely unrelated.)