### PR TITLE
[0.12.1] Bump version number for remaining Xenial docs

### DIFF
--- a/docs/upgrade/xenial_backup_install_restore.rst
+++ b/docs/upgrade/xenial_backup_install_restore.rst
@@ -157,7 +157,7 @@ code is up-to-date and validated. From a terminal, run the following commands:
 
  cd ~/Persistent/securedrop
  git fetch --tags
- git tag -v 0.12.0
+ git tag -v 0.12.1
 
 You should see ``Good signature from "SecureDrop Release Signing Key"`` in the
 output of that last command, along with the fingerprint ``"2224 5C81 E3BA EB41
@@ -175,7 +175,7 @@ First, check out the release tag that you validated above:
 
 .. code:: sh
  
- git checkout 0.12.0
+ git checkout 0.12.1
 
 Next, run the following command to set up the SecureDrop administration environment:
 

--- a/docs/upgrade/xenial_prep.rst
+++ b/docs/upgrade/xenial_prep.rst
@@ -8,8 +8,9 @@ to upgrade to Ubuntu 16.04 LTS (Xenial) before April 30, 2019.
 
 SecureDrop servers provisioned before February 26, 2019 use Ubuntu 14.04 LTS as
 the base operating system. Support for Ubuntu 16.04 LTS (which will receive
-security updates until April 2021) is included with SecureDrop 0.12.0, released
-on February 26. The operating system update itself must be performed manually.
+security updates until April 2021) is included starting with the SecureDrop 0.12
+release series on February 26. The operating system update itself must be
+performed manually.
 
 We recommend that you plan two working days (after your instance has been
 updated to SecureDrop 0.12.1) to backup your instance, perform the upgrade, and
@@ -50,10 +51,9 @@ from the command line on the *Application Server* by running the command:
 
 
 SecureDrop servers are updated automatically with the latest release version
-(0.12.1 as of March 20, 2019). Recently, some long-running SecureDrop
-instances were affected by a bug which will cause any updates after 0.10.0 to
-fail. If your instance is still running 0.10.0, please `consult our advisory
-<https://securedrop.org/news/advisory-automatic-update-failure-version-0100-0110-some-securedrop-instances/>`_
+(0.12.1). Recently, some long-running SecureDrop instances were affected by a 
+bug which will cause any updates after 0.10.0 to fail. If your instance is still
+running 0.10.0, please `consult our advisory <https://securedrop.org/news/advisory-automatic-update-failure-version-0100-0110-some-securedrop-instances/>`_
 to update to the latest version.
 
 .. important:: If your instance is affected by this bug, it will no longer

--- a/docs/upgrade/xenial_upgrade_in_place.rst
+++ b/docs/upgrade/xenial_upgrade_in_place.rst
@@ -30,7 +30,8 @@ Before performing the upgrade, please perform all the steps outlined in
 .. warning::
   In order to successfully upgrade your SecureDrop instance, it is of critical
   importance that your *Admin Workstation* and your servers use SecureDrop
-  0.12.0. Older releases of SecureDrop do not not support Ubuntu 16.04.
+  0.12.1. Releases prior to the 0.12 series of SecureDrop do not not support
+  Ubuntu 16.04.
 
                                                                                 
 We expect that the upgrade should take under 8 hours to complete, but recommend 
@@ -212,7 +213,7 @@ code is up-to-date and validated. From a terminal, run the following commands:
                                                                                 
  cd ~/Persistent/securedrop                                                     
  git fetch --tags
- git tag -v 0.12.0                                                              
+ git tag -v 0.12.1                                                              
                                                                                 
 You should see ``Good signature from "SecureDrop Release Signing Key"`` in the 
 output of that last command, along with the fingerprint 
@@ -230,7 +231,7 @@ First, check out the release tag that you validated above:
 
 .. code:: sh
  
- git checkout 0.12.0                                                            
+ git checkout 0.12.1                                                            
 
 Next, in the terminal, run the following command to set up the SecureDrop 
 admin environment:
@@ -276,7 +277,7 @@ Server* and your *Monitor Server*.
 Validate the application version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To confirm that you are running SecureDrop 0.12.0 for Xenial, on the Tails
+To confirm that you are running SecureDrop 0.12.1 for Xenial, on the Tails
 desktop, you should find a shortcut called **SecureDrop Source Interface**.
 Double-click it to launch the Tor browser.
 
@@ -284,7 +285,7 @@ After the *Source Interface* loads, add the path ``/metadata`` to the URL in
 your address bar. If your *Source Interface* can be found at
 ``examplenot4real.onion``, then the address you should visit is
 ``examplenot4real.onion/metadata``. That page should show you key/value pairs,
-including ``0.12.0`` for ``sd_version`` and ``16.04`` for ``server_os``.
+including ``0.12.1`` for ``sd_version`` and ``16.04`` for ``server_os``.
 
 End-to-end test
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Status

Ready for review, backport to 0.12.1; see #4316 for previous review (this PR omits the change to `update_version.sh` for simplicity)