### PR TITLE
Support simultaneous dev containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ test-config: securedrop/config.py
 .PHONY: dev
 dev:  ## Run the development server in a Docker container.
 	@echo "███ Starting development server..."
-	@DOCKER_RUN_ARGUMENTS='-p127.0.0.1:8080:8080 -p127.0.0.1:8081:8081' DOCKER_BUILD_VERBOSE='true' $(DEVSHELL) $(SDBIN)/run
+	@DOCKER_BUILD_VERBOSE='true' $(DEVSHELL) $(SDBIN)/run
 	@echo
 
 .PHONY: docs

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ test-config: securedrop/config.py
 .PHONY: dev
 dev:  ## Run the development server in a Docker container.
 	@echo "███ Starting development server..."
-	@USE_PORT_PREFIX='false' DOCKER_BUILD_VERBOSE='true' $(DEVSHELL) $(SDBIN)/run
+	@OFFSET_PORTS='false' DOCKER_BUILD_VERBOSE='true' $(DEVSHELL) $(SDBIN)/run
 	@echo
 
 .PHONY: docs

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ test-config: securedrop/config.py
 .PHONY: dev
 dev:  ## Run the development server in a Docker container.
 	@echo "███ Starting development server..."
-	@DOCKER_BUILD_VERBOSE='true' $(DEVSHELL) $(SDBIN)/run
+	@USE_PORT_PREFIX='false' DOCKER_BUILD_VERBOSE='true' $(DEVSHELL) $(SDBIN)/run
 	@echo
 
 .PHONY: docs

--- a/devops/scripts/vnc-docker-connect.sh
+++ b/devops/scripts/vnc-docker-connect.sh
@@ -6,10 +6,20 @@
 
 set -e
 
-# Bomb out if container not running
-docker inspect securedrop-dev >/dev/null 2>&1 || (echo "ERROR: SD container not running."; exit 1)
+## Get a short identifier for the working directory
+hashpath() {
+    pwd | sum | awk '{print $1}'
+}
 
-VNCPORT=5909
+PORT_PREFIX=${PORT_PREFIX:-""}
+SD_CONTAINER="sd-$(hashpath)${PORT_PREFIX:+-${PORT_PREFIX}}"
+
+# Bomb out if container not running
+docker inspect "${SD_CONTAINER}" >/dev/null 2>&1 || (echo "ERROR: SD container not running."; exit 1)
+
+VNCPORT=${PORT_PREFIX}5909
+
+echo "Connecting to container ${SD_CONTAINER}:${VNCPORT}..."
 
 # Maybe we are running macOS
 if [ "$(uname -s)" == "Darwin" ]; then
@@ -17,11 +27,8 @@ if [ "$(uname -s)" == "Darwin" ]; then
     exit 0
 fi
 
-# Find our securedrop docker ip
-SD_DOCKER_IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' securedrop-dev)"
-
 # Quit if the VNC port not found
-nc -w5 -z "$SD_DOCKER_IP" ${VNCPORT} || (echo "ERROR: VNC server not found"; exit 1)
+nc -w5 -z "127.0.0.1" ${VNCPORT} || (echo "ERROR: VNC server not found"; exit 1)
 
 if [ ! "$(which remote-viewer)" ]
 then
@@ -36,6 +43,6 @@ fi
 
 
 rv_config="${TMPDIR:-/tmp}/sd-vnc.ini"
-echo -e "[virt-viewer]\ntype=vnc\nhost=${SD_DOCKER_IP}\nport=${VNCPORT}\npassword=freedom" > "${rv_config}"
+echo -e "[virt-viewer]\ntype=vnc\nhost=127.0.0.1\nport=${VNCPORT}\npassword=freedom" > "${rv_config}"
 
-remote-viewer "${rv_config}" 2>/dev/null &
+remote-viewer "${rv_config}"

--- a/devops/scripts/vnc-docker-connect.sh
+++ b/devops/scripts/vnc-docker-connect.sh
@@ -6,20 +6,14 @@
 
 set -e
 
-## Get a short identifier for the working directory
-hashpath() {
-    pwd | sum | awk '{print $1}'
-}
-
 PORT_PREFIX=${PORT_PREFIX:-""}
-SD_CONTAINER="sd-$(hashpath)${PORT_PREFIX:+-${PORT_PREFIX}}"
 
 # Bomb out if container not running
