### PR TITLE
Improve loading behavior of language selector in Tor

### DIFF
--- a/securedrop/sass/modules/_menu.sass
+++ b/securedrop/sass/modules/_menu.sass
@@ -12,6 +12,7 @@
 @media only screen and (min-width: 768px)
   .menu
     width: 80%
+    min-width: 125px
 
 .menu
   margin: 0 auto


### PR DESCRIPTION
Specifying a minimum width ensures the widget is always rendered as it should be.

Fixes #4810

## Status

Ready for review 

## Test plan

Visit the Source Interface and the Journalist Interface in Tor Browser and ensure the behavior described in #4810 no longer occurs, and that there are no regressions in desktop or mobile view.

I have done this using the Docker-based dev env.