### PR TITLE
reduce failure rate of 2FA admin functional tests

### DIFF
--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -385,7 +385,7 @@ class FunctionalTest(object):
 
     def alert_wait(self, timeout=None):
         if timeout is None:
-            timeout = self.timeout * 2
+            timeout = self.timeout * 10
         WebDriverWait(self.driver, timeout, self.poll_frequency).until(
             expected_conditions.alert_is_present(), "Timed out waiting for confirmation popup."
         )


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4580
Fixes #4541

This PR adds a retry loop function for clicking Selenium alerts for the 2FA tests. My procedure for debugging these test issues is to:

0. Hop into the dev container and [`pip3 install pytest-repeat`](https://pypi.org/project/pytest-repeat/) 

1. Add the `--count` arg that `pytest-repeat` provides so I can rerun the offending test, e.g. here 100 times:

```diff
diff --git a/securedrop/bin/run-test b/securedrop/bin/run-test
index 4571276ff..bcb548639 100755
--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -33,6 +33,7 @@ export PAGE_LAYOUT_LOCALES
 export TOR_FORCE_NET_CONFIG=0


 pytest \
+    --count 100 \
     --page-layout \
     --durations 10 \
     --junitxml=/tmp/test-results/junit.xml \
```

2. Use the above to run single tests 100 times on this diff versus `develop` to confirm I'm reducing the failure rate, my observations from local testing:

```
bin/run-test tests/functional/test_admin_interface.py::TestAdminInterface::test_admin_edits_hotp_secret
```
With this PR: 100/100 success
On develop: 99/100 success

```
bin/run-test tests/functional/test_admin_interface.py::TestAdminInterface::test_admin_edits_totp_secret
```

With this PR: 100/100 success
On develop: 97/100 success

Note that there's obviously going to be some variability and these are low number statistics so your results may be slightly different. 

## Testing

While one _could_ redo the above, since these are test only changes I don't think it's super valuable redoing the above. Instead, I would just scan the diff and see if it looks reasonable (e.g. `_admin_visits_reset_2fa_totp` didn't have any retry logic previously so not surprising it had a higher failure rate). If we see these same issues pop up again, we can reopen the tickets. 

## Deployment

Test only

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container
