### PR TITLE
Remove unused tor_apt_repo_url override

### DIFF
--- a/molecule/upgrade/ansible-override-vars.yml
+++ b/molecule/upgrade/ansible-override-vars.yml
@@ -10,7 +10,6 @@ monitor_ip: "{{ hostvars['mon-staging']['ansible_'+primary_network_iface].ipv4.a
 monitor_hostname: "{{ hostvars['mon-staging'].ansible_hostname }}"
 app_ip: "{{ hostvars['app-staging']['ansible_'+primary_network_iface].ipv4.address }}"
 app_hostname: "{{ hostvars['app-staging'].ansible_hostname }}"
-tor_apt_repo_url: "https://tor-apt.freedom.press"
 securedrop_code: "/var/www/securedrop"
 
 etc_hosts:


### PR DESCRIPTION
This was overlooked in the migration away from tor-apt.freedom.press
in #4080. It's harmless but unnecessary and potentially confusing.

## Status

Ready for review

## Deployment considerations

None, should be a noop since the variable is never used.