### PR TITLE
calculated etag as sha256 of file on disk

### DIFF
--- a/securedrop/alembic/versions/b58139cfdc8c_add_checksum_columns.py
+++ b/securedrop/alembic/versions/b58139cfdc8c_add_checksum_columns.py
@@ -1,0 +1,84 @@
+"""add checksum columns
+
+Revision ID: b58139cfdc8c
+Revises: f2833ac34bb6
+Create Date: 2019-04-02 10:45:05.178481
+
+"""
+import os
+from alembic import op
+import sqlalchemy as sa
+
+# raise the errors if we're not in production
+raise_errors = os.environ.get('SECUREDROP_ENV', 'prod') != 'prod'
+
+try:
+    from journalist_app import create_app
+    from models import Submission, Reply
+    from sdconfig import config
+    from store import queued_add_checksum_for_file
+    from worker import rq_worker_queue
+except:
+    if raise_errors:
+        raise
+
+# revision identifiers, used by Alembic.
+revision = 'b58139cfdc8c'
+down_revision = 'f2833ac34bb6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('replies', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('checksum', sa.String(length=255), nullable=True))
+
+    with op.batch_alter_table('submissions', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('checksum', sa.String(length=255), nullable=True))
+
+    try:
+        app = create_app(config)
+
+        # we need an app context for the rq worker extension to work properly
+        with app.app_context():
+            conn = op.get_bind()
+            query = sa.text('''SELECT submissions.id, sources.filesystem_id, submissions.filename
+                               FROM submissions
+                               INNER JOIN sources
+                               ON submissions.source_id = sources.id
+                            ''')
+            for (sub_id, filesystem_id, filename) in conn.execute(query):
+                full_path = app.storage.path(filesystem_id, filename)
+                rq_worker_queue.enqueue(
+                    queued_add_checksum_for_file,
+                    Submission,
+                    int(sub_id),
+                    full_path,
+                    app.config['SQLALCHEMY_DATABASE_URI'],
+                )
+
+            query = sa.text('''SELECT replies.id, sources.filesystem_id, replies.filename
+                               FROM replies
+                               INNER JOIN sources
+                               ON replies.source_id = sources.id
+                            ''')
+            for (rep_id, filesystem_id, filename) in conn.execute(query):
+                full_path = app.storage.path(filesystem_id, filename)
+                rq_worker_queue.enqueue(
+                    queued_add_checksum_for_file,
+                    Reply,
+                    int(rep_id),
+                    full_path,
+                    app.config['SQLALCHEMY_DATABASE_URI'],
+                )
+    except:
+        if raise_errors:
+            raise
+
+
+def downgrade():
+    with op.batch_alter_table('submissions', schema=None) as batch_op:
+        batch_op.drop_column('checksum')
+
+    with op.batch_alter_table('replies', schema=None) as batch_op:
+        batch_op.drop_column('checksum')

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -21,6 +21,7 @@ from journalist_app.utils import (get_source, logged_in,
                                   JournalistInterfaceSessionInterface)
 from models import Journalist
 from store import Storage
+from worker import rq_worker_queue
 
 import typing
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
@@ -82,6 +83,9 @@ def create_app(config):
         adjectives_file=config.ADJECTIVES,
         gpg_key_dir=config.GPG_KEY_DIR,
     )
+
+    app.config['RQ_WORKER_NAME'] = config.RQ_WORKER_NAME
+    rq_worker_queue.init_app(app)
 
     @app.errorhandler(CSRFError)
     def handle_csrf_error(e):

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -177,7 +177,7 @@ def make_blueprint(config):
                methods=['GET'])
     @token_required
     def download_submission(source_uuid, submission_uuid):
-        source = get_or_404(Source, source_uuid, column=Source.uuid)
+        get_or_404(Source, source_uuid, column=Source.uuid)
         submission = get_or_404(Submission, submission_uuid,
                                 column=Submission.uuid)
 
@@ -185,16 +185,16 @@ def make_blueprint(config):
         submission.downloaded = True
         db.session.commit()
 
