### PR TITLE
[provisioning] cleanup now not needed trusty gettext install logic

### DIFF
--- a/install_files/ansible-base/roles/app-test/tasks/modern_gettext.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/modern_gettext.yml
@@ -1,29 +1,7 @@
 ---
-#
-# This can be removed when VM against which this is run are more
-# recent than trusty
-#
-- name: Add gettext xenial apt repository
-  apt_repository:
-    repo: deb http://archive.ubuntu.com/ubuntu/ xenial main
-    state: present
-    update_cache: yes
-  when: ansible_distribution_release != "xenial"
-  tags:
-    - apt
-
-- name: Install modern gettext
+- name: Install gettext
   apt:
     name: gettext
     state: latest
-  tags:
-    - apt
-
-- name: Remove gettext xenial apt repository
-  apt_repository:
-    repo: deb http://archive.ubuntu.com/ubuntu/ xenial main
-    state: absent
-    update_cache: yes
-  when: ansible_distribution_release != "xenial"
   tags:
     - apt


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3636 

Changes proposed in this pull request:
 - Remove logic needed on trusty only to install gettext from the xenial repos

## Testing

Does CI pass? Do you agree that the next release series based from `develop` is 0.13.0 and will be xenial only due to trusty EOL? ;) 

## Deployment

None, this was never used in prod (it's in the app-test role)

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

