### PR TITLE
Upgrade boxes for SecureDrop 1.2.0

### DIFF
--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -89,6 +89,17 @@
         }
       ],
       "version": "1.1.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "834debf3efea4f96b8527e3af1e6d79ae09c059365d1d0f1f26ebe3ee279439b",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_1.2.0.box"
+        }
+      ],
+      "version": "1.2.0"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -89,6 +89,17 @@
         }
       ],
       "version": "1.1.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "efe6bccc1d5aa84fad998cf42f038984ad60f4d9cd4a1fc12320327cdc7348bd",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_1.2.0.box"
+        }
+      ],
+      "version": "1.2.0"
     }
   ]
 }


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

Closes #5004 

## Testing

- Checkout this branch
- `make build-debs`
- `make upgrade-start` (will take a while as it needs to fetch the boxes)
- [ ] source interface shows SecureDrop version 1.2.0
- [ ] `make upgrade-test-local` completes without error
- [ ] source interface shows SecureDrop version 1.3.0~rc1

## Deployment

Dev-only
## Checklist
### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

