### PR TITLE
[docs] Add instructions to backup and restore workstation USBs using rsync

### DIFF
--- a/docs/backup_workstations.rst
+++ b/docs/backup_workstations.rst
@@ -1,7 +1,10 @@
+Backing Up and Restoring Workstations
+=====================================
+
 .. _backup_workstations:
 
 Backup the Workstations
-=======================
+-----------------------
 
 .. note::  This workflow will create a single USB drive with the data backed up
  from all Tails drives. If instead you'd like to create a single duplicate
@@ -16,7 +19,7 @@ unexpected may happen.
 In all these cases, it is useful to have a backup of your data for each device.
 
 What You Need
--------------
+~~~~~~~~~~~~~
 
   #. You will need your *existing SecureDrop Tails USB sticks* (*Admin
      Workstation*, *Journalist Workstation*, and *Secure Viewing Station*).
@@ -44,7 +47,7 @@ hub which may reduce transfer speeds.
  your organization.
 
 Preparing the Backup Device
----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First you must boot the *primary Tails USB* drive. Ensure you set an administrator
 password set at the login screen. Then navigate to **Applications** ▸ **Utilities** ▸ **Disks**.
@@ -94,17 +97,14 @@ when you :ref:`created your Tails devices <set_up_tails>`.
 You should now have both the Backup and TailsData partition to be backed up
 mounted and ready to access.
 
+Create the backup using Rsync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 |Backup and TailsData Mounted|
 
-Open a terminal with administrative privileges by going to
-**Applications** ▸ **System Tools** ▸ **Root Terminal**.
+Open a terminal by going to
+**Applications** ▸ **Favorites** ▸ **Terminal**.
 
-|Root Terminal|
-
-.. note::
- If you can't find the "Root Terminal" window, it might be because an
- administrator passphrase wasn't set when you logged in to Tails. If
- that's the case, you'll need to restart Tails and set one at the login screen.
 
 Next, create a directory on the Backup USB for the device to be backed up - the
 command below creates a directory named ``admin-backup``:
@@ -118,16 +118,94 @@ Then, copy the contents of the device's persistent volume to the directory using
 
 .. code:: sh
 
-  rsync -a --info=progress2 --no-specials --no-devices \
-      /media/amnesia/TailsData/ /media/amnesia/Backup/admin-backup
+  sudo bash -c "rsync -a --info=progress2 --no-specials --no-devices \
+      /media/amnesia/TailsData/ /media/amnesia/Backup/admin-backup/ && sync"
 
-Once complete, unmount the TailsData partition.
+
+.. note:: Please make sure to include the trailing ``/`` in the directory
+          paths in the command above, otherwise the files will not 
+          be backed up correctly.
+
+Once complete, unmount the TailsData partition by clicking the Eject button 
+beside its entry in the lefthand column of the file manager. When its entry is 
+no longer shown in the lefthand column, it is save to remove the 
+*Admin Workstation* USB.
 
 Repeat these steps for every device, making a new folder on the backup device
 for each device you back up.
 
 Finally, once you have completed the steps described in this section for each
-USB drive, unmount the Backup partition and store the drive somewhere safely.
+USB drive, unmount the Backup partition by clicking its Eject button. Wait until
+the Backup USB can be safely removed, and store it somewhere safely.
+
+.. note:: After the Eject button is clicked, it may be take some time before 
+          the drive can be safely removed. Wait until its entry  is removed from
+          the lefthand column of the file manager.
+
+.. _restore_workstations:
+
+Restoring a Workstation from a Backup
+-------------------------------------
+
+To recreate a backed-up *Admin Workstation*, *Journalist Workstation*, or 
+*Secure Viewing Station* Tails USB,  you will need 
+
+- your Backup USB containing the persistent volume to be restored,
+- a blank USB stick to be set up as the new workstation USB,  
+- an airgapped machine and a USB with Tails already installed, referred to as 
+  the host Tails USB in this document. The host Tails USB is only used to 
+  transfer files between the Backup USB and the new workstation USB.
+
+The process will require 3 USB ports - if necessary, you can use a USB hub. We
+recommend labeling USB devices before use, as it can be easy to confuse them.
+
+Prepare the new Tails USB
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Follow the guide to :ref:`creating a Tails USB <set_up_tails>` to install
+Tails and create a persistent volume on the blank USB stick to create the new 
+workstation USB.
+
+ 
+Open the Backup USB and new Tails Persistent Volume
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First, boot up the host Tails USB on the airgapped machine, making sure to set
+an administration password on the Tails Greeter dialog.
+
+Then, navigate to **Places** ▸ **Computer** to open the file manager, and insert
+the Backup USB. Click its entry in the lefthand column and enter its decryption
+passphrase when prompted. Its volume name (``Backup`` in the instructions above)
+will appear in place of the generic ``N.M GB Encrypted`` name.
+
+Next, insert the new workstation USB, and click its entry in the lefhand column. When
+prompted, enter its persistent volume's passphrase. The volume name ``TailsData``
+will appear in the lefthand column.
+
+Copy the Backup to the New Workstation USB's Persistent Volume
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Open a terminal by navigating to **Applications** ▸ **Favorites** 
+▸ **Terminal** . Next, use the ``rsync`` command to copy the appropriate backup
+folder to the new workstation USB's persistent volume. For example, if the backup
+folder to be copied is named ``admin-backup``, run the following command:
+
+.. code:: sh
+ 
+  sudo bash -c "rsync -a --info=progress2 --no-specials --no-devices \
+      /media/amnesia/Backup/admin-backup/ /media/amnesia/TailsData/ && sync"
+
+.. note:: Please make sure to include the trailing ``/`` in the directory
+          paths in the command above, otherwise the backup files will not 
+          be restored correctly.
+
+Once the command is complete, click the Eject button for the ``TailsData`` volume
+in the lefthand column of the file manager, wait for the ``TailsData`` entry to
+disappear from the column, and remove the new workstation USB.
+
+You may now repeat the restore process for any other USBs that you wish to 
+restore, or shut down the host Tails USB and test your new workstation USB by 
+booting it with persistence unlocked and verifying its functionality.
 
 .. |Browse to Places Computer| image:: images/upgrade_to_tails_3x/browse_to_places_computer.png
 .. |Click Cogs| image:: images/upgrade_to_tails_3x/click_the_button_with_cogs.png
@@ -137,6 +215,5 @@ USB drive, unmount the Backup partition and store the drive somewhere safely.
 .. |Make Folders for All Drives| image:: images/upgrade_to_tails_3x/make_folders_for_all_drives.png
 .. |Backup and TailsData Mounted| image:: images/upgrade_to_tails_3x/backup_and_tailsdata_mounted.png
 .. |Applications Utilities Disks| image:: images/upgrade_to_tails_3x/navigate_to_applications.png
-.. |Root Terminal| image:: images/screenshots/root_terminal.png
 .. |Select the Disk| image:: images/upgrade_to_tails_3x/select_the_disk.png
 .. |Two Partitions Appear| image:: images/upgrade_to_tails_3x/two_partitions_appear.png


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #4397 .

Changes proposed in this pull request: Docs changes to workstation backup instructions, to switch from manual drag-and-drop to `rsync` and include a section on restoring from a backup.
 
## Testing
Docs-only PR:
 
- work through the documented process and verify that it produces a working Workstation USB
- review for clarity and correctness

## Deployment
Will be deployed by standard docs build once merged.

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
