### PR TITLE
Fix journalist test_delete_one

### DIFF
--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -17,6 +17,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.ui import WebDriverWait
 
 
 # Number of times to try flaky clicks.
@@ -879,7 +880,12 @@ class JournalistNavigationStepsMixin:
 
     def _journalist_delete_one(self):
         self.safe_click_by_css_selector("[name=doc_names_selected]")
-        self.safe_click_by_id("delete-selected-link")
+
+        el = WebDriverWait(self.driver, self.timeout, self.poll_frequency).until(
+            expected_conditions.element_to_be_clickable((By.ID, "delete-selected-link"))
+        )
+        el.location_once_scrolled_into_view
+        ActionChains(self.driver).move_to_element(el).click().perform()
 
     def _journalist_flags_source(self):
         self.safe_click_by_id("flag-button")


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

JournalistNavigationStepsMixin's _journalist_delete_one is more reliable with an ActionChains move/click incantation, but switching to that in the functional test safe_click* methods breaks a bunch of other tests, so I'm just rolling with the Selenium voodoo.

Fixes #4818.

## Testing

Run:
```
export PAGE_LAYOUT_LOCALES="ar,de_DE,es_ES,fr_FR,hi,is,it_IT,nb_NO,nl,pt_BR,ro,ru,sv,tr,zh_Hant"
make test TESTFILES=tests/pageslayout/test_journalist.py::TestJournalistLayout::test_delete_one
```

The test should pass every time.

## Deployment

Tests only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
