### PR TITLE
Upgrade boxes for SecureDrop 0.14.0

### DIFF
--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -56,6 +56,17 @@
         }
       ],
       "version": "0.13.1"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "79a8684d46c8e77c2793e45818101f985e8654020ff345b11f543b87110927d0",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_0.14.0.box"
+        }
+      ],
+      "version": "0.14.0"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -56,6 +56,17 @@
         }
       ],
       "version": "0.13.1"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "752106cb530810d39ac860dcaf6d1829266560a3b0c578898698983f41d4154a",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_0.14.0.box"
+        }
+      ],
+      "version": "0.14.0"
     }
   ]
 }


### PR DESCRIPTION
## Status

Work in progress : Must be rebased once https://github.com/freedomofpress/securedrop/pull/4616 is merged due to version bump required for makefile targets to work
## Description of Changes

Towards #4550 .


## Testing

On this branch:
* `make build-debs`
* `make upgrade-start`
- [ ] Boxes come up and source interface shows version 0.14.0
- `make upgrade-test-local`
- [ ] Upgrade is successful and source interface shows version 1.0.0~rc1

## Deployment

Dev only

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
