### PR TITLE
using is keyword instead of deprecated pipe filters

### DIFF
--- a/install_files/ansible-base/roles/common/tasks/apt_upgrade.yml
+++ b/install_files/ansible-base/roles/common/tasks/apt_upgrade.yml
@@ -44,7 +44,7 @@
   # Not using a conditional `when` to control task execution because
   # we want to ensure the hold is removed, otherwise nightly upgrades
   # will not install security patches.
-  changed_when: tor_hold_package_result|changed
+  changed_when: tor_hold_package_result is changed
 
 
   # Ansible doesn't support notifying handlers based on file existence, results,

--- a/install_files/ansible-base/roles/grsecurity/tasks/clean_packages.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/clean_packages.yml
@@ -27,7 +27,7 @@
 - name: Validate that all installed kernels are grsecurity-hardened.
   assert:
     that:
-      - item | search('-grsec')
+      - item is search('-grsec')
     msg: "Not all non-grsec kernels have been removed, run dpkg-query -W 'linux-image*' for more details."
   with_items: "{{ apt_installed_kernels.stdout_lines }}"
   tags:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4385.

Changes proposed in this pull request:
- Removing usage of deprecated pipe syntax jinja filters
- using better logical operators such as `is` 

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
