### PR TITLE
Remove v3 onion secrets when transitioning to ssh over local

### DIFF
--- a/install_files/ansible-base/tasks/transistion_ssh_local.yml
+++ b/install_files/ansible-base/tasks/transistion_ssh_local.yml
@@ -6,6 +6,7 @@
           - "{{ playbook_dir }}"
         patterns:
           - '*ssh-aths'
+          - '*ssh.auth_private'
       register: find_ssh_aths_result
 
     - name: Delete any aths ssh files found
@@ -20,13 +21,15 @@
   run_once: yes
 
 - name: Force a reboot conditionally, when tor_over_ssh status changed
-  command: shutdown -r now
+  shell: sleep 2 && shutdown -r now
+  async: 1
+  poll: 0
   when: aths_deletion_results|changed
 
 - name: Provide helpful user message and end early
   fail:
     msg: |
       Due to the transition from ssh-over-tor to ssh-over-localnet
-      please re-run `./securedrop-admin install` again to continue
-      re-configuration.
+      please run `./securedrop-admin tailsconfig` and then re-run
+      `./securedrop-admin install` again to continue re-configuration.
   when: aths_deletion_results|changed


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #4780 and fixes #4779.


## Testing

Using a Tails prod setup (either VMs or hardware)

- Install with default settings (ssh over tor, using v3 onion services)
- set `enable_ssh_over_tor` to false, run `./securedrop-admin install`
-  [ ] v3 onion secrets (app-ssh.auth_private and mon-ssh.auth_private) are no longer in `install_files/ansible-base
- [ ] I can ssh to both app and mon servers after transitioning to ssh over local
- set `enable_ssh_over_tor` to true, run `./securedrop-admin install`
- run `./securedrop-admin tailsconfig`
- [ ] I can ssh to app and mon servers over tor

- Follow steps to reproduce in #4779
- [ ] This pr also closes #4779
## Deployment
This will be provided via the Ansible scripts delivered by git.
## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make -C securedrop test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
