### PR TITLE
Footer tweaks: final language, HR fix, class rename

### DIFF
--- a/securedrop/sass/modules/_hr-horizontal-rule-line.sass
+++ b/securedrop/sass/modules/_hr-horizontal-rule-line.sass
@@ -5,7 +5,9 @@
       border-bottom: none
       border-color: #c3c3c3
 
-    &.box-separator
+    &.footer-separator
+      // Avoid squeezing the separator into the content layout in mobile view
+      clear: both
       width: 100%
       margin-top: 2.5em
       margin-bottom: 0

--- a/securedrop/source_templates/footer.html
+++ b/securedrop/source_templates/footer.html
@@ -1,4 +1,4 @@
-<hr class="box-separator">
+<hr class="footer-separator">
 <footer>
   <div id="footer-powered-by">
     <img id="footer-logo" src="{{url_for('static', filename='i/logo-footer.png') }}" width="20" height="23">{{ gettext('Powered by') }} <strong>SecureDrop {{ version }}</strong>.

--- a/securedrop/source_templates/footer.html
+++ b/securedrop/source_templates/footer.html
@@ -7,6 +7,6 @@
     {{ gettext('Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop.') }}
   </div>
   <div id="footer-fpf">
-    {{ gettext('SecureDrop is free and open source software stewarded by Freedom of the Press Foundation.') }}
+    {{ gettext('SecureDrop is a project of Freedom of the Press Foundation.') }}
   </div>
 </footer>


### PR DESCRIPTION
Resolves #4700
Resolves #4701

## Status

Ready for review

## Testing

0. Verify that final languages matches agreement in #4700 
1. View the Source Interface in [responsive design mode](https://developer.mozilla.org/en-US/docs/Tools/Responsive_Design_Mode) and step through to the page that lets you submits documents or messages.
2. Verify that #4701 is resolved on all pages.
3. Quickly step through the Source Interface and Journalist Interface in both modes and verify that there are no new regressions.

Note: Currently in mobile view the footer separator renders as a double line, as it bleeds into the main container's border. I consider this acceptable for now, as we'll likely eliminate that main container border in a future revision, and the main goal here is to address a significant design regression.