### PR TITLE
Update builder images

### DIFF
--- a/molecule/builder-trusty/image_hash
+++ b/molecule/builder-trusty/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2019_03_20
-a65d1c5d75849a9ceda5e42f742b37156f71babb336911ae70fc7bc8f2e2489f
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2019_04_16
+325e42af186f314fc752b41603fcc6ddc653a5d0d3a32be902c1bc07a9b19946

--- a/molecule/builder-xenial/image_hash
+++ b/molecule/builder-xenial/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2019_03_20
-63d2e4d1a5d9c03f8767a30710e7bcbfddd37db96389a81979756de1ec2795cd
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2019_04_16
+191edf6f5728af8f17c1aab0070ee38d10e00d100816185c316d2feacb343b48


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Updates xenial and trusty builder images with latest security updates.


## Testing

- Check out this branch locally
- [ ] `make build-debs` completes without error (all tests pass)
- [ ] `make build-debs` completes without error (all tests pass) when this commit is cherry-picked ontop of 0.12.1 (it will fail on develop due to cryptography library update)

## Deployment

Dev only

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
