### PR TITLE
Adds v2 and v3 source interface urls to metadata endpoint.

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -135,6 +135,8 @@
   /var/lib/securedrop/shredder/*/ w,
   /var/lib/securedrop/store/** rw,
   /var/lib/securedrop/store/*/ w,
+  /var/lib/securedrop/source_v2_url r,
+  /var/lib/securedrop/source_v3_url r,
   /var/lib/securedrop/tmp/** rw,
   /var/lib/ssl/* r,
   /var/log/apache2/* w,

--- a/securedrop/source_app/api.py
+++ b/securedrop/source_app/api.py
@@ -3,6 +3,8 @@ import platform
 
 from flask import Blueprint, current_app, make_response
 
+from source_app.utils import get_sourcev2_url, get_sourcev3_url
+
 import version
 
 
@@ -16,7 +18,9 @@ def make_blueprint(config):
             'gpg_fpr': config.JOURNALIST_KEY,
             'sd_version': version.__version__,
             'server_os': platform.linux_distribution()[1],
-            'supported_languages': config.SUPPORTED_LOCALES
+            'supported_languages': config.SUPPORTED_LOCALES,
+            'v2_source_url': get_sourcev2_url(),
+            'v3_source_url': get_sourcev3_url()
         }
         resp = make_response(json.dumps(meta))
         resp.headers['Content-Type'] = 'application/json'

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -116,6 +116,11 @@ def normalize_timestamps(filesystem_id):
 
 
 def check_url_file(path, regexp):
+    """
+    Check that a file exists at the path given and contains a single line
+    matching the regexp. Used for checking the source interface address
+    files at /var/lib/securedrop/source_{v2,v3}_url.
+    """
     try:
         f = open(path, "r")
         contents = f.readline().strip()

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from threading import Thread
 
 import i18n
+import re
 
 from crypto_util import CryptoException
 from models import Source
@@ -112,3 +113,26 @@ def normalize_timestamps(filesystem_id):
                 "Couldn't normalize submission "
                 "timestamps (touch exited with %d)" %
                 rc)
+
+
+def check_url_file(path, regexp):
+    try:
+        f = open(path, "r")
+        contents = f.readline().strip()
+        f.close()
+        if re.match(regexp, contents):
+            return contents
+        else:
+            return None
+    except IOError:
+        return None
+
+
+def get_sourcev2_url():
+    return check_url_file("/var/lib/securedrop/source_v2_url",
+                          r"^[a-z0-9]{16}\.onion$")
+
+
+def get_sourcev3_url():
+    return check_url_file("/var/lib/securedrop/source_v3_url",
+                          r"^[a-z0-9]{56}\.onion$")

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -558,6 +558,32 @@ def test_metadata_route(config, source_app):
             assert resp.json.get('server_os') == '16.04'
             assert resp.json.get('supported_languages') ==\
                 config.SUPPORTED_LOCALES
+            assert resp.json.get('v2_source_url') is None
+            assert resp.json.get('v3_source_url') is None
+
+
+def test_metadata_v2_url(config, source_app):
+    onion_test_url = "abcdabcdabcdabcd.onion"
+    with patch.object(source_app_api, "get_sourcev2_url") as mocked_v2_url:
+        mocked_v2_url.return_value = (onion_test_url)
+        with source_app.test_client() as app:
+            resp = app.get(url_for('api.metadata'))
+            assert resp.status_code == 200
+            assert resp.headers.get('Content-Type') == 'application/json'
+            assert resp.json.get('v2_source_url') == onion_test_url
+            assert resp.json.get('v3_source_url') is None
+
+
+def test_metadata_v3_url(config, source_app):
+    onion_test_url = "abcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh.onion"
+    with patch.object(source_app_api, "get_sourcev3_url") as mocked_v3_url:
+        mocked_v3_url.return_value = (onion_test_url)
+        with source_app.test_client() as app:
+            resp = app.get(url_for('api.metadata'))
+            assert resp.status_code == 200
+            assert resp.headers.get('Content-Type') == 'application/json'
+            assert resp.json.get('v2_source_url') is None
+            assert resp.json.get('v3_source_url') == onion_test_url
 
 
 def test_login_with_overly_long_codename(source_app):

--- a/securedrop/tests/test_source_utils.py
+++ b/securedrop/tests/test_source_utils.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import os
+
+from source_app.utils import check_url_file
+
+
+def test_check_url_file(config):
+
+    assert check_url_file("nosuchfile", "whatever") is None
+
+    try:
+        def write_url_file(path, content):
+            url_file = open(path, "w")
+            url_file.write("{}\n".format(content))
+
+        url_path = "test_source_url"
+
+        onion_test_url = "abcdabcdabcdabcd.onion"
+        write_url_file(url_path, onion_test_url)
+        assert check_url_file(url_path, r"^[a-z0-9]{16}\.onion$") == onion_test_url
+
+        onion_test_url = "abcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh.onion"
+        write_url_file(url_path, onion_test_url)
+        assert check_url_file(url_path, r"^[a-z0-9]{56}\.onion$") == onion_test_url
+
+        write_url_file(url_path, "NO.onion")
+        assert check_url_file(url_path, r"^[a-z0-9]{56}\.onion$") is None
+    finally:
+        if os.path.exists(url_path):
+            os.unlink(url_path)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #4757 

Changes proposed in this pull request:

Source Interface information, including versions and submission key fingerprint, is currently available via the `/metadata` endpoint. This PR adds the v2 and v3 source URLs to the endpoint payload, allowing for discovery and monitoring of v3 versions of Source Interfaces.

This feature relies on the files `/var/lib/securedrop/source_{v2,v3}_url`, which are created when the install playbook is run from version 1.0.0 onward. In the absence of said files, null values are returned instead.

(I decided against adding a postinst task to create said files if the playbook hasn't been run, as if it hasn't been run then v3 hasn't been enabled anyway. Open to debate on this!)

## Testing

# Dev env:
- check out this branch and run `make dev`, then visit `localhost:8080/metadata`:
  - [ ] the response includes `v2_source_url` and `v3_source_url` fields with value `null`
- use `docker ps` and `docker exec -it <PID> bash` to log into the dev container, then create a file `/var/lib/securedrop/source_v2_url` containing an invalid onion URL (ie. NOT 16 alphanumeric chars followed by `.onion`), with ownership user:root and permissions 777, then check the `/metadata` endpoint again
  - [ ] both URL fields are still null
- update the `/var/lib/securedrop/source_v2_url` to contain a valid v2 URL, and check `/metadata` again
  - [ ] the `v2_source_url`contains the onion URL specified above
- [ ] repeat the two steps above for the `/var/lib/source_v3_url `file and verify that the `v3_source_url` behaves as expected.

# Staging env:
- check out this branch and run `make build-debs; make staging`, then check the SI url in `install_files/ansible-base/app-source-ths` and visit its `/metadata` endpoint in Tor Browser.
  - [ ] the response includes the v2 and v3 source url fields, with values matching the contents of `install_files/ansible-base/app-source-ths` and `install_files/ansible-base/app-sourcev3-ths`

## Deployment
As this change relies on files created by the install playbook, it will only return non-null values on instances where the playbook has been recently run (most likely to enable v3 onion services).  For instances where this is not the case, null values will be returned instead.

For new instances, the file dependencies will exist, and so the values will be populated.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
