### PR TITLE
[1.1.0] Backport #4889 upgrading Tor version

### DIFF
--- a/molecule/fetch-tor-packages/playbook.yml
+++ b/molecule/fetch-tor-packages/playbook.yml
@@ -12,7 +12,7 @@
     tor_repo_pubkey: "{{ sd_repo_root + '/install_files/ansible-base/roles/tor-hidden-services/files/tor-signing-key.pub' }}"
     tor_repo_url: "deb https://deb.torproject.org/torproject.org {{ ansible_distribution_release }} main"
     # Used to fetch a precise version; must also be updated in the test vars
-    tor_version: "0.4.1.5-1~xenial+1"
+    tor_version: "0.4.1.6-1~xenial+1"
 
   tasks:
     - name: Add Tor apt repo pubkey

--- a/molecule/fetch-tor-packages/tests/test_tor_packages.py
+++ b/molecule/fetch-tor-packages/tests/test_tor_packages.py
@@ -8,7 +8,7 @@ TOR_PACKAGES = [
     {"name": "tor", "arch": "amd64"},
     {"name": "tor-geoipdb", "arch": "all"},
 ]
-TOR_VERSION = "0.4.1.5-1~xenial+1"
+TOR_VERSION = "0.4.1.6-1~xenial+1"
 
 
 def test_tor_apt_repo(host):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Please make sure that the commit is the same from https://github.com/freedomofpress/securedrop/pull/4889

