### PR TITLE
More consistent usage of two-factor related terminology

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -163,7 +163,7 @@ enter.
 
 If FreeOTP was set up correctly, you will be redirected
 back to the Admin Interface and will see a confirmation that the
-two-factor token was verified.
+two-factor code was verified.
 
 .. include:: includes/otp-app.txt
 
@@ -184,12 +184,12 @@ inserting it into the workstation and pressing the button.
 |Verify YubiKey|
 
 If everything was set up correctly, you will be redirected back to the
-Admin Interface, where you should see a flashed message that says "Two
-factor token successfully verified for user *new username*!".
+Admin Interface, where you should see a flashed message that says "The
+two-factor code for user *new username* was verified successfully.".
 
 Congratulations! You have successfully set up a journalist on
 SecureDrop. Make sure the journalist remembers their username and
-passphrase and always has their 2 factor authentication device in their
+passphrase and always has their two-factor authentication device in their
 possession when they attempt to log in to SecureDrop.
 
 .. |SecureDrop main page|

--- a/docs/development/journalist_api.rst
+++ b/docs/development/journalist_api.rst
@@ -27,15 +27,15 @@ Clients shall send the following headers:
 Authentication
 ~~~~~~~~~~~~~~
 
-``POST /api/v1/token`` to get a token with the username, password, and 2FA
-token in the request body:
+``POST /api/v1/token`` to get a token with the username, password, and two-factor
+code in the request body:
 
 .. code:: sh
 
   {
-  	"username": "journalist",
-  	"passphrase": "monkey potato pizza quality silica growing deduce",
-  	"one_time_code": "123456"
+    "username": "journalist",
+    "passphrase": "monkey potato pizza quality silica growing deduce",
+    "one_time_code": "123456"
   }
 
 This will produce a response with your Authorization token:
@@ -58,7 +58,7 @@ HTTP Authorization header:
   Authorization: Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTUzMDU4NjU4MiwifWF0IjoxNTMwNTc5MzgyfQ.eyJpZCI6MX0.P_PfcLMk1Dq5VCIANo-lJbu0ZyCL2VcT8qf9fIZsTCM
 
 This header will be checked with each API request to see if it is valid and
-not yet expired. Tokens currently expire after 8 hours. 
+not yet expired. Tokens currently expire after 8 hours.
 
 Logout
 ------

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -142,7 +142,7 @@ can simply scan the following QR code:
 
 .. image:: ../images/devenv/test-users-totp-qrcode.png
 
-You can also generate the 2FA code using the Python interpreter:
+You can also generate the two-factor code using the Python interpreter:
 
 .. code:: python
 

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -132,7 +132,7 @@ development.
 * **Password:** ``correct horse battery staple profanity oil chewy``
 * **TOTP secret:** ``JHCO GO7V CER3 EJ4L``
 
-If you need to generate the six digit token, use the TOTP secret in
+If you need to generate the six digit two-factor code, use the TOTP secret in
 combination with an authenticator application that implements
 `RFC 6238 <https://tools.ietf.org/html/rfc6238>`__, such as
 `FreeOTP <https://freeotp.github.io/>`__ (Android and iOS) or

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -137,14 +137,14 @@ The *Submission Private Key* should never be accessible to a computer with
 Internet connectivity. Instead, it should remain on the *Secure Viewing Station*
 and on offline backup storage.
 
-Two-Factor Authenticator
-------------------------
+Two-Factor Authentication
+-------------------------
 
 There are several places in the SecureDrop architecture where two-factor
 authentication is used to protect access to sensitive information or
 systems. These instances use the standard TOTP and/or HOTP algorithms,
-and so a variety of devices can be used to provide two-factor
-authentication for devices. We recommend using one of:
+and so a variety of devices can be used to generate 6-digit two-factor
+authentication codes. We recommend using one of:
 
 -  FreeOTP `for Android <https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp>`__ or `for iOS <https://itunes.apple.com/us/app/freeotp-authenticator/id872559395>`__ installed
 -  A `YubiKey <https://www.yubico.com/products/yubikey-hardware/>`__

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -164,11 +164,11 @@ keep track of, so you should consider how you will label or identify them and
 buy drives accordingly. Drives that are physically larger are often easier to
 label (e.g. with tape, printed sticker or a label from a labelmaker).
 
-Two-factor Authenticator
-^^^^^^^^^^^^^^^^^^^^^^^^
+Two-factor Device
+^^^^^^^^^^^^^^^^^
 Two-factor authentication is used when connecting to different parts of the
 SecureDrop system. Each admin and each journalist needs a two-factor
