### PR TITLE
Match label for values with checkbox ids

### DIFF
--- a/securedrop/journalist_templates/admin_add_user.html
+++ b/securedrop/journalist_templates/admin_add_user.html
@@ -56,7 +56,7 @@
   <p>{{ gettext("The user's password will be:") }} <span class="password" id="password">{{ password }}</span></p>
   <p>
     {{ form.is_admin(id="is-admin") }}
-    <label for="is_admin">{{ gettext('Is Admin') }}</label>
+    <label for="is-admin">{{ gettext('Is Admin') }}</label>
     <br>
     {% for error in form.is_admin.errors %}
       <span class="form-validation-error">{{ error }}</span>
@@ -64,7 +64,7 @@
   </p>
   <p>
     {{ form.is_hotp(id="is-hotp") }}
-    <label for="is_hotp">{{ gettext("Is using a YubiKey [HOTP]") }} </label>
+    <label for="is-hotp">{{ gettext("Is using a YubiKey [HOTP]") }} </label>
     {{ form.otp_secret(placeholder=gettext('HOTP Secret'), size="60") }}
     <br>
     {% for error in form.is_hotp.errors + form.otp_secret.errors %}

--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -22,7 +22,7 @@
     </p>
     <p>
       <input name="is_admin" id="is-admin" type="checkbox" {% if user.is_admin %}checked{% endif %}>
-      <label for="is_admin">{{ gettext('Is Admin') }}</label>
+      <label for="is-admin">{{ gettext('Is Admin') }}</label>
     </p>
     <button type="submit" id="update">{{ gettext('UPDATE') }}</button>
   </form>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5013.

Changes proposed in this pull request:

Change three label `for` values to match the corresponding checkbox `id` values.

Two mismatches were identified in #5013 by @eloquence and I identified a third mismatch in `/admin/edit/` by making a systematic review of all checkboxes having a label.

## Testing

In the dev environment, login to the Journalist Interface as admin.
1. Access `/admin/add` and verify that clicking on the "Is Admin" and "Is using a YubiKey [HOTP]" labels toggles the respective checkboxes.
1. Access `/admin/edit/1` and verify that clicking on the "Is Admin" label toggles the checkbox.

## Deployment

Any special considerations for deployment?

N/A

## Checklist

### If you made changes to the server application code:

- [X] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