-docker inspect "${SD_CONTAINER}" >/dev/null 2>&1 || (echo "ERROR: SD container not running."; exit 1)
+docker inspect securedrop-dev-${PORT_PREFIX} >/dev/null 2>&1 || (echo "ERROR: SD container not running."; exit 1)
 
 VNCPORT=${PORT_PREFIX}5909
 
-echo "Connecting to container ${SD_CONTAINER}:${VNCPORT}..."
+echo "Connecting to container securedrop-dev-${PORT_PREFIX}:${VNCPORT}..."
 
 # Maybe we are running macOS
 if [ "$(uname -s)" == "Darwin" ]; then
@@ -45,4 +39,4 @@ fi
 rv_config="${TMPDIR:-/tmp}/sd-vnc.ini"
 echo -e "[virt-viewer]\ntype=vnc\nhost=127.0.0.1\nport=${VNCPORT}\npassword=freedom" > "${rv_config}"
 
-remote-viewer "${rv_config}"
+remote-viewer "${rv_config}" 2>/dev/null &

--- a/devops/scripts/vnc-docker-connect.sh
+++ b/devops/scripts/vnc-docker-connect.sh
@@ -6,14 +6,14 @@
 
 set -e
 
-PORT_PREFIX=${PORT_PREFIX:-""}
+PORT_OFFSET=${PORT_OFFSET:-100}
 
 # Bomb out if container not running
-docker inspect securedrop-dev-${PORT_PREFIX} >/dev/null 2>&1 || (echo "ERROR: SD container not running."; exit 1)
+docker inspect securedrop-dev-${PORT_OFFSET} >/dev/null 2>&1 || (echo "ERROR: SD container not running."; exit 1)
 
-VNCPORT=${PORT_PREFIX}5909
+VNCPORT=$((PORT_OFFSET + 5909))
 
-echo "Connecting to container securedrop-dev-${PORT_PREFIX}:${VNCPORT}..."
+echo "Connecting to container securedrop-dev-${PORT_OFFSET}:${VNCPORT}..."
 
 # Maybe we are running macOS
 if [ "$(uname -s)" == "Darwin" ]; then

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -11,17 +11,15 @@ export PATH="/opt/venvs/securedrop-app-code/bin:$PATH"
 TOPLEVEL=$(git rev-parse --show-toplevel)
 BASE_OS=xenial
 
