### PR TITLE
Enable TLSv1.3 ciphers

### DIFF
--- a/install_files/ansible-base/roles/app/defaults/main.yml
+++ b/install_files/ansible-base/roles/app/defaults/main.yml
@@ -34,6 +34,9 @@ securedrop_app_https_certificate_chain_src: DigiCertCA.crt
 # The `SSLHonorCipherOrder` option is set to true, so ciphers below are
 # listed in order of preference.
 securedrop_app_https_ssl_ciphers:
+  - TLS13-AES-256-GCM-SHA384
+  - TLS13-CHACHA20-POLY1305-SHA256
+  - TLS13-AES-128-GCM-SHA256
   - ECDHE-ECDSA-AES256-GCM-SHA384
   - ECDHE-RSA-AES256-GCM-SHA384
   - ECDHE-ECDSA-CHACHA20-POLY1305

--- a/install_files/ansible-base/roles/app/defaults/main.yml
+++ b/install_files/ansible-base/roles/app/defaults/main.yml
@@ -34,9 +34,9 @@ securedrop_app_https_certificate_chain_src: DigiCertCA.crt
 # The `SSLHonorCipherOrder` option is set to true, so ciphers below are
 # listed in order of preference.
 securedrop_app_https_ssl_ciphers:
+  - TLS13-AES-128-GCM-SHA256
   - TLS13-AES-256-GCM-SHA384
   - TLS13-CHACHA20-POLY1305-SHA256
-  - TLS13-AES-128-GCM-SHA256
   - ECDHE-ECDSA-AES256-GCM-SHA384
   - ECDHE-RSA-AES256-GCM-SHA384
   - ECDHE-ECDSA-CHACHA20-POLY1305


### PR DESCRIPTION
This pull request adds support for a set of TLSv1.3 ciphers and is actually necessary in order to enable support for TLSv1.3.
