### PR TITLE
Fixes CSRF error on JI password reset

### DIFF
--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -61,6 +61,7 @@
   <p><input type="password" name="current_password" placeholder="{{ gettext('Current Password') }}"></p>
   <p><input name="token" id="token" type="text" placeholder="{{ gettext('Two-factor Code') }}"></p>
   {% endif %}
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   <input name="password" type="hidden" value="{{ password }}">
   <p>
     {% if user %}

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -200,6 +200,7 @@ class FunctionalTest(object):
 
                     self.source_app = source_app.create_app(config)
                     self.journalist_app = journalist_app.create_app(config)
+                    self.journalist_app.config['WTF_CSRF_ENABLED'] = True
 
                     self.__context = self.journalist_app.app_context()
                     self.__context.push()


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #4463 

Changes proposed in this pull request:
Restores CSRF hidden field in Journalist Interface password reset form, enables CSRF for functional tests to guard against future regressions.

## Testing
In a staging environment:
- Create 2 admin accounts in the JI
- Log in with one account, go to the **Admin** section, and reset the password for the other account
- reset the password for the logged-in account.

## Deployment
No special requirements for deployment, will be part of app build.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container