### PR TITLE
Fix securedrop-admin crash when no operation given under Python 3

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -990,7 +990,12 @@ def parse_argv(argv):
                                             help=reset_admin_access.__doc__)
     parse_reset_ssh.set_defaults(func=reset_admin_access)
 
-    return set_default_paths(parser.parse_args(argv))
+    args = parser.parse_args(argv)
+    if getattr(args, 'func', None) is None:
+        print('Please specify an operation.\n')
+        parser.print_help()
+        sys.exit(1)
+    return set_default_paths(args)
 
 
 def main(argv):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4910.

Under Python 3, running securedrop-admin with no positional argument results in an ugly error, due to https://bugs.python.org/issue16308.

Under Python 3.7, we could simply add `dest` and `required` arguments to the `add_subparsers` call, but `required` isn't available in Python 3.5, so would break under Tails 3.

## Testing

Run `securedrop/bin/dev-shell bash` to start a shell in the dev container, then run:
- `cd ..`
- `./securedrop-admin setup`
- `./securedrop-admin -v`

You should see `Please specify an operation.` followed by the `securedrop-admin` help.

## Deployment

This only affects the admin workstation.

## Checklist


### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
