### PR TITLE
[1.1.0] Backport #4886

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@
 
 SecureDrop is an open-source whistleblower submission system that media organizations can use to securely accept documents from, and communicate with anonymous sources. It was originally created by the late Aaron Swartz and is currently managed by the [Freedom of the Press Foundation](https://freedom.press).
 
-The SecureDrop documentation is now built and hosted by [Read the Docs](https://readthedocs.org): https://docs.securedrop.org. If you are still trying to use links to Markdown files on our GitHub to read documentation, please update your bookmarks.
+## Documentation
 
-There are two *versions* of the [SecureDrop documentation](https://docs.securedrop.org): **stable** and **latest**. The **stable** documentation is the default, and corresponds to the latest stable release of SecureDrop; therefore, it is the best version of the documentation for end users (Sources, Journalists, or Administrators). The **latest** documentation is automatically built from the latest commit on the SecureDrop development branch; therefore, it is most useful for developers and contributors to the project. You can choose to view a different version of the documentation by using the version picker shown at the bottom left of the screen.
+SecureDrop's documentation is built and hosted by [Read the Docs](https://readthedocs.org) at https://docs.securedrop.org.
+
+There are two versions of the [SecureDrop documentation](https://docs.securedrop.org): **stable** and **latest**. The **stable** documentation is the default, and corresponds to the latest stable release of SecureDrop. It is the best version of the documentation for end users (Sources, Journalists, or Administrators). The **latest** documentation is automatically built from the most recent commit to the SecureDrop development branch. It is most useful for developers and contributors to the project. You can switch between versions of the documentation by using the toolbar in the bottom left corner of the Read the Docs screen.
 
 ## Found an issue?
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Edits for readability and concision. Also remove last of language
related to RTD migration.

(cherry picked from commit e5741f814cf45b0eede2683493e393aecf911eee)

## Testing

Please make sure that the commit is same from https://github.com/freedomofpress/securedrop/pull/4886
