### PR TITLE
[1.1.0] Bump app tests timeout to 15 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ jobs:
             export TESTFILES=$(cd securedrop; circleci tests glob 'tests/test*py' 'tests/**/test*py' |circleci tests split --split-by=timings |xargs echo)
             fromtag=$(docker images |grep securedrop-test-xenial-py3 |head -n1 |awk '{print $2}')
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" make test
+          no_output_timeout: 15m
 
       - store_test_results:
           path: ~/project/test-results


### PR DESCRIPTION
Backport of #4904 to reduce CI pain in release branch (see #4691).

(cherry picked from commit 5f4fa6bc6451280f87fc980186899da26a78785a)

## Status

Ready for review 