### PR TITLE
Get screenshots working -- only use one browser in layout tests

### DIFF
--- a/securedrop/bin/translation-test
+++ b/securedrop/bin/translation-test
@@ -20,7 +20,7 @@ mkdir -p "/tmp/test-results/logs"
 # Taking screenshots for consumes a lot of memory
 # and can result in OOM errors in CI. Running each locale
 # separately avoids this.
-for locale in ar de_DE es_ES fr_FR nb_NO nl pt_BR zh_Hant it_IT tr hi ru sv ro is
+for locale in ar de_DE es_ES fr_FR hi is it_IT nb_NO nl pt_BR ro ru sv tr zh_Hant
 do
   PAGE_LAYOUT_LOCALES=$locale pytest \
     -v \

--- a/securedrop/tests/functional/test_source_warnings.py
+++ b/securedrop/tests/functional/test_source_warnings.py
@@ -11,8 +11,8 @@ class TestSourceInterfaceBannerWarnings(
     functional_test.FunctionalTest, source_navigation_steps.SourceNavigationStepsMixin
 ):
     def test_warning_appears_if_tor_browser_not_in_use(self):
-        self.switch_to_firefox_driver()
         try:
+            self.switch_to_firefox_driver()
             self.driver.get(self.source_location)
 
             warning_banner = self.driver.find_element_by_id("use-tor-browser")

--- a/securedrop/tests/functional/test_submit_and_retrieve_file.py
+++ b/securedrop/tests/functional/test_submit_and_retrieve_file.py
@@ -14,8 +14,8 @@ class TestSubmitAndRetrieveFile(
         self._source_continues_to_submit_page()
         self._source_submits_a_file()
         self._source_logs_out()
-        self.switch_to_firefox_driver()
         try:
+            self.switch_to_firefox_driver()
             self._journalist_logs_in()
             self._journalist_checks_messages()
             self._journalist_stars_and_unstars_single_message()

--- a/securedrop/tests/pageslayout/functional_test.py
+++ b/securedrop/tests/pageslayout/functional_test.py
@@ -35,18 +35,22 @@ def list_locales():
 
 
 class FunctionalTest(functional_test.FunctionalTest):
-    @pytest.fixture(autouse=True, params=list_locales())
-    def i18n_fixture(self, request):
-        logging.debug("i18n_fixture: setting accept_languages to '%s'", request.param)
-        self.accept_languages = request.param
+    default_driver_name = functional_test.FIREFOX
 
-    @pytest.fixture(autouse=True)
-    def use_firefox(self):
-        self.switch_to_firefox_driver()
+    @pytest.fixture(autouse=True, params=list_locales())
+    def set_accept_languages(self, request):
+        accept_language_list = request.param.replace("_", "-")
+        logging.debug(
+            "accept_languages fixture: setting accept_languages to %s", accept_language_list
+        )
+        self.accept_languages = accept_language_list
 
     def _screenshot(self, filename):
+        # revert the HTTP Accept-Language format
+        locale = self.accept_languages.replace("-", "_")
+
         log_dir = abspath(
-            os.path.join(dirname(realpath(__file__)), "screenshots", self.accept_languages)
+            os.path.join(dirname(realpath(__file__)), "screenshots", locale)
         )
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Somehow having two browsers open in the test container resulted in corrupted screenshots, where all text was tofu (undefined unicode glyphs).

Fixes #4558.

## Testing

Run some page layout tests with a few locales and check the screenshots:

- `export PAGE_LAYOUT_LOCALES=ar,el,en_US,fr_FR`  # (Arabic, Greek, English, French)
- `make -C securedrop test TESTFILES=tests/pageslayout/test_journalist.py`
- open the PNG images under `securedrop/pageslayout/screenshots/*/*.png` and confirm that all text is rendered properly. Note that at the moment we have some untranslated strings on `develop`, so it's not necessarily a problem to find unexpected English text in some of the screenshots.

## Deployment

This only involves the functional tests. There are no deployment concerns.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
