### PR TITLE
Handle multiple instances of /generate

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -61,10 +61,9 @@ def make_blueprint(config):
     @view.route('/create', methods=['POST'])
     def create():
         if session.get('logged_in', False):
-            flash(gettext("You have already logged-in from a different browser tab. " +
-                          "Please verify your codename below as it may differ from " +
-                          "the one displayed on the previous page."), 'notification')
-            return redirect(url_for('.lookup', _anchor='codename-hint-visible'))
+            flash(gettext("You are already logged in. Please verify your codename below as it " +
+                          "may differ from the one displayed on the previous page."),
+                  'notification')
         else:
             tab_id = request.form['tab_id']
             codename = session['codenames'][tab_id]
@@ -98,7 +97,7 @@ def make_blueprint(config):
                 os.mkdir(current_app.storage.path(filesystem_id))
 
             session['logged_in'] = True
-            return redirect(url_for('.lookup'))
+        return redirect(url_for('.lookup'))
 
     @view.route('/lookup', methods=('GET',))
     @login_required

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -38,6 +38,7 @@
 
 <form id="create-form" method="post" action="/create" autocomplete="off">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+  <input name="tab_id" type="hidden" value="{{ tab_id }}">
   <button type="submit" class="btn--space pull-right" id="continue-button">
      {{ gettext('SUBMIT DOCUMENTS') }}
   </button>

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -229,5 +229,5 @@ class SourceNavigationStepsMixin:
         notification = self.driver.find_element_by_css_selector(".notification")
 
         if not hasattr(self, "accepted_languages"):
-            expected_text = "You have already logged-in from a different browser tab. "
+            expected_text = "You are already logged in."
             assert expected_text in notification.text

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -40,6 +40,9 @@ class SourceNavigationStepsMixin:
         # a diceware codename they can use for subsequent logins
         assert self._is_on_generate_page()
 
+    def _source_regenerates_codename(self):
+        self.safe_click_by_id("regenerate-submit")
+
     def _source_chooses_to_submit_documents(self):
         self._source_clicks_submit_documents_on_homepage()
 
@@ -230,4 +233,11 @@ class SourceNavigationStepsMixin:
 
         if not hasattr(self, "accepted_languages"):
             expected_text = "You are already logged in."
+            assert expected_text in notification.text
+
+    def _source_sees_redirect_already_logged_in_message(self):
+        notification = self.driver.find_element_by_css_selector(".notification")
+
+        if not hasattr(self, "accepted_languages"):
+            expected_text = "You were redirected because you are already logged in."
             assert expected_text in notification.text

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -48,7 +48,7 @@ class SourceNavigationStepsMixin:
         assert len(codename.text) > 0
         self.source_name = codename.text
 
-    def _source_shows_codename(self):
+    def _source_shows_codename(self, verify_source_name=True):
         content = self.driver.find_element_by_id("codename-hint-content")
         assert not content.is_displayed()
 
@@ -57,7 +57,8 @@ class SourceNavigationStepsMixin:
         self.wait_for(lambda: content.is_displayed())
         assert content.is_displayed()
         content_content = self.driver.find_element_by_css_selector("#codename-hint-content p")
-        assert content_content.text == self.source_name
+        if verify_source_name:
+            assert content_content.text == self.source_name
 
     def _source_hides_codename(self):
         content = self.driver.find_element_by_id("codename-hint-content")
@@ -223,3 +224,10 @@ class SourceNavigationStepsMixin:
     def _source_does_not_sees_document_attachment_item(self):
         with pytest.raises(NoSuchElementException):
             self.driver.find_element_by_class_name("attachment")
