### PR TITLE
[0.12.2] Add pinentry-gtk-2 to Apache2 AppArmor profile

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -89,6 +89,7 @@
   /usr/bin/gpg-agent rix,
   /usr/bin/gpg2 rix,
   /usr/bin/pinentry-curses rix,
+  /usr/bin/pinentry-gtk-2 rix,
   /usr/bin/python2.7 r,
   /usr/bin/srm rix,
   /usr/lib/python2.7/uuid.py r,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backports #4367 to 0.12.2 release branch.

## Testing

Ensure the changes are the same as #4367.
