### PR TITLE
Backup: fetch tarball with synchronize instead of fetch

### DIFF
--- a/install_files/ansible-base/roles/backup/tasks/backup.yml
+++ b/install_files/ansible-base/roles/backup/tasks/backup.yml
@@ -22,11 +22,11 @@
     backup_filename: "{{ backup_script_result.stdout }}"
 
 - name: Fetch the backup tarball back to the Admin Workstation.
-  fetch:
+  synchronize:
+    checksum: yes
+    mode: pull
     src: /tmp/{{ backup_filename }}
     dest: ./{{ backup_filename }}
-    flat: yes
-    fail_on_missing: yes
 
 - name: Delete backup tarball from Application Server (to save disk space).
   file:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Ansible's fetch module causes MemoryError with large files when run with 'become':
```
https://docs.ansible.com/ansible/latest/modules/fetch_module.html#notes
```
It was easily replaced with the synchronize module:
```
https://docs.ansible.com/ansible/latest/modules/synchronize_module.html
```
## Testing

You'll need working app and admin machines. I tested with hardware, but it should be possible to test with virtual machines.

On the app server, create a one-gigabyte file in the SecureDrop store:
```
$ sudo dd if=/dev/urandom of=/var/lib/securedrop/store/bigfile.bin bs=1MB count=1000
```

On the admin workstation, using the `develop` branch, back up the app server with `securedrop-admin backup`. It should fail with a `MemoryError`. If it does not, try creating a bigger file by adjusting the `dd` command above.

On the admin workstation, check out this branch:
```
$ git remote add rmol git@github.com:rmol/securedrop.git
$ git fetch --all
$ git checkout -b fix-backup-fetch rmol/fix-backup-fetch
```
Then run `./securedrop-admin backup`. It should complete successfully.

## Deployment

This should be a drop-in replacement for the `fetch` module usage. The backup tarball creation has not changed, only the way in which it's transferred to the admin workstation. Restoration should not be affected.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
