### PR TITLE
Fix "make test-config"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ securedrop/config.py: ## Generate the test SecureDrop application config.
 		 ctx.update(dict((k, {"stdout":v}) for k,v in os.environ.items())); \
 		 ctx = open("config.py", "w").write(env.get_template("config.py.example").render(ctx))'
 	@echo >> securedrop/config.py
-	@echo "SUPPORTED_LOCALES = $$(securedrop/i18n_tool.py list-locales)"  >> securedrop/config.py
+	@echo "SUPPORTED_LOCALES = $$(DOCKER_BUILD_VERBOSE=false $(DEVSHELL) ./i18n_tool.py list-locales)" >> securedrop/config.py
 	@echo
 
 .PHONY: test-config

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ securedrop/config.py: ## Generate the test SecureDrop application config.
 		 ctx.update(dict((k, {"stdout":v}) for k,v in os.environ.items())); \
 		 ctx = open("config.py", "w").write(env.get_template("config.py.example").render(ctx))'
 	@echo >> securedrop/config.py
-	@echo "SUPPORTED_LOCALES = $$(DOCKER_BUILD_VERBOSE=false $(DEVSHELL) ./i18n_tool.py list-locales)" >> securedrop/config.py
+	@echo "SUPPORTED_LOCALES = $$(if test -f /opt/venvs/securedrop-app-code/bin/python3; then ./securedrop/i18n_tool.py list-locales; else DOCKER_BUILD_VERBOSE=false $(DEVSHELL) ./i18n_tool.py list-locales; fi)" >> securedrop/config.py
 	@echo
 
 .PHONY: test-config

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -42,5 +42,11 @@ function docker_run() {
            -ti ${DOCKER_RUN_ARGUMENTS:-} "securedrop-test-${1}-py3" "${@:2}"
 }
 
-docker_image $BASE_OS
+if [ "${DOCKER_BUILD_VERBOSE:-'false'}" = "true" ]
+then
+   docker_image $BASE_OS
+else
+   docker_image $BASE_OS >/dev/null
+fi
+
 docker_run $BASE_OS "$@"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Outside of a dev container, "make test-config" was broken since the shebang line in i18n_tool.py was pointed to /opt/venvs/securedrop-app-code. When run with dev-shell, the generated config was broken by all the Docker build noise. This change updates dev-shell to observe the DOCKER_BUILD_VERBOSE environment variable and silence the docker build if it's not "true", and generates the test config with dev-shell, with DOCKER_BUILD_VERBOSE=false.

## Testing

Check out this branch. Remove or move aside `securedrop/config.py` and run `make test-config`. The config file should be generated correctly, with a clean `SUPPORTED_LOCALES` line at the end and no Docker build output included.

## Deployment

Dev only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

