### PR TITLE
Updated logs playbook to clean up unencrypted tarballs

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -41,6 +41,8 @@ from pkg_resources import parse_version
 sdlog = logging.getLogger(__name__)
 RELEASE_KEY = '22245C81E3BAEB4138B36061310F561200F4AD77'
 DEFAULT_KEYSERVER = 'hkps://keys.openpgp.org'
+SUPPORT_ONION_URL = 'http://support6kv2242qx.onion'
+SUPPORT_URL = 'https://support.freedom.press'
 EXIT_SUCCESS = 0
 EXIT_SUBPROCESS_ERROR = 1
 EXIT_INTERRUPT = 2
@@ -741,8 +743,8 @@ def get_logs(args):
         os.path.join(args.ansible_path, 'securedrop-logs.yml'),
     ]
     subprocess.check_call(ansible_cmd, cwd=args.ansible_path)
-    sdlog.info("Encrypt logs and send to securedrop@freedom.press or upload "
-               "to the SecureDrop support portal.")
+    sdlog.info("Please send the encrypted logs to securedrop@freedom.press or "
+               "upload them to the SecureDrop support portal: " + SUPPORT_URL)
     return 0
 
 

--- a/install_files/ansible-base/securedrop-logs.yml
+++ b/install_files/ansible-base/securedrop-logs.yml
@@ -65,6 +65,16 @@
         src: "{{ log_tarball_filename }}"
         dest: "{{ playbook_dir }}/{{ log_tarball_filename }}"
 
+    - name: Delete tarball from server admin home directory.
+      file:
+        path: "{{ log_tarball_filename }}"
+        state: absent
+
+    - name: Clean directory for generated logs to save disk space
+      file:
+        path: /tmp/generated-logs
+        state: absent
+
     - name: Fetch FPF GPG key.
       become: no
       local_action: >-
@@ -86,12 +96,14 @@
       environment:
         GNUPG_HOME: /home/amensia/.gnupg
 
+    - name: Delete local unencrypted log tarballs.
+      become: no
+      local_action:
+        module: file
+        path: "{{ log_tarball_filename }}"
+        state: absent
+
     - name: Display filenames of local log tarballs.
       debug:
         msg: >-
           Logs copied successfully, find them at {{ (playbook_dir +'/'+ log_tarball_filename )|realpath }}.gpg .
-
-    - name: Clean directory for generated logs to save disk space
-      file:
-        path: /tmp/generated-logs
-        state: absent


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4593 

Updates `securedrop-logs.yml` to delete unencrypted tarballs from the servers and Admin Workstation.

## Testing
On a VM or HW production instance, via the Admin Workstation:
- [ ] verify that `./securedrop-admin logs` completes without error
- [ ] verify that the unencrypted tarballs do not exist in `~/Persistent/securedrop/install_files/ansible-base`
- [ ] verify that the unencrypted tarballs do not exist in the server admin home directory for either the Application or Monitor Server.
- [ ] if you have access to the necessary key, verify that the encrypted tarballs can be decrypted.

## Deployment
Deployed when workstation USBs are updated.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
