### PR TITLE
Rename 'Terminology' section to 'Glossary'

### DIFF
--- a/docs/before_you_begin.rst
+++ b/docs/before_you_begin.rst
@@ -2,7 +2,7 @@ Before You Begin
 ================
 
 Before you get started, read the :doc:`Overview <overview>` and familiarize
-yourself with the :doc:`terminology<terminology>` and the :doc:`passphrases
+yourself with the :doc:`glossary<glossary>` and the :doc:`passphrases
 <passphrases>` involved in SecureDrop's operations. You may wish to leave these
 documents open in other tabs for reference as you work.
 

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -95,14 +95,14 @@ Line Wrapping
 Lines in the plain-text documentation files should wrap at 80 characters. (Some
 exceptions: complex code blocks showing example commands, or long URLs.)
 
-Terminology
-^^^^^^^^^^^
+Glossary
+^^^^^^^^
 
 Text taken directly from a user interface is in **bold face**.
 
     "Once you’re sure you have the right drive, click **Format Drive**."
 
-SecureDrop-specific :doc:`terminology <../terminology>` is in *italics*.
+SecureDrop-specific :doc:`glossary <../glossary>` is in *italics*.
 
     "To get started, you’ll need two Tails drives: one for the *Admin
     Workstation* and one for the *Secure Viewing Station*."

--- a/docs/development/l10n.rst
+++ b/docs/development/l10n.rst
@@ -162,7 +162,7 @@ and comment if they disagree.
 Glossary
 --------
 
-A :doc:`glossary <../terminology>` is available, explaining terms specific
+A :doc:`glossary <../glossary>` is available, explaining terms specific
 to SecureDrop. It is also important that key
 terms are understood and precisely translated.
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,5 +1,5 @@
-Terminology
-===========
+Glossary
+========
 
 A number of terms used in this guide, and in the `SecureDrop workflow
 diagram <https://docs.securedrop.org/en/latest/overview.html#infrastructure>`__,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ anonymous sources.
    :maxdepth: 2
 
    overview
-   terminology
+   glossary
    passphrases
    hardware
    before_you_begin

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -116,10 +116,10 @@ published, decrypted documents are never accessed on an Internet-connected
 computer.
 
 .. note:: The terms in italics are terms of art specific to SecureDrop. The
-	  :doc:`Terminology Guide <terminology>` provides more-precise
+	  :doc:`Glossary <glossary>` provides more-precise
           definitions of these and other terms. SecureDrop is designed against
           a comprehensive :doc:`threat_model/threat_model`, and has a specific
-          notion of the :doc:`roles <terminology>` that are involved in its
+          notion of the :doc:`roles <glossary>` that are involved in its
           operation.
 
 Operation


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4083 

Changes proposed in this pull request: Rename 'Terminology' section of docs to 'Glossary' for clarily


## Testing

How should the reviewer test this PR? Run the docs locally
Write out any special testing steps here. Click on glossary-related links

## Deployment

Docs-only change

## Checklist

### If you made changes to documentation:

- [X] Doc linting (`make docs-lint`) passed locally
