### PR TITLE
[0.14.0] Update builder image

### DIFF
--- a/molecule/builder-xenial/image_hash
+++ b/molecule/builder-xenial/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2019_06_18
-26628e7442142dd81c9897eed632f0c3b7cf256362ce838adc92da44529d6e91
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2019_07_09
+c28c18eb758674f51c1d95ea45af849fb4c751815445cd6329ebd1e9c7adcbe7


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backports builder image from #4601 into the release branch. CI fixes are not needed here, because the python3 dev env changes introduced in #4544 are not in the release/0.14.0 branch.


## Testing

- [x] Ensure commit hash same as first commit in #4601 
- [x] #4601 is merged to develop 
- [x] CI passes (including deb-tests)

## Deployment

Dev env only 
## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
