### PR TITLE
Use dev-shell for make translate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,8 +292,8 @@ upgrade-test-qa:  ## Upgrade a running test environment with apt packages from t
 .PHONY: translate
 translate:  ## Update POT files from translated strings in source code.
 	@echo "Updating translations..."
-	@securedrop/i18n_tool.py translate-messages --extract-update
-	@securedrop/i18n_tool.py translate-desktop --extract-update
+	@$(DEVSHELL) $(SDROOT)/securedrop/i18n_tool.py translate-messages --extract-update
+	@$(DEVSHELL) $(SDROOT)/securedrop/i18n_tool.py translate-desktop --extract-update
 	@echo
 
 .PHONY: translation-test


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Using the dev-shell for `make translate` runs it in the right directory with the right requirements.

## Testing

Check out this branch. Run `make translate`. There should be no errors.

## Deployment

This is development-only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
