### PR TITLE
Correct cleanup of disconnected submission files

### DIFF
--- a/securedrop/tests/test_submission_cleanup.py
+++ b/securedrop/tests/test_submission_cleanup.py
@@ -13,7 +13,7 @@ def test_delete_disconnected_db_submissions(journalist_app, config):
     Test that Submission records without corresponding files are deleted.
     """
     with journalist_app.app_context():
-        source, codename = utils.db_helper.init_source()
+        source, _ = utils.db_helper.init_source()
         source_id = source.id
 
         # make two submissions
@@ -43,13 +43,18 @@ def test_delete_disconnected_fs_submissions(journalist_app, config):
     """
     Test that files in the store without corresponding Submission records are deleted.
     """
-    source, codename = utils.db_helper.init_source()
+    source, _ = utils.db_helper.init_source()
 
     # make two submissions
     utils.db_helper.submit(source, 2)
     source_filesystem_id = source.filesystem_id
     submission_filename = source.submissions[0].filename
     disconnect_path = os.path.join(config.STORE_DIR, source_filesystem_id, submission_filename)
+
+    # make two replies, to make sure that their files are not seen
+    # as disconnects
+    journalist, _ = utils.db_helper.init_journalist("Mary", "Lane")
+    utils.db_helper.reply(journalist, source, 2)
 
     # delete the first Submission record
     db.session.delete(source.submissions[0])


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In `securedrop.management.submissions.find_disconnected_fs_submissions`, check replies as well as submissions for a valid association to any file found in the store, before reporting it as disconnected.

Fixes #4734.

## Testing

- Run `make dev`
- In another shell:
  - Run `docker container ls` to get the dev container's ID
  - Run `docker exec -it "container-id" bash`
  - Run `./manage.py list-disconnected-fs-submissions`

No disconnects should be reported.

- In the second shell:
  - `cd /var/lib/securedrop`
  - `sqlite3 db.sqlite`
    - `select * from submissions;`  -- there should be four records
    - `delete from submissions where id = 4;`  -- adjust if there is no record with ID 4
  - `cd -`
  - `./manage.py list-disconnected-fs-submissions`

The file whose submission you just deleted should be the only disconnect reported.

## Deployment

No concerns; this fixes a serious bug.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
