### PR TITLE
Remove "now" from "SecureDrop now uses automatically generated .."

### DIFF
--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -46,7 +46,7 @@
 
 <h2>{{ gettext('Reset Password') }}</h2>
 
-<p>{{ gettext('SecureDrop now uses automatically generated diceware passwords.') }}</p>
+<p>{{ gettext('SecureDrop uses automatically generated diceware passwords.') }}</p>
 <p>{{ gettext('Your password will be changed immediately, so you will need to save it before pressing the "Reset Password" button.') }}</p>
 
 {% if user and g.user != user %}


### PR DESCRIPTION
The change this refers to was made in February 2017, in this commit: b85bffc8dc4a07a24b975485d9cd3f44d7a1418a

## Status

Ready for review

## Checklist

String change only, have not run tests locally but have checked for additional occurrences of the string to ensure it is not repeated or matched against.