### PR TITLE
Clean up orphaned submissions/replies no longer associated with sources

### DIFF
--- a/securedrop/alembic/versions/3da3fcab826a_delete_orphaned_submissions.py
+++ b/securedrop/alembic/versions/3da3fcab826a_delete_orphaned_submissions.py
@@ -26,9 +26,9 @@ depends_on = None
 def raw_sql_grab_orphaned_objects(table_name):
     """Objects that have a source ID that doesn't exist in the
     sources table OR a NULL source ID should be deleted."""
-    return ('SELECT id, filename, source_id FROM {table} '
+    return ('SELECT id, filename, source_id FROM {table} '  # nosec
             'WHERE source_id NOT IN (SELECT id FROM sources) '
-            'UNION SELECT id, filename, source_id FROM {table} '
+            'UNION SELECT id, filename, source_id FROM {table} '  # nosec
             'WHERE source_id IS NULL').format(table=table_name)
 
 

--- a/securedrop/alembic/versions/3da3fcab826a_delete_orphaned_submissions.py
+++ b/securedrop/alembic/versions/3da3fcab826a_delete_orphaned_submissions.py
@@ -1,37 +1,62 @@
-"""delete orphaned submissions
+"""delete orphaned submissions and replies
+
+Ref: https://github.com/freedomofpress/securedrop/issues/1189
 
 Revision ID: 3da3fcab826a
-Revises: f2833ac34bb6
+Revises: a9fe328b053a
 Create Date: 2018-11-25 19:40:25.873292
 
 """
 from alembic import op
 import sqlalchemy as sa
-
+from journalist_app import create_app
+from models import Submission, Reply
+from rm import srm
+from sdconfig import config
+from worker import rq_worker_queue
 
 # revision identifiers, used by Alembic.
 revision = '3da3fcab826a'
-down_revision = 'f2833ac34bb6'
+down_revision = 'a9fe328b053a'
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    # Get all submissions with null source IDs
     conn = op.get_bind()
-    replies = conn.execute(
-        sa.text('SELECT id, source_id FROM submissions WHERE source_id IS NULL')
+    submissions = conn.execute(
+        sa.text('SELECT id, filename, source_id FROM submissions WHERE source_id IS NULL')
     ).fetchall()
 
-    # Delete them
-    for reply in replies:
-        conn.execute(
+    replies = conn.execute(
+        sa.text('SELECT id, filename, source_id FROM replies WHERE source_id IS NULL')
+    ).fetchall()
+
+    app = create_app(config)
+    with app.app_context():
+        for submission in submissions:
+            file_path = app.storage.path_without_filesystem_id(submission.filename)
+            rq_worker_queue.enqueue(srm, file_path)
+
+            conn.execute(
             sa.text("""
                 DELETE FROM submissions
                 WHERE id=:id
-            """).bindparams(id=reply.id)
-        )
+            """).bindparams(id=submission.id)
+            )
+
+        for reply in replies:
+            file_path = app.storage.path_without_filesystem_id(reply.filename)
+            rq_worker_queue.enqueue(srm, file_path)
+
+            conn.execute(
+                sa.text("""
+                    DELETE FROM replies
+                    WHERE id=:id
+                """).bindparams(id=reply.id)
+            )
 
 
 def downgrade():
+    # This is a destructive alembic migration, it cannot be downgraded
     pass

