### PR TITLE
Clear Ansible SSH control path on reboot

### DIFF
--- a/install_files/ansible-base/ansible.cfg
+++ b/install_files/ansible-base/ansible.cfg
@@ -13,5 +13,5 @@ agnostic_become_prompt=False
 
 [ssh_connection]
 scp_if_ssh=True
-ssh_args = -o ControlMaster=auto -o ControlPersist=1200
+ssh_args = -o ControlMaster=auto -o ControlPersist=1200 -o ServerAliveInterval=10 -o ServerAliveCountMax=3
 pipelining=True


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

When rebooting the SecureDrop servers in `securedrop-admin install`, remove the local Ansible SSH control path directory, ensuring stale connections won't break later steps.

Fixes #4364.

## Testing

I was able to reliably induce a failure doing a clean installation of the release/0.12.2 branch. The installation should get an error like `Timeout (62s) waiting for privilege escalating prompt` at `Set sysctl flags for grsecurity`.

With this change in place, the installation should make it past that step.

## Deployment

This shouldn't affect the installed product; it only manipulates the filesystem on the admin workstation, reusing logic from `restart-tor-carefully.yml`.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
