### PR TITLE
Fix Marionette, low-entropy and mock-induced test flakes.

### DIFF
--- a/securedrop/dockerfiles/xenial/python2/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python2/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -LO https://ftp.mozilla.org/pub/firefox/releases/${FF_ESR_VER}/linux-x8
 
 COPY ./tor_project_public.pub /opt/
 
-ENV TBB_VERSION 8.0.8
+ENV TBB_VERSION 8.0.9
 RUN gpg --import /opt/tor_project_public.pub && \
     wget  https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \

--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -LO https://ftp.mozilla.org/pub/firefox/releases/${FF_ESR_VER}/linux-x8
 
 COPY ./tor_project_public.pub /opt/
 
-ENV TBB_VERSION 8.0.8
+ENV TBB_VERSION 8.0.9
 RUN gpg --import /opt/tor_project_public.pub && \
     wget  https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -141,7 +141,7 @@ def alembic_config(config):
 @pytest.fixture(scope='function')
 def source_app(config):
     app = create_source_app(config)
-    app.config['SERVER_NAME'] = 'localhost'
+    app.config['SERVER_NAME'] = 'localhost.localdomain'
     with app.app_context():
         db.create_all()
         yield app
@@ -150,7 +150,7 @@ def source_app(config):
 @pytest.fixture(scope='function')
 def journalist_app(config):
     app = create_journalist_app(config)
-    app.config['SERVER_NAME'] = 'localhost'
+    app.config['SERVER_NAME'] = 'localhost.localdomain'
     with app.app_context():
         db.create_all()
         yield app

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -96,7 +96,6 @@ class JournalistNavigationStepsMixin:
                 while token == new_token:
                     time.sleep(1)
                     new_token = str(otp.now())
-                    print("Token: {} New token: {}".format(token, new_token))
                 token = new_token
             else:
                 return
@@ -291,7 +290,6 @@ class JournalistNavigationStepsMixin:
 
         if hotp:
             hotp_checkbox = self.driver.find_element_by_css_selector('input[name="is_hotp"]')
-            print(str(hotp_checkbox.__dict__))
             hotp_checkbox.click()
             hotp_secret = self.driver.find_element_by_css_selector('input[name="otp_secret"]')
             hotp_secret.send_keys(hotp)

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -246,8 +246,8 @@ class SourceNavigationStepsMixin:
     def _source_why_journalist_key(self):
         self.driver.get(self.source_location + "/why-journalist-key")
 
-    def _source_waits_for_session_to_timeout(self, session_length_minutes):
-        time.sleep(session_length_minutes * 60 + 0.1)
+    def _source_waits_for_session_to_timeout(self):
+        time.sleep(self.session_expiration + 2)
 
     def _source_sees_session_timeout_message(self):
         notification = self.driver.find_element_by_css_selector(".important")

--- a/securedrop/tests/functional/test_source_session_timeout.py
+++ b/securedrop/tests/functional/test_source_session_timeout.py
@@ -6,20 +6,12 @@ class TestSourceSessions(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationStepsMixin):
 
-    def setup(self):
-        # The session expiration here cannot be set to -1
-        # as it will trigger an exception in /create.
-        # Instead, we pick a 1-2s value to allow the account
-        # to be generated.
-        self.session_length_minutes = 0.03
-        super(TestSourceSessions, self).setup(
-            session_expiration=self.session_length_minutes)
+    session_expiration = 5
 
     def test_source_session_timeout(self):
         self._source_visits_source_homepage()
         self._source_clicks_submit_documents_on_homepage()
         self._source_continues_to_submit_page()
-        self._source_waits_for_session_to_timeout(
-            self.session_length_minutes)
-        self._source_visits_source_homepage()
+        self._source_waits_for_session_to_timeout()
+        self.driver.refresh()
         self._source_sees_session_timeout_message()

--- a/securedrop/tests/pageslayout/functional_test.py
+++ b/securedrop/tests/pageslayout/functional_test.py
@@ -39,7 +39,10 @@ class FunctionalTest(functional_test.FunctionalTest):
     def i18n_fixture(self, request):
         logging.debug("i18n_fixture: setting accept_languages to '%s'", request.param)
         self.accept_languages = request.param
-        self.use_firefox = True
+
+    @pytest.fixture(autouse=True)
+    def use_firefox(self):
+        self.switch_to_firefox_driver()
 
     def _screenshot(self, filename):
         log_dir = abspath(

--- a/securedrop/tests/pageslayout/test_source.py
+++ b/securedrop/tests/pageslayout/test_source.py
@@ -131,24 +131,3 @@ class TestSourceLayout(
     def test_why_journalist_key(self):
         self._source_why_journalist_key()
         self._screenshot('source-why_journalist_key.png')
-
-
-@pytest.mark.pagelayout
-class TestSourceSessionLayout(
-        functional_test.FunctionalTest,
-        source_navigation_steps.SourceNavigationStepsMixin,
-        journalist_navigation_steps.JournalistNavigationStepsMixin):
-
-    def setup(self):
-        self.session_length_minutes = 0.03
-        super(TestSourceSessionLayout, self).setup(
-            session_expiration=self.session_length_minutes)
-
-    def test_source_session_timeout(self):
-        self._source_visits_source_homepage()
-        self._source_clicks_submit_documents_on_homepage()
-        self._source_continues_to_submit_page()
-        self._source_waits_for_session_to_timeout(self.session_length_minutes)
-        self._source_enters_text_in_message_field()
-        self._source_visits_source_homepage()
-        self._screenshot('source-session_timeout.png')

--- a/securedrop/tests/pageslayout/test_source.py
+++ b/securedrop/tests/pageslayout/test_source.py
@@ -131,3 +131,21 @@ class TestSourceLayout(
     def test_why_journalist_key(self):
         self._source_why_journalist_key()
         self._screenshot('source-why_journalist_key.png')
+
+
+@pytest.mark.pagelayout
+class TestSourceSessionLayout(
+        functional_test.FunctionalTest,
+        source_navigation_steps.SourceNavigationStepsMixin,
+        journalist_navigation_steps.JournalistNavigationStepsMixin):
+
+    session_expiration = 5
+
+    def test_source_session_timeout(self):
+        self._source_visits_source_homepage()
+        self._source_clicks_submit_documents_on_homepage()
+        self._source_continues_to_submit_page()
+        self._source_waits_for_session_to_timeout()
+        self._source_enters_text_in_message_field()
+        self._source_visits_source_homepage()
+        self._screenshot('source-session_timeout.png')

--- a/securedrop/tests/test_alembic.py
+++ b/securedrop/tests/test_alembic.py
@@ -21,7 +21,7 @@ ALL_MIGRATIONS = [x.split('.')[0].split('_')[0]
                   for x in os.listdir(MIGRATION_PATH)
                   if x.endswith('.py')]
 
-WHITESPACE_REGEX = re.compile('\s*')
+WHITESPACE_REGEX = re.compile(r'\s+')
 
 
 def list_migrations(cfg_path, head):

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -1,27 +1,43 @@
 # -*- coding: utf-8 -*-
 
-from distutils.version import StrictVersion
 import gzip
 import os
 import random
 import re
 import zipfile
-import six
-
 from base64 import b32encode
 from binascii import unhexlify
-from bs4 import BeautifulSoup
+from distutils.version import StrictVersion
 from io import BytesIO
-from flask import session, g, escape, current_app
-from pyotp import TOTP, HOTP
+
+import six
+
+import mock
+import pytest
+from bs4 import BeautifulSoup
+from flask import current_app, escape, g, session
+from pyotp import HOTP, TOTP
+
+from . import utils
+from .utils.instrument import InstrumentedApp
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-from . import utils
 
-from .utils.instrument import InstrumentedApp
 
 # Seed the RNG for deterministic testing
 random.seed('ಠ_ಠ')
+
+
+@pytest.fixture(autouse=True, scope="module")
+def patch_get_entropy_estimate():
+    mock_get_entropy_estimate = mock.patch(
+        "source_app.main.get_entropy_estimate",
+        return_value=8192
+    ).start()
+
+    yield
+
+    mock_get_entropy_estimate.stop()
 
 
 def _login_user(app, user_dict):

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -160,6 +160,7 @@ def test_unauthorized_access_redirects_to_login(journalist_app):
 
 def test_login_throttle(journalist_app, test_journo):
     # Overwrite the default value used during testing
+    original_hardening = models.LOGIN_HARDENING
     models.LOGIN_HARDENING = True
     try:
         with journalist_app.test_client() as app:
@@ -183,13 +184,14 @@ def test_login_throttle(journalist_app, test_journo):
             assert ("Please wait at least {} seconds".format(
                 Journalist._LOGIN_ATTEMPT_PERIOD) in text)
     finally:
-        models.LOGIN_HARDENING = False
+        models.LOGIN_HARDENING = original_hardening
 
 
 def test_login_throttle_is_not_global(journalist_app, test_journo, test_admin):
     """The login throttling should be per-user, not global. Global login
     throttling can prevent all users logging into the application."""
 
+    original_hardening = models.LOGIN_HARDENING
     # Overwrite the default value used during testing
     # Note that this may break other tests if doing parallel testing
     models.LOGIN_HARDENING = True
@@ -226,7 +228,7 @@ def test_login_throttle_is_not_global(journalist_app, test_journo, test_admin):
             text = resp.data.decode('utf-8')
             assert "Sources" in text
     finally:
-        models.LOGIN_HARDENING = False
+        models.LOGIN_HARDENING = original_hardening
 
 
 def test_login_invalid_credentials(journalist_app, test_journo):
@@ -474,7 +476,7 @@ def test_admin_edits_user_password_error_response(journalist_app,
 def test_user_edits_password_success_response(journalist_app, test_journo):
     original_hardening = models.LOGIN_HARDENING
     try:
-        # Set this to false because we login then immedialtey reuse the same
+        # Set this to false because we login then immediately reuse the same
         # token when authenticating to change the password. This triggers login
         # hardening measures.
         models.LOGIN_HARDENING = False
@@ -499,7 +501,7 @@ def test_user_edits_password_success_response(journalist_app, test_journo):
 def test_user_edits_password_expires_session(journalist_app, test_journo):
     original_hardening = models.LOGIN_HARDENING
     try:
-        # Set this to false because we login then immedialtey reuse the same
+        # Set this to false because we login then immediately reuse the same
         # token when authenticating to change the password. This triggers login
         # hardening measures.
         models.LOGIN_HARDENING = False
@@ -527,7 +529,7 @@ def test_user_edits_password_expires_session(journalist_app, test_journo):
 def test_user_edits_password_error_reponse(journalist_app, test_journo):
     original_hardening = models.LOGIN_HARDENING
     try:
-        # Set this to false because we login then immedialtey reuse the same
+        # Set this to false because we login then immediately reuse the same
         # token when authenticating to change the password. This triggers login
         # hardening measures.
         models.LOGIN_HARDENING = False
@@ -1572,7 +1574,7 @@ def test_render_locales(config, journalist_app, test_journo, test_source):
     # (which are only triggered during `create_app`
     config.SUPPORTED_LOCALES = ['en_US', 'fr_FR']
     app = journalist_app_module.create_app(config)
-    app.config['SERVER_NAME'] = 'localhost'  # needed for url_for
+    app.config['SERVER_NAME'] = 'localhost.localdomain'  # needed for url_for
     url = url_for('col.col', filesystem_id=test_source['filesystem_id'])
 
     # we need the relative URL, not the full url including proto / localhost

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -579,25 +579,26 @@ def test_failed_normalize_timestamps_logs_warning(source_app):
     still occur, but a warning should be logged (this will trigger an
     OSSEC alert)."""
 
-    with patch.object(source_app.logger, 'warning') as logger:
-        with patch.object(subprocess, 'call', return_value=1):
-            with source_app.test_client() as app:
-                new_codename(app, session)
-                _dummy_submission(app)
-                resp = app.post(
-                    url_for('main.submit'),
-                    data=dict(
-                        msg="This is a test.",
-                        fh=(six.StringIO(six.u('')), '')),
-                    follow_redirects=True)
-                assert resp.status_code == 200
-                text = resp.data.decode('utf-8')
-                assert "Thanks! We received your message" in text
+    with patch("source_app.main.get_entropy_estimate", return_value=8192):
+        with patch.object(source_app.logger, 'warning') as logger:
+            with patch.object(subprocess, 'call', return_value=1):
+                with source_app.test_client() as app:
+                    new_codename(app, session)
+                    _dummy_submission(app)
+                    resp = app.post(
+                        url_for('main.submit'),
+                        data=dict(
+                            msg="This is a test.",
+                            fh=(six.StringIO(six.u('')), '')),
+                        follow_redirects=True)
+                    assert resp.status_code == 200
+                    text = resp.data.decode('utf-8')
+                    assert "Thanks! We received your message" in text
 
-                logger.assert_called_once_with(
-                    "Couldn't normalize submission "
-                    "timestamps (touch exited with 1)"
-                )
+                    logger.assert_called_once_with(
+                        "Couldn't normalize submission "
+                        "timestamps (touch exited with 1)"
+                    )
 
 
 def test_source_is_deleted_while_logged_in(source_app):

--- a/securedrop/tests/utils/instrument.py
+++ b/securedrop/tests/utils/instrument.py
@@ -135,7 +135,7 @@ class InstrumentedApp:
         if parts.netloc:
             expected_location = location
         else:
-            server_name = self.app.config.get('SERVER_NAME') or 'localhost'
+            server_name = self.app.config.get('SERVER_NAME') or 'localhost.localdomain'
             expected_location = urljoin("http://%s" % server_name, location)
 
         valid_status_codes = (301, 302, 303, 305, 307)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In tests/functional/functional_test.py, FunctionalTest.setup mocked things up, and if an exception were thrown after that in setup, the mocks weren't getting cleaned up. Subsequent two-factor tests were then failing because models.Journalist.verify_token would always return true. This replaces setup/teardown with pytest fixtures and ensures that the mocks are stopped. (Thanks @redshiftzero for finding this one.)

Also retry web driver creation to work around intermittent Marionette problems.

We had redundant session timeout tests, so I removed one.

In a couple of places we were changing models.LOGIN_HARDENING and not resetting it to the original value, so those have been fixed.

Also, because we just set the servers' names to "localhost" in the tests, Flask was warning that it wasn't a valid cookie domain. So I've appended ".localdomain" to shut it up. We have enough noise in our
test output.

In test_alembic, the whitespace pattern '\s*' could be empty, potentially causing trouble for split(). Make it r'\s+'.

Patch get_entropy_estimate in tests/test_integration.py and tests/test_source.py to prevent failures when CI machines run low on entropy. In test_source.py, the call to logger.assert_called_once_with
in test_failed_normalize_timestamps_logs_warning fails if entropy is low in CI -- it's failing not because the message is repeated, but because the mock is called more than once, when the submit route logs
that it can't generate the source's key.

Fixes #4433.

## Testing

Running `make -C securedrop test` should pass, but is not sufficient to verify these changes. Most of the flakes only reliably (heh) happened in CI, due to low entropy or test ordering after exceptions like failures to set up web drivers because of Firefox/geckodriver bugs. (Tests can run in a different order in CI because of how they're divided up and run concurrently.)

A truly diligent test would be to set up CI under your account, create a branch from `rmol/fix-4433-tbb-flakes`, add a trivial change and push to get CI run. 

At this point, having been through that process a lot over the last week, I would say it's optional if the CI for this PR passes.

## Deployment

The changes are all in tests; this should not affect deployment.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
