### PR TITLE
Improve Source Interface /lookup UX

### DIFF
--- a/securedrop/sass/modules/_hr-horizontal-rule-line.sass
+++ b/securedrop/sass/modules/_hr-horizontal-rule-line.sass
@@ -19,3 +19,8 @@
       clear: both
       border: none
       height: 10px
+
+    &.header-separator-high
+      clear: both
+      border: none
+      height: 30px

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -26,8 +26,14 @@
   background: rgba(0, 0, 0, 0.05)
   box-sizing: border-box
   -moz-box-sizing: border-box
+  margin-top: 5px
   padding: 5px 10px
   text-align: center
+  width: 80%
+
+@media only screen and (max-width: 880px)
+  #codename-hint
+    width: 100%
 
 #codename-hint-visible
   .visible-codename
@@ -181,8 +187,12 @@ p#codename
         margin: 0 2%
         padding: 5px 15px
 
-p#no-replies
+h4#no-replies
   text-align: center
+  color: $color_grey_medium
+  background: $color_grey_xlight
+  padding: 40px
+  margin: 0.5em 0
 
 p.explanation
   text-align: left

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -30,6 +30,13 @@
         {% endblock %}
 
         <div class="panel selected">
+          {% if 'logged_in' in session %}
+            <a href="{{ url_for('main.logout') }}" class="btn pull-right" id="logout">{{ gettext('LOG OUT') }}</a>
+          {% endif %}
+
+          {% if not new_user%}
+            <hr class="no-line">
+          {% endif %}
 
           {% block body %}{% endblock %}
 

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -30,10 +30,6 @@
         {% endblock %}
 
         <div class="panel selected">
-        {% if 'logged_in' in session %}
-          <a href="{{ url_for('main.logout') }}" class="btn pull-right" id="logout">{{ gettext('LOG OUT') }}</a>
-        {% endif %}
-          <hr class="no-line">
 
           {% block body %}{% endblock %}
 

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -1,10 +1,6 @@
 {% extends "base.html" %}
 {% block body %}
 
-{% if 'logged_in' in session %}
-  <a href="{{ url_for('main.logout') }}" class="btn pull-right" id="logout">{{ gettext('LOG OUT') }}</a>
-{% endif %}
-
 {% if new_user %}
 <div class="code-reminder pull-left" id="codename-hint">
   <div id="codename-hint-visible">

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -1,6 +1,26 @@
 {% extends "base.html" %}
 {% block body %}
 
+{% if 'logged_in' in session %}
+  <a href="{{ url_for('main.logout') }}" class="btn pull-right" id="logout">{{ gettext('LOG OUT') }}</a>
+{% endif %}
+
+{% if new_user %}
+<div class="code-reminder pull-left" id="codename-hint">
+  <div id="codename-hint-visible">
+    <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/lock-black.png') }}" width="17" height="20"> {{ gettext('Remember, your codename is:') }}
+    <a id="codename-hint-show" class="show pull-right visible-codename" href="#codename-hint-visible">{{ gettext('Show') }}</a>
+    <div id="codename-hint-content" class="hidden-codename codename">
+      <a id="codename-hint-hide" class="pull-right" href="#codename-hint">{{ gettext('Hide') }}</a>
+      <p>{{ codename }}</p>
+    </div>
+  </div>
+</div>
+<hr class="header-separator-high">
+{% else %}
+  <hr class="no-line">
+{% endif %}
+
 <div class="center">
   {% include 'flashed.html' %}
 
@@ -104,23 +124,8 @@
       </div>
     </form>
   {% else %}
-    <p id="no-replies" class="explanation">{{ gettext('There are no replies at this time.') }}</p>
+    <h4 id="no-replies" class="explanation">{{ gettext('— No Messages —') }}</h4>
   {% endif %}
 </div>
-
-<hr class="no-line">
-
-{% if new_user %}
-<div class="code-reminder" id="codename-hint">
-  <div id="codename-hint-visible">
-    <img class="pull-left" src="{{ url_for('static', filename='i/font-awesome/lock-black.png') }}" width="17" height="20"> {{ gettext('Remember, your codename is:') }}
-    <a id="codename-hint-show" class="show pull-right visible-codename" href="#codename-hint-visible">{{ gettext('Show') }}</a>
-    <div id="codename-hint-content" class="hidden-codename codename">
-      <a id="codename-hint-hide" class="pull-right" href="#codename-hint">{{ gettext('Hide') }}</a>
-      <p>{{ codename }}</p>
-    </div>
-  </div>
-</div>
-{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #5080.

Changes proposed in this pull request:

Implement source interface UX changes on `/lookup` as per #5080:
- Move codename hint section to top of page.
- Adjust codename hint section width and make responsive.
- Increase vertical space between codename and "Submit" h2.
- Set empty replies area backgroud to light grey.
- Increase height of empty replies area.
- Change empty replies text to "- No Messages -".
- Change empty replies text p to h4.
- Change empty replies text color to grey.

## Testing

With the exception of reordering and moving element in the templates, there are not changes to the application logic. No changes in behaviour are therefore expected. The following tests are nevertheless recommended:

**Codename hint position and visibility on subsequent logins**
1. Access `/lookup` as a new source.
1. Check the codename hint is visible at the top of the panel, left of the "LOGOUT" button as per the screenshots below.
1. Check that the "Show" / "Hide" links in the codename hint work as expected.
1. Submit a document or message.
1. Check that the "Forgot your codename?" link in the flash message makes the codename hint visible.
1. Logout.
1. Login as the same source.
1. Check that the codename hint is not visible any more.

**Read Replies section**
1. Access `/lookup` as a source.
1. Check the "- No Messages -" item displays as per the screenshot below.
1. Logout.
1. Login to the Journalist Interface.
1. Reply to the source.
1. Log back in as the same source as in 1.
1. Check that the reply displays as expected in the "Read Replies" section.
1. Delete the reply.
1. Check that the "- No Messages -" item displays as per the screenshot below.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

N/A.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container
N/A.

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
N/A.

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR
N/A.

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
N/A.

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
N/A.
