### PR TITLE
add confirmation flash when submission preferences are saved

### DIFF
--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -59,7 +59,7 @@ def make_blueprint(config):
         form = SubmissionPreferencesForm()
         if form.validate_on_submit():
             # The UI prompt ("prevent") is the opposite of the setting ("allow"):
-            flash(gettext("Preferences Saved."), "submission-preferences-success")
+            flash(gettext("Preferences saved."), "submission-preferences-success")
             value = not bool(request.form.get('prevent_document_uploads'))
             InstanceConfig.set('allow_document_uploads', value)
             return redirect(url_for('admin.manage_config'))

--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -59,6 +59,7 @@ def make_blueprint(config):
         form = SubmissionPreferencesForm()
         if form.validate_on_submit():
             # The UI prompt ("prevent") is the opposite of the setting ("allow"):
+            flash(gettext("Preferences Saved."), "submission-preferences-success")
             value = not bool(request.form.get('prevent_document_uploads'))
             InstanceConfig.set('allow_document_uploads', value)
             return redirect(url_for('admin.manage_config'))

--- a/securedrop/journalist_templates/config.html
+++ b/securedrop/journalist_templates/config.html
@@ -54,6 +54,7 @@
   <button type="submit" id="submit-submission-preferences">
     <i class="fas fa-pencil-alt"></i> {{ gettext('UPDATE SUBMISSION PREFERENCES') }}
   </button>
+  {% include 'submission_preferences_saved_flash.html' %}
 </form>
 
 {% endblock %}

--- a/securedrop/journalist_templates/logo_upload_flashed.html
+++ b/securedrop/journalist_templates/logo_upload_flashed.html
@@ -1,4 +1,4 @@
-{# these are flashed messages for the logo upload file verifiaction #}
+{# these are flashed messages for the logo upload file verification #}
 {% with messages = get_flashed_messages(with_categories=True, category_filter=["logo-success", "logo-error"]) %}
   {% for category, message in messages %}
     {% set category_status = category[5:] %}

--- a/securedrop/journalist_templates/submission_preferences_saved_flash.html
+++ b/securedrop/journalist_templates/submission_preferences_saved_flash.html
@@ -1,0 +1,10 @@
+{# these are flashed messages for the logo upload file verifiaction #}
+{% with messages = get_flashed_messages(with_categories=True, category_filter=["submission-preferences-success"]) %}
+  {% for category, message in messages %}
+    {% set category_status = category[23:] %}
+      <div class="flash {{ category_status }}">
+        <img src="{{ url_for('static', filename='i/success_checkmark.png') }}" height="17" width="20">
+        {{ message }}
+      </div>
+  {% endfor %}
+{% endwith %}

--- a/securedrop/journalist_templates/submission_preferences_saved_flash.html
+++ b/securedrop/journalist_templates/submission_preferences_saved_flash.html
@@ -1,6 +1,7 @@
-{# these are flashed messages for the logo upload file verifiaction #}
 {% with messages = get_flashed_messages(with_categories=True, category_filter=["submission-preferences-success"]) %}
   {% for category, message in messages %}
+{#  Get the end of the of the category message which
+    contains the category status.(success/error)#}
     {% set category_status = category[23:] %}
       <div class="flash {{ category_status }}">
         <img src="{{ url_for('static', filename='i/success_checkmark.png') }}" height="17" width="20">

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -287,10 +287,20 @@ class JournalistNavigationStepsMixin:
             self.safe_click_by_id("prevent_document_uploads")
             self.safe_click_by_id("submit-submission-preferences")
 
+        def preferences_saved():
+            flash_msg = self.driver.find_element_by_css_selector(".flash")
+            assert "Preferences saved." in flash_msg.text
+        self.wait_for(preferences_saved, timeout=self.timeout * 6)
+
     def _admin_allows_document_uploads(self):
         if self.driver.find_element_by_id("prevent_document_uploads").is_selected():
             self.safe_click_by_id("prevent_document_uploads")
             self.safe_click_by_id("submit-submission-preferences")
+
+        def preferences_saved():
+            flash_msg = self.driver.find_element_by_css_selector(".flash")
+            assert "Preferences saved." in flash_msg.text
+        self.wait_for(preferences_saved, timeout=self.timeout * 6)
 
     def _add_user(self, username, first_name="", last_name="", is_admin=False, hotp=None):
         self.safe_send_keys_by_css_selector('input[name="username"]', username)

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1299,8 +1299,8 @@ def test_prevent_document_uploads(journalist_app, test_admin):
         assert InstanceConfig.get_current().allow_document_uploads is False
         with InstrumentedApp(journalist_app) as ins:
             app.post(url_for('admin.update_submission_preferences'),
-                    data=form.data,
-                    follow_redirects=True)
+                     data=form.data,
+                     follow_redirects=True)
             ins.assert_message_flashed('Preferences saved.', 'submission-preferences-success')
 
 
@@ -1313,8 +1313,9 @@ def test_no_prevent_document_uploads(journalist_app, test_admin):
         assert InstanceConfig.get_current().allow_document_uploads is True
         with InstrumentedApp(journalist_app) as ins:
             app.post(url_for('admin.update_submission_preferences'),
-                    follow_redirects=True)
+                     follow_redirects=True)
             ins.assert_message_flashed('Preferences saved.', 'submission-preferences-success')
+
 
 def test_logo_upload_with_valid_image_succeeds(journalist_app, test_admin):
     # Save original logo to restore after test run

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1297,6 +1297,11 @@ def test_prevent_document_uploads(journalist_app, test_admin):
                  data=form.data,
                  follow_redirects=True)
         assert InstanceConfig.get_current().allow_document_uploads is False
+        with InstrumentedApp(journalist_app) as ins:
+            app.post(url_for('admin.update_submission_preferences'),
+                    data=form.data,
+                    follow_redirects=True)
+            ins.assert_message_flashed('Preferences saved.', 'submission-preferences-success')
 
 
 def test_no_prevent_document_uploads(journalist_app, test_admin):
@@ -1306,7 +1311,10 @@ def test_no_prevent_document_uploads(journalist_app, test_admin):
         app.post(url_for('admin.update_submission_preferences'),
                  follow_redirects=True)
         assert InstanceConfig.get_current().allow_document_uploads is True
-
+        with InstrumentedApp(journalist_app) as ins:
+            app.post(url_for('admin.update_submission_preferences'),
+                    follow_redirects=True)
+            ins.assert_message_flashed('Preferences saved.', 'submission-preferences-success')
 
 def test_logo_upload_with_valid_image_succeeds(journalist_app, test_admin):
     # Save original logo to restore after test run


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5009.

Changes proposed in this pull request:

Add a flashed message when a user succesfully submits a change with the submission preferences form. The current implementation doesn't differentiate between submissions which actually change anything, but that should be easy enough if it would be desirable.

## Testing

### manual
* navigate to /admin/config
* choose a submission preference by checking/unchecking box
* hit 'update submission preferences'

A flashed message should show up, indicating that the setting has been successfully saved. 

## automated

I'm unsure if this feature needs automated testing. I'll be happy to add some if required!

## Checklist

### If you made changes to the server application code:

- [x ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Unsure if I need to do this, as mentioned above.