### PR TITLE
Add pytest flaky plugin

### DIFF
--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -33,6 +33,7 @@ export PAGE_LAYOUT_LOCALES
 export TOR_FORCE_NET_CONFIG=0
 
 pytest \
+    --force-flaky --max-runs=3 \
     --page-layout \
     --durations 10 \
     --junitxml=/tmp/test-results/junit.xml \

--- a/securedrop/requirements/python2/test-requirements.in
+++ b/securedrop/requirements/python2/test-requirements.in
@@ -1,6 +1,7 @@
 beautifulsoup4
 blinker
 Flask-Testing
+flaky
 mock
 pip-tools>=3.8.0,<4
 py

--- a/securedrop/requirements/python2/test-requirements.txt
+++ b/securedrop/requirements/python2/test-requirements.txt
@@ -13,6 +13,7 @@ click==6.7                # via flask, pip-tools
 coverage==4.4.2           # via pytest-cov
 easyprocess==0.2.3        # via pyvirtualdisplay
 enum34==1.1.6             # via hypothesis
+flaky==3.6.0
 flask-testing==0.7.1
 flask==1.0.2              # via flask-testing
 funcsigs==1.0.2           # via mock, pytest

--- a/securedrop/requirements/python3/test-requirements.in
+++ b/securedrop/requirements/python3/test-requirements.in
@@ -1,6 +1,7 @@
 beautifulsoup4
 blinker
 Flask-Testing
+flaky
 mock
 pip-tools>=3.8.0,<4
 py

--- a/securedrop/requirements/python3/test-requirements.txt
+++ b/securedrop/requirements/python3/test-requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file=requirements/python3/test-requirements.txt requirements/python3/test-requirements.in
 #
+atomicwrites==1.3.0       # via pytest
 attrs==17.4.0             # via hypothesis, pytest
 beautifulsoup4==4.6.0
 blinker==1.4
@@ -12,29 +13,34 @@ chardet==3.0.4            # via requests
 click==6.7                # via flask, pip-tools
 coverage==4.4.2           # via pytest-cov
 easyprocess==0.2.3        # via pyvirtualdisplay
+flaky==3.6.0
 flask-testing==0.7.1
 flask==1.0.2              # via flask-testing
 hypothesis==4.22.2
 idna==2.8                 # via requests
+importlib-metadata==0.18  # via pluggy
 itsdangerous==0.24        # via flask
 jinja2==2.10.1            # via flask
 markupsafe==1.0           # via jinja2
 mock==2.0.0
+more-itertools==7.1.0     # via pytest
+pathlib2==2.3.4           # via pytest
 pbr==3.1.1                # via mock
 pip-tools==3.8.0
-pluggy==0.6.0             # via pytest
+pluggy==0.12.0            # via pytest
 py==1.5.2
 pysocks==1.6.8            # via requests
 pytest-cov==2.5.1
 pytest-mock==1.7.1
-pytest==3.3.2
+pytest==3.10
 pyvirtualdisplay==0.2.1
 requests[socks]==2.22.0
 selenium==3.141.0
-six==1.11.0               # via mock, pip-tools, pytest
+six==1.11.0               # via mock, pathlib2, pip-tools, pytest
 tbselenium==0.4.2
 urllib3==1.24.1           # via requests, selenium
 werkzeug==0.14.1          # via flask
+zipp==0.5.1               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools==41.0.1        # via pytest

--- a/securedrop/tests/test_alembic.py
+++ b/securedrop/tests/test_alembic.py
@@ -10,8 +10,6 @@ from alembic.script import ScriptDirectory
 from os import path
 from sqlalchemy import text
 
-from . import conftest
-
 from db import db
 from journalist_app import create_app
 
@@ -104,9 +102,7 @@ def test_alembic_head_matches_db_models(journalist_app,
     '''
     models_schema = get_schema(journalist_app)
 
-    config.DATABASE_FILE = config.DATABASE_FILE + '.new'
-    # Use the fixture to rewrite the config with the new URI
-    conftest.alembic_config(config)
+    os.remove(config.DATABASE_FILE)
 
     # Create database file
     subprocess.check_call(['sqlite3', config.DATABASE_FILE, '.databases'])


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds the pytest [flaky](https://github.com/box/flaky) plugin to automatically rerun failed tests. Adding it to the functional test classes with three retries seems to solve all of our famous flakes. We'll see how it does in CI.

I went with `flaky` over [pytest-rerunfailures](https://github.com/pytest-dev/pytest-rerunfailures) because the latter warns that it's not compatible with class-, module-, or package-level fixtures, which we're trying to move toward with #3836.

Fixes #4604.

## Testing

Check out the branch, run the tests a few hundred times. It's the only way to be sure.

## Deployment

This should only affect tests and test requirements.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
