### PR TITLE
Add safe send_keys methods to FunctionalTest. Stop implicit wait.

### DIFF
--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -24,7 +24,6 @@ import tbselenium.common as cm
 from selenium import webdriver
 from selenium.common.exceptions import NoAlertPresentException
 from selenium.common.exceptions import WebDriverException
-from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.remote_connection import LOGGER
 from selenium.webdriver.support import expected_conditions
@@ -56,6 +55,7 @@ class FunctionalTest(object):
     session_expiration = 30
     secret_message = "These documents outline a major government invasion of privacy."
     timeout = 10
+    poll_frequency = 0.1
 
     accept_languages = None
     driver = None
@@ -124,7 +124,6 @@ class FunctionalTest(object):
                 )
                 self.firefox_driver.set_window_position(0, 0)
                 self.firefox_driver.set_window_size(1024, 768)
-                self.firefox_driver.implicitly_wait(self.timeout)
                 logging.info("Created Firefox web driver")
                 break
             except Exception as e:
@@ -149,21 +148,7 @@ class FunctionalTest(object):
         self.create_firefox_driver()
 
         self.switch_to_torbrowser_driver()
-
-        # Polls the DOM to wait for elements. To read more about why
-        # this is necessary:
-        #
-        # http://www.obeythetestinggoat.com/how-to-get-selenium-to-wait-for-page-load-after-a-click.html
-        #
-        # A value of 5 is known to not be enough in some cases, when
-        # the machine hosting the tests is slow, reason why it was
-        # raised to 10. Setting the value to 60 or more would surely
-        # cover even the slowest of machine. However it also means
-        # that a test failing to find the desired element in the DOM
-        # will only report failure after 60 seconds which is painful
-        # for quickly debuging.
-        #
-        self.driver.implicitly_wait(self.timeout)
+        self.driver.implicitly_wait(0)
 
         yield
 
@@ -200,7 +185,7 @@ class FunctionalTest(object):
 
                     self.source_app = source_app.create_app(config)
                     self.journalist_app = journalist_app.create_app(config)
-                    self.journalist_app.config['WTF_CSRF_ENABLED'] = True
+                    self.journalist_app.config["WTF_CSRF_ENABLED"] = True
 
                     self.__context = self.journalist_app.app_context()
                     self.__context.push()
@@ -296,45 +281,107 @@ class FunctionalTest(object):
             try:
                 return function_with_assertion()
             except (AssertionError, WebDriverException):
-                time.sleep(0.1)
+                time.sleep(self.poll_frequency)
         # one more try, which will raise any errors if they are outstanding
         return function_with_assertion()
 
     def safe_click_by_id(self, element_id):
