### PR TITLE
Add upgrade boxes for SecureDrop 1.1.0

### DIFF
--- a/molecule/upgrade/playbook.yml
+++ b/molecule/upgrade/playbook.yml
@@ -81,7 +81,6 @@
         name: supervisor
         state: started
       delegate_to: app-staging
-      runonce: yes
       tags: always
   become: yes
 

--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -78,6 +78,17 @@
         }
       ],
       "version": "1.0.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "0a316e65c307ce67ee1056ae59a81378286d31e6527e65e246268b51c18cc148",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_1.1.0.box"
+        }
+      ],
+      "version": "1.1.0"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -78,6 +78,17 @@
         }
       ],
       "version": "1.0.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "54961b42d6213ddb9c196db2d51f5036bcbf625ccafd124153ad94f1e0d63ac5",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_1.1.0.box"
+        }
+      ],
+      "version": "1.1.0"
     }
   ]
 }


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Closes #4887 

Add upgrade boxes for SecureDrop 1.1.0
## Testing
- make upgrade start
- [ ] Source interface is accessible over Tor v3 service and version string is 1.1.0
- make build-debs
- [ ] make upgrade-test-local succeeds
- [ ] Source and journalist interfaces come up, version string is 1.2.0~rc1
## Deployment

Dev env only

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

