### PR TITLE
Fixes CVE CI job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,9 @@ safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 # https://wiki.openstack.org/wiki/Security/Projects/Bandit
 .PHONY: bandit
 bandit: ## Run bandit with medium level excluding test-related folders
-	pip install --upgrade bandit && \
-		bandit --recursive . --exclude admin/.tox,admin/.venv,admin/.eggs,molecule,testinfra,securedrop/tests,.tox,.venv -ll
+	pip install --upgrade pip && \
+        pip install --upgrade bandit!=1.6.0 && \
+	bandit --recursive . --exclude admin/.tox,admin/.venv,admin/.eggs,molecule,testinfra,securedrop/tests,.tox,.venv -ll
 
 .PHONY: update-pip-requirements
 update-pip-requirements: ## Updates all Python requirements files via pip-compile.


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Fixes #4424 

Changes proposed in this pull request:
In Makefile bandit target, blacklists bandit 1.6.0 due to directory exclusion bug, installs latest pip. (A fix for the directory exclusion bug as mentioned here: https://github.com/PyCQA/bandit/issues/488 will be forthcoming in v1.6.1 - it shouldn't be necessary to roll back the Makefile change when this happens.)

## Testing
This should fix the CI CVE check job. To test it locally, check out the branch and run `make bandit`

## Deployment
No deployment, CI fix only
