### PR TITLE
Provide full MDS mitigations and move linkcheck to weekly cron

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
 
       - run:
           name: Run documentation linting
-          command: make docs-lint && make docs-linkcheck
+          command: make docs-lint
 
   app-tests:
     machine:
@@ -328,6 +328,22 @@ jobs:
             if ! [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
             make ci-deb-tests
 
+  docs-linkcheck:
+    machine:
+      enabled: true
+    steps:
+      - checkout
+      - *rebaseontarget
+      - *installenchant
+
+      - run:
+          name: Install development dependencies
+          command: pip install -U -r securedrop/requirements/develop-requirements.txt
+
+      - run:
+          name: Run documentation linting
+          command: make docs-lint && make docs-linkcheck
+
 workflows:
   version: 2
   securedrop_ci:
@@ -422,3 +438,4 @@ workflows:
     jobs:
       - deb-tests
       - translation-tests
+      - docs-linkcheck

--- a/install_files/securedrop-grsec/etc/default/grub.d/50-mds-smt.cfg
+++ b/install_files/securedrop-grsec/etc/default/grub.d/50-mds-smt.cfg
@@ -1,0 +1,3 @@
+# disables smt and provide full mds mitigations
+# see https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mds=full,nosmt"

--- a/molecule/testinfra/staging/common/test_grsecurity.py
+++ b/molecule/testinfra/staging/common/test_grsecurity.py
@@ -192,3 +192,15 @@ def test_wireless_disabled_in_kernel_config(host, kernel_opts):
 
     line = "# CONFIG_{} is not set".format(kernel_opts)
     assert line in kernel_config
+
+
+def test_mds_mitigations_and_smt_disabled(host):
+    """
+    Ensure that full mitigations are in place for MDS
+    see https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html
+    """
+
+    grub_config_path = "/boot/grub/grub.cfg"
+    grub_config = host.file(grub_config_path)
+
+    assert grub_config.contains("mds=full,nosmt")


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4520 

Provides Kernel options to enable full MDS mitigations and disable SMT (see https://www.kernel.org/doc/html/latest/x86/mds.html#kernel-internal-mitigation-modes)
## Testing
- [ ] We want to move docs-linkcheck to a weekly cron job
This requires hardware testing - VM testing might return failures, if libvirt configuration does not pass proper parameters (see https://docs.openstack.org/nova/latest/admin/mitigation-for-Intel-MDS-security-flaws.html)
- build `securedrop-grsec-4.4.182-amd64.deb` (securedrop kernel metapackage) on this branch and install it on a hardware instance that has apt-test.freedom.press as sources.list (needs 4.4.182 kernel images)
- [ ] Download and run the script provided at https://meltdown.ovh . All tests should pass
- [ ] Kernel can boot in the previous kernel (4.4.177-grsec)
## Deployment

New and existing installs will be updated via deb packages (securedrop-grsec package)

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR