### PR TITLE
Bump app tests timeout to 15 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ jobs:
             export TESTFILES=$(cd securedrop; circleci tests glob 'tests/test*py' 'tests/**/test*py' |circleci tests split --split-by=timings |xargs echo)
             fromtag=$(docker images |grep securedrop-test-xenial-py3 |head -n1 |awk '{print $2}')
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" make test
+          no_output_timeout: 15m
 
       - store_test_results:
           path: ~/project/test-results


### PR DESCRIPTION
Towards #4691

## Testing/deployment 

https://circleci.com/workflow-run/4ea610b1-da9d-47c8-b4c6-faa023bdb135 shows successful app-tests job run with this change applied; per discussion w/ @redshiftzero would suggest we run it at 15m for a while and observe for recurrence of #4691

## Status

Ready for review