### PR TITLE
Prevent Docker from complaining that it stole the VNC port from itself

### DIFF
--- a/securedrop/Makefile
+++ b/securedrop/Makefile
@@ -30,7 +30,7 @@ translation-test: ## Run all pages-layout tests in all supported languages
 
 .PHONY: dev
 dev: ## Run the dev server
-	 DOCKER_RUN_ARGUMENTS='-p127.0.0.1:8080:8080 -p127.0.0.1:8081:8081 -p127.0.0.1:5901:5901' ./bin/dev-shell ./bin/run
+	 DOCKER_RUN_ARGUMENTS='-p127.0.0.1:8080:8080 -p127.0.0.1:8081:8081' ./bin/dev-shell ./bin/run
 
 config.py: test-config
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The extraction of the VNC changes from the Tor Browser Selenium branch(es) broke `make -C securedrop dev`. The setup of the VNC port was present in both `DOCKER_RUN_ARGUMENTS` in `securedrop/Makefile` and the `docker run` arguments in `securedrop/bin/dev-shell`, which led to  Docker complaining that it couldn't set up the external connectivity that it had already set up. 

This change removes the port setup from the Makefile.

## Testing

Check out `develop` and confirm that when running `make -C securedrop dev` you get an error like `docker: Error response from daemon: driver failed programming external connectivity on endpoint securedrop-dev (c4dbdf3382bc730e537684848e651445a976a3f4f8c36828c3e8e7bb2ca7cfdf): Bind for 127.0.0.1:5901 failed: port is already allocated.`

Check out this branch and verify that running `make -C securedrop dev` works.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
