### PR TITLE
Added `testinfra` target to makefile that runs `molecule test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,13 @@ staging:  ## Create a local staging environment in virtual machines.
 	@$(SDROOT)/devops/scripts/create-staging-env
 	@echo
 
+
+.PHONY: testinfra
+testinfra:  ## Run infra tests against a local staging environment.
+	@echo "███ Creating staging environment..."
+	@MOLECULE_ACTION=test $(SDROOT)/devops/scripts/create-staging-env
+	@echo
+
 .PHONY: libvirt-share
 libvirt-share:  ## Configure ACLs to allow RWX for libvirt VM (e.g. Admin Workstation).
 	@echo "███ Configuring ACLs for admin workstation..."

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ staging:  ## Create a local staging environment in virtual machines.
 .PHONY: testinfra
 testinfra:  ## Run infra tests against a local staging environment.
 	@echo "███ Creating staging environment..."
-	@MOLECULE_ACTION=test $(SDROOT)/devops/scripts/create-staging-env
+	@MOLECULE_ACTION=verify $(SDROOT)/devops/scripts/create-staging-env
 	@echo
 
 .PHONY: libvirt-share

--- a/devops/scripts/create-staging-env
+++ b/devops/scripts/create-staging-env
@@ -7,6 +7,8 @@
 #   * Qubes (via Admin API)
 #
 # Set the VAGRANT_DEFAULT_PROVIDER env var to override autodetection.
+#
+# Defaults to `converge` action - override with MOLECULE_ACTION env var
 
 set -e
 set -o pipefail
@@ -23,5 +25,5 @@ virtualenv_bootstrap
 if [ "$USER" = "sdci" ]; then
     molecule test -s "${securedrop_staging_scenario}"
 else
-    molecule converge -s "${securedrop_staging_scenario}"
+    molecule "${MOLECULE_ACTION:-converge}" -s "${securedrop_staging_scenario}"
 fi

--- a/docs/development/testing_configuration_tests.rst
+++ b/docs/development/testing_configuration_tests.rst
@@ -26,33 +26,8 @@ provision the environment and run the tests, run the following commands:
 .. code:: sh
 
     make build-debs
+    make staging
     make testinfra
-
-.. note:: The staging environmment will be destroyed after the tests complete. To keep 
-  the environment aroundm use the Molecule ``verify`` action directly instead,
-  as described below.
-
-The VMs will be set up using either the libvirt or virtualbox Vagrant VM provider,
-depending on your system settings. 
-To run the tests against an already-provisioned staging environment,
-use the `molecule` command below corresponding to your VM provider:
-
-libvirt:
-~~~~~~~~
-
-.. code:: sh
-
-   molecule verify -s libvirt-staging-xenial
-
-virtualbox:
-~~~~~~~~~~~
-
-.. code:: sh
-
-   molecule verify -s virtualbox-staging-xenial
-
-.. tip:: To run only a single test, set ``PYTEST_ADDOPTS="-k name_of_test"``
-         in your environment.
 
 Test failure against any host will generate a report with informative output
 about the specific test that triggered the error. Molecule

--- a/docs/development/testing_configuration_tests.rst
+++ b/docs/development/testing_configuration_tests.rst
@@ -20,21 +20,22 @@ Installation
 Running the Config Tests
 ------------------------
 
-In order to run the tests, first create and provision the VM you intend
-to test.
-
-For the staging VMs:
+Testinfra tests are executed against a virtualized staging environment. To
+provision the environment and run the tests, run the following commands:
 
 .. code:: sh
 
     make build-debs
-    make staging
+    make testinfra
+
+.. note:: The staging environmment will be destroyed after the tests complete. To keep 
+  the environment aroundm use the Molecule ``verify`` action directly instead,
+  as described below.
 
 The VMs will be set up using either the libvirt or virtualbox Vagrant VM provider,
-depending on your system settings. You'll need to use the appropriate commands below
-based on your choice of provider.
-
-Then, to run the tests:
+depending on your system settings. 
+To run the tests against an already-provisioned staging environment,
+use the `molecule` command below corresponding to your VM provider:
 
 libvirt:
 ~~~~~~~~
@@ -57,8 +58,6 @@ Test failure against any host will generate a report with informative output
 about the specific test that triggered the error. Molecule
 will also exit with a non-zero status code.
 
-.. note:: To build and test the VMs with one command, use the Molecule ``test``
-  action: ``molecule test -s libvirt-staging-xenial --destroy=never``, or ``molecule test -s virtualbox-staging-xenial --destroy=never``.
 
 Updating the Config Tests
 -------------------------


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2437.

Adds a Makefile target for the `testinfra` tests, that runs `testinfra` against an existing staging enviroment.
Updates documentation on running testinfra tests.

## Testing
(Assuming Ubuntu/Debian and staging env requirements already set up, venv enabled):

- [ ] run the following commands - tests are successfully run and environment is still accessible:
```
make build-debs
make staging
make testinfra
```

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally