### PR TITLE
added StartupNotify=true to desktop shortcuts

### DIFF
--- a/install_files/ansible-base/roles/tails-config/templates/desktop-journalist-icon.j2
+++ b/install_files/ansible-base/roles/tails-config/templates/desktop-journalist-icon.j2
@@ -4,6 +4,7 @@
 Version=1.0
 Type=Application
 Terminal=false
+StartupNotify=true
 Categories=Network;
 Name[es_ES]=Interfaz de periodista de SecureDrop
 Name[it]=Interfaccia Giornalista di SecureDrop

--- a/install_files/ansible-base/roles/tails-config/templates/desktop-journalist-icon.j2.in
+++ b/install_files/ansible-base/roles/tails-config/templates/desktop-journalist-icon.j2.in
@@ -4,6 +4,7 @@
 Version=1.0
 Type=Application
 Terminal=false
+StartupNotify=true
 Categories=Network;
 Name=SecureDrop Journalist Interface
 Icon={{ tails_config_securedrop_dotfiles }}/securedrop_icon.png

--- a/install_files/ansible-base/roles/tails-config/templates/desktop-source-icon.j2
+++ b/install_files/ansible-base/roles/tails-config/templates/desktop-source-icon.j2
@@ -4,6 +4,7 @@
 Version=1.0
 Type=Application
 Terminal=false
+StartupNotify=true
 Categories=Network;
 Name[es_ES]=Interfaz de fuente de SecureDrop
 Name[it]=Interfaccia Fonte di SecureDrop

--- a/install_files/ansible-base/roles/tails-config/templates/desktop-source-icon.j2.in
+++ b/install_files/ansible-base/roles/tails-config/templates/desktop-source-icon.j2.in
@@ -4,6 +4,7 @@
 Version=1.0
 Type=Application
 Terminal=false
+StartupNotify=true
 Categories=Network;
 Name=SecureDrop Source Interface
 Icon={{ tails_config_securedrop_dotfiles }}/securedrop_icon.png


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4837 .

Adds a loading spinner displayed when a user clicks the desktop shortcuts in Tails.

## Testing

In a VM or HW env:

- checkout this branch and perform an installation via 
```
./securedrop-admin setup
./securedrop-admin sdconfig  # use any valid config
./securedrop-admin install
./securedrop-admin tailsconfig
```
- [ ] double-click the Journalist desktop icon. The mouse pointer will change to a spinner and Tor Browser will open.
- [ ] Close Tor Browser.  double-click the Journalist desktop icon. The mouse pointer will change to a spinner and Tor Browser will open.

## Deployment

Deployed by `./securedrop-admin tailsconfig` - will not be applied until either `tailsconfig` or the GUI updater is run.

## Checklist

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR
