### PR TITLE
added Greek and Arabic supported locales in staging

### DIFF
--- a/install_files/ansible-base/group_vars/staging.yml
+++ b/install_files/ansible-base/group_vars/staging.yml
@@ -24,7 +24,9 @@ securedrop_app_gpg_fingerprint: "65A1B5FF195B56353CC63DFFCC40EF1228271441"
 
 source_apache_log_location: "/var/log/apache2/source-error.log"
 apache_logging_level: "info"
-
+securedrop_supported_locales:
+- el
+- ar
 ### Used by the mon role ###
 # The OSSEC alert GPG public key has to be in the install_files/ansible-base/ or
 # install_files/ansible-base/roles/app/files/ directory

--- a/molecule/testinfra/staging/app-code/test_securedrop_app_code.py
+++ b/molecule/testinfra/staging/app-code/test_securedrop_app_code.py
@@ -36,7 +36,7 @@ def test_securedrop_application_apt_dependencies(host, package):
 
 def test_securedrop_application_test_locale(host):
     """
-    Ensure SecureDrop DEFAULT_LOCALE is present.
+    Ensure both SecureDrop DEFAULT_LOCALE and SUPPORTED_LOCALES are present.
     """
     securedrop_config = host.file("{}/config.py".format(
         securedrop_test_vars.securedrop_code))
@@ -44,6 +44,8 @@ def test_securedrop_application_test_locale(host):
         assert securedrop_config.is_file
         assert securedrop_config.contains("^DEFAULT_LOCALE")
         assert securedrop_config.content.count("DEFAULT_LOCALE") == 1
+        assert securedrop_config.contains("^SUPPORTED_LOCALES = \[u'el', u'ar', 'en_US'\]")
+        assert securedrop_config.content.count("SUPPORTED_LOCALES") == 1
 
 
 def test_securedrop_application_test_journalist_key(host):


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #4418.

Adds Greek and Arabic as supported locales in staging environment, to simplify verification of locale-specific features and layouts.

## Testing

- with this branch
```
make build-debs
make staging
```
- then, verify that the source and journalist interface on the staging environment contain the locale dropdowns, with the choice of English, Greek, and Arabic.
- for extra credit, run the testinfra tests for your container of choice with `molecule verify -s {container}-staging` and verify that the locale tests still pass. 

## Deployment

Staging-only change.

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass - **there are unrelated testinfra failures (at least on the `qubes-staging` scenario) that will be fixed separately. **

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
