### PR TITLE
Changed newsroom logo alt tag to 'Logo Image' (#4280)

### DIFF
--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -17,7 +17,7 @@
         {% block header %}
         <div id="header">
           <a href="{% if 'logged_in' in session %}{{ url_for('main.lookup') }}{% else %}{{ url_for('main.index') }}{% endif %}" class="no-bottom-border">
-            <img src="{{ url_for('main.select_logo') }}" class="logo small" alt="Logo Image" width="250">
+            <img src="{{ url_for('main.select_logo') }}" class="logo small" alt="{{ gettext('Logo Image') }}" width="250">
           </a>
           {% include 'locales.html' %}
           {% if use_custom_header_image %}

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -17,7 +17,7 @@
         {% block header %}
         <div id="header">
           <a href="{% if 'logged_in' in session %}{{ url_for('main.lookup') }}{% else %}{{ url_for('main.index') }}{% endif %}" class="no-bottom-border">
-            <img src="{{ url_for('main.select_logo') }}" class="logo small" alt="SecureDrop" width="250">
+            <img src="{{ url_for('main.select_logo') }}" class="logo small" alt="Logo Image" width="250">
           </a>
           {% include 'locales.html' %}
           {% if use_custom_header_image %}

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -26,7 +26,7 @@
            See _source_index.sass for a more full understanding. #}
         <div class="index-wrap">
           <div class="header">
-            <img src="{{ url_for('main.select_logo') }}" alt="SecureDrop" class="logo-image">
+            <img src="{{ url_for('main.select_logo') }}" alt="Logo Image" class="logo-image">
             {% if use_custom_header_image %}
             <div class="powered">
               {{ gettext('Powered by') }}<br>

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -26,7 +26,7 @@
            See _source_index.sass for a more full understanding. #}
         <div class="index-wrap">
           <div class="header">
-            <img src="{{ url_for('main.select_logo') }}" alt="Logo Image" class="logo-image">
+            <img src="{{ url_for('main.select_logo') }}" alt="{{ gettext('Logo Image') }}" class="logo-image">
             {% if use_custom_header_image %}
             <div class="powered">
               {{ gettext('Powered by') }}<br>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Related to #4280 (does not fix completely).

Changes proposed in this pull request:

Change the `<alt>` tag of the Newsroom logo image in the source application from `SecureDrop` to `Logo Image`.

Note that this change addresses item 1) of #4280 but does not implement the dynamic Newsroom name suggested in item 2) of #4280.

## Testing

Run `make dev` and login to the Source Interface.

Use the brower's inspection feature to verify that the `<alt>` tag of the logo is set to `Logo Image`. Perform this verification on the `index` page as well as in the other pages accessible via the Source Interface.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

N/A.

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

N/A.

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

N/A.

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

N/A.

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review

N/A.