### PR TITLE
Update builder hashes

### DIFF
--- a/molecule/builder-trusty/image_hash
+++ b/molecule/builder-trusty/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder:2019_04_16
-325e42af186f314fc752b41603fcc6ddc653a5d0d3a32be902c1bc07a9b19946
+# sha256 digest quay.io/freedomofpress/sd-docker-builder:2019_04_25
+b35899255e952ae23c22b04bb89e03fbc40494baa0942c1ca4ac927567a64569

--- a/molecule/builder-xenial/image_hash
+++ b/molecule/builder-xenial/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2019_04_16
-191edf6f5728af8f17c1aab0070ee38d10e00d100816185c316d2feacb343b48
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2019_04_25
+79d8b8c8068f486eb914ff8340beaa4d1f17782a16cf00f0d63b4eb021379a66


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Towards #4338

Updates builder images with latest security updates.

## Testing

- [ ] `make build-debs` should not return an error, all tests should pass.
- Due to Trusty support being dropped after 0.12.x series, `make build-debs` trusty unfortunately will no longer work in develop.

## Deployment

Dev only

## Checklist

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR
