### PR TITLE
Spelling: two-factor authentication, YubiKey, second one, Reset password

### DIFF
--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -72,7 +72,7 @@
     <br>
     <span id="password" class="password">{{ password }}</span>
   </p>
-  <button class="sd-button btn" type="submit" id="reset-password"><i class="fas fa-sync"></i> {{ gettext('RESET PASSWORD') }}</button>
+  <button class="sd-button btn" type="submit" id="reset-password"><i class="fas fa-sync"></i> {{ gettext('Reset Password') }}</button>
 </form>
 
 <hr class="no-line">
@@ -84,7 +84,7 @@
 {% else %}
 <p>{{ gettext('If your two-factor authentication credentials have been lost or compromised, or you got a new device, you can reset your credentials here. <em>If you do this, make sure you are ready to set up your new device, otherwise you will be locked out of your account.</em>') }}</p>
 {% endif %}
-<p>{{ gettext('To reset two-factor authentication for mobile apps such as FreeOTP, choose the first option. For hardware tokens like the Yubikey, choose the second.') }}</p>
+<p>{{ gettext('To reset two-factor authentication for mobile apps such as FreeOTP, choose the first option. For hardware tokens like the YubiKey, choose the second one.') }}</p>
 
 {% if user %}
   {% set totp_reset_url = url_for('admin.reset_two_factor_totp') %}
@@ -109,7 +109,7 @@
 </form>
 {%- endmacro %}
 
-{{ twofa_reset(user, totp_reset_url, "totp", gettext("Reset 2FA for mobile apps such as FreeOTP or Google Authenticator"), gettext("RESET APP TOKEN"))}}
-{{ twofa_reset(user, hotp_reset_url, "hotp", gettext("Reset 2FA for hardware tokens like Yubikey"), gettext("RESET HARDWARE TOKEN"))}}
+{{ twofa_reset(user, totp_reset_url, "totp", gettext("Reset two-factor authentication for mobile apps, such as FreeOTP"), gettext("RESET APP TOKEN"))}}
+{{ twofa_reset(user, hotp_reset_url, "hotp", gettext("Reset two-factor authentication for hardware tokens, like YubiKey"), gettext("RESET HARDWARE TOKEN"))}}
 
 {% endblock %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Calms and corrects some translated strings. Cherry-picked from @comradekingu's [PR](https://github.com/freedomofpress/securedrop-i18n/pull/1) in the `securedrop-i18n` repo, which will be closed, as we prefer to get PRs here on the main SecureDrop repo.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container
