### PR TITLE
[docs] updated documentation to include references to v3 services

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -453,15 +453,31 @@ into your Admin Workstation, you should first perform the following troubleshoot
    your *Application Server* is online, and you can trigger a `test OSSEC alert`_
    to verify your *Monitor Server* is online.
 
-#. **Ensure that SSH aliases and the HidServAuth values are configured:** From
-   ``~/Persistent/securedrop``, run  ``./securedrop-admin tailsconfig``. This
-   will ensure your local Tails environment is configured properly.
+#. **Ensure that SSH aliases and onion service authentication are configured:**
 
-    .. note:: If you get an error during the Tails configuration step, as an Administrator,
-       you should ensure you have four files ``app-ssh-aths``, ``mon-ssh-aths``,
-       ``app-journalist-aths`` and ``app-source-ths`` in
-       ``~/Persistent/securedrop/install_files/ansible-base/``. These are used by
-       the Tails configuration scripts to configure Tor.
+   - First, ensure that the correct configuration files are present in 
+     ``~/Persistent/securedrop/install_files/ansible-base``. 
+
+     If v2 onion services
+     are configured, you should have 4 files:
+
+     - ``app-ssh-aths``
+     - ``mon-ssh-aths``
+     - ``app-journalist-aths``
+     - ``app-source-ths`` 
+
+
+     If v3 onion services are 
+     enabled, you should have the following 5 files:
+
+     - ``app-ssh.auth_private``
+     - ``mon-ssh.auth_private``
+     - ``app-journalist.auth_private``
+     - ``app-sourcev3-ths``
+     - ``tor_v3_keys.json``
+
+   - Then, from ``~/Persistent/securedrop``, run  ``./securedrop-admin tailsconfig``.
+     This will ensure your local Tails environment is configured properly.
 
 #. **Confirm that your SSH key is available**: During the install, you
    configured SSH public key authentication using ``ssh-copy-id``.

--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -1,6 +1,7 @@
 Back Up, Restore, Migrate
 =========================
 
+
 There are a number of reasons why you might want to backup and restore a
 SecureDrop installation. Maintaining periodic backups is generally a good
 practice to guard against data loss. In the event of hardware failure on
@@ -80,13 +81,12 @@ to debug your connectivity before proceeding further. Make sure:
 * Ansible is installed
 * the *Admin Workstation* is connected to the Internet
 * Tor starts successfully
-* the ``HidServAuth`` values from ``install_files/ansible-base/app-ssh-aths``
-  and ``install_files/ansible-base/mon-ssh-aths`` are in Tails at
-  ``/etc/tor/torrc``
+* The appropriate onion service configuration files are present in 
+  ``~/Persistent/securedrop/install_files/ansible-base`` and the 
+  ``./securedrop-admin tailsconfig`` command completes successfully
 
-(If Ansible is not installed, or the ``HidServAuth`` values are missing
-or incorrect, see :doc:`configure_admin_workstation_post_install` for detailed
-instructions.)
+If Ansible is not installed, or ``./securedrop-admin tailsconfig`` fails, see
+:doc:`configure_admin_workstation_post_install` for detailed setup instructions.
 
 Create the Backup
 '''''''''''''''''
@@ -138,6 +138,11 @@ command. Otherwise, you should copy the backup archive that you wish to restore 
 
 Restoring From a Backup File
 ''''''''''''''''''''''''''''
+
+.. important:: This documentation applies to a SecureDrop instance using
+               v2 onion services. If your instance uses v3 onion services,
+               you will need to follow additional steps depending on your
+               specific restore scenario.
 
 To perform a restore, you must already have a backup archive. Provide its
 filename in the following command:

--- a/docs/development/tips_and_tricks.rst
+++ b/docs/development/tips_and_tricks.rst
@@ -121,6 +121,13 @@ to append values to your local ``torrc``, as in the ``cat`` example above.
 Note that the ``cat`` example above will also add the ATHS info for the
 *Journalist Interface*, as well, which is useful for testing.
 
+.. note:: The instructions above refer to VMs set up with v2 onion services. If
+          v3 onion services are configured instead, the steps required for the 
+          local ``tor`` setup will differ. You will need to add a 
+          ``ClientOnionAuthDir`` directive to ``torrc``, pointing to a directory
+          containing the ``*.auth_private`` files created during the installation
+          process under ``install_files/ansible-base``.
+
 Architecture Diagrams
 ---------------------
 

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -102,11 +102,33 @@ local git repository and then installed on the staging servers.
           (last tested on 10.11.6).
 
 The web interfaces and SSH are available over Tor. A copy of the the Onion URLs
-for Source and Journalist Interfaces, as well as SSH access, are written to the
-Vagrant host's ``install_files/ansible-base`` directory, named:
+for *Source* and *Journalist Interfaces*, as well as SSH access, are written to the
+Vagrant host's ``install_files/ansible-base`` directory.
 
-* ``app-source-ths``
-* ``app-journalist-aths``
+To access the *Source Interface* from Tor Browser, use the v3 onion URL from the file 
+``install_files/ansible-base/app-sourcev3-ths``.
+
+To use the *Journalist Interface*, you will need to modify Tor Browser's 
+configuration to allow access to an authenticated onion service:
+
+- First, add the following line to your Tor Browser's ``torrc`` file, typically
+  found at ``tor-browser_en-US/Browser/TorBrowser/Data/Tor/torrc``:
+
+  .. code-block:: none
+
+    ClientOnionAuthDir TorBrowser/Data/Tor/onion_auth
+
+- Next, create the ``onion_auth`` directory:
+
+  .. code:: sh
+
+    mkdir tor-browser_en-US/Browser/TorBrowser/Data/Tor/onion_auth
+    chmod 0700 tor-browser_en-US/Browser/TorBrowser/Data/Tor/onion_auth
+
+- Finally, copy the file ``install_files/ansible-base/app-journalist.auth_private``
+  to the ``onion_auth`` directory and restart Tor Browser. You should now be able 
+  to visit the v3 onion address in ``app-journalist.auth_private`` from Tor Browser.
+
 
 For working on OSSEC monitoring rules with most system hardening active, update
 the OSSEC-related configuration in
@@ -318,10 +340,10 @@ A copy of the Onion URLs for Source and Journalist Interfaces, as well as
 SSH access, are written to the Vagrant host's ``install_files/ansible-base``
 directory, named:
 
-* ``app-source-ths``
-* ``app-journalist-aths``
-* ``app-ssh-aths``
-* ``mon-ssh-aths``
+* ``app-sourcev3-ths``
+* ``app-journalist.auth_private``
+* ``app-ssh.auth_private``
+* ``mon-ssh.auth_private``
 
 SSH Access
 ~~~~~~~~~~

--- a/docs/https_source_interface.rst
+++ b/docs/https_source_interface.rst
@@ -15,16 +15,12 @@ encryption and authentication via HTTPS:
   they are communicating with the intended organization when they access a
   given Source Interface.
 
-* The cryptographic primitives used by Tor Onion Services are considered to be
-  outdated, and while there are no known compromises of the security of Tor
-  Onion Services due to this issue, you may wish to provide an additional
-  layer of transport encryption using stronger cryptographic primitives, which
-  is most easily achieved by setting up HTTPS on the Source Interface.
-
-  .. note:: This issue is being addressed by the Tor Project with their Next
-     Generation Onion Services design, but the implementation of the new design
-     is still a work in progress and is not expected to be deployed until
-     December 2017 at the earliest.
+* SecureDrop supports v3 onion services, which use updated cryptographic 
+  primitives that provide better transport-layer encryption than those used 
+  by v2 onion services. It is **strongly** recommended that you configure your
+  instance to use :doc:`v3 onion services <v3_services>`, but if you cannot 
+  switch your instance to v3, using HTTPS on the source interface will provide
+  an extra layer of encryption for data in transit.
 
 .. _`SecureDrop Directory`: https://securedrop.org/directory/
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,6 +80,7 @@ anonymous sources.
    rebuild_admin
    kernel_troubleshooting
    getting_support
+   v3_services
 
 .. toctree::
    :caption: Upgrade SecureDrop

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,7 +13,7 @@ command:
 
     ./securedrop-admin setup
 
-The package installation will take approximately 10 minutes, depending
+The package installation will take approximately 10 minutes or longer, depending
 on network speed and computing power.
 
 .. note:: On Tails 3.9 or later, the apt persistence feature will prompt
@@ -52,6 +52,18 @@ parentheses.
           submitting documents are likely to expect a journalist fluent in
           French to be available to read the documents and follow up in that
           language.
+
+Onion Service Options
+---------------------
+SecureDrop supports the use of tradtional (v2)  or next-generation (v3) onion
+services for the *Source* and *Journalist Interfaces*, as well as the SSH proxy
+services if they are configured. Either or both may be enabled, but we recommend
+the use of v3 onion services for any new instances, as they offer greater
+security.
+
+For more information on v3 onion services, including upgrade options 
+for existing instances, see 
+:doc:`SecureDrop v3 onion services <v3_services>`.
 
 Configure the Installation
 --------------------------
@@ -156,9 +168,12 @@ an email to securedrop@freedom.press.
 
 .. _`Source Offer`: https://github.com/freedomofpress/securedrop/blob/develop/SOURCE_OFFER
 
-Once the installation is complete, addresses and credentials for each Tor Hidden
-Service will be available in the following files under
+Once the installation is complete, addresses and credentials for each 
+onion service will be available in the following files under
 ``install_files/ansible-base``:
+
+V2 onion services
+^^^^^^^^^^^^^^^^^
 
 - ``app-source-ths`` contains the ``.onion`` address of the *Source
   Interface*.
@@ -174,13 +189,38 @@ Service will be available in the following files under
 
 .. warning:: The ``app-journalist-aths``, ``app-ssh-aths``, and
              ``mon-ssh-aths`` files contain passwords for their corresponding
-             authenticated Onion Services. They should not be shared with
+             authenticated onion services. They should not be shared with
              third parties or copied from the *Admin Workstation* for any
              reason other than well-defined administrative tasks such as
              onboarding new users or performing backups.
 
-The dynamic inventory file will automatically read the Onion URLs
-from the ``app-ssh-aths`` and ``mon-ssh-aths`` files and use them to connect
-to the servers over SSH during subsequent playbook runs.
+If v3 onion services are not enabled, the dynamic inventory file will 
+automatically read the Onion URLs from the ``app-ssh-aths`` and ``mon-ssh-aths``
+files and use them to connect to the servers over SSH during subsequent playbook
+runs.
+
+V3 onion services
+^^^^^^^^^^^^^^^^^
+
+- ``app-sourcev3-ths`` contains the v3 ``.onion`` address of the *Source
+  Interface*.
+- ``app-journalist.auth_private`` contains the ``onion`` address and private key
+  providing access to the *Journalist Interface*.
+- ``app-ssh.auth_private`` contains the ``onion`` address and private key
+  providing SSH access to the *Application Server*.
+- ``mon-ssh.auth_private`` contains the ``onion`` address and private key
+  providing SSH access to the *Monitor Server*.
+- ``tor_v3_keys.json`` contains the keypairs required for access to the
+  *Journalist Interface* and SSH access to the servers - it is required for 
+  future runs of ``./securedrop-admin install``.
+
+.. warning:: The three ``.auth_private`` files and the ``tor_v3_keys.json`` file 
+             contain secret keys that should not be shared with third parties,
+             or copied from the *Admin Workstation* for any purpose other than
+             tasks such as performing backups or onboarding new users.
+
+The dynamic inventory file will automatically read the ``onion`` addresses from
+the ``app-ssh.auth_private`` and ``mon-ssh.auth_private`` files and use them to
+connect to the servers over SSH during subsequent playbook runs.
 
 .. |Tails Apt Persistence| image:: images/tails-install-once-or-every-time.png

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -11,8 +11,8 @@ In order to use SecureDrop, each journalist needs two things:
 
 1. A *Journalist Tails USB*.
 
-     The *Journalist Interface* is only accessible as an Authenticated Tor
-     Hidden Service (ATHS). For ease of configuration and security, we
+     The *Journalist Interface* is only accessible as an authenticated
+     onion service. For ease of configuration and security, we
      require journalists to set up a Tails USB with persistence that
      they are required to use to access the *Journalist Interface*.
 
@@ -68,52 +68,64 @@ passphrase before continuing with the next section.
 Set Up Automatic Access to the *Journalist Interface*
 -----------------------------------------------------
 
-Since the *Journalist Interface* is an ATHS, we need to set up the
-*Journalist Workstation* to auto-configure Tor just as we did with the
-*Admin Workstation*. The procedure is essentially identical, except the
+Since the *Journalist Interface* is an authenticated onion service, you must
+set up the *Journalist Workstation* to auto-configure Tor, similarly to 
+the *Admin Workstation*. The procedure is essentially identical, except the
 SSH configuration will be skipped, since only admins need
 to access the servers over SSH.
 
-.. tip:: Copy the files ``app-journalist-aths`` and ``app-source-ths`` from
-         the *Admin Workstation* via the Transfer Device. Place these files
-         in ``~/Persistent/securedrop/install_files/ansible-base`` on the
-         *Journalist Workstation*, and the ``./securedrop-admin tailsconfig``
-         tool will automatically use them. Don't forget to securely delete
-         these files from the *Transfer Device* when you're done, by
-         right-clicking them in the file manager and selecting **Wipe**.
+- First, boot into the *Admin Workstation*. If your instance has not been set up
+  to use v3 onion services, copy the following v2 service files to a *Transfer Device*:
 
-.. warning:: Do **not** copy the files ``app-ssh-aths`` and ``mon-ssh-aths``
-             to the *Journalist Workstation*. Those files grant access via SSH,
-             and only the *Admin Workstation* should have shell access to the
+  .. code-block:: none
+ 
+    ~/Persistent/securedrop/install_files/ansible_base/app-source-ths
+    ~/Persistent/securedrop/install_files/ansible_base/app-journalist-ths
+
+  If your instance was set up to use v3 services, copy the following files instead:
+
+  .. code-block:: none
+
+    ~/Persistent/securedrop/install_files/ansible_base/app-sourcev3-ths
+    ~/Persistent/securedrop/install_files/ansible_base/app-journalist.auth_private
+
+  Then, boot into the new *Journalist Workstation* USB.
+
+- Install the SecureDrop application code on the workstation's persistent volume,
+  following the documentation for :ref:`cloning the SecureDrop
+  repository <Download the SecureDrop repository>`.
+
+- Copy the files from the *Transfer Device* to ``~/Persistent/securedrop/install_files/ansible-base``
+
+- Open a terminal and run the following commands:
+
+  .. code:: sh
+ 
+    cd ~/Persistent/securedrop
+    ./securedrop-admin setup
+    ./securedrop-admin tailsconfig
+
+  .. note:: The ``setup`` command may take several minutes, and may fail partway
+            due to network issues. If so, run it again before proceeding.
+
+- Once the ``tailsconfig`` command is complete, verify that the *Source* and
+  *Journalist Interfaces* are accessible at their v2 addresses via the 
+  SecureDrop desktop shortcuts.
+
+- Securely wipe the files on the *Transfer Device*, by right-clicking them
+  in the file manager and selecting **Wipe**.
+
+.. warning:: Do **not** copy the ``app-ssh-aths``, ``mon-ssh-aths``,
+             ``app-ssh.auth_private``, ``mon-ssh.auth_private``, or ``tor_v3_keys.json``
+             files to the *Journalist Workstation*. Those files contain private
+             keys and authentication information for SSH server access.
+             Only the *Admin Workstation* should have shell access to the
              servers.
 
-.. warning:: The ``app-journalist-aths`` file contains a password for the
-             authenticated Onion Service used by the *Journalist Interface*,
+.. warning:: The ``app-journalist-aths`` and ``app-journalist.auth_private`` 
+             files contain secret authentication information for the
+             authenticated onion service used by the *Journalist Interface*,
              and should not be shared except through the onboarding process.
-
-Since you need will the Tails setup scripts (``securedrop/tails_files``) that
-you used to :doc:`Configure the *Admin Workstation* Post-Install
-<configure_admin_workstation_post_install>`, clone (and verify) the SecureDrop
-repository on the *Journalist Workstation*, just like you did for the Admin
-Workstation. Refer to the docs for :ref:`cloning the SecureDrop
-repository <Download the SecureDrop repository>`, then return here to
-continue setting up the *Journalist Workstation*.
-
-Once you've done this, use the ``securedrop-admin`` script to configure the
-shortcuts for the Source and *Journalist Interfaces*: ::
-
-  ./securedrop-admin setup
-  ./securedrop-admin tailsconfig
-
-If you did not copy over the ``app-source-ths`` and ``app-journalist-aths``
-files from the *Admin Workstation*, the script will prompt for the information.
-Make sure to type the information carefully, as any typos will break access
-for the *Journalist Workstation*.
-
-Once the script is finished, you should be able to access the
-*Journalist Interface*. Open the Tor Browser and navigate to the .onion address for
-the *Journalist Interface*. You should be able to connect, and will be
-automatically taken to a login page.
 
 Add an account on the *Journalist Interface*
 --------------------------------------------

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -80,7 +80,7 @@ to access the servers over SSH.
   .. code-block:: none
  
     ~/Persistent/securedrop/install_files/ansible_base/app-source-ths
-    ~/Persistent/securedrop/install_files/ansible_base/app-journalist-ths
+    ~/Persistent/securedrop/install_files/ansible_base/app-journalist-aths
 
   If your instance was set up to use v3 services, copy the following files instead:
 
@@ -90,6 +90,13 @@ to access the servers over SSH.
     ~/Persistent/securedrop/install_files/ansible_base/app-journalist.auth_private
 
   Then, boot into the new *Journalist Workstation* USB.
