### PR TITLE
docs: fix typos

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -77,7 +77,7 @@ the sources, and the journalists.
 Servers
 ~~~~~~~
 
-At SecureDrop's heart is a pair of severs: the *Application (“App”) Server*,
+At SecureDrop's heart is a pair of servers: the *Application (“App”) Server*,
 which runs the core SecureDrop software, and the *Monitor (“Mon”) Server*,
 which keeps track of the *Application Server* and sends out alerts if there's a
 problem. These two servers run on dedicated hardware connected to a dedicated

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -233,8 +233,8 @@ reboot. An admin will need to be on hand to enter the passphrase
 in order to decrypt the disks and complete the startup process, which
 will occur anytime there is an automatic software update, and also
 several times during SecureDrop's installation. We recommend that the
-servers be integrated with a monitoring solution that so that you
-receive an alert when the system becomes unavailable.
+servers be integrated with a monitoring solution so that you receive
+an alert when the system becomes unavailable.
 
 To enable FDE, select *Guided - use entire disk and set up encrypted
 LVM* during the disk partitioning step and write the changes to disk.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes typos

Changes proposed in this pull request:

severs -> servers
that so that -> so that

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
