### PR TITLE
Backport tor version update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,12 +185,6 @@ jobs:
           command: sudo apt-get update && sudo apt-get install -y libqt5designer5
 
       - run:
-          name: Install pip==18.0 to work pipenv/pip bug
-          command: |
-            cd journalist_gui
-            pipenv run pip install pip==18.0
-
-      - run:
           name: Install requirements
           command: |
             cd journalist_gui

--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -31,8 +31,8 @@ COPY ./tor_project_public.pub /opt/
 
 ENV TBB_VERSION 9.0.4
 RUN gpg --import /opt/tor_project_public.pub && \
-    wget  https://dist.torproject.org/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
-    wget https://dist.torproject.org/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \
+    wget  https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
+    wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \
     gpg --verify tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     tar -xvJf tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     mkdir -p /root/.local/tbb && mv tor-browser_en-US /root/.local/tbb &&\

--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -29,10 +29,10 @@ RUN curl -LO https://ftp.mozilla.org/pub/firefox/releases/${FF_ESR_VER}/linux-x8
 
 COPY ./tor_project_public.pub /opt/
 
-ENV TBB_VERSION 9.0.1
+ENV TBB_VERSION 9.0.4
 RUN gpg --import /opt/tor_project_public.pub && \
-    wget  https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
-    wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \
+    wget  https://dist.torproject.org/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
+    wget https://dist.torproject.org/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \
     gpg --verify tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     tar -xvJf tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     mkdir -p /root/.local/tbb && mv tor-browser_en-US /root/.local/tbb &&\


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backports #5095 to release/1.2.0, and a commit from #5090, to fix CI and unblock docs backports

Updates TBB version to 9.0.4 as 9.0.1 is no longer available.

## Testing

- [x] Does it contain the same commits as #5095, plus commit `2fbabfeeb898df7c9e69d9e5d3b5f28fd3b7313c` from #5090 ?
- [x] Does CI pass?