-authenticator. We currently support two options for two-factor authentication:
+device. We currently support two options for two-factor authentication:
 
 * Your existing smartphone with an app that computes TOTP codes
   (e.g. FreeOTP `for Android <https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp>`__ and `for iOS <https://itunes.apple.com/us/app/freeotp-authenticator/id872559395>`__).

--- a/docs/includes/otp-app.txt
+++ b/docs/includes/otp-app.txt
@@ -1,6 +1,6 @@
 .. tip:: We recommend using FreeOTP (available `for Android <https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp>`__
    and `for iOS <https://itunes.apple.com/us/app/freeotp-authenticator/id872559395>`__)
-   to generate two-factor authentication tokens because it is Free Software.
+   to generate two-factor codes because it is Free Software.
    However, if it does not work for you for any reason, alternatives exist:
 
    * Google Authenticator `for Android <https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2>`__ and `iOS <https://itunes.apple.com/us/app/google-authenticator/id388497605>`__ (proprietary)

--- a/docs/includes/pre-install-hardware-optional.txt
+++ b/docs/includes/pre-install-hardware-optional.txt
@@ -5,7 +5,7 @@
 * an external hard drive for server backups.
 * a USB drive to store :ref:`backups of your Tails workstation drives <backup_workstations>`.
 * a network switch, if you use a firewall with fewer than four ports.
-* a hardware token for HOTP authentication, such as a YubiKey, if you want to
+* a security key for HOTP authentication, such as a YubiKey, if you want to
   use hardware-based two-factor authentication instead of a mobile app.
 * a USB drive with a physical write protection switch, or a USB write blocker,
   if you want to mitigate the risk of introducing malware from your network to

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -53,22 +53,23 @@ computer, unless explicitly configured with an access token.
 
 To visit the *Journalist Interface*, click the *Journalist Interface* icon on the
 desktop. This will open Tor Browser to an ".onion" address. Log in with
