### PR TITLE
Use virtio for video_type in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,9 @@ Vagrant.configure("2") do |config|
     staging.vm.box = "bento/ubuntu-16.04"
     staging.vm.network "private_network", ip: "10.0.1.3"
     staging.vm.synced_folder './', '/vagrant', disabled: true
+    staging.vm.provider "libvirt" do |lv, override|
+      lv.video_type = "virtio"
+    end
   end
 
   config.vm.define 'app-staging', autostart: false do |staging|
@@ -46,6 +49,7 @@ Vagrant.configure("2") do |config|
     end
     staging.vm.provider "libvirt" do |lv, override|
       lv.memory = 1024
+      lv.video_type = "virtio"
     end
     staging.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/securedrop-staging.yml"
@@ -70,6 +74,9 @@ Vagrant.configure("2") do |config|
     prod.vm.box = "bento/ubuntu-16.04"
     prod.vm.network "private_network", ip: "10.0.1.5", virtualbox__intnet: internal_network_name
     prod.vm.synced_folder './', '/vagrant', disabled: true
+    prod.vm.provider "libvirt" do |lv, override|
+      lv.video_type = "virtio"
+    end
   end
 
   config.vm.define 'app-prod', autostart: false do |prod|
@@ -87,6 +94,7 @@ Vagrant.configure("2") do |config|
     end
     prod.vm.provider "libvirt" do |lv, override|
       lv.memory = 1024
+      lv.video_type = "virtio"
     end
     prod.vm.provision "ansible" do |ansible|
       ansible.playbook = "install_files/ansible-base/securedrop-prod.yml"

--- a/molecule/libvirt-staging-xenial/molecule.yml
+++ b/molecule/libvirt-staging-xenial/molecule.yml
@@ -11,6 +11,7 @@ platforms:
     box: bento/ubuntu-16.04
     raw_config_args:
       - "cpu_mode = 'host-passthrough'"
+      - "video_type = 'virtio'"
     instance_raw_config_args:
       - "vm.synced_folder './', '/vagrant', disabled: true"
       - "vm.network 'private_network', ip: '10.0.1.2'"
@@ -26,6 +27,7 @@ platforms:
     box: bento/ubuntu-16.04
     raw_config_args:
       - "cpu_mode = 'host-passthrough'"
+      - "video_type = 'virtio'"
     instance_raw_config_args:
       - "vm.synced_folder './', '/vagrant', disabled: true"
       - "vm.network 'private_network', ip: '10.0.1.3'"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #4993 

Sets the video_type to virtio for libvirt/virt-manager console compatibility with the new 4.14.x kernels provided by SecureDrop. Since the default option has been reported to work with Virtualbox in https://github.com/freedomofpress/securedrop/issues/4993#issuecomment-555716356 , we should scope this change to libvirt-only.

## Testing
- Destroy any staging environments you may have prior to testing this PR
- checkout this branch
- make staging
- [ ] I can log into the server via the virt-manager/libvirt console, the console is no longer blocked on the error described in https://github.com/freedomofpress/securedrop/issues/4993#issuecomment-554142103

## Deployment
Dev-only change
## Checklist
### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
