### PR TITLE
Adjust tooltip sizing/weight to reduce likelihood of abbreviation

### DIFF
--- a/securedrop/sass/modules/_tooltip.sass
+++ b/securedrop/sass/modules/_tooltip.sass
@@ -7,7 +7,6 @@
     &:before,
     .tooltip
       text-transform: none
-      font-size: .9em
       line-height: 1
       user-select: none
       pointer-events: none
@@ -34,6 +33,7 @@
       background: #333
       color: #fff
       z-index: 1000
+      font-weight: normal
 
     /* Make the tooltips respond to hover */
     &:hover::before,


### PR DESCRIPTION
Resolves #4716

## Status

Ready for review

## Testing

- Verify in the *Admin Interface* whether the tooltips on the "edit user" screen are abbreviated in your standard screen resolution before and after the change.