### PR TITLE
Use the same 2FA instructions in journo/admin templates

### DIFF
--- a/securedrop/journalist_templates/admin_new_user_two_factor.html
+++ b/securedrop/journalist_templates/admin_new_user_two_factor.html
@@ -15,7 +15,7 @@
 <p>{{ gettext("Can't scan the barcode? You can manually pair FreeOTP with this account by entering the following two-factor secret into the app:") }}</p>
 <p class="center"><span id="shared-secret">{{ user.formatted_otp_secret }}</span></p>
 
-<p>{{ gettext('Once you have paired FreeOTP with this account, enter the 6-digit code below:') }}</p>
+<p>{{ gettext('Once you have paired FreeOTP with this account, enter the 6-digit verification code below:') }}</p>
 {% else %}
 <h1>{{ gettext('Enable YubiKey (OATH-HOTP)') }}</h1>
 <p>{{ gettext('Once you have configured your YubiKey, enter the 6-digit code below:') }}</p>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The journalist template says "verification code" instead of just "code" in "Once you have paired FreeOTP with this account, enter the 6-digit code below". This makes the equivalent admin template consistent and reduces the translation work.

This isn't urgent and can be dealt with after 1.2.0.

## Testing

- Run `make dev`.
- Log in as `journalist`
- Visit [the account editing page](http://localhost:8081/account/account)
- Click `RESET MOBILE APP CREDENTIALS`
- Note the string at the bottom: `Once you have paired FreeOTP with this account, enter the 6-digit verification code below:`
- Click on `Admin` in the top navigation bar.
- Click the pencil icon under `Edit` for one of the accounts.
- Click `RESET MOBILE APP CREDENTIALS`
- Confirm that the string at the bottom is the same: `Once you have paired FreeOTP with this account, enter the 6-digit verification code below:`

## Deployment

Adds a clarifying word to the admin 2FA reset template, making it consistent. Has no effect beyond the user interface.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
