### PR TITLE
[0.14.0] Update keyserver to keys.openpgp.org for comms key

### DIFF
--- a/install_files/ansible-base/securedrop-logs.yml
+++ b/install_files/ansible-base/securedrop-logs.yml
@@ -69,7 +69,7 @@
       become: no
       local_action: >-
         command
-        gpg --recv-key "{{ fpf_support_gpg_fingerprint }}"
+        gpg --keyserver hkps://keys.openpgp.org --recv-key "{{ fpf_support_gpg_fingerprint }}"
       register: fpf_gpg_key_fetch_result
       changed_when: "'imported: 1' in fpf_gpg_key_fetch_result.stderr"
       run_once: yes


### PR DESCRIPTION
Part of #4128

Backport #4576 to release branch 

(cherry picked from commit 5f4025f1a2b1b088f34ff1673909d2c4d022bb94)

## Status

Ready for review 