### PR TITLE
Logout to revoke tokens

### DIFF
--- a/docs/development/journalist_api.rst
+++ b/docs/development/journalist_api.rst
@@ -56,11 +56,22 @@ HTTP Authorization header:
   Authorization: Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTUzMDU4NjU4MiwifWF0IjoxNTMwNTc5MzgyfQ.eyJpZCI6MX0.P_PfcLMk1Dq5VCIANo-lJbu0ZyCL2VcT8qf9fIZsTCM
 
 This header will be checked with each API request to see if it is valid and
-not yet expired. Tokens currently expire after 8 hours, but note that clients
-should use the expiration time provided in the response to determine when
-the token will expire. After the token expires point, users must
-login again. Clients implementing logout functionality should delete tokens
-locally upon logout.
+not yet expired. Tokens currently expire after 8 hours. 
+
+Logout
+------
+
+Clients should use the logout endpoint to invalidate their token:
+
+``POST /api/v1/logout`` with the token in the HTTP Authorization header
+and you will get the following response upon successful invalidation of the
+API token:
+
+.. code:: sh
+
+  {
+  "message": "Your token has been revoked."
+  }
 
 Errors
 ~~~~~~

--- a/securedrop/alembic/versions/b58139cfdc8c_add_checksum_columns_revoke_table.py
+++ b/securedrop/alembic/versions/b58139cfdc8c_add_checksum_columns_revoke_table.py
@@ -1,4 +1,4 @@
-"""add checksum columns
+"""add checksum columns and revoke token table
 
 Revision ID: b58139cfdc8c
 Revises: f2833ac34bb6
@@ -35,6 +35,16 @@ def upgrade():
 
     with op.batch_alter_table('submissions', schema=None) as batch_op:
         batch_op.add_column(sa.Column('checksum', sa.String(length=255), nullable=True))