-function docker_image() {
-
 ## Get a short identifier for the working directory
 hashpath() {
     pwd | sum | awk '{print $1}'
 }
 
-## Get an integer prefix for exposed ports, to support running dev and
-## test, or containers from different directories simultaneously
+## Get an integer prefix for exposed ports, to support multiple containers
+
 get_port_prefix() {
-    port_prefix="${PORT_PREFIX:-}"
+    port_prefix="${PORT_PREFIX:-1}"
     tries=0
     while true
     do
@@ -33,21 +31,26 @@ get_port_prefix() {
     echo "$port_prefix"
 }
 
+function docker_image() {
     docker build \
            ${DOCKER_BUILD_ARGUMENTS:-} \
            --build-arg=USER_ID="$(id -u)" \
            --build-arg=USER_NAME="${USER:-root}" \
-           -t "sd-${1}-py${2}-$(hashpath)" \
+           -t "securedrop-test-${1}-py3-$(hashpath)" \
            --file "${TOPLEVEL}/securedrop/dockerfiles/${1}/python3/Dockerfile" \
            "${TOPLEVEL}/securedrop"
 }
 
 function docker_run() {
     find . \( -name '*.pyc' -o -name __pycache__ \) -delete
+    if [ "${USE_PORT_PREFIX:-true}" = "true" ]
+    then
+       port_prefix="$(get_port_prefix)"
+    else
+       port_prefix=""
+    fi
 
-    port_prefix="$(get_port_prefix)"
-
-    SD_CONTAINER="sd-$(hashpath)${port_prefix:+-${port_prefix}}"
+    SD_CONTAINER="securedrop-dev-${port_prefix}"
     export SD_HOSTPORT_JI="${port_prefix}8081"
     export SD_HOSTPORT_SI="${port_prefix}8080"
     export SD_HOSTPORT_VNC="${port_prefix}5909"
@@ -73,9 +76,6 @@ function docker_run() {
            -e LANG=C.UTF-8 \
            -e PAGE_LAYOUT_LOCALES \
            -e PATH \
-           -e SD_HOSTPORT_JI \
-           -e SD_HOSTPORT_SI \
-           -e SD_HOSTPORT_VNC \
            --user "${USER:-root}" \
            --volume "${TOPLEVEL}:${TOPLEVEL}" \
            --workdir "${TOPLEVEL}/securedrop" \

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -16,19 +16,18 @@ hashpath() {
     pwd | sum | awk '{print $1}'
 }
 
-## Get an integer prefix for exposed ports, to support multiple containers
 
-get_port_prefix() {
-    port_prefix="${PORT_PREFIX:-1}"
+## Get an integer offset for exposed ports, to support multiple containers
+get_port_offset() {
     tries=0
     while true
     do
-        vnc="${port_prefix}5909"
+        tries=$((tries + 1))
+	port_offset=$((tries * 100))
+        vnc=$((port_offset + 5909))
         nc -z localhost "$vnc" || break
-        tries=$(( tries + 1 ))
-        port_prefix="${tries}"
     done
-    echo "$port_prefix"
+    echo "$port_offset"
 }
 
 function docker_image() {
@@ -43,21 +42,21 @@ function docker_image() {
 
 function docker_run() {
     find . \( -name '*.pyc' -o -name __pycache__ \) -delete
-    if [ "${USE_PORT_PREFIX:-true}" = "true" ]
+    if [ "${OFFSET_PORTS:-true}" = "true" ]
     then
-       port_prefix="$(get_port_prefix)"
+       port_offset="$(get_port_offset)"
     else
-       port_prefix=""
+       port_offset=0
     fi
 
-    SD_CONTAINER="securedrop-dev-${port_prefix}"
-    export SD_HOSTPORT_JI="${port_prefix}8081"
-    export SD_HOSTPORT_SI="${port_prefix}8080"
-    export SD_HOSTPORT_VNC="${port_prefix}5909"
+    SD_CONTAINER="securedrop-dev-${port_offset}"
+    SD_HOSTPORT_JI=$((port_offset + 8081))
+    SD_HOSTPORT_SI=$((port_offset + 8080))
+    SD_HOSTPORT_VNC=$((port_offset + 5909))
 
     echo "************************************************************"
     echo "Exposed Docker ports will be available on localhost with"
-    echo "port prefix ${port_prefix}:"
+    echo "Port offset: $port_offset"
     echo "Source interface: $SD_HOSTPORT_SI"
     echo "Journalist interface: $SD_HOSTPORT_JI"
     echo "VNC: $SD_HOSTPORT_VNC"

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -12,11 +12,32 @@ TOPLEVEL=$(git rev-parse --show-toplevel)
 BASE_OS=xenial
 
 function docker_image() {
+
+## Get a short identifier for the working directory
+hashpath() {
+    pwd | sum | awk '{print $1}'
+}
+
+## Get an integer prefix for exposed ports, to support running dev and
+## test, or containers from different directories simultaneously
+get_port_prefix() {
+    port_prefix="${PORT_PREFIX:-}"
+    tries=0
+    while true
+    do
+        vnc="${port_prefix}5909"
+        nc -z localhost "$vnc" || break
+        tries=$(( tries + 1 ))
+        port_prefix="${tries}"
+    done
+    echo "$port_prefix"
+}
+
     docker build \
            ${DOCKER_BUILD_ARGUMENTS:-} \
            --build-arg=USER_ID="$(id -u)" \
            --build-arg=USER_NAME="${USER:-root}" \
-           -t "securedrop-test-${1}-py3" \
+           -t "sd-${1}-py${2}-$(hashpath)" \
            --file "${TOPLEVEL}/securedrop/dockerfiles/${1}/python3/Dockerfile" \
            "${TOPLEVEL}/securedrop"
 }
@@ -24,12 +45,27 @@ function docker_image() {
 function docker_run() {
     find . \( -name '*.pyc' -o -name __pycache__ \) -delete
 
+    port_prefix="$(get_port_prefix)"
+
+    if [ -z "$port_prefix" ]
+    then
+        echo "Using no prefix for exposed Docker ports."
+    else
+        echo "************************************************************"
+        echo "Exposed Docker ports will be available on localhost prefixed"
+        echo "with \"${port_prefix}\", e.g. ${port_prefix}8080 for the source interface, and "
+        echo "${port_prefix}8081 for the journalist interface."
+        echo "************************************************************"
+    fi
+
     # The --shm-size argument sets up dedicated shared memory for the
     # container. Our tests can fail with the default of 64m.
     docker run \
            --shm-size 2g \
-           -p 127.0.0.1:5909:5909 \
            --rm \
+           -p "127.0.0.1:${port_prefix}5909:5909" \
+           -p "127.0.0.1:${port_prefix}8080:8080" \
+           -p "127.0.0.1:${port_prefix}8081:8081" \
            -e NUM_SOURCES \
            -e LC_ALL=C.UTF-8 \
            -e LANG=C.UTF-8 \
@@ -38,7 +74,7 @@ function docker_run() {
            --user "${USER:-root}" \
            --volume "${TOPLEVEL}:${TOPLEVEL}" \
            --workdir "${TOPLEVEL}/securedrop" \
-           --name securedrop-dev \
+           --name "sd-$(uuid)" \
            -ti ${DOCKER_RUN_ARGUMENTS:-} "securedrop-test-${1}-py3" "${@:2}"
 }
 

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -47,34 +47,39 @@ function docker_run() {
 
     port_prefix="$(get_port_prefix)"
 
-    if [ -z "$port_prefix" ]
-    then
-        echo "Using no prefix for exposed Docker ports."
-    else
-        echo "************************************************************"
-        echo "Exposed Docker ports will be available on localhost prefixed"
-        echo "with \"${port_prefix}\", e.g. ${port_prefix}8080 for the source interface, and "
-        echo "${port_prefix}8081 for the journalist interface."
-        echo "************************************************************"
-    fi
+    SD_CONTAINER="sd-$(hashpath)${port_prefix:+-${port_prefix}}"
+    export SD_HOSTPORT_JI="${port_prefix}8081"
+    export SD_HOSTPORT_SI="${port_prefix}8080"
+    export SD_HOSTPORT_VNC="${port_prefix}5909"
+
+    echo "************************************************************"
+    echo "Exposed Docker ports will be available on localhost with"
+    echo "port prefix ${port_prefix}:"
+    echo "Source interface: $SD_HOSTPORT_SI"
+    echo "Journalist interface: $SD_HOSTPORT_JI"
+    echo "VNC: $SD_HOSTPORT_VNC"
+    echo "************************************************************"
 
     # The --shm-size argument sets up dedicated shared memory for the
     # container. Our tests can fail with the default of 64m.
     docker run \
            --shm-size 2g \
            --rm \
-           -p "127.0.0.1:${port_prefix}5909:5909" \
-           -p "127.0.0.1:${port_prefix}8080:8080" \
-           -p "127.0.0.1:${port_prefix}8081:8081" \
+           -p "127.0.0.1:${SD_HOSTPORT_VNC}:5909" \
+           -p "127.0.0.1:${SD_HOSTPORT_SI}:8080" \
+           -p "127.0.0.1:${SD_HOSTPORT_JI}:8081" \
            -e NUM_SOURCES \
            -e LC_ALL=C.UTF-8 \
            -e LANG=C.UTF-8 \
            -e PAGE_LAYOUT_LOCALES \
            -e PATH \
+           -e SD_HOSTPORT_JI \
+           -e SD_HOSTPORT_SI \
+           -e SD_HOSTPORT_VNC \
            --user "${USER:-root}" \
            --volume "${TOPLEVEL}:${TOPLEVEL}" \
            --workdir "${TOPLEVEL}/securedrop" \
-           --name "sd-$(uuid)" \
+           --name "${SD_CONTAINER}" \
            -ti ${DOCKER_RUN_ARGUMENTS:-} "securedrop-test-${1}-py3" "${@:2}"
 }
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Teach dev-shell to use a prefix for ports exposed in the dev containers, when necessary. This permits running multiple container-based tasks (anything run with dev-shell in the Makefile) simultaneously.

For example, if you run `make dev` with no other containers running, VNC will be on 5909, the source interface on 8080, and the journalist interface on 8081. If you then run `make test` while that container is running, the test container's services should be available at 15909, 18080, and 18081. Obviously the number of containers we can run with this simple scheme is limited, but probably sufficient.

## Testing

- Check out this branch.
- Run `make dev`.
- In another shell, run `make test`. You should see a notice that the container used for running tests will be offering services on different ports, e.g.:
```
************************************************************
Exposed Docker ports will be available on localhost prefixed
with "1", e.g. 18080 for the source interface, and 
18081 for the journalist interface.
************************************************************
```

The tests should run, and you should be able to interact with the dev servers normally.

## Deployment

This should only affect development activities using `dev-shell`.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
