### PR TITLE
Update builder image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,8 +355,11 @@ jobs:
   deb-tests:
     docker:
       - image: gcr.io/cloud-builders/docker
+    environment:
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
     steps:
-      - run: apt-get install -y make virtualenv enchant jq
+      - run: apt-get install -y make virtualenv enchant jq python3-dev build-essential
       - checkout
       - setup_remote_docker
       - run:

--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ ci-teardown:  ## Destroy GCE host for testing staging environment.
 .PHONY: ci-deb-tests
 ci-deb-tests:  ## Test SecureDrop Debian packages in CI environment.
 	@echo "███ Running Debian package tests in CI..."
-	@(SDROOT)/devops/scripts/test-built-packages.sh
+	@$(SDROOT)/devops/scripts/test-built-packages.sh
 	@echo
 
 .PHONY: build-gcloud-docker

--- a/molecule/builder-xenial/image_hash
+++ b/molecule/builder-xenial/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2019_06_18
-26628e7442142dd81c9897eed632f0c3b7cf256362ce838adc92da44529d6e91
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2019_07_09
+c28c18eb758674f51c1d95ea45af849fb4c751815445cd6329ebd1e9c7adcbe7


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #4550 


## Testing

- [x] CI (including deb tests) passes

## Deployment

Dev env only

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
