### PR TITLE
CI: Require lint before running any other job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,36 +305,48 @@ workflows:
               ignore:
                 - /docs-.*/
                 - /i18n-.*/
+          requires:
+            - lint
       - python3-app-tests:
           filters:
             branches:
               ignore:
                 - /docs-.*/
                 - /i18n-.*/
+          requires:
+            - lint
       - admin-tests:
           filters:
             branches:
               ignore:
                 - /docs-.*/
                 - /i18n-.*/
+          requires:
+            - lint
       - fetch-tor-debs:
           filters:
             branches:
               ignore:
                 - /docs-.*/
                 - /i18n-.*/
+          requires:
+            - lint
       - updater-gui-tests:
           filters:
             branches:
               ignore:
                 - /docs-.*/
                 - /i18n-.*/
+          requires:
+            - lint
       - static-analysis-and-no-known-cves:
           filters:
             branches:
               ignore:
                 - /docs-.*/
                 - /i18n-.*/
+          requires:
+            - lint
       - staging-test-with-rebase:
           filters:
             branches:
@@ -348,11 +360,15 @@ workflows:
             branches:
               only:
                 - /i18n-.*/
+          requires:
+            - lint
       - deb-tests:
           filters:
             branches:
               only:
                 - /update-builder-.*/
+          requires:
+            - lint
 
   nightly:
     triggers:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Make the lint job a prerequisite for other CI

## Testing

- [ ] Running lint before all else is a strategy that might make sense to alleviate CI traffic at times
- [ ] lint is a pre-requisite for other jobs : see  https://circleci.com/workflow-run/8c455d95-0b2a-4223-900f-872679ed362d
- [ ] CI passes