### PR TITLE
Restore dropped virtualenv activation in securedrop-admin

### DIFF
--- a/securedrop-admin
+++ b/securedrop-admin
@@ -15,5 +15,6 @@ if test "$1" = "setup" || test "$2" = "setup"; then
    fi
 else
    python3 "$d/admin/bootstrap.py" "checkenv"
+   source "$d/admin/.venv3/bin/activate"
    exec "$d/admin/.venv3/bin/securedrop-admin" --root "$d" "$@"
 fi


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4920.

Restores dropped virtualenv activation in securedrop-admin.

## Testing

Follow the STR in #4920. The last step (raging) should not be required.

## Deployment

Fixes `securedrop-admin`.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
