### PR TITLE
Set Ansible connection timeout to 120s and updated playbooks to use Ansible's reboot module

### DIFF
--- a/devops/gce-nested/gce-runner.sh
+++ b/devops/gce-nested/gce-runner.sh
@@ -57,3 +57,5 @@ ssh_gce "make build-debs-notest"
 # so register a trap to ensure the fetch always runs.
 trap fetch_junit_test_results EXIT
 ssh_gce "make staging"
+# pause to allow for post-staging reboot
+sleep 30

--- a/devops/gce-nested/gce-runner.sh
+++ b/devops/gce-nested/gce-runner.sh
@@ -57,5 +57,3 @@ ssh_gce "make build-debs-notest"
 # so register a trap to ensure the fetch always runs.
 trap fetch_junit_test_results EXIT
 ssh_gce "make staging"
-# pause to allow for post-staging reboot
-sleep 30

--- a/install_files/ansible-base/ansible.cfg
+++ b/install_files/ansible-base/ansible.cfg
@@ -2,12 +2,12 @@
 #ask_pass=False
 #ask_sudo_pass=False
 display_skipped_hosts=False
-timeout=60
+timeout=120
 # Use dynamic inventory script to determine local IPv4 addresses
 # from site-specific vars, or Onion URLs for SSH over ATHS.
 inventory=inventory-dynamic
 
 [ssh_connection]
 scp_if_ssh=True
-ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ConnectTimeout=60
+ssh_args = -o ControlMaster=auto -o ControlPersist=1200
 pipelining=True

--- a/install_files/ansible-base/roles/reboot-if-first-install/tasks/main.yml
+++ b/install_files/ansible-base/roles/reboot-if-first-install/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - include: check_whether_reboot_needed.yml
 
-- include: "{{ role_path }}/../../tasks/reboot.yml"
+- include: reboot-no-check.yml
   # The conditional vars below are defined via set_fact
   # in the `check_whether_reboot_needed` task list.
   when: securedrop_initial_installation or securedrop_conditional_reboot

--- a/install_files/ansible-base/roles/reboot-if-first-install/tasks/reboot-no-check.yml
+++ b/install_files/ansible-base/roles/reboot-if-first-install/tasks/reboot-no-check.yml
@@ -1,0 +1,10 @@
+---
+# reboot without checking to see if server comes back - required
+# for final reboot in initial install, as connection switches from
+# IPv4 to Onion URLs 
+- name: Reboot without checking, if required due to security updates.
+  shell: sleep 2 && shutdown -r now
+  async: 1
+  poll: 0
+  tags:
+    - reboot-no-check

--- a/install_files/ansible-base/roles/reboot-if-first-install/tasks/reboot-no-check.yml
+++ b/install_files/ansible-base/roles/reboot-if-first-install/tasks/reboot-no-check.yml
@@ -1,7 +1,7 @@
 ---
 # reboot without checking to see if server comes back - required
 # for final reboot in initial install, as connection switches from
-# IPv4 to Onion URLs 
+# IPv4 to Onion URLs
 - name: Reboot without checking, if required due to security updates.
   shell: sleep 2 && shutdown -r now
   async: 1

--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -110,11 +110,6 @@
     LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
-  vars:
-    # Override the default behavior of waiting for the servers to come back.
-    # Won't work on initial installs because the connection addresses change
-    # from IPv4 to Onion URLs, so just reboot and don't wait.
-    reboot_wait: no
   roles:
     - role: reboot-if-first-install
   become: yes

--- a/install_files/ansible-base/securedrop-staging.yml
+++ b/install_files/ansible-base/securedrop-staging.yml
@@ -103,6 +103,7 @@
     LC_ALL: C
   max_fail_percentage: 0
   any_errors_fatal: yes
-  roles:
-    - role: reboot-if-first-install
+  tasks:
+    - name: Reboot using generic module
+      include_tasks: "tasks/reboot.yml"
   become: yes

--- a/install_files/ansible-base/tasks/reboot.yml
+++ b/install_files/ansible-base/tasks/reboot.yml
@@ -1,35 +1,6 @@
 ---
-# Registering a temporary host fact to store the remote address
-# (either IPv4 address for first-run, or Onion URL for prod instances),
-# to avoid problems with remote address resolution when using `local_action`
-# and `wait_for` together.
-- name: Register host name to wait for.
-  set_fact:
-    # The `remote_host_ref` var is declared at the site-level,
-    # intended to make IPv4 resolution accurate across backend
-    # providers (i.e. mostly useful for testing).
-    _hostname_to_wait_for: "{{ remote_host_ref|default(ansible_ssh_host|default(ansible_host)) }}"
-
 - name: Reboot if required due to security updates.
-  shell: sleep 2 && shutdown -r now
-  async: 1
-  poll: 0
+  reboot:
   tags:
     - reboot
 
-- name: Wait for server to come back.
-  local_action: wait_for
-  args:
-    host: "{{ _hostname_to_wait_for }}"
-    port: "{{ ansible_ssh_port|default(ansible_port|default(22)) }}"
-    delay: 20
-    search_regex: OpenSSH
-    state: started
-  # Wait action runs on localhost, and does NOT require sudo.
-  become: false
-  # Provide opt-out ability for waiting for the host to come back.
-  # During initial installation, waiting won't work, since the connection
-  # switches from IPv4 to Onion URLs.
-  when: reboot_wait|default(True)
-  tags:
-    - reboot

--- a/install_files/ansible-base/tasks/reboot.yml
+++ b/install_files/ansible-base/tasks/reboot.yml
@@ -3,4 +3,3 @@
   reboot:
   tags:
     - reboot
-

--- a/molecule/upgrade/playbook.yml
+++ b/molecule/upgrade/playbook.yml
@@ -51,7 +51,7 @@
         path: "/var/log/{{ item }}"
       with_items:
         - cron-apt
-    # Reuse existing "reboot-and-wait" logic from site config
+    # Reuse existing "reboot" logic from site config
     - import_tasks: ../../install_files/ansible-base/tasks/reboot.yml
       tags: reboot
 

--- a/molecule/upgrade/playbook.yml
+++ b/molecule/upgrade/playbook.yml
@@ -52,7 +52,7 @@
       with_items:
         - cron-apt
     # Reuse existing "reboot" logic from site config
-    - import_tasks: ../../install_files/ansible-base/tasks/reboot.yml
+    - import_tasks: ../../install_files/ansible-base/roles/reboot-if-first-install/tasks/reboot-no-check.yml
       tags: reboot
 
     - name: Wait longer for machines to reboot

--- a/molecule/vagrant-packager/playbook.yml
+++ b/molecule/vagrant-packager/playbook.yml
@@ -65,6 +65,6 @@
   any_errors_fatal: yes
   tasks:
     # Reuse existing "reboot-and-wait" logic from site config
-    - import_tasks: ../../install_files/ansible-base/tasks/reboot-no-check.yml
+    - import_tasks: ../../install_files/ansible-base/roles/reboot-if-first-install/tasks/reboot-no-check.yml
       tags: reboot-no-check
   become: yes

--- a/molecule/vagrant-packager/playbook.yml
+++ b/molecule/vagrant-packager/playbook.yml
@@ -65,6 +65,6 @@
   any_errors_fatal: yes
   tasks:
     # Reuse existing "reboot-and-wait" logic from site config
-    - import_tasks: ../../install_files/ansible-base/tasks/reboot.yml
-      tags: reboot
+    - import_tasks: ../../install_files/ansible-base/tasks/reboot-no-check.yml
+      tags: reboot-no-check
   become: yes


### PR DESCRIPTION
 ## Status

Ready for review

## Description of Changes

Fixes #4358. (Well, mitigates it.)

This PR:
- updates the installer playbook, vagrant-packager, and upgrade Molecule scenarios to use the Ansible reboot module in most cases, or a simple `shutdown -r now` when there won't be a response from the rebooting servers.
- increases the Ansible connection timeout from 60s to 120s

## Testing

### Installer:

On prod VMs or hardware:
- [ ] Complete an installation with SSH-over-Tor set and verify that it finishes without errors
- [ ] Update the config to use SSH-over-LAN, rerun the install (including the tailsconfig step when prompted) and verify that it finishes without errors
- [ ] Update random configuration fields via `./securedrop-admin sdconfig`, rerun `./securedrop-admin install` and verify that it completes without errors *or* if an SSH timeout is observed, that the timeout mentioned in the error message is 120sec approximately.

### Upgrade scenario
- [ ] On this branch, run through the "upgrade with local packages" scenario documented below, and verify that it completes successfully: 
https://docs.securedrop.org/en/release-1.2.0/development/upgrade_testing.html

### Vagrant packager
- [ ] on this branch, run `make vagrant-package` and verify that it completes successfully.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

