### PR TITLE
Upgrade SecureDrop kernels to 4.14.154

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -40,5 +40,5 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder/tests/vars.yml
 securedrop_pkg_grsec:
-  ver: "4.14.152"
-  depends: "linux-image-4.14.152-grsec-securedrop,linux-image-4.4.182-grsec,linux-firmware-image-4.4.182-grsec,intel-microcode"
+  ver: "4.14.154"
+  depends: "linux-image-4.14.154-grsec-securedrop,linux-image-4.4.182-grsec,linux-firmware-image-4.4.182-grsec,intel-microcode"

--- a/molecule/builder-xenial/tests/vars.yml
+++ b/molecule/builder-xenial/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "1.2.0~rc1"
 ossec_version: "3.0.0"
 keyring_version: "0.1.3"
 config_version: "0.1.3"
-grsec_version: "4.14.152"
+grsec_version: "4.14.154"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/staging/common/test_grsecurity.py
+++ b/molecule/testinfra/staging/common/test_grsecurity.py
@@ -176,6 +176,7 @@ def test_pax_flags(host, binary):
   'WIMAX',
   'WIRELESS',
   'HAMRADIO',
+  'IRDA',
   'BT',
 ])
 def test_wireless_disabled_in_kernel_config(host, kernel_opts):

--- a/molecule/testinfra/staging/common/test_grsecurity.py
+++ b/molecule/testinfra/staging/common/test_grsecurity.py
@@ -193,6 +193,23 @@ def test_wireless_disabled_in_kernel_config(host, kernel_opts):
     assert line in kernel_config
 
 
+@pytest.mark.parametrize('kernel_opts', [
+  'CONFIG_X86_INTEL_TSX_MODE_OFF',
+  'CONFIG_PAX',
+  'CONFIG_GRKERNSEC',
+])
+def test_kernel_options_enabled_config(host, kernel_opts):
+    """
+    Tests kernel config for options that should be enabled
+    """
+
+    kernel_config_path = "/boot/config-{}-grsec-securedrop".format(KERNEL_VERSION)
+    kernel_config = host.file(kernel_config_path).content_string
+
+    line = "{}=y".format(kernel_opts)
+    assert line in kernel_config
+
+
 def test_mds_mitigations_and_smt_disabled(host):
     """
     Ensure that full mitigations are in place for MDS

--- a/molecule/testinfra/staging/vars/staging.yml
+++ b/molecule/testinfra/staging/vars/staging.yml
@@ -192,4 +192,4 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
-grsec_version: "4.14.152"
+grsec_version: "4.14.154"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4989, towards #4992 upgrades SecureDrop kernels to 4.14.184

## Testing
- Review and merge https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/52
- Review and merge https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/23
- Restart full CI run for this PR
- Review and merge this PR
## Deployment

New and existing installs will be updated via deb packages and unattended upgrades via cron-apt

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
