### PR TITLE
[docs] Specify Ubuntu keyserver and both public key fingerprints in install/verify instructions

### DIFF
--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -61,10 +61,12 @@ You should verify the Ubuntu image you downloaded hasn't been modified by
 a malicious attacker or otherwise corrupted. We can do so by checking its
 integrity with cryptographic signatures and hashes.
 
-First, we will download *Ubuntu Image Signing Key* and verify its
-fingerprint. ::
+First, we will download both *Ubuntu Image Signing Keys* and verify their
+fingerprints. ::
 
-    gpg --recv-key "C598 6B4F 1257 FFA8 6632 CBA7 4618 1433 FBB7 5451"
+    gpg --recv-key --keyserver hkps://keyserver.ubuntu.com \
+    "C598 6B4F 1257 FFA8 6632 CBA7 4618 1433 FBB7 5451" \
+    "8439 38DF 228D 22F7 B374 2BC0 D94A A3F0 EFE2 1092"
 
 .. note:: It is important you type this out correctly. If you are not
           copy-pasting this command, we recommend you double-check you have


### PR DESCRIPTION
Include second public key required for verifying Ubuntu sha256sums, and pass ubuntu keyserver to gpg-recv-key because of UID stripping issue with keys.openpgp.org

## Status

Ready for review 

## Description of Changes

Resolves #5082.

Changes proposed in this pull request: docs only; change to command recommended for downloading Ubuntu Signing Keys.

## Testing

0. Reproduce #5082: Delete Ubuntu Signing keys from your GPG keychain and following current documentation to try to receive and install keys. You will encounter the `no user ID - skipped` issue. Once specifying another keyserver (hkps://keyserver.ubuntu.com), you will be able to download the first key, but verification of `SHA256SUMS` will fail because a second key is required. 
1. Manual review of documentation if proposed steps (retrieve both public keys, specify keyserver) are deemed appropriate.

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
