### PR TITLE
[docs] Add instructions for deleting ~/.ansible/cp to work around #4364

### DIFF
--- a/docs/includes/rerun-install-is-safe.txt
+++ b/docs/includes/rerun-install-is-safe.txt
@@ -3,3 +3,15 @@
           network connectivity to the servers), it is safe to run the
           ``./securedrop-admin install`` command again. If you see the same
           issue consistently, then you will need to troubleshoot it.
+
+          If you see the error message "timeout (62s) waiting for privilege
+          escalation prompt", try deleting the Ansible control path directory on
+          your *Admin Workstation* (``rm -rf ~/.ansible/cp``) to reset the
+          connection to the servers, then re-run the
+          ``./securedrop-admin install`` command from within
+          ``~/Persistent/securedrop``.
+
+          If you encounter other errors, we encourage you to
+          `submit a bug report <https://github.com/freedomofpress/securedrop/issues/new>`_,
+          or to contact us at securedrop@freedom.press
+          (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).

--- a/docs/upgrade/xenial_backup_install_restore.rst
+++ b/docs/upgrade/xenial_backup_install_restore.rst
@@ -205,8 +205,9 @@ using the following command:
  ./securedrop-admin install
 
 This command will take several minutes to complete, and will reboot the
-*Application* and *Monitor* servers as part of the process. If it fails, try
-running it again. If it fails repeatedly, :ref:`contact us. <bir_contact_us>`
+*Application* and *Monitor* servers as part of the process.
+
+.. include:: ../includes/rerun-install-is-safe.txt
 
 When the server installation completes successfully, you should set up the
 *Admin Workstation* to connect to the new servers over Tor. To do so, run the

--- a/docs/upgrade/xenial_upgrade_in_place.rst
+++ b/docs/upgrade/xenial_upgrade_in_place.rst
@@ -257,6 +257,8 @@ configuration:
 You will be prompted for the admin user's passphrase on the servers. Type it in
 and press Enter.
 
+.. include:: ../includes/rerun-install-is-safe.txt
+
 Step 4: Validate the Instance
 -----------------------------
 


### PR DESCRIPTION
These instructions should be removed once #4364 is reliably
resolved.

## Status

Ready for review

## Checklist

- [x] Doc linting (`make docs-lint`) passed locally