-        return utils.serve_file_with_etag(source, submission.filename)
+        return utils.serve_file_with_etag(submission)
 
     @api.route('/sources/<source_uuid>/replies/<reply_uuid>/download',
                methods=['GET'])
     @token_required
     def download_reply(source_uuid, reply_uuid):
-        source = get_or_404(Source, source_uuid, column=Source.uuid)
+        get_or_404(Source, source_uuid, column=Source.uuid)
         reply = get_or_404(Reply, reply_uuid, column=Reply.uuid)
 
-        return utils.serve_file_with_etag(source, reply.filename)
+        return utils.serve_file_with_etag(reply)
 
     @api.route('/sources/<source_uuid>/submissions/<submission_uuid>',
                methods=['GET', 'DELETE'])

--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import os
 
 from datetime import datetime
@@ -7,6 +6,8 @@ from flask import (Blueprint, request, current_app, session, url_for, redirect,
                    render_template, g, flash, abort)
 from flask_babel import gettext
 from sqlalchemy.sql.expression import false
+
+import store
 
 from db import db
 from models import Source, SourceStar, Submission, Reply
@@ -114,6 +115,7 @@ def make_blueprint(config):
         try:
             db.session.add(reply)
             db.session.commit()
+            store.async_add_checksum_for_file(reply)
         except Exception as exc:
             flash(gettext(
                 "An unexpected error occurred! Please "

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -9,7 +9,7 @@ import hashlib
 from sqlalchemy.sql.expression import false
 
 import i18n
-import worker
+from worker import rq_worker_queue
 
 from db import db
 from models import (get_one_or_else, Source, Journalist,
@@ -174,7 +174,7 @@ def download(zip_basename, submissions):
 
 def delete_file(filesystem_id, filename, file_object):
     file_path = current_app.storage.path(filesystem_id, filename)
-    worker.enqueue(srm, file_path)
+    rq_worker_queue.enqueue(srm, file_path)
     db.session.delete(file_object)
     db.session.commit()
 
@@ -261,7 +261,7 @@ def make_password(config):
 
 def delete_collection(filesystem_id):
     # Delete the source's collection of submissions
-    job = worker.enqueue(srm, current_app.storage.path(filesystem_id))
+    job = rq_worker_queue.enqueue(srm, current_app.storage.path(filesystem_id))
 
     # Delete the source's reply keypair
     current_app.crypto_util.delete_reply_keypair(filesystem_id)

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -164,6 +164,12 @@ class Submission(db.Model):
     filename = Column(String(255), nullable=False)
     size = Column(Integer, nullable=False)
     downloaded = Column(Boolean, default=False)
+    '''
+    The checksum of the encrypted file on disk.
+    Format: $hash_name:$hex_encoded_hash_value
+    Example: sha256:05fa5efd7d1b608ac1fbdf19a61a5a439d05b05225e81faa63fdd188296b614a
+    '''
+    checksum = Column(String(255))
 
     def __init__(self, source, filename):
         self.source_id = source.id
@@ -213,6 +219,12 @@ class Reply(db.Model):
 
     filename = Column(String(255), nullable=False)
     size = Column(Integer, nullable=False)
+    '''
+    The checksum of the encrypted file on disk.
+    Format: $hash_name:$hex_encoded_hash_value
+    Example: sha256:05fa5efd7d1b608ac1fbdf19a61a5a439d05b05225e81faa63fdd188296b614a
+    '''
+    checksum = Column(String(255))
 
     deleted_by_source = Column(Boolean, default=False, nullable=False)
 

--- a/securedrop/rm.py
+++ b/securedrop/rm.py
@@ -21,4 +21,5 @@ import subprocess
 
 def srm(fn):
     subprocess.check_call(['srm', '-r', fn])
+    # We need to return a non-`None` value so the rq worker writes this back to Redis
     return "success"

--- a/securedrop/sdconfig.py
+++ b/securedrop/sdconfig.py
@@ -160,5 +160,10 @@ class SDConfig(object):
         except AttributeError:
             pass
 
+        if getattr(self, 'env', 'prod') == 'test':
+            self.RQ_WORKER_NAME = 'test'
+        else:
+            self.RQ_WORKER_NAME = 'default'
+
 
 config = SDConfig()  # type: SDConfig

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -20,6 +20,7 @@ from source_app import main, info, api, disable
 from source_app.decorators import ignore_static
 from source_app.utils import logged_in
 from store import Storage
+from worker import rq_worker_queue
 
 import typing
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
@@ -74,6 +75,9 @@ def create_app(config):
         adjectives_file=config.ADJECTIVES,
         gpg_key_dir=config.GPG_KEY_DIR,
     )
+
+    app.config['RQ_WORKER_NAME'] = config.RQ_WORKER_NAME
+    rq_worker_queue.init_app(app)
 
     @app.errorhandler(CSRFError)
     def handle_csrf_error(e):

--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -216,6 +216,7 @@ def queued_add_checksum_for_file(db_model, model_id, file_path, db_uri):
     session = sessionmaker(bind=create_engine(db_uri))()
     db_obj = session.query(db_model).filter_by(id=model_id).one()
     add_checksum_for_file(session, db_obj, file_path)
+    # We need to return a non-`None` value so the rq worker writes this back to Redis
     return "success"
 
 

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -234,9 +234,11 @@ def journalist_api_token(journalist_app, test_journo):
 def _start_test_rqworker(config):
     if not psutil.pid_exists(_get_pid_from_file(TEST_WORKER_PIDFILE)):
         tmp_logfile = io.open('/tmp/test_rqworker.log', 'w')
-        subprocess.Popen(['rqworker', 'test',
+        subprocess.Popen(['rqworker', config.RQ_WORKER_NAME,
                           '-P', config.SECUREDROP_ROOT,
-                          '--pid', TEST_WORKER_PIDFILE],
+                          '--pid', TEST_WORKER_PIDFILE,
+                          '--logging_level', 'debug',
+                          '-v'],
                          stdout=tmp_logfile,
                          stderr=subprocess.STDOUT)
 

--- a/securedrop/tests/migrations/migration_b58139cfdc8c.py
+++ b/securedrop/tests/migrations/migration_b58139cfdc8c.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+import io
+import os
+import random
+import uuid
+
+from os import path
+from sqlalchemy import text
+from sqlalchemy.exc import NoSuchColumnError
+
+from db import db
+from journalist_app import create_app
+from .helpers import random_chars, random_datetime
+
+random.seed('ᕕ( ᐛ )ᕗ')
+
+DATA = b'wat'
+DATA_CHECKSUM = 'sha256:f00a787f7492a95e165b470702f4fe9373583fbdc025b2c8bdf0262cc48fcff4'
+
+
+class Helper:
+
+    def __init__(self):
+        self.journalist_id = None
+        self.source_id = None
+        self._counter = 0
+
+    @property
+    def counter(self):
+        self._counter += 1
+        return self._counter
+
+    def create_journalist(self):
+        if self.journalist_id is not None:
+            raise RuntimeError('Journalist already created')
+
+        params = {
+            'uuid': str(uuid.uuid4()),
+            'username': random_chars(50),
+        }
+        sql = '''INSERT INTO journalists (uuid, username)
+                 VALUES (:uuid, :username)
+              '''
+        self.journalist_id = db.engine.execute(text(sql), **params).lastrowid
+
+    def create_source(self):
+        if self.source_id is not None:
+            raise RuntimeError('Source already created')
+
+        self.source_filesystem_id = 'aliruhglaiurhgliaurg-{}'.format(self.counter)
+        params = {
+            'filesystem_id': self.source_filesystem_id,
+            'uuid': str(uuid.uuid4()),
+            'journalist_designation': random_chars(50),
+            'flagged': False,
+            'last_updated': random_datetime(nullable=True),
+            'pending': False,
+            'interaction_count': 0,
+        }
+        sql = '''INSERT INTO sources (filesystem_id, uuid, journalist_designation, flagged,
+                    last_updated, pending, interaction_count)
+                 VALUES (:filesystem_id, :uuid, :journalist_designation, :flagged, :last_updated,
+                    :pending, :interaction_count)
+              '''
+        self.source_id = db.engine.execute(text(sql), **params).lastrowid
+
+    def create_submission(self, checksum=False):
+        filename = str(uuid.uuid4())
+        params = {
+            'uuid': str(uuid.uuid4()),
+            'source_id': self.source_id,
+            'filename': filename,
+            'size': random.randint(10, 1000),
+            'downloaded': False,
+
+        }
+
+        if checksum:
+            params['checksum'] = \
+                'sha256:f00a787f7492a95e165b470702f4fe9373583fbdc025b2c8bdf0262cc48fcff4'
+            sql = '''INSERT INTO submissions (uuid, source_id, filename, size, downloaded, checksum)
+                     VALUES (:uuid, :source_id, :filename, :size, :downloaded, :checksum)
+                  '''
+        else:
+            sql = '''INSERT INTO submissions (uuid, source_id, filename, size, downloaded)
+                     VALUES (:uuid, :source_id, :filename, :size, :downloaded)
+                  '''
+
+        return (db.engine.execute(text(sql), **params).lastrowid, filename)
+
+    def create_reply(self, checksum=False):
+        filename = str(uuid.uuid4())
+        params = {
+            'uuid': str(uuid.uuid4()),
+            'source_id': self.source_id,
+            'journalist_id': self.journalist_id,
+            'filename': filename,
+            'size': random.randint(10, 1000),
+            'deleted_by_source': False,
+        }
+
+        if checksum:
+            params['checksum'] = \
+                'sha256:f00a787f7492a95e165b470702f4fe9373583fbdc025b2c8bdf0262cc48fcff4'
+            sql = '''INSERT INTO replies (uuid, source_id, journalist_id, filename, size,
+                        deleted_by_source, checksum)
+                     VALUES (:uuid, :source_id, :journalist_id, :filename, :size,
+                        :deleted_by_source, :checksum)
+                  '''
+        else:
+            sql = '''INSERT INTO replies (uuid, source_id, journalist_id, filename, size,
+                        deleted_by_source)
+                     VALUES (:uuid, :source_id, :journalist_id, :filename, :size,
+                        :deleted_by_source)
+                  '''
+        return (db.engine.execute(text(sql), **params).lastrowid, filename)
+
+
+class UpgradeTester(Helper):
+
+    def __init__(self, config):
+        Helper.__init__(self)
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        global DATA
+        with self.app.app_context():
+            self.create_journalist()
+            self.create_source()
+
+            submission_id, submission_filename = self.create_submission()
+            reply_id, reply_filename = self.create_reply()
+
+            # we need to actually create files and write data to them so the RQ worker can hash them
+            for fn in [submission_filename, reply_filename]:
+                full_path = self.app.storage.path(self.source_filesystem_id, fn)
+
+                dirname = path.dirname(full_path)
+                if not path.exists(dirname):
+                    os.mkdir(dirname)
+
+                with io.open(full_path, 'wb') as f:
+                    f.write(DATA)
+
+    def check_upgrade(self):
+        '''
+        We cannot inject the `SDConfig` object provided by the fixture `config` into the alembic
+        subprocess that actually performs the migration. This is needed to get both the value of the
+        DB URL and access to the function `storage.path`. These values are passed to the `rqworker`,
+        and without being able to inject this config, the checksum function won't succeed. The above
+        `load_data` function provides data that can be manually verified by checking the `rqworker`
+        log file in `/tmp/`.
+        '''
+        pass
+
+
+class DowngradeTester(Helper):
+
+    def __init__(self, config):
+        Helper.__init__(self)
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            self.create_journalist()
+            self.create_source()
+
+            # create a submission and a reply that we don't add checksums to
+            self.create_submission(checksum=False)
+            self.create_reply(checksum=False)
+
+            # create a submission and a reply that have checksums added
+            self.create_submission(checksum=True)
+            self.create_reply(checksum=True)
+
+    def check_downgrade(self):
+        '''
+        Verify that the checksum column is now gone.
+        '''
+        with self.app.app_context():
+            sql = "SELECT * FROM submissions"
+            submissions = db.engine.execute(text(sql)).fetchall()
+            for submission in submissions:
+                try:
+                    # this should produce an exception since the column is gone
+                    submission['checksum']
+                except NoSuchColumnError:
+                    pass
+
+            sql = "SELECT * FROM replies"
+            replies = db.engine.execute(text(sql)).fetchall()
+            for reply in replies:
+                try:
+                    # this should produce an exception since the column is gone
+                    submission['checksum']
+                except NoSuchColumnError:
+                    pass

--- a/securedrop/tests/utils/async.py
+++ b/securedrop/tests/utils/async.py
@@ -4,6 +4,7 @@ timeout of asynchronous processes.
 """
 import time
 
+# This is an arbitarily defined value in the SD codebase and not something from rqworker
 REDIS_SUCCESS_RETURN_VALUE = 'success'
 
 

--- a/securedrop/worker.py
+++ b/securedrop/worker.py
@@ -1,14 +1,37 @@
-import os
-
 from redis import Redis
 from rq import Queue
 
-queue_name = 'test' if os.environ.get(
-    'SECUREDROP_ENV') == 'test' else 'default'
 
-# `srm` can take a long time on large files, so allow it run for up to an hour
-q = Queue(name=queue_name, connection=Redis(), default_timeout=3600)
+class RqWorkerQueue(object):
+
+    '''
+    A reference to a `rq` worker queue.
+
+    Configuration:
+        `RQ_WORKER_NAME`: Name of the `rq` worker.
+    '''
+
+    __EXT_NAME = 'rq-worker-queue'
+
+    def __init__(self, app=None):
+        self.__app = app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        self.__app = app
+        self.__app.config.setdefault('RQ_WORKER_NAME', 'default')
+
+        if not hasattr(self.__app, 'extensions'):
+            self.__app.extensions = {}
+
+        queue_name = self.__app.config['RQ_WORKER_NAME']
+        queue = Queue(name=queue_name, connection=Redis(), default_timeout=3600)
+        self.__app.extensions[self.__EXT_NAME] = queue
+
+    def enqueue(self, *nargs, **kwargs):
+        queue = self.__app.extensions[self.__EXT_NAME]
+        return queue.enqueue(*nargs, **kwargs)
 
 
-def enqueue(*args, **kwargs):
-    return q.enqueue(*args, **kwargs)
+rq_worker_queue = RqWorkerQueue()

--- a/securedrop/worker.py
+++ b/securedrop/worker.py
@@ -22,7 +22,10 @@ class RqWorkerQueue(object):
         self.__app = app
         self.__app.config.setdefault('RQ_WORKER_NAME', 'default')
 
-        if not hasattr(self.__app, 'extensions'):
+        try:
+            # check for presence of existing extension dict
+            self.__app.extensions
+        except AttributeError:
             self.__app.extensions = {}
 
         queue_name = self.__app.config['RQ_WORKER_NAME']


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4032

Add the column `checksum` to the `submissions` and `replies` tables. Use this value as the `ETag` header in the API responses.

## Testing

CI covers most of this, but there is one part that needs manual review because of the complexity of injecting `pytest` fixtures across the subprocess boundary.

1. `./bin/dev-shell`
2. `./bin/run-test -vv tests/test_alembic.py::test_upgrade_with_data[b58139cfdc8c]`
3. `cat /tmp/test_rqworker.log`
4. Look for two failures of type `OperationalError`. The tables are missing because the app context in the alembic migration uses the prod values.

Additionally, the part of the migration is allowed to fail because it is covered by the fact that the columns are nullable and the `checksum` value is populated when the response is generated if it is missing.

## Deployment

This PR has a migration and it should be checked that it is sufficiently robust.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR