### PR TITLE
Use system provided pip/setuptools

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -107,6 +107,7 @@
   /opt/venvs/securedrop-app-code/bin/python3 r,
   /opt/venvs/securedrop-app-code/lib/python3.5/ r,
   /opt/venvs/securedrop-app-code/lib/python3.5/** rm,
+  /opt/venvs/securedrop-app-code/pyvenv.cfg r,
   /var/lib/securedrop/ r,
   /var/lib/securedrop/db.sqlite kw,
   /var/lib/securedrop/db.sqlite rwk,

--- a/install_files/securedrop-app-code/debian/rules
+++ b/install_files/securedrop-app-code/debian/rules
@@ -28,6 +28,7 @@ override_dh_virtualenv:
 	dh_virtualenv \
 		--python=/usr/bin/python3.5 \
 		--setuptools \
+		--builtin-venv \
 		--extra-pip-arg "--verbose" \
 		--extra-pip-arg "--ignore-installed" \
 		--extra-pip-arg "--no-binary=:all:" \

--- a/install_files/securedrop-app-code/debian/rules
+++ b/install_files/securedrop-app-code/debian/rules
@@ -32,6 +32,7 @@ override_dh_virtualenv:
 		--extra-pip-arg "--verbose" \
 		--extra-pip-arg "--ignore-installed" \
 		--extra-pip-arg "--no-binary=:all:" \
+		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-cache-dir"
 
 #

--- a/molecule/builder-xenial/Dockerfile
+++ b/molecule/builder-xenial/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         paxctl \
         python3-all \
         python3-pip \
+        python3-venv \
         python3-setuptools \
         rsync \
         ruby \

--- a/molecule/builder-xenial/image_hash
+++ b/molecule/builder-xenial/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2019_12_03
-1e61e825bd7bc221eacb071ae200924f99fb1728e736d9a707fd183d22f0dfcb
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2020_01_29
+697a3f1a4b67a30670b44fc02eada36689b09c6b3da1e99e42d60907a81e916e

--- a/molecule/testinfra/staging/app/apache/test_apache_journalist_interface.py
+++ b/molecule/testinfra/staging/app/apache/test_apache_journalist_interface.py
@@ -139,7 +139,6 @@ def test_apache_journalist_interface_vhost(host):
     assert common_apache2_directory_declarations in f.content_string
 
 
-@pytest.mark.skip(reason="Blocking #5110")
 def test_apache_logging_journalist_interface(host):
     """
     Check that logging is configured correctly for the Journalist Interface.

--- a/molecule/testinfra/staging/app/apache/test_apache_journalist_interface.py
+++ b/molecule/testinfra/staging/app/apache/test_apache_journalist_interface.py
@@ -139,6 +139,7 @@ def test_apache_journalist_interface_vhost(host):
     assert common_apache2_directory_declarations in f.content_string
 
 
+@pytest.mark.skip(reason="Blocking #5110")
 def test_apache_logging_journalist_interface(host):
     """
     Check that logging is configured correctly for the Journalist Interface.


### PR DESCRIPTION
This will need a new build of the container image for packaging.

## Status

Ready for review 

## Description of Changes

Fixes #5109 

Using venv module to create the virtualenv.

## Testing

- [ ] `cd molecule/builder-xenial/`
- [ ] `make  build-container`
- [ ] `cd -`
- [ ] `BUILDER_IMAGE="quay.io/freedomofpress/sd-docker-builder-xenial:$(date +%Y_%m_%d)" make build-debs` 

We have to use the locally built container image to build the debian packages while testing the PR.
## Deployment

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
