### PR TITLE
Added supervisor to packages installed in dev env

### DIFF
--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y paxctl && \
                        gnupg2 ruby redis-server git xvfb haveged curl wget \
                        gettext paxctl x11vnc enchant libffi-dev sqlite3 gettext sudo \
                        libasound2 libdbus-glib-1-2 libgtk2.0-0 libfontconfig1 libxrender1 \
-                       libcairo-gobject2 libgtk-3-0 libstartup-notification0 tor
+                       libcairo-gobject2 libgtk-3-0 libstartup-notification0 supervisor tor
 
 RUN gem install sass -v 3.4.23
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4979 .

Adds `supervisor` package via `apt` in the SecureDrop dev VM.

## Testing
- checkout this branch
- (optional) run `docker system prune` to start from a clean slate 
- [ ] run `make dev` - the output does not contain the message ``setsid: failed to execute supervisord: No such file or directory``

## Deployment

Dev-only change, will be picked up by the initial or next run of `make dev` on a developer's machine.
