### PR TITLE
[docs] Add documentation of submission cleanup

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -87,7 +87,7 @@ FPF through the `SecureDrop Support Portal`_. See the :doc:`OSSEC Guide <ossec_a
 for more information on common OSSEC alerts.
 
 .. warning:: Do not post logs or alerts to public forums without first carefully
-	     examining and redacting any sensitive information.
+         examining and redacting any sensitive information.
 
 .. _test OSSEC alert:
 
@@ -248,7 +248,7 @@ Rebooting the Servers
 .. _investigating_logs:
 
 Investigating Logs
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 
 Consult our :doc:`Investigating Logs <logging>` topic guide for locations of the
 most relevant log files you may want to examine as part of troubleshooting, and
@@ -293,6 +293,65 @@ web server to apply the changes:
 .. code:: sh
 
   sudo service apache2 restart
+
+.. _submission-cleanup:
+
+Cleaning up deleted submissions
+&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+
+When submissions are deleted through the web interface, their database
+records are deleted and their encrypted files are securely wiped. For
+large files, secure removal can take some time, and it's possible,
+though unlikely, that it can be interrupted, for example by a server
+reboot. In older versions of SecureDrop this could leave a submission
+file present without a database record.
+
+As of SecureDrop 1.0.0, automated checks send OSSEC alerts when this
+situation is detected, recommending you run ``manage.py
+list-disconnected-fs-submissions`` to see the files affected. As with
+any ``manage.py`` usage, you would run the following on the admin
+workstation:
+
+.. code:: sh
+
+   ssh app
+   sudo -u www-data bash
+   cd /var/www/securedrop
+   ./manage.py list-disconnected-fs-submissions
+
+You then have the option of running:
+
+.. code:: sh
+
+   manage.py delete-disconnected-fs-submissions
+
+to clean them up. As with any potentially destructive operation, it's
+recommended that you :doc:`back the system up <backup_and_restore>`
+before doing so.
+
+There is also the inverse scenario, where a database record could
+point to a file that no longer exists. This would usually only have
+happened as a result of disaster recovery, where perhaps the database
+was recovered from a failed hard drive, but some submissions could not
+be. The OSSEC alert in this case would recommend running:
+
+.. code:: sh
+
+   manage.py list-disconnected-db-submissions
+
+
+To clean up the affected records you would run (again, preferably
+after a backup):
+
+.. code:: sh
+
+   manage.py delete-disconnected-db-submissions
+
+
+Even when submissions are completely removed from the application
+server, their encrypted files may still exist in backups. We recommend
+that you delete old backup files with ``shred``, which is available on
+Tails.
 
 Monitor Server
 ^^^^^^^^^^^^^^

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -323,7 +323,7 @@ You then have the option of running:
 
 .. code:: sh
 
-   manage.py delete-disconnected-fs-submissions
+   ./manage.py delete-disconnected-fs-submissions
 
 to clean them up. As with any potentially destructive operation, it's
 recommended that you :doc:`back the system up <backup_and_restore>`
@@ -337,7 +337,7 @@ be. The OSSEC alert in this case would recommend running:
 
 .. code:: sh
 
-   manage.py list-disconnected-db-submissions
+   ./manage.py list-disconnected-db-submissions
 
 
 To clean up the affected records you would run (again, preferably
@@ -345,7 +345,7 @@ after a backup):
 
 .. code:: sh
 
-   manage.py delete-disconnected-db-submissions
+   ./manage.py delete-disconnected-db-submissions
 
 
 Even when submissions are completely removed from the application

--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -31,13 +31,17 @@ You can use the following command to determine the volume of submissions
 currently on the *Application Server*: log in over SSH and run
 ``sudo du -sh /var/lib/securedrop/store``.
 
-.. note:: Submissions are deleted asynchronously and one at a time, so if you
-          delete a lot of submissions through the *Journalist Interface*, it may
-          take a while for all of the submissions to actually be
-          deleted. SecureDrop uses ``srm`` to securely erase files, which takes
-          significantly more time than normal file deletion. You can monitor the
-          progress of queued deletion jobs with ``sudo tail -f
-          /var/log/securedrop_worker/err.log``.
+.. note:: Submissions are deleted asynchronously and one at a time, so
+          if you delete a lot of submissions through the *Journalist
+          Interface*, it may take a while for all of the submissions
+          to actually be deleted. SecureDrop uses ``shred`` to
+          securely erase files, which takes significantly more time
+          than normal file deletion. You can monitor the progress of
+          queued deletion jobs by logging in to the *Application
+          Server* over SSH and running::
+
+            sudo tail -f /var/log/securedrop_worker/rqworker.err
+
 
 If you find you cannot perform a backup or restore due to this constraint,
 and have already deleted old submissions from the *Journalist Interface*,

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -95,6 +95,8 @@ use to connect to the *Application Server* and the *Monitor Server* using Tor
 and SSH. The admin will also need to have an Android or iOS
 device with the FreeOTP app installed.
 
+.. _svs:
+
 Secure Viewing Station
 ----------------------
 
@@ -116,6 +118,8 @@ Since this machine will never touch the Internet or run an operating
 system other than Tails on a USB, it does not need a hard drive or
 network device. We recommend physically removing the drive and any
 networking cards (wireless, Bluetooth, etc.) from this machine.
+
+.. _submission-key:
 
 Submission Key
 --------------

--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -530,6 +530,11 @@ securedrop@freedom.press for help.
 Uncommon OSSEC Alerts
 ~~~~~~~~~~~~~~~~~~~~~
 
+SecureDrop also runs automatic checks for submission data integrity
+problems. For example, secure deletion of large submissions could
+potentially be interrupted, resulting in an alert recommending steps
+to :ref:`clean them up <submission-cleanup>`.
+
 If you believe that the system is behaving abnormally, you should
 contact us at the `SecureDrop Support Portal`_ or securedrop@freedom.press for
 help.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Documents submission cleanup alerts and commands.

## Testing

- Check out this branch
- Run `make docs`
- Read:
  - http://localhost:8000/ossec_alerts.html#uncommon-ossec-alerts
  - http://localhost:8000/admin.html#submission-cleanup
  - http://localhost:8000/backup_and_restore.html#minimizing-disk-use (the note about deletion)

## Deployment

Docs only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
