### PR TITLE
Fix scaling of diagrams in docs

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -181,4 +181,4 @@ SecureDrop *Landing Page* and our guide to
 :doc:`promoting your SecureDrop instance <getting_the_most_out_of_securedrop>`.
 
 .. |SecureDrop architecture overview diagram| image:: ./diagrams/SecureDrop.png
-  :scale: 100%
+  :width: 100%

--- a/docs/threat_model/dataflow.rst
+++ b/docs/threat_model/dataflow.rst
@@ -7,4 +7,4 @@ The following diagram captures all data flows to and from a SecureDrop deploymen
 
 
 .. |SecureDrop data flow diagram| image:: ../diagrams/SecureDrop_DataFlow.png
-  :scale: 100%
+  :width: 100%


### PR DESCRIPTION
Resolves #4873

## Status

Ready for review. 

## Testing

I can't easily test the prod rendering, and I don't know why the themes are different between prod and dev. That said, if I manually alter the generated inline styles on docs.securedrop.org in the inspector to the `width:100%` that the `:width:` rule generates in my dev env, the diagrams render correctly with the prod CSS, so this should work, or at the very least have no negative side effects.

Workaround taken from https://github.com/readthedocs/sphinx_rtd_theme/issues/630