### PR TITLE
Prevent duplicate instances of source /generate page

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -36,6 +36,14 @@ def make_blueprint(config):
                   "notification")
             return redirect(url_for('.lookup'))
 
+        if request.method == 'GET' and 'codename' in session:
+            flash(gettext(
+                "A browser window or tab is already on the \"Get Started\" page. "
+                "Please continue using this window or tab or close all browser windows and "
+                "start over."),
+                  "notification")
+            return redirect(url_for('.index'))
+
         codename = generate_unique_codename(config)
         session['codename'] = codename
         session['new_user'] = True

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -213,3 +213,15 @@ class SourceNavigationStepsMixin:
         if not hasattr(self, "accept_languages"):
             expected_text = "Your session timed out due to inactivity."
             assert expected_text in notification.text
+
+    def _source_clicks_submit_documents_on_homepage_duplicate_window(self):
+        # Similar to self._source_clicks_submit_documents_on_homepage except we do not check
+        # that the source is directed to the page showing the generated codename, ref. #4458.
+        self.safe_click_by_id("submit-documents-button")
+
+    def _source_sees_get_started_page_already_open_message(self):
+        notification = self.driver.find_element_by_css_selector(".notification")
+
+        if not hasattr(self, "accepted_languages"):
+            expected_text = "A browser window or tab is already on the \"Get Started\" page. "
+            assert expected_text in notification.text

--- a/securedrop/tests/functional/test_source_warnings.py
+++ b/securedrop/tests/functional/test_source_warnings.py
@@ -76,3 +76,21 @@ class TestSourceInterfaceBannerWarnings(
 
         banner = self.driver.find_element_by_id("js-warning")
         assert "Security Slider to Safest", banner.text
+
+
+class TestSourceInterfaceFlashWarnings(
+    functional_test.FunctionalTest, source_navigation_steps.SourceNavigationStepsMixin
+):
+
+    def test_duplicate_get_started_windows(self):
+
+        assert len(self.driver.window_handles) == 1
+        main_window = self.driver.current_window_handle  # noqa F841
+        self._source_visits_source_homepage()
+        self._source_clicks_submit_documents_on_homepage()
+
+        self.driver.execute_script("window.open()")
+        new_window = self.driver.window_handles[1]  # noqa F841
+        self._source_visits_source_homepage()
+        self._source_clicks_submit_documents_on_homepage_duplicate_window()
+        self._source_sees_get_started_page_already_open_message()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4458.

If a source clicks on 'Get Started' in two separate browser windows or tabs, instead of returning a server error (status code 500), the second instance will redirect the source to the source index page with a flash message stating that another window is already on the 'Get Started' page.

## Testing

How should the reviewer test this PR?

1. In the dev VM, launch the Source Interface in a browser and click on "Get Sarted".
1. Note the codename displayed.
1. Open a second browser tab (or window), navigate to the Source Interface index page and click "Get Started".
1. Verify that the second tab (or window) redirects to the source index page with an appropriate flash message.
1. Return to the first tab (or window), click on "Submmit Documents".
1. Display the hidden codename on the submission page and verify it matches the one noted in item 2.

## Deployment

Any special considerations for deployment?

No special considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Test added in `tests/functional/test_source_warnings.py`.

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
