### PR TITLE
Override level of apache error log in ossec config

### DIFF
--- a/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
+++ b/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
@@ -200,4 +200,10 @@
   </rule>
 </group>
 
+<group name="Apache logs">
+  <rule id="400700" level="7">
+    <if_sid>30301</if_sid>
+    <description>Apache application error.</description>
+  </rule>
+</group>
 

--- a/molecule/testinfra/staging/vars/staging.yml
+++ b/molecule/testinfra/staging/vars/staging.yml
@@ -162,5 +162,20 @@ log_events_with_ossec_alerts:
     level: "1"
     rule_id: "400503"
 
+  - name: test_ossec_server_apache_error_log_alert
+    alert: >
+      [Fri Apr 12 14:39:25.596318 2019] [wsgi:error]
+      [pid 1480:tid 4201987876608] ERROR:flask.app:Login for 'user' failed:
+      invalid username 'user'
+    level: "7"
+    rule_id: "400700"
+
+  - name: test_ossec_server_test_notification_alert
+    alert: >
+      [Fri Apr 12 15:45:05.310796 2019] [wsgi:error]
+      [pid 1479:tid 4201988093696] ERROR:flask.app:This is a test OSSEC alert
+    level: "7"
+    rule_id: "400700"
+
 fpf_apt_repo_url: "https://apt-test.freedom.press"
 grsec_version: "4.4.177"


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #4339 


## Testing

1. Set up a production (VM or physical) SecureDrop instance
2. `make build-debs` on this branch
3. Go to Journalist Interface, click on Admin, navigate to Instance Config and click on "Send Test OSSEC Alert" button
- [ ] Observe no email received
4. copy securedrop-ossec-agent and ossec-agent debs to app server and install
5. copy securedrop-ossec-server and ossec-server debs to mon server and install 
6.  Go to Journalist Interface, click on Admin, navigate to Instance Config and click on "Send Test OSSEC Alert" button
- [ ] Observe email received
## Deployment

New and existing SecureDrop instances will be upgraded via the securedrop-ossec-{client, server} deb packages.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
