### PR TITLE
[docs] Clarified workstation hardware requirements

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -17,34 +17,50 @@ Technical Summary
 SecureDrop is a tool for sources to communicate securely with journalists. The
 SecureDrop application environment consists of three dedicated computers:
 
-- *Secure Viewing Station*: An air-gapped laptop running the
-   `Tails operating system`_ from a USB stick that journalists use to decrypt
-   and view submitted documents.
-- *Application Server*: Ubuntu server running two segmented Tor hidden
+- *Secure Viewing Station*: 
+   A physically-secured and air-gapped laptop running 
+   the `Tails operating system`_ from a USB stick, that journalists use to
+   decrypt and view submitted documents.
+- *Application Server*: 
+   An Ubuntu server running two segmented Tor hidden
    services. The source connects to the *Source Interface*, a public-facing Tor
    hidden service, to send messages and documents to the journalist. The
    journalist connects to the *Journalist Interface*, an `authenticated Tor
    hidden service
    <https://gitweb.torproject.org/torspec.git/tree/rend-spec-v2.txt#n851>`__, to
    download encrypted documents and respond to sources.
-- *Monitor Server*: Ubuntu server that monitors the *Application Server*
+- *Monitor Server*: 
+   An Ubuntu server that monitors the *Application Server*
    with `OSSEC <https://ossec.github.io/>`__ and sends email alerts.
 
-In addition to these dedicated computers, the journalist will also use their
-normal workstation computer:
-
-- *Journalist Workstation*: The every-day laptop that the journalist uses for
-   their work. The journalist will use this computer to connect to the
-   *Application Server* to download encrypted documents that they will
-   transfer to the *Secure Viewing Station*. The *Journalist Workstation*
-   is also used to respond to sources via the *Journalist Interface*.
-
-Depending on the news organization's threat model, it is recommended that
-journalists always use the `Tails operating system`_ on their
-*Journalist Workstation* when connecting to the *Application Server*.
-Alternatively, this can also be its own dedicated computer.
-
 These computers should all physically be in your organization's office.
+
+In addition to these dedicated computers, each journalist will also need a 
+computer to connect to SecureDrop:
+
+- *Journalist Workstation:*
+   The computer used by the journalist to connect to
+   the *Journalist Interface* to download encrypted documents that they will
+   transfer to the *Secure Viewing Station*. The *Journalist Workstation*
+   is also used to respond to sources via the *Journalist Interface*. 
+
+Depending on the news organization's threat model, the *Journalist Workstation*
+can either be the journalist's every-day laptop or a dedicated computer. In 
+either case, it is recommended that journalists always use the 
+`Tails operating system`_ on their *Journalist Workstation* when connecting
+to the *Journalist Interface*. 
+
+SecureDrop administrators will also require a computer to connect to SecureDrop
+and perform administrative tasks via SSH or the *Journalist Interface*.
+This computer is referred to as the *Admin Workstation*, and must be capable of 
+running the `Tails operating system`_. The *Admin Workstation* may also be used
+as a *Journalist Workstation* if necessary.
+
+.. note:: The SecureDrop installation guide includes documentation on setting up 
+          Tails-based `Admin Workstation` and `Journalist Workstation` USB 
+          sticks. It is strongly recommended that these be used in preference to
+          other undocumented solutions.
+
 
 .. _`Tails operating system`: https://tails.boum.org
 
@@ -72,9 +88,9 @@ Admins
 
 The SecureDrop servers are managed by a systems admin; for larger
 newsrooms, there may be a team of systems admins. The admin
-uses a dedicated *Admin Workstation* running `Tails <https://tails.boum.org>`__
-and connects to the *Application* and *Monitor Servers* over authenticated `Tor Hidden Services
-<https://www.torproject.org/docs/hidden-services.html>`__ and manages them
+uses a dedicated *Admin Workstation* running `Tails <https://tails.boum.org>`__,
+connects to the *Application* and *Monitor Servers* over authenticated `Tor Hidden Services
+<https://www.torproject.org/docs/hidden-services.html>`__, and manages them
 using `Ansible <http://www.ansible.com/>`__.
 
 Sources


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4307.

Updates overview documentation to clarify requirements for Journalist and Admin Workstations.

## Testing
Docs-only: review for clarity and correctness.

## Deployment
Deployed by standard process when merged into appropriate branch.

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
