### PR TITLE
Add make target to test docs for broken links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
 
       - run:
           name: Run documentation linting
-          command: make docs-lint
+          command: make docs-lint && make docs-linkcheck
 
   app-tests:
     machine:

--- a/Makefile
+++ b/Makefile
@@ -33,16 +33,20 @@ typelint: install-mypy ## Runs type linting
 ansible-config-lint: ## Runs custom Ansible env linting tasks.
 	molecule verify -s ansible-config
 
+.PHONY: docs
+docs: ## Build project documentation in live reload for editing
+# Spins up livereload environment for editing; blocks.
+	make -C docs/ clean && sphinx-autobuild docs/ docs/_build/html
+
 .PHONY: docs-lint
 docs-lint: ## Check documentation for common syntax errors.
 # The `-W` option converts warnings to errors.
 # The `-n` option enables "nit-picky" mode.
 	make -C docs/ clean && sphinx-build -Wn docs/ docs/_build/html
 
-.PHONY: docs
-docs: ## Build project documentation in live reload for editing
-# Spins up livereload environment for editing; blocks.
-	make -C docs/ clean && sphinx-autobuild docs/ docs/_build/html
+.PHONY: docs-linkcheck
+docs-linkcheck: ## Check documentation for broken links
+	make -C docs/ clean && sphinx-build -b linkcheck -Wn docs/ docs/_build/html
 
 .PHONY: flake8
 flake8: ## Validates PEP8 compliance for Python source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -299,3 +299,14 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
+
+# -- Options for linkcheck --
+
+linkcheck_retries = 3
+
+linkcheck_ignore = [
+  r'http://127.0.0.1(:\d+)?/?',
+  r'http://localhost(:\d+)?/?',
+  'https://forum.securedrop.org/admin/users/list/active',
+  'https://weblate.securedrop.org/projects/securedrop/securedrop/#repository',
+]

--- a/docs/development/apt_repo.rst
+++ b/docs/development/apt_repo.rst
@@ -41,6 +41,6 @@ securedrop-keyring
    with the grsecurity patch set. Only binary images are hosted in the apt
    repo. For source packages, see the `Source Offer`_.
 
-.. _SecureDrop 0.3.10: https://github.com/freedomofpress/securedrop/blob/c5b4220e04e3c81ad6f92d5e8a92798f07f0aca2/changelog.md#0310
+.. _SecureDrop 0.3.10: https://github.com/freedomofpress/securedrop/blob/c5b4220e04e3c81ad6f92d5e8a92798f07f0aca2/changelog.md
 .. _apt.freedom.press: https://apt.freedom.press
 .. _`Source Offer`: https://github.com/freedomofpress/securedrop/blob/develop/SOURCE_OFFER

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -115,7 +115,7 @@ are covered in :doc:`detailed documentation <release_management>`.
 If you are a `Debian developer <https://www.debian.org/devel/>`__ you can help
 improve packaging and the release process:
 
-* `Building SecureDrop application and OSSEC packages <https://github.com/freedomofpress/securedrop/blob/develop/install_files/ansible-base/build-deb-pkgs.yml>`__ and `pending bugs and tasks <https://github.com/freedomofpress/securedrop/issues?q=is%3Aissue+is%3Aopen+package+label%3A%22goals%3A+packaging%22>`__
+* `Building SecureDrop application and OSSEC packages <https://github.com/freedomofpress/securedrop/tree/develop/molecule/builder-xenial>`__ and `pending bugs and tasks <https://github.com/freedomofpress/securedrop/issues?q=is%3Aissue+is%3Aopen+package+label%3A%22goals%3A+packaging%22>`__
 * Building `grsecurity kernels <https://github.com/freedomofpress/ansible-role-grsecurity>`__ and `pending bugs and tasks <https://github.com/freedomofpress/ansible-role-grsecurity/issues>`__
 
 

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -50,6 +50,13 @@ will convert any warnings to errors, causing the build to fail.
 The :ref:`CI tests<ci_tests>` will automatically perform linting via the same
 command.
 
+To test the documentation for broken links, run the following command from
+a reliable internet connection:
+
+   .. code:: sh
+
+      make docs-linkcheck
+
 The :ref:`CI tests<ci_tests>` by default create staging servers to test the
 application code. If your PR only makes documentation changes, you should
 prefix the branch name with ``docs-`` to skip the staging run. Project

--- a/docs/development/l10n.rst
+++ b/docs/development/l10n.rst
@@ -399,7 +399,7 @@ Should you need help, you can do one of the following:
 
 .. _`translation category of the SecureDrop forum`: https://forum.securedrop.org/c/translations
 .. _`SecureDrop instant messenging channel`: https://gitter.im/freedomofpress/securedrop
