### PR TITLE
Add instructions for SecureDrop upgrades to Ubuntu 16.04 after EOL

### DIFF
--- a/docs/includes/trusty-warning.txt
+++ b/docs/includes/trusty-warning.txt
@@ -1,0 +1,6 @@
+.. warning:: Ubuntu 14.04 has reached End-of-Life on **May 1, 2019** and will
+  no longer receive security updates. If you are still running Ubuntu 14.04
+  on your SecureDrop servers, due to the increased risk of a server compromise,
+  we do not recommend following the procedure outlined below. Instead, we
+  recommend saving your existing submissions on your *Secure Viewing Station*,
+  and re-installing SecureDrop: :doc:`../upgrade/xenial_after_april_30`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ anonymous sources.
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/xenial_after_april_30.rst
    upgrade/xenial_prep.rst
    upgrade/xenial_upgrade_in_place.rst
    upgrade/xenial_backup_install_restore.rst

--- a/docs/upgrade/xenial_after_april_30.rst
+++ b/docs/upgrade/xenial_after_april_30.rst
@@ -1,0 +1,55 @@
+Upgrading to Ubuntu 16.04 After April 30
+========================================
+As of **May 1, 2019**, Ubuntu 14.04 has reached End of Life. If you are still
+running Ubuntu 14.04 on your *Application* and *Monitor Server*, your servers
+will no longer receive security updates for operating system packages, the
+kernel, or SecureDrop itself.
+
+That means that a sufficiently severe vulnerability discovered in any of those
+components may permit an adversary to compromise SecureDrop servers running
+Ubuntu 14.04.
+
+For this reason, starting May 1, we recommend a reinstall on Ubuntu 16.04
+for any SecureDrop still on Ubuntu 14.04. See our
+:doc:`installation guide <../install>`.
+
+This will result in a new ``.onion`` address for your *Source Interface* and your
+*Journalist Interface*. You will need to create new user accounts and USB drives
+for administrators and journalists, and sources you are currently in touch with
+will no longer be able to log in using their codename. We recommend notifying
+your sources about this change on your *Landing Page*.
+
+Unless you have reason to believe that the *Submission Key* may have been
+compromised, you do **not** need to reinstall the *Secure Viewing Station*.
+Instead, during this part of the installation process, use a copy of your
+public key obtained from your *Secure Viewing Station*.
+
+Saving old submissions
+----------------------
+If you require access to old submissions to your SecureDrop, you need to save
+them securely. We do not recommend using the standard backup procedure via
+``securedrop-admin backup``, as restoring such a backup will reinstate secrets
+and credentials that may have been compromised.
+
+Instead, download any submissions you have not already downloaded to
+your *Secure Viewing Station* following the standard process as described in the
+:doc:`Journalist Guide <../journalist>`. If you do not reinstall the *Secure
+Viewing Station*, you will be able to continue to view these submissions on the
+*Secure Viewing Station* as before, but you will no longer be able to reply to
+the sources that sent them, until they create a new account.
+
+.. caution:: If you do reinstall your *Secure Viewing Station*, you **must** copy
+  the public and private *Submission Key* from the old *Secure Viewing Station*
+  to the new one. Without the keypair, you will not be able to decrypt old
+  submissions on a new *Secure Viewing  Station*.
+
+Contact us
+----------
+If you have questions or comments regarding this process, please don't hesitate
+to reach out:
+
+ - via our `Support Portal <https://support.freedom.press>`_, if you are a
+   member (membership is approved on a case-by-case basis);
+ - via securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__)
+   for sensitive security issues (please use judiciously);
+ - via our `community forums <https://forum.securedrop.org>`_.

--- a/docs/upgrade/xenial_backup_install_restore.rst
+++ b/docs/upgrade/xenial_backup_install_restore.rst
@@ -1,3 +1,5 @@
+.. include:: ../includes/trusty-warning.txt
+
 Ubuntu 16.04 LTS (Xenial) -  Back Up, Install, Restore
 ======================================================
 

--- a/docs/upgrade/xenial_prep.rst
+++ b/docs/upgrade/xenial_prep.rst
@@ -1,6 +1,8 @@
 Ubuntu 16.04 LTS (Xenial) migration - Preparatory steps
 =======================================================
 
+.. include:: ../includes/trusty-warning.txt
+
 On 30 April 2019, Ubuntu 14.04 LTS (Trusty) will reach End of Life. After this
 date, no new security updates to the base operating system will be provided. It
 is therefore of critical importance for the security of all SecureDrop instances

--- a/docs/upgrade/xenial_upgrade_in_place.rst
+++ b/docs/upgrade/xenial_upgrade_in_place.rst
@@ -1,3 +1,5 @@
+.. include:: ../includes/trusty-warning.txt
+
 Ubuntu 16.04 LTS (Xenial) - Upgrading in Place
 ==============================================
 


### PR DESCRIPTION
## Status

Ready for review

Towards #4322 

## Testing

As described here, these instructions are pretty high level; if we want to explain in greater detail, e.g., how to copy keys around, then that'll require more testing. As it is, verifying whether everything is conceptually correct should be sufficient.

## Checklist

- [x] Doc linting (`make docs-lint`) passed locally
