### PR TITLE
Revert "Fixes safe click for localized languages"

### DIFF
--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -308,6 +308,7 @@ class FunctionalTest(object):
         el = WebDriverWait(self.driver, self.timeout, self.poll_frequency).until(
             expected_conditions.element_to_be_clickable((By.ID, element_id))
         )
+        el.location_once_scrolled_into_view
         el.click()
         return el
 

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -27,7 +27,6 @@ from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.remote_connection import LOGGER
 from selenium.webdriver.support import expected_conditions
-from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support.ui import WebDriverWait
 from sqlalchemy.exc import IntegrityError
 from tbselenium.tbdriver import TorBrowserDriver
@@ -309,8 +308,7 @@ class FunctionalTest(object):
         el = WebDriverWait(self.driver, self.timeout, self.poll_frequency).until(
             expected_conditions.element_to_be_clickable((By.ID, element_id))
         )
-        el.location_once_scrolled_into_view
-        ActionChains(self.driver).move_to_element(el).click().perform()
+        el.click()
         return el
 
     def safe_click_by_css_selector(self, selector):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

I'm getting #4614 consistently locally unless I revert 220aea096b4474edb0f82109f0eeab653592dfb0. Fixes #4614. 

Note that this was added to improve reliability of the translation tests, so we need to address it in some other way e.g. via implementing #4604 or something else prior to the next regular release (Sept 4)

## Testing

```
bin/dev-shell bin/run-test tests/functional/test_source.py::TestSourceInterface::test_lookup_codename_hint
```

passes

and CI should pass

## Deployment

Test only

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container (only tested the one test above, going to see what CI thinks of this)
