### PR TITLE
[docs] Instruct localization manager to squash translation commits

### DIFF
--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -299,7 +299,18 @@ Push your branch and create a pull request
 
 After you've checked the translations, you're ready to push your
 ``i18n-merge`` branch and create a pull request to get the
-translations merged to the SecureDrop ``develop`` branch:
+translations merged to the SecureDrop ``develop`` branch.
+
+.. note:: If there have been multiple commits per language, as can
+          happen if source strings need to be translated again after
+          being changed to correct critical errors, or to incorporate
+          suggestions from the source string feedback period, they
+          should be combined via an interactive rebase. Reorder the
+          commits to group them by language, then squash the commits
+          for each language into one. The goal is to end up with one
+          commit per supported language on the merge branch.
+
+When you're happy with the state of language commits on your merge branch:
 
 .. code:: sh
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds instructions for the localization manager to squash translation commits down to one per language before merging. This keeps translations easy to review when source strings have had to be translated more than once because of errors that had to be corrected, or to incorporate suggestions from the feedback period.

Fixes #4625.

## Testing

- Check out this branch.
- Run `make docs`
- Visit [the i18n page under `Push your branch and create a pull request`](http://localhost:8000/development/i18n.html#push-your-branch-and-create-a-pull-request) and see if you find the instructions in the new note intelligible.

## Deployment

Docs only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
