### PR TITLE
fix(docs): Convert misformatted text to subheading(s)

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -248,14 +248,15 @@ If you use nginx, `you can follow this
 link <https://gist.github.com/mtigas/8601685>`__ and use the
 configuration example provided by ProPublica.
 
-**Change detection monitoring for the web application configuration and
-*Landing Page* content**
+Change detection monitoring for the web application configuration and *Landing Page* content
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 OSSEC is a free and open source host-based intrusion detection suite
 that includes a file integrity monitor. More information can be found
 `here. <https://ossec.github.io/>`__
 
-**Don't log access to the *Landing Page* in the webserver**
+Don't log access to the *Landing Page* in the webserver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Here's an Apache example that would exclude the *Landing Page* from
 logging. However you still need to make sure no other assets get logged!


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4542

This Pull Request converts the misformatted bold/italic pseudo-headings in `docs/deployment/landing_page.rst` and converts them to subheadings.

## Testing

1. Build docs
2. Verify that the formatting issue has been resolved

## Deployment

This PR should not affect deployment in any way.

## Checklist

This is a two-line documentation fix, so it shouldn't be non-trivial by definition. Having said that, I ran all tests listed below prior to committing and all tests passed. 

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
