### PR TITLE
Address LGTM alerts in securedrop/

### DIFF
--- a/securedrop/alembic/env.py
+++ b/securedrop/alembic/env.py
@@ -1,6 +1,6 @@
 from __future__ import with_statement
 
-import os
+import os  # lgtm [py/import-and-import-from]
 import sys
 
 from alembic import context

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -14,7 +14,7 @@ from pretty_bad_protocol._util import _is_stream, _make_binary_stream
 
 import rm
 
-import typing
+import typing  # lgtm [py/import-and-import-from]
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
 if typing.TYPE_CHECKING:
     # flake8 can not understand type annotation yet.

--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -20,7 +20,7 @@ from flask_babel import Babel
 from babel import core
 
 import collections
-import os
+import os  # lgtm [py/import-and-import-from]
 import re
 
 from os import path

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -23,7 +23,7 @@ from journalist_app.utils import (get_source, logged_in,
 from models import InstanceConfig, Journalist
 from store import Storage
 
-import typing
+import typing  # lgtm [py/import-and-import-from]
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
 if typing.TYPE_CHECKING:
     # flake8 can not understand type annotation yet.

--- a/securedrop/management/submissions.py
+++ b/securedrop/management/submissions.py
@@ -144,7 +144,6 @@ def delete_disconnected_fs_submissions(args):
         time_elapsed = 0.0
         rate = 1.0
         filecount = len(disconnected_files)
-        eta = 1.0
         eta_msg = ""
         for i, f in enumerate(disconnected_files, 1):
             remove = args.force

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 from db import db
 
-import typing
+import typing  # lgtm [py/import-and-import-from]
 
 if typing.TYPE_CHECKING:
     # flake8 can not understand type annotation yet.
@@ -782,7 +782,7 @@ class InstanceConfig(db.Model):
         '''
 
         try:
-            return cls.query.filter(cls.valid_until == None).one()  # noqa: E711
+            return cls.query.filter(cls.valid_until == None).one()  # lgtm [py/test-equals-none]  # noqa: E711, E501
         except NoResultFound:
             current = cls()
             db.session.add(current)

--- a/securedrop/qa_loader.py
+++ b/securedrop/qa_loader.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import math
-import os
+import os  # lgtm [py/import-and-import-from]
 import random
 import string
 import sys

--- a/securedrop/sdconfig.py
+++ b/securedrop/sdconfig.py
@@ -2,7 +2,7 @@
 
 import config as _config
 
-import typing
+import typing  # lgtm [py/import-and-import-from]
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
 if typing.TYPE_CHECKING:
     # flake8 can not understand type annotation yet.

--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -3,7 +3,7 @@ import binascii
 import gzip
 import os
 import re
-import tempfile
+import tempfile  # lgtm [py/import-and-import-from]
 import zipfile
 
 from flask import current_app
@@ -18,7 +18,7 @@ import rm
 from worker import create_queue
 
 
-import typing
+import typing  # lgtm [py/import-and-import-from]
 
 if typing.TYPE_CHECKING:
     # flake8 can not understand type annotation yet.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5007.

Address the remaining LGTM alerts in `securedrop/`.

## Testing

Check the LGTM bot message in this PR for the number of alerts fixed (expected fixed: 1, ignored: 10).

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [X] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
