### PR TITLE
[1.1.0] Fix Tails detection in Python 3 + Tails 3.x

### DIFF
--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -64,12 +64,12 @@ def run_command(command):
 def is_tails():
     try:
         id = subprocess.check_output('lsb_release --id --short',
-                                     shell=True).strip()
+                                     shell=True).decode('utf-8').strip()
     except subprocess.CalledProcessError:
         id = None
 
     # dirty hack to unreliably detect Tails 4.0~beta2
-    if id == b'Debian':
+    if id == 'Debian':
         if os.uname()[1] == 'amnesia':
             id = 'Tails'
 


### PR DESCRIPTION
(Backport of #4927 to the release branch.)

The final comparison failed to account for the fact that the
subprocess module returns a byte literal.

Incorrect Tails detection caused torify not to be used, which
caused a network error during the creation of the virtualenv
on Tails 3.x.

Decoding the string first reduces the likelihood of such
coding errors.

Fixes #4925

(cherry picked from commit a267c79b5d7eaa55c06cc423e07881bf92b29dfc)

## Status

Ready for review