### PR TITLE
Fixes #4762 adds missing variables for tailsconfig

### DIFF
--- a/install_files/ansible-base/roles/tails-config/defaults/main.yml
+++ b/install_files/ansible-base/roles/tails-config/defaults/main.yml
@@ -41,3 +41,9 @@ tails_config_deprecated_directories:
 tails_config_deprecated_config_files:
   - 70-tor-reload.sh
   - 99-tor-reload.sh
+
+# v2 Tor onion services are on / v3 Tor onion services are off by default for backwards
+# compatibility. Note that new installs after 1.0 will have v3 enabled by sdconfig which
+# will override these variables.
+v2_onion_services: true
+v3_onion_services: false


### PR DESCRIPTION
## Status

Ready for review 

Adds the missing variables for `tailsconfig` when `sdconfig` was not run.

Fixes #4762 


## Testing

Make sure that following two variables are not present in the `install_files/ansible-role/group_vars/all/site-specific` file.

```
v2_onion_services
v3_onion_services
```

Then execute `./securedrop-admin tailsconfig` command.


## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
