### PR TITLE
Update Jinja2 to 2.10.1, Ansible to 2.6.14 and SQLAlchemy to 1.3.0

### DIFF
--- a/admin/requirements.txt
+++ b/admin/requirements.txt
@@ -103,10 +103,9 @@ idna==2.6 \
 ipaddress==1.0.19 \
     --hash=sha256:200d8686011d470b5e4de207d803445deee427455cd0cb7c982b68cf82524f81 \
     # via cryptography
-jinja2==2.10 \
-    --hash=sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd \
-    --hash=sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4 \
-    # via ansible
+jinja2==2.10.1 \
+    --hash=sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013 \
+    --hash=sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b
 markupsafe==1.0 \
     --hash=sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665 \
     # via jinja2

--- a/admin/requirements.txt
+++ b/admin/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --generate-hashes --output-file requirements.txt requirements.in requirements-ansible.in
 #
-ansible==2.6.8 \
-    --hash=sha256:012649806427e630ef8e8b71d42483af882bc39ade3b19e1f369b14c0afd5b87
+ansible==2.6.14 \
+    --hash=sha256:412f130f4c5d1953ccd95f01b5a4675cbff4ba225762bafb74a2f3bb6c807827
 asn1crypto==0.24.0 \
     --hash=sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87 \
     --hash=sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49 \

--- a/install_files/ansible-base/callback_plugins/ansible_version_check.py
+++ b/install_files/ansible-base/callback_plugins/ansible_version_check.py
@@ -21,7 +21,7 @@ class CallbackModule(CallbackBase):
     def __init__(self):
         # Can't use `on_X` because this isn't forwards compatible
         # with Ansible 2.0+
-        required_version = '2.6.8'  # Keep synchronized with requirements files
+        required_version = '2.6.14'  # Keep synchronized with requirements files
         if not ansible.__version__.startswith(required_version):
             print_red_bold(
                 "SecureDrop restriction: only Ansible {version}.*"

--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.10         # via sphinx
 ansible-lint==3.4.23      # via molecule
-ansible==2.6.8
+ansible==2.6.14
 anyconfig==0.9.7          # via molecule
 apipkg==1.4               # via execnet
 argh==0.26.2              # via sphinx-autobuild, watchdog

--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -17,6 +17,6 @@ redis
 rq
 scrypt
 sh
-SQLAlchemy
+SQLAlchemy>=1.3.0
 typing
 Werkzeug

--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -6,7 +6,7 @@ Flask-Babel
 Flask-SQLAlchemy
 Flask-WTF
 Flask>0.12.2
-Jinja2
+Jinja2>=2.10.1
 jsmin
 passlib
 pretty-bad-protocol>=3.1.1

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -19,7 +19,7 @@ flask-wtf==0.14.2
 flask==1.0.2
 ipaddress==1.0.22         # via cryptography
 itsdangerous==0.24        # via flask
-jinja2==2.10
+jinja2==2.10.1
 jsmin==2.2.2
 mako==1.0.7               # via alembic
 markupsafe==1.0           # via jinja2, mako

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -37,7 +37,7 @@ rq==0.10.0
 scrypt==0.8.0
 sh==1.12.14
 six==1.11.0               # via argon2-cffi, cryptography, python-dateutil, qrcode
-sqlalchemy==1.2.0
+sqlalchemy==1.3.3
 typing==3.6.4
 webassets==0.12.1         # via flask-assets
 werkzeug==0.14.1

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -17,7 +17,7 @@ flask==1.0.2              # via flask-testing
 funcsigs==1.0.2           # via mock, pytest
 idna==2.8                 # via requests
 itsdangerous==0.24        # via flask
-jinja2==2.10              # via flask
+jinja2==2.10.1            # via flask
 markupsafe==1.0           # via jinja2
 mock==2.0.0
 pbr==3.1.1                # via mock

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1148,10 +1148,10 @@ def test_admin_add_user_integrity_error(journalist_app, test_admin, mocker):
     log_event = mocked_error_logger.call_args[0][0]
     if six.PY2:
         assert ("Adding user 'username' failed: (__builtin__.NoneType) "
-                "None [SQL: 'STATEMENT'] [parameters: 'PARAMETERS']") in log_event
+                "None\n[SQL: STATEMENT]\n[parameters: 'PARAMETERS']") in log_event
     else:
         assert ("Adding user 'username' failed: (builtins.NoneType) "
-                "None [SQL: 'STATEMENT'] [parameters: 'PARAMETERS']") in log_event
+                "None\n[SQL: STATEMENT]\n[parameters: 'PARAMETERS']") in log_event
 
 
 def test_logo_upload_with_valid_image_succeeds(journalist_app, test_admin):


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Closes #4345, Closes #4350, towards #4343 :

dev-requirements.txt cannot be updated yet due to molecule pinning version of Jinja2: https://github.com/ansible/molecule/blob/master/setup.cfg#L80
An upstream issue has been opened to track


## Testing

Minor version bumps and automated testing should have sufficient coverage

- [ ] Jinja2 was updated to 2.10.1 everywhere except in `develop-requirements.txt`: that will require updating the molecule dependency.
- [ ] Ansible was updated to 2.6.14 everywhere.
- [ ] SQLAlchemy was updated to 1.3.0 everywhere

## Deployment

- App dependencies will be brought in via securedrop-app-code package
- Admin dependencies via the GUI updater/securedrop-admin setup
- Dev dependencies should be installed via pip by developers

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
