### PR TITLE
Add Catalan as a supported language.

### DIFF
--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -37,6 +37,7 @@ class I18NTool(object):
     #
     SUPPORTED_LANGUAGES = {
         'ar': {'name': 'Arabic', 'desktop': 'ar', },
+        'ca': {'name': 'Catalan', 'desktop': 'ca', },
         'de_DE': {'name': 'German', 'desktop': 'de_DE', },
         'es_ES': {'name': 'Spanish', 'desktop': 'es_ES', },
         'fr_FR': {'name': 'French', 'desktop': 'fr', },


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This adds Catalan to the list of languages supported by SecureDrop, defined in `I18NTool.SUPPORTED_LANGUAGES`  in `securedrop/i18n_tool.py`. This is required for our automatic merge of Weblate translations to pick up Catalan.

Until the Catalan translations are merged, this will have no other effect, as `securedrop-admin sdconfig` generates its list of supported locales from the contents of the `securedrop/translations` directory.

Fixes #4595.

## Testing

- Check out this branch.
- Run `make list-translators`.
- `ca (Catalan)` should appear in the output. Note that because the Catalan translations haven't been merged yet, there will be errors about non-existent Catalan `.po` files.

## Deployment

This should have no effect on existing installations until `securedrop-admin sdconfig` and `securedrop-admin install` are run and Catalan is added to the list of languages a site wants to support.

There will be a small window on `develop` between the merge of this PR and the merge of the 0.14.0 translations where Catalan will be a supported language option, but have no translations.

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
