### PR TITLE
Teach update_version.sh to bump the expected sdist tarball version

### DIFF
--- a/update_version.sh
+++ b/update_version.sh
@@ -54,6 +54,10 @@ sed -i "s/^\(Version: [0-9.]\++\).*/\1$NEW_VERSION/" install_files/securedrop-co
 # Update the version used by Ansible for the filename of the output of the deb building role
 sed -i "s/^\(securedrop_app_code_version: \"\).*/\1$NEW_VERSION\"/" install_files/ansible-base/group_vars/all/securedrop
 
+# Update the version used for the sdist tarball
+NEW_SDIST_VERSION=$(echo "$NEW_VERSION" | sed -r -e 's/~/-/')
+sed -i "s/^\(securedrop_app_code_sdist_version: \"securedrop-app-code-\).*/\1${NEW_SDIST_VERSION}\"/" install_files/ansible-base/group_vars/all/securedrop
+
 # Update the version in molecule testinfra vars
 sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" molecule/builder-xenial/tests/vars.yml
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Teach `update_version.sh` to bump the expected sdist tarball version, so that the securedrop-app-code Debian package can be built.

Fixes #4748.

## Testing

- Check out this branch. 
- Run `securedrop/bin/dev-shell ../update_version.sh 1.0.0~rc2`
- Confirm that `securedrop/install_files/ansible-base/group_vars/all/securedrop` has the new version in the value of `securedrop_app_code_sdist_version`.
- Confirm that `make build-debs` runs without errors

## Deployment

This is just for development/packaging.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
