### PR TITLE
bugfix 4361: resolve KeyError on codename session bug

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -67,6 +67,13 @@ def make_blueprint(config):
 
             # Issue 2386: don't log in on duplicates
             del session['codename']
+
+            # Issue 4361: Delete 'logged_in' if it's in the session
+            try:
+                del session['logged_in']
+            except KeyError:
+                pass
+
             abort(500)
         else:
             os.mkdir(current_app.storage.path(filesystem_id))

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -146,7 +146,31 @@ def test_generate_too_long_codename(source_app):
     )
 
 
-def test_create_duplicate_codename(source_app):
+def test_create_duplicate_codename_logged_in_not_in_session(source_app):
+    with patch.object(source.app.logger, 'error') as logger:
+        with source_app.test_client() as app:
+            resp = app.get(url_for('main.generate'))
+            assert resp.status_code == 200
+
+            # Create a source the first time
+            resp = app.post(url_for('main.create'), follow_redirects=True)
+            assert resp.status_code == 200
+            codename = session['codename']
+
+        with source_app.test_client() as app:
+            # Attempt to add the same source
+            with app.session_transaction() as sess:
+                sess['codename'] = codename
+            resp = app.post(url_for('main.create'), follow_redirects=True)
+            logger.assert_called_once()
+            assert ("Attempt to create a source with duplicate codename"
+                    in logger.call_args[0][0])
+            assert resp.status_code == 500
+            assert 'codename' not in session
+            assert 'logged_in' not in session
+
+
+def test_create_duplicate_codename_logged_in_in_session(source_app):
     with patch.object(source.app.logger, 'error') as logger:
         with source_app.test_client() as app:
             resp = app.get(url_for('main.generate'))
@@ -157,11 +181,16 @@ def test_create_duplicate_codename(source_app):
             assert resp.status_code == 200
 
             # Attempt to add the same source
-            app.post(url_for('main.create'), follow_redirects=True)
+            resp = app.post(url_for('main.create'), follow_redirects=True)
             logger.assert_called_once()
             assert ("Attempt to create a source with duplicate codename"
                     in logger.call_args[0][0])
+            assert resp.status_code == 500
             assert 'codename' not in session
+
+            # Reproducer for bug #4361
+            resp = app.post(url_for('main.index'), follow_redirects=True)
+            assert 'logged_in' not in session
 
 
 def test_lookup(source_app):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4361

Changes proposed in this pull request:
 - The situation in #4361 arises when `logged_in` is in the session, but the `codename` is not. This scenario can happen in cases where the logic preventing the creation of duplicate sources is triggered, for example:

1. User goes to `/generate` endpoint in tab A
2. User opens link to `/create` in tab B, logging the user in
3. User goes back to tab A, continues trying to log in. Duplicate sources logic is trigged, `codename` is removed from the session, but `logged_in` is not. 

The solution here is to prevent there from being a scenario where `logged_in` is in the `session` but `codename` is not. This case where the duplicate sources logic is triggered is the only situation I am aware of in the app code where this can occur (all other places we del both the `codename` and `logged_in` from the `session`). 

## Testing

- [ ] Follow STR in ticket in #4361, ensure that you no longer get the `KeyError`

- [ ] Cherry pick just the unit tests in this PR onto `develop`, you will observe the traceback in #4361 from one of the tests (`test_create_duplicate_codename_logged_in_in_session`)

## Deployment

No special considerations, app code only

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR
