### PR TITLE
[1.1.0] Fix securedrop-admin crash when no operation given under Python 3

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -990,7 +990,12 @@ def parse_argv(argv):
                                             help=reset_admin_access.__doc__)
     parse_reset_ssh.set_defaults(func=reset_admin_access)
 
-    return set_default_paths(parser.parse_args(argv))
+    args = parser.parse_args(argv)
+    if getattr(args, 'func', None) is None:
+        print('Please specify an operation.\n')
+        parser.print_help()
+        sys.exit(1)
+    return set_default_paths(args)
 
 
 def main(argv):


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes
Under Python 3, running securedrop-admin with no positional argument
results in an ugly error, due to https://bugs.python.org/issue16308.

Under Python 3.7, we could simply add dest and required arguments to
the add_subparsers call, but required isn't available in Python 3.5,
so would break under Tails 3.

(cherry picked from commit d3fd59a8e31b6f60c9f0279ca883231b56550f26)

## Testing

Please make sure that the commit is same from https://github.com/freedomofpress/securedrop/pull/4912

