### PR TITLE
[xenial docs] Bump from 0.12.0 to 0.12.1 where version is specified

### DIFF
--- a/docs/upgrade/xenial_backup_install_restore.rst
+++ b/docs/upgrade/xenial_backup_install_restore.rst
@@ -157,7 +157,7 @@ code is up-to-date and validated. From a terminal, run the following commands:
 
  cd ~/Persistent/securedrop
  git fetch --tags
- git tag -v 0.12.0
+ git tag -v 0.12.1
 
 You should see ``Good signature from "SecureDrop Release Signing Key"`` in the
 output of that last command, along with the fingerprint ``"2224 5C81 E3BA EB41
@@ -175,7 +175,7 @@ First, check out the release tag that you validated above:
 
 .. code:: sh
  
- git checkout 0.12.0
+ git checkout 0.12.1
 
 Next, run the following command to set up the SecureDrop administration environment:
 

--- a/docs/upgrade/xenial_upgrade_in_place.rst
+++ b/docs/upgrade/xenial_upgrade_in_place.rst
@@ -30,7 +30,7 @@ Before performing the upgrade, please perform all the steps outlined in
 .. warning::
   In order to successfully upgrade your SecureDrop instance, it is of critical
   importance that your *Admin Workstation* and your servers use SecureDrop
-  0.12.0. Older releases of SecureDrop do not not support Ubuntu 16.04.
+  0.12.1. Releases before the 0.12 series do not not support Ubuntu 16.04.
 
                                                                                 
 We expect that the upgrade should take under 8 hours to complete, but recommend 
@@ -212,7 +212,7 @@ code is up-to-date and validated. From a terminal, run the following commands:
                                                                                 
  cd ~/Persistent/securedrop                                                     
  git fetch --tags
- git tag -v 0.12.0                                                              
+ git tag -v 0.12.1                                                              
                                                                                 
 You should see ``Good signature from "SecureDrop Release Signing Key"`` in the 
 output of that last command, along with the fingerprint 
@@ -230,7 +230,7 @@ First, check out the release tag that you validated above:
 
 .. code:: sh
  
- git checkout 0.12.0                                                            
+ git checkout 0.12.1                                                            
 
 Next, in the terminal, run the following command to set up the SecureDrop 
 admin environment:
@@ -276,7 +276,7 @@ Server* and your *Monitor Server*.
 Validate the application version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To confirm that you are running SecureDrop 0.12.0 for Xenial, on the Tails
+To confirm that you are running SecureDrop 0.12.1 for Xenial, on the Tails
 desktop, you should find a shortcut called **SecureDrop Source Interface**.
 Double-click it to launch the Tor browser.
 
@@ -284,7 +284,7 @@ After the *Source Interface* loads, add the path ``/metadata`` to the URL in
 your address bar. If your *Source Interface* can be found at
 ``examplenot4real.onion``, then the address you should visit is
 ``examplenot4real.onion/metadata``. That page should show you key/value pairs,
-including ``0.12.0`` for ``sd_version`` and ``16.04`` for ``server_os``.
+including ``0.12.1`` for ``sd_version`` and ``16.04`` for ``server_os``.
 
 End-to-end test
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

During the point release we bumped the version in the prep doc, but not in the detailed upgrade docs.

## Status

Ready for review

## Checklist

- [x] Doc linting (`make docs-lint`) passed locally
