### PR TITLE
Expose v2/v3 Onion URLs to webapp code

### DIFF
--- a/docs/development/testing_configuration_tests.rst
+++ b/docs/development/testing_configuration_tests.rst
@@ -32,7 +32,7 @@ For the staging VMs:
 
 The VMs will be set up using either the libvirt or virtualbox Vagrant VM provider,
 depending on your system settings. You'll need to use the appropriate commands below
-based on your choice of provider. 
+based on your choice of provider.
 
 Then, to run the tests:
 
@@ -40,7 +40,7 @@ libvirt:
 ~~~~~~~~
 
 .. code:: sh
-   
+
    molecule verify -s libvirt-staging
 
 virtualbox:
@@ -50,12 +50,15 @@ virtualbox:
 
    molecule verify -s virtualbox-staging
 
+.. tip:: To run only a single test, set ``PYTEST_ADDOPTS="-k name_of_test"``
+         in your environment.
+
 Test failure against any host will generate a report with informative output
 about the specific test that triggered the error. Molecule
 will also exit with a non-zero status code.
 
 .. note:: To build and test the VMs with one command, use the Molecule ``test``
-  action: ``molecule test -s libvirt-staging --destroy=never``, or ``molecule test -s virtualbox-staging --destroy=never``. 
+  action: ``molecule test -s libvirt-staging --destroy=never``, or ``molecule test -s virtualbox-staging --destroy=never``.
 
 Updating the Config Tests
 -------------------------
@@ -75,7 +78,7 @@ than the Ansible playbooks: ::
 
 Any variable changes in the Ansible config should have a corresponding
 entry in these vars files. These vars are dynamically loaded for each
-host via the ``molecule/testinfra/staging/conftest.py`` file. Make sure to add 
+host via the ``molecule/testinfra/staging/conftest.py`` file. Make sure to add
 your tests to the relevant location for the host you plan to test: ::
 
     molecule/testinfra/staging/app/
@@ -105,7 +108,7 @@ Molecule configuration: ::
     ├── app
     ├── app-code
     ├── common
-    ├── mon 
+    ├── mon
     ├── ossec
     └── vars
 

--- a/install_files/ansible-base/roles/app/defaults/main.yml
+++ b/install_files/ansible-base/roles/app/defaults/main.yml
@@ -87,3 +87,9 @@ apache_disabled_modules:
 securedrop_default_locale: en_US
 # The subset of the available locales that will be proposed to the user
 securedrop_supported_locales: []
+
+# v2 Tor onion services are on / v3 Tor onion services are off by default for backwards
+# compatibility. Note that new installs after 1.0 will have v3 enabled by sdconfig which
+# will override these variables.
+v2_onion_services: true
+v3_onion_services: false

--- a/install_files/ansible-base/roles/app/tasks/copy_tor_url_info_to_app_dir.yml
+++ b/install_files/ansible-base/roles/app/tasks/copy_tor_url_info_to_app_dir.yml
@@ -1,0 +1,36 @@
+---
+- name: Look up Tor v2 URL info
+  command: cat /var/lib/tor/services/source/hostname
+  changed_when: false
+  register: v2_onion_url_lookup_result
+  # File may not exist, depending on host config
+  failed_when: false
+  when: v2_onion_services
+
+- name: Look up Tor v3 URL info
+  command: cat /var/lib/tor/services/sourcev3/hostname
+  changed_when: false
+  register: v3_onion_url_lookup_result
+  # File may not exist, depending on host config
+  failed_when: false
+  when: v3_onion_services
+
+- name: Expose Tor v2 Onion URL info to app
+  copy:
+    dest: /var/lib/securedrop/source_v2_url
+    owner: www-data
+    group: www-data
+    mode: "0644"
+    content: |
+      {{ v2_onion_url_lookup_result.stdout|default('') }}
+  when: v2_onion_services
+
+- name: Expose Tor v3 Onion URL info to app
+  copy:
+    dest: /var/lib/securedrop/source_v3_url
+    owner: www-data
+    group: www-data
+    mode: "0644"
+    content: |
+      {{ v3_onion_url_lookup_result.stdout|default('') }}
+  when: v3_onion_services

--- a/install_files/ansible-base/roles/app/tasks/main.yml
+++ b/install_files/ansible-base/roles/app/tasks/main.yml
@@ -4,6 +4,8 @@
 
 - include: initialize_securedrop_app.yml
 
+- include: copy_tor_url_info_to_app_dir.yml
+
 # If HTTPS is enabled, certs must land before Apache vhost configs
 # are written, otherwise the Apache enmod tasks will fail.
 - include: copy_ssl_certs.yml

--- a/molecule/testinfra/staging/app/test_tor_config.py
+++ b/molecule/testinfra/staging/app/test_tor_config.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 
 testinfra_hosts = ["app-staging"]
 sdvars = pytest.securedrop_test_vars
@@ -58,3 +59,23 @@ def test_tor_torrc_sandbox(host):
     # Only `Sandbox 1` will enable, but make sure there are zero occurrances
     # of "Sandbox", otherwise we may have a regression somewhere.
     assert not f.contains("^.*Sandbox.*$")
+
+
+def test_tor_v2_onion_url_readable_by_app(host):
+    v2_url_filepath = "/var/lib/securedrop/source_v2_url"
+    with host.sudo():
+        f = host.file(v2_url_filepath)
+        assert f.is_file
+        assert f.user == "www-data"
+        assert f.mode == 0o644
+        assert re.search(r"^[a-z0-9]{16}\.onion$", f.content_string)
+
+
+def test_tor_v3_onion_url_readable_by_app(host):
+    v3_url_filepath = "/var/lib/securedrop/source_v3_url"
+    with host.sudo():
+        f = host.file(v3_url_filepath)
+        assert f.is_file
+        assert f.user == "www-data"
+        assert f.mode == 0o644
+        assert re.search(r"^[a-z0-9]{56}\.onion$", f.content_string)


### PR DESCRIPTION
## Status

Ready for review. 

## Description of Changes

Fixes #4631. Fixes #4674.

Changes proposed in this pull request:

* Writes plaintext files to disk, readable by the `www-data` user, containing Onion URL info. Separate files are used for each URL.
* Updates documentation with a quick tip about running a subset of testinfra tests for developer velocity.

Files will exist only if the relevant generation of Onion URLs are configured in site-specific vars. That means that future implementations consuming these files must not assume file existence, and shold also validate the strings inside the files.

## Testing

CI will validate that the staging setup works well. Bust out your Tails/prod VM setup.

* [ ] Configure site-specific vars so that _only_ v2 URLs are enabled, install
* [ ] Log into app server (`ssh app`), confirm that `/var/lib/securedrop/source_v2_url` exists and matches the contents of `/var/lib/tor/services/source/hostname`.
* [ ] Confirm `/var/lib/securedrop/source_v3_url` does not exist
* [ ] Re-configure site-specific vars to enable v3 Onions, re-install
* [ ] Log into app server (`ssh app`), confirm that `/var/lib/securedrop/source_v2_url` exists and matches the contents of `/var/lib/tor/services/source/hostname`.
* [ ] Log into app server (`ssh app`), confirm that `/var/lib/securedrop/source_v3_url` exists and matches the contents of `/var/lib/tor/services/sourcev3/hostname`.

## Deployment
These changes are intended to enable future user-facing messaging regarding URL transitions. We aim to ship them in 1.0 to take advantage of the Admin process of enabling v3 URLs, which requires running the playbooks, to create these files. 

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
