### PR TITLE
Runs builder security update test for RC branches/tags only.

### DIFF
--- a/molecule/builder-xenial/tests/test_security_updates.py
+++ b/molecule/builder-xenial/tests/test_security_updates.py
@@ -1,16 +1,34 @@
 import os
+from subprocess import check_output
+import re
+import pytest
+
 SECUREDROP_TARGET_PLATFORM = os.environ.get("SECUREDROP_TARGET_PLATFORM")
 testinfra_hosts = [
         "docker://{}-sd-sec-update".format(SECUREDROP_TARGET_PLATFORM)
 ]
 
 
+def test_should_run():
+    command = ["git", "describe", "--all"]
+    version = check_output(command).decode("utf8")[0:-1]
+    candidates = (r"(^tags/[\d]+\.[\d]+\.[\d]+-rc[\d]+)|"
+                  r"(^tags/[\d]+\.[\d]+\.[\d]+)|"
+                  r"(^heads/release/[\d]+\.[\d]+\.[\d]+)|"
+                  r"(^heads/update-builder.*)")
+    result = re.match(candidates, version)
+    if result:
+        return True
+    else:
+        return False
+
+
+@pytest.mark.skipif(not test_should_run(), reason="Only tested for RCs and builder updates")
 def test_ensure_no_updates_avail(host):
     """
         Test to make sure that there are no security-updates in the
         base builder container.
     """
-
     # Filter out all the security repos to their own file
     # without this change all the package updates appeared as if they were
     # coming from normal ubuntu update channel (since they get posted to both)


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #4982 
Fixes #4764

Adds a check for git branch/tag matching the SecureDrop RC format, and a conditional xfail on the builder security update test that is triggered for all non-RC branches/tags

## Testing
- [ ] check out this branch and run `make build-debs` - it should pass with the `test_ensure_no_updates_avail` test xfailed
- [ ] create a branch from the current branch named `update-builderRandomStringHere` and run `make build-debs`- It should either fail due to `test_ensure_no_updates_avail` (most likely) or pass with no tests xfailed (if the builder security updates are current).
- [ ] create a branch from the current branch named `release/1.33.7` (or the numbers of your choice) and run `make build-debs`- It should either fail due to `test_ensure_no_updates_avail` (most likely) or pass with no tests xfailed (if the builder security updates are current).
- [ ] create and check out an RC-format tag (for example, `1.33.7-rc3`).  Run `make build-debs` - It should either fail due to `test_ensure_no_updates_avail` (most likely) or pass with no tests xfailed (if the builder security updates are current).
- [ ] create and check out a release tag (for example, `1.33.7`).  Run `make build-debs` - It should either fail due to `test_ensure_no_updates_avail` (most likely) or pass with no tests xfailed (if the builder security updates are current).

## Deployment

Dev/CI/release process change only.

## Checklist
### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR
