### PR TITLE
Modified CLI update function to use keys.openpgp.org for release key

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -683,13 +683,18 @@ def update(args):
                          'Good signature from "SecureDrop Release Signing ' +
                          'Key <securedrop-release-key@freedom.press>"']
         bad_sig_text = 'BAD signature'
-        # To ensure that an adversary cannot name a malicious key good_sig_text
-        # we check that bad_sig_text does not appear and that the release key
-        # appears on the second line of the output.
         gpg_lines = sig_result.split('\n')
+
+        # Check if any strings in good_sig_text match against gpg_lines[]
+        good_sig_matches = [s for s in gpg_lines if
+                            any(xs in s for xs in good_sig_text)]
+
+        # To ensure that an adversary cannot name a malicious key good_sig_text
+        # we check that bad_sig_text does not appear, that the release key
+        # appears on the second line of the output, and that there is a single
+        # match from good_sig_text[]
         if RELEASE_KEY in gpg_lines[1] and \
-                len([s for s in gpg_lines if
-                    any(xs in s for xs in good_sig_text)]) == 1 and \
+                len(good_sig_matches) == 1 and \
                 bad_sig_text not in sig_result:
             # Finally, we check that there is no branch of the same name
             # prior to reporting success.

--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -40,6 +40,7 @@ from pkg_resources import parse_version
 
 sdlog = logging.getLogger(__name__)
 RELEASE_KEY = '22245C81E3BAEB4138B36061310F561200F4AD77'
+DEFAULT_KEYSERVER = 'hkps://keys.openpgp.org'
 EXIT_SUCCESS = 0
 EXIT_SUBPROCESS_ERROR = 1
 EXIT_INTERRUPT = 2
@@ -667,14 +668,9 @@ def update(args):
 
     sdlog.info("Verifying signature on latest update...")
 
-    try:
-        # First try to get the release key using Tails default keyserver
-        get_release_key_from_keyserver(args)
-    except subprocess.CalledProcessError:
-        # Now try to get the key from a secondary keyserver.
-        secondary_keyserver = 'hkps://hkps.pool.sks-keyservers.net'
-        get_release_key_from_keyserver(args,
-                                       keyserver=secondary_keyserver)
+    # Retrieve key from openpgp.org keyserver
+    get_release_key_from_keyserver(args,
+                                   keyserver=DEFAULT_KEYSERVER)
 
     git_verify_tag_cmd = ['git', 'tag', '-v', latest_tag]
     try:
@@ -682,14 +678,18 @@ def update(args):
                                              stderr=subprocess.STDOUT,
                                              cwd=args.root)
 
-        good_sig_text = 'Good signature from "SecureDrop Release Signing Key"'
+        good_sig_text = ['Good signature from "SecureDrop Release Signing ' +
+                         'Key"',
+                         'Good signature from "SecureDrop Release Signing ' +
+                         'Key <securedrop-release-key@freedom.press>"']
         bad_sig_text = 'BAD signature'
         # To ensure that an adversary cannot name a malicious key good_sig_text
         # we check that bad_sig_text does not appear and that the release key
         # appears on the second line of the output.
         gpg_lines = sig_result.split('\n')
         if RELEASE_KEY in gpg_lines[1] and \
-                sig_result.count(good_sig_text) == 1 and \
+                len([s for s in gpg_lines if
+                    any(xs in s for xs in good_sig_text)]) == 1 and \
                 bad_sig_text not in sig_result:
             # Finally, we check that there is no branch of the same name
             # prior to reporting success.

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -485,7 +485,7 @@ def set_reliable_keyserver(gpgdir):
     if not os.path.exists(gpgconf_path):
         os.mkdir(gpgdir)
         with open(gpgconf_path, 'a') as f:
-            f.write('keyserver hkp://ipv4.pool.sks-keyservers.net')
+            f.write('keyserver hkps://keys.openpgp.org')
 
         # Ensure correct permissions on .gnupg home directory.
         os.chmod(gpgdir, 0o700)

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -149,16 +149,35 @@ class TestSecureDropAdmin(object):
             securedrop_admin.get_release_key_from_keyserver(
                 args, keyserver='test.com')
 
-    def test_update_signature_verifies(self, tmpdir, caplog):
+    @pytest.mark.parametrize("git_output",
+                             ['gpg: Signature made Tue 13 Mar '
+                              '2018 01:14:11 AM UTC\n'
+                              'gpg:                using RSA key '
+                              '22245C81E3BAEB4138B36061310F561200F4AD77\n'
+                              'gpg: Good signature from "SecureDrop Release '
+                              'Signing Key" [unknown]\n',
+
+                              'gpg: Signature made Thu 20 Jul '
+                              '2017 08:12:25 PM EDT\n'
+                              'gpg:                using RSA key '
+                              '22245C81E3BAEB4138B36061310F561200F4AD77\n'
+                              'gpg: Good signature from "SecureDrop Release '
+                              'Signing Key '
+                              '<securedrop-release-key@freedom.press>"\n',
+
+                              'gpg: Signature made Thu 20 Jul '
+                              '2017 08:12:25 PM EDT\n'
+                              'gpg:                using RSA key '
+                              '22245C81E3BAEB4138B36061310F561200F4AD77\n'
+                              'gpg: Good signature from "SecureDrop Release '
+                              'Signing Key" [unknown]\n'
+                              'gpg:                 aka "SecureDrop Release '
+                              'Signing Key '
+                              '<securedrop-release-key@freedom.press>" '
+                              '[unknown]\n'])
+    def test_update_signature_verifies(self, tmpdir, caplog, git_output):
         git_repo_path = str(tmpdir)
         args = argparse.Namespace(root=git_repo_path)
-
-        git_output = ('gpg: Signature made Tue 13 Mar 2018 01:14:11 AM UTC\n'
-                      'gpg:                using RSA key '
-                      '22245C81E3BAEB4138B36061310F561200F4AD77\n'
-                      'gpg: Good signature from "SecureDrop Release '
-                      'Signing Key" [unknown]\n')
-
         patchers = [
             mock.patch('securedrop_admin.check_for_updates',
                        return_value=(True, "0.6.1")),


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #4128.

Updates the securedrop-admin tool to use only hkps://keys.openpgp.org when retrieving the release key for tag signature verification.

## Testing

On an Admin Workstation (virtual or USB stick):
- [ ] Verify that the update process works when a release key is already in the GPG keychain, using the following commands in a terminal:
```
cd ~/Persistent/securedrop
gpg --recv-key "22245C81E3BAEB4138B36061310F561200F4AD77"   # use Tails' default keyserver
git remote add zenmonkeykstop https://github.com/zenmonkeykstop/securedrop.git
git checkout openpgp-admin-cli-update
./securedrop-admin update
git status    # should now be on 0.13.1 tag
```
- [ ] Next, verify the process works with no pre-existing key:
```
gpg --delete-keys "22245C81E3BAEB4138B36061310F561200F4AD77"
git checkout openpgp-admin-cli-update
./securedrop-admin update
git status    # should now be on 0.13.1 tag
```

## Deployment
This will be deployed via the GUI updater, CLI update as above, or directly by checking out the release tag containing the change. Nothing special required.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

