### PR TITLE
[0.12.1] Transitions lint container to Debian Stretch

### DIFF
--- a/devops/docker/Dockerfile.linting
+++ b/devops/docker/Dockerfile.linting
@@ -1,6 +1,6 @@
 FROM koalaman/shellcheck:v0.4.7 as shellcheck
 
-FROM gcr.io/google-containers/python:2.7.11-slim
+FROM python:2.7.16-slim-stretch
 LABEL MAINTAINER="Freedom of the Press Foundation"
 LABEL APP="SDLinter"
 


### PR DESCRIPTION
**Backport of #4306 to fix CI for release branch.**

## Status

Ready for review

## Description

Switching to a Stretch-based container for linting tasks, given that
Jessie is EOL and has started throwing errors on apt list updates.
Furthermore, the previous Jessie-based container appears unmaintained,
with the last updat on 2016-03-20 [0].

The new container was suggested by @cji, docs at [1] & [2]

[0] https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/python
[1] https://hub.docker.com/_/python
[2] https://github.com/docker-library/python/blob/636e02777ea417851942e6e826fe5a6b4dee6f74/2.7/stretch/slim/Dockerfile

(cherry picked from commit 9ef201addc52aa548f5790133511ba7cb12b6f34)