### PR TITLE
[wip] Add HTTP Alternative Service header to source, journalist interfaces when both v2 and v3 onion services are enabled

### DIFF
--- a/install_files/ansible-base/roles/app/defaults/main.yml
+++ b/install_files/ansible-base/roles/app/defaults/main.yml
@@ -87,3 +87,9 @@ apache_disabled_modules:
 securedrop_default_locale: en_US
 # The subset of the available locales that will be proposed to the user
 securedrop_supported_locales: []
+
+# v2 Tor onion services are on / v3 Tor onion services are off by default for backwards
+# compatibility. Note that new installs after 1.0 will have v3 enabled by sdconfig which
+# will override these variables.
+v2_onion_services: true
+v3_onion_services: false

--- a/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
+++ b/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
@@ -31,6 +31,16 @@
   tags:
     - apache
 
+- name: Grab source interface v3 onion URL.
+  command: cat /var/lib/tor/services/sourcev3/hostname
+  # Read-only
+  changed_when: false
+  register: v3_source_hostname
+  when: "v3_onion_services"
+  tags:
+    - tor
+    - apache
+
 - name: Copy Apache ports and site configs.
   template:
     src: "{{ item }}"

--- a/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
+++ b/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
@@ -31,12 +31,18 @@
   tags:
     - apache
 
-- name: Grab source interface v3 onion URL.
-  command: cat /var/lib/tor/services/sourcev3/hostname
+- name: Grab web interface v3 onion URLs.
+  command: "cat /var/lib/tor/services/{{ item }}/hostname"
   # Read-only
   changed_when: false
-  register: v3_source_hostname
+  register: v3_hostname
   when: "v3_onion_services"
+  # Order is important here since the resulting variable
+  # v3_hostname will be accessed by index when the Apache
+  # templates are written.
+  loop:
+    - sourcev3
+    - journalistv3
   tags:
     - tor
     - apache

--- a/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/journalist.conf
@@ -32,6 +32,12 @@ Header set X-Download-Options: noopen
 Header set X-Content-Security-Policy: "default-src 'self'"
 Header set Content-Security-Policy: "default-src 'self'"
 
+{% if v2_onion_services and v3_onion_services %}
+# Set Alt-Srv header to transparently route traffic to v3 onion
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Alt-Svc
+Header set Alt-Svc: h2="{{ v3_hostname.results[1].stdout }}:8080"
+{% endif %}
+
 # Limit the max submitted size of requests.
 LimitRequestBody 524288000
 

--- a/install_files/ansible-base/roles/app/templates/sites-available/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/source.conf
@@ -55,6 +55,12 @@ Header set X-Download-Options: noopen
 Header set Content-Security-Policy: "default-src 'self'"
 Header unset Etag
 
+{% if v2_onion_services and v3_onion_services %}
+# Set Alt-Srv header to transparently route traffic to v3 onion
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Alt-Svc
+Header set Alt-Svc: http/1.1="{{ v3_source_hostname.stdout }}:80"
+{% endif %}
+
 # Limit the max submitted size of requests.
 LimitRequestBody 524288000
 

--- a/install_files/ansible-base/roles/app/templates/sites-available/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/source.conf
@@ -58,7 +58,7 @@ Header unset Etag
 {% if v2_onion_services and v3_onion_services %}
 # Set Alt-Srv header to transparently route traffic to v3 onion
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Alt-Svc
-Header set Alt-Svc: http/1.1="{{ v3_source_hostname.stdout }}:80"
+Header set Alt-Svc: h2="{{ v3_hostname.results[0].stdout }}:80"
 {% endif %}
 
 # Limit the max submitted size of requests.

--- a/molecule/testinfra/staging/app/apache/test_apache_journalist_interface.py
+++ b/molecule/testinfra/staging/app/apache/test_apache_journalist_interface.py
@@ -35,6 +35,19 @@ def test_apache_headers_journalist_interface(host, header):
     assert re.search(header_regex, f.content_string, re.M)
 
 
+def test_alt_svc_set_on_journalist_interface(host):
+    """
+    HTTP Alternative Service header should be set on journalist interface.
+    """
+    with host.sudo():
+        v3 = host.file("/var/lib/tor/services/journalistv3/hostname")
+
+        apache_config = host.file("/etc/apache2/sites-available/journalist.conf")
+        expected_alt_svc = 'Header set Alt-Svc: h2="{}:8080"'.format(
+            v3.content_string)
+        assert expected_alt_svc in apache_config.content_string
+
+
 # Block of directory declarations for Apache vhost is common
 # to both Source and Journalist interfaces. Hardcoding these values
 # across multiple test files to speed up development; they should be

--- a/molecule/testinfra/staging/app/apache/test_apache_source_interface.py
+++ b/molecule/testinfra/staging/app/apache/test_apache_source_interface.py
@@ -19,6 +19,19 @@ def test_apache_headers_source_interface(host, header):
     assert re.search(header_regex, f.content_string, re.M)
 
 
+def test_alt_svc_set_on_source_interface(host):
+    """
+    HTTP Alternative Service header should be set on source interface.
+    """
+    with host.sudo():
+        v3 = host.file("/var/lib/tor/services/sourcev3/hostname")
+
+        apache_config = host.file("/etc/apache2/sites-available/source.conf")
+        expected_alt_svc = 'Header set Alt-Svc: h2="{}:80"'.format(
+            v3.content_string)
+        assert expected_alt_svc in apache_config.content_string
+
+
 @pytest.mark.parametrize("apache_opt", [
     "<VirtualHost {}:80>".format(
         securedrop_test_vars.apache_listening_address),


### PR DESCRIPTION
## Status

work in progress

## Description of Changes

Fixes #4630

Changes proposed in this pull request:
 - When both v2 and v3 are enabled, this PR adds an `Alt-Svc` header to send user traffic from v2 to v3 

## Testing

It's not possible as far as I can tell to determine that the Alt-Svc header is being used in Tor Browser (see my thoughts/explanation in #4630 for the full details) but I'll see if I can cook up something better on this for the 1.0.0 QA period. 

For now, you can verify that the header is being set by provisioning staging and visiting the v2 onions. Enabling developer tools in Tor Browser you should see: 

![Screen Shot 2019-08-28 at 4 48 31 PM](https://user-images.githubusercontent.com/7832803/63893884-45e0bd80-c9b9-11e9-8bc5-6a1510747de8.png)

To convince yourself that this is correct, you can read the [spec](https://tools.ietf.org/html/rfc7838) or you can check out [this site](https://perfectoid.space/test.php), which nicely shows via the color of the background in the page that is visited when the Alt-Svc is being used. It uses an Alt-Svc from Cloudflare:

![Screen Shot 2019-08-28 at 4 49 05 PM](https://user-images.githubusercontent.com/7832803/63893989-82141e00-c9b9-11e9-933c-d7fcd38f37e8.png)

### Bonus

I'm marking these as bonus because I think since the reviewer will be inspecting the diff doing this testing as part of 1.0.0 QA is OK:

1. v2_onion_services=False, v3_onion_services=True -> No Alt-Svc header
2. v2_onion_services=True, v3_onion_services=False -> No Alt-Svc header

## Deployment

This will be ran the next time an administrator runs the Ansible playbook. The

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR - well, I validated the non-bonus steps

