### PR TITLE
Tighten Content Security Policy

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -168,7 +168,7 @@ If you use Apache, you can use these:
     Header set X-Content-Type-Options: nosniff
     Header set X-Download-Options: noopen
     Header set X-Permitted-Cross-Domain-Policies: master-only
-    Header set Content-Security-Policy: "default-src 'self'"
+    Header set Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
     Header set Referrer-Policy "no-referrer"
 
 If you intend to run nginx as your webserver instead, this will work:
@@ -183,7 +183,7 @@ If you intend to run nginx as your webserver instead, this will work:
     add_header X-Content-Type-Options nosniff;
     add_header X-Download-Options: noopen;
     add_header X-Permitted-Cross-Domain-Policies master-only;
-    add_header Content-Security-Policy "default-src 'self'";
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
     add_header Referrer-Policy "no-referrer";
 
 

--- a/docs/threat_model/mitigations.rst
+++ b/docs/threat_model/mitigations.rst
@@ -62,7 +62,7 @@ Countermeasures on both *Source* and *Journalist Interfaces*
 -  A number of mitigations are in place as protection against malicious input vulnerabilities on the Source and Journalist Interfaces:
 
     - X-XSS-PROTECTION is enabled
-    - Content-Security-Policy is set to self
+    - Content-Security-Policy is set to "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
     - SQLAlchemy is used as ORM for all database queries
     - Application does not execute uploaded submission data
 -  A number of mitigations are in place as protection against the risk of an HTTP misconfiguration on the *Source* and *Journalist Interfaces*:
@@ -70,7 +70,7 @@ Countermeasures on both *Source* and *Journalist Interfaces*
     - Cache control header is set to “no store;”
     - HTTP headers do not expose version information of system components
     - X-Content-Type is set to "nosniff;"
-    - Content-Security-Policy is set to "self;"
+    - Content-Security-Policy is set to "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
     - X-XSS-Protection is set to "1"
 
 Countermeasures unique to *Source Interface*

--- a/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
@@ -29,8 +29,8 @@ Header set Referrer-Policy "no-referrer"
 Header set X-XSS-Protection: "1; mode=block"
 Header set X-Content-Type-Options: nosniff
 Header set X-Download-Options: noopen
-Header set X-Content-Security-Policy: "default-src 'self'"
-Header set Content-Security-Policy: "default-src 'self'"
+Header set X-Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+Header set Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 
 # Limit the max submitted size of requests.
 LimitRequestBody 524288000

--- a/install_files/ansible-base/roles/app/templates/sites-available/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/source.conf
@@ -50,9 +50,9 @@ Header always append X-Frame-Options: DENY
 Header set Referrer-Policy "same-origin"
 Header set X-XSS-Protection: "1; mode=block"
 Header set X-Content-Type-Options: nosniff
-Header set X-Content-Security-Policy: "default-src 'self'"
+Header set X-Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 Header set X-Download-Options: noopen
-Header set Content-Security-Policy: "default-src 'self'"
+Header set Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 Header unset Etag
 
 # Limit the max submitted size of requests.

--- a/molecule/testinfra/staging/app/apache/test_apache_journalist_interface.py
+++ b/molecule/testinfra/staging/app/apache/test_apache_journalist_interface.py
@@ -13,11 +13,20 @@ wanted_apache_headers = [
   'Header set X-XSS-Protection: "1; mode=block"',
   'Header set X-Content-Type-Options: nosniff',
   'Header set X-Download-Options: noopen',
-  "Header set X-Content-Security-Policy: \"default-src 'self'\"",
-  "Header set Content-Security-Policy: \"default-src 'self'\"",
+  'Header set X-Content-Security-Policy: "'
+  'default-src \'none\'; '
+  'script-src \'self\'; '
+  'style-src \'self\'; '
+  'img-src \'self\'; '
+  'font-src \'self\';"',
+  'Header set Content-Security-Policy: "'
+  'default-src \'none\'; '
+  'script-src \'self\'; '
+  'style-src \'self\'; '
+  'img-src \'self\'; '
+  'font-src \'self\';"',
   'Header set Referrer-Policy "no-referrer"',
 ]
-
 
 # Test is not DRY; haven't figured out how to parametrize on
 # multiple inputs, so explicitly redeclaring test logic.

--- a/molecule/testinfra/staging/vars/app-staging.yml
+++ b/molecule/testinfra/staging/vars/app-staging.yml
@@ -7,8 +7,8 @@ wanted_apache_headers:
   - 'Header set X-XSS-Protection: "1; mode=block"'
   - 'Header set X-Content-Type-Options: nosniff'
   - 'Header set X-Download-Options: noopen'
-  - "Header set X-Content-Security-Policy: \"default-src 'self'\""
-  - "Header set Content-Security-Policy: \"default-src 'self'\""
+  - "Header set X-Content-Security-Policy: \"default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';\""
+  - "Header set Content-Security-Policy: \"default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';\""
   - 'Header unset Etag'
 
 securedrop_code: /var/www/securedrop

--- a/molecule/testinfra/staging/vars/staging.yml
+++ b/molecule/testinfra/staging/vars/staging.yml
@@ -7,8 +7,8 @@ wanted_apache_headers:
   - 'Header set X-XSS-Protection: "1; mode=block"'
   - 'Header set X-Content-Type-Options: nosniff'
   - 'Header set X-Download-Options: noopen'
-  - "Header set X-Content-Security-Policy: \"default-src 'self'\""
-  - "Header set Content-Security-Policy: \"default-src 'self'\""
+  - "Header set X-Content-Security-Policy: \"default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';\""
+  - "Header set Content-Security-Policy: \"default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';\""
   - 'Header unset Etag'
 
 securedrop_code: /var/www/securedrop


### PR DESCRIPTION
With this pull request I propose to restrict the existing content security policy to the strictly necessary.

Existing policy:
```Content-Security-Policy: "default-src 'self'"```

Proposed policy:
```default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';```

Comment:
The current policy restricts any resource to be loaded from 'self' (current domain / same proto); this reduces the attack surface but still leaves open many kind of resources that are not used by the application;  for example ```object-src``` and ```connect-src``` could be set to 'none'.
This result could be achieved with the proposed policy that first block any kind of resource and then enables only a limited set of resources.