### PR TITLE
Adds admin-viewable-only internal Flask and SecureDrop metrics

### DIFF
--- a/securedrop/journalist_app/metrics.py
+++ b/securedrop/journalist_app/metrics.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+from flask import Blueprint, Response
+from models import Journalist, JournalistLoginAttempt, Reply, Source, Submission
+from journalist_app.decorators import admin_required
+from prometheus_client import Gauge, generate_latest, CONTENT_TYPE_LATEST
+
+SECUREDROP_USERS = Gauge(
+    "securedrop_users",
+    "Number of journalists who can access SecureDrop and their details",
+    labelnames=["username", "user_id", "created", "last"],
+)
+
+SECUREDROP_SUBMISSIONS = Gauge(
+    "securedrop_submissions",
+    "Number of submissions, from which source, their size in bytes, whether they've been read",
+    labelnames=["size_bytes", "downloaded", "author"],
+)
+
+SECUREDROP_REPLIES = Gauge(
+    "securedrop_replies", "Number of replies from journalists to sources"
+)
+
+SECUREDROP_SOURCES = Gauge(
+    "securedrop_sources",
+    "Number of sources who have made submissions, whether they're flagged, number of interactions and when they last logged in",
+    labelnames=["designation", "flagged", "last", "interactions"],
+)
+
+SECUREDROP_LOGINS = Gauge(
+    "securedrop_logins",
+    "Number of login attempts (both failed and successful) to the journalist interface, with timestamp and username+id",
+    labelnames=["when", "user_id", "username"],
+)
+
+
+def make_blueprint(config):
+    view = Blueprint("metrics", __name__)
+
+    @view.route("/", methods=["GET"])
+    @admin_required
+    def index():
+        users = Journalist.query.all()
+        submissions = Submission.query.all()
+        replies = Reply.query.all()
+        sources = Source.query.all()
+        logins = JournalistLoginAttempt.query.all()
+        for user in users:
+            SECUREDROP_USERS.labels(
+                username=user.username,
+                user_id=user.id,
+                created=user.created_on,
+                last=user.last_access,
+            ).set(len(users))
+        for submission in submissions:
+            source = Source.query.filter_by(id=submission.source_id).one()
+            SECUREDROP_SUBMISSIONS.labels(
+                size_bytes=submission.size,
+                downloaded=bool(submission.downloaded),
+                author=source.journalist_designation,
+            ).set(len(submissions))
+        SECUREDROP_REPLIES.set(len(replies))
+        for source in sources:
+            SECUREDROP_SOURCES.labels(
+                designation=source.journalist_designation,
+                flagged=bool(source.flagged),
+                last=source.last_updated,
+                interactions=source.interaction_count,
+            ).set(len(sources))
+        for login in logins:
+            journalist = Journalist.query.filter_by(id=login.id).one_or_none()
+            SECUREDROP_LOGINS.labels(
+                when=login.timestamp, user_id=login.id, username=journalist.username
+            ).set(len(logins))
+
+        return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
+
+    return view

--- a/securedrop/journalist_templates/admin.html
+++ b/securedrop/journalist_templates/admin.html
@@ -46,6 +46,10 @@
 
 <a href="{{ url_for('admin.manage_config') }}" class="btn sd-button" id="update-instance-config">
   <i class="fas fa-pencil-alt"></i>{{ gettext('INSTANCE CONFIG') }}
+</a> &nbsp; &nbsp; &nbsp; &nbsp;
+
+<a href="{{ url_for('metrics.index') }}" class="btn sd-button" id="view-metrics">
+  <i class="fas fa-chart-bar"></i>{{ gettext('METRICS') }}
 </a>
 
 <hr class="no-line">

--- a/securedrop/requirements/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/securedrop-app-code-requirements.in
@@ -10,6 +10,8 @@ Jinja2>=2.10.1
 jsmin
 passlib
 pretty-bad-protocol>=3.1.1
+prometheus_client
+prometheus-flask-exporter
 psutil
 pyotp
 qrcode

--- a/securedrop/requirements/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/securedrop-app-code-requirements.txt
@@ -25,6 +25,8 @@ mako==1.0.7               # via alembic
 markupsafe==1.0           # via jinja2, mako
 passlib==1.7.1
 pretty-bad-protocol==3.1.1
+prometheus_client==0.6.0
+prometheus-flask-exporter==0.7.2
 psutil==5.4.3
 pycparser==2.18           # via cffi
 pyotp==2.2.6


### PR DESCRIPTION
Internal metrics! Somewhat related to #4411, but instruments the SecureDrop web application with its own exporter that can help admins and developers get a sense of general activity as well as the performance via response times, frequency of requests for specific static assets, and the appearance of any HTTP errors on Flask views/routes/endpoints.

Affects the journalist interface only, it would not be good thinking to implement this in the source app; there's no reason.

Two new Python libraries are required: prometheus_client and prometheus_flask_exporter. For more info, please see:
- https://github.com/prometheus/client_python
- https://github.com/rycus86/prometheus_flask_exporter

At `/metrics` we have HTTP request metrics provided by the flask_exporter, which is by default tracking all routes and paths within the journalist app.

To disinclude an endpoint/view in the future just prepend the decorator:
```
    @internal_metrics.do_not_track()
```
Secondly, there're five internal SecureDrop metrics being exported, one as info,
the rest as gauges. (there are other types one can instrument with, such as Counter, Enum, Summary, Histogram...)

Those are:

-  securedrop_version=version.__version
-  securedrop_users[username, id, created, last] = len(Journalist.query.all)
-  securedrop_submissions[size_bytes, downloaded, author] = len(Submission.query.all)
-  securedrop_replies = len(Reply.query.all)
-  securedrop_sources[designation, flagged, last, interactions] = len(Source.query.all)
-  securedrop_logins[when, user_id, username] = len(JournalistLoginAttempt.query.all)

Analytical possibilities are plenty. You could graph submission sizes, login trends, source and journalist profilicness in comparison with others, etc. were-there-submissions-today? Well, has the securedrop_submissions metric incremented? :P I anticipate some debate about whether everyone thinks this is a great idea, whether it adds unnecessary code or could be a risk in some way. I personally don't see that. And in any event, we wouldn't be alone in this approach; there's plenty of inspiration out there:

- https://medium.com/@andrei.chernyshev/prometheus-python-flask-8487c3bc5b36
- https://blog.codeship.com/monitoring-your-synchronous-python-web-applications-using-prometheus/
- https://burhan.io/flask-application-monitoring-with-prometheus/
- https://blog.insightdatascience.com/monitoring-your-flask-application-on-kubernetes-with-prometheus-1d06db99b244
- https://github.com/kubernetes-for-developers/kfd-flask

## Status

Ready for review. Not sure what would be needed in terms of tests, feel free to supply guidance on that.

## Description of Changes

Adds new route `/metrics` to the journalist interface, with a button link to it on the admin page. Adds two Python libraries to requirements. 

## Testing

Check out my branch and stand up a dev server using the Docker method e.g. `make dev`. Then login to the journalist interface, go to /metrics and check it out.

## Deployment

No special considerations for deployment; I'm not sure if app code is still installed from a Debian package but I assume you have sound means of updating the Pip requirements.

## Checklist

I'll complete the below part later. Tests are failing due to mypy, which I doubt is my fault.

### If you made changes to the server application code:

- [ ] Linting (`make ci-lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
