### PR TITLE
Adds upgrade testing boxes for 0.13.1

### DIFF
--- a/docs/development/upgrade_testing.rst
+++ b/docs/development/upgrade_testing.rst
@@ -123,10 +123,11 @@ When a new version of SecureDrop is released, we must create and upload
 new VM images, to enable testing against that base version in future upgrade
 testing. The procedure is as follows:
 
-1. ``git checkout <version>``
-2. ``make vagrant-package``
-3. ``cd molecule/vagrant-packager && ./push.yml`` to upload to S3
-4. Commit the local changes to JSON files and open a PR.
+1. ``make clean`` to remove any previous artifacts (which would also be pushed)
+2. ``git checkout <version>`` (if a point release, ``git checkout develop``)
+3. ``make vagrant-package``
+4. ``cd molecule/vagrant-packager && ./push.yml`` to upload to S3
+5. Commit the local changes to JSON files and open a PR.
 
 Subsequent invocations of ``make upgrade-start`` will pull the latest
 version of the box.

--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -45,6 +45,17 @@
         }
       ],
       "version": "0.13.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "9e4e2cd973c0daa955d24597ab9ae4e0915b032fe7cd26fdd0f410d4e4300143",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_0.13.1.box"
+        }
+      ],
+      "version": "0.13.1"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -45,6 +45,17 @@
         }
       ],
       "version": "0.13.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "cbe347281867def31e6f6383d40a072d1336bde1ead14fd886192bf548ef41f7",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_0.13.1.box"
+        }
+      ],
+      "version": "0.13.1"
     }
   ]
 }


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Checks the final box on, and therefore closes, #4524.

Includes only Xenial boxes, since Trusty support was dropped in 0.13.0 [sic]. 

Changes proposed in this pull request:

  * New base images for the "upgrade" scenario posted to S3
  * New corresponding metadata for base images
  * Docs clarifications on the maintenance procedures

## Testing

**Note:** I have not tested these boxes myself yet, only built and uploaded.

* [ ] Run `rm -rf build/* && make build-debs` to ensure you have clean debs
* [ ] `make upgrade-start` ; first run will take a while to fetch the images, then future runs will be snappy
* [ ] `make upgrade-test-local` ; confirm no errors
* [ ] Manually verify that the Source Interface shows 0.14.0~rc1

## Deployment
No, dev env only.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
