### PR TITLE
prevent unintentional deleting of directories during move to shredder dir

### DIFF
--- a/securedrop/bin/run
+++ b/securedrop/bin/run
@@ -17,5 +17,6 @@ reset_demo
 # run the batch processing services normally managed by systemd
 /opt/venvs/securedrop-app-code/bin/rqworker &
 PYTHONPATH="${REPOROOT}/securedrop" /opt/venvs/securedrop-app-code/bin/python "${REPOROOT}/securedrop/scripts/rqrequeue" --interval 60 &
+/opt/venvs/securedrop-app-code/bin/python "${REPOROOT}/securedrop/scripts/shredder" --interval 60 &
 
 ./manage.py run

--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -68,6 +68,25 @@ class NotEncrypted(Exception):
     pass
 
 
+def safe_renames(old, new):
+    """safe_renames(old, new)
+
+    This is a modified version of Python's os.renames that does not
+    prune directories.
+    Super-rename; create directories as necessary without deleting any
+    left empty.  Works like rename, except creation of any intermediate
+    directories needed to make the new pathname good is attempted
+    first.
+    Note: this function can fail with the new directory structure made
+    if you lack permissions needed to unlink the leaf directory or
+    file.
+    """
+    head, tail = os.path.split(new)
+    if head and tail and not os.path.exists(head):
+        os.makedirs(head)
+    os.rename(old, new)
+
+
 class Storage:
 
     def __init__(self, storage_path, temp_dir, gpg_key):
@@ -207,7 +226,7 @@ class Storage:
         """
         Moves content from the store to the shredder for secure deletion.
 
-        Python's os.renames (and the underlying rename(2) calls) will
+        Python's safe_renames (and the underlying rename(2) calls) will
         silently overwrite content, which could bypass secure
         deletion, so we create a temporary directory under the
         shredder directory and move the specified content there.
@@ -230,7 +249,7 @@ class Storage:
         relpath = os.path.relpath(path, start=self.storage_path)
         dest = os.path.join(tempfile.mkdtemp(dir=self.__shredder_path), relpath)
         current_app.logger.info("Moving {} to shredder: {}".format(path, dest))
-        os.renames(path, dest)
+        safe_renames(path, dest)
 
     def clear_shredder(self):
         current_app.logger.info("Clearing shredder")


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5031 

Changes proposed in this pull request:
 - Adds shredder to dev env to more easily replicate issues like this
 - Adds a modified version of `os.renames` that does _not_ prune directories (cc @kushaldas you might want to review)

## Testing

First reproduce the underlying issue, this can be done on `develop` or on the 1.2.0-rc1 tag even in dev:

1. `make dev`
2. `docker exec -it <container> /bin/bash`
3. in container: `ls /var/lib/securedrop`. Confirm `store` is in there.
4. now via the journalist interface index: select all -> delete
5. in container: `ls /var/lib/securedrop`. Confirm `store` is gone.
6. note that if you try to submit again, you'll get a 500 because `store` is gone

Now on this branch:

1. `make dev`
2. `docker exec -it <container> /bin/bash`
3. in container: `ls /var/lib/securedrop`. Confirm `store` is in there.
4. now via the journalist interface index: select all -> delete
5. in container: `ls /var/lib/securedrop`. Confirm `store` is in there. Also confirm all the source docs/directories were moved _from_ `/var/lib/securedrop/store` to `/var/lib/securedrop/shredder`.
6. note that if you try to submit again, you should succeed
7. After 60 seconds, shredder will delete the contents of `/var/lib/securedrop/shredder`.

## Deployment

app code only, so will be deployed via `securedrop-app-code`

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container (relying on CI, ran only a subset of tests locally)

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

