### PR TITLE
added --preserve-tor-config flag to securedrop-admin restore

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -698,12 +698,25 @@ def restore_securedrop(args):
     # Would like readable output if there's a problem
     os.environ["ANSIBLE_STDOUT_CALLBACK"] = "debug"
 
-    ansible_cmd = [
+    ansible_cmd_full_restore = [
         'ansible-playbook',
         os.path.join(args.ansible_path, 'securedrop-restore.yml'),
         '-e',
         "restore_file='{}'".format(restore_file_basename),
     ]
+
+    ansible_cmd_skip_tor = [
+        'ansible-playbook',
+        os.path.join(args.ansible_path, 'securedrop-restore.yml'),
+        '-e',
+        "restore_file='{}' restore_skip_tor='True'".format(restore_file_basename),
+    ]
+
+    if args.restore_skip_tor:
+        ansible_cmd = ansible_cmd_skip_tor
+    else:
+        ansible_cmd = ansible_cmd_full_restore
+
     return subprocess.check_call(ansible_cmd, cwd=args.ansible_path)
 
 
@@ -935,6 +948,10 @@ def parse_argv(argv):
                                           help=restore_securedrop.__doc__)
     parse_restore.set_defaults(func=restore_securedrop)
     parse_restore.add_argument("restore_file")
+    parse_restore.add_argument("--preserve-tor-config", default=False,
+                               action='store_true',
+                               dest='restore_skip_tor',
+                               help="Preserve the server's current Tor config")
 
     parse_update = subparsers.add_parser('update', help=update.__doc__)
     parse_update.set_defaults(func=update)

--- a/admin/tox.ini
+++ b/admin/tox.ini
@@ -1,6 +1,9 @@
 [tox]
 envlist = pylint,flake8,py3
 
+[flake8]
+max-line-length = 100
+
 [testenv]
 usedevelop = true
 deps =

--- a/install_files/ansible-base/roles/restore/tasks/main.yml
+++ b/install_files/ansible-base/roles/restore/tasks/main.yml
@@ -52,6 +52,15 @@
     dest: /
     remote_src: yes
     src: "/tmp/{{ restore_file}}"
+  when: restore_skip_tor is not defined
+
+- name: Extract backup, skipping tor service configuration
+  unarchive:
+    dest: /
+    remote_src: yes
+    src: "/tmp/{{ restore_file}}"
+    exclude: "var/lib/tor,etc/tor/torrc"
+  when: restore_skip_tor is defined
 
 - name: Reconfigure securedrop-app-code
   command: dpkg-reconfigure securedrop-app-code


### PR DESCRIPTION
## Status

 Ready for review

## Description of Changes

Fixes #5107 

Adds a `--preserve-tor-config` flag to the `securedrop-admin restore` command, that, if set, will restore a backup tarball without overwriting the server's existing Tor configurations. This will allow a dataset from an SD instance to be applied and available on another instance at a different onion address.

Sets flake8 max-line-length to 100, in line with standard for application code.

## Testing

On prod instance (VMs or hardware):
- install latest release version, create JI accounts and add source submissions
- from the Admin Workstation, take a backup using `./securedrop-admin backup`
- copy the initial install's THS, auth_private, and tor_v3_keys.json` files from the `install_files/ansible-base` directory to ~/Persistent/
- wipe the servers and reinstall from scratch, thereby generating new Tor service definitions
- check out this branch and restore from  backup using the command:
  ```
  ./securedrop-admin restore --preserve-tor-config  <backupfilehere>
  ```
- [ ] confirm that the sources, submissions, and accounts from the initial install are present
- [ ] confirm that none of the Tor service addresses from the second install have changed
- next, delete all sources, then restore from backup using the command:
  ```
  ./securedrop-admin restore  <backupfilehere>
  ```
- The restore command will time out, as the SSH connection details will change. When it does, log into the application server from the console and issue the command `sudo service tor reload` to load the new service config.
- copy the initial install's THS, auth_private, and tor_v3_keys.json` files from  ~/Persistent/  to the `install_files/ansible-base` directory, and run:
  ```
  ./securedrop-admin tailsconfig
  ```
  to restore the original local Tor config
- [ ] Confirm that the sources, submissions, and accounts from the initial install are present
- [ ] Confirm that the initial install's hidden services are available at their original addresses.

## Deployment

 (deployed when workstation copies of the repo are updated)

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
