### PR TITLE
Replaced duplicate updater message modal with syslog call

### DIFF
--- a/journalist_gui/journalist_gui/SecureDropUpdater.py
+++ b/journalist_gui/journalist_gui/SecureDropUpdater.py
@@ -7,6 +7,7 @@ import re
 import pexpect
 import socket
 import sys
+import syslog as log
 
 from journalist_gui import updaterUI, strings, resources_rc  # noqa
 
@@ -35,9 +36,7 @@ def prevent_second_instance(app: QtWidgets.QApplication, name: str) -> None:  # 
         app.instance_binding.bind(IDENTIFIER)
     except OSError as e:
         if e.errno == ALREADY_BOUND_ERRNO:
-            err_dialog = QtWidgets.QMessageBox()
-            err_dialog.setText(name + strings.app_is_already_running)
-            err_dialog.exec()
+            log.syslog(log.LOG_NOTICE, name + strings.app_is_already_running)
             sys.exit()
         else:
             raise

--- a/journalist_gui/test_gui.py
+++ b/journalist_gui/test_gui.py
@@ -13,7 +13,7 @@ from journalist_gui.SecureDropUpdater import prevent_second_instance
 
 
 @mock.patch('journalist_gui.SecureDropUpdater.sys.exit')
-@mock.patch('journalist_gui.SecureDropUpdater.QtWidgets.QMessageBox')
+@mock.patch('syslog.syslog')
 class TestSecondInstancePrevention(unittest.TestCase):
     def setUp(self):
         self.mock_app = mock.MagicMock()


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #4878.

Removes the modal dialog alerting users that there's a pre-existing instance of the GUI updater on starting another one, replacing it it with a call to syslog, logging at NOTICE level.

## Testing

- Check out this branch on a Tails Admin Workstation (VM or physical) with an admin password set.
- Open a terminal and run `sudo journalctl -f | grep SecureDropUpdater` 
- [ ] Open a second terminal and run `python3 ~/Persistent/securedrop/journalist_gui/SecureDropUpdater` - verify that the  GUI updater appears
- [ ] Open a third terminal and run `python3 ~/Persistent/securedrop/journalist_gui/SecureDropUpdater` - verify that the  GUI updater does not appear, and a line "SecureDrop Workstation Updater is already running" is logged in the first terminal
- [ ] in the running GUI updater, click **Update Now** and verify that the update completes successfully.

## Deployment
Deployed when workstations are updated.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
