### PR TITLE
Fix update_version.sh

### DIFF
--- a/update_version.sh
+++ b/update_version.sh
@@ -65,9 +65,6 @@ if [[ ! $NEW_VERSION == *~rc* ]]; then
     # Upgrade docs to Ubuntu 16.04 reference current stable version explicitly.
     # Where we're talking about the 0.12 _series_ (the first to support Xenial),
     # the phrase "0.12 series" is used, so this regex is safe to run.
-    sed -i "s@$(echo "${OLD_RELEASE}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/upgrade/xenial_upgrade_in_place.rst
-    sed -i "s@$(echo "${OLD_RELEASE}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/upgrade/xenial_prep.rst
-    sed -i "s@$(echo "${OLD_RELEASE}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/upgrade/xenial_backup_install_restore.rst
 fi
 
 # Update the changelog


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #4611 : 


## Testing
- [ ] I can successfully bump a version of SecureDrop based on the documentation provided in https://docs.securedrop.org/en/release-0.13.1/development/release_management.html?highlight=release%20management
- [ ] The sed commands that were removed refer to files that are no longer tracked in the repo
## Deployment

Dev only
## Checklist


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