--- a/securedrop/alembic/versions/3da3fcab826a_delete_orphaned_submissions.py
+++ b/securedrop/alembic/versions/3da3fcab826a_delete_orphaned_submissions.py
@@ -1,0 +1,37 @@
+"""delete orphaned submissions
+
+Revision ID: 3da3fcab826a
+Revises: f2833ac34bb6
+Create Date: 2018-11-25 19:40:25.873292
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3da3fcab826a'
+down_revision = 'f2833ac34bb6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Get all submissions with null source IDs
+    conn = op.get_bind()
+    replies = conn.execute(
+        sa.text('SELECT id, source_id FROM submissions WHERE source_id IS NULL')
+    ).fetchall()
+
+    # Delete them
+    for reply in replies:
+        conn.execute(
+            sa.text("""
+                DELETE FROM submissions
+                WHERE id=:id
+            """).bindparams(id=reply.id)
+        )
+
+
+def downgrade():
+    pass

--- a/securedrop/alembic/versions/3da3fcab826a_delete_orphaned_submissions.py
+++ b/securedrop/alembic/versions/3da3fcab826a_delete_orphaned_submissions.py
@@ -10,15 +10,15 @@ Create Date: 2018-11-25 19:40:25.873292
 import os
 from alembic import op
 import sqlalchemy as sa
-from journalist_app import create_app
 from rm import secure_delete
-from store import NoFileFoundException, TooManyFilesException
 
 # raise the errors if we're not in production
 raise_errors = os.environ.get("SECUREDROP_ENV", "prod") != "prod"
 
 try:
+    from journalist_app import create_app
     from sdconfig import config
+    from store import NoFileFoundException, TooManyFilesException
     from worker import create_queue
 except ImportError:
     # This is a fresh install, and config.py has not been created yet.

--- a/securedrop/alembic/versions/3da3fcab826a_delete_orphaned_submissions.py
+++ b/securedrop/alembic/versions/3da3fcab826a_delete_orphaned_submissions.py
@@ -13,13 +13,13 @@ import sqlalchemy as sa
 from journalist_app import create_app
 from rm import secure_delete
 from store import NoFileFoundException, TooManyFilesException
-from worker import create_queue
 
 # raise the errors if we're not in production
 raise_errors = os.environ.get("SECUREDROP_ENV", "prod") != "prod"
 
 try:
     from sdconfig import config
+    from worker import create_queue
 except ImportError:
     # This is a fresh install, and config.py has not been created yet.
     if raise_errors:

--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -43,11 +43,19 @@ class PathException(Exception):
     pass
 
 
-class WrongNumberOfFilesException(Exception):
-    """An exception raised by path_without_filesystem_id when an unexpected
-    number of files has been found for a given submission or reply.
-    This could be due to an admin manually deleting files from the server
-    or due to a extremely unlikely collision between journalist_designations.
+class TooManyFilesException(Exception):
+    """An exception raised by path_without_filesystem_id when too many
+    files has been found for a given submission or reply.
+    This could be due to a very unlikely collision between
+    journalist_designations.
+    """
+    pass
+
+
+class NoFileFoundException(Exception):
+    """An exception raised by path_without_filesystem_id when a file could
+    not be found for a given submission or reply.
+    This is likely due to an admin manually deleting files from the server.
     """
     pass
 
@@ -130,9 +138,9 @@ class Storage:
                     joined_paths.append(os.path.join(rootdir, file_))
 
         if len(joined_paths) > 1:
-            raise WrongNumberOfFilesException('Found duplicate files!')
+            raise TooManyFilesException('Found duplicate files!')
         elif len(joined_paths) == 0:
-            raise WrongNumberOfFilesException('File not found: {}'.format(filename))
+            raise NoFileFoundException('File not found: {}'.format(filename))
         else:
             absolute = joined_paths[0]
 

--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -107,6 +107,29 @@ class Storage:
         self.verify(absolute)
         return absolute
 
+    def path_without_filesystem_id(self, filename):
+        # type: (str) -> str
+        """Get the normalized, absolute file path, within
+           `self.__storage_path` for a filename when the filesystem_id
+           is not known.
+        """
+
+        joined_paths = []
+        for rootdir, _, files in os.walk(os.path.abspath(self.__storage_path)):
+            for file_ in files:
+                if file_ in filename:
+                    joined_paths.append(os.path.join(rootdir, file_))
+
+        if len(joined_paths) > 1:
+            raise PathException('Found duplicate files!')
+        elif len(joined_paths) == 0:
+            raise PathException('File not found: {}'.format(filename))
+        else:
+            absolute = joined_paths[0]
+
+        self.verify(absolute)
+        return absolute
+
     def get_bulk_archive(self, selected_submissions, zip_directory=''):
         # type: (List, str) -> _TemporaryFileWrapper
         """Generate a zip file from the selected submissions"""

--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -43,6 +43,15 @@ class PathException(Exception):
     pass
 
 