-your username, passphrase, and two-factor authentication token, as
-shown in the first screenshot below. (If you have been provided with a YubiKey,
-see :doc:`Using YubiKey with the Journalist Interface <yubikey_setup>` for
+your username, passphrase, and two-factor code, as shown in the first screenshot
+below. (If you have been provided with a YubiKey, see
+:doc:`Using YubiKey with the Journalist Interface <yubikey_setup>` for
 detailed setup and usage information.)
 
 |Journalist Interface Login|
 
-Reset Passphrase or Two-factor Authentication Token
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Reset Passphrase or Two-factor Authentication Credentials
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If necessary, journalists may reset their user passphrase or two-factor
-authentication token in their user profile. To navigate to your user profile,
-log in to the *Journalist Interface* and click on the link in the upper right of
-the screen where it says **Logged on as <your user name>.**
+authentication credentials in their user profile. To navigate to your user
+profile, log in to the *Journalist Interface* and click on the link in the upper
+right of the screen where it says **Logged on as <your user name>.**
 
-If you have lost or forgotten your passphrase or two-factor authentication
-device, you will need to contact your SecureDrop admin for assistance.
+If you have lost or forgotten your passphrase or your two-factor device (i.e.
+your mobile phone or security key), you will need to contact your SecureDrop
+admin for assistance.
 
 |Journalist account profile|
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -154,7 +154,7 @@ Provisioning & Training
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Once SecureDrop is installed, journalists will need to be provided with
-accounts, two-factor tokens, workstations, and so on — and then
+accounts, two-factor credentials, workstations, and so on — and then
 :doc:`trained <training_schedule>` to use these tools safely and reliably. You
 will probably also need to train additional backup admins so that you
 can be sure that your SecureDrop setup keeps running even when your main

--- a/docs/passphrases.rst
+++ b/docs/passphrases.rst
@@ -42,7 +42,7 @@ passphrases:
 
 
 The admin will also need to have a way to generate two-factor
-authentication tokens.
+authentication codes.
 
 .. include:: includes/otp-app.txt
 

--- a/docs/test_the_installation.rst
+++ b/docs/test_the_installation.rst
@@ -23,7 +23,7 @@ try using the verbose command format to troubleshoot: ::
    ssh <username>@<mon .onion>
 
 .. tip:: If your instance uses v2 onion services, you can find the Onion
-         URLs for SSH in ``app-ssh-aths`` and ``mon-ssh-aths`` inside the 
+         URLs for SSH in ``app-ssh-aths`` and ``mon-ssh-aths`` inside the
          ``install_files/ansible-base`` directory. If your instance uses v3
          onion services, check the ``app-ssh.auth_private`` and
          ``mon-ssh.auth_private`` files instead.
@@ -60,7 +60,7 @@ Test the Web Interfaces
 #. Make sure the *Source Interface* is available, and that you can make a
    submission.
 
-   - Open the *Source Interface* in the Tor Browser by clicking on its desktop 
+   - Open the *Source Interface* in the Tor Browser by clicking on its desktop
      shortcut. Proceed through the codename
      generation (copy this down somewhere) and submit a
      test message or file.
@@ -70,9 +70,8 @@ Test the Web Interfaces
 #. Test that you can access the *Journalist Interface*, and that you can log
    in as the admin user you just created.
 
-   - Open the *Journalist Interface* in the Tor Browser by clicking on its desktop 
-     shortcut.  Enter your passphrase and two-factor
-     authentication code to log in.
+   - Open the *Journalist Interface* in the Tor Browser by clicking on its desktop
+     shortcut.  Enter your passphrase and two-factor code to log in.
    - If you have problems logging in to the *Admin/Journalist Interface*,
      SSH to the *Application Server* and restart the ntp daemon to synchronize
      the time: ``sudo service ntp restart``. Also check that your

--- a/docs/threat_model/mitigations.rst
+++ b/docs/threat_model/mitigations.rst
@@ -28,7 +28,7 @@ Countermeasures on the Application Code — SecureDrop Repository/Release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 -  Code (git tags) and releases (packages uploaded to apt) are signed with the airgapped signing key
 -  Protection is placed on master and develop branch on GitHub
--  For SecureDrop Developers, 2-factor authentication is mandated on GitHub
+-  For SecureDrop Developers, two-factor authentication is mandated on GitHub
 -  Community trust is built through 3 trusted code owners and code reviews
 
 Application Code — *Source Interface* and *Journalist Interface*
@@ -95,7 +95,8 @@ Countermeasures unique to *Journalist Interface*
     - Journalist/Admin passphrases are long and automatically generated
     - Passphrases are stored in a database hashed with a unique salt
     - Account generation/revocation/reset is restricted to Admin role
-    - Two-factor authentication is required through a TOTP token or a Yubikey
+    - Two-factor authentication is required (via a TOTP app, or an HOTP
+      device like a YubiKey)
 
 *Application Server* and *Monitor Server*
 -----------------------------------------
@@ -232,5 +233,5 @@ Countermeasures in User Behavior Recommendations
 -  `SecureDrop Deployment Guide <https://docs.securedrop.org/en/stable/deployment_practices.html>`__ gives best practices for proper administration of the SecureDrop system, and its public-facing properties like the Landing Page
 -  `Admin Guide <https://docs.securedrop.org/en/stable/admin.html>`__ gives instructions for long-term maintenance of the technical properties of the SecureDrop system, as well as operations to support Journalists
 -  All Admin tasks are completed over Tor/Tor authenticated Onion Services after installation
--  Any Journalist/Admin password/2FA token resets can only be done by an Admin with password-protected SSH capability or authenticated Onion Service credentials.
+-  Any Journalist/Admin password/2FA credentials resets can only be done by an Admin with password-protected SSH capability or authenticated Onion Service credentials.
 -  Persistent storage on the Admin Workstation is protected with LUKS/dm-crypt encryption

--- a/docs/yubikey_setup.rst
+++ b/docs/yubikey_setup.rst
@@ -12,7 +12,7 @@ requires some configuration steps using a separate software tool.
 What is a YubiKey?
 ------------------
 
-A YubiKey is a physical token used for two-factor authentication. They
+A YubiKey is a physical security key used for two-factor authentication. They
 are made by a company called Yubico and are `commercially available`_.
 
 .. _`commercially available`: https://www.yubico.com/products/yubikey-hardware/fido-u2f-security-key
@@ -28,7 +28,7 @@ Download and Launch the YubiKey Personalization Tool
 
    sudo apt-get update;
    sudo apt-get install yubikey-personalization-gui
-   
+
 #. Once you have downloaded and installed the personalization program,
    open a **Root Terminal** by choosing **Applications ▸ System Tools
    ▸ Root Terminal**.

--- a/securedrop/journalist_app/account.py
+++ b/securedrop/journalist_app/account.py
@@ -46,12 +46,12 @@ def make_blueprint(config):
         if request.method == 'POST':
             token = request.form['token']
             if g.user.verify_token(token):
-                flash(gettext("Token in two-factor authentication verified."),
+                flash(gettext("Your two-factor credentials have been reset successfully."),
                       "notification")
                 return redirect(url_for('account.edit'))
             else:
                 flash(gettext(
-                    "Could not verify token in two-factor authentication."),
+                    "There was a problem verifying the two-factor code. Please try again."),
                       "error")
 
         return render_template('account_new_two_factor.html', user=g.user)

--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -127,14 +127,13 @@ def make_blueprint(config):
             token = request.form['token']
             if user.verify_token(token):
                 flash(gettext(
-                    "Token in two-factor authentication "
-                    "accepted for user {user}.").format(
-                        user=user.username),
+                    "The two-factor code for user \"{user}\" was verified "
+                    "successfully.").format(user=user.username),
                     "notification")
                 return redirect(url_for("admin.index"))
             else:
                 flash(gettext(
-                    "Could not verify token in two-factor authentication."),
+                    "There was a problem verifying the two-factor code. Please try again"),
                       "error")
 
         return render_template("admin_new_user_two_factor.html", user=user)

