### PR TITLE
Reordered manage.py args in parser.

### DIFF
--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -337,12 +337,6 @@ def get_args():
                         default=config.STORE_DIR,
                         help=('directory in which the documents are stored'))
     subps = parser.add_subparsers()
-    # Run WSGI app
-    run_subp = subps.add_parser('run', help='Run the Werkzeug source & '
-                                'journalist WSGI apps. WARNING!!! For '
-                                'development only, not to be used in '
-                                'production.')
-    run_subp.set_defaults(func=run)
     # Add/remove journalists + admins
     admin_subp = subps.add_parser('add-admin', help='Add an admin to the '
                                   'application.')
@@ -360,29 +354,36 @@ def get_args():
     delete_user_subp_a = subps.add_parser('delete_user', help='^')
     delete_user_subp_a.set_defaults(func=delete_user)
 
-    # Reset application state
-    reset_subp = subps.add_parser('reset', help='DANGER!!! ONLY FOR DEVELOPMENT '
-                                  'USE. DO NOT USE IN PRODUCTION. Clears the '
-                                  "SecureDrop application\'s state.")
-    reset_subp.set_defaults(func=reset)
-    # Cleanup the SD temp dir
-    set_clean_tmp_parser(subps, 'clean-tmp')
-    set_clean_tmp_parser(subps, 'clean_tmp')
-
-    init_db_subp = subps.add_parser('init-db', help='initialize the DB')
-    init_db_subp.add_argument('-u', '--user',
-                              help='Unix user for the DB',
-                              required=True)
-    init_db_subp.set_defaults(func=init_db)
-
     add_check_db_disconnect_parser(subps)
     add_check_fs_disconnect_parser(subps)
     add_delete_db_disconnect_parser(subps)
     add_delete_fs_disconnect_parser(subps)
     add_list_db_disconnect_parser(subps)
     add_list_fs_disconnect_parser(subps)
+
+    # Cleanup the SD temp dir
+    set_clean_tmp_parser(subps, 'clean-tmp')
+    set_clean_tmp_parser(subps, 'clean_tmp')
+
+    init_db_subp = subps.add_parser('init-db', help='Initialize the database.\n')
+    init_db_subp.add_argument('-u', '--user',
+                              help='Unix user for the DB',
+                              required=True)
+    init_db_subp.set_defaults(func=init_db)
+
     add_were_there_submissions_today(subps)
 
+    # Run WSGI app
+    run_subp = subps.add_parser('run', help='DANGER!!! ONLY FOR DEVELOPMENT '
+                                'USE. DO NOT USE IN PRODUCTION. Run the '
+                                'Werkzeug source and journalist WSGI apps.\n')
+    run_subp.set_defaults(func=run)
+
+    # Reset application state
+    reset_subp = subps.add_parser('reset', help='DANGER!!! ONLY FOR DEVELOPMENT '
+                                  'USE. DO NOT USE IN PRODUCTION. Clear the '
+                                  'SecureDrop application\'s state.\n')
+    reset_subp.set_defaults(func=reset)
     return parser
 
 

--- a/securedrop/management/submissions.py
+++ b/securedrop/management/submissions.py
@@ -242,6 +242,6 @@ def add_list_fs_disconnect_parser(subps):
 def add_were_there_submissions_today(subps):
     parser = subps.add_parser(
         "were-there-submissions-today",
-        help=("Update the file indicating " "whether submissions were received in the past 24h"),
+        help=("Update the file indicating " "whether submissions were received in the past 24h."),
     )
     parser.set_defaults(func=were_there_submissions_today)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Reorders the list  of commands in the `./manage.py` parser help output to put common operations first and dev-only operations last, with some description cleanup.

Changes proposed in this pull request:

## Testing

- checkout this branch and run `make dev`

- [ ] verify that output of `./manage.py` with no arguments looks like:
<details>
<summary>Click to view</summary>

```
 ./manage.py 
usage: ./manage.py [-h] [-v] [--data-root DATA_ROOT] [--store-dir STORE_DIR]
                   {add-admin,add_admin,add-journalist,add_journalist,delete-user,delete_user,check-disconnected-db-submissions,check-disconnected-fs-submissions,delete-disconnected-db-submissions,delete-disconnected-fs-submissions,list-disconnected-db-submissions,list-disconnected-fs-submissions,clean-tmp,clean_tmp,init-db,were-there-submissions-today,run,reset}
                   ...

Management and testing utility for SecureDrop.

positional arguments:
  {add-admin,add_admin,add-journalist,add_journalist,delete-user,delete_user,check-disconnected-db-submissions,check-disconnected-fs-submissions,delete-disconnected-db-submissions,delete-disconnected-fs-submissions,list-disconnected-db-submissions,list-disconnected-fs-submissions,clean-tmp,clean_tmp,init-db,were-there-submissions-today,run,reset}
    add-admin           Add an admin to the application.
    add_admin           ^
    add-journalist      Add a journalist to the application.
    add_journalist      ^
    delete-user         Delete a user from the application.
    delete_user         ^
    check-disconnected-db-submissions
                        Check for submissions that exist in the database but
                        not the filesystem.
    check-disconnected-fs-submissions
                        Check for submissions that exist in the filesystem but
                        not in the database.
    delete-disconnected-db-submissions
                        Delete submissions that exist in the database but not
                        the filesystem.
    delete-disconnected-fs-submissions
                        Delete submissions that exist in the filesystem but
                        not the database.
    list-disconnected-db-submissions
                        List submissions that exist in the database but not
                        the filesystem.
    list-disconnected-fs-submissions
                        List submissions that exist in the filesystem but not
                        the database.
    clean-tmp           Cleanup the SecureDrop temp directory.
    clean_tmp           Cleanup the SecureDrop temp directory.
    init-db             Initialize the database.
    were-there-submissions-today
                        Update the file indicating whether submissions were
                        received in the past 24h.
    run                 DANGER!!! ONLY FOR DEVELOPMENT USE. DO NOT USE IN
                        PRODUCTION. Run the Werkzeug source and journalist
                        WSGI apps.
    reset               DANGER!!! ONLY FOR DEVELOPMENT USE. DO NOT USE IN
                        PRODUCTION. Clear the SecureDrop application's state.

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose
  --data-root DATA_ROOT
                        directory in which the securedrop data is stored
  --store-dir STORE_DIR
                        directory in which the documents are stored
```

</details>

- [ ] Run `./manage.py` commands. verify that the correct action is invoked by each command.

## Deployment
 Deployed as part of securedrop app code.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
