### PR TITLE
Update Ansible to 2.7.13

### DIFF
--- a/admin/requirements-ansible.in
+++ b/admin/requirements-ansible.in
@@ -1,3 +1,3 @@
-ansible>2.6<2.7
+ansible>2.7<2.8
 cryptography>=2.7
 netaddr

--- a/admin/requirements.txt
+++ b/admin/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --generate-hashes --output-file=requirements.txt requirements-ansible.in requirements.in
 #
-ansible==2.6.19 \
-    --hash=sha256:dbcfc9ddf620d05e1147b4c713738045a67c32be7260b11cbdbd84e92b77ca06
+ansible==2.7.13 \
+    --hash=sha256:339c87a1bf9e8555ce1e1c1a9452d8ed1df240944ec1a3fc2e813e6c7d70aeae
 asn1crypto==0.24.0 \
     --hash=sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87 \
     --hash=sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49 \

--- a/install_files/ansible-base/callback_plugins/ansible_version_check.py
+++ b/install_files/ansible-base/callback_plugins/ansible_version_check.py
@@ -21,7 +21,7 @@ class CallbackModule(CallbackBase):
     def __init__(self):
         # Can't use `on_X` because this isn't forwards compatible
         # with Ansible 2.0+
-        required_version = '2.6.19'  # Keep synchronized with requirements files
+        required_version = '2.7.13'  # Keep synchronized with requirements files
         if not ansible.__version__.startswith(required_version):
             print_red_bold(
                 "SecureDrop restriction: only Ansible {version}.*"

--- a/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
+++ b/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
@@ -1,11 +1,10 @@
 ---
 - name: Install apache packages.
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ apache_packages }}"
     state: latest
     update_cache: yes
     cache_valid_time: 3600
-  with_items: "{{ apache_packages }}"
   tags:
     - apt
     - apache

--- a/install_files/ansible-base/roles/common/tasks/install_ntp.yml
+++ b/install_files/ansible-base/roles/common/tasks/install_ntp.yml
@@ -1,11 +1,8 @@
 ---
 - name: Install ntp for ntpd.
   apt:
-    pkg: "{{ item }}"
+    pkg: ['ntp', 'ntpdate']
     state: present
   tags:
     - apt
     - ntp
-  with_items:
-    - ntp
-    - ntpdate

--- a/install_files/ansible-base/roles/common/tasks/remove_unused_packages.yml
+++ b/install_files/ansible-base/roles/common/tasks/remove_unused_packages.yml
@@ -1,9 +1,8 @@
 ---
 - name: Remove unused packages
   apt:
-    name: "{{ item }}"
+    name: "{{ unused_packages }}"
     state: absent
-  with_items: "{{ unused_packages }}"
   tags:
     - apt
     - hardening

--- a/install_files/ansible-base/roles/postfix/tasks/install_postfix.yml
+++ b/install_files/ansible-base/roles/postfix/tasks/install_postfix.yml
@@ -1,9 +1,8 @@
 ---
 - name: Install mailing utilities.
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ postfix_dependencies }}"
     state: present
-  with_items: "{{ postfix_dependencies }}"
   tags:
     - apt
     - postfix

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -12,8 +12,8 @@ ansible-lint==4.1.0 \
     --hash=sha256:9430ea6e654ba4bf5b9c6921efc040f46cda9c4fd2896a99ff71d21037bcb123 \
     --hash=sha256:c1b442b01091eca13ef11d98c3376e9489ba5b69a8467828ca86044f384bc0a1 \
     # via molecule
-ansible==2.6.19 \
-    --hash=sha256:dbcfc9ddf620d05e1147b4c713738045a67c32be7260b11cbdbd84e92b77ca06
+ansible==2.7.13 \
+    --hash=sha256:339c87a1bf9e8555ce1e1c1a9452d8ed1df240944ec1a3fc2e813e6c7d70aeae
 anyconfig==0.9.7 \
     --hash=sha256:4d6016ae6eecc5e502bc7e99ae0639c5710c5c67bde5f21b06b9eaafd9ce0e7e \
     # via molecule


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #4881.
Upgrades Ansible to the 2.7 series

## Testing

- [ ] CI should pass
- [ ] Clean install (including tails workstation playbooks) work in tails (either virtual or standalone)

## Deployment

For both new and existing installs, these dependencies will be brought in by the admin workstation virtualenv and updated when a user updates their workstation using the workstation graphical updater

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you added or updated a code dependency:

- [x] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)

note that due to the large diff (200K+ LOC), I have timeboxed the review to 3-4h
[link to review](https://github.com/freedomofpress/securedrop-debian-packaging/wiki/Ansible-2.6.19----2.7.13)

