### PR TITLE
[1.1.0] Backport of #4914 Remove Tails 3 Python 3 venv in Tails 4

### DIFF
--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -76,7 +76,7 @@ def is_tails():
     return id == 'Tails'
 
 
-def clean_up_tails3_venv():
+def clean_up_tails3_venv(VENV_DIR):
     """
     Tails 3.x, based on debian stretch uses libpython3.5, whereas Tails 4.x is
     based on Debian Buster and uses libpython3.7. This means that the Tails 3.x
@@ -100,6 +100,8 @@ def clean_up_tails3_venv():
                 shutil.rmtree(VENV_DIR)
                 sdlog.info("Tails 3 Python 3 virtualenv deleted. It will be "
                            "rebuilt to complete migration to Tails 4.x")
+            else:
+                sdlog.info("No Tails 3 Python 3 virtualenv detected.")
 
 
 def maybe_torify():
@@ -158,7 +160,7 @@ def envsetup(args):
     installation of packages again.
     """
     # clean up tails 3.x venv when migrating to tails 4.x
-    clean_up_tails3_venv()
+    clean_up_tails3_venv(VENV_DIR)
 
     # virtualenv doesnt exist? Install dependencies and create
     if not os.path.exists(VENV_DIR):

--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -69,14 +69,14 @@ def is_tails():
         id = None
 
     # dirty hack to unreliably detect Tails 4.0~beta2
-    if id == 'Debian':
+    if id == b'Debian':
         if os.uname()[1] == 'amnesia':
             id = 'Tails'
 
     return id == 'Tails'
 
 
-def clean_up_tails3_venv(VENV_DIR):
+def clean_up_tails3_venv(virtualenv_dir=VENV_DIR):
     """
     Tails 3.x, based on debian stretch uses libpython3.5, whereas Tails 4.x is
     based on Debian Buster and uses libpython3.7. This means that the Tails 3.x
@@ -93,15 +93,22 @@ def clean_up_tails3_venv(VENV_DIR):
             dist = None
 
         # tails4 is based on buster
-        if dist == 'buster':
-            python_lib_path = os.path.join(VENV_DIR, "lib/python3.5")
+        if dist == b'buster':
+            python_lib_path = os.path.join(virtualenv_dir, "lib/python3.5")
             if os.path.exists(os.path.join(python_lib_path)):
-                sdlog.info("Tails 3 Python 3 virtualenv detected.")
-                shutil.rmtree(VENV_DIR)
-                sdlog.info("Tails 3 Python 3 virtualenv deleted. It will be "
-                           "rebuilt to complete migration to Tails 4.x")
-            else:
-                sdlog.info("No Tails 3 Python 3 virtualenv detected.")
+                sdlog.info(
+                    "Tails 3 Python 3 virtualenv detected. "
+                    "Removing it."
+                )
+                shutil.rmtree(virtualenv_dir)
+                sdlog.info("Tails 3 Python 3 virtualenv deleted.")
+
+
+def checkenv(args):
+    clean_up_tails3_venv(VENV_DIR)
+    if not os.path.exists(os.path.join(VENV_DIR, "bin/activate")):
+        sdlog.error('Please run "securedrop-admin setup".')
+        sys.exit(1)
 
 
 def maybe_torify():
@@ -241,18 +248,30 @@ def parse_argv(argv):
                         help="Increase verbosity on output")
     parser.set_defaults(func=envsetup)
 
+    subparsers = parser.add_subparsers()
+
+    envsetup_parser = subparsers.add_parser(
+        'envsetup',
+        help='Set up the admin virtualenv.'
+    )
+    envsetup_parser.set_defaults(func=envsetup)
+
+    checkenv_parser = subparsers.add_parser(
+        'checkenv',
+        help='Check that the admin virtualenv is properly set up.'
+    )
+    checkenv_parser.set_defaults(func=checkenv)
+
     return parser.parse_args(argv)
 
 
 if __name__ == "__main__":
     args = parse_argv(sys.argv[1:])
     setup_logger(args.v)
-    if args.v:
+
+    try:
         args.func(args)
+    except Exception:
+        sys.exit(1)
     else:
-        try:
-            args.func(args)
-        except Exception:
-            sys.exit(1)
-        else:
-            sys.exit(0)
+        sys.exit(0)

--- a/admin/tests/test_securedrop-admin-setup.py
+++ b/admin/tests/test_securedrop-admin-setup.py
@@ -18,6 +18,8 @@
 #
 
 import argparse
+import mock
+import os
 import pytest
 import subprocess
 
@@ -74,3 +76,44 @@ class TestSecureDropAdmin(object):
         assert 'Failed to install' in caplog.text
         assert 'in stdout' in caplog.text
         assert 'in stderr' in caplog.text
+
+    def test_python3_stretch_venv_deleted_in_buster(self, tmpdir, caplog):
+        venv_path = str(tmpdir)
+        python_lib_path = os.path.join(str(tmpdir), 'lib/python3.5')
+        os.makedirs(python_lib_path)
+        with mock.patch('bootstrap.is_tails', return_value=True):
+            with mock.patch('subprocess.check_output', return_value="buster"):
+                bootstrap.clean_up_tails3_venv(venv_path)
+                assert 'Tails 3 Python 3 virtualenv detected.' in caplog.text
+                assert 'Tails 3 Python 3 virtualenv deleted.' in caplog.text
+                assert not os.path.exists(venv_path)
+
+    def test_python3_buster_venv_not_deleted_in_buster(self, tmpdir, caplog):
+        venv_path = str(tmpdir)
+        python_lib_path = os.path.join(venv_path, 'lib/python3.7')
+        os.makedirs(python_lib_path)
+        with mock.patch('bootstrap.is_tails', return_value=True):
+            with mock.patch('subprocess.check_output', return_value="buster"):
+                bootstrap.clean_up_tails3_venv(venv_path)
+                assert 'No Tails 3 Python 3 virtualenv detected' in caplog.text
+                assert os.path.exists(venv_path)
+
+    def test_python3_stretch_venv_not_deleted_in_stretch(self, tmpdir, caplog):
+        venv_path = str(tmpdir)
+        python_lib_path = os.path.join(venv_path, 'lib/python3.5')
+        os.makedirs(python_lib_path)
+        with mock.patch('bootstrap.is_tails', return_value=True):
+            with mock.patch('subprocess.check_output', return_value="stretch"):
+                bootstrap.clean_up_tails3_venv(venv_path)
+                assert os.path.exists(venv_path)
+
+    def test_venv_cleanup_subprocess_exception(self, tmpdir, caplog):
+        venv_path = str(tmpdir)
+        python_lib_path = os.path.join(venv_path, 'lib/python3.5')
+        os.makedirs(python_lib_path)
+        with mock.patch('bootstrap.is_tails', return_value=True):
+            with mock.patch('subprocess.check_output',
+                            side_effect=subprocess.CalledProcessError(1,
+                                                                      ':o')):
+                bootstrap.clean_up_tails3_venv(venv_path)
+                assert os.path.exists(venv_path)

--- a/admin/tests/test_securedrop-admin-setup.py
+++ b/admin/tests/test_securedrop-admin-setup.py
@@ -82,7 +82,7 @@ class TestSecureDropAdmin(object):
         python_lib_path = os.path.join(str(tmpdir), 'lib/python3.5')
         os.makedirs(python_lib_path)
         with mock.patch('bootstrap.is_tails', return_value=True):
-            with mock.patch('subprocess.check_output', return_value="buster"):
+            with mock.patch('subprocess.check_output', return_value=b"buster"):
                 bootstrap.clean_up_tails3_venv(venv_path)
                 assert 'Tails 3 Python 3 virtualenv detected.' in caplog.text
                 assert 'Tails 3 Python 3 virtualenv deleted.' in caplog.text
@@ -95,7 +95,9 @@ class TestSecureDropAdmin(object):
         with mock.patch('bootstrap.is_tails', return_value=True):
             with mock.patch('subprocess.check_output', return_value="buster"):
                 bootstrap.clean_up_tails3_venv(venv_path)
-                assert 'No Tails 3 Python 3 virtualenv detected' in caplog.text
+                assert (
+                    'Tails 3 Python 3 virtualenv detected' not in caplog.text
+                )
                 assert os.path.exists(venv_path)
 
     def test_python3_stretch_venv_not_deleted_in_stretch(self, tmpdir, caplog):

--- a/securedrop-admin
+++ b/securedrop-admin
@@ -3,20 +3,17 @@
 # this is for backward compatibility and also because it
 # is more convenient for the admin to have the script at
 # the top level of the SecureDrop repository
+set -eo pipefail
+
 d=$(dirname "$0")
 if test "$1" = "setup" || test "$2" = "setup"; then
    if test "$1" = "setup"; then
      shift
-     exec python "$d/admin/bootstrap.py" "$@"
+     exec python3 "$d/admin/bootstrap.py" "$@"
    else
-     exec python "$d/admin/bootstrap.py" "$1"
+     exec python3 "$d/admin/bootstrap.py" "$1"
    fi
 else
-   activate="$d/admin/.venv3/bin/activate"
-   if test -f "$activate" ; then
-      source "$activate"
-      exec "$d/admin/.venv3/bin/securedrop-admin" --root "$d" "$@"
-   else
-      echo "please run '$0 setup' first"
-   fi
+   python3 "$d/admin/bootstrap.py" "checkenv"
+   exec "$d/admin/.venv3/bin/securedrop-admin" --root "$d" "$@"
 fi


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Backports #4914 to the 1.1.0 release branch

Cleans up any old venv3 from Tails3.

## Testing

Please make sure that the commits are the same  from #4914 
