### PR TITLE
Remove apparmor rule for the shell execution of /bin/dash (#5084)

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -10,7 +10,6 @@
   capability net_bind_service,
   capability sys_ptrace,
 
-  /bin/dash rix,
   /bin/touch rix,
   /bin/uname rix,
   /dev/null w,


### PR DESCRIPTION
Implement correction as for ticket #5084