### PR TITLE
Add Weblate translation status widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 [![CircleCI branch](https://img.shields.io/circleci/project/github/freedomofpress/securedrop/develop.svg)](https://circleci.com/gh/freedomofpress/workflows/securedrop/tree/develop)
 [![codecov](https://codecov.io/gh/freedomofpress/securedrop/branch/develop/graph/badge.svg)](https://codecov.io/gh/freedomofpress/securedrop)
+[![Translation status](https://weblate.securedrop.org/widgets/securedrop/-/svg-badge.svg)](https://weblate.securedrop.org)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/freedomofpress/securedrop?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
 
 SecureDrop is an open-source whistleblower submission system that media organizations can use to securely accept documents from, and communicate with anonymous sources. It was originally created by the late Aaron Swartz and is currently managed by the [Freedom of the Press Foundation](https://freedom.press).
 

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -122,12 +122,26 @@ improve packaging and the release process:
 Translators
 ~~~~~~~~~~~
 
-All are kindly invited to help translate SecureDrop `using the Weblate interface
-<https://weblate.securedrop.org/>`__. We provide a :doc:`detailed guide <l10n>`
-to use as reference for details such as the meaning of placeholders, etc. Feel
-free to reach out on the `translation section of the forum
-<https://forum.securedrop.org/c/translations>`__ for help. Non-English forum
-discussions are welcome to help facilitate translations.
+Translating SecureDrop is crucial to making it useful for
+investigative journalism around the world. If you know English and
+another language, we would welcome your help.
+
+SecureDrop is translated using `Weblate
+<https://weblate.securedrop.org/>`__. We provide a :doc:`detailed
+guide <l10n>` for translators, and feel free to contact us in the
+`translation section of the SecureDrop forum
+<https://forum.securedrop.org/c/translations>`__ for help. Non-English
+forum discussions are also welcome.
+
+|SecureDrop translation status|
+
+|SecureDrop language status|
+
+.. |SecureDrop translation status| image:: https://weblate.securedrop.org/widgets/securedrop/-/287x66-white.png
+   :alt: SecureDrop translation status
+
+.. |SecureDrop language status| image:: https://weblate.securedrop.org/widgets/securedrop/-/horizontal-auto.svg
+   :alt: SecureDrop language status
 
 
 Designers


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Weblate provides widgets showing translation progress. Add a badge to our README, and larger widgets to the Translators section of our Contributing doc.

## Testing

Check out this branch, `make docs`, and check http://localhost:8000/development/contributing.html#translators to review the text changes and status widgets. The widgets should look like these:

![Translation summary](https://weblate.securedrop.org/widgets/securedrop/-/287x66-white.png)

![Language status](https://weblate.securedrop.org/widgets/securedrop/-/horizontal-auto.svg)

If you have Markdown installed, run it on `README.md` in the repo root and check that the status widgets at the beginning now include a translation widget:

[![Translation status](https://weblate.securedrop.org/widgets/securedrop/-/svg-badge.svg)](https://weblate.securedrop.org)

## Deployment

This is documentation-only.

## Checklist

### If you made changes to the server application code:


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
