### PR TITLE
Apply mix fixes in install_files/securedrop-app-code/debian/copyright

### DIFF
--- a/install_files/securedrop-app-code/debian/copyright
+++ b/install_files/securedrop-app-code/debian/copyright
@@ -1,5 +1,5 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: securedrop-proxy
+Upstream-Name: securedrop
 Source: https://github.com/freedomofpress/securedrop
 
 Files: *

--- a/install_files/securedrop-app-code/debian/copyright
+++ b/install_files/securedrop-app-code/debian/copyright
@@ -1,9 +1,9 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: securedrop-proxy
-Source: https://github.com/freedomofpress/securedrop-proxy
+Source: https://github.com/freedomofpress/securedrop
 
 Files: *
-Copyright: 2018 Freedom of the Press Foundation <securedrop@freedom.press>
+Copyright: 2019 Freedom of the Press Foundation <securedrop@freedom.press>
 License: GPLv3+
 
 Files: orderedmultidict*


### PR DESCRIPTION
Looking at the package i just noticed two minor declaration mistakes

1) The referenced repository is wrong
2) The copyright date is outdated