### PR TITLE
Update SecureDrop kernels to 4.14 series

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -40,5 +40,5 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder/tests/vars.yml
 securedrop_pkg_grsec:
-  ver: "4.4.182"
-  depends: "linux-image-4.4.177-grsec,linux-firmware-image-4.4.177-grsec,linux-image-4.4.182-grsec,linux-firmware-image-4.4.182-grsec,intel-microcode"
+  ver: "4.14.152"
+  depends: "linux-image-4.14.152-grsec-securedrop,linux-image-4.4.182-grsec,linux-firmware-image-4.4.182-grsec,intel-microcode"

--- a/install_files/securedrop-grsec/DEBIAN/postinst
+++ b/install_files/securedrop-grsec/DEBIAN/postinst
@@ -23,6 +23,11 @@ case "$1" in
     # highest kernel version. Any kernel provided by apt.freedom.press must
     # suprecede the ones provided by Ubuntu.
     sed -i '/^GRUB_DEFAULT=/s/=.*/=0/' /etc/default/grub
+    # When using CONFIG_PAX_KERNEXEC, the grsecurity team recommends the kernel
+    # is booted with "noefi" on the kernel command line if "CONFIG_EFI" is
+    # enabled, as EFI runtime services are necessarily mapped as RWX.
+    sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT=/s/=.*/=\"noefi\"/' /etc/default/grub
+
     update-grub
     ;;
 

--- a/molecule/builder-xenial/tests/vars.yml
+++ b/molecule/builder-xenial/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "1.2.0~rc1"
 ossec_version: "3.0.0"
 keyring_version: "0.1.3"
 config_version: "0.1.3"
-grsec_version: "4.4.182"
+grsec_version: "4.14.152"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/staging/common/test_grsecurity.py
+++ b/molecule/testinfra/staging/common/test_grsecurity.py
@@ -176,7 +176,6 @@ def test_pax_flags(host, binary):
   'WIMAX',
   'WIRELESS',
   'HAMRADIO',
-  'IRDA',
   'BT',
 ])
 def test_wireless_disabled_in_kernel_config(host, kernel_opts):

--- a/molecule/testinfra/staging/common/test_grsecurity.py
+++ b/molecule/testinfra/staging/common/test_grsecurity.py
@@ -16,8 +16,7 @@ def test_ssh_motd_disabled(host):
 
 
 @pytest.mark.parametrize("package", [
-    'linux-firmware-image-{}-grsec'.format(KERNEL_VERSION),
-    'linux-image-{}-grsec'.format(KERNEL_VERSION),
+    'linux-image-{}-grsec-securedrop'.format(KERNEL_VERSION),
     'paxctl',
     'securedrop-grsec',
 ])
@@ -71,8 +70,8 @@ def test_grsecurity_kernel_is_running(host):
     Make sure the currently running kernel is specific grsec kernel.
     """
     c = host.run('uname -r')
-    assert c.stdout.strip().endswith('-grsec')
-    assert c.stdout.strip() == '{}-grsec'.format(KERNEL_VERSION)
+    assert c.stdout.strip().endswith('-grsec-securedrop')
+    assert c.stdout.strip() == '{}-grsec-securedrop'.format(KERNEL_VERSION)
 
 
 @pytest.mark.parametrize('sysctl_opt', [
@@ -187,7 +186,7 @@ def test_wireless_disabled_in_kernel_config(host, kernel_opts):
     disabled in the running kernel config!
     """
 
-    kernel_config_path = "/boot/config-{}-grsec".format(KERNEL_VERSION)
+    kernel_config_path = "/boot/config-{}-grsec-securedrop".format(KERNEL_VERSION)
     kernel_config = host.file(kernel_config_path).content_string
 
     line = "# CONFIG_{} is not set".format(kernel_opts)

--- a/molecule/testinfra/staging/vars/staging.yml
+++ b/molecule/testinfra/staging/vars/staging.yml
@@ -192,4 +192,4 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
-grsec_version: "4.4.182"
+grsec_version: "4.14.152"


### PR DESCRIPTION
Update strings for 4.14.150-grsec, kernel configuration can be found in https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/51

## Status

Order of operations before closing this PR:
- [x] https://github.com/freedomofpress/containers/pull/19
- [x] https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/51
- [x] https://github.com/freedomofpress/securedrop-debian-packaging/pull/84
- [x] https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/22
- [x] Debug/fix incompatibilities described in https://github.com/freedomofpress/securedrop/pull/4962#issuecomment-547216232
- [x] Amend this PR with the proper version strings (`4.14.152-grsec-securedrop`), ready for final review
- [x] Review/merge https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/21
- [ ] Review / merge PR with config changes: https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/52 (there is also a fix in this PR that changes the kernel commandline option to noefi
## Description of Changes

Fixes #4843 


## Testing
- [ ] CI is green
- [Testing QA Matrix](https://docs.google.com/spreadsheets/d/1UlJqos2EAaA4kUuaElBeNqSz9gP5fV_sBCEakwi5Z2s/edit?usp=sharing)
## Deployment

New and existing installs will be updated via apt and unattended upgrades via cron-apt

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
