### PR TITLE
Fix Dockerfiles, create-dev-data

### DIFF
--- a/securedrop/create-dev-data.py
+++ b/securedrop/create-dev-data.py
@@ -103,8 +103,8 @@ def create_source_and_submissions(num_submissions=2, num_replies=2):
     db.session.commit()
 
     print("Test source (codename: '{}', journalist designation '{}') "
-          "added with {} submissions and {} replies").format(
-              codename, journalist_designation, num_submissions, num_replies)
+          "added with {} submissions and {} replies".format(
+              codename, journalist_designation, num_submissions, num_replies))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/securedrop/dockerfiles/xenial/python2/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python2/Dockerfile
@@ -9,9 +9,8 @@ ENV USER_ID ${USER_ID:-0}
 RUN apt-get update && \
     apt-get install -y paxctl && \
     { apt-get install -y libgtk2.0 || echo 'libgtk2.0 was not installed'; } && \
-    paxctl -cm /usr/bin/mono-sgen && dpkg-reconfigure mono-runtime-sgen
-
-RUN apt-get install -y devscripts vim \
+    paxctl -cm /usr/bin/mono-sgen && dpkg-reconfigure mono-runtime-sgen && \
+    apt-get install -y devscripts vim \
                        python-pip libpython2.7-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
                        gettext paxctl x11vnc enchant libffi-dev sqlite3 gettext sudo

--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -8,9 +8,8 @@ ENV USER_ID ${USER_ID:-0}
 # If running grsecurity kernel on the host, Memprotect must be disabled on mono-sgen in the container
 RUN apt-get update && apt-get install -y paxctl && \
     { apt-get install -y libgtk2.0 || echo 'libgtk2.0 was not installed'; } && \
-    paxctl -cm /usr/bin/mono-sgen && dpkg-reconfigure mono-runtime-sgen
-
-RUN apt-get install -y devscripts \
+    paxctl -cm /usr/bin/mono-sgen && dpkg-reconfigure mono-runtime-sgen && \
+    apt-get install -y devscripts \
                        python3-pip libpython3.5-dev libssl-dev secure-delete \
                        gnupg2 ruby redis-server firefox git xvfb haveged curl \
                        gettext paxctl x11vnc enchant libffi-dev sqlite3 gettext sudo \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In the Dockerfiles, running `apt-install` in a separate `RUN` after `apt-update` could fail if the output of the `apt-update`'s `RUN` were cached; `apt-install` could be looking for outdated versions of packages.

In `create-dev-data.py`, fix a misplaced print/format parenthesis.

## Testing

Run `make -C securedrop dev` to build and run the Python 2 container.

Run `PYTHON_VERSION=3 make -C securedrop dev` to build and run the Python 3 container.

Both should get through image building/updating and end up running the SD services.

### If you made changes to the server application code:

- [x] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
