### PR TITLE
api: add journalist first name, last name to token response

### DIFF
--- a/docs/development/journalist_api.rst
+++ b/docs/development/journalist_api.rst
@@ -45,7 +45,9 @@ This will produce a response with your Authorization token:
   {
       "expiration": "2018-07-10T04:29:41.696321Z",
       "token": "eyJhbGciOiJIUzI1NiIsImV4cCI6MTUzMTE5Njk4MSwiaWF0IjoxNTMxMTY4MTgxfQ.eyJpZCI6MX0.TBSvfrICMxtvWgpVZzqTl6wHYNQuGPOaZpuAKwwIXXo",
-      "journalist_uuid": "54d81dae-9d94-4145-8a57-4c804a04cfe0"
+      "journalist_uuid": "54d81dae-9d94-4145-8a57-4c804a04cfe0",
+      "journalist_first_name": "daniel",
+      "journalist_last_name": "ellsberg"
   }
 
 Thereafter in order to authenticate to protected endpoints, send the token in

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -118,6 +118,8 @@ def make_blueprint(config):
                 'token': journalist.generate_api_token(expiration=TOKEN_EXPIRATION_MINS * 60),
                 'expiration': token_expiry.isoformat() + 'Z',
                 'journalist_uuid': journalist.uuid,
+                'journalist_first_name': journalist.first_name,
+                'journalist_last_name': journalist.last_name,
             })
 
             # Update access metadata

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -45,6 +45,8 @@ def test_valid_user_can_get_an_api_token(journalist_app, test_journo):
         assert isinstance(Journalist.validate_api_token_and_get_user(
             response.json['token']), Journalist) is True
         assert response.status_code == 200
+        assert response.json['journalist_first_name'] == test_journo['first_name']
+        assert response.json['journalist_last_name'] == test_journo['last_name']
 
 
 def test_user_cannot_get_an_api_token_with_wrong_password(journalist_app,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards https://github.com/freedomofpress/securedrop-client/issues/575

Changes proposed in this pull request:
 * Simply adds the journalist first name and last name on the token response such that another round trip is not needed to fetch them on the client side.

## Testing

You can follow the steps in securedrop-client PR here to test the server, SDK, and client side changes together: https://github.com/freedomofpress/securedrop-client/pull/605

## Deployment

deployed via `securedrop-app-code` package

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
