### PR TITLE
Make admin requirements update work under Python 3

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -5,6 +5,9 @@ ENV USER_NAME ${USER_NAME:-root}
 ARG USER_ID
 ENV USER_ID ${USER_ID:-0}
 
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
 RUN apt-get update && \
     apt-get install -y python3 sudo lsb-release gnupg2 git
 RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4954.

Python 3 breaks the Click package used by pip-compile unless the environment's locale is properly configured. This change sets the "LANG" and "LC_ALL" environment variables in the Docker container used for compiling requirements such that Click can function.

## Testing

- Check out this branch (`4954-fix-admin-requirements-update`).
- Follow the STR in #4954 (run `make update-admin-pip-requirements`). There should be no error.

## Deployment

This just affects the container used for the admin dev-shell.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
