### PR TITLE
Add in hypothesis support and example hypothesis test on encrypt/decrypt functionality in test_crypto_utils.py.

### DIFF
--- a/securedrop/requirements/test-requirements.in
+++ b/securedrop/requirements/test-requirements.in
@@ -9,3 +9,4 @@ pytest-cov
 pytest-mock
 requests
 selenium < 3
+hypothesis

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -4,17 +4,19 @@
 #
 #    pip-compile --output-file securedrop/requirements/test-requirements.txt securedrop/requirements/test-requirements.in
 #
-attrs==17.4.0             # via pytest
+attrs==17.4.0             # via hypothesis, pytest
 beautifulsoup4==4.6.0
 blinker==1.4
 certifi==2018.11.29       # via requests
 chardet==3.0.4            # via requests
 click==6.7                # via flask, pip-tools
 coverage==4.4.2           # via pytest-cov
+enum34==1.1.6             # via hypothesis
 first==2.0.1              # via pip-tools
 flask-testing==0.7.1
 flask==1.0.2              # via flask-testing
 funcsigs==1.0.2           # via mock, pytest
+hypothesis==4.22.2
 idna==2.8                 # via requests
 itsdangerous==0.24        # via flask
 jinja2==2.10.1            # via flask

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import pretty_bad_protocol as gnupg
 import logging
+from hypothesis import settings
 import os
 import io
 import json
@@ -43,6 +44,11 @@ valid_levels = {'INFO': logging.INFO, 'DEBUG': logging.DEBUG}
 gnupg_logger.setLevel(
    valid_levels.get(os.environ.get('GNUPG_LOG_LEVEL', ""), logging.ERROR)
 )
+
+# `hypothesis` sets a default deadline of 200 milliseconds before failing tests,
+# which doesn't work for integration tests. Turn off deadlines.
+settings.register_profile("securedrop", deadline=None)
+settings.load_profile("securedrop")
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Initial deployment of hypothesis (property-based testing framework), and initial test case added into cryptography utilities.

Changes proposed in this pull request:

## Testing

Run `make test` on all distros/arch; it should work.

## Deployment

Need to upgrade development environments in order to install updated packages.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container
