### PR TITLE
Fixes #4521 download journalist key via source interface

### DIFF
--- a/securedrop/source_app/info.py
+++ b/securedrop/source_app/info.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
-
-from io import StringIO
+import six
 from flask import Blueprint, render_template, send_file, current_app
+
+if six.PY2:
+    from cStringIO import StringIO  # noqa
+else:
+    from io import BytesIO  # noqa
 
 
 def make_blueprint(config):
@@ -19,7 +23,11 @@ def make_blueprint(config):
     def download_journalist_pubkey():
         journalist_pubkey = current_app.crypto_util.gpg.export_keys(
             config.JOURNALIST_KEY)
-        return send_file(StringIO(journalist_pubkey),
+        if six.PY2:
+            data = StringIO(journalist_pubkey)
+        else:
+            data = BytesIO(journalist_pubkey.encode('utf-8'))
+        return send_file(data,
                          mimetype="application/pgp-keys",
                          attachment_filename=config.JOURNALIST_KEY + ".asc",
                          as_attachment=True)

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -1,5 +1,6 @@
-from . import source_navigation_steps
+from . import source_navigation_steps, journalist_navigation_steps
 from . import functional_test
+import six
 
 
 class TestSourceInterface(
@@ -17,3 +18,16 @@ class TestSourceInterface(
         self._source_chooses_to_login()
         self._source_proceeds_to_login()
         self._source_sees_no_codename()
+
+
+class TestDownloadKey(
+        functional_test.FunctionalTest,
+        journalist_navigation_steps.JournalistNavigationStepsMixin):
+
+    def test_journalist_key_from_source_interface(self):
+        data = self.return_downloaded_content(self.source_location +
+                                              "/journalist-key", None)
+
+        if six.PY3:
+            data = data.decode('utf-8')
+        assert "BEGIN PGP PUBLIC KEY BLOCK" in data


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #4521 

We need different code for Python2 and Python3 to download
journalist key via the source interface. This also adds a functional
test for the same.

## Testing

- `make test`

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
