### PR TITLE
Updated references to workstation virtualenv to Python3 version

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -26,8 +26,7 @@ on network speed and computing power.
 .. note:: Occasionally this command times out due to network latency issues. You
           should be able to re-run the command and complete the setup. If you
           run into a problem, try removing the
-          ``~/Persistent/securedrop/admin/.venv/`` directory and the
-          ``~/Persistent/securedrop/.venv`` symbolic link and running the
+          ``~/Persistent/securedrop/admin/.venv3/`` directory and running the
           command again.
 
 .. important:: The setup command should only be run as the ``amnesia`` user,

--- a/docs/kernel_troubleshooting.rst
+++ b/docs/kernel_troubleshooting.rst
@@ -175,7 +175,7 @@ Run the following commands via SSH from the *Admin Workstation*:
 .. code:: sh
 
   cd ~/Persistent/securedrop/
-  source .venv/bin/activate
+  source admin/.venv3/bin/activate
   cd install_files/ansible-base
   ansible all -b -m setup > server-facts.log
 


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #5016

Updates references to the workstation securedrop virtualenv to use the correct path for Python 3.

## Testing
docs-only PR

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally