### PR TITLE
Parallelize CI translation tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,11 +115,12 @@ jobs:
 
   translation-tests:
     machine:
+      image: ubuntu-1604:201903-01
       enabled: true
     environment:
       DOCKER_API_VERSION: 1.23
       BASE_OS: xenial
-    parallelism: 2
+    parallelism: 20
     steps:
       - checkout
       - *rebaseontarget
@@ -135,8 +136,9 @@ jobs:
           command: |
             BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^i18n")
             if ! [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
-            export TESTFILES=$(cd securedrop; circleci tests glob 'tests/pageslayout/test*py' |circleci tests split --split-by=timings |xargs echo)
-            fromtag=$(docker images |grep securedrop-test-xenial-py3 |head -n1 |awk '{print $2}')
+            sudo apt update && sudo apt install python-sh python-pybabel
+            export LOCALE="$(/usr/bin/python2 securedrop/i18n_tool.py list-locales --lines | circleci tests split | tr '\n' ' ')"
+            fromtag=$(docker images | grep securedrop-test-xenial-py3 | head -n1 | awk '{print $2}')
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" make translation-test
 
       - store_test_results:

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ securedrop/config.py: ## Generate the test SecureDrop application config.
 		 ctx.update(dict((k, {"stdout":v}) for k,v in os.environ.items())); \
 		 ctx = open("config.py", "w").write(env.get_template("config.py.example").render(ctx))'
 	@echo >> securedrop/config.py
-	@echo "SUPPORTED_LOCALES = $$(if test -f /opt/venvs/securedrop-app-code/bin/python3; then ./securedrop/i18n_tool.py list-locales; else DOCKER_BUILD_VERBOSE=false $(DEVSHELL) ./i18n_tool.py list-locales; fi)" >> securedrop/config.py
+	@echo "SUPPORTED_LOCALES = $$(if test -f /opt/venvs/securedrop-app-code/bin/python3; then ./securedrop/i18n_tool.py list-locales --python; else DOCKER_BUILD_VERBOSE=false $(DEVSHELL) ./i18n_tool.py list-locales --python; fi)" >> securedrop/config.py
 	@echo
 
 .PHONY: test-config
@@ -284,7 +284,7 @@ translate:  ## Update POT files from translated strings in source code.
 .PHONY: translation-test
 translation-test:  ## Run page layout tests in all supported languages.
 	@echo "Running translation tests..."
-	@$(DEVSHELL) $(SDBIN)/translation-test $${TESTFILES:-tests/pageslayout}
+	@$(DEVSHELL) $(SDBIN)/translation-test "$${LOCALE:-$(./i18n_tool.py list-locales)}"
 	@echo
 
 .PHONY: list-translators

--- a/securedrop/bin/translation-test
+++ b/securedrop/bin/translation-test
@@ -17,17 +17,29 @@ maybe_create_config_py
 
 mkdir -p "/tmp/test-results/logs"
 
+SUPPORTED_LOCALES=$(./i18n_tool.py list-locales)
+LOCALES="${*:-${SUPPORTED_LOCALES}}"
+
+function locale_is_supported {
+    echo "$SUPPORTED_LOCALES" | grep -q "$1"
+}
+
+for l in $LOCALES
+do
+    locale_is_supported "$l" || (printf "Unsupported locale \"%s\"\n" "$l"; exit 1 )
+done
+
+printf "Running tests in these locales: %s\n" "$LOCALES"
+
 # Taking screenshots for consumes a lot of memory
 # and can result in OOM errors in CI. Running each locale
 # separately avoids this.
-SUPPORTED_LOCALES=$(./i18n_tool.py list-locales | sed -r -e "s/[][',]//g")
-printf "Running tests in these locales: %s\n" "$SUPPORTED_LOCALES"
-for locale in $SUPPORTED_LOCALES
+for locale in $LOCALES
 do
   PAGE_LAYOUT_LOCALES=$locale pytest \
     -v \
     --force-flaky --max-runs=3 \
     --page-layout \
     --durations 10 \
-    "$@"
+    tests/pageslayout
 done

--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -369,10 +369,26 @@ class I18NTool(object):
 
     def set_list_locales_parser(self, subps):
         parser = subps.add_parser('list-locales', help='List supported locales')
+        parser.add_argument(
+            '--python',
+            action='store_true',
+            help=('Print the locales as a Python list suitable for config.py')
+        )
+        parser.add_argument(
+            '--lines',
+            action='store_true',
+            help=('List one locale per line')
+        )
         parser.set_defaults(func=self.list_locales)
 
     def list_locales(self, args):
-        print(sorted(list(self.SUPPORTED_LANGUAGES.keys()) + ['en_US']))
+        if args.lines:
+            for l in sorted(list(self.SUPPORTED_LANGUAGES.keys()) + ['en_US']):
+                print(l)
+        elif args.python:
+            print(sorted(list(self.SUPPORTED_LANGUAGES.keys()) + ['en_US']))
+        else:
+            print(" ".join(sorted(list(self.SUPPORTED_LANGUAGES.keys()) + ['en_US'])))
 
     def set_list_translators_parser(self, subps):
         parser = subps.add_parser('list-translators',


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Split the CI translation test job up by locale instead of test file, and increase the parallelism to 20. This lets the current set of 20 locales finish in less than 20 minutes; as we add languages we may
want to increase the container count further, or we may decide that other work needs to get through CI too and the LM shouldn't be such a pig.

To make the parsing and splitting of our supported locales a little nicer, I added options to the list-locales function of i18n_tool.py. Now the default is to print a space-separated list suitable for most shell use; --python prints a Python list suitable for inclusion in the SecureDrop config.py; and --lines prints one locale per line, suitable for feeding to `circleci tests split`, among other things.


## Testing

Check the CircleCI translation-tests job run for this PR and verify that tested one locale in each of 20 containers.

## Deployment

Should not affect production deployments. This does change `i18n_tool.py`'s `list-locales` function, which affects config.py generation in dev/test environments, but in production the locales are obtained via `securedrop-admin sdconfig`.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
