### PR TITLE
Set up Tor in bin/translation-test

### DIFF
--- a/securedrop/bin/translation-test
+++ b/securedrop/bin/translation-test
@@ -5,8 +5,11 @@ set -euo pipefail
 
 source "${BASH_SOURCE%/*}/dev-deps"
 
-run_xvfb &
+run_xvfb
+run_tor &
 run_redis &
+setup_vncauth
+run_x11vnc &
 urandom
 run_sass --force --update
 maybe_create_config_py


### PR DESCRIPTION
Since we currently start both browsers for all functional tests, Tor needs to be running in the test container.

## Status

Ready for review

## Description of Changes

This sets up Tor in the container used for translation tests.

## Testing

Running `make translation-test` on latest develop should produce nothing but errors like `Error creating Tor Browser web driver: SOCKS port 9050 is not listening` because Tor's not running.

Running `make translation-test` on this branch should produce no errors.

## Deployment

This only affects the translation tests.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
