### PR TITLE
Updating tailsconfig to always run network hook

### DIFF
--- a/install_files/ansible-base/roles/tails-config/handlers/main.yml
+++ b/install_files/ansible-base/roles/tails-config/handlers/main.yml
@@ -1,7 +1,0 @@
----
-# Run the SecureDrop init script, which implements the torrc additions
-# so the ATHS Onion URLs are accessible. See `securedrop_init.py` for details.
-- name: run securedrop network hook
-  # Writes files to /etc, so elevated privileges are required.
-  become: yes
-  command: /usr/bin/python "{{ tails_config_securedrop_dotfiles }}/securedrop_init.py"

--- a/install_files/ansible-base/roles/tails-config/tasks/configure_network_hook.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/configure_network_hook.yml
@@ -18,4 +18,8 @@
   with_items:
     - "{{ tails_config_live_persistence }}/custom-nm-hooks"
     - "{{ tails_config_network_manager_dispatcher }}"
-  notify: run securedrop network hook
+
+- name: Run SecureDrop network hook
+  # Writes files to /etc, so elevated privileges are required.
+  become: yes
+  command: /usr/bin/python "{{ tails_config_securedrop_dotfiles }}/securedrop_init.py"


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #4738 

Previously, the network hook set up by `./securedrop-admin tailsconfig` was invoked by a handler notification if the script adding it changed. This PR removes the handler and adds a task that runs the hook every time `tailsconfig` runs.

Changes proposed in this pull request:

## Testing
Testing against prod VMs or hardware:
-  run `./securedrop-admin tailsconfig` after completing an install. 
- [ ] Verify connectivity via the Journalist desktop shortcut, `ssh app`, and `ssh mon` 
- Then run `./securedrop-admin tailsconfig` again
- [ ] Verify that the Ansible output includes:
```
TASK [tails-config : Run SecureDrop network hook] ******************************
changed: [localhost]
```
- [ ] Verify connectivity via the Journalist desktop shortcut, `ssh app`, and `ssh mon` 

## Deployment

Any special considerations for deployment? Consider both:

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
