### PR TITLE
CI: update apt lists for installing enchant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ common-steps:
   - &installenchant
     run:
       name: Install enchant
-      command: sudo apt-get install enchant
+      command: sudo apt-get update && sudo apt-get install -y enchant
 
   # Python 3 (default) Docker layer caching
   - &createcachedir


### PR DESCRIPTION
Recent CI runs have failed to locate a package called "enchant", which
likely indicates that the apt lists are out of date, whether due to
docker layer caching or some other factor. Let's ensure the lists
are always up to date when that step is run.

(cherry picked from commit 223626ef63e3b6fef5f483f5ff55d30cadd0b455, authored by @conorsch)

## Status

Ready for review