### PR TITLE
Reduce setup time per test by cloning GPG homedir

### DIFF
--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -107,8 +107,10 @@ def config(tmpdir):
     cnf.TEMP_DIR = str(tmp)
     cnf.DATABASE_FILE = str(sqlite)
 
+    DEVNULL = io.open(os.devnull, 'w')
     # create the db file
-    subprocess.check_call(['sqlite3', cnf.DATABASE_FILE, '.databases'])
+    subprocess.check_call(['sqlite3', cnf.DATABASE_FILE, '.databases'],
+                          stdout=DEVNULL)
 
     return cnf
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Create one master GPG dir and clone it. Each GPG home creation takes ~2 seconds on my laptop, so even running a single module's tests can be minutes longer than necessary.

## Testing

Does CI pass?

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container