### PR TITLE
monkey patch gnupg._parsers.DeleteResult._handle_status

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -37,6 +37,23 @@ DICEWARE_SAFE_CHARS = (' !#%$&)(+*-1032547698;:=?@acbedgfihkjmlonqpsrutwvyxzA'
                        'BCDEFGHIJKLMNOPQRSTUVWXYZ')
 
 
+def monkey_patch_delete_handle_status(self, key, value):
+        """Parse a status code from the attached GnuPG process.
+        :raises: :exc:`~exceptions.ValueError` if the status message is unknown.
+        """
+        if key in ("DELETE_PROBLEM", "KEY_CONSIDERED"):
+            self.status = self.problem_reason.get(value, "Unknown error: %r"
+                                                  % value)
+        elif key in ("PINENTRY_LAUNCHED"):
+            self.status = key.replace("_", " ").lower()
+        else:
+            raise ValueError("Unknown status message: %r" % key)
+
+
+# Monkey patching to resolve https://github.com/freedomofpress/securedrop/issues/4294
+gnupg._parsers.DeleteResult._handle_status = monkey_patch_delete_handle_status
+
+
 class CryptoException(Exception):
     pass
 

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -268,6 +268,24 @@ def test_delete_reply_keypair(source_app, test_source):
     assert source_app.crypto_util.getkey(fid) is None
 
 
+def test_delete_reply_keypair_pinentry_status_is_handled(source_app, test_source,
+                                                         mocker, capsys):
+    """
+    Regression test for https://github.com/freedomofpress/securedrop/issues/4294
+    """
+    fid = test_source['filesystem_id']
+
+    # Patch private python-gnupg method to reproduce the issue in #4294
+    mocker.patch('pretty_bad_protocol._util._separate_keyword',
+                 return_value=('PINENTRY_LAUNCHED', 'does not matter'))
+
+    source_app.crypto_util.delete_reply_keypair(fid)
+
+    captured = capsys.readouterr()
+    assert "ValueError: Unknown status message: 'PINENTRY_LAUNCHED'" not in captured.err
+    assert source_app.crypto_util.getkey(fid) is None
+
+
 def test_delete_reply_keypair_no_key(source_app):
     """No exceptions should be raised when provided a filesystem id that
     does not exist.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4294.

Changes proposed in this pull request:
 - Monkey patch internal method to ensure that gpg's PINENTRY_LAUNCHED status does not raise a ValueError

## Testing

0. Delete a source
1. See no PINENTRY_LAUNCHED ValueError

## Deployment

app code only

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