+
+    def _source_sees_already_logged_in_in_other_tab_message(self):
+        notification = self.driver.find_element_by_css_selector(".notification")
+
+        if not hasattr(self, "accepted_languages"):
+            expected_text = "You have already logged-in from a different browser tab. "
+            assert expected_text in notification.text

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -84,3 +84,51 @@ class TestDuplicateSourceInterface(
         # We expect the codename to be the one from Tab A
         assert codename_lookup_b == codename_a
         self._source_submits_a_message()
+
+    def test_duplicate_generate_pages_with_refresh(self):
+        # Test generation of multiple codenames in different browser tabs, including behavior
+        # of refreshing the codemae in each tab. Ref. issue 4458.
+
+        # Generate a codename in Tab A
+        assert len(self.driver.window_handles) == 1
+        tab_a = self.driver.current_window_handle
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        codename_a1 = self.get_codename_generate()
+        # Regenerate codename in Tab A
+        self._source_regenerates_codename()
+        codename_a2 = self.get_codename_generate()
+        assert codename_a1 != codename_a2
+
+        # Generate a different codename in Tab B
+        self.driver.execute_script("window.open()")
+        tab_b = self.driver.window_handles[1]
+        self.driver.switch_to.window(tab_b)
+        assert self.driver.current_window_handle == tab_b
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        codename_b = self.get_codename_generate()
+        assert codename_b != codename_a1 != codename_a2
+
+        # Proceed to submit documents in Tab A
+        self.driver.switch_to.window(tab_a)
+        assert self.driver.current_window_handle == tab_a
+        self._source_continues_to_submit_page()
+        assert self._is_on_lookup_page()
+        self._source_shows_codename(verify_source_name=False)
+        codename_lookup_a = self.get_codename_lookup()
+        assert codename_lookup_a == codename_a2
+        self._source_submits_a_message()
+
+        # Regenerate codename in Tab B
+        self.driver.switch_to.window(tab_b)
+        assert self.driver.current_window_handle == tab_b
+        self._source_regenerates_codename()
+        # We expect the source to be directed to /lookup with a flash message
+        assert self._is_on_lookup_page()
+        self._source_sees_redirect_already_logged_in_message()
+        # Check codename
+        self._source_shows_codename(verify_source_name=False)
+        codename_lookup_b = self.get_codename_lookup()
+        assert codename_lookup_b == codename_a2
+        self._source_submits_a_message()

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -29,3 +29,57 @@ class TestDownloadKey(
 
         data = data.decode('utf-8')
         assert "BEGIN PGP PUBLIC KEY BLOCK" in data
+
+
+class TestDuplicateSourceInterface(
+        functional_test.FunctionalTest,
+        source_navigation_steps.SourceNavigationStepsMixin):
+
+    def get_codename_generate(self):
+        return self.driver.find_element_by_css_selector("#codename").text
+
+    def get_codename_lookup(self):
+        return self.driver.find_element_by_css_selector("#codename-hint-content p").text
+
+    def test_duplicate_generate_pages(self):
+        # Test generation of multiple codenames in different browser tabs, ref. issue 4458.
+
+        # Generate a codename in Tab A
+        assert len(self.driver.window_handles) == 1
+        tab_a = self.driver.current_window_handle
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        codename_a = self.get_codename_generate()
+
+        # Generate a different codename in Tab B
+        self.driver.execute_script("window.open()")
+        tab_b = self.driver.window_handles[1]
+        self.driver.switch_to.window(tab_b)
+        assert self.driver.current_window_handle == tab_b
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        codename_b = self.get_codename_generate()
+
+        assert tab_a != tab_b
+        assert codename_a != codename_b
+
+        # Proceed to submit documents in Tab A
+        self.driver.switch_to.window(tab_a)
+        assert self.driver.current_window_handle == tab_a
+        self._source_continues_to_submit_page()
+        assert self._is_on_lookup_page()
+        self._source_shows_codename(verify_source_name=False)
+        codename_lookup_a = self.get_codename_lookup()
+        assert codename_lookup_a == codename_a
+        self._source_submits_a_message()
+
+        # Proceed to submit documents in Tab B
+        self.driver.switch_to.window(tab_b)
+        assert self.driver.current_window_handle == tab_b
+        self._source_continues_to_submit_page()
+        assert self._is_on_lookup_page()
+        self._source_sees_already_logged_in_in_other_tab_message()
+        codename_lookup_b = self.get_codename_lookup()
+        # We expect the codename to be the one from Tab A
+        assert codename_lookup_b == codename_a
+        self._source_submits_a_message()

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -79,6 +79,7 @@ class TestDuplicateSourceInterface(
         self._source_continues_to_submit_page()
         assert self._is_on_lookup_page()
         self._source_sees_already_logged_in_in_other_tab_message()
+        self._source_shows_codename(verify_source_name=False)
         codename_lookup_b = self.get_codename_lookup()
         # We expect the codename to be the one from Tab A
         assert codename_lookup_b == codename_a

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -56,7 +56,8 @@ def test_submit_message(source_app, journalist_app, test_journo):
 
     with source_app.test_client() as app:
         app.get('/generate')
-        app.post('/create', follow_redirects=True)
+        tab_id = next(iter(session['codenames'].keys()))
+        app.post('/create', data={'tab_id': tab_id}, follow_redirects=True)
         filesystem_id = g.filesystem_id
         # redirected to submission form
         resp = app.post('/submit', data=dict(
@@ -153,7 +154,8 @@ def test_submit_file(source_app, journalist_app, test_journo):
 
     with source_app.test_client() as app:
         app.get('/generate')
-        app.post('/create', follow_redirects=True)
+        tab_id = next(iter(session['codenames'].keys()))
+        app.post('/create', data={'tab_id': tab_id}, follow_redirects=True)
         filesystem_id = g.filesystem_id
         # redirected to submission form
         resp = app.post('/submit', data=dict(
@@ -254,7 +256,8 @@ def _helper_test_reply(journalist_app, source_app, config, test_journo,
 
     with source_app.test_client() as app:
         app.get('/generate')
-        app.post('/create', follow_redirects=True)
+        tab_id = next(iter(session['codenames'].keys()))
+        app.post('/create', data={'tab_id': tab_id}, follow_redirects=True)
         codename = session['codename']
         filesystem_id = g.filesystem_id
         # redirected to submission form
@@ -474,7 +477,8 @@ def test_delete_collection(mocker, source_app, journalist_app, test_journo):
     # first, add a source
     with source_app.test_client() as app:
         app.get('/generate')
-        app.post('/create')
+        tab_id = next(iter(session['codenames'].keys()))
+        app.post('/create', data={'tab_id': tab_id})
         resp = app.post('/submit', data=dict(
             msg="This is a test.",
             fh=(BytesIO(b''), ''),
@@ -523,7 +527,8 @@ def test_delete_collections(mocker, journalist_app, source_app, test_journo):
         num_sources = 2
         for i in range(num_sources):
             app.get('/generate')
-            app.post('/create')
+            tab_id = next(iter(session['codenames'].keys()))
+            app.post('/create', data={'tab_id': tab_id})
             app.post('/submit', data=dict(
                 msg="This is a test " + str(i) + ".",
                 fh=(BytesIO(b''), ''),
@@ -577,7 +582,8 @@ def test_filenames(source_app, journalist_app, test_journo):
     # add a source and submit stuff
     with source_app.test_client() as app:
         app.get('/generate')
-        app.post('/create')
+        tab_id = next(iter(session['codenames'].keys()))
+        app.post('/create', data={'tab_id': tab_id})
         _helper_filenames_submit(app)
 
     # navigate to the collection page
@@ -603,7 +609,8 @@ def test_filenames_delete(journalist_app, source_app, test_journo):
     # add a source and submit stuff
     with source_app.test_client() as app:
         app.get('/generate')
-        app.post('/create')
+        tab_id = next(iter(session['codenames'].keys()))
+        app.post('/create', data={'tab_id': tab_id})
         _helper_filenames_submit(app)
 
     # navigate to the collection page
@@ -714,7 +721,8 @@ def test_prevent_document_uploads(source_app, journalist_app, test_admin):
     # Check that the source interface accepts only messages:
     with source_app.test_client() as app:
         app.get('/generate')
-        resp = app.post('/create', follow_redirects=True)
+        tab_id = next(iter(session['codenames'].keys()))
+        resp = app.post('/create', data={'tab_id': tab_id}, follow_redirects=True)
         assert resp.status_code == 200
 
         text = resp.data.decode('utf-8')
@@ -739,7 +747,8 @@ def test_no_prevent_document_uploads(source_app, journalist_app, test_admin):
     # Check that the source interface accepts both files and messages:
     with source_app.test_client() as app:
         app.get('/generate')
-        resp = app.post('/create', follow_redirects=True)
+        tab_id = next(iter(session['codenames'].keys()))
+        resp = app.post('/create', data={'tab_id': tab_id}, follow_redirects=True)
         assert resp.status_code == 200
 
         text = resp.data.decode('utf-8')

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -189,7 +189,7 @@ def test_create_duplicate_codename_logged_in_in_session(source_app):
         assert resp.status_code == 200
         assert session['codename'] == codename
         text = resp.data.decode('utf-8')
-        assert "You have already logged-in" in text
+        assert "You are already logged in." in text
         assert "Submit Files" in text
 
 

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -173,6 +173,6 @@ def new_codename(client, session):
     """Helper function to go through the "generate codename" flow.
     """
     client.get('/generate')
-    codename = session['codename']
-    client.post('/create')
+    tab_id, codename = next(iter(session['codenames'].items()))
+    client.post('/create', data={'tab_id': tab_id})
     return codename


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #4458.

Changes proposed in this pull request:

Associate codenames from different browser tabs open to `/generate` with a unique tab id hidden in the form. This allows to register the source using the codename displayed in the browser tab from which the source proceeds to submit documents instead of the last codename generated (current behavior).

Proceeding to submit documents from another tab open to `/generate` redirects to `/lookup` with a flash message informing the source they are already logged-in and to verify their codename. The codename is made visible at the bottom of the `/lookup` page.

## Testing

In the dev VM:
1. Open one browser tab (A) to `/generate` and note the codename (A).
1. Open a second  browser tab (B) to `/generate`.
1. Return to tab A and click "SUBMIT DOCUMENTS".
1. Verify that tab A redirects to `/lookup`.
1. Verify that the codename at bottom of `/lookup` in tab A corresponds to codename A.
1. Verify that a message can be submitted successfully from tab A.
1. Return to tab B and click "SUBMIT DOCUMENTS".
1. Verify that tab B redirects to `/lookup`.
1. Verify that a flash message indicates the source is already logged-in and recommends verifying the codename.
1. Verify that the codename at the bottom of `/lookup` in tab B is visible and matches codename A.
1. Verify that a message can be submitted successfully from tab B.

Additional tests:
1. Logout of both tabs A & B
1. Proceed to `/generate`.
1. Verify that refreshing the TAB (via the browser button or the button to the right of the codename) refreshes the page as expected.

## Deployment

Any special considerations for deployment?

N/A

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
* Updated existing tests in `test_source.py` and `test_integration.py`.
* Added functional tests in `functional/test_source.py`.

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
