### PR TITLE
Expand .gitgnore for venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,7 +112,8 @@ docs/_build/
 .env
 
 # virtualenv
-.venv*/
+.venv/
+.venv3/
 venv/
 ENV/
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

The wilcard did not match `.venv/` folder used for python2 virtualenv in the securedrop-admin context

(cherry picked from commit 2eb257d81095830529f3e893bf548cbbf8cea81a)

## Testing

Verify that it is the same commit from #4800 
