### PR TITLE
admin CLI integration tests: re-run flaky git tests up to 3 times

### DIFF
--- a/admin/tox.ini
+++ b/admin/tox.ini
@@ -11,7 +11,7 @@ commands = env \
          {envbindir}/coverage run --source=securedrop_admin,bootstrap \
          {envbindir}/py.test -v {posargs:tests}
          {envbindir}/coverage combine --append
-         {envbindir}/coverage report --omit=*test*,*tox* --show-missing
+         {envbindir}/coverage report --omit=*tox* --show-missing
 
 [testenv:flake8]
 commands =


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3553

Changes proposed in this pull request:
 - Add `@flaky` decorator to the git integration tests in the admin CLI (and removes the unnecessary class)

## Testing

Verify that these five builds pass (5 consecutive re-runs of the admin CI test job): 
- https://circleci.com/gh/freedomofpress/securedrop/28384 (you can see in the flaky test report in the build output that a test did fail but then was re-ran by the flaky plugin and passed)
- https://circleci.com/gh/freedomofpress/securedrop/28394 (all tests passed on first run)
- https://circleci.com/gh/freedomofpress/securedrop/28395 (all tests passed on first run)
- https://circleci.com/gh/freedomofpress/securedrop/28396 (all tests passed on first run)
- https://circleci.com/gh/freedomofpress/securedrop/28397  (all tests passed on first run)

## Deployment

Test only

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

