### PR TITLE
type hinting: securedrop/rm.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ install-mypy: ## pip install mypy in a dedicated python3 virtualenv
 .PHONY: typelint
 typelint: install-mypy ## Runs type linting
 	.python3/.venv/bin/mypy ./securedrop ./admin
+	.python3/.venv/bin/mypy --disallow-incomplete-defs --disallow-untyped-defs ./securedrop/rm.py
 
 .PHONY: ansible-config-lint
 ansible-config-lint: ## Runs custom Ansible env linting tasks.

--- a/securedrop/rm.py
+++ b/securedrop/rm.py
@@ -20,6 +20,7 @@ import subprocess
 
 
 def srm(fn):
+    # type: (str) -> str
     subprocess.check_call(['srm', '-r', fn])
     # We need to return a non-`None` value so the rq worker writes this back to Redis
     return "success"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Example PR towards #4399: Adds type annotations in a new file, adds that file to a new mypy call such that missing annotations in that file will fail CI

## Test Plan

- [ ] Are the annotations accurate for the function in question?  
- [ ] `make typelint` exits zero