### PR TITLE
Fix column/button alignment problems on source start page

### DIFF
--- a/securedrop/sass/_source_index.sass
+++ b/securedrop/sass/_source_index.sass
@@ -46,7 +46,7 @@
       padding: .5em 2em 1em 2em
       display: flex
       flex-direction: column
-      justify-content: center
+      justify-content: space-between
       width: 47%
       border-top-width: 0
       border-bottom-width: 0
@@ -74,6 +74,12 @@
       // Standard secondary buttons have a margin to set them apart from the primary
       margin-left: 0
       margin-right: 10%
+      white-space: nowrap
+      text-transform: uppercase
+      border: 2px solid transparent
+
+    #login-button
+      border: 2px solid $color_button_blue
 
     // Desktop view
     @media only screen and (min-width: 768px)

--- a/securedrop/sass/_source_index.sass
+++ b/securedrop/sass/_source_index.sass
@@ -39,6 +39,7 @@
     .index-row
       display: flex
       justify-content: space-between
+      align-self: flex-start
       flex-wrap: wrap
       width: 70%
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4891.

Certain combinations of language and viewport size could result in the two columns on the source start page not lining up with each other. This changes the columns' `justify-content` property to push the top and bottom containers apart, and controls the borders and content of the buttons to align them better.

## Testing

Run `make dev` and visit the source interface start page. Use the language chooser to confirm that the columns' contents are always in alignment. The header and explanatory text should always start at the top of the column. The buttons should always align at the bottom, and stay the same height.

Resize the browser window, reducing the width until you force a vertical layout. At no point in the horizontal layout should the button text wrap, causing the buttons' heights to differ, nor should the column headings ever appear at different vertical positions (they may wrap).

## Deployment

This only affects the UI.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
