### PR TITLE
Restore installation of supervisor in Dockerfiles

### DIFF
--- a/securedrop/dockerfiles/xenial/python2/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python2/Dockerfile
@@ -53,8 +53,8 @@ COPY requirements requirements
 RUN pip install pip-tools && \
     pip install --require-hashes -r requirements/python2/securedrop-app-code-requirements.txt && \
     pip install -r requirements/python2/test-requirements.txt && \
-    pip install --upgrade setuptools  # Fixes #4036 pybabel requires latest version of setuptools && \
-    pip install supervisor
+    pip install supervisor && \
+    pip install --upgrade setuptools  # Fixes #4036 pybabel requires latest version of setuptools
 
 RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi && \
     cp -r /root/.local /tmp/ && chmod +x /tmp/.local/tbb/tor-browser_en-US/Browser/firefox && chmod -R 777 /tmp/.local && \

--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -51,8 +51,8 @@ COPY requirements requirements
 RUN pip3 install pip-tools && \
     pip3 install --require-hashes -r requirements/python3/securedrop-app-code-requirements.txt && \
     pip3 install -r requirements/python3/test-requirements.txt && \
-    pip3 install --upgrade setuptools  # Fixes #4036 pybabel requires latest version of setuptools && \
-    pip3 install supervisor
+    pip3 install supervisor && \
+    pip3 install --upgrade setuptools  # Fixes #4036 pybabel requires latest version of setuptools
 
 # Temporary workaround: Revert when python 3 is deployed to prod
 RUN sudo rm /usr/bin/python && sudo ln -s /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In commit [ec2549](https://github.com/freedomofpress/securedrop/commit/ec254954ebe1b8a72bd82f5e1b3e3f16e6fa7520#diff-370e0b3735825dd422e1c450b0f5a0c4R56) I broke the installation of supervisor in the dev Dockerfiles. This corrects that mistake.

## Testing

- Check out current `develop` and run `make dev`. Right after the image is built and tagged, you should see this error: `setsid: failed to execute supervisord: No such file or directory`. 
- Stop the dev container, check out [this branch](https://github.com/rmol/securedrop/tree/fix-container-supervisor) and run `make dev` again. The error should no longer appear.

## Deployment

This only affects the development containers.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
