### PR TITLE
Add workaround docs for MemoryError during backup

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -111,6 +111,8 @@ of backup action.
              be stored on the *Admin Workstation*, or on a
              :doc:`dedicated encrypted backup USB <backup_workstations>`.
 
+.. include:: includes/backup-warning.txt
+
 Restoring
 ---------
 

--- a/docs/includes/backup-warning.txt
+++ b/docs/includes/backup-warning.txt
@@ -1,0 +1,19 @@
+.. note::
+  When dealing with larger backups, the ``securedrop-admin backup`` command may
+  fail with a ``MemoryError`` at this stage of the operation: "Fetch the backup
+  tarball back to the Admin Workstation".
+  
+  If this happens, a backup was successfully generated, but it is still
+  on the server. Run this command from your ``~/Persistent/securedrop``
+  directory to copy the backup your *Admin Workstation*:
+  
+  .. code:: bash
+
+    rsync -av --progress --partial app:$(ssh app ls -1rt /tmp/sd-backup* | tail -1) install_files/ansible-base/
+  
+  If the transfer fails or is interrupted, you can simply run this command again
+  to resume it.
+
+  Note that this method will only work if you have first run the 
+  ``securedrop-admin backup`` command, and the backup has successfully progressed
+  at least until the "Fetch the backup tarball" stage.  

--- a/docs/upgrade/xenial_backup_install_restore.rst
+++ b/docs/upgrade/xenial_backup_install_restore.rst
@@ -72,6 +72,8 @@ do so, run the following commands from the terminal:
 Once you have completed the backup process, you may shut down the *Admin
 Workstation* and move to the next step: installing a Xenial-based instance.
 
+.. include:: ../includes/backup-warning.txt
+
 Step 2: Install Xenial
 ----------------------
 

--- a/docs/upgrade/xenial_prep.rst
+++ b/docs/upgrade/xenial_prep.rst
@@ -309,6 +309,8 @@ that you store those on an encrypted volume on a separate USB stick for safe
 keeping. For more information on the backup process, see
 :doc:`Backup, Restore, Migrate <../backup_and_restore>`.
 
+.. include:: ../includes/backup-warning.txt
+
 
 .. _verify_ssh_access:
 


### PR DESCRIPTION
Time-sensitive due to Xenial updates in progress.

This will be resolved with #4326 in 0.12.1, though we may want to
keep some version of this documentation around in case people
still encounter issues during the playbook run.

Credit to @rmol for authoring the rsync command used here, which
has been used during real-world upgrades.

## Status

Ready for review

### Checklist

- [x] Doc linting (`make docs-lint`) passed locally
