### PR TITLE
Add flaky to translation-test

### DIFF
--- a/securedrop/bin/translation-test
+++ b/securedrop/bin/translation-test
@@ -24,6 +24,7 @@ for locale in ar de_DE es_ES fr_FR hi is it_IT nb_NO nl pt_BR ro ru sv tr zh_Han
 do
   PAGE_LAYOUT_LOCALES=$locale pytest \
     -v \
+    --force-flaky --max-runs=3 \
     --page-layout \
     --durations 10 \
     "$@"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds the flaky pytest plugin to `securedrop/bin/translation-test`.

Fixes #4808.

## Testing

- Run `make translation-test`
- Verify that `flaky` appears in the list of pytest plugins
- Interrupt the tests after the first one passes, then verify that you see the `Flaky Test Report` in the output

## Deployment

This is dev/test only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