+
+    op.create_table(
+        'revoked_tokens',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('journalist_id', sa.Integer(), nullable=True),
+        sa.Column('token', sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(['journalist_id'], ['journalists.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('token')
+    )
 
     try:
         app = create_app(config)
@@ -77,6 +87,8 @@ def upgrade():
 
 
 def downgrade():
+    op.drop_table('revoked_tokens')
+
     with op.batch_alter_table('submissions', schema=None) as batch_op:
         batch_op.drop_column('checksum')
 

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -18,7 +18,8 @@ from crypto_util import CryptoUtil
 from db import db
 from journalist_app import account, admin, api, main, col
 from journalist_app.utils import (get_source, logged_in,
-                                  JournalistInterfaceSessionInterface)
+                                  JournalistInterfaceSessionInterface,
+                                  cleanup_expired_revoked_tokens)
 from models import Journalist
 from store import Storage
 from worker import rq_worker_queue
@@ -123,6 +124,10 @@ def create_app(config):
     app.jinja_env.filters['rel_datetime_format'] = \
         template_filters.rel_datetime_format
     app.jinja_env.filters['filesizeformat'] = template_filters.filesizeformat
+
+    @app.before_first_request
+    def expire_blacklisted_tokens():
+        return cleanup_expired_revoked_tokens()
 
     @app.before_request
     def setup_g():

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -574,6 +574,11 @@ class Journalist(db.Model):
             data = s.loads(token)
         except BadData:
             return None
+
+        revoked_token = RevokedToken.query.filter_by(token=token).one_or_none()
+        if revoked_token is not None:
+            return None
+
         return Journalist.query.get(data['id'])
 
     def to_json(self):
@@ -598,3 +603,16 @@ class JournalistLoginAttempt(db.Model):
 
     def __init__(self, journalist):
         self.journalist_id = journalist.id
+
+
+class RevokedToken(db.Model):
+
+    """
+    API tokens that have been revoked either through a logout or other revocation mechanism.
+    """
+
+    __tablename__ = 'revoked_tokens'
+
+    id = Column(Integer, primary_key=True)
+    journalist_id = Column(Integer, ForeignKey('journalists.id'))
+    token = db.Column(db.Text, nullable=False, unique=True)

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -568,6 +568,16 @@ class Journalist(db.Model):
         return s.dumps({'id': self.id}).decode('ascii')
 
     @staticmethod
+    def validate_token_is_not_expired_or_invalid(token):
+        s = TimedJSONWebSignatureSerializer(current_app.config['SECRET_KEY'])
+        try:
+            s.loads(token)
+        except BadData:
+            return None
+
+        return True
+
+    @staticmethod
     def validate_api_token_and_get_user(token):
         s = TimedJSONWebSignatureSerializer(current_app.config['SECRET_KEY'])
         try:

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -25,6 +25,7 @@ from werkzeug.datastructures import Headers
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 from sdconfig import SDConfig
+from db import db
 import i18n
 import i18n_tool
 import journalist_app as journalist_app_module
@@ -217,6 +218,8 @@ def test_i18n(journalist_app, config):
     # grabs values at init time and we can't inject them later.
     for app in (journalist_app_module.create_app(fake_config),
                 source_app.create_app(fake_config)):
+        with app.app_context():
+            db.create_all()
         assert i18n.LOCALES == fake_config.SUPPORTED_LOCALES
         verify_i18n(app)
 

--- a/securedrop/tests/test_journalist_utils.py
+++ b/securedrop/tests/test_journalist_utils.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from flask import url_for
+import os
+import pytest
+import random
+
+from models import RevokedToken
+from sqlalchemy.orm.exc import NoResultFound
+
+from journalist_app.utils import cleanup_expired_revoked_tokens
+
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
+from .utils.api_helper import get_api_headers
+
+random.seed('◔ ⌣ ◔')
+
+
+def test_revoke_token_cleanup_does_not_delete_tokens_if_not_expired(journalist_app, test_journo,
+                                                                    journalist_api_token):
+    with journalist_app.test_client() as app:
+        resp = app.post(url_for('api.logout'), headers=get_api_headers(journalist_api_token))
+        assert resp.status_code == 200
+
+        cleanup_expired_revoked_tokens()
+
+        revoked_token = RevokedToken.query.filter_by(token=journalist_api_token).one()
+        assert revoked_token.journalist_id == test_journo['id']
+
+
+def test_revoke_token_cleanup_does_deletes_tokens_that_are_expired(journalist_app, test_journo,
+                                                                   journalist_api_token, mocker):
+    with journalist_app.test_client() as app:
+        resp = app.post(url_for('api.logout'), headers=get_api_headers(journalist_api_token))
+        assert resp.status_code == 200
+
+        # Mock response from expired token method when token is expired
+        mocker.patch('journalist_app.admin.Journalist.validate_token_is_not_expired_or_invalid',
+                     return_value=None)
+        cleanup_expired_revoked_tokens()
+
+        with pytest.raises(NoResultFound):
+            RevokedToken.query.filter_by(token=journalist_api_token).one()

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -5,6 +5,7 @@ import os
 from flask import session
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
+from db import db
 import i18n
 import i18n_tool
 import journalist_app
@@ -110,6 +111,8 @@ def do_test(config, create_app):
         pybabel('init', '-i', pot, '-d', config.TEMP_DIR, '-l', l)
 
     app = create_app(config)
+    with app.app_context():
+        db.create_all()
 
     assert i18n.LOCALES == config.SUPPORTED_LOCALES
     verify_filesizeformat(app)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3933

Added a `/logout` endpoint to the API. Added a `revoked_tokens` DB table.

## Test Plan

(edited by @redshiftzero)

### Preconditions

1. set `TOKEN_EXPIRATION_MINS` in `securedrop/journalist_app/api.py` to a smaller value, like  5 minutes or so.
2. replace `./manage.py run` with `bash` in `securedrop/bin/run` (this is so we can re-run the dev server manually to check the token cleanup works as expected with all the dev env setup in `securedrop/bin/run`)

### Testing

1. Run dev env with `make -C securedrop dev`
2. Start dev server with `./manage.py run`
3. Get a token with:

```
curl -X POST -H "Content-Type: application/json" --data '{"username":"journalist","passphrase":"correct horse battery staple profanity oil chewy","one_time_code":"875674"}' 127.0.0.1:8081/api/v1/token
```

4. Confirm you can revoke the token

```
$ curl -X POST -H "Content-Type: application/json" -H "Authorization: Token yourtokengoeshere" 127.0.0.1:8081/api/v1/logout

{
  "message": "Your token has been revoked."
}
```

5. Attempt to revoke the token once more to confirm that your token no longer works on the logout endpoint:

```
curl -X POST -H "Content-Type: application/json" -H "Authorization: Token yourtokengoeshere" 127.0.0.1:8081/api/v1/logout

{
  "error": "Forbidden",
  "message": "API token is invalid or expired."
}
```

6. Stop the server, and inspect the database:

```
$ sqlite3 /var/lib/securedrop/db.sqlite
select * from revoked_tokens;
```

Confirm that you see a single row in this database and that it contains your token expired.

7. _Provided it has been less than 5 minutes since you created that token_ restart the server and run once more with `./manage.py run`.

8. Confirm that you can still not use this token (this confirms it was not removed from the database incorrectly):

```
curl -X POST -H "Content-Type: application/json" -H "Authorization: Token yourtokengoeshere" 127.0.0.1:8081/api/v1/logout

{
  "error": "Forbidden",
  "message": "API token is invalid or expired."
}
```

9. Wait _until 5 minutes have passed_ from when you first created this token (since we set 5 minutes as the expiration time) and restart the server one last time. 

10. Confirm that the token is now gone from the revoked_tokens table in the database following the same steps as above:

```
$ sqlite3 /var/lib/securedrop/db.sqlite
select * from revoked_tokens;
```

(and for good measure if you like you can also verify that you still cannot use the token because it’s expired). 

## Deployment

Nothing special. Backwards compatible API change.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container