### PR TITLE
Update firewall reference in server docs

### DIFF
--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -169,8 +169,8 @@ remember to propagate your choices through the rest of the installation
 process.
 
 Below are the configurations you should enter, assuming you used the
-network settings from the network firewall guide for the recommended 4 NIC
-firewall. If you did not, adjust these settings accordingly.
+network settings from the network firewall guide for a 3 NIC or 4 NIC firewall.
+If you did not, adjust these settings accordingly.
 
 -  *Application Server*:
 


### PR DESCRIPTION
## Description

Last year we updated our hardware firewall reference to the 3 NIC SG-3100. Unfortunately parts of the docs are still structured with the old  4 NIC recommendation in mind. This is one of a few pending edits to fix that.

## Status

Ready for review

## Checklist

- [x] Doc linting (`make docs-lint`) passed locally
