### PR TITLE
Upgrade boxes for SecureDrop 1.0.0

### DIFF
--- a/molecule/upgrade/ansible-override-vars.yml
+++ b/molecule/upgrade/ansible-override-vars.yml
@@ -26,3 +26,7 @@ etc_hosts:
 
 # Set Xenial as apt repo channel for hosting deb packages
 rep_dist: xenial
+
+# Override path to repo root, to use the nested repo on the previous version.
+# See molecule/shared/sd_clone.yml for details on the path structure.
+sd_root_dir: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/sd-orig"

--- a/molecule/upgrade/playbook.yml
+++ b/molecule/upgrade/playbook.yml
@@ -94,10 +94,13 @@
   tasks:
     - name: Spit out tor details
       debug:
-        msg: "Source interface available at {{ lookup('file', molecule_ephemeral_directory+'/sd-orig/'+source_ths_path) }}"
+        msg:
+          - "V2 Source interface available at {{ lookup('file', molecule_ephemeral_directory+'/sd-orig/'+source_ths_path) }}"
+          - "V3 Source interface available at {{ lookup('file', molecule_ephemeral_directory+'/sd-orig/'+source_ths_v3_path) }}"
       tags:
         - onion
         - always
   vars:
     molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
     source_ths_path: /install_files/ansible-base/app-source-ths
+    source_ths_v3_path: /install_files/ansible-base/app-sourcev3-ths

--- a/molecule/vagrant-packager/ansible-override-vars.yml
+++ b/molecule/vagrant-packager/ansible-override-vars.yml
@@ -8,3 +8,7 @@ ssh_listening_address: 0.0.0.0
 app_ip: "{{ hostvars['app-staging']['ansible_'+primary_network_iface].ipv4.address }}"
 monitor_ip: "{{ hostvars['mon-staging']['ansible_'+primary_network_iface].ipv4.address }}"
 apt_repo_url: https://apt.freedom.press
+
+# Override path to repo root, to use the nested repo on the previous version.
+# See molecule/shared/sd_clone.yml for details on the path structure.
+sd_root_dir: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/sd-orig"

--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -67,6 +67,17 @@
         }
       ],
       "version": "0.14.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "7045b1a593c70e6256bb059db43723d121001337d8c060498b6e463a93102c65",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_1.0.0.box"
+        }
+      ],
+      "version": "1.0.0"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -67,6 +67,17 @@
         }
       ],
       "version": "0.14.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "5a2b003e4eb5f396f78efec5ac64257f1df32a0416564937d5bfc405f8f6f6b0",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_1.0.0.box"
+        }
+      ],
+      "version": "1.0.0"
     }
   ]
 }

--- a/molecule/vagrant-packager/playbook.yml
+++ b/molecule/vagrant-packager/playbook.yml
@@ -14,8 +14,8 @@
   any_errors_fatal: yes
   roles:
     - { role: install-fpf-repo, tags: fpf }
-    - { role: common, tags: common }
     - { role: grsecurity, when: grsecurity, tags: [grsec, grsecurity] }
+    - { role: common, tags: common }
     - { role: tor-hidden-services, tags: tor }
   become: yes
 


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #4854, #4724 

- Adds SecureDrop 1.0.0 upgrade boxes
- Updates upgrade playbook to display both v2 and v3 source interface onion URLs

## Test plan
- [ ] Upgrade boxes should use v2 and v3 onion URLs (instead of only v3)
- checkout this branch
- make build-debs
- make upgrade-start
- [ ] v2 and v3 THS source urls are accessible
- make upgrade-test-local
- [ ] v2 and v3 THS source urls are accessible
- [ ] Upgrade VMs are successfully updated to 1.1.0~rc1
## Deployment

Dev env only

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
