### PR TITLE
Re-add Apache AppArmor rule for /etc/lsb-release

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -63,6 +63,7 @@
   /etc/apache2/sites-enabled/ r,
   /etc/ld.so.cache r,
   /etc/localtime r,
+  /etc/lsb-release r,
   /etc/magic r,
   /etc/mime.types r,
   /etc/services r,


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #4470 



## Testing
- `make build-debs`
- `make staging`
- `torify curl $SOURCE_INTERFACE.onion/metadata`
- [ ] Returns `"server_os": "16.04"` as well as other information
- [ ] There are no AppArmor messages in /var/log/syslog
## Deployment

Changes via securedrop-app-code deb package, though this is a regression introduced after 0.12.2 so there should be no change on the servers

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

