### PR TITLE
[1.2.0] backport docs update to Ubuntu signing key fingerprint

### DIFF
--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -61,10 +61,12 @@ You should verify the Ubuntu image you downloaded hasn't been modified by
 a malicious attacker or otherwise corrupted. We can do so by checking its
 integrity with cryptographic signatures and hashes.
 
-First, we will download *Ubuntu Image Signing Key* and verify its
-fingerprint. ::
+First, we will download both *Ubuntu Image Signing Keys* and verify their
+fingerprints. ::
 
-    gpg --recv-key "C598 6B4F 1257 FFA8 6632 CBA7 4618 1433 FBB7 5451"
+    gpg --recv-key --keyserver hkps://keyserver.ubuntu.com \
+    "C598 6B4F 1257 FFA8 6632 CBA7 4618 1433 FBB7 5451" \
+    "8439 38DF 228D 22F7 B374 2BC0 D94A A3F0 EFE2 1092"
 
 .. note:: It is important you type this out correctly. If you are not
           copy-pasting this command, we recommend you double-check you have


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes
(cherry picked from commit 818087f0f0b379d422828549ef3757d633d1709d)

Backports changes from #5098 , updating Ubuntu ISO verification steps with appropriate signing key fingerprints.

## Testing

- [ ] does the PR contain the same commits as #5098 ?