### PR TITLE
Updated CI TBB and gui-updater-test pip dependencies 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,12 +187,6 @@ jobs:
           command: sudo apt-get update && sudo apt-get install -y libqt5designer5
 
       - run:
-          name: Install pip==18.0 to work pipenv/pip bug
-          command: |
-            cd journalist_gui
-            pipenv run pip install pip==18.0
-
-      - run:
           name: Install requirements
           command: |
             cd journalist_gui

--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -LO https://ftp.mozilla.org/pub/firefox/releases/${FF_ESR_VER}/linux-x8
 
 COPY ./tor_project_public.pub /opt/
 
-ENV TBB_VERSION 9.0.1
+ENV TBB_VERSION 9.0.2
 RUN gpg --import /opt/tor_project_public.pub && \
     wget  https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5091.

CI fixes - updates TBB version, and removes explicit pip 18.0 install in favour of the default version in CircleCI's image.

## Testing

- CI-only change - so does CI pass?

