### PR TITLE
dockerfiles: bump Tor Browser version to 8.5.1 and fix broken lint target

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -237,7 +237,7 @@ Here's a similar example for nginx if the system supports TLS 1.3:
 .. note:: We have prioritized security in selecting these cipher suites, so if
           you choose to use them then your site might not be compatible with
           legacy or outdated browsers and operating systems. For a good
-          reference check out `Cipherli.st <https://cipherli.st/>`__.
+          reference check out `Mozilla's recommendations <https://wiki.mozilla.org/Security/Server_Side_TLS>`__.
 
 You'll need to run ``a2enmod headers ssl rewrite`` for all these to
 work. You should also set ``ServerSignature Off`` and

--- a/securedrop/dockerfiles/xenial/python2/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python2/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -LO https://ftp.mozilla.org/pub/firefox/releases/${FF_ESR_VER}/linux-x8
 
 COPY ./tor_project_public.pub /opt/
 
-ENV TBB_VERSION 8.5
+ENV TBB_VERSION 8.5.1
 RUN gpg --import /opt/tor_project_public.pub && \
     wget  https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \

--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -LO https://ftp.mozilla.org/pub/firefox/releases/${FF_ESR_VER}/linux-x8
 
 COPY ./tor_project_public.pub /opt/
 
-ENV TBB_VERSION 8.5
+ENV TBB_VERSION 8.5.1
 RUN gpg --import /opt/tor_project_public.pub && \
     wget  https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4538
Fixes #4540

## Testing

Does CI pass?

## Deployment

Dev only

## Checklist

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

