### PR TITLE
Update UA regex to match TB9 user agent strings

### DIFF
--- a/securedrop/static/js/source.js
+++ b/securedrop/static/js/source.js
@@ -1,4 +1,4 @@
-const TBB_UA_REGEX = /Mozilla\/5\.0 \((Windows NT 6\.1|X11; Linux x86_64|Macintosh; Intel Mac OS X 10\.13|Windows NT 6\.1; Win64; x64); rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/;
+const TBB_UA_REGEX = /Mozilla\/5\.0 \((Windows NT 10\.0|X11; Linux x86_64|Macintosh; Intel Mac OS X 10\.14|Windows NT 10\.0; Win64; x64); rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/;
 const ORFOX_UA_REGEX = /Mozilla\/5\.0 \(Android; Mobile; rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/;
 
 function fadeIn(el, duration = 200, displayStyle = "block") {
@@ -64,8 +64,9 @@ function addFadingClose(id, elementToClose, fadeDuration = 200) {
 
 /**
    Tor Browser always reports a UTC timezone and window dimensions
-   that match the device dimensions, which is very unlikely in desktop
-   browsers.
+   that match the device dimensions. This is unlikely in desktop
+   browsers unless they implement anti-fingerprinting techniques
+   (such as Firefox privacy.resistFingerprinting).
 */
 function looksLikeTorBrowser() {
   return window.navigator.userAgent.match(TBB_UA_REGEX) &&
@@ -87,7 +88,7 @@ function looksLikeOrfox() {
 */
 function showTorSuggestions() {
   show("#js-warning");
-  
+
   let infoBubble = document.getElementById("security-setting-info");
 
   // show the instruction popup when the link is clicked


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5052 (for now).

Update User Agent String regex in line with what Tor Browser currently sends. Note that as mentioned in the comments of that issue:

- this will have to be kept up to date as Tor Browser/Firefox update the spoofed `navigator.userAgent` string
- this will only match users on an up to date version of Tor browser
- this will falsely identify Firefox users who enable `privacy.resistFingerprinting` as being Tor users. 

## Testing

- Open Tor Browser and another browser on different platforms and visit Source Interface
- Test when Tor Browser security slider is at "Safest" and also at a lower security setting
- Warning bar should not be present (Safest) or should encourage user to adjust Tor browser security settings (other settings)

## Deployment

n/a

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

** Note ** _I'm having `make` problems that I suspect are unrelated to this issue, but I don't want to keep being a bottleneck on this while I resolve those._