### PR TITLE
Fixes #4165 adds steps to push to remote before locking

### DIFF
--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -236,7 +236,10 @@ The translations must be suspended in `Weblate`_ to avoid conflicts.
 
 |Weblate commit Lock|
 
-* Click ``Lock``
+* Click ``Commit``
+* Click ``Push`` (we do these two steps, so that uncommitted changes
+  in the repo do not create merge conflicts.)
+* And finally, click ``Lock``
 
 |Weblate commit Locked|
 


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Fixes #4165

Adds instructions for the localization manager to commit and push
before locking the weblate.

## Testing

- [x] `make docs-lint`

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
