### PR TITLE
[0.12.1] Backport version bumps and update script changes

### DIFF
--- a/docs/upgrade/xenial_backup_install_restore.rst
+++ b/docs/upgrade/xenial_backup_install_restore.rst
@@ -157,7 +157,7 @@ code is up-to-date and validated. From a terminal, run the following commands:
 
  cd ~/Persistent/securedrop
  git fetch --tags
- git tag -v 0.12.0
+ git tag -v 0.12.1
 
 You should see ``Good signature from "SecureDrop Release Signing Key"`` in the
 output of that last command, along with the fingerprint ``"2224 5C81 E3BA EB41
@@ -175,7 +175,7 @@ First, check out the release tag that you validated above:
 
 .. code:: sh
  
- git checkout 0.12.0
+ git checkout 0.12.1
 
 Next, run the following command to set up the SecureDrop administration environment:
 

--- a/docs/upgrade/xenial_prep.rst
+++ b/docs/upgrade/xenial_prep.rst
@@ -8,8 +8,9 @@ to upgrade to Ubuntu 16.04 LTS (Xenial) before April 30, 2019.
 
 SecureDrop servers provisioned before February 26, 2019 use Ubuntu 14.04 LTS as
 the base operating system. Support for Ubuntu 16.04 LTS (which will receive
-security updates until April 2021) is included with SecureDrop 0.12.0, released
-on February 26. The operating system update itself must be performed manually.
+security updates until April 2021) is included starting with the SecureDrop 0.12
+release series on February 26. The operating system update itself must be
+performed manually.
 
 We recommend that you plan two working days (after your instance has been
 updated to SecureDrop 0.12.1) to backup your instance, perform the upgrade, and
@@ -50,10 +51,9 @@ from the command line on the *Application Server* by running the command:
 
 
 SecureDrop servers are updated automatically with the latest release version
-(0.12.1 as of March 20, 2019). Recently, some long-running SecureDrop
-instances were affected by a bug which will cause any updates after 0.10.0 to
-fail. If your instance is still running 0.10.0, please `consult our advisory
-<https://securedrop.org/news/advisory-automatic-update-failure-version-0100-0110-some-securedrop-instances/>`_
+(0.12.1). Recently, some long-running SecureDrop instances were affected by a 
+bug which will cause any updates after 0.10.0 to fail. If your instance is still
+running 0.10.0, please `consult our advisory <https://securedrop.org/news/advisory-automatic-update-failure-version-0100-0110-some-securedrop-instances/>`_
 to update to the latest version.
 
 .. important:: If your instance is affected by this bug, it will no longer

--- a/docs/upgrade/xenial_upgrade_in_place.rst
+++ b/docs/upgrade/xenial_upgrade_in_place.rst
@@ -30,7 +30,8 @@ Before performing the upgrade, please perform all the steps outlined in
 .. warning::
   In order to successfully upgrade your SecureDrop instance, it is of critical
   importance that your *Admin Workstation* and your servers use SecureDrop
-  0.12.0. Older releases of SecureDrop do not not support Ubuntu 16.04.
+  0.12.1. Releases prior to the 0.12 series of SecureDrop do not not support
+  Ubuntu 16.04.
 
                                                                                 
 We expect that the upgrade should take under 8 hours to complete, but recommend 
@@ -212,7 +213,7 @@ code is up-to-date and validated. From a terminal, run the following commands:
                                                                                 
  cd ~/Persistent/securedrop                                                     
  git fetch --tags
- git tag -v 0.12.0                                                              
+ git tag -v 0.12.1                                                              
                                                                                 
 You should see ``Good signature from "SecureDrop Release Signing Key"`` in the 
 output of that last command, along with the fingerprint 
@@ -230,7 +231,7 @@ First, check out the release tag that you validated above:
 
 .. code:: sh
  
- git checkout 0.12.0                                                            
+ git checkout 0.12.1                                                            
 
 Next, in the terminal, run the following command to set up the SecureDrop 
 admin environment:
@@ -276,7 +277,7 @@ Server* and your *Monitor Server*.
 Validate the application version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To confirm that you are running SecureDrop 0.12.0 for Xenial, on the Tails
+To confirm that you are running SecureDrop 0.12.1 for Xenial, on the Tails
 desktop, you should find a shortcut called **SecureDrop Source Interface**.
 Double-click it to launch the Tor browser.
 
@@ -284,7 +285,7 @@ After the *Source Interface* loads, add the path ``/metadata`` to the URL in
 your address bar. If your *Source Interface* can be found at
 ``examplenot4real.onion``, then the address you should visit is
 ``examplenot4real.onion/metadata``. That page should show you key/value pairs,
-including ``0.12.0`` for ``sd_version`` and ``16.04`` for ``server_os``.
+including ``0.12.1`` for ``sd_version`` and ``16.04`` for ``server_os``.
 
 End-to-end test
 ^^^^^^^^^^^^^^^

--- a/update_version.sh
+++ b/update_version.sh
@@ -60,6 +60,12 @@ if [[ ! $NEW_VERSION == *~rc* ]]; then
     echo "${NEW_VERSION}" > molecule/shared/stable.ver
     sed -i "s@$(echo "${OLD_RELEASE}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/set_up_admin_tails.rst
     sed -i "s@$(echo "${OLD_RELEASE}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/conf.py
+    # Upgrade docs to Ubuntu 16.04 reference current stable version explicitly.
+    # Where we're talking about the 0.12 _series_ (the first to support Xenial),
+    # the phrase "0.12 series" is used, so this regex is safe to run.
+    sed -i "s@$(echo "${OLD_RELEASE}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/upgrade/xenial_upgrade_in_place.rst
+    sed -i "s@$(echo "${OLD_RELEASE}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/upgrade/xenial_prep.rst
+    sed -i "s@$(echo "${OLD_RELEASE}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/upgrade/xenial_backup_install_restore.rst
 fi
 
 # Update the changelog

--- a/update_version.sh
+++ b/update_version.sh
@@ -52,14 +52,14 @@ sed -i "s/^\(securedrop_app_code_version: \"\).*/\1$NEW_VERSION\"/" install_file
 # Update the version in molecule testinfra vars
 sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" molecule/builder-trusty/tests/vars.yml
 
-# Update the version that we tell people to check out in the install doc
-sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/set_up_admin_tails.rst
-sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/conf.py
-
 # If version doesnt have an rc designator, its considered stable
 # theres a few things that peg to that stable version like upgrade testing logic
+# and strings inside the documentation
+OLD_RELEASE=$(cat molecule/shared/stable.ver)
 if [[ ! $NEW_VERSION == *~rc* ]]; then
     echo "${NEW_VERSION}" > molecule/shared/stable.ver
+    sed -i "s@$(echo "${OLD_RELEASE}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/set_up_admin_tails.rst
+    sed -i "s@$(echo "${OLD_RELEASE}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/conf.py
 fi
 
 # Update the changelog


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This backports the changes in #4074 and #4316 in preparation for 0.12.2, but does not include #4263 to avoid scope creep on the release branches. 

## Test plan

Given selective backport, I recommend at least one other person follow these steps (I have done so):

1. Run `update_versions.sh 0.12.2` in Docker container and abort the commit
2. Inspect diff: are all expected changes performed?