### PR TITLE
Cache CryptoUtil.getkey (redshiftzero's idea)

### DIFF
--- a/securedrop/journalist.py
+++ b/securedrop/journalist.py
@@ -3,8 +3,23 @@
 from sdconfig import config
 
 from journalist_app import create_app
+from models import Source
+from source_app.utils import asynchronous
 
 app = create_app(config)
+
+
+@asynchronous
+def prime_keycache():
+    """
+    Preloads CryptoUtil.keycache.
+    """
+    with app.app_context():
+        for source in Source.query.filter_by(pending=False).all():
+            app.crypto_util.getkey(source.filesystem_id)
+
+
+prime_keycache()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -11,7 +11,7 @@ os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 import crypto_util
 import models
 
-from crypto_util import CryptoUtil, CryptoException
+from crypto_util import CryptoUtil, CryptoException, FIFOCache
 from db import db
 
 
@@ -343,3 +343,25 @@ def test_encrypt_then_decrypt_gives_same_result(
     decrypted_text = crypto.decrypt(secret, ciphertext)
 
     assert decrypted_text == message
+
+
+def test_fifo_cache():
+    cache = FIFOCache(3)
+
+    cache.put('item 1', 1)
+    cache.put('item 2', 2)
+    cache.put('item 3', 3)
+
+    assert cache.get('item 1') == 1
+    assert cache.get('item 2') == 2
+    assert cache.get('item 3') == 3
+
+    cache.put('item 4', 4)
+    # Maxsize is 3, so adding item 4 should kick out item 1
+    assert not cache.get('item 1')
+    assert cache.get('item 2') == 2
+    assert cache.get('item 3') == 3
+    assert cache.get('item 4') == 4
+
+    cache.delete('item 2')
+    assert not cache.get('item 2')


### PR DESCRIPTION
## Status

Work in process

## Description of Changes

Adds caching to CryptoUtil.getkey, to reduce the number of expensive GPG key lookup operations. It uses CryptoUtil.keycache, an OrderedDict, so we can push out old items once we reach the cache size limit. Using functools.lru_cache would have taken care of that, but meant we couldn't avoid caching sources without keys, so delays in key generation would mean the source key would be unusable until the server were restarted.

The cache is primed in securedrop/journalist.py to avoid cold starts.

Credit to @redshiftzero for the solution.

## Testing

- Check out this branch. 

Save this script as `securedrop/securedrop/getkeytest.py`:
```
#!/usr/bin/env python3

import time

import pyotp
import requests


def api_url(path):
    return "http://localhost:8081/api/v1{}".format(path)


def get_all_sources(headers):
    start = time.perf_counter()
    get_all_sources_response = requests.get(api_url("/sources"), headers=headers)
    elapsed = time.perf_counter() - start
    sources = get_all_sources_response.json()["sources"]
    print("get_all_sources with {:d} sources took {:.2f} seconds".format(len(sources), elapsed))


if __name__ == "__main__":
    token_data = {
        "username": "journalist",
        "passphrase": "correct horse battery staple profanity oil chewy",
        "one_time_code": pyotp.TOTP("JHCOGO7VCER3EJ4L").now(),
    }
    token_response = requests.post(api_url("/token"), json=token_data).json()
    headers = {
        "Authorization": "Token {}".format(token_response["token"])
    }

    get_all_sources(headers)
    get_all_sources(headers)
```

- `export NUM_SOURCES=50`
- `make dev`

The dev server will take considerably longer to start than usual, as it creates the extra sources.

In another shell, once the server has finished populating the database and is fully ready:

- `docker exec -it securedrop-dev bash`
- `/opt/venvs/securedrop-app-code/bin/python3 getkeytest.py`  # this is run in the container

You should see output like this:
```
get_all_sources with 50 sources took 0.47 seconds
get_all_sources with 50 sources took 0.47 seconds
```

Now edit `securedrop/journalist.py` to comment out the call to `prime_keycache()` on line 22, and back in the container shell, run `getkeytest.py` again. If you get a key error about `token`, you were too quick at editing and your login attempt has been throttled. Wait 10-15 seconds and try again.

You should see output like this:
```
get_all_sources with 50 sources took 1.59 seconds
get_all_sources with 50 sources took 0.50 seconds
```
Note that this time the first call to `get_all_sources` is slower, as the cache hasn't been primed. 

## Deployment

The cache will increase memory consumption of both the source and journalist interfaces, but it's limited to 1000 keys, so should not be a problem.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

