### PR TITLE
Incorporate source string feedback from KwadroNaut

### DIFF
--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -110,6 +110,6 @@
 {%- endmacro %}
 
 {{ twofa_reset(user, totp_reset_url, "totp", gettext("Reset two-factor authentication for mobile apps, such as FreeOTP"), gettext("RESET APP TOKEN"))}}
-{{ twofa_reset(user, hotp_reset_url, "hotp", gettext("Reset two-factor authentication for hardware tokens, like YubiKey"), gettext("RESET HARDWARE TOKEN"))}}
+{{ twofa_reset(user, hotp_reset_url, "hotp", gettext("Reset two-factor authentication for hardware tokens, like a YubiKey"), gettext("RESET HARDWARE TOKEN"))}}
 
 {% endblock %}

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -62,7 +62,7 @@
               </div>
               <div class="index-column-bottom-container">
                 <a href="{{ url_for('main.login') }}" id="login-button" class="btn secondary">
-                  {{ gettext('CHECK-IN') }}
+                  {{ gettext('LOG IN') }}
                 </a>
               </div>
             </div>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

On the source start page, change the text on the button for returning sources from "CHECK-IN" to "LOG IN".

On the account editing page in the journalist interface, change "Reset two-factor authentication for hardware tokens, like YubiKey" to "Reset two-factor authentication for hardware tokens, like a YubiKey". This appears in the tooltip for the "RESET HARDWARE TOKEN" button.

Thanks to @kwadronaut for the suggestions!

## Testing

Check out this branch,  `make dev`, and confirm that the two strings appear as described.

## Deployment

The changes are just in text on a button and tooltip.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR