### PR TITLE
Run deb tests when updating builder image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,6 +322,15 @@ jobs:
       - store_artifacts:
           path: ~/sd/junit
 
+  deb-tests:
+    docker:
+      - image: gcr.io/cloud-builders/docker
+    steps:
+      - run: apt-get install -y make virtualenv python-pip
+      - checkout
+      - setup_remote_docker
+      - run: make ci-deb-tests
+
 workflows:
   version: 2
   securedrop_ci:
@@ -376,6 +385,11 @@ workflows:
             branches:
               only:
                 - /i18n-.*/
+      - deb-tests:
+          filters:
+            branches:
+              only:
+                - /update-builder-.*/
 
   nightly:
     triggers:

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ ci-teardown: ## Destroys GCE host for testing staging environment.
 ci-lint: ## Runs linting in linting container.
 	devops/scripts/dev-shell-ci run make --keep-going lint typelint
 
+.PHONY: ci-deb-tests
+ci-deb-tests: ## Runs deb tests in ci
+	@./devops/scripts/test-built-packages.sh
+
 .PHONY: install-mypy
 install-mypy: ## pip install mypy in a dedicated python3 virtualenv
 	if [[ ! -d .python3/.venv ]] ; then \

--- a/devops/scripts/test-built-packages.sh
+++ b/devops/scripts/test-built-packages.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# shellcheck disable=SC2209
+#
+# Wrapper around debian build logic to bootstrap virtualenv
+
+set -e
+set -u
+set -o pipefail
+
+. ./devops/scripts/boot-strap-venv.sh
+
+virtualenv_bootstrap
+
+make build-debs

--- a/docs/development/dockerbuildmaint.rst
+++ b/docs/development/dockerbuildmaint.rst
@@ -41,4 +41,4 @@ You can now test the container by going back to the SecureDrop repository root:
     cd ../..
     make build-debs
 
-Assuming no errors here, commit the changes in ``molecule/builder/image_hash``.
+Assuming no errors here, commit the changes in ``molecule/builder/image_hash`` in a branch containing the prefix ``update-builder-``.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

When updating builder images, we should run the deb tests as part of the CI suite. As a SecureDrop maintainer, validating that the builder images are functional is time consuming.

## Testing

- [ ] Observe failed build (https://circleci.com/gh/freedomofpress/securedrop/26436) due to old builder image.
- [ ] Rebased on latest develop, this is passing because builder images were updated yesterday in #4382
- [ ] Circle CI conditional branch logic is correct

## Deployment

Dev-only

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR


