### PR TITLE
Use updated links from Tails website

### DIFF
--- a/docs/tails_guide.rst
+++ b/docs/tails_guide.rst
@@ -35,13 +35,11 @@ The `Tails website <https://tails.boum.org/>`__ has detailed and up-to-date
 instructions on how to download and verify Tails, and how to create a Tails USB
 stick. Here are some links to help you out:
 
--  `Download and verify the Tails .iso`_
--  `Install onto a USB stick or SD card`_
+-  `Download and verify the Tails .iso and install onto a USB stick or SD card`_
 -  `Create & configure the persistent volume`_
 
-.. _`Download and verify the Tails .iso`: https://tails.boum.org/download/index.en.html
-.. _`Install onto a USB stick or SD card`: https://tails.boum.org/doc/first_steps/installation/index.en.html
-.. _`Create & configure the persistent volume`: https://tails.boum.org/doc/first_steps/persistence/configure/index.en.html
+.. _`Download and verify the Tails .iso and install onto a USB stick or SD card`: https://tails.boum.org/install/index.en.html
+.. _`Create & configure the persistent volume`: https://tails.boum.org/install/linux/usb/index.en.html#create-persistence
 
 Note for macOS Users Manually Installing Tails
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#4403
I left the later link about persistence which describes the things you can enable.
In the list, I used the new link which gives clear, pretty instructions
`Download and verify the Tails .iso and install onto a USB stick or SD card` isn't showing up as a link in the preview, and I don't know why.

## Status

Ready for review / Work in progress

## Description of Changes

Fixes #.

Changes proposed in this pull request:

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
