### PR TITLE
[0.13.0] Re-add Apache AppArmor rule for /etc/lsb-release

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -63,6 +63,7 @@
   /etc/apache2/sites-enabled/ r,
   /etc/ld.so.cache r,
   /etc/localtime r,
+  /etc/lsb-release r,
   /etc/magic r,
   /etc/mime.types r,
   /etc/services r,


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Backports #4471 to the 0.13.0 release branch


## Testing

- [x] #4471 is merged into develop
- [ ] Changes are identical to the ones in #4471 
