### PR TITLE
Fix path to requirements.txt for docs-linkcheck CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,8 +361,8 @@ jobs:
             make ci-deb-tests
 
   docs-linkcheck:
-    machine:
-      enabled: true
+    docker:
+      - image: circleci/python:3.5
     steps:
       - checkout
       - *rebaseontarget
@@ -370,7 +370,7 @@ jobs:
 
       - run:
           name: Install development dependencies
-          command: pip install -U -r securedrop/requirements/develop-requirements.txt
+          command: sudo pip3 install -U -r securedrop/requirements/python3/develop-requirements.txt
 
       - run:
           name: Run documentation linting

--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -305,81 +305,81 @@ don't want any unnecessary code or services running as this increases
 the attack surface.
 
 .. _`fail2ban` : https://github.com/fail2ban/fail2ban
-.. _`sshguard` : https://www.sshguard.net/
+.. _`sshguard` : https://bitbucket.org/sshguard/sshguard/
 
 *Landing Page* Content Suggestions
 ----------------------------------
 
-The content below presents sample text for the SecureDrop component of a news 
-organization’s tips page. It does not account for any specific legal 
-or organizational needs, but should provide guidance for any outlet getting 
-started on crafting *Landing Page* language. Any tweaks to the sample content 
-should be left to the legal and editorial discretion of the individual outlet, 
+The content below presents sample text for the SecureDrop component of a news
+organization’s tips page. It does not account for any specific legal
+or organizational needs, but should provide guidance for any outlet getting
+started on crafting *Landing Page* language. Any tweaks to the sample content
+should be left to the legal and editorial discretion of the individual outlet,
 and should be viewed as essential to upholding source protection and transparency.
 
 ----
 
 **What is SecureDrop?**
 
-SecureDrop is an anonymity tool for journalists and whistleblowers. As a source, 
-you can use our SecureDrop installation to anonymously submit documents to our 
-organization. Our journalists use SecureDrop to receive source materials and 
+SecureDrop is an anonymity tool for journalists and whistleblowers. As a source,
+you can use our SecureDrop installation to anonymously submit documents to our
+organization. Our journalists use SecureDrop to receive source materials and
 securely communicate with anonymous contacts.
 
 **What should I know before submitting material through SecureDrop?**
 
-To protect your anonymity when using SecureDrop, it is essential that you do 
-not use a network or device that can easily be traced back to your real 
+To protect your anonymity when using SecureDrop, it is essential that you do
+not use a network or device that can easily be traced back to your real
 identity. Instead, use public wifi networks and devices you control.
 
 - Do NOT access SecureDrop on your employer’s network.
 
-- Do NOT access SecureDrop using your employer’s hardware. 
+- Do NOT access SecureDrop using your employer’s hardware.
 
-- Do NOT access SecureDrop on your home network. 
+- Do NOT access SecureDrop on your home network.
 
 - DO access SecureDrop on a network not associated with you, like the wifi at a library or cafe.
 
 **Got it. How can I submit files and messages through SecureDrop?**
 
-Once you are connected to a public network at a cafe or library, download 
-and install the `Tor Browser <https://www.torproject.org/projects/torbrowser>`_. 
+Once you are connected to a public network at a cafe or library, download
+and install the `Tor Browser <https://www.torproject.org/projects/torbrowser>`_.
 
-Launch the Tor Browser. Visit our organization’s unique SecureDrop URL at 
-**http://our-unique-URL.onion/**. 
-Follow the instructions you find on our source page to 
+Launch the Tor Browser. Visit our organization’s unique SecureDrop URL at
+**http://our-unique-URL.onion/**.
+Follow the instructions you find on our source page to
 send us materials and messages.
 
-When you make your first submission, you will receive a unique codename. 
-Memorize it. If you write it down, be sure to destroy the copy as soon as 
-you’ve committed it to memory. Use your codename to sign back in to 
-our source page, check for responses from our journalists, and upload 
+When you make your first submission, you will receive a unique codename.
+Memorize it. If you write it down, be sure to destroy the copy as soon as
+you’ve committed it to memory. Use your codename to sign back in to
+our source page, check for responses from our journalists, and upload
 additional materials.
 
 **As a source, what else should I know?**
 
-No tool can absolutely guarantee your security or anonymity. 
-The best way to protect your privacy and anonymity as a source 
+No tool can absolutely guarantee your security or anonymity.
+The best way to protect your privacy and anonymity as a source
 is to adhere to best practices.
 
-You can use a separate computer you’ve designated specifically to handle 
-the submission process. 
-Or, you can use an alternate operating system like Tails, 
+You can use a separate computer you’ve designated specifically to handle
+the submission process.
+Or, you can use an alternate operating system like Tails,
 which boots from a USB stick and erases your activity at the end of every session.
 
-A file contains valuable `metadata <https://ssd.eff.org/en/module/why-metadata-matters>`_ about its source — when it was created 
+A file contains valuable `metadata <https://ssd.eff.org/en/module/why-metadata-matters>`_ about its source — when it was created
 and downloaded, what machine was involved, the machine’s owner, etc.
-You can scrub metadata from some files prior to submission using the Metadata 
+You can scrub metadata from some files prior to submission using the Metadata
 Anonymization Toolkit featured in Tails.
 
-Your online behavior can be extremely revealing. 
-Regularly monitoring our publication’s social media or website can potentially 
-flag you as a source. Take great care to think about what your online behavior 
+Your online behavior can be extremely revealing.
+Regularly monitoring our publication’s social media or website can potentially
+flag you as a source. Take great care to think about what your online behavior
 might reveal, and consider using Tor Browser to mitigate such monitoring.
 
-Our organization retains strict access control over our SecureDrop project. 
-A select few journalists within our organization will have access to 
-SecureDrop submissions. We control the servers that store your submissions, 
+Our organization retains strict access control over our SecureDrop project.
+A select few journalists within our organization will have access to
+SecureDrop submissions. We control the servers that store your submissions,
 so no third party has direct access to the metadata or content of what you send us.
 
-Do not discuss leaking or whistleblowing, even with trusted contacts. 
+Do not discuss leaking or whistleblowing, even with trusted contacts.


### PR DESCRIPTION
Resolves #4671; fixes CI failure caused by broken link along the way.

## Status

Ready for review

## Testing

Since this runs weekly, tested in separate commit in test branch (see below)