### PR TITLE
securedrop-config: remove function setting HiddenServiceVersion

### DIFF
--- a/install_files/securedrop-config/DEBIAN/postinst
+++ b/install_files/securedrop-config/DEBIAN/postinst
@@ -53,16 +53,6 @@ allow_apt_user_in_iptables() {
            "$rules_v4"
     fi
 }
-# Tor 0.3.5.x series now defaults to v3 onion URLs, but SecureDrop currently
-# uses v2 onion URLs. We must explictly set this definition in torrc to avoid
-# breakage when upgrading from Tor 0.3.4.x to 0.3.5.x.
-set_v2_hidserv_in_torrc() {
-    if [ -f /etc/tor/torrc ]; then
-        if ! grep -q HiddenServiceVersion /etc/tor/torrc ; then
-            perl -pi -e 's/^(HiddenServiceDir.*)$/$1\nHiddenServiceVersion 2/' /etc/tor/torrc
-        fi
-    fi
-}
 
 manage_tor_repo_config() {
     # Ensure official Tor repo entry is removed, so that only FPF mirror is used.
@@ -93,7 +83,6 @@ case "$1" in
     fi
 
     allow_apt_user_in_iptables
-    set_v2_hidserv_in_torrc
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
##  Status

Ready for review

## Description of Changes

Fixes #4676

For new installs that wish to use v2, the HiddenServiceVersion
will be set via the torrc template in the tor-hidden-services
Ansible role.

For existing installs that still wish to use v2, if they have
updated to Xenial, then they already have this HiddenServiceVersion
set to 2 in their existing torrc. Installs _not_ on Xenial
are no longer supported.

## Testing

Mostly inspecting my logic above and agreeing this securedrop-config postinst logic is no longer needed for current installs is what is needed: since this test https://github.com/freedomofpress/securedrop/blob/develop/molecule/testinfra/staging/app/test_tor_hidden_services.py#L84 ensures that the hidden service version is set to 2 for new installs.

## Deployment

[covered by main PR description]

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

