### PR TITLE
changes docs references to 'sudo su' to 'sudo -u www-data bash'.

### DIFF
--- a/docs/create_admin_account.rst
+++ b/docs/create_admin_account.rst
@@ -33,7 +33,7 @@ If you are installing SecureDrop yourself, to create the first admin account, :d
 
 .. code:: sh
 
-   sudo su
+   sudo -u www-data bash
    cd /var/www/securedrop
    ./manage.py add-admin
 

--- a/docs/development/database_migrations.rst
+++ b/docs/development/database_migrations.rst
@@ -166,7 +166,7 @@ During QA, the release manager should follow these steps to test the migrations.
 2. Build Debian packages locally
 3. Provision staging VMs
 4. ``vagrant ssh app-staging``
-5. ``sudo su``
+5. ``sudo -u www-data bash``
 6. ``cd /var/www/securedrop && ./qa_loader.py``
 7. Checkout the release candidate
 8. Re-provision the staging VMs

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -46,7 +46,7 @@ Debian packages on the staging machines:
    molecule login -s virtualbox-staging-xenial -h app-staging
    # or:
    molecule login -s libvirt-staging-xenial -h app-staging
-   sudo su
+   sudo -u www-data bash
    cd /var/www/securedrop
    ./manage.py add-admin
    pytest -v tests/
@@ -310,7 +310,7 @@ To create the prod servers, run:
 
    vagrant up /prod/
    vagrant ssh app-prod
-   sudo su
+   sudo -u www-data bash
    cd /var/www/securedrop/
    ./manage.py add-admin
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #4455.

Updates docs references to `sudo su` to `sudo -u www-data bash` where possible, to ensure commands run with appropriate privilege and files are created. 

## Testing

Docs-only PR.

## Deployment

Deployed as normal when merged/backported.


## Checklist


### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
