### PR TITLE
Assign unread checkbox class only to unread submissions

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -44,7 +44,7 @@
               <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
               <span title="{{ gettext('Unread') }}" class="icon"><i class="fa fa-envelope"></i></span>
             {% else %}
-              <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
+              <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
               <span title="{{ gettext('Read') }}" class="icon"><i class="fa fa-envelope-open"></i></span>
             {% endif %}
             <a class="file {% if not doc.downloaded and not doc.filename.endswith('reply.gpg') %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_file', filesystem_id=filesystem_id, fn=doc.filename) }}">


### PR DESCRIPTION
This is required to ensure the "Select unread" feature works
correctly.

Resolves #4653

## Test plan

See steps in #4653 and verify that the issue no longer occurs

## Status

Ready for review