--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -133,7 +133,7 @@ def make_blueprint(config):
                 return redirect(url_for("admin.index"))
             else:
                 flash(gettext(
-                    "There was a problem verifying the two-factor code. Please try again"),
+                    "There was a problem verifying the two-factor code. Please try again."),
                       "error")
 
         return render_template("admin_new_user_two_factor.html", user=user)

--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -26,7 +26,7 @@ def make_blueprint(config):
                                  request.form['password'],
                                  request.form['token'])
             if user:
-                current_app.logger.info("'{}' logged in with the token {}"
+                current_app.logger.info("'{}' logged in with the two-factor code {}"
                                         .format(request.form['username'],
                                                 request.form['token']))
 

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -101,8 +101,8 @@ def validate_user(username, password, token, error_message=None):
                 if user.is_totp:
                     login_flashed_msg += " "
                     login_flashed_msg += gettext(
-                        "Please wait for a new code from your two-factor token"
-                        " or application before trying again.")
+                        "Please wait for a new code from your two-factor device"
+                        " (mobile app or security key) before trying again.")
             except Exception:
                 pass
 

--- a/securedrop/journalist_templates/account_new_two_factor.html
+++ b/securedrop/journalist_templates/account_new_two_factor.html
@@ -2,7 +2,7 @@
 {% block body %}
 {% if user.is_totp %}
 <h1>{{ gettext('Enable FreeOTP') }}</h1>
-<p>{{ gettext("You're almost done! To finish resetting your two-factor authentication, follow the instructions below to set up FreeOTP. Once you've added the entry for your account in the app, enter one of the 6-digit codes from the app to confirm that two factor authentication is set up correctly.") }}</p>
+<p>{{ gettext("You're almost done! To finish resetting your two-factor authentication, follow the instructions below to set up FreeOTP. Once you've added the entry for your account in the app, enter one of the 6-digit codes from the app to confirm that two-factor authentication is set up correctly.") }}</p>
 
 <ol>
   <li>{{ gettext('Install FreeOTP on your phone') }}</li>
@@ -11,11 +11,12 @@
   <li>{{ gettext('Your phone will now be in "scanning" mode. When you are in this mode, scan the barcode below:') }}</li>
 </ol>
 <div id="qrcode-container">{{ user.shared_secret_qrcode }}</div>
-<p>{{ gettext("Can't scan the barcode? Enter the following code manually:") }} <span id="shared-secret">{{ user.formatted_otp_secret }}</span></p>
-<p>{{ gettext("Once you have scanned the barcode, enter the 6-digit code below:") }}</p>
+<p>{{ gettext("Can't scan the barcode? You can manually pair FreeOTP with your SecureDrop account by entering the following two-factor secret into the app:") }}
+<p class="center"><span id="shared-secret">{{ user.formatted_otp_secret }}</span></p>
+<p>{{ gettext("Once you have paired FreeOTP with this account, enter the 6-digit verification code below:") }}</p>
 {% else %}
 <h1>{{ gettext('Enable YubiKey (OATH-HOTP)') }}</h1>
-<p>{{ gettext('Once you have configured your YubiKey, enter the 6-digit code below:') }}</p>
+<p>{{ gettext('Once you have configured your YubiKey, enter the 6-digit verification code below:') }}</p>
 {% endif %}
 <form id="check-token" method="post">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">

