### PR TITLE
Adds check for valid v3 config on Admin Workstation

### DIFF
--- a/install_files/ansible-base/roles/validate/tasks/validate_tails_environment.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_tails_environment.yml
@@ -26,3 +26,43 @@
       The SecureDrop git repository should be cloned
       to `~/Persistent/securedrop`.
   with_items: "{{ tails_persistence_check_result.results }}"
+
+- name: Check for v3 client auth files
+  stat:
+    path: "/home/amnesia/Persistent/securedrop/install_files/ansible-base/{{ item }}"
+  register: v3_client_auth_files
+  with_items:
+    - app-ssh.auth_private
+    - app-journalist.auth_private
+    - mon-ssh.auth_private
+
+- name: Count the number of v3 client auth files
+  set_fact:
+    v3_client_auth_file_count: "{{ v3_client_auth_files.results | selectattr('stat.exists') | list | count }}"
+
+- name: Check for Tor v3 key file
+  stat:
+    path: "/home/amnesia/Persistent/securedrop/install_files/ansible-base/tor_v3_keys.json"
+  register: v3_tor_key
+
+- name: Confirm that all necessary v3 client auth files are present
+  assert:
+    that:
+      - v3_client_auth_file_count == "0" or v3_client_auth_file_count == "3"
+    msg: >-
+      Some v3 onion service client auth files are missing. Please add
+      all 3 `.client_auth` files under
+      `~/Persistent/securedrop/install_files/ansible-base`.
+  when: v3_onion_services == True
+
+- name: Confirm that a valid set of v3 configuration files is present
+  assert:
+    that:
+      - v3_tor_key.stat.exists
+    msg: >-
+      Authentication files for v3 onion services were found, but the
+      corresponding `tor_v3_keys.json` file is missing. To enable updates
+      to an existing SecureDrop instance, please add this file under
+      `~/Persistent/securedrop/install_files/ansible-base`.
+  when:
+    - v3_onion_services == True and v3_client_auth_file_count == "3"

--- a/install_files/ansible-base/roles/validate/tasks/validate_tails_environment.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_tails_environment.yml
@@ -1,4 +1,3 @@
----
 - name: Confirm host OS is Tails.
   assert:
     that:
@@ -27,35 +26,53 @@
       to `~/Persistent/securedrop`.
   with_items: "{{ tails_persistence_check_result.results }}"
 
-- name: Check for v3 client auth files
+- name: Check for v3 SSH auth files
   stat:
     path: "/home/amnesia/Persistent/securedrop/install_files/ansible-base/{{ item }}"
-  register: v3_client_auth_files
+  register: v3_ssh_auth_files
   with_items:
     - app-ssh.auth_private
-    - app-journalist.auth_private
     - mon-ssh.auth_private
 
-- name: Count the number of v3 client auth files
+- name: Count the number of v3 SSH auth files
   set_fact:
-    v3_client_auth_file_count: "{{ v3_client_auth_files.results | selectattr('stat.exists') | list | count }}"
+    v3_ssh_auth_file_count: "{{ v3_ssh_auth_files.results | selectattr('stat.exists') | list | count }}"
+
+- name: Check for Journalist client auth file
+  stat:
+    path: "/home/amnesia/Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private"
+  register: v3_journalist_auth_file
 
 - name: Check for Tor v3 key file
   stat:
     path: "/home/amnesia/Persistent/securedrop/install_files/ansible-base/tor_v3_keys.json"
   register: v3_tor_key
 
-- name: Confirm that all necessary v3 client auth files are present
+- name: Confirm that a valid set of SSH auth files is present
   assert:
     that:
-      - v3_client_auth_file_count == "0" or v3_client_auth_file_count == "3"
+      - v3_ssh_auth_file_count == "0" or v3_ssh_auth_file_count == "2"
     msg: >-
-      Some v3 onion service client auth files are missing. Please add
-      all 3 `.client_auth` files under
-      `~/Persistent/securedrop/install_files/ansible-base`.
-  when: v3_onion_services == True
+      One of the SSH `.auth_private` files is missing. Please add the missing
+      file under `~/Persistent/securedrop/install_files/ansible-base/ and
+      retry the install command.
+  when:
+    - v3_onion_services
 
-- name: Confirm that a valid set of v3 configuration files is present
+- name: Confirm that the Journalist auth file is present
+  assert:
+    that:
+      - v3_journalist_auth_file.stat.exists
+    msg: >-
+      The `app-journalist.auth_private` file is missing. Please add the missing
+      file under `~/Persistent/securedrop/install_files/ansible-base/ and
+      retry the install command.
+  when:
+    - v3_onion_services
+    - enable_ssh_over_tor
+    - v3_ssh_auth_file_count == "2"
+
+- name: Confirm that the Tor keys file is present
   assert:
     that:
       - v3_tor_key.stat.exists
@@ -65,4 +82,5 @@
       to an existing SecureDrop instance, please add this file under
       `~/Persistent/securedrop/install_files/ansible-base`.
   when:
-    - v3_onion_services == True and v3_client_auth_file_count == "3"
+    - v3_onion_services
+    - v3_journalist_auth_file.stat.exists


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #4681.

## Testing

### Scenario 1: fresh install, no v3 config files present
- [x] `./securedrop-admin install` completes successfully

### Scenario 2: install with `tor_v3_keys.json` present and no `.auth_private` files present
- [x] `./securedrop-admin install` completes successfully

### Scenario 3a (SSH-over-Tor): install with `tor_v3_keys.json` present and all `.auth_private` files present
- [x] `./securedrop-admin install` completes successfully

### Scenario 3b (SSH-over-LAN): install with `tor_v3_keys.json` present and  `app-journalist.auth_private` file present
- [x] `./securedrop-admin install` completes successfully

### Scenario 4 (SSH-over-TOR or SSH-over-LAN): install with  `app-journalist.auth_private` file present and no `tor_v3_keys.json` file present
- [x] `./securedrop-admin install` fails with message about missing `tor_v3_keys.json`

### Scenario 5 (SSH-over-TOR): install with  SSH `.auth_private` files present and no `app-journalist.auth_private` file present.
- [x] `./securedrop-admin install` fails with message about missing `app-journalist.auth_private` file.

## Deployment

## Checklist
### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR