### PR TITLE
ci: bump staging timeout to 30m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,7 +328,7 @@ jobs:
             BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|docs)")
             if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
             make ci-go
-          no_output_timeout: 25m
+          no_output_timeout: 35m
 
       - run:
           name: Ensure environment torn down


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #4743

Changes proposed in this pull request:

- Bump staging job timeout up by 5 mins to reduce staging failures

## Deployment

CI only

Probably also worth picking this into `release/1.0.0` to reduce staging failures when merging into there