### PR TITLE
add functional test for /metadata endpoint

### DIFF
--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -1,5 +1,6 @@
 import tempfile
 import time
+import json
 
 from selenium.webdriver.common.action_chains import ActionChains
 
@@ -21,6 +22,13 @@ class SourceNavigationStepsMixin:
     def _source_visits_source_homepage(self):
         self.driver.get(self.source_location)
         assert self._is_on_source_homepage()
+
+    def _source_checks_instance_metadata(self):
+        self.driver.get(self.source_location + "/metadata")
+        j = json.loads(self.driver.find_element_by_tag_name("body").text)
+        assert j["server_os"] == "16.04"
+        assert j["sd_version"] == self.source_app.jinja_env.globals['version']
+        assert j["gpg_fpr"] != ""
 
     def _source_clicks_submit_documents_on_homepage(self):
         # First move the cursor to a known position in case it happens to

--- a/securedrop/tests/functional/test_source_metadata.py
+++ b/securedrop/tests/functional/test_source_metadata.py
@@ -1,0 +1,10 @@
+from . import source_navigation_steps
+from . import functional_test
+
+
+class TestInstanceMetadata(
+        functional_test.FunctionalTest,
+        source_navigation_steps.SourceNavigationStepsMixin):
+
+    def test_instance_metadata(self):
+        self._source_checks_instance_metadata()


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Towards #4526 .

Adds a functional test for the Source Interface's `/metadata` endpoint.

## Testing
- [ ] verify that CI passes
- [ ] (optional) run functional tests locally with command `securedrop/bin/dev-shell bin/run-test -v tests/functional`

## Deployment

No special considerations for deployment

