### PR TITLE
Update Python script interpreter directives

### DIFF
--- a/install_files/ansible-base/roles/backup/files/0.3_collect.py
+++ b/install_files/ansible-base/roles/backup/files/0.3_collect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/opt/venvs/securedrop-app-code/bin/python
 """
 
 This script should be copied to the App server and ran by the anisble

--- a/install_files/ansible-base/roles/backup/files/backup.py
+++ b/install_files/ansible-base/roles/backup/files/backup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/opt/venvs/securedrop-app-code/bin/python
 """
 This script is copied to the App server and run by the Ansible playbook. When
 run (as root), it collects all of the necessary information to backup the 0.3

--- a/install_files/ansible-base/roles/restore/files/restore.py
+++ b/install_files/ansible-base/roles/restore/files/restore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/opt/venvs/securedrop-app-code/bin/python
 """
 This script and backup archive should be copied to the App server and run by
 the Ansible playbook. When run (as root), it restores the contents of the 0.3

--- a/securedrop/create-dev-data.py
+++ b/securedrop/create-dev-data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/venvs/securedrop-app-code/bin/python
 # -*- coding: utf-8 -*-
 
 import datetime

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from distutils.version import StrictVersion

--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/venvs/securedrop-app-code/bin/python
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/securedrop/qa_loader.py
+++ b/securedrop/qa_loader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/venvs/securedrop-app-code/bin/python
 # -*- coding: utf-8 -*-
 
 import math


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

For Python scripts run where the `/opt/venvs/securedrop-app-code` virtualenv is used, specify that in the interpreter directive line.

Remove the shebang line from `crypto_util.py`, since it's never run.

Leave unmodified the scripts used on workstations or in packaging VMs.

Fixes #4731.

## Testing

- Run `make test` to verify the changes work in the dev container
- Run `make build-debs` and `make staging` to verify package building and VM configuration
- Test `securedrop-admin backup` and `securedrop-admin restore` with VMs or hardware

## Deployment

These changes should only affect backup and restore (the manage.py interpreter directive was already changed like this in a previous PR).

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
