### PR TITLE
Replaced deprecated make -C securedrop in docs (#4959)

### DIFF
--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -73,7 +73,7 @@ To update these screenshots automatically you can run:
 
 .. code:: sh
 
-   make -C securedrop update-user-guides
+   make update-user-guides
 
 This will generate screenshots for each page in the web application and copy
 them to the folder under ``docs/images/manual/screenshots`` where they will

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -150,11 +150,11 @@ The ``develop`` branch can now be merged into ``i18n``:
     $ git fetch i18n
     $ git checkout -b i18n i18n/i18n
     $ git merge origin/develop
-    $ make -C securedrop translate
+    $ make translate
 
 The ``translate`` Makefile target uses the ``i18n_tool.py`` command to
 keep the ``*.pot`` and ``*.po`` files in sync with the SecureDrop
-source code. After running ``make -C securedrop translate``, carefully
+source code. After running ``make translate``, carefully
 review the output of ``git diff``. Check ``messages.pot`` first for
 updated strings, looking for formatting problems. Then review the
 ``messages.po`` of one existing translation, with a focus on ``fuzzy``
@@ -261,7 +261,7 @@ start the development servers with:
 
 .. code:: sh
 
-     $ make -C securedrop dev
+     $ make dev
 
 The translations can be checked automatically by running the
 SecureDrop page layout tests:
@@ -269,7 +269,7 @@ SecureDrop page layout tests:
 .. code:: sh
 
      $ export PAGE_LAYOUT_LOCALES="en_US,fr_FR"  # may be set to any supported languages
-     $ make -C securedrop test TESTFILES=tests/pageslayout
+     $ make test TESTFILES=tests/pageslayout
      [...]
      tests/pageslayout/test_journalist.py::TestJournalistLayout::test_account_edit_hotp_secret[en_US] PASSED
      tests/pageslayout/test_journalist.py::TestJournalistLayout::test_account_edit_hotp_secret[fr_FR] PASSED

--- a/docs/development/testing_application_tests.rst
+++ b/docs/development/testing_application_tests.rst
@@ -39,7 +39,7 @@ The tests can be run inside the development VM:
 
 .. code:: sh
 
-    make -C securedrop test
+    make test
 
 Or the app-staging VM:
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4959.

Changes proposed in this pull request:

Replaced deprecated `make -C securedrop <target>` instructions in docs with appropriate `make <target>` instructions.

## Testing

Run `make docs` and review the modified instructions to ensure they reflect the latest valid `make` command:

1. `make update-user-guides` in [Updating Screenshots](http://127.0.0.1:8000/development/documentation_guidelines.html#updating-screenshots),
![image](https://user-images.githubusercontent.com/22901938/67641203-d747af80-f8d6-11e9-9f22-503ad7c9ec55.png)
1. `make translate` in [Merge develop into the Weblate fork](http://127.0.0.1:8000/development/i18n.html#merge-develop-into-the-weblate-fork) (two places),
![image](https://user-images.githubusercontent.com/22901938/67641209-e4fd3500-f8d6-11e9-9d5d-8c3e44993fe2.png)
1. `make dev` and `make test` in [Verify Translations](http://127.0.0.1:8000/development/i18n.html#verify-translations),
![image](https://user-images.githubusercontent.com/22901938/67641217-f34b5100-f8d6-11e9-8c8b-5dc600de97d5.png)
1. `make test` in [Running the Application Tests](http://127.0.0.1:8000/development/testing_application_tests.html#running-the-application-tests).
![image](https://user-images.githubusercontent.com/22901938/67641230-0f4ef280-f8d7-11e9-98c7-271b40a302e1.png)

Optionally, run the modified make commands to ensure they are correct.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

N/A: Docs change only.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
