### PR TITLE
Enables Source and Journalist desktop icons in Tails 4

### DIFF
--- a/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
+++ b/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
@@ -126,7 +126,14 @@ for shortcut in ['source.desktop', 'journalist.desktop']:
     subprocess.call(['ln', '-s', path_persistent_desktop + shortcut,
                      path_desktop + shortcut], env=env)
     subprocess.call(['gio', 'set', path_desktop + shortcut,
-                     'metadata::trusted', 'yes'], env=env)
+                     'metadata::trusted', 'true'], env=env)
+
+# in Tails 4, reload gnome-shell desktop icons extension to update with changes above
+cmd = ["lsb_release", "--id", "--short"]
+p = subprocess.check_output(cmd)
+distro_id = p.rstrip()
+if distro_id == 'Debian' and os.uname()[1] == 'amnesia':
+    subprocess.call(['gnome-shell-extension-tool', '-r', 'desktop-icons@csoriano'], env=env)
 
 # reacquire uid0 and notify the user
 os.setresuid(0, 0, -1)


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #4771.

Changes proposed in this pull request:

## Tails 4.0 Testing

- Using a Tails 4 USB, complete an install on prod VMs or hardware as far as `./securedrop-admin install`, then:

- [ ] run `./securedrop-admin tailsconfig` and verify that it completes successfully
- [ ] verify that source and journalist desktop icons were created with the correct icon image, and that double-clicking them opens Tor Browser with the appropriate hidden service link

- Next, restart the Tails distro.

- [ ] verify that the source and journalist desktop icons appear correctly and are functional once a Tor network connection has been made.

## Tails 3.16 Testing
- [ ] Repeat the Tails 4.0 test steps above with a Tails 3.16 USB and verify that they pass.

## Deployment

Deployed by `./securedrop-admin tailsconfig` after code update on workstation.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
