### PR TITLE
Clarified language about localhost setup for local development

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -130,9 +130,7 @@ following ports:
 * Source Interface: `localhost:8080 <http://localhost:8080>`__
 * *Journalist Interface*: `localhost:8081 <http://localhost:8081>`__
 
-If you are using Tor to connect to your local Docker instance, make sure to set 
-"No Proxy" for 0.0.0.0, otherwise Tor will not be able to connect (make sure you 
-understand the security implications for your setup before doing so).
+You should use Tor Browser to test web application changes, `see here for instructions <https://docs.securedrop.org/en/release-0.12.2/development/tips_and_tricks.html#using-tor-browser-with-the-development-environment>`.
 
 A test administrator (``journalist``) and non-admin user (``dellsberg``) are
 created by default when running ``make dev``. In addition, sources and

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -130,7 +130,8 @@ following ports:
 * Source Interface: `localhost:8080 <http://localhost:8080>`__
 * *Journalist Interface*: `localhost:8081 <http://localhost:8081>`__
 
-You should use Tor Browser to test web application changes, `see here for instructions <https://docs.securedrop.org/en/release-0.12.2/development/tips_and_tricks.html#using-tor-browser-with-the-development-environment>`.
+You should use Tor Browser to test web application changes, `see here for instructions
+<tips_and_tricks.html#using-tor-browser-with-the-development-environment>`__.
 
 A test administrator (``journalist``) and non-admin user (``dellsberg``) are
 created by default when running ``make dev``. In addition, sources and

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -130,6 +130,10 @@ following ports:
 * Source Interface: `localhost:8080 <http://localhost:8080>`__
 * *Journalist Interface*: `localhost:8081 <http://localhost:8081>`__
 
+If you are using Tor to connect to your local Docker instance, make sure to set 
+"No Proxy" for 0.0.0.0, otherwise Tor will not be able to connect (make sure you 
+understand the security implications for your setup before doing so).
+
 A test administrator (``journalist``) and non-admin user (``dellsberg``) are
 created by default when running ``make dev``. In addition, sources and
 submissions are present. The test users have the following credentials. Note that


### PR DESCRIPTION
## Status

Ready for review  

## Description of Changes

Fixes #4460 

Changes proposed in this pull request:
- Slight text change to make setting up a local deployment with Tor obvious.
## Testing

How should the reviewer test this PR?
Non, text only. 

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.
Negatory.
## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [X] Doc linting (`make docs-lint`) passed locally
