### PR TITLE
Update instructions for current version of Tor Browser

### DIFF
--- a/docs/development/tips_and_tricks.rst
+++ b/docs/development/tips_and_tricks.rst
@@ -20,20 +20,20 @@ development. Unfortunately, it is not possible to access the local
 development servers by default, due to Tor Browser's proxy
 configuration.
 
-To test the development environment in Tor Browser, you need to add an
-exception to allow Tor Browser to access localhost:
+To test the development environment in Tor Browser, you need to modify Tor
+Browser's default settings to prevent localhost from being resolved by the
+proxy:
 
-#. Open the "Tor Browser" menu and click "Preferences..."
-#. Choose the "Advanced" section and the "Network" subtab under it
-#. In the "Connection" section, click "Settings..."
-#. In the text box labeled "No Proxy for:", enter ``127.0.0.1``
+#. In a new tab, navigate to ``about:config``.
+#. Click "I accept the Risk!"
+#. In the search bar, enter ``network.proxy.allow_hijacking_localhost``.
+#. The default value is true. Double-click to set it to false.
 
-   -  Note: for some reason, ``localhost`` doesn't work here.
+Now you should be able to navigate to ``127.0.0.1:8080`` and ``127.0.0.1:8081``
+in Tor Browser. For some reason, you have to use ``127.0.0.1`` -- ``localhost``
+doesn't work.
 
-#. Click "Ok" and close the Preferences window
-
-You should now be able to access the development server in the Tor
-Browser by navigating to ``127.0.0.1:8080`` and ``127.0.0.1:8081``.
+The modified value persists across restarts of Tor Browser.
 
 .. _updating_pip_dependencies:
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #4985.

Documents an alternative method of allowing Tor Browser to access localhost addresses that works in the current version of Tor Browser (9.0.1).

## Testing

Follow the updated instructions and confirm that this allows you to access localhost address in the current version of Tor Browser.

## Deployment

This change only affects developer documentation, so there are no deployment considerations.

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally