### PR TITLE
Update keyserver to keys.openpgp.org for comms key

### DIFF
--- a/install_files/ansible-base/securedrop-logs.yml
+++ b/install_files/ansible-base/securedrop-logs.yml
@@ -69,7 +69,7 @@
       become: no
       local_action: >-
         command
-        gpg --recv-key "{{ fpf_support_gpg_fingerprint }}"
+        gpg --keyserver hkps://keys.openpgp.org --recv-key "{{ fpf_support_gpg_fingerprint }}"
       register: fpf_gpg_key_fetch_result
       changed_when: "'imported: 1' in fpf_gpg_key_fetch_result.stderr"
       run_once: yes


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Part of #4128

## Testing

- Use a virtualized Tails env or a prod-like setup to test this PR.
- Remove the `securedrop@freedom.press` key from your keyring
- Run the `securedrop-admin logs` playbook from this branch and verify that the key is successfully imported and the logs are encrypted to the comms key

## Deployment

This is important mitigation against cert flooding attacks, so admins should be encouraged to update their workstations to pick up this fix

## Checklist
- [x] I have followed my own test plan