### PR TITLE
Add workaround for CircleCI's problems filtering from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,9 @@ jobs:
           name: Run tests
           no_output_timeout: 20m
           command: |
+            BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|docs|update-builder)")
+            echo "match-ci-branch.sh said: ${BRANCH_MATCH}"
+            if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
             export TESTFILES=$(cd securedrop; circleci tests glob 'tests/test*py' 'tests/**/test*py' |circleci tests split --split-by=timings |xargs echo)
             docker rm -f securedrop-test-xenial-py2 || true
             fromtag=$(docker images |grep securedrop-test-xenial-py2 |head -n1 |awk '{print $2}')
@@ -155,6 +158,9 @@ jobs:
       - run:
           name: Run tests
           command: |
+            BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|docs|update-builder)")
+            echo "match-ci-branch.sh said: ${BRANCH_MATCH}"
+            if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
             export TESTFILES=$(cd securedrop; circleci tests glob 'tests/test*py' 'tests/**/test*py' |circleci tests split --split-by=timings |xargs echo)
             docker rm -f securedrop-test-xenial-py3 || true
             fromtag=$(docker images |grep securedrop-test-xenial-py3 |head -n1 |awk '{print $2}')
@@ -190,6 +196,9 @@ jobs:
       - run:
           name: Run tests
           command: |
+            BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^i18n")
+            echo "match-ci-branch.sh said: ${BRANCH_MATCH}"
+            if ! [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
             export TESTFILES=$(cd securedrop; circleci tests glob 'tests/pageslayout/test*py' |circleci tests split --split-by=timings |xargs echo)
             docker rm -f securedrop-test-xenial-py2 || true
             fromtag=$(docker images |grep securedrop-test-xenial-py2 |head -n1 |awk '{print $2}')
@@ -202,19 +211,31 @@ jobs:
     docker:
       - image: gcr.io/cloud-builders/docker
     steps:
-      - run: apt-get install -y make
+      - run: apt-get install -y make jq
       - checkout
       - setup_remote_docker
-      - run: cd admin ; make test
+      - run:
+          name: Run tests
+          command: |
+            BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|docs|update-builder)")
+            echo "match-ci-branch.sh said: ${BRANCH_MATCH}"
+            if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
+            cd admin; make test
 
   fetch-tor-debs:
     docker:
       - image: gcr.io/cloud-builders/docker
     steps:
-      - run: apt-get install -y make virtualenv python-pip enchant
+      - run: apt-get install -y make virtualenv python-pip enchant jq
       - checkout
       - setup_remote_docker
-      - run: make fetch-tor-packages
+      - run:
+          name: Fetch Tor packages
+          command: |
+            BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|docs|update-builder)")
+            echo "match-ci-branch.sh said: ${BRANCH_MATCH}"
+            if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
+            make fetch-tor-packages
 
   updater-gui-tests:
     docker:
@@ -241,6 +262,9 @@ jobs:
       - run:
           name: Run tests
           command: |
+            BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|docs|update-builder)")
+            echo "match-ci-branch.sh said: ${BRANCH_MATCH}"
+            if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
             cd journalist_gui
             xvfb-run -a pipenv run python3 test_gui.py
 
@@ -268,8 +292,12 @@ jobs:
       - *installenchant
 
       - run:
-          name: Run Staging tests on GCE (Xenial)
-          command: make ci-go
+          name: Run Staging tests on GCE
+          command: |
+            BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|docs)")
+            echo "match-ci-branch.sh said: ${BRANCH_MATCH}"
+            if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
+            make ci-go
           no_output_timeout: 20m
 
       - run:
@@ -292,7 +320,13 @@ jobs:
       - run: apt-get install -y make virtualenv python-pip enchant
       - checkout
       - setup_remote_docker
-      - run: make ci-deb-tests
+      - run:
+          name: Test Debian package build
+          command: |
+            BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^update-builder")
+            echo "match-ci-branch.sh said: ${BRANCH_MATCH}"
+            if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
+            make ci-deb-tests
 
 workflows:
   version: 2