-        WebDriverWait(self.driver, self.timeout).until(
+        """
+        Clicks the element with the given ID attribute.
+
+        Returns:
+            el: The element, if found.
+
+        Raises:
+            selenium.common.exceptions.TimeoutException: If the element cannot be found in time.
+
+        """
+        el = WebDriverWait(self.driver, self.timeout, self.poll_frequency).until(
             expected_conditions.element_to_be_clickable((By.ID, element_id))
         )
-
-        el = self.wait_for(lambda: self.driver.find_element_by_id(element_id))
-        el.location_once_scrolled_into_view
-        ActionChains(self.driver).move_to_element(el).click().perform()
+        el.click()
+        return el
 
     def safe_click_by_css_selector(self, selector):
-        WebDriverWait(self.driver, self.timeout).until(
+        """
+        Clicks the first element with the given CSS selector.
+
+        Returns:
+            el: The element, if found.
+
+        Raises:
+            selenium.common.exceptions.TimeoutException: If the element cannot be found in time.
+
+        """
+        el = WebDriverWait(self.driver, self.timeout, self.poll_frequency).until(
             expected_conditions.element_to_be_clickable((By.CSS_SELECTOR, selector))
         )
-
-        el = self.wait_for(lambda: self.driver.find_element_by_css_selector(selector))
-        el.location_once_scrolled_into_view
-        ActionChains(self.driver).move_to_element(el).click().perform()
+        el.click()
+        return el
 
     def safe_click_all_by_css_selector(self, selector, root=None):
+        """
+        Clicks each element that matches the given CSS selector.
+
+        Returns:
+            els (list): The list of elements that matched the selector.
+
+        Raises:
+            selenium.common.exceptions.TimeoutException: If the element cannot be found in time.
+
+        """
         if root is None:
             root = self.driver
         els = self.wait_for(lambda: root.find_elements_by_css_selector(selector))
         for el in els:
-            el.location_once_scrolled_into_view
-            self.wait_for(lambda: el.is_enabled() and el.is_displayed())
-            ActionChains(self.driver).move_to_element(el).click().perform()
+            clickable_el = WebDriverWait(self.driver, self.timeout, self.poll_frequency).until(
+                expected_conditions.element_to_be_clickable((By.CSS_SELECTOR, selector))
+            )
+            clickable_el.click()
+        return els
 
-    def _alert_wait(self, timeout=None):
+    def safe_send_keys_by_id(self, element_id, text):
+        """
+        Sends the given text to the element with the specified ID.
+
+        Returns:
+            el: The element, if found.
+
+        Raises:
+            selenium.common.exceptions.TimeoutException: If the element cannot be found in time.
+
+        """
+        el = WebDriverWait(self.driver, self.timeout, self.poll_frequency).until(
+            expected_conditions.element_to_be_clickable((By.ID, element_id))
+        )
+        el.send_keys(text)
+        return el
+
+    def safe_send_keys_by_css_selector(self, selector, text):
+        """
+        Sends the given text to the first element with the given CSS selector.
+
+        Returns:
+            el: The element, if found.
+
+        Raises:
+            selenium.common.exceptions.TimeoutException: If the element cannot be found in time.
+
+        """
+        el = WebDriverWait(self.driver, self.timeout, self.poll_frequency).until(
+            expected_conditions.element_to_be_clickable((By.CSS_SELECTOR, selector))
+        )
+        el.send_keys(text)
+        return el
+
+    def alert_wait(self, timeout=None):
         if timeout is None:
-            timeout = self.timeout
-        WebDriverWait(self.driver, timeout).until(
+            timeout = self.timeout * 2
+        WebDriverWait(self.driver, timeout, self.poll_frequency).until(
             expected_conditions.alert_is_present(), "Timed out waiting for confirmation popup."
         )
 
-    def _alert_accept(self):
+    def alert_accept(self):
         # adapted from https://stackoverflow.com/a/34795883/837471
         def alert_is_not_present(object):
             """ Expect an alert to not be present."""
@@ -346,6 +393,6 @@ class FunctionalTest(object):
                 return True
 
         self.driver.switch_to.alert.accept()
-        WebDriverWait(self.driver, self.timeout).until(
+        WebDriverWait(self.driver, self.timeout, self.poll_frequency).until(
             alert_is_not_present, "Timed out waiting for confirmation popup to disappear."
         )

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -7,14 +7,10 @@ from selenium.webdriver.common.action_chains import ActionChains
 
 class SourceNavigationStepsMixin:
     def _is_on_source_homepage(self):
-        return self.wait_for(
-            lambda: self.driver.find_element_by_id("source-index")
-        )
+        return self.wait_for(lambda: self.driver.find_element_by_id("source-index"))
 
     def _is_logged_in(self):
-        return self.wait_for(
-            lambda: self.driver.find_element_by_id("logout")
-        )
+        return self.wait_for(lambda: self.driver.find_element_by_id("logout"))
 
     def _is_on_lookup_page(self):
         return self.wait_for(lambda: self.driver.find_element_by_id("upload"))
@@ -27,7 +23,7 @@ class SourceNavigationStepsMixin:
         self.driver.get(self.source_location + "/metadata")
         j = json.loads(self.driver.find_element_by_tag_name("body").text)
         assert j["server_os"] == "16.04"
-        assert j["sd_version"] == self.source_app.jinja_env.globals['version']
+        assert j["sd_version"] == self.source_app.jinja_env.globals["version"]
         assert j["gpg_fpr"] != ""
 
     def _source_clicks_submit_documents_on_homepage(self):
@@ -102,9 +98,7 @@ class SourceNavigationStepsMixin:
         assert self._is_on_source_homepage()
 
     def _source_proceeds_to_login(self):
-        codename_input = self.driver.find_element_by_id("login-with-existing-codename")
-        codename_input.send_keys(self.source_name)
-
+        self.safe_send_keys_by_id("login-with-existing-codename", self.source_name)
         self.safe_click_by_id("login")
 
         # Check that we've logged in
@@ -114,8 +108,9 @@ class SourceNavigationStepsMixin:
         assert len(replies) == 1
 
     def _source_enters_codename_in_login_form(self):
-        codename_input = self.driver.find_element_by_id("login-with-existing-codename")
-        codename_input.send_keys("ascension hypertext concert synopses")
+        self.safe_send_keys_by_id(
+            "login-with-existing-codename", "ascension hypertext concert synopses"
+        )
 
     def _source_hits_cancel_at_submit_page(self):
         self.driver.find_element_by_id("cancel").click()
@@ -153,13 +148,12 @@ class SourceNavigationStepsMixin:
 
     def _source_submits_a_file(self):
         with tempfile.NamedTemporaryFile() as file:
-            file.write(self.secret_message.encode('utf-8'))
+            file.write(self.secret_message.encode("utf-8"))
             file.seek(0)
 
             filename = file.name
 
-            file_upload_box = self.driver.find_element_by_css_selector("[name=fh]")
-            file_upload_box.send_keys(filename)
+            self.safe_send_keys_by_css_selector("[name=fh]", filename)
 
             submit_button = self.driver.find_element_by_id("submit-doc-button")
             ActionChains(self.driver).move_to_element(submit_button).perform()
@@ -199,8 +193,7 @@ class SourceNavigationStepsMixin:
         time.sleep(self.timeout)
 
     def _source_enters_text_in_message_field(self):
-        text_box = self.driver.find_element_by_css_selector("[name=msg]")
-        text_box.send_keys(self.secret_message)
+        self.safe_send_keys_by_css_selector("[name=msg]", self.secret_message)
 
     def _source_clicks_submit_button_on_submission_page(self):
         submit_button = self.driver.find_element_by_id("submit-doc-button")
@@ -235,9 +228,7 @@ class SourceNavigationStepsMixin:
         self.wait_for(reply_deleted)
 
     def _source_logs_out(self):
-        logout = self.driver.find_element_by_id("logout")
-        logout.send_keys(" ")
-        logout.click()
+        self.safe_click_by_id("logout")
         self.wait_for(lambda: ("Submit for the first time" in self.driver.page_source))
 
     def _source_not_found(self):

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -15,9 +15,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-import logging
-
-from selenium.common.exceptions import NoSuchElementException
 
 from . import functional_test
 from . import journalist_navigation_steps
@@ -68,20 +65,8 @@ class TestJournalist(
         self._source_submits_a_file()
         self._source_logs_out()
 
-        tries = 10
-        for i in range(tries):
-            try:
-                self._journalist_logs_in()
-                self._journalist_uses_js_filter_by_sources()
-                break
-            except NoSuchElementException:
-                if i < tries:
-                    logging.error(
-                        "Journalist home page JS stymied Selenium again. Retrying login."
-                    )
-                else:
-                    raise
-
+        self._journalist_logs_in()
+        self._journalist_uses_js_filter_by_sources()
         self._journalist_source_selection_honors_filter()
         self._journalist_selects_all_sources_then_selects_none()
         self._journalist_selects_the_first_source()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Add methods to more reliably send key events to elements. This seems
to have fixed one of the most pernicious flaky tests,
test_journalist_interface_ui_with_modal, allowing removal of the
hideous retry hack that could make the tests take minutes longer.

Use them to replace other usages of send_keys, including some that
have definitely been flaky, though not as bad as that one.

Also simplify the safe_click* methods, as WebDriverWait.until returns
the result of the wait condition, and some of the other element
manipulations were unnecessary, given the expected conditions.

Stop setting a default implicit wait in the web drivers. If an element
might not be present, we should use explicit waits instead of adding
this potential delay to every element-locating call. There's also
ample Selenium folklore that mixing implicit and explicit waits leads
to unpredictable timeouts and possible bad behavior.

Rename _alert_wait and _alert_accept.

Double the timeout in alert_wait. This helped with some timeouts
waiting for confirmation popups.

Fixes #4541.

## Testing

Run `make -C securedrop test`. Or just wait for the CI results here. 

## Deployment

This only involves the functional tests.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