--- a/securedrop/journalist_templates/admin_new_user_two_factor.html
+++ b/securedrop/journalist_templates/admin_new_user_two_factor.html
@@ -3,7 +3,7 @@
 {% block body %}
 {% if user.is_totp %}
 <h1>{{ gettext('Enable FreeOTP') }}</h1>
-<p>{{ gettext("You're almost done! To finish adding this new user, have them follow the instructions below to set up two-factor authentication with FreeOTP. Once they've added an entry for this account in the app, have them enter one of the 6-digit codes from the app to confirm that two factor authentication is set up correctly.") }}</p>
+<p>{{ gettext("You're almost done! To finish adding this new user, have them follow the instructions below to set up two-factor authentication with FreeOTP. Once they've added an entry for this account in the app, have them enter one of the 6-digit codes from the app to confirm that two-factor authentication is set up correctly.") }}</p>
 
 <ol>
   <li>{{ gettext('Install FreeOTP on your phone') }}</li>
@@ -12,10 +12,10 @@
   <li>{{ gettext('Your phone will now be in "scanning" mode. When you are in this mode, scan the barcode below:') }}</li>
 </ol>
 <div id="qrcode-container">{{ user.shared_secret_qrcode }}</div>
-<p>{{ gettext("Can't scan the barcode? Enter the following code manually:") }}</p>
+<p>{{ gettext("Can't scan the barcode? You can manually pair FreeOTP with this account by entering the following two-factor secret into the app:") }}</p>
 <p class="center"><span id="shared-secret">{{ user.formatted_otp_secret }}</span></p>
 
-<p>{{ gettext('Once you have scanned the barcode, enter the 6-digit code below:') }}</p>
+<p>{{ gettext('Once you have pair FreeOTP with this account, enter the 6-digit code below:') }}</p>
 {% else %}
 <h1>{{ gettext('Enable YubiKey (OATH-HOTP)') }}</h1>
 <p>{{ gettext('Once you have configured your YubiKey, enter the 6-digit code below:') }}</p>

--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -84,7 +84,7 @@
 {% else %}
 <p>{{ gettext('If your two-factor authentication credentials have been lost or compromised, or you got a new device, you can reset your credentials here. <em>If you do this, make sure you are ready to set up your new device, otherwise you will be locked out of your account.</em>') }}</p>
 {% endif %}
-<p>{{ gettext('To reset two-factor authentication for mobile apps such as FreeOTP, choose the first option. For hardware tokens like the YubiKey, choose the second one.') }}</p>
+<p>{{ gettext('To reset two-factor authentication for mobile apps such as FreeOTP, choose the first option. For security keys like the YubiKey, choose the second one.') }}</p>
 
 {% if user %}
   {% set totp_reset_url = url_for('admin.reset_two_factor_totp') %}
@@ -109,7 +109,7 @@
 </form>
 {%- endmacro %}
 
-{{ twofa_reset(user, totp_reset_url, "totp", gettext("Reset two-factor authentication for mobile apps, such as FreeOTP"), gettext("RESET APP TOKEN"))}}
-{{ twofa_reset(user, hotp_reset_url, "hotp", gettext("Reset two-factor authentication for hardware tokens, like a YubiKey"), gettext("RESET HARDWARE TOKEN"))}}
+{{ twofa_reset(user, totp_reset_url, "totp", gettext("Reset two-factor authentication for mobile apps, such as FreeOTP"), gettext("RESET MOBILE APP CREDENTIALS"))}}
+{{ twofa_reset(user, hotp_reset_url, "hotp", gettext("Reset two-factor authentication for security keys, like a YubiKey"), gettext("RESET SECURITY KEY CREDENTIALS"))}}
 
 {% endblock %}

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -661,10 +661,10 @@ class Journalist(db.Model):
             # Prevent TOTP token reuse
             if user.last_token is not None:
                 if pyotp.utils.compare_digest(token, user.last_token):
