### PR TITLE
Fixes #4677 warns admin if v3 and https both are enabled

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -446,6 +446,19 @@ class SiteConfig(object):
         self.save()
         self.validate_gpg_keys()
         self.validate_journalist_alert_email()
+        self.validate_https_and_v3()
+        return True
+
+    def validate_https_and_v3(self):
+        """
+        Checks if https is enabled with v3 onion service.
+
+        :returns: False if both v3 and https enabled, True otherwise.
+        """
+        if self.config.get("v3_onion_services", False) and \
+                self.config.get("securedrop_app_https_certificate_cert_src"):
+            print("Hello we need the message")
+            return False
         return True
 
     def check_for_v2_onion(self):

--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -455,9 +455,15 @@ class SiteConfig(object):
 
         :returns: False if both v3 and https enabled, True otherwise.
         """
+        warning_msg = ("You have configured HTTPS on your source interface "
+                       "and v3 onion services. "
+                       "IMPORTANT: Ensure that you update your certificate "
+                       "to include your v3 source URL before advertising "
+                       "it to sources! ")
+
         if self.config.get("v3_onion_services", False) and \
                 self.config.get("securedrop_app_https_certificate_cert_src"):
-            print("Hello we need the message")
+            print(warning_msg)
             return False
         return True
 

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -1042,3 +1042,22 @@ def test_find_or_generate_new_torv3_keys_subsequent_run(tmpdir, capsys):
         v3_onion_service_keys = json.load(f)
 
     assert v3_onion_service_keys == old_keys
+
+
+def test_v3_and_https_cert_message(tmpdir, capsys):
+    args = argparse.Namespace(site_config='UNKNOWN',
+                              ansible_path='tests/files',
+                              app_path=dirname(__file__))
+    site_config = securedrop_admin.SiteConfig(args)
+    site_config.config = {"v3_onion_services": False,
+                          "securedrop_app_https_certificate_cert_src": "ab.crt"}  # noqa: E501
+    # This should return True as v3 is not setup
+    assert site_config.validate_https_and_v3()
+
+    # This should return False as v3 and https are both setup
+    site_config.config.update({"v3_onion_services": True})
+    assert not site_config.validate_https_and_v3()
+
+    # This should return True as https is not setup
+    site_config.config.update({"securedrop_app_https_certificate_cert_src": ""})  # noqa: E501
+    assert site_config.validate_https_and_v3()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4677 This should be pulled in after #4710 is merged

We should decide the actual warning text and update in this PR. @redshiftzero 

## Testing

`./securedrop-admin sdconfig`

- If you enable v3 and https both, this should print an warning message
- If either of them disabled, the user should not see any warning.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
