### PR TITLE
Use torbrowser_driver for specific screenshots (#4961)

### DIFF
--- a/securedrop/bin/update-user-guides
+++ b/securedrop/bin/update-user-guides
@@ -6,6 +6,7 @@ set -eu
 source "${BASH_SOURCE%/*}/dev-deps"
 
 run_xvfb &
+run_tor &
 run_redis &
 run_x11vnc &
 urandom

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -30,6 +30,7 @@ from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 from sqlalchemy.exc import IntegrityError
 from tbselenium.tbdriver import TorBrowserDriver
+from tbselenium.utils import disable_js
 
 import journalist_app
 import source_app
@@ -104,6 +105,8 @@ class FunctionalTest(object):
                     tbb_logfile_path=LOGFILE_PATH,
                 )
                 logging.info("Created Tor Browser web driver")
+                self.torbrowser_driver.set_window_position(0, 0)
+                self.torbrowser_driver.set_window_size(1024, 1200)
                 break
             except Exception as e:
                 logging.error("Error creating Tor Browser web driver: %s", e)
@@ -148,6 +151,10 @@ class FunctionalTest(object):
             self.create_torbrowser_driver()
         self.driver = self.torbrowser_driver
         logging.info("Switched %s to TorBrowser driver: %s", self, self.driver)
+
+    def disable_js_torbrowser_driver(self):
+        if hasattr(self, 'torbrowser_driver'):
+            disable_js(self.torbrowser_driver)
 
     @pytest.fixture(autouse=True)
     def set_default_driver(self):

--- a/securedrop/tests/pageslayout/test_source.py
+++ b/securedrop/tests/pageslayout/test_source.py
@@ -17,6 +17,7 @@
 #
 from tests.functional import journalist_navigation_steps
 from tests.functional import source_navigation_steps
+from tests.functional.functional_test import TORBROWSER
 from . import functional_test
 import pytest
 
@@ -26,10 +27,6 @@ class TestSourceLayout(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationStepsMixin,
         journalist_navigation_steps.JournalistNavigationStepsMixin):
-
-    def test_index(self):
-        self._source_visits_source_homepage()
-        self._screenshot('source-index.png')
 
     def test_lookup(self):
         self._source_visits_source_homepage()
@@ -64,14 +61,6 @@ class TestSourceLayout(
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()
         self._screenshot('source-generate.png')
-
-    def test_logout_flashed_message(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_logs_out()
-        self._screenshot('source-logout_flashed_message.png')
 
     def test_submission_entered_text(self):
         self._source_visits_source_homepage()
@@ -138,10 +127,12 @@ class TestSourceSessionLayout(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationStepsMixin,
         journalist_navigation_steps.JournalistNavigationStepsMixin):
+    default_driver_name = TORBROWSER
 
     session_expiration = 5
 
     def test_source_session_timeout(self):
+        self.disable_js_torbrowser_driver()
         self._source_visits_source_homepage()
         self._source_clicks_submit_documents_on_homepage()
         self._source_continues_to_submit_page()
@@ -149,3 +140,24 @@ class TestSourceSessionLayout(
         self._source_enters_text_in_message_field()
         self._source_visits_source_homepage()
         self._screenshot('source-session_timeout.png')
+
+
+class TestSourceLayoutTorbrowser(
+        functional_test.FunctionalTest,
+        source_navigation_steps.SourceNavigationStepsMixin,
+        journalist_navigation_steps.JournalistNavigationStepsMixin):
+    default_driver_name = TORBROWSER
+
+    def test_index(self):
+        self.disable_js_torbrowser_driver()
+        self._source_visits_source_homepage()
+        self._screenshot('source-index.png')
+    
+    def test_logout_flashed_message(self):
+        self.disable_js_torbrowser_driver()
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_logs_out()
+        self._screenshot('source-logout_flashed_message.png')

--- a/securedrop/tests/pageslayout/test_source.py
+++ b/securedrop/tests/pageslayout/test_source.py
@@ -152,7 +152,7 @@ class TestSourceLayoutTorbrowser(
         self.disable_js_torbrowser_driver()
         self._source_visits_source_homepage()
         self._screenshot('source-index.png')
-    
+
     def test_logout_flashed_message(self):
         self.disable_js_torbrowser_driver()
         self._source_visits_source_homepage()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4961.

Changes proposed in this pull request:

Use Tor Browser to capture specific screenshots:
* `source-index.png`
* `source-logout_flashed_message.png`
* `source-session_timeout.png` (currently not used in the source guide but changed so it is ready to use if the need comes).

Specific code changes:
- Added `run_tor` in `update-user-guides` script.
- Change `torbrowser_driver` window height to allow complete page capture (ref #4958).
- Added method in `FunctionalTest` class to disable JS in `torbrowser_driver`.
- Moved `test_index` and `test_logout_flashed_message` methods to a new class using `torbrowser_driver` as default driver.
- Set `torbrowser_driver` as default in `TestSourceSessionLayout` class.

## Testing

1. Run `make update-user-guides` and check that the `source-index.png`, `source-logout_flashed_message.png` and `source-session_timeout.png` screenshots do not show the banner recommending to use Tor Browser or the banner stating that the Tor Browser security settings are too low.
2. Check other screenshots to ensure they are all OK.
3. Run `make test` to ensure the changes to the `FunctionalTest` class have not broken other tests.

## Deployment

Any special considerations for deployment? Consider both:

N/A; Docs screenshots changes only

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

N/A. `make test` pass as per comment in "Testing" above.

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

N/A.

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

N/A.

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

N/A. Docs only.

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

N/A. No changes to the docs contents (screenshots only).

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review

N/A.