### PR TITLE
Adds workarounds for Tails 4.0 detection.

### DIFF
--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -66,6 +66,12 @@ def is_tails():
                                      shell=True).strip()
     except subprocess.CalledProcessError:
         id = None
+
+    # dirty hack to unreliably detect Tails 4.0~beta2
+    if id == 'Debian':
+        if os.uname()[1] == 'amnesia':
+            id = 'Tails'
+
     return id == 'Tails'
 
 

--- a/install_files/ansible-base/inventory-dynamic
+++ b/install_files/ansible-base/inventory-dynamic
@@ -160,6 +160,8 @@ def lookup_host_distro_id():
     cmd = ["lsb_release", "--id", "--short"]
     p = subprocess.check_output(cmd)
     distro_id = p.rstrip()
+    if distro_id == 'Debian' and os.uname()[1] == 'amnesia':
+        distro_id = 'Tails'
     return distro_id
 
 

--- a/install_files/ansible-base/roles/validate/tasks/validate_tails_environment.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_tails_environment.yml
@@ -1,7 +1,14 @@
+- name: Check /etc/os-release for Tails string
+  find:
+    name: "/etc"
+    patterns: "os-release"
+    contains: "^TAILS_PRODUCT_NAME="
+  register: tails_os_string
+
 - name: Confirm host OS is Tails.
   assert:
     that:
-      - ansible_lsb.id == "Tails"
+      - ansible_lsb.id == "Tails" or tails_os_string.matched
       - ansible_lsb.major_release >= 9
     msg: >-
       SecureDrop requires Tails 3 or greater for workstation environments.

--- a/securedrop/dockerfiles/xenial/python2/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python2/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -LO https://ftp.mozilla.org/pub/firefox/releases/${FF_ESR_VER}/linux-x8
 
 COPY ./tor_project_public.pub /opt/
 
-ENV TBB_VERSION 8.5.4
+ENV TBB_VERSION 8.5.5
 RUN gpg --import /opt/tor_project_public.pub && \
     wget  https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Fixes #4751 and #4767 

Adds a check in `securedrop-admin setup` to make a reasonable guess as to system type in the absence of accurate `lsb_release` output, a separate check in the Ansible `validate` role to detect Tails, and a check in `inventory-dynamic` similar to the one in `setup`.

## Testing

In prod VMs, using a Tails 4.0~beta2 VM USB:

- clone the repo into ~/Persistent/securedrop and check out this branch
- [ ] run `cd ~/Persistent/securedrop && ./securedrop-admin setup` - verify that the setup procedure completes successfully
- [ ] run `./securedrop-admin sdconfig`, providing valid values, and then `./securedrop-admin install`. Verify that Ansible SSH connections work and the `install` command completes successfully
- [ ] run `./securedrop-admin tailsconfig` and verify that Tails is detected. 

In Tails 3.x (VM or USB):
- [ ] repeat the steps above and verify that tests above also pass with Tails 3.x

## Deployment
Deployed as part of workstation setup or upgrades.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
