### PR TITLE
Expand .gitgnore for venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,7 +112,8 @@ docs/_build/
 .env
 
 # virtualenv
-.venv*/
+.venv/
+.venv3/
 venv/
 ENV/
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4796

## Testing

In Tails:
- `securedrop-admin setup`
- [ ] `git status` does not track the `.venv` folder
- [ ] `.venv3/` will be the virtualenv folder once securedrop-admin is moved to python3

## Deployment

Updates will be provided to new and existing SecureDrop admin workstations using git via the securedrop updater GUI or manual git fetch

