### PR TITLE
bump Tor Browser version to 9.0.2

### DIFF
--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -LO https://ftp.mozilla.org/pub/firefox/releases/${FF_ESR_VER}/linux-x8
 
 COPY ./tor_project_public.pub /opt/
 
-ENV TBB_VERSION 9.0.1
+ENV TBB_VERSION 9.0.2
 RUN gpg --import /opt/tor_project_public.pub && \
     wget  https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Update Tor Browser version from 9.0.1 -> 9.0.2, since the tarball for 9.0.1 is no longer available from dist.torproject.org.

Changes proposed in this pull request: Change Tor browser env variable in Dockerfile. 

## Testing

After importing the tor browser pgp key, ensure that 

```wget  https://www.torproject.org/dist/torbrowser/9.0.2/tor-browser-linux64-9.0.2_en-US.tar.xz && \
  wget https://www.torproject.org/dist/torbrowser/9.0.2/tor-browser-linux64-9.0.2_en-US.tar.xz.asc && \
  gpg --verify tor-browser-linux64-9.0.2_en-US.tar.xz.asc tor-browser-linux64-9.0.2_en-US.tar.xz
``` 

completes without error.

## Deployment

n/a

## Checklist

*skipped per @zenmonkeykstop because I have been having env troubles - review from @zenmonkeykstop requested* 

