### PR TITLE
Add pinentry-gtk-2 to Apache2 AppArmor profile

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -89,6 +89,7 @@
   /usr/bin/gpg-agent rix,
   /usr/bin/gpg2 rix,
   /usr/bin/pinentry-curses rix,
+  /usr/bin/pinentry-gtk-2 rix,
   /usr/bin/python2.7 r,
   /usr/bin/srm rix,
   /usr/lib/python2.7/uuid.py r,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4362.

Adds `/usr/bin/pinentry-gtk-2` to the Apache2 AppArmor profile, eliminating errors when deleting sources.

## Testing

The `pinentry-gtk2` package is installed on systems that have been upgraded from Ubuntu 14.04. On a clean install of 16.04, you may have to run `sudo apt install pinentry-gtk2` to ensure `/usr/bin/pinentry-gtk-2` is present on the system before you can reproduce the error in #4362.

Once it is, visit the journalist interface and delete a source. You should see the AppArmor error described in #4262. 

Then, check out the `fix-4362` branch and run `make build-debs`. Copy the resulting `securedrop-app-code_0.13.0~rc1+xenial_amd64.deb` to the app server and install it with `dpkg -i`.

Delete another source, and confirm that there is no AppArmor error in `/var/log/syslog`.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR