### PR TITLE
Bump prod app server memory to 1024MB in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -85,6 +85,9 @@ Vagrant.configure("2") do |config|
     prod.vm.provider "virtualbox" do |v|
       v.memory = 1024
     end
+    prod.vm.provider "libvirt" do |lv, override|
+      lv.memory = 1024
+    end
     prod.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/securedrop-prod.yml"
       ansible.verbose = 'v'


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Staging app VM has 1024MB of RAM for Virtualbox and libvirt, but the prod app VM has 1024MB for Virtualbox and the default value (512MB) for libvirt.

## Testing

On a machine using libvirt for vagrant virtualization:
- `vagrant up --no-provision /prod/`
- [ ] `app-prod` and `mon-prod` vagrant boxes start successfully
- [ ] `app-prod` has 1024MB of RAM
- [ ] `mon-prod` has 512MB of RAM


## Deployment

Dev-only

## Checklist

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR

