### PR TITLE
Update the path to rqworker in dev-deps supervisor config

### DIFF
--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -23,7 +23,7 @@ function run_redis() {
 }
 
 function run_supervisor() {
-    mkdir -p /tmp/supervisor/log /tmp/supervisor/run && printf "[unix_http_server]\nfile=/tmp/supervisor/run/supervisor.sock\nchmod=0700\n\n[supervisord]logfile=/tmp/supervisor/log/supervisord.log\npidfile=/tmp/supervisor/run/supervisord.pid\nchildlogdir=/tmp/supervisor/log\n[rpcinterface:supervisor]\nsupervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface\n\n[supervisorctl]\nserverurl=unix:///tmp/supervisor/run/supervisor.sock\n\n[program:securedrop_worker]\ncommand=/usr/local/bin/rqworker\ndirectory=$(pwd)\nautostart=true\nautorestart=true\nstartretries=3\nstderr_logfile=/tmp/supervisor/log/securedrop_worker.err\nstdout_logfile=/tmp/supervisor/log/securedrop_worker.out\nuser=%s\n" "$USER_NAME" > /tmp/supervisor/supervisor.conf
+    mkdir -p /tmp/supervisor/log /tmp/supervisor/run && printf "[unix_http_server]\nfile=/tmp/supervisor/run/supervisor.sock\nchmod=0700\n\n[supervisord]logfile=/tmp/supervisor/log/supervisord.log\npidfile=/tmp/supervisor/run/supervisord.pid\nchildlogdir=/tmp/supervisor/log\n[rpcinterface:supervisor]\nsupervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface\n\n[supervisorctl]\nserverurl=unix:///tmp/supervisor/run/supervisor.sock\n\n[program:securedrop_worker]\ncommand=/opt/venvs/securedrop-app-code/bin/rqworker\ndirectory=$(pwd)\nautostart=true\nautorestart=true\nstartretries=3\nstderr_logfile=/tmp/supervisor/log/securedrop_worker.err\nstdout_logfile=/tmp/supervisor/log/securedrop_worker.out\nuser=%s\n" "$USER_NAME" > /tmp/supervisor/supervisor.conf
 
     setsid supervisord -c /tmp/supervisor/supervisor.conf >& /tmp/supervisor/log/supervisor.out || cat /tmp/supervisor/log/supervisor.out
 }


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The supervisor configuration in the dev container was still pointing to /usr/local/bin/rqworker, which has been moved to /opt/venvs/securedrop-app-code/bin. Correcting the path fixes submission hashing and deletion.

Fixes #4733.

## Testing

Follow the steps to reproduce in issue #4733. The submissions should be properly hashed and deleted.

## Deployment

This change only affects the dev container.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made non-trivial code changes:

- [x] @eloquence has written a test plan and I've validated it for this PR
