### PR TITLE
Default v3_onion_services to off in validate_tails_environment.yml

### DIFF
--- a/install_files/ansible-base/roles/validate/tasks/validate_tails_environment.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_tails_environment.yml
@@ -26,6 +26,10 @@
       to `~/Persistent/securedrop`.
   with_items: "{{ tails_persistence_check_result.results }}"
 
+- name: Default v3_onion_services to false
+  set_fact:
+    v3_onion_services: "{{ v3_onion_services | default(False) }}"
+
 - name: Check for v3 SSH auth files
   stat:
     path: "/home/amnesia/Persistent/securedrop/install_files/ansible-base/{{ item }}"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The lack of this variable has tripped us up in several roles, and depending on how the validate role is used, adding it to defaults/main.yml within that role might not fix it, so let's add a fact in the  `validate_tails_environment.yml` playbook defaulting it to off.

Fixes #4774.

## Testing

Follow the 1.0.0 test plan through to `Tor onion services: upgrade to v2 QA`. You should get no error from `securedrop-admin install`.

## Deployment

This should improve the reliability of `securedrop-admin install` when run on an existing admin workstation with an `install_files/ansible-base/group_vars/all/site-specific` that does not contain the new onion service variables.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
