### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Reporting security issues
+
+### Reporting a Vulnerability
+
+If you have found a vulnerability, please **DO NOT** file a public issue. Please send us your report privately either via:
+
+- SecureDrop's public bug bounty program managed by [Bugcrowd](https://bugcrowd.com/freedomofpress)
+- Email to security@freedom.press (Optionally GPG-encrypted to [734F6E707434ECA6C007E1AE82BD6C9616DABB79](https://securedrop.org/documents/6/fpf-email.asc))


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #4468 

Provides a basic SECURITY.md file for the SecureDrop repository.


## Testing
- Does this make sense?
- Should we add other contact methods?
- Is this in line with [GitHub's guidance](https://help.github.com/en/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository)
