### PR TITLE
Use archive module in `securedrop-admin logs` playbook

### DIFF
--- a/install_files/ansible-base/securedrop-logs.yml
+++ b/install_files/ansible-base/securedrop-logs.yml
@@ -54,7 +54,9 @@
         log_paths: "{{ log_paths_reference[inventory_hostname] }}"
 
     - name: Create tar archive.
-      shell: tar -czf "{{ log_tarball_filename|escape }}" {{ log_paths|join(' ') }}
+      archive:
+        path: "{{ log_paths }}"
+        dest: "{{ log_tarball_filename }}"
 
     - name: Fetch tarball back to Admin Workstation.
       fetch:


### PR DESCRIPTION
This is a straightforward archive operation and does not require running tar manually.

Resolves #4357

## Status

Ready for review 

## Test plan

In a virtualized or prod environment, run the `securedrop-admin logs` command before and after this change. The resulting archives should be identical.

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container