### PR TITLE
Removed  hash in docker image names, increased CI docker build verbosity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ common-steps:
         set +o pipefail
         docker images
         fromtag=$(docker images |grep securedrop-test-xenial-py3 |head -n1 |awk '{print $2}')
-        cd securedrop && DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" ./bin/dev-shell true
+        cd securedrop && DOCKER_BUILD_VERBOSE=true DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" ./bin/dev-shell true
 
   - &saveimagelayers
     run:

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -11,12 +11,6 @@ export PATH="/opt/venvs/securedrop-app-code/bin:$PATH"
 TOPLEVEL=$(git rev-parse --show-toplevel)
 BASE_OS=xenial
 
-## Get a short identifier for the working directory
-hashpath() {
-    pwd | sum | awk '{print $1}'
-}
-
-
 ## Get an integer offset for exposed ports, to support multiple containers
 get_port_offset() {
     tries=0
@@ -35,7 +29,7 @@ function docker_image() {
            ${DOCKER_BUILD_ARGUMENTS:-} \
            --build-arg=USER_ID="$(id -u)" \
            --build-arg=USER_NAME="${USER:-root}" \
-           -t "securedrop-test-${1}-py3-$(hashpath)" \
+           -t "securedrop-test-${1}-py3" \
            --file "${TOPLEVEL}/securedrop/dockerfiles/${1}/python3/Dockerfile" \
            "${TOPLEVEL}/securedrop"
 }


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5112 .

Removes a unique hash appended `securedrop-test-xenial-py3` docker image name, that was breaking CI image caching.

## Testing

CI:
- [ ] Does CI pass?

Locally:
- On this branch and with a venv enabled run the following:  
  ```
  fromtag=$(docker images |grep securedrop-test-xenial-py3 |head -n1 |awk '{print $2}')
  cd securedrop && DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" DOCKER_BUILD_VERBOSE=true ./bin/dev-shell true
  ```
- [ ] commands complete successfully

## Checklist


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR