### PR TITLE
[docs] Add 0.12.1->0.12.2 upgrade docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,6 +89,7 @@ anonymous sources.
    upgrade/xenial_prep.rst
    upgrade/xenial_upgrade_in_place.rst
    upgrade/xenial_backup_install_restore.rst
+   upgrade/0.12.1_to_0.12.2.rst
    upgrade/0.12.0_to_0.12.1.rst
    upgrade/0.11.1_to_0.12.0.rst
    upgrade/0.10.0_to_0.11.0.rst

--- a/docs/upgrade/0.12.1_to_0.12.2.rst
+++ b/docs/upgrade/0.12.1_to_0.12.2.rst
@@ -1,0 +1,67 @@
+Upgrade from 0.12.1 to 0.12.2
+=============================
+
+.. important:: If you installed SecureDrop before the release of SecureDrop
+  0.12.0 and have not upgraded to Ubuntu 16.04 yet, you must do so before
+  April 30, 2019. Please see :ref:`our detailed instructions <Ubuntu_Upgrade>`.
+
+Updating the Tails Workstations
+-------------------------------
+If you have not already done so, we recommend that you update all Tails drives
+to version 3.13.1, which was `released <https://tails.boum.org/news/version_3.13.1/index.en.html>`_
+on March 23, 2019. Follow the Tails graphical prompts on your workstations to
+perform this upgrade.
+
+On a subsequent boot of your SecureDrop *Journalist* and *Admin Workstations*,
+the *SecureDrop Workstation Updater* will alert you to workstation updates.
+Choose "Update Now" on each of the workstations:
+
+.. image:: ../images/0.6.x_to_0.7/securedrop-updater.png
+
+Please note that this only updates the SecureDrop code on your Tails
+workstations. Tails upgrades must be performed separately.
+
+If you don't see the graphical updater, or if the automated update fails, you
+can perform a manual update by running the following commands: ::
+
+    cd ~/Persistent/securedrop
+    git fetch --tags
+    gpg --recv-key "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
+    git tag -v 0.12.2
+
+.. note:: You may have to run the ``--recv-key`` command repeatedly for it to
+  work.
+
+The output should include the following two lines: ::
+
+    gpg:                using RSA key 22245C81E3BAEB4138B36061310F561200F4AD77
+    gpg: Good signature from "SecureDrop Release Signing Key"
+
+Please verify that each character of the fingerprint above matches what
+on the screen of your workstation. If it does, you can check out the
+new release: ::
+
+    git checkout 0.12.2
+
+.. important:: If you do see the warning "refname '0.12.2' is ambiguous" in the
+  output, we recommend that you contact us immediately at securedrop@freedom.press
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
+
+Finally, run the following commands: ::
+
+  ./securedrop-admin setup
+  ./securedrop-admin tailsconfig
+
+Getting Support
+---------------
+
+Should you require further support with your SecureDrop installation or the
+upgrade to Ubuntu 16.04, we are happy to help!
+
+- Community support is available at https://forum.securedrop.org
+- If you are already a member of our support portal, please don't hesitate to
+  open a ticket there. If you would like to request access, please contact us
+  at securedrop@freedom.press
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
+- The Freedom of the Press Foundation offers training and priority support
+  services. See https://securedrop.org/priority-support/ for more information.


### PR DESCRIPTION
Mainly standard workstation update docs in case the graphical
updater fails, and a reminder to upgrade to Ubuntu 16.04.

## Status

Ready for review 

## Checklist

- [x] Doc linting (`make docs-lint`) passed locally
