### PR TITLE
Bumps tor version 0.3.5.8 -> 0.4.0.5

### DIFF
--- a/molecule/fetch-tor-packages/playbook.yml
+++ b/molecule/fetch-tor-packages/playbook.yml
@@ -12,7 +12,7 @@
     tor_repo_pubkey: "{{ sd_repo_root + '/install_files/ansible-base/roles/tor-hidden-services/files/tor-signing-key.pub' }}"
     tor_repo_url: "deb https://deb.torproject.org/torproject.org {{ ansible_distribution_release }} main"
     # Used to fetch a precise version; must also be updated in the test vars
-    tor_version: "0.3.5.8-1~xenial+1"
+    tor_version: "0.4.0.5-2~xenial+1"
 
   tasks:
     - name: Add Tor apt repo pubkey

--- a/molecule/fetch-tor-packages/tests/test_tor_packages.py
+++ b/molecule/fetch-tor-packages/tests/test_tor_packages.py
@@ -8,7 +8,7 @@ TOR_PACKAGES = [
     {"name": "tor", "arch": "amd64"},
     {"name": "tor-geoipdb", "arch": "all"},
 ]
-TOR_VERSION = "0.3.5.8-1~xenial+1"
+TOR_VERSION = "0.4.0.5-2~xenial+1"
 
 
 def test_tor_apt_repo(host):


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #4658. 

Changes proposed in this pull request:

Updates the fetch-tor-packages logic to pull in current stable LTS [0]
versions of Tor. The prior 0.3.x versions are no longer available from
upstream tor repo, so they cannot be fetched.

Includes updates to test vars, as well.

[0] https://trac.torproject.org/projects/tor/wiki/org/teams/NetworkTeam/CoreTorReleases


## Testing
* [x] Review the tor release schedule (above) and confirm 0.4.0.x is the series we want to target
* [x] Review and merge https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/9
* [x] Confirm 0.4.0.5 packages are available in https://apt-test.freedom.press/pool/main/t/tor/ (takes ~15m)
* [x] Restart CI on this PR (so the new tor packages are used)
* [x] Spin up staging VMs, confirm running tor 0.4.05
* [x] Confirm Source & Journalist Interface working well over Onion URLs

We should also confirm that tor-over-ssh works fine on 0.4.x, but that can wait until dedicated QA period.

## Deployment

Yes, significant version change to tor. Must be tested thoroughly prior to release of SD 1.0.0.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
