### PR TITLE
Fix broken link to Tails upgrade documentation in Journo guide 

### DIFF
--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -28,7 +28,7 @@ administrator if you have trouble.
 .. include:: includes/update-gui.txt
 
 .. _`Tails
-   Upgrade Documentation`: https://tails.boum.org/doc/first_steps/upgrade/index.en.html
+   Upgrade Documentation`: https://tails.boum.org/doc/upgrade/index.en.html
 
 Connecting to the *Journalist Interface*
 ----------------------------------------


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Resolves #4976

Changes proposed in this pull request: docs only

## Testing

Manual review

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
