### PR TITLE
Adds upgrade testing boxes for 0.13.0

### DIFF
--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -34,6 +34,17 @@
         }
       ],
       "version": "0.12.2"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "30987d6f81b50822ef5234b1dc76a6640cf3e0f784b8f9a97aa21b22d5bb2950",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_0.13.0.box"
+        }
+      ],
+      "version": "0.13.0"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -34,6 +34,17 @@
         }
       ],
       "version": "0.12.2"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "6b8a4f2acec2453c79bec78e5dfa1d5a4045f1a322d33b8571b6d41bfa74ae28",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_0.13.0.box"
+        }
+      ],
+      "version": "0.13.0"
     }
   ]
 }


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Checks the final box on, and therefore closes, #4439.

Includes only Xenial boxes, as 0.13.0 is the first release to support Ubuntu Xenial 16.04 exclusively.

Changes proposed in this pull request:

  * New base images for the "upgrade" scenario posted to S3
  * New corresponding metadata for base images

## Testing

* [ ] Run `rm -rf build/* && make build-debs` to ensure you have clean debs
* [ ] `make upgrade-start` ; first run will take a while to fetch the images, then future runs will be snappy
* [ ] `make upgrade-test-local` ; confirm no errors
* [ ] Manually verify that the Source Interface shows 0.14.0~rc1

## Deployment
No, dev env only.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
