### PR TITLE
Correct dependency update command in Tips & Tricks doc

### DIFF
--- a/docs/development/tips_and_tricks.rst
+++ b/docs/development/tips_and_tricks.rst
@@ -51,7 +51,7 @@ directly, please:
 
      .. code:: sh
 
-        make update-pip-dependencies
+        make update-pip-requirements
 
   #. Commit both the ``securedrop/requirements/*.in`` and
      ``securedrop/requirements/*.txt`` files
@@ -122,8 +122,8 @@ Note that the ``cat`` example above will also add the ATHS info for the
 *Journalist Interface*, as well, which is useful for testing.
 
 .. note:: The instructions above refer to VMs set up with v2 onion services. If
-          v3 onion services are configured instead, the steps required for the 
-          local ``tor`` setup will differ. You will need to add a 
+          v3 onion services are configured instead, the steps required for the
+          local ``tor`` setup will differ. You will need to add a
           ``ClientOnionAuthDir`` directive to ``torrc``, pointing to a directory
           containing the ``*.auth_private`` files created during the installation
           process under ``install_files/ansible-base``.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4956.

## Testing

- Check out this branch.
- Run `make docs`
- Check that the command given [here](http://localhost:8000/development/tips_and_tricks.html#upgrading-or-adding-python-dependencies) is valid.

## Deployment

Docs only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