-                    raise BadTokenException("previously used token "
+                    raise BadTokenException("previously used two-factor code "
                                             "{}".format(token))
         if not user.verify_token(token):
-            raise BadTokenException("invalid token")
+            raise BadTokenException("invalid two-factor code")
         if not user.valid_password(password):
             raise WrongPasswordException("invalid password")
         return user

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -342,7 +342,7 @@ class JournalistNavigationStepsMixin:
                 # Successfully verifying the code should redirect to the admin
                 # interface, and flash a message indicating success
                 flash_msg = self.driver.find_elements_by_css_selector(".flash")
-                assert ("Token in two-factor authentication accepted for user {}.").format(
+                assert "The two-factor code for user \"{user}\" was verified successfully.".format(
                     self.new_user["username"]
                 ) in [el.text for el in flash_msg]
 
@@ -721,12 +721,14 @@ class JournalistNavigationStepsMixin:
     def _visit_edit_hotp_secret(self):
         self._visit_edit_secret(
             "hotp",
-            "Reset 2FA for hardware tokens like Yubikey")
+            "Reset two-factor authentication for security keys like Yubikey")
 
     def _visit_edit_totp_secret(self):
         self._visit_edit_secret(
             "totp",
-            "Reset 2FA for mobile apps such as FreeOTP or Google Authenticator")
+            "Reset two-factor authentication for mobile apps such as FreeOTP or "
+            "Google Authenticator"
+        )
 
     def _admin_visits_add_user(self):
         add_user_btn = self.driver.find_element_by_css_selector("button#add-user")
@@ -793,7 +795,7 @@ class JournalistNavigationStepsMixin:
             assert tip_opacity == "1"
 
             if not hasattr(self, "accept_languages"):
-                assert tip_text == "Reset 2FA for hardware tokens like Yubikey"
+                assert tip_text == "Reset two-factor authentication for security keys like Yubikey"
 
             self.safe_click_by_id("button-reset-two-factor-hotp")
 
@@ -823,7 +825,10 @@ class JournalistNavigationStepsMixin:
 
             assert tip_opacity == "1"
             if not hasattr(self, "accept_languages"):
-                expected_text = "Reset 2FA for mobile apps such as FreeOTP or Google Authenticator"
+                expected_text = (
+                    "Reset two-factor authentication for mobile apps such as FreeOTP "
+                    "or Google Authenticator"
+                )
                 assert tip_text == expected_text
 
             self.safe_click_by_id("button-reset-two-factor-totp")

--- a/securedrop/tests/test_2fa.py
+++ b/securedrop/tests/test_2fa.py
@@ -102,7 +102,7 @@ def test_bad_token_fails_to_verify_on_admin_new_user_two_factor_page(
 
                 assert resp.status_code == 200
                 ins.assert_message_flashed(
-                    'Could not verify token in two-factor authentication.',
+                    'There was a problem verifying the two-factor code. Please try again.',
                     'error')
 
         # last_token should be set to the token we just tried to use
@@ -118,8 +118,9 @@ def test_bad_token_fails_to_verify_on_admin_new_user_two_factor_page(
                                         uid=test_admin['id']),
                                 data=dict(token=invalid_token))
                 ins.assert_message_flashed(
-                    'Could not verify token in two-factor authentication.',
-                    'error')
+                    'There was a problem verifying the two-factor code. Please try again.',
+                    'error'
+                )
 
 
 def test_bad_token_fails_to_verify_on_new_user_two_factor_page(
@@ -139,8 +140,9 @@ def test_bad_token_fails_to_verify_on_new_user_two_factor_page(
 
                 assert resp.status_code == 200
                 ins.assert_message_flashed(
-                    'Could not verify token in two-factor authentication.',
-                    'error')
+                    'There was a problem verifying the two-factor code. Please try again.',
+                    'error'
+                )
 
         # last_token should be set to the token we just tried to use
         with journalist_app.app_context():
@@ -155,5 +157,6 @@ def test_bad_token_fails_to_verify_on_new_user_two_factor_page(
                 resp = app.post(url_for('account.new_two_factor'),
                                 data=dict(token=invalid_token))
                 ins.assert_message_flashed(
-                    'Could not verify token in two-factor authentication.',
-                    'error')
+                    'There was a problem verifying the two-factor code. Please try again.',
+                    'error'
+                )


### PR DESCRIPTION
Towards #2331 

- Use "two-factor code" when referring to 6 digit codes
- Use "two-factor secret" for 2FA seeds
- Use "two-factor credentials" for reset operations
- Use "two-factor device" as umbrella term for YubiKey OR mobile
  app, but minimize usage and always explain it, to avoid
  confusion
- Avoid use of "authenticator"
- Avoid use of "token" in 2FA contexts
- Use "security key" to describe physical devices like YubiKeys
- Clearer error/success messages using this language
- Clearer instructions to the user on 2FA screens

## Status

Work in progress