### PR TITLE
[0.14.0] Update Admin Workstation setup instructions to use keys.openpgp.org

### DIFF
--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -61,55 +61,70 @@ Start by running the following commands to download the git repository.
 Verify the Release Tag
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. caution:: Do not skip this step as this steps validates the files
-             in your Git repository.
+.. important::
 
-First, download and verify the **SecureDrop Release Signing Key**.
+   It is crucial for the integrity of your installation that you carefully
+   follow the instructions below. By following these steps, you will verify
+   if your copy of the codebase has been approved by the SecureDrop
+   development team.
+
+Download and verify the **SecureDrop Release Signing Key** using the following
+command:
 
 .. code:: sh
 
-    gpg --recv-key "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
+   gpg --keyserver hkps://keys.openpgp.org --recv-key \
+    "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
 
-.. note:: It is important you type this out correctly. If you are not
-          copy-pasting this command, we recommend you double-check you have
-          entered it correctly before pressing enter.
-
-.. tip:: If the ``--recv-key`` command fails, first double-check that
-   `Tails is connected to Tor`_.
-
-   Once you've confirmed that you're successfully connected to Tor, try
-   re-running the ``--recv-key`` command a few times. The default GPG
-   configuration on Tails uses a keyserver pool, which may occasionally return
-   a malfunctioning keyserver, causing the ``--recv-key`` command to fail.
-
-   If the command is consistently failing after a few tries, it could
-   indicate that the default GPG key servers are down or unreachable. As a
-   workaround, another keyserver can be specified by adding the ``--keyserver``
-   option to the ``gpg --recv-key`` command. In our experience, the SKS HKPS
-   keyserver pool is usually a reliable alternative, so try:
-
-   .. code:: sh
-
-      gpg --keyserver hkps://hkps.pool.sks-keyservers.net --recv-key "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
-
-   Again, this is a keyserver pool, so you may need to retry the command a
-   couple of times before it succeeds.
+If you are not copy-pasting this command, we recommend you double-check you have
+entered it correctly before pressing enter. GPG will implicitly verify that the
+fingerprint of the key received matches the argument passed.
 
 .. _Tails is connected to Tor: https://tails.boum.org/doc/anonymous_internet/tor_status/index.en.html
 
-When passing the full public key fingerprint to the ``--recv-key`` command, GPG
-will implicitly verify that the fingerprint of the key received matches the
-argument passed.
+If GPG warns you that the fingerprint of the key received does not
+match the one requested, do **not** proceed with the installation. If this
+happens, please contact us at securedrop@freedom.press.
 
-.. caution:: If GPG warns you that the fingerprint of the key received
-             does not match the one requested **do not** proceed with
-             the installation. If this happens, please email us at
-             securedrop@freedom.press.
+.. note::
+
+   If the ``--recv-key`` command fails, first double-check that
+   `Tails is connected to Tor`_. Once you've confirmed that you're successfully
+   connected to Tor, try re-running the ``--recv-key`` command a few times.
+
+   If the command still fails, the *keys.openpgp.org* keyserver may be down.
+   In that case, we recommend downloading the key from the SecureDrop website:
+
+   .. code:: sh
+
+      cd ~/Persistent
+      torify curl -LO https://securedrop.org/securedrop-release-key.asc
+
+   Before importing it, inspect the key's fingerprint using the following
+   command. The ``--dry-run`` option ensures that the key is not imported just
+   yet:
+
+   .. code:: sh
+
+      gpg --with-fingerprint --import-options import-show --dry-run \
+        --import securedrop-release-key.asc
+
+   Compare the fingerprint in the output with the fingerprint at the beginning
+   of this section. If the fingerprints match, you can safely import the key,
+   using the following command:
+
+   .. code:: sh
+
+      gpg --import securedrop-release-key.asc
+
+   If you encounter any difficulties verifying the integrity of the
+   release key, do **not** proceed with the installation. Instead, please
+   contact us at securedrop@freedom.press.
 
 .. _Checkout and Verify the Current Release Tag:
 
-Verify that the current release tag was signed with the release signing
-key:
+Once you have imported the release key, verify that the current release tag was
+signed with the release signing key:
 
 .. code:: sh
 
@@ -120,9 +135,11 @@ key:
 You should see ``Good signature from "SecureDrop Release Signing Key"`` in the
 output of that last command along with the fingerprint above.
 
-.. caution:: If you do not, signature verification has failed and you
-             *should not* proceed with the installation. If this
-             happens, please contact us at securedrop@freedom.press.
+.. important::
+
+   If you do not see the message above, signature verification has failed
+   and you should **not** proceed with the installation. If this happens,
+   please contact us at securedrop@freedom.press.
 
 Create the Admin Passphrase Database
 ------------------------------------


### PR DESCRIPTION
Backport #4586 to 0.14.0

Includes instructions for importing the key from securedrop.org
as a fallback (may be superseded by WKD fallback in future)

(cherry picked from commit 6ebf31d37cdd9cf6ac0abfc4eb6d173a54362258)

## Status

Ready for review