### PR TITLE
Removes journalist UI modal test xfail.

### DIFF
--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -28,6 +28,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.remote_connection import LOGGER
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
 from sqlalchemy.exc import IntegrityError
 from tbselenium.tbdriver import TorBrowserDriver
 from tbselenium.utils import disable_js
@@ -76,6 +78,28 @@ class FunctionalTest(object):
         port = s.getsockname()[1]
         s.close()
         return port
+
+    def set_tbb_securitylevel(self, toLevel):
+        if self.torbrowser_driver is None:
+            self.create_torbrowser_driver()
+        driver = self.torbrowser_driver
+
+        driver.get("about:config")
+        accept_risk_button = driver.find_element_by_id("warningButton")
+        if accept_risk_button:
+            accept_risk_button.click()
+        ActionChains(driver).send_keys(Keys.RETURN).\
+            send_keys("extensions.torbutton.security_slider").perform()
+        time.sleep(2)
+        ActionChains(driver).send_keys(Keys.TAB).\
+            send_keys(Keys.RETURN).perform()
+        time.sleep(2)
+        alert = driver.switch_to.alert
+        time.sleep(2)
+        alert.send_keys(str(toLevel))
+        time.sleep(2)
+        alert.accept()
+        time.sleep(2)
 
     def create_torbrowser_driver(self):
         logging.info("Creating TorBrowserDriver")

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -19,7 +19,6 @@
 from . import functional_test
 from . import journalist_navigation_steps
 from . import source_navigation_steps
-import pytest
 
 
 class TestJournalist(
@@ -59,13 +58,16 @@ class TestJournalist(
         self._journalist_logs_in()
         self._journalist_uses_delete_collections_button_confirmation()
 
-    @pytest.mark.xfail(reason="Filter widget not displayed in TBB 9.0.1")
     def test_journalist_interface_ui_with_modal(self):
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()
         self._source_continues_to_submit_page()
         self._source_submits_a_file()
         self._source_logs_out()
+
+        # Toggle security slider to force prefs change
+        self.set_tbb_securitylevel(1)
+        self.set_tbb_securitylevel(4)
 
         self._journalist_logs_in()
         self._journalist_uses_js_filter_by_sources()

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -16,13 +16,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from . import functional_test
+from . import functional_test as ft
 from . import journalist_navigation_steps
 from . import source_navigation_steps
 
 
 class TestJournalist(
-    functional_test.FunctionalTest,
+    ft.FunctionalTest,
     source_navigation_steps.SourceNavigationStepsMixin,
     journalist_navigation_steps.JournalistNavigationStepsMixin,
 ):
@@ -66,8 +66,8 @@ class TestJournalist(
         self._source_logs_out()
 
         # Toggle security slider to force prefs change
-        self.set_tbb_securitylevel(1)
-        self.set_tbb_securitylevel(4)
+        self.set_tbb_securitylevel(ft.TBB_SECURITY_HIGH)
+        self.set_tbb_securitylevel(ft.TBB_SECURITY_LOW)
 
         self._journalist_logs_in()
         self._journalist_uses_js_filter_by_sources()


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #4978

Adds a function to set TBB security level explicitly, uses it to switch TBB to correct state for journalist functional tests.

Change required because TBB 9.0.1 is being started with Javascript disabled. Rather than getting into managing individual preferences related to browser functionality, it makes sense to simulate user behaviour by toggling the security slider pref to get TBB 9.0.1 into the correct state. (This would also be useful for testing security warnings on the source interface, or any other featurest that rely on specific TBB security levels.)

## Testing

- [ ] Does CI pass, including `test_journalist_interface_ui_with_modal`?

## Deployment

Testing-only.

## Checklist