@@ -345,11 +379,6 @@ workflows:
           requires:
             - lint
       - static-analysis-and-no-known-cves:
-          filters:
-            branches:
-              ignore:
-                - /docs-.*/
-                - /i18n-.*/
           requires:
             - lint
       - staging-test-with-rebase:
@@ -361,10 +390,6 @@ workflows:
           requires:
             - lint
       - translation-tests:
-          filters:
-            branches:
-              only:
-                - /i18n-.*/
           requires:
             - lint
       - deb-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ jobs:
     docker:
       - image: gcr.io/cloud-builders/docker
     steps:
-      - run: apt-get install -y make virtualenv python-pip enchant
+      - run: apt-get install -y make virtualenv python-pip enchant jq
       - checkout
       - setup_remote_docker
       - run:
@@ -325,7 +325,7 @@ jobs:
           command: |
             BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^update-builder")
             echo "match-ci-branch.sh said: ${BRANCH_MATCH}"
-            if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
+            if ! [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
             make ci-deb-tests
 
 workflows:

--- a/devops/scripts/match-ci-branch.sh
+++ b/devops/scripts/match-ci-branch.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+#
+# Checks the given regular expression against the branch names
+# involved in a Circle CI job.
+#
+# The branch names are collected from the CIRCLE_BRANCH environment
+# variable and, for pull requests, from the GitHub API, as CircleCI
+# sets CIRCLE_BRANCH to something useless like /pull/123.
+#
+# Returns:
+#   0 unless there's an error
+#   1 otherwise
+#
+# To avoid lots of "set +e; ...; set -e" in the CircleCI commands,
+# we'll parse the output instead of looking at the return code.
+
+JQ=$(which jq)
+if [ -z "${JQ}" ]
+then
+    echo "Error: jq must be installed."
+    exit 1
+fi
+
+BRANCH_RE=$1
+if [ -z "${BRANCH_RE}" ]
+then
+    echo "Error: please specify a regular expression."
+    exit 1
+fi
+
+CIRCLE_PR_BRANCH=""
+if [ -n "${CIRCLE_PR_NUMBER}" ]
+then
+    GH_PULL_URL="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER}"
+    CIRCLE_PR_BRANCH=$(curl -s "${GH_PULL_URL}" | jq -r '.head.ref')
+fi
+
+if [[ "${CIRCLE_BRANCH}" =~ ${BRANCH_RE} ]]
+then
+    echo "found \"${BRANCH_RE}\" in CIRCLE_BRANCH \"${CIRCLE_BRANCH}\""
+    exit 0
+fi
+
+if [[ "${CIRCLE_PR_BRANCH}" =~ ${BRANCH_RE} ]]
+then
+    echo "found \"${BRANCH_RE}\" in CIRCLE_PR_BRANCH \"${CIRCLE_PR_BRANCH}\""
+    exit 0
+fi
+
+echo "did not find \"${BRANCH_RE}\" in CIRCLE_BRANCH \"${CIRCLE_BRANCH}\" or CIRCLE_PR_BRANCH \"${CIRCLE_PR_BRANCH}\""
+exit 0


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

CircleCI's branch filtering does not work properly with pull requests
from forks. The `CIRCLE_BRANCH` variable contains something like `/pull/3`
in this case. This means that docs and i18n PRs from forks are not
being tested as we wish; the translation tests are not run for i18n
PRs, and the app tests are being run for docs PRs.

A CircleCI [feature request](https://discuss.circleci.com/t/only-build-pull-requests-targetting-specific-branch/6082/6) to improve this was closed without
explanation, so I'm incorporating a workaround suggested in the
CircleCI forums: using the GitHub API to obtain the real branch name
for PRs from forks, and skipping tests if it doesn't match. Not all
steps of the relevant jobs are skipped, but the most expensive ones
are.

Also, stop skipping static-analysis-and-no-known-cves, as it doesn't
take that long, and might prevent problems from sneaking in on
branches with inaccurate names.

Fixes #4479.

## Testing

We're going to test this with two PRs, one for docs and one for i18n, to verify that the right tests run and pass.

## Deployment

This will only affect CI.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