+class WrongNumberOfFilesException(Exception):
+    """An exception raised by path_without_filesystem_id when an unexpected
+    number of files has been found for a given submission or reply.
+    This could be due to an admin manually deleting files from the server
+    or due to a extremely unlikely collision between journalist_designations.
+    """
+    pass
+
+
 class NotEncrypted(Exception):
     """An exception raised if a file expected to be encrypted client-side
     is actually plaintext.
@@ -121,9 +130,9 @@ class Storage:
                     joined_paths.append(os.path.join(rootdir, file_))
 
         if len(joined_paths) > 1:
-            raise PathException('Found duplicate files!')
+            raise WrongNumberOfFilesException('Found duplicate files!')
         elif len(joined_paths) == 0:
-            raise PathException('File not found: {}'.format(filename))
+            raise WrongNumberOfFilesException('File not found: {}'.format(filename))
         else:
             absolute = joined_paths[0]
 

--- a/securedrop/tests/migrations/helpers.py
+++ b/securedrop/tests/migrations/helpers.py
@@ -36,6 +36,10 @@ def random_chars(len, chars=string.printable):
     return ''.join([random.choice(chars) for _ in range(len)])
 
 
+def random_ascii_chars(len, chars=string.ascii_lowercase):
+    return ''.join([random.choice(chars) for _ in range(len)])
+
+
 def random_datetime(nullable):
     if nullable and random_bool():
         return None

--- a/securedrop/tests/migrations/migration_3da3fcab826a.py
+++ b/securedrop/tests/migrations/migration_3da3fcab826a.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+import random
+from uuid import uuid4
+
+from sqlalchemy import text
+
+from db import db
+from journalist_app import create_app
+from .helpers import random_bool, random_chars, random_datetime, bool_or_none
+
+
+class UpgradeTester:
+
+    """This migration verifies that any orphaned submission data from deleted
+    sources is also deleted.
+    """
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            self.add_source()
+
+            # Add submissions with and without a source
+            self.add_submission(1)
+            self.add_submission(None)
+
+            db.session.commit()
+
+    @staticmethod
+    def add_source():
+        filesystem_id = random_chars(96) if random_bool() else None
+        params = {
+            'uuid': str(uuid4()),
+            'filesystem_id': filesystem_id,
+            'journalist_designation': random_chars(50),
+            'flagged': bool_or_none(),
+            'last_updated': random_datetime(nullable=True),
+            'pending': bool_or_none(),
+            'interaction_count': random.randint(0, 1000),
+        }
+        sql = '''INSERT INTO sources (uuid, filesystem_id,
+                    journalist_designation, flagged, last_updated, pending,
+                    interaction_count)
+                 VALUES (:uuid, :filesystem_id, :journalist_designation,
+                    :flagged, :last_updated, :pending, :interaction_count)
+              '''
+        db.engine.execute(text(sql), **params)
+
+    @staticmethod
+    def add_submission(source_id):
+        params = {
+            'uuid': str(uuid4()),
+            'source_id': source_id,
+            'filename': random_chars(50),
+            'size': random.randint(0, 1024 * 1024 * 500),
+            'downloaded': bool_or_none(),
+        }
+        sql = '''INSERT INTO submissions (uuid, source_id, filename, size,
+                    downloaded)
+                 VALUES (:uuid, :source_id, :filename, :size, :downloaded)
+              '''
+        db.engine.execute(text(sql), **params)
+
+    def check_upgrade(self):
+        with self.app.app_context():
+            submissions = db.engine.execute(
+                text('SELECT * FROM submissions')).fetchall()
+
+            # Submission without a source should be deleted
+            assert len(submissions) == 1
+            assert submissions[0].source_id is not None
+
+
+class DowngradeTester:
+
+    def __init__(self, config):
+        self.config = config
+
+    def load_data(self):
+        pass
+
+    def check_downgrade(self):
+        pass

--- a/securedrop/tests/migrations/migration_3da3fcab826a.py
+++ b/securedrop/tests/migrations/migration_3da3fcab826a.py
@@ -41,13 +41,16 @@ class UpgradeTester:
         with self.app.app_context():
             self.create_journalist()
             self.add_source()
+            self.valid_source_id = 1
 
             # Add submissions and replies with and without a source
-            self.add_submission(1)
-            self.add_submission(None)
+            self.add_submission(self.valid_source_id)
+            self.add_submission(2)  # Not a real source
+            self.add_submission(None)  # NULL source
 
-            self.add_reply(self.journalist_id, 1)
-            self.add_reply(self.journalist_id, None)
+            self.add_reply(self.journalist_id, self.valid_source_id)
+            self.add_reply(self.journalist_id, 2)  # Not a real source
+            self.add_reply(self.journalist_id, None)  # NULL source
 
             db.session.commit()
 
@@ -127,14 +130,16 @@ class UpgradeTester:
 
             # Submissions without a source should be deleted
             assert len(submissions) == 1
-            assert submissions[0].source_id is not None
+            for submission in submissions:
+                assert submission.source_id == self.valid_source_id
 
             replies = db.engine.execute(
                 text('SELECT * FROM replies')).fetchall()
 
             # Replies without a source should be deleted
             assert len(replies) == 1
-            assert replies[0].source_id is not None
+            for reply in replies:
+                assert reply.source_id == self.valid_source_id
 
 
 class DowngradeTester:

--- a/securedrop/tests/migrations/migration_3da3fcab826a.py
+++ b/securedrop/tests/migrations/migration_3da3fcab826a.py
@@ -42,14 +42,17 @@ class UpgradeTester:
             self.create_journalist()
             self.add_source()
             self.valid_source_id = 1
+            deleted_source_id = 2
 
-            # Add submissions and replies with and without a source
+            # Add submissions and replies with and without a valid source
             self.add_submission(self.valid_source_id)
-            self.add_submission(2)  # Not a real source
+            self.add_submission(deleted_source_id)
+            self.add_submission(deleted_source_id, with_file=False)
             self.add_submission(None)  # NULL source
 
             self.add_reply(self.journalist_id, self.valid_source_id)
-            self.add_reply(self.journalist_id, 2)  # Not a real source
+            self.add_reply(self.journalist_id, deleted_source_id)
+            self.add_reply(self.journalist_id, deleted_source_id, with_file=False)
             self.add_reply(self.journalist_id, None)  # NULL source
 
             db.session.commit()
@@ -67,7 +70,7 @@ class UpgradeTester:
               '''
         self.journalist_id = db.engine.execute(text(sql), **params).lastrowid
 
-    def add_reply(self, journalist_id, source_id):
+    def add_reply(self, journalist_id, source_id, with_file=True):
         filename = '1-' + random_ascii_chars(5) + '-' + random_ascii_chars(5) + '-reply.gpg'
         params = {
             'uuid': str(uuid4()),
@@ -84,7 +87,8 @@ class UpgradeTester:
               '''
         db.engine.execute(text(sql), **params)
 
-        create_file_in_dummy_source_dir(filename)
+        if with_file:
+            create_file_in_dummy_source_dir(filename)
 
     @staticmethod
     def add_source():
@@ -106,7 +110,7 @@ class UpgradeTester:
               '''
         db.engine.execute(text(sql), **params)
 
-    def add_submission(self, source_id):
+    def add_submission(self, source_id, with_file=True):
         filename = '1-' + random_ascii_chars(5) + '-' + random_ascii_chars(5) + '-doc.gz.gpg'
         params = {
             'uuid': str(uuid4()),
@@ -121,7 +125,8 @@ class UpgradeTester:
               '''
         db.engine.execute(text(sql), **params)
 
-        create_file_in_dummy_source_dir(filename)
+        if with_file:
+            create_file_in_dummy_source_dir(filename)
 
     def check_upgrade(self):
         with self.app.app_context():

--- a/securedrop/tests/migrations/migration_3da3fcab826a.py
+++ b/securedrop/tests/migrations/migration_3da3fcab826a.py
@@ -64,9 +64,10 @@ class UpgradeTester:
         params = {
             'uuid': str(uuid4()),
             'username': random_chars(50),
+            'session_nonce': 0
         }
-        sql = '''INSERT INTO journalists (uuid, username)
-                 VALUES (:uuid, :username)
+        sql = '''INSERT INTO journalists (uuid, username, session_nonce)
+                 VALUES (:uuid, :username, :session_nonce)
               '''
         self.journalist_id = db.engine.execute(text(sql), **params).lastrowid
 

--- a/securedrop/tests/test_store.py
+++ b/securedrop/tests/test_store.py
@@ -84,13 +84,13 @@ def test_path_without_filesystem_id_duplicate_files(journalist_app, config):
         with open(path_to_file, 'a'):
             os.utime(path_to_file, None)
 
-    with pytest.raises(store.WrongNumberOfFilesException):
+    with pytest.raises(store.TooManyFilesException):
         journalist_app.storage.path_without_filesystem_id(item_filename)
 
 
 def test_path_without_filesystem_id_no_file(journalist_app, config):
     item_filename = 'not there'
-    with pytest.raises(store.WrongNumberOfFilesException):
+    with pytest.raises(store.NoFileFoundException):
         journalist_app.storage.path_without_filesystem_id(item_filename)
 
 

--- a/securedrop/tests/test_store.py
+++ b/securedrop/tests/test_store.py
@@ -51,6 +51,49 @@ def test_path_returns_filename_of_items_within_folder(journalist_app, config):
     assert generated_absolute_path == expected_absolute_path
 
 
+def test_path_without_filesystem_id(journalist_app, config):
+    filesystem_id = 'example'
+    item_filename = '1-quintuple_cant-msg.gpg'
+
+    basedir = os.path.join(config.STORE_DIR, filesystem_id)
+    os.makedirs(basedir)
+
+    path_to_file = os.path.join(basedir, item_filename)
+    with open(path_to_file, 'a'):
+        os.utime(path_to_file, None)
+
+    generated_absolute_path = \
+        journalist_app.storage.path_without_filesystem_id(item_filename)
+
+    expected_absolute_path = os.path.join(config.STORE_DIR,
+                                          filesystem_id, item_filename)
+    assert generated_absolute_path == expected_absolute_path
+
+
+def test_path_without_filesystem_id_duplicate_files(journalist_app, config):
+    filesystem_id = 'example'
+    filesystem_id_duplicate = 'example2'
+    item_filename = '1-quintuple_cant-msg.gpg'
+
+    basedir = os.path.join(config.STORE_DIR, filesystem_id)
+    duplicate_basedir = os.path.join(config.STORE_DIR, filesystem_id_duplicate)
+
+    for directory in [basedir, duplicate_basedir]:
+        os.makedirs(directory)
+        path_to_file = os.path.join(directory, item_filename)
+        with open(path_to_file, 'a'):
+            os.utime(path_to_file, None)
+
+    with pytest.raises(store.PathException):
+        journalist_app.storage.path_without_filesystem_id(item_filename)
+
+
+def test_path_without_filesystem_id_no_file(journalist_app, config):
+    item_filename = 'not there'
+    with pytest.raises(store.PathException):
+        journalist_app.storage.path_without_filesystem_id(item_filename)
+
+
 def test_verify_path_not_absolute(journalist_app, config):
     with pytest.raises(store.PathException):
         journalist_app.storage.verify(

--- a/securedrop/tests/test_store.py
+++ b/securedrop/tests/test_store.py
@@ -84,13 +84,13 @@ def test_path_without_filesystem_id_duplicate_files(journalist_app, config):
         with open(path_to_file, 'a'):
             os.utime(path_to_file, None)
 
-    with pytest.raises(store.PathException):
+    with pytest.raises(store.WrongNumberOfFilesException):
         journalist_app.storage.path_without_filesystem_id(item_filename)
 
 
 def test_path_without_filesystem_id_no_file(journalist_app, config):
     item_filename = 'not there'
-    with pytest.raises(store.PathException):
+    with pytest.raises(store.WrongNumberOfFilesException):
         journalist_app.storage.path_without_filesystem_id(item_filename)
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1189

Changes proposed in this pull request:
 - Remove submissions and replies that are associated with null sources or sources that no longer exist

## Testing

Other than reviewing the diff (see commit messages for details):

0. Provision staging on `develop`
1. SSH in and do the following as the `www-data` user (`sudo su www-data -s /bin/bash`)
2. Don’t submit anything via the source interface, so the database will be empty. 
3. Create a submission associated with a source that doesn’t exist:

```
www-data@app-staging:/home/vagrant$ cd /var/lib/securedrop/
www-data@app-staging:/home/vagrant$ sqlite3 db.sqlite
sqlite> insert into submissions values (1, "uuid-1", 9000, "1-test-potato-doc.gz.gpg", 1, 0, "checksum”);
```

4. Insert one more submission - we won’t create a file for this one to simulate a scenario where the admin has gone ahead and manually deleted some of the orphaned files (for example if they were running low on disk utilization):

```
sqlite> insert into submissions values (2, "uuid-2", 9000, "2-test-potato-doc.gz.gpg", 1, 0, "checksum");
```

5. Make a test file such that we can assert that the procedure cleans up the files also:

```
www-data@app-staging:/home/vagrant$ mkdir /var/lib/securedrop/store/filesystem_id
www-data@app-staging:/home/vagrant$ touch /var/lib/securedrop/store/filesystem_id/1-test-potato-doc.gz.gpg
```

6. Now build debs _on this branch_ and provision staging again (e.g. `make build-debs` and `vagrant provision /staging/`). The migration should run as the app code package is installed.
7. Verify the submission we added is now gone, as are the files themselves:

```
www-data@app-staging:/home/vagrant$ ls /var/lib/securedrop/store/filesystem_id/
www-data@app-staging:/home/vagrant$ 
```

```
sqlite> select * from submissions;
sqlite>
```

## Deployment

This will run in postinst of `securedrop-app-code` package

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
