### PR TITLE
Update grsecurity kernels to 4.4.182

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -53,4 +53,4 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 # If you bump this, also remember to bump in molecule/builder/tests/vars.yml
 securedrop_pkg_grsec:
   ver: "4.4.182"
-  depends: "linux-image-4.4.177-grsec,linux-firmware-image-4.4.177-grsec,linux-image-4.4.182-grsec,linux-firmware-image-4.4.182-grsec"
+  depends: "linux-image-4.4.177-grsec,linux-firmware-image-4.4.177-grsec,linux-image-4.4.182-grsec,linux-firmware-image-4.4.182-grsec,intel-microcode"

--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -52,5 +52,5 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder/tests/vars.yml
 securedrop_pkg_grsec:
-  ver: "4.4.177"
-  depends: "linux-image-4.4.167-grsec,linux-firmware-image-4.4.167-grsec,linux-image-4.4.177-grsec,linux-firmware-image-4.4.177-grsec"
+  ver: "4.4.182"
+  depends: "linux-image-4.4.177-grsec,linux-firmware-image-4.4.177-grsec,linux-image-4.4.182-grsec,linux-firmware-image-4.4.182-grsec"

--- a/molecule/builder-xenial/tests/vars.yml
+++ b/molecule/builder-xenial/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "0.14.0~rc1"
 ossec_version: "3.0.0"
 keyring_version: "0.1.2"
 config_version: "0.1.3"
-grsec_version: "4.4.177"
+grsec_version: "4.4.182"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/staging/vars/staging.yml
+++ b/molecule/testinfra/staging/vars/staging.yml
@@ -178,4 +178,4 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
-grsec_version: "4.4.177"
+grsec_version: "4.4.182"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4520, #3663 .

Bumps kernels to 4.4.182
Adds intel-microcode to list of dependencies

## Testing
Testing can only be done once kernels are upgraded to apt test.
### Clean install
- [ ] completes without error
- [ ] `uname -r` returns `4.4.182-grsec` on `app` and `mon` servers
### Upgrade testing
- check out this branch
- change `molecule/shared/stable-ver` to 0.13.0 (because 0.13.1 boxes not yet uploaded, see #4524 )
- `make upgrade-start`
- On app and mon, change `security.list` apt.freedom.press -> apt-test.freedom.press and `sudo cron-apt -i -s
- [ ] Cron-apt completes without error on `app` and `mon` servers
- Reboot app and mon
- [ ] `uname -r` returns `4.4.182-grsec` on `app` and `mon` servers
- [ ] `intel-microcode` package is installed on `app` and `mon` servers
## Deployment
Both new and existing installs will be updated via unattended apt updates.
## Checklist


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR


