### PR TITLE
Redirect to index after session expiration on /generate

### DIFF
--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -145,7 +145,9 @@ def create_app(config):
             # clear the session after we render the message so it's localized
             session.clear()
 
+            # Redirect to index with flashed message
             flash(Markup(msg), "important")
+            return redirect(url_for('main.index'))
 
         session['expires'] = datetime.utcnow() + \
             timedelta(minutes=getattr(config,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4490. 

Previous logic when sessions expire on `/generate`:
1. On `/generate` page, codename is added to the session.
2. When expiration occurs, session is cleared.
3. A flashed message indicating that the session has expired
would be added to the current session (this is done [via passing
`_flashes` on Flask's `session` object](https://github.com/pallets/flask/blob/cd4023d9d2ab630ce4f95856f065072ef8badb2b/flask/helpers.py#L449)).
4. Execution enters the view function associated with `/create`.
But `/create` expects codename to be in the session (which was
cleared in step 2), thus a `KeyError` will occur.

If you're wondering "but why does step 4 even happen" - it's because we don't immediately redirect to the index when a session expires. When the session expires when the `@login_required` decorator is on the view function corresponding to the request path, execution doesn't end up entering the view function itself, as the logic in `@login_required` will redirect the user to the `login` page if `logged_in` is not in the `session` object (and `logged_in` won't be in the `session` object, because it gets cleared in step 2). 

Logic with this diff when sessions expire on `/generate`:
1. On `/generate` page, codename is added to the session
2. When expiration occurs, session is cleared and user is immediately redirected to the index.

## Testing

1. Follow STR in #4490, confirm bug is fixed
2. Revert fix, make sure regression test fails

## Deployment

No special instructions (deployed via `securedrop-app-code` deb)

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container 

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