-.. _`Weblate documentation`: http://docs.weblate.org/en/latest/user/index.html
+.. _`Weblate documentation`: http://docs.weblate.org/en/latest/index.html
 
 
 Frequently Asked Questions

--- a/docs/development/testing_continuous_integration.rst
+++ b/docs/development/testing_continuous_integration.rst
@@ -62,7 +62,7 @@ output as shown below:
     This message shows that your installation appears to be working correctly.
     ...
 
-.. _Docker installation: https://www.docker.com/community-edition#/download
+.. _Docker installation: https://docs.docker.com/install/
 
 Setup Environment Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -346,8 +346,8 @@ support is preferable, since you want neither WiFi nor Bluetooth.
 	  <http://arstechnica.com/gadgets/2014/02/new-intel-nuc-bios-update-fixes-steamos-other-linux-booting-problems/>`__.
 
 .. caution:: Some older NUC BIOS versions will cause the server to `brick itself <https://communities.intel.com/message/359708>`__ if the device
-    attempts to suspend. This has `since been fixed <https://communities.intel.com/message/432692#432692>`__
-    in a BIOS update. See these `release notes <https://downloadmirror.intel.com/26263/eng/RY_0359_ReleaseNotes.pdf>`__ (PDF) for more details.
+    attempts to suspend. This has `since been fixed <https://communities.intel.com/message/432692>`__
+    in a BIOS update. See these `release notes <https://downloadmirror.intel.com/28826/eng/RY_0380_ReleaseNotes.pdf>`__ (PDF) for more details.
 
 2014 Mac Minis
 ~~~~~~~~~~~~~~

--- a/docs/includes/docs-branches.txt
+++ b/docs/includes/docs-branches.txt
@@ -1,7 +1,7 @@
 .. note:: SecureDrop maintains two versions of documentation: `stable
-          <https://docs.securedrop.org/en/stable/development/getting_started.html>`_
+          <https://docs.securedrop.org/en/stable/development/contributing.html>`_
           and `latest
-          <https://docs.securedrop.org/en/latest/development/getting_started.html>`_.
+          <https://docs.securedrop.org/en/latest/development/contributing.html>`_.
           ``stable`` is the default used by our Read the Docs site, and is built
           from our latest signed git tag. ``latest`` is built from the head of
           the ``develop`` git branch. In almost all cases involving development

--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -39,10 +39,10 @@ recommend the following resources:
 
 If you're using the recommended SG-3100 firewall, then you may find the
 following resource useful. In particular, you can find instructions on factory
-resetting the firewall in ``Section 1.3``.
+resetting the firewall in ``Chapter 8``.
 
 -  `SG-3100
-   Product Manual <https://www.netgate.com/docs/manuals/sg-3100-product-manual.pdf>`__
+   Product Manual <https://docs.netgate.com/manuals/pfsense/en/latest/sg-3100-security-gateway-manual.pdf>`__
 
 Before You Begin
 ----------------

--- a/docs/tails_guide.rst
+++ b/docs/tails_guide.rst
@@ -41,30 +41,6 @@ stick. Here are some links to help you out:
 .. _`Download and verify the Tails .iso and install onto a USB stick or SD card`: https://tails.boum.org/install/index.en.html
 .. _`Create & configure the persistent volume`: https://tails.boum.org/install/linux/usb/index.en.html#create-persistence
 
-Note for macOS Users Manually Installing Tails
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The Tails documentation for `manually installing Tails onto a USB device
-on macOS`_ describes how to copy the downloaded .iso image to a USB stick in
-Section 4, "Do the copy". This section includes the following ``dd`` invocation
-to copy the .iso to the USB:
-
-::
-
-    dd if=[tails.iso] of=/dev/diskX
-
-This command is *very slow*. In our testing, it took about 18 minutes to copy
-the .iso to a USB 2.0 drive. You can speed it up by changing the arguments to
-``dd`` like so:
-
-::
-
-    dd if=[tails.iso] of=/dev/rdiskX bs=1m
-
-Note the change from ``diskX`` to ``rdiskX``. This reduced the copy time to 3
-minutes for us.
-
-.. _`manually installing Tails onto a USB device on macOS`: https://tails.boum.org/doc/first_steps/installation/manual/mac/index.en.html
 
 Configure Tails for Use with SecureDrop
 ---------------------------------------


### PR DESCRIPTION
`make docs-linkcheck` can now be used to test the docs for broken links.

closes #4410

## Status

Ready for review
