### PR TITLE
Add html markup to data in dev container

### DIFF
--- a/securedrop/create-dev-data.py
+++ b/securedrop/create-dev-data.py
@@ -18,14 +18,14 @@ from models import Journalist, Reply, Source, Submission
 
 submissions = cycle([
     'This is a test submission without markup!',
-    'This is a test submission with markup and characters such as \, \\, \', "" and ". ' +  # noqa: W605, E501
+    'This is a test submission with markup and characters such as \, \\, \', \" and ". ' +  # noqa: W605, E501
     '<strong>This text should not be bold</strong>!'
 ])
 
 replies = cycle([
     'This is a test reply without markup!',
-    'This is a test reply with markup and characters such as \, \\, \', "" and ". ' +  # noqa: W605, E501
-    '<strong>This test should not be bold</strong>!'
+    'This is a test reply with markup and characters such as \, \\, \', \" and ". ' +  # noqa: W605, E501
+    '<strong>This text should not be bold</strong>!'
 ])
 
 

--- a/securedrop/create-dev-data.py
+++ b/securedrop/create-dev-data.py
@@ -4,6 +4,7 @@
 import datetime
 import os
 import argparse
+from itertools import cycle
 
 from flask import current_app
 from sqlalchemy.exc import IntegrityError
@@ -14,6 +15,18 @@ import journalist_app
 from sdconfig import config
 from db import db
 from models import Journalist, Reply, Source, Submission
+
+submissions = cycle([
+    'This is a test submission without markup!',
+    'This is a test submission with markup and characters such as \, \\, \', "" and ". ' +  # noqa: W605, E501
+    '<strong>This text should not be bold</strong>!'
+])
+
+replies = cycle([
+    'This is a test reply without markup!',
+    'This is a test reply with markup and characters such as \, \\, \', "" and ". ' +  # noqa: W605, E501
+    '<strong>This test should not be bold</strong>!'
+])
 
 
 def main(staging=False):
@@ -79,7 +92,7 @@ def create_source_and_submissions(num_submissions=2, num_replies=2):
             source.filesystem_id,
             source.interaction_count,
             source.journalist_filename,
-            'test submission!'
+            next(submissions)
         )
         source.last_updated = datetime.datetime.utcnow()
         submission = Submission(source, fpath)
@@ -91,7 +104,7 @@ def create_source_and_submissions(num_submissions=2, num_replies=2):
         fname = "{}-{}-reply.gpg".format(source.interaction_count,
                                          source.journalist_filename)
         current_app.crypto_util.encrypt(
-            'this is a test reply!',
+            next(replies),
             [current_app.crypto_util.getkey(source.filesystem_id),
              config.JOURNALIST_KEY],
             current_app.storage.path(source.filesystem_id, fname))


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4272.

Adds html markup and characters in submissions and replies in the dev container to allow possible detection of regression with escaping.

## Testing

1. Login to the Journalist Interface
1. Download and decrypt the sources' submissions
1. Verify that the submissions with markup shows the markup in plain text, as well as the backslash and single and double quotation marks.
1. Login to the Source Interface
1. Verify that the reply with markup shows the markup in plain text, as well as the backslash and single and double quotation marks.

## Deployment

Any special considerations for deployment? Consider both:

N/A

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
