### PR TITLE
[1.0.0] ci: bump staging timeout to 35m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,7 +328,7 @@ jobs:
             BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|docs)")
             if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
             make ci-go
-          no_output_timeout: 25m
+          no_output_timeout: 35m
 
       - run:
           name: Ensure environment torn down


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Backport of #4750  bumping staging job timeout from 25 to 35 min.

## Testing

Backport - Verify that the commit is the same as #4750's
