### PR TITLE
Fixes #4627 Adds v2 and v3 onion service variables

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -409,10 +409,32 @@ class SiteConfig(object):
 
     def update_config(self):
         self.config.update(self.user_prompt_config())
+        self.update_onion_version_config()
         self.save()
         self.validate_gpg_keys()
         self.validate_journalist_alert_email()
         return True
+
+    def update_onion_version_config(self):
+        """
+        This method updates onion service related configurations.
+        """
+        v2 = False
+        v3 = True
+        source_ths = os.path.join(self.args.ansible_path, "app-source-ths")
+        if os.path.exists(source_ths):  # Means old installation
+            data = ""
+            with open(source_ths) as fobj:
+                data = fobj.read()
+
+            data = data.strip()
+            if len(data) < 56:  # Old v2 onion address
+                v2 = True
+
+        # Now update the configuration
+        config = {"v2_onion_services": v2,
+                  "v3_onion_services": v3}
+        self.config.update(config)
 
     def user_prompt_config(self):
         config = {}

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -44,6 +44,8 @@ securedrop_supported_locales:
 smtp_relay: smtp.gmail.com
 smtp_relay_port: 587
 ssh_users: sd
+v2_onion_services: false
+v3_onion_services: true
 '''
 
 JOURNALIST_ALERT_OUTPUT = '''app_hostname: app
@@ -74,6 +76,8 @@ securedrop_supported_locales:
 smtp_relay: smtp.gmail.com
 smtp_relay_port: 587
 ssh_users: sd
+v2_onion_services: false
+v3_onion_services: true
 '''
 
 HTTPS_OUTPUT = '''app_hostname: app
@@ -104,6 +108,8 @@ securedrop_supported_locales:
 smtp_relay: smtp.gmail.com
 smtp_relay_port: 587
 ssh_users: sd
+v2_onion_services: false
+v3_onion_services: true
 '''
 
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #4627 

Adds the two new variables on the `site-specific` file, these variables
will be used in the future code changes.
Also adds 3 test cases for the same.

## Testing

```
cd admin
make test
```

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
