### PR TITLE
Sets TBB security level to standard for admin interface TOTP and HOTP tests.

### DIFF
--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -1,11 +1,9 @@
-import pytest
-
-from . import functional_test
+from . import functional_test as ft
 from . import journalist_navigation_steps
 
 
 class TestAdminInterface(
-        functional_test.FunctionalTest,
+        ft.FunctionalTest,
         journalist_navigation_steps.JournalistNavigationStepsMixin):
 
     def test_admin_interface(self):
@@ -15,8 +13,11 @@ class TestAdminInterface(
         self._new_user_can_log_in()
         self._admin_can_edit_new_user()
 
-    @pytest.mark.skip(reason="hanging forever, needs investigation")
     def test_admin_edits_hotp_secret(self):
+        # Toggle security slider to force prefs change
+        self.set_tbb_securitylevel(ft.TBB_SECURITY_HIGH)
+        self.set_tbb_securitylevel(ft.TBB_SECURITY_LOW)
+
         self._admin_logs_in()
         self._admin_visits_admin_interface()
         self._admin_adds_a_user()
@@ -24,8 +25,11 @@ class TestAdminInterface(
         self._admin_visits_reset_2fa_hotp()
         self._admin_visits_edit_hotp()
 
-    @pytest.mark.skip(reason="hanging forever, needs investigation")
     def test_admin_edits_totp_secret(self):
+        # Toggle security slider to force prefs change
+        self.set_tbb_securitylevel(ft.TBB_SECURITY_HIGH)
+        self.set_tbb_securitylevel(ft.TBB_SECURITY_LOW)
+
         self._admin_logs_in()
         self._admin_visits_admin_interface()
         self._admin_adds_a_user()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4977.

Sets TBB security level to Standard before running the TOTP and HOTP functional tests.

## Testing

- [ ] Does CI pass, with the TOTP and HOTP tests run instead of skipped?
