### PR TITLE
Added check for admin password in GUI updater

### DIFF
--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -15,6 +15,15 @@ FLAG_LOCATION = "/home/amnesia/Persistent/.securedrop/securedrop_update.flag"  #
 ESCAPE_POD = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
 
 
+def password_is_set():
+
+    pwd_flag = subprocess.check_output(['passwd', '--status']).decode('utf-8').split()[1]
+
+    if pwd_flag == 'NP':
+        return False
+    return True
+
+
 def prevent_second_instance(app: QtWidgets.QApplication, name: str) -> None:  # noqa
 
     # Null byte triggers abstract namespace
@@ -27,7 +36,7 @@ def prevent_second_instance(app: QtWidgets.QApplication, name: str) -> None:  # 
     except OSError as e:
         if e.errno == ALREADY_BOUND_ERRNO:
             err_dialog = QtWidgets.QMessageBox()
-            err_dialog.setText(name + ' is already running.')
+            err_dialog.setText(name + strings.app_is_already_running)
             err_dialog.exec()
             sys.exit()
         else:
@@ -280,11 +289,17 @@ class UpdaterApp(QtWidgets.QMainWindow, updaterUI.Ui_MainWindow):
         self.progressBar.setProperty("value", 0)
 
     def update_securedrop(self):
-        self.pushButton_2.setEnabled(False)
-        self.pushButton.setEnabled(False)
-        self.progressBar.setProperty("value", 10)
-        self.update_status_bar_and_output(strings.fetching_update)
-        self.update_thread.start()
+        if password_is_set():
+            self.pushButton_2.setEnabled(False)
+            self.pushButton.setEnabled(False)
+            self.progressBar.setProperty("value", 10)
+            self.update_status_bar_and_output(strings.fetching_update)
+            self.update_thread.start()
+        else:
+            self.pushButton_2.setEnabled(False)
+            pwd_err_dialog = QtWidgets.QMessageBox()
+            pwd_err_dialog.setText(strings.no_password_set_message)
+            pwd_err_dialog.exec()
 
     def alert_success(self):
         self.success_dialog = QtWidgets.QMessageBox()

--- a/journalist_gui/journalist_gui/strings.py
+++ b/journalist_gui/journalist_gui/strings.py
@@ -42,3 +42,7 @@ output_tab = 'Detailed Update Progress'
 initial_text_box = ("When the update begins, this area will populate with "
                     "output.\n")
 doing_setup = "Checking dependencies are up to date... (2 mins remaining)"
+no_password_set_message = ("The Tails Administration Password was not set.\n\n"
+                           "Please reboot and set a password before updating "
+                           "SecureDrop.")
+app_is_already_running = " is already running."

--- a/journalist_gui/test_gui.py
+++ b/journalist_gui/test_gui.py
@@ -250,6 +250,14 @@ class WindowTestCase(AppTestCase):
         mock_remove.assert_not_called()
         self.assertEqual(self.window.progressBar.value(), 0)
 
+    @mock.patch('journalist_gui.SecureDropUpdater.QtWidgets.QMessageBox')
+    def test_no_update_without_password(self, mock_msgbox):
+        with mock.patch('journalist_gui.SecureDropUpdater.password_is_set',
+                        return_value=False):
+            self.window.update_securedrop()
+        self.assertEqual(self.window.pushButton.isEnabled(), True)
+        self.assertEqual(self.window.pushButton_2.isEnabled(), False)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4387 

Adds a check for the administration password when **Update Now** is clicked in the GUI updater in Tails. If an administration password is set, the update proceeds as normal. If a password is not set, a modal dialog is displayed with an appropriate message, and the Update Now button is disabled.

## Testing

- On an existing install (prod VMs or hardware), start up Tails workstation  with PV unlocked. Check out this branch.
- Reboot Tails with PV unlocked and an admin password **not set**.
- [ ] verify that the GUI updater appears after Tails connects to the Tor network
- [ ] click **Update Now**. Verify that the modal warning appears, the Update Now button is disabled, and the update is not triggered. 
- Reboot Tails with PV unlocked and an admin password **set**
- [ ] verify that the GUI updater appears after Tails connects to the Tor network
- [ ] click **Update Now**. Verify that the modal does not  appear, and that  the update is triggered.
 
## Deployment
Deployed with initial install or workstation code update.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR