### PR TITLE
Updated Tails network hook to use python3

### DIFF
--- a/install_files/ansible-base/roles/tails-config/files/65-configure-tor-for-securedrop.sh
+++ b/install_files/ansible-base/roles/tails-config/files/65-configure-tor-for-securedrop.sh
@@ -14,4 +14,4 @@ if [ "$2" != "up" ]; then
   exit 0
 fi
 
-/usr/bin/python /home/amnesia/Persistent/.securedrop/securedrop_init.py
+/usr/bin/python3 /home/amnesia/Persistent/.securedrop/securedrop_init.py

--- a/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
+++ b/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
@@ -138,10 +138,10 @@ if distro_id == 'Debian' and os.uname()[1] == 'amnesia':
 # reacquire uid0 and notify the user
 os.setresuid(0, 0, -1)
 os.setresgid(0, 0, -1)
+success_message = 'You can now access the Journalist Interface.\nIf you are an admin, you can now SSH to the servers.'  # noqa: E501
 subprocess.call(['tails-notify-user',
                  'SecureDrop successfully auto-configured!',
-                 'You can now access the Journalist Interface.\n',
-                 'If you are an admin, you can now SSH to the servers.'])
+                 success_message])
 
 # As the amnesia user, check for SecureDrop workstation updates.
 os.setresgid(amnesia_gid, amnesia_gid, -1)
@@ -152,6 +152,6 @@ output = subprocess.check_output([path_securedrop_admin_venv,
                                   'check_for_updates'], env=env)
 
 flag_location = "/home/amnesia/Persistent/.securedrop/securedrop_update.flag"
-if 'Update needed' in output or os.path.exists(flag_location):
+if b'Update needed' in output or os.path.exists(flag_location):
     # Start the SecureDrop updater GUI.
     subprocess.Popen(['python3', path_gui_updater], env=env)


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #5030, including a fix to Tails notification not mentioned in issue :)



## Testing

On an existing prod VM or h/w install:

- in the Admin Workstation, remove the existing network hook and files:
```
sudo rm /live/persistence/TailsData_unlocked/custom-nm-hooks/65-configure-tor-for-securedrop.sh
sudo rm -rf ~/Persistent/.securedrop
```
- check out this branch and run `./securedrop-admin tailsconfig`
- [ ] Verify that the updater appears, the tails "SecureDrop successfully configured!" notification appears, and the interfaces and SSH proxies are available.

On a new install using this branch:
- run `./securedrop-admin tailsconfig` after the install command
- [ ] Verify that the updater appears, the tails "SecureDrop successfully configured!" notification appears, and the interfaces and SSH proxies are available.

## Deployment
Deployed when workstation set up or updated.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR