### PR TITLE
Delete virtualenv if creation failed on setup

### DIFF
--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -187,6 +187,9 @@ def envsetup(args):
             sdlog.debug(e.output)
             sdlog.error(("Unable to create virtualenv. Check network settings"
                          " and try again."))
+            sdlog.debug("Cleaning up virtualenv")
+            if os.path.exists(VENV_DIR):
+                shutil.rmtree(VENV_DIR)
             raise
     else:
         sdlog.info("Virtualenv already exists, not creating")

--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -154,7 +154,7 @@ def install_apt_dependencies(args):
         raise
 
 
-def envsetup(args):
+def envsetup(args, virtualenv_dir=VENV_DIR):
     """Installs Admin tooling required for managing SecureDrop. Specifically:
 
         * updates apt-cache
@@ -167,10 +167,10 @@ def envsetup(args):
     installation of packages again.
     """
     # clean up tails 3.x venv when migrating to tails 4.x
-    clean_up_tails3_venv(VENV_DIR)
+    clean_up_tails3_venv(virtualenv_dir)
 
     # virtualenv doesnt exist? Install dependencies and create
-    if not os.path.exists(VENV_DIR):
+    if not os.path.exists(virtualenv_dir):
 
         install_apt_dependencies(args)
 
@@ -181,15 +181,18 @@ def envsetup(args):
         sdlog.info("Setting up virtualenv")
         try:
             sdlog.debug(subprocess.check_output(
-                maybe_torify() + ['virtualenv', '--python=python3', VENV_DIR],
+                maybe_torify() + ['virtualenv',
+                                  '--python=python3',
+                                  virtualenv_dir
+                                  ],
                 stderr=subprocess.STDOUT))
         except subprocess.CalledProcessError as e:
             sdlog.debug(e.output)
             sdlog.error(("Unable to create virtualenv. Check network settings"
                          " and try again."))
             sdlog.debug("Cleaning up virtualenv")
-            if os.path.exists(VENV_DIR):
-                shutil.rmtree(VENV_DIR)
+            if os.path.exists(virtualenv_dir):
+                shutil.rmtree(virtualenv_dir)
             raise
     else:
         sdlog.info("Virtualenv already exists, not creating")

--- a/admin/tests/test_securedrop-admin-setup.py
+++ b/admin/tests/test_securedrop-admin-setup.py
@@ -119,3 +119,19 @@ class TestSecureDropAdmin(object):
                                                                       ':o')):
                 bootstrap.clean_up_tails3_venv(venv_path)
                 assert os.path.exists(venv_path)
+
+    def test_envsetup_cleanup(self, tmpdir, caplog):
+        venv = os.path.join(str(tmpdir), "empty_dir")
+        args = ""
+        with pytest.raises(subprocess.CalledProcessError):
+            with mock.patch('subprocess.check_output',
+                            side_effect=self.side_effect_venv_bootstrap(venv)):
+                bootstrap.envsetup(args, venv)
+                assert not os.path.exists(venv)
+                assert 'Cleaning up virtualenv' in caplog.text
+
+    def side_effect_venv_bootstrap(self, venv_path):
+        # emulate the venv being created, and raise exception to simulate
+        # failure in virtualenv creation
+        os.makedirs(venv_path)
+        raise subprocess.CalledProcessError(1, ':o')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4929 

## Testing

This test requires disconnecting the network to ensure the exception is properly thrown.
In both Tails 3 and Tails 4:
- remove the existing admin venv: `rm -r admin/.venv3`
- run `./securedrop-admin setup`
- While or immediately after apt dependencies are installed (preferably before `[INFO] Setting up virtualenv` appears) disconnect the network.
- The setup will fail after 60s timeout
- [ ] admin/.venv3 folder was correctly deleted

## Deployment

This will be deployed to new and existing installs via git.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
