### PR TITLE
ci: export junit XML test metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,10 +143,6 @@ jobs:
       - *p2savecache
 
       - run:
-          name: Make test results directory
-          command: mkdir -p ~/test-results
-
-      - run:
           name: Run tests
           no_output_timeout: 20m
           command: |
@@ -157,10 +153,10 @@ jobs:
             PYTHON_VERSION=2 DOCKER_RUN_ARGUMENTS=$(bash <(curl -s https://codecov.io/env)) DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py2:${fromtag:-latest}" make test
 
       - store_test_results:
-          path: ~/test-results
+          path: ~/project/test-results
 
       - store_artifacts:
-          path: ~/test-results
+          path: ~/project/test-results
 
   python3-app-tests:
     machine:
@@ -181,10 +177,6 @@ jobs:
       - *savecache
 
       - run:
-          name: Make test results directory
-          command: mkdir -p ~/test-results
-
-      - run:
           name: Run tests
           command: |
             BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|docs|update-builder)")
@@ -194,10 +186,10 @@ jobs:
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" make test
 
       - store_test_results:
-          path: ~/test-results
+          path: ~/project/test-results
 
       - store_artifacts:
-          path: ~/test-results
+          path: ~/project/test-results
 
   translation-tests:
     machine:
@@ -217,10 +209,6 @@ jobs:
       - *savecache
 
       - run:
-          name: Make test results directory
-          command: mkdir -p ~/test-results
-
-      - run:
           name: Run tests
           command: |
             BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^i18n")
@@ -230,7 +218,10 @@ jobs:
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" make translation-test
 
       - store_test_results:
-          path: ~/test-results
+          path: ~/project/test-results
+
+      - store_artifacts:
+          path: ~/project/test-results
 
   admin-tests:
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# ignore the test-results directory which is used to share logs and
+# test files with the development containers
+test-results
+
 # ignore the production config files that don't end in .example
 securedrop-app-conf.yml
 securedrop-mon-conf.yml

--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -20,13 +20,13 @@ maybe_create_config_py
 if [ -n "${CIRCLE_BRANCH:-}" ] ; then
     touch tests/log/firefox.log
     function finish {
-        cp tests/log/firefox.log /tmp/test-results/logs/
+        cp tests/log/firefox.log ../test-results
         bash <(curl -s https://codecov.io/bash)
     }
     trap finish EXIT
 fi
 
-mkdir -p "/tmp/test-results/logs"
+mkdir -p "../test-results"
 
 : "${PAGE_LAYOUT_LOCALES:=en_US,ar}"
 export PAGE_LAYOUT_LOCALES
@@ -35,10 +35,10 @@ export TOR_FORCE_NET_CONFIG=0
 pytest \
     --page-layout \
     --durations 10 \
-    --junitxml=/tmp/test-results/junit.xml \
+    --junitxml=../test-results/junit.xml \
     --cov-report term-missing \
-    --cov-report html:/tmp/test-results/cov_html \
-    --cov-report xml:/tmp/test-results/cov.xml \
-    --cov-report annotate:/tmp/test-results/cov_annotate \
+    --cov-report html:../test-results/cov_html \
+    --cov-report xml:../test-results/cov.xml \
+    --cov-report annotate:../test-results/cov_annotate \
     --cov=. \
     "$@"


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

Fixes #3799

Changes proposed in this pull request:
 - Circle CI decides how to split tests across the containers via various methods: we've been using [timings](https://circleci.com/docs/2.0/parallelism-faster-jobs/#splitting-by-timings-data). Circle gets these timings from test result metadata and _should_ iteratively improve the test distribution across the containers based on the run time of the tests. However, our test metadata has been broken for some time (this is bug #3799). This PR fixes the test metadata export.
 - Another reason it's nice to have this metadata exported as the failed test results populate a dashboard at https://circleci.com/build-insights (need to be a project contributor) which can be used to see at a glance which tests are flaky and which tests are the slowest. 

## Testing

Verify by clicking on an app-test Circle CI build on this PR that the "Test Summary" area is now populated and you now see information about the run time of our tests: 

<img width="920" alt="Screen Shot 2019-07-03 at 7 30 03 PM" src="https://user-images.githubusercontent.com/7832803/60636042-bd370e00-9dc9-11e9-8010-8495258fc4f2.png">

## Deployment

CI only

## Checklist

CI changes only