### PR TITLE
Improve specification of securedrop-app-code dependencies

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -170,7 +170,7 @@ Ubuntu or Debian GNU/Linux
 .. code:: sh
 
    sudo apt-get update
-   sudo apt-get install -y build-essential libssl-dev libffi-dev python-dev \
+   sudo apt-get install -y build-essential libssl-dev libffi-dev python3-dev \
        dpkg-dev git linux-headers-$(uname -r) virtualbox
 
 We recommend using the latest stable version of Vagrant, ``1.8.5`` at the time
@@ -206,7 +206,7 @@ you have the latest stable version.
 
 .. code:: sh
 
-    sudo apt-get install python-pip
+    sudo apt-get install python3-pip
 
 The version of Ansible recommended to provision SecureDrop VMs may not be the
 same as the version in your distro's repos, or may at some point flux out of
@@ -280,7 +280,7 @@ Visit our repository_ fork it and clone it on you local machine:
 Install Python Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-SecureDrop uses many third-party open source packages from the python community.
+SecureDrop uses many third-party open source packages from the Python community.
 Ensure your virtualenv is activated and install the packages.
 
 .. code:: sh

--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -30,19 +30,6 @@ apparmor_profiles:
 securedrop_staging_install_target_distro: xenial
 securedrop_app_code_deb: "securedrop-app-code_{{ securedrop_app_code_version }}+{{ securedrop_staging_install_target_distro }}_amd64" # do not enter .deb extension
 
-# Apt package dependencies for running the SecureDrop application.
-appserver_dependencies:
-  - gnupg2
-  - haveged
-  - python
-  - python-pip
-  - coreutils
-  - sqlite3
-  - apparmor-utils
-  - redis-server
-  - supervisor
-  - libpython2.7-dev
-
 # Enable Tor over SSH by default
 enable_ssh_over_tor: true
 

--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -1,12 +1,4 @@
 ---
-- name: Install SecureDrop Application Server dependencies.
-  apt:
-    pkg: "{{ item }}"
-    state: latest
-  with_items: "{{ appserver_dependencies }}"
-  tags:
-    - apt
-
 - name: Copy the SecureDrop Application GPG public key to the Application Server.
   copy:
     src: "{{ securedrop_app_gpg_public_key }}"

--- a/install_files/securedrop-app-code/debian/control
+++ b/install_files/securedrop-app-code/debian/control
@@ -11,5 +11,5 @@ Package: securedrop-app-code
 Architecture: amd64
 Conflicts: libapache2-mod-wsgi
 Replaces: libapache2-mod-wsgi
-Depends: ${python3:Depends},${misc:Depends},apache2,paxctld,apparmor-utils,gnupg2,haveged,coreutils,sqlite3,${dist:Depends},libapache2-mod-xsendfile,redis-server,supervisor,securedrop-keyring,securedrop-config
+Depends: ${dist:Depends}, ${misc:Depends}, ${python3:Depends}, apache2, apparmor-utils, coreutils, gnupg2, haveged, libapache2-mod-xsendfile, libpython3.5, paxctld, python3 (>= 3.5), python3 (<< 3.6), redis-server, securedrop-config, securedrop-keyring, sqlite3, supervisor
 Description: Packages the SecureDrop application code pip dependencies and apparmor profiles. This package will put the apparmor profiles in enforce mode. This package does use pip to install the pip wheelhouse

--- a/molecule/testinfra/staging/app-code/test_securedrop_app_code.py
+++ b/molecule/testinfra/staging/app-code/test_securedrop_app_code.py
@@ -15,15 +15,20 @@ def test_apache_default_docroot_is_absent(host):
 
 
 @pytest.mark.parametrize('package', [
-  'apparmor-utils',
-  'coreutils',
-  'gnupg2',
-  'haveged',
-  'python',
-  'python-pip',
-  'redis-server',
-  'sqlite3',
-  'supervisor',
+    'apache2',
+    'apparmor-utils',
+    'coreutils',
+    'gnupg2',
+    'haveged',
+    'libapache2-mod-xsendfile',
+    'libpython3.5',
+    'paxctld',
+    'python3',
+    'redis-server',
+    'securedrop-config',
+    'securedrop-keyring',
+    'sqlite3',
+    'supervisor',
 ])
 def test_securedrop_application_apt_dependencies(host, package):
     """


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4875.
Fixes #4864.

The `securedrop-app-code` Debian package didn't fully specify its dependencies, crucially `libpython3.5`, which is almost always installed on SecureDrop servers built according to our instructions, but doesn't have to be. This fixes that, and makes the `securedrop-app-code` package the sole source of truth about its dependencies, eliminating the out-of-band installation of some of them via the `app` Ansible role.

This also fixes a few dependency specifications in the instructions for setting up a development environment.

## Testing

The [upgrade scenario](https://docs.securedrop.org/en/latest/development/upgrade_testing.html) is the easiest way to test this:

- Check out this branch.
- `make build-debs`
- `make upgrade-start`
- `molecule login -s upgrade -h app-staging`
  - `sudo apt remove libpython3.5`
  - `sudo service apache2 restart`

The Apache restart should fail, and in the output of `journalctl -xe --no-pager` you should see a failure to locate `libpython3.5m.so.1.0`:

    Sep 26 22:28:04 app-prod apache2[7358]: apache2: Syntax error on line 140 of /etc/apache2/apache2.conf: Syntax error on line 1 of /etc/apache2/mods-enabled/wsgi.load: Cannot load /opt/venvs/securedrop-app-code/lib/python3.5/site-packages/mod_wsgi/server/mod_wsgi-py35.cpython-35m-x86_64-linux-gnu.so into server: libpython3.5m.so.1.0: cannot open shared object file: No such file or directory

To fix this, install the packages you just built:

- `make upgrade-test-local`
- `molecule login -s upgrade -h app-staging`
  - `dpkg -l securedrop-app-code libpython3.5`
    Confirm that `securedrop-app-code` was upgraded and that `libpython3.5` is installed.
  - Run `curl http://127.0.0.1` to confirm that the source interface is working again.

## Deployment

This ensures that `securedrop-app-code` dependencies are present. It should have no effect on most SecureDrop installations, where they should already installed, but will make installation more robust on atypical systems.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