+
+.. warning:: Do **not** copy the ``app-ssh-aths``, ``mon-ssh-aths``,
+             ``app-ssh.auth_private``, ``mon-ssh.auth_private``, or ``tor_v3_keys.json``
+             files to the *Journalist Workstation*. Those files contain private
+             keys and authentication information for SSH server access.
+             Only the *Admin Workstation* should have shell access to the
+             servers.
 
 - Install the SecureDrop application code on the workstation's persistent volume,
   following the documentation for :ref:`cloning the SecureDrop
@@ -115,12 +122,6 @@ to access the servers over SSH.
 - Securely wipe the files on the *Transfer Device*, by right-clicking them
   in the file manager and selecting **Wipe**.
 
-.. warning:: Do **not** copy the ``app-ssh-aths``, ``mon-ssh-aths``,
-             ``app-ssh.auth_private``, ``mon-ssh.auth_private``, or ``tor_v3_keys.json``
-             files to the *Journalist Workstation*. Those files contain private
-             keys and authentication information for SSH server access.
-             Only the *Admin Workstation* should have shell access to the
-             servers.
 
 .. warning:: The ``app-journalist-aths`` and ``app-journalist.auth_private`` 
              files contain secret authentication information for the

--- a/docs/rebuild_admin.rst
+++ b/docs/rebuild_admin.rst
@@ -1,6 +1,14 @@
 Rebuilding an *Admin Workstation* USB
 -------------------------------------
 
+.. note:: These instructions refer to a SecureDrop instance using v2 onion 
+          services. If your instance uses v3 onion services and you need to
+          rebuild your *Admin Workstation*, please contact FPF through the
+          `SecureDrop Support Portal`_.                            
+                                                                                
+.. _SecureDrop Support Portal: https://securedrop-support.readthedocs.io/en/latest/
+
+
 In cases where an *Admin Workstation* USB stick has been lost or destroyed, and no
 backup exists, it is possible to rebuild one. In order to do so, you'll need
  

--- a/docs/test_the_installation.rst
+++ b/docs/test_the_installation.rst
@@ -22,8 +22,11 @@ try using the verbose command format to troubleshoot: ::
    ssh <username>@<app .onion>
    ssh <username>@<mon .onion>
 
-.. tip:: You can find the Onion URLs for SSH in ``app-ssh-aths`` and
-         ``mon-ssh-aths`` inside the ``install_files/ansible-base`` directory.
+.. tip:: If your instance uses v2 onion services, you can find the Onion
+         URLs for SSH in ``app-ssh-aths`` and ``mon-ssh-aths`` inside the 
+         ``install_files/ansible-base`` directory. If your instance uses v3
+         onion services, check the ``app-ssh.auth_private`` and
+         ``mon-ssh.auth_private`` files instead.
 
 Log in to Both Servers via TTY
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -57,18 +60,18 @@ Test the Web Interfaces
 #. Make sure the *Source Interface* is available, and that you can make a
    submission.
 
-   - Do this by opening the Tor Browser and navigating to the onion
-     URL from ``app-source-ths``. Proceed through the codename
-     generation (copy this down somewhere) and you can submit a
-     message or attach any random unimportant file.
+   - Open the *Source Interface* in the Tor Browser by clicking on its desktop 
+     shortcut. Proceed through the codename
+     generation (copy this down somewhere) and submit a
+     test message or file.
    - Usage of the Source Interface is covered by our :doc:`Source User
      Manual <source>`.
 
 #. Test that you can access the *Journalist Interface*, and that you can log
    in as the admin user you just created.
 
-   - Open the Tor Browser and navigate to the onion URL from
-     ``app-journalist-aths``. Enter your passphrase and two-factor
+   - Open the *Journalist Interface* in the Tor Browser by clicking on its desktop 
+     shortcut.  Enter your passphrase and two-factor
      authentication code to log in.
    - If you have problems logging in to the *Admin/Journalist Interface*,
      SSH to the *Application Server* and restart the ntp daemon to synchronize
@@ -85,13 +88,10 @@ Test the Web Interfaces
 
 #. Test that the source received the reply.
 
-   - Within Tor Browser, navigate back to the ``app-source-ths`` URL and
+   - Within Tor Browser, navigate back to the *Source Interface* and
      use your previous test source codename to log in (or reload the
      page if it's still open) and check that the reply you just made
      is present.
-
-#. We highly recommend that you create persistent bookmarks for the
-   *Source Interface* and *Journalist Interface* Interface addresses within Tor Browser.
 
 #. Remove the test submissions you made prior to putting SecureDrop to
    real use. On the main *Journalist Interface* page, select all sources and

--- a/docs/v3_services.rst
+++ b/docs/v3_services.rst
@@ -1,13 +1,13 @@
 Securedrop V3 Onion Services
 ============================
 Tor onion services provide anonymous inbound connections to websites and other
-servers over the Tor network. For example, SecureDrop uses onion services
+servers exclusively over the Tor network. For example, SecureDrop uses onion services
 for the *Journalist* and *Source Interface* websites, as well as for 
 adminstrative access to the servers in SSH-over-Tor mode.
 
 Previous to the release of SecureDrop 1.0.0, only v2 onion services were available,
 but administrators now have the option of enabling next-generation (v3) onion 
-services. V3 onion services use more secure cryptography than v2 onion 
+services. V3 onion services use stronger cryptographic primitives than v2 onion 
 services, and include redesigned protocols that guard against service 
 information leaks on the Tor network. The unique identifier in V3 onion 
 addresses is 56 characters long - for example:
@@ -73,7 +73,13 @@ Workstation* with ``./securedrop-admin tailsconfig``.
 
 - First, boot into the *Admin Workstation* with the persistent volume unlocked
   and an admin password set.
-- Next, open a terminal via **Applications > Favorites > Terminal**.
+- Next, open a terminal via **Applications > Favorites > Terminal** and change
+  the working directory to the Securedrop application directory:
+
+  .. code:: sh
+ 
+    cd ~/Persistent/securedrop
+
 - Verify that SecureDrop version 1.0.0 or greater is available or installed on
   your instance with the command:
 
@@ -164,20 +170,28 @@ Journalist Workstation:
 ~~~~~~~~~~~~~~~~~~~~~~~
 
  - In the *Admin Workstation* used to enable v3 onion services, copy the 
-   following files to a *Transfer Device*:
+   following files to an encrypted *Transfer Device*:
 
    .. code-block:: none
 
      ~/Persistent/securedrop/install_files/ansible-base/app-sourcev3-ths
      ~/Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private
 
-   Then, boot into the *Journalist Workstation* to be updated.
+ - Then, boot into the *Journalist Workstation* to be updated, with the persistent 
+   volume unlocked and an admin password set.
+ - Next, open a terminal via **Applications > Favorites > Terminal** and change
+   the working directory to the Securedrop application directory:
 
- - In the *Journalist Workstation*,  first ensure that the 
-   SecureDrop application code has been updated to the latest version, using
-   either the GUI updater or the ``./securedrop-admin update`` command.
+   .. code:: sh
  
- - Copy the ``app-sourcev3-ths`` and ``app-journalist.auth_private`` files from
+     cd ~/Persistent/securedrop
+
+
+ - Ensure that the SecureDrop application code has been updated to the latest version,
+   using either the GUI updater or the ``./securedrop-admin update`` command.
+ 
+ - Insert the *Transfer Device*.
+   Copy the ``app-sourcev3-ths`` and ``app-journalist.auth_private`` files from
    the *Transfer Device* to ``~/Persistent/securedrop/install_files/ansible-base``.
  
  - Open a terminal and run ``./securedrop-admin tailsconfig`` to update the 
@@ -186,13 +200,14 @@ Journalist Workstation:
  - Verify that the new 56-character addresses are in use by visiting the *Source*
    and *Journalist Interfaces* via the SecureDrop desktop shortcuts.
 
- - Securely wipe the files on the *Transfer Device*.
+ - Securely wipe the files on the *Transfer Device*, by right-clicking them
+   in the file manager and selecting **Wipe**.
 
 Admin Workstation:
 ~~~~~~~~~~~~~~~~~~
 
  - In the *Admin Workstation* used to enable v3 onion services, copy the 
-   following files to a *Transfer Device*:
+   following files to an encrypted *Transfer Device*:
 
    .. code-block:: none
 
@@ -208,12 +223,20 @@ Admin Workstation:
      ~/Persistent/securedrop/install_files/ansible-base/app-ssh.auth_private
      ~/Persistent/securedrop/install_files/ansible-base/mon-ssh.auth_private
 
-   Then, boot into the *Admin Workstation* to be updated.
+ - Then, boot into the *Admin Workstation* to be updated, with the persistent 
+   volume unlocked and an admin password set.
+ - Next, open a terminal via **Applications > Favorites > Terminal** and change
+   the working directory to the Securedrop application directory:
 
-   First, ensure SecureDrop application code has been updated to the latest version, using
-   either the GUI updater or the ``./securedrop-admin update`` command.
+   .. code:: sh
  
- - Copy the ``app-sourcev3-ths``, ``*.auth_private``, and ``tor_v3_keys.json`` files from
+     cd ~/Persistent/securedrop
+
+ - Ensure that the SecureDrop application code has been updated to the latest version,
+   using either the GUI updater or the ``./securedrop-admin update`` command.
+
+ - Insert the *Transfer Device*.
+   Copy the ``app-sourcev3-ths``, ``*.auth_private``, and ``tor_v3_keys.json`` files from
    the *Transfer Device* to ``~/Persistent/securedrop/install_files/ansible-base``.
  
  - Copy the ``site-specific`` file from the *Transfer Device* to 
@@ -229,7 +252,8 @@ Admin Workstation:
    ``app`` and ``mon`` host entries, and that the *Application* and *Monitor
    Servers* are accessible via ``ssh app`` and ``ssh mon`` respectively.
 
- - Securely wipe the files on the *Transfer Device*.
+ - Securely wipe the files on the *Transfer Device*, by right-clicking them
+   in the file manager and selecting **Wipe**.
 
 
 Updating Source Interface references
@@ -252,13 +276,54 @@ Disabling v2 onion services
 Once you've successfully enabled v3 onion services, and updated your workstations,
 you should disable v2 onion services altogether.
 
-- First, it's recommended that you coordinate with the journalists using the 
-  instance to ensure that any ongoing source conversations are uninterrupted. They
-  can use SecureDrop's reply feature to give active sources advance notice of
-  the address change.
+First, it's recommended that you coordinate with the journalists using the 
+instance to ensure that any ongoing source conversations are uninterrupted. They
+can use SecureDrop's reply feature to give active sources advance notice of
+the address change.
 
-- When you're ready, follow the steps in `Enabling v3 onion services`_ again,
-  this time choosing ``no`` when asked to enable v2 services and ``yes`` to v3 services. 
+When you're ready, follow the steps below to transition to v3 services only:
+
+- First, boot into the *Admin Workstation* with the persistent volume unlocked
+  and an admin password set.
+
+- Open a terminal and change the working directory to the SecureDrop application
+  directory with the command:
+
+  .. code:: sh
+
+    cd ~/Persistent/securedrop
+
+
+- Next, update the application configuration using the command:
+
+  .. code:: sh
+    
+    ./securedrop-admin sdconfig
+
+  This command will step through the current instance configuration. When prompted
+  you should type ``no`` for v2 services and ``yes`` for v3 services to migrate to
+  v3 only. No other settings should be modified.
+
+- Once the configuration has been updated, run the installation playbook using 
+  the command:
+
+  .. code:: sh
+  
+    ./securedrop-admin install
+
+  This will disable v2 onion services on the *Application* and *Monitor Servers*.
+
+- When the installation playbook run is complete, update the *Admin Workstation*
+  to use v3 onion services only using the command:
+
+  .. code:: sh
+  
+    ./securedrop-admin tailsconfig
+
+- Next, verify connectivity between the *Admin Workstation* and the SecureDrop
+  instance, checking the desktop shortcuts and SSH access.
+
+- Then back up the instance and *Admin Workstation* USB.
 
 - Finally, update your other *Admin Workstations*: from a terminal, run:
 

--- a/docs/v3_services.rst
+++ b/docs/v3_services.rst
@@ -1,0 +1,261 @@
+Securedrop V3 Onion Services
+============================
+Tor onion services provide anonymous inbound connections to websites and other
+servers over the Tor network. For example, SecureDrop uses onion services
+for the *Journalist* and *Source Interface* websites, as well as for 
+adminstrative access to the servers in SSH-over-Tor mode.
+
+Previous to the release of SecureDrop 1.0.0, only v2 onion services were available,
+but administrators now have the option of enabling next-generation (v3) onion 
+services. V3 onion services use more secure cryptography than v2 onion 
+services, and include redesigned protocols that guard against service 
+information leaks on the Tor network. The unique identifier in V3 onion 
+addresses is 56 characters long - for example:
+
+.. code-block:: none
+
+  http://vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd.onion/
+
+This makes them easily distinguishable from 16-character v2 onion addresses,
+such as:
+
+.. code-block:: none
+
+  http://secrdrop5wyphb5x.onion/
+
+For new SecureDrop instances, it is recommended to
+enable v3 onion services only. For existing instances, migration
+to v3 onion services is recommended, and the ability to run both
+v2 and v3 onion services simultaneously is supported to make the process
+easier.
+
+Migrating from v2 to v3 only or v2+v3
+-------------------------------------
+
+.. important:: In a future release of SecureDrop, v3 onion services will 
+               be required rather than optional, and there is no automatic
+               downgrade path from v3 to v2 using the ``securedrop-admin`` 
+               tool. It is recommended that you follow the v2+v3 migration
+               path and test v3 functionality thoroughly before disabling
+               v2 services.
+
+Preparing for the migration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Before starting the migration process, you should decide whether to move 
+straight to v3 only, or move to v2+v3 temporarily. As the URLs of your onion
+services will change with the move to v3, moving to v2+v3 first will allow
+you to minimize the impact of the migration on sources and journalists.
+
+URL changes will affect the following:
+
+- The *Source Interface* address will change - once the migration is complete, 
+  you will need to update your landing page and other resources that reference
+  the address, such as your SecureDrop directory entry.
+- If your instance uses HTTPS, you will need to provision a new certificate for
+  the v3 *Source Interface* address - this will need to be done `after` the new
+  address has been generated.
+- *Journalist* and *Admin Workstations* will need to be updated to use the v3
+  addresses of the *Journalist* and *Source Interface*, and the SSH proxy 
+  services if your instance is using SSH over Tor.
+
+Before proceeding with the migration, you should also back up the instance and
+*Admin Workstation* USB - for more information, see the following instructions:
+
+- :doc:`Back up the instance <backup_and_restore>`.
+- :doc:`Back up the Admin Workstation <backup_workstations>`.
+
+
+Enabling v3 onion services
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+To enable v3 onion services, you will need to run the installation playbook, 
+via the ``./securedrop-admin install`` command, and then update the *Admin 
+Workstation* with ``./securedrop-admin tailsconfig``.
+
+- First, boot into the *Admin Workstation* with the persistent volume unlocked
+  and an admin password set.
+- Next, open a terminal via **Applications > Favorites > Terminal**.
+- Verify that SecureDrop version 1.0.0 or greater is available or installed on
+  your instance with the command:
+
+  .. code:: sh
+
+    ssh app apt-cache policy securedrop-app-code
+
+  Version 1.0.0 should be listed as installed or as an installation candidate.
+- Verify that the *Admin Workstation*'s SecureDrop code is on 1.0.0 or greater,
+  using the GUI updater or the command:
+
+  .. code:: sh
+ 
+    ./securedrop-admin update
+
+- Next, enable v3 onion services (and optionally disable v2 services) using:
+
+  .. code:: sh
+    
+    ./securedrop-admin sdconfig
+
+  This command will step through the current instance configuration. None of the
+  current settings should be changed. When prompted to enable v2 and v3 
+  services, you should choose either ``yes`` to both to use v2 and v3 
+  concurrently, or ``no`` to v2 and ``yes`` to v3 to migrate to v3 only. 
+
+- Once the configuration has been updated, run the installation playbook using 
+  the command:
+
+  .. code:: sh
+  
+    ./securedrop-admin install
+
+  This will enable v3 onion services on the *Application* and *Monitor Servers*.
+
+- When the installation playbook run is complete, update the *Admin Workstation*
+  to use v3 onion services using the command:
+
+  .. code:: sh
+  
+    ./securedrop-admin tailsconfig
+
+- Next, verify connectivity between the *Admin Workstation* and the SecureDrop
+  instance as follows:
+
+  - Use the Source desktop shortcut to connect to the *Source Interface* and 
+    verify that the new 56-character address is present in the Tor Browser 
+    address bar.
+  - Use the Journalist desktop shortcut to connect to the *Journalist Interface*
+    and verify that the new 56-character address is present in the Tor Browser 
+    address bar.
+  - Use the commands ``ssh app`` and ``ssh mon`` in a terminal to verify 
+    SSH access to the *Application* and *Monitor Servers*.
+
+- Finally, back up the instance and *Admin Workstation* USB.
+
+(Optional) enabling HTTPS
+^^^^^^^^^^^^^^^^^^^^^^^^^
+If your instance serves the *Source Interface* over HTTPS, and you plan to 
+continue using HTTPS with v3 onion services, you'll need to provision a 
+new certificate for the new v3 address.
+
+You'll find the new *Source Interface* address in the file:
+
+.. code-block:: none
+ 
+  ~/Persistent/securedrop/install_files/ansible-base/app-sourcev3-ths
+
+Follow the instructions in :doc:`HTTPS on the Source Interface <https_source_interface>`
+to provision and install the new certificate. 
+
+
+Updating Workstation USBs
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you chose to keep v2 enabled, *Admin* and *Journalist Workstations* that have
+not yet been updated will still be able to connect to the v2 onion services. Even
+so, you should update all workstations to use v3 services as soon as possible.
+
+Journalist Workstation:
+~~~~~~~~~~~~~~~~~~~~~~~
+
+ - In the *Admin Workstation* used to enable v3 onion services, copy the 
+   following files to a *Transfer Device*:
+
+   .. code-block:: none
+
+     ~/Persistent/securedrop/install_files/ansible-base/app-sourcev3-ths
+     ~/Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private
+
+   Then, boot into the *Journalist Workstation* to be updated.
+
+ - In the *Journalist Workstation*,  first ensure that the 
+   SecureDrop application code has been updated to the latest version, using
+   either the GUI updater or the ``./securedrop-admin update`` command.
+ 
+ - Copy the ``app-sourcev3-ths`` and ``app-journalist.auth_private`` files from
+   the *Transfer Device* to ``~/Persistent/securedrop/install_files/ansible-base``.
+ 
+ - Open a terminal and run ``./securedrop-admin tailsconfig`` to update the 
+   SecureDrop desktop shortcuts.
+
+ - Verify that the new 56-character addresses are in use by visiting the *Source*
+   and *Journalist Interfaces* via the SecureDrop desktop shortcuts.
+
+ - Securely wipe the files on the *Transfer Device*.
+
+Admin Workstation:
+~~~~~~~~~~~~~~~~~~
+
+ - In the *Admin Workstation* used to enable v3 onion services, copy the 
+   following files to a *Transfer Device*:
+
+   .. code-block:: none
+
+     ~/Persistent/securedrop/install_files/ansible-base/app-sourcev3-ths
+     ~/Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private
+     ~/Persistent/securedrop/install_files/ansible-base/tor_v3_keys.json
+     ~/Persistent/securedrop/install_files/ansible-base/group_vars/all/site-specific
+
+   If your instance uses SSH over Tor, also copy the following files:
+ 
+   .. code-block:: none 
+
+     ~/Persistent/securedrop/install_files/ansible-base/app-ssh.auth_private
+     ~/Persistent/securedrop/install_files/ansible-base/mon-ssh.auth_private
+
+   Then, boot into the *Admin Workstation* to be updated.
+
+   First, ensure SecureDrop application code has been updated to the latest version, using
+   either the GUI updater or the ``./securedrop-admin update`` command.
+ 
+ - Copy the ``app-sourcev3-ths``, ``*.auth_private``, and ``tor_v3_keys.json`` files from
+   the *Transfer Device* to ``~/Persistent/securedrop/install_files/ansible-base``.
+ 
+ - Copy the ``site-specific`` file from the *Transfer Device* to 
+   ``~/Persistent/securedrop/install_files/ansible-base/group_vars/all``.
+
+ - Open a terminal and run ``./securedrop-admin tailsconfig`` to update the 
+   SecureDrop desktop shortcuts.
+
+ - Verify that the new 56-character addresses are in use by visiting the *Source*
+   and *Journalist Interfaces* via the SecureDrop desktop shortcuts.
+
+ - Verify that ``~/.ssh/config`` contains the new 56-character addresses for the
+   ``app`` and ``mon`` host entries, and that the *Application* and *Monitor
+   Servers* are accessible via ``ssh app`` and ``ssh mon`` respectively.
+
+ - Securely wipe the files on the *Transfer Device*.
+
+
+Updating Source Interface references
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In order for sources to find and use the new v3 *Source Interface*, you'll 
+need to update your landing page. If your instance details are listed 
+anywhere else (for example, in the SecureDrop directory), you should update
+those listings too.
+
+You'll find the new *Source Interface* address in the file:
+
+.. code-block:: none
+
+  ~/Persistent/securedrop/install_files/ansible-base/app-sourcev3-ths
+
+
+Disabling v2 onion services
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once you've successfully enabled v3 onion services, and updated your workstations,
+you should disable v2 onion services altogether.
+
+- First, it's recommended that you coordinate with the journalists using the 
+  instance to ensure that any ongoing source conversations are uninterrupted. They
+  can use SecureDrop's reply feature to give active sources advance notice of
+  the address change.
+
+- When you're ready, follow the steps in `Enabling v3 onion services`_ again,
+  this time choosing ``no`` when asked to enable v2 services and ``yes`` to v3 services. 
+
+- Finally, update your other *Admin Workstations*: from a terminal, run:
+
+  .. code:: sh
+  
+    ./securedrop-admin sdconfig   # choose "no" for v2, "yes" for v3
+    ./securedrop-admin tailsconfig

--- a/docs/v3_services.rst
+++ b/docs/v3_services.rst
@@ -89,6 +89,13 @@ Workstation* with ``./securedrop-admin tailsconfig``.
  
     ./securedrop-admin update
 
+- After updating the latest SecureDrop version, use the following command to 
+  update ``securedrop-admin``'s dependencies:
+
+  .. code:: sh
+  
+    ./securedrop-admin setup
+
 - Next, enable v3 onion services (and optionally disable v2 services) using:
 
   .. code:: sh


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4632 .

Adds upgrade documentation for v3 onion services.
Updates installation and onboarding documentation to refer to v3 services
Updates development documentation to refer to v3 services.

Note: The documentation for the instance restore and workstation rebuild process has not been addressed in this PR, as it's unclear to me how they will work under v3. More investigation required. Notes have been added to those docs temporarily, to let admins know that they're not applicable to instances running v3 services.

## Testing

Docs-only PR:
- [ ] review for clarity and correctness
- [ ] follow installation and instance test instructions to verify that they're correct.
- [ ] follow migration instructions to verify that servers are correctly updated to use v3
- [ ] follow admin and journalist workstation update instructions to verify that they are also cut over correctly to v3.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
