### PR TITLE
Handle multiple instances of source /generate

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -60,7 +60,7 @@ def make_blueprint(config):
         if logged_in():
             flash(gettext("You have already logged-in from a different browser tab.\n"
                           "Please verify your codename below as it may differ from "
-                          "the one displayed on the previous page"),
+                          "the one displayed on the previous page."),
                   'notification')
         else:
             if session['multiple_codenames']:


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #4458.

Changes proposed in this pull request:

When the source opens more than one browser tabs on /generate before clicking on SUBMIT DOCUMENTS:
- Flashes a message promting the source to verify their codename in /lookup after they click on SUBMIT DOCUMENTS in a fist instance of /generate.
- Redirects the source to /lookup when they click on SUBMIT DOCUMENTS in a second instance of /generate and displays a flash message prompting the source to verify their codename.
- Makes the codename in /lookup visible by default.

This eliminates the 500 server error reported in #4458 and reduces the potential of codename confusion following the generation of multiple codenames in different browser tabs or windows.

The behavior when only one instance of /generate is opened remains unchanged.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
