### PR TITLE
Remove Tails 3 Python 3 venv in Tails 4

### DIFF
--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -76,7 +76,7 @@ def is_tails():
     return id == 'Tails'
 
 
-def clean_up_tails3_venv():
+def clean_up_tails3_venv(VENV_DIR):
     """
     Tails 3.x, based on debian stretch uses libpython3.5, whereas Tails 4.x is
     based on Debian Buster and uses libpython3.7. This means that the Tails 3.x
@@ -100,6 +100,8 @@ def clean_up_tails3_venv():
                 shutil.rmtree(VENV_DIR)
                 sdlog.info("Tails 3 Python 3 virtualenv deleted. It will be "
                            "rebuilt to complete migration to Tails 4.x")
+            else:
+                sdlog.info("No Tails 3 Python 3 virtualenv detected.")
 
 
 def maybe_torify():
@@ -158,7 +160,7 @@ def envsetup(args):
     installation of packages again.
     """
     # clean up tails 3.x venv when migrating to tails 4.x
-    clean_up_tails3_venv()
+    clean_up_tails3_venv(VENV_DIR)
 
     # virtualenv doesnt exist? Install dependencies and create
     if not os.path.exists(VENV_DIR):

--- a/admin/tests/test_securedrop-admin-setup.py
+++ b/admin/tests/test_securedrop-admin-setup.py
@@ -18,6 +18,8 @@
 #
 
 import argparse
+import mock
+import os
 import pytest
 import subprocess
 
@@ -74,3 +76,44 @@ class TestSecureDropAdmin(object):
         assert 'Failed to install' in caplog.text
         assert 'in stdout' in caplog.text
         assert 'in stderr' in caplog.text
+
+    def test_python3_stretch_venv_deleted_in_buster(self, tmpdir, caplog):
+        venv_path = str(tmpdir)
+        python_lib_path = os.path.join(str(tmpdir), 'lib/python3.5')
+        os.makedirs(python_lib_path)
+        with mock.patch('bootstrap.is_tails', return_value=True):
+            with mock.patch('subprocess.check_output', return_value="buster"):
+                bootstrap.clean_up_tails3_venv(venv_path)
+                assert 'Tails 3 Python 3 virtualenv detected.' in caplog.text
+                assert 'Tails 3 Python 3 virtualenv deleted.' in caplog.text
+                assert not os.path.exists(venv_path)
+
+    def test_python3_buster_venv_not_deleted_in_buster(self, tmpdir, caplog):
+        venv_path = str(tmpdir)
+        python_lib_path = os.path.join(venv_path, 'lib/python3.7')
+        os.makedirs(python_lib_path)
+        with mock.patch('bootstrap.is_tails', return_value=True):
+            with mock.patch('subprocess.check_output', return_value="buster"):
+                bootstrap.clean_up_tails3_venv(venv_path)
+                assert 'No Tails 3 Python 3 virtualenv detected' in caplog.text
+                assert os.path.exists(venv_path)
+
+    def test_python3_stretch_venv_not_deleted_in_stretch(self, tmpdir, caplog):
+        venv_path = str(tmpdir)
+        python_lib_path = os.path.join(venv_path, 'lib/python3.5')
+        os.makedirs(python_lib_path)
+        with mock.patch('bootstrap.is_tails', return_value=True):
+            with mock.patch('subprocess.check_output', return_value="stretch"):
+                bootstrap.clean_up_tails3_venv(venv_path)
+                assert os.path.exists(venv_path)
+
+    def test_venv_cleanup_subprocess_exception(self, tmpdir, caplog):
+        venv_path = str(tmpdir)
+        python_lib_path = os.path.join(venv_path, 'lib/python3.5')
+        os.makedirs(python_lib_path)
+        with mock.patch('bootstrap.is_tails', return_value=True):
+            with mock.patch('subprocess.check_output',
+                            side_effect=subprocess.CalledProcessError(1,
+                                                                      ':o')):
+                bootstrap.clean_up_tails3_venv(venv_path)
+                assert os.path.exists(venv_path)


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Closes #4910 

## Testing

Starting from a Tails 3.16 drive with securedrop repo cloned:
- Check out 1.1.0-rc2 tag
- `./securedrop-admin setup`
- [ ] Python 3 venv is present in ~/persistent/securedrop/admin/.venv3
- Upgrade Tails drive to Tails 4.0-rc1
- Run `./securedrop-admin setup`
- [ ] Observe failure described in #4910 
- Check out this branch
- [ ] Run `./securedrop-admin setup`
- [ ] Venv is recreated under Tails 4.0, `./securedrop-admin` now works

## Deployment
Admins upgrading both admin and journalist (if `./securedrop-admin tailsconfig` is needed, for example when migrating to v3 onions) workstations will need to run `./securedrop-admin setup` after upgrading their workstations to Tails 4.0. We will need to update the 1.0.0 -> 1.1.0 (or Tails upgrade docs) to this effect (cc @eloquence )

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

