### PR TITLE
adding supported locales in metadata api

### DIFF
--- a/securedrop/source_app/api.py
+++ b/securedrop/source_app/api.py
@@ -11,10 +11,12 @@ def make_blueprint(config):
 
     @view.route('/metadata')
     def metadata():
-        meta = {'gpg_fpr': config.JOURNALIST_KEY,
-                'sd_version': version.__version__,
-                'server_os': platform.linux_distribution()[1],
-                }
+        meta = {
+            'gpg_fpr': config.JOURNALIST_KEY,
+            'sd_version': version.__version__,
+            'server_os': platform.linux_distribution()[1],
+            'supported_languages': config.SUPPORTED_LOCALES
+        }
         resp = make_response(json.dumps(meta))
         resp.headers['Content-Type'] = 'application/json'
         return resp

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -545,7 +545,7 @@ def test_why_journalist_key(source_app):
         assert "Why download the journalist's public key?" in text
 
 
-def test_metadata_route(source_app):
+def test_metadata_route(config, source_app):
     with patch.object(source_app_api.platform, "linux_distribution") as mocked_platform:
         mocked_platform.return_value = ("Ubuntu", "16.04", "xenial")
         with source_app.test_client() as app:
@@ -554,6 +554,8 @@ def test_metadata_route(source_app):
             assert resp.headers.get('Content-Type') == 'application/json'
             assert resp.json.get('sd_version') == version.__version__
             assert resp.json.get('server_os') == '16.04'
+            assert resp.json.get('supported_languages') ==\
+                config.SUPPORTED_LOCALES
 
 
 def test_login_with_overly_long_codename(source_app):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4267.

Changes proposed in this pull request:
- Added supported locales in the metadata api.

## Testing

How should the reviewer test this PR?
- Added a test statement within the `test_source/test_metadata` should be enough.
- Can also be reviewed by manually checking the `/metadata` api

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
