### PR TITLE
updated pip commands in scripts and docs to include --no-deps flag

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -19,6 +19,6 @@ RUN python3 bootstrap.py -v
 ENV VIRTUAL_ENV /opt/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY requirements-dev.txt .
-RUN pip3 install --require-hashes -r requirements-dev.txt
+RUN pip3 install --no-deps --require-hashes -r requirements-dev.txt
 
 RUN chown -R $USER_NAME /opt

--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -221,6 +221,7 @@ def install_pip_self(args):
 def install_pip_dependencies(args, pip_install_cmd=[
         os.path.join(VENV_DIR, 'bin', 'pip3'),
         'install',
+        '--no-deps',
         # Specify requirements file.
         '-r', os.path.join(DIR, 'requirements.txt'),
         '--require-hashes',

--- a/docs/development/admin_development.rst
+++ b/docs/development/admin_development.rst
@@ -10,7 +10,7 @@ tested on Debian GNU/Linux stretch with:
 
    python3 bootstrap.py
    source .venv3/bin/activate
-   pip3 install -r requirements-dev.txt
+   pip3 install --no-deps --require-hashes -r requirements-dev.txt
    tox
 
 A Docker helper is provided to simplify the installation and make

--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -58,7 +58,7 @@ root of the repository:
 
   .. code:: sh
 
-     pip install --require-hashes -r securedrop/requirements/python3/develop-requirements.txt
+     pip install --no-deps --require-hashes -r securedrop/requirements/python3/develop-requirements.txt
 
 Python
 ~~~~~~

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -23,7 +23,7 @@ To get started editing the docs:
 
    .. code:: sh
 
-      pip install --require-hashes -r securedrop/requirements/python3/develop-requirements.txt
+      pip install --no-deps --require-hashes -r securedrop/requirements/python3/develop-requirements.txt
 
 #. Build the docs for viewing in your web browser:
 

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -285,6 +285,6 @@ Ensure your virtualenv is activated and install the packages.
 
 .. code:: sh
 
-    pip install --require-hashes -r securedrop/requirements/python3/develop-requirements.txt
+    pip install --no-deps --require-hashes -r securedrop/requirements/python3/develop-requirements.txt
 
 .. note:: You will need to run this everytime new packages are added.

--- a/docs/development/testing_configuration_tests.rst
+++ b/docs/development/testing_configuration_tests.rst
@@ -14,7 +14,7 @@ Installation
 
 .. code:: sh
 
-    pip install --require-hashes -r securedrop/requirements/python3/develop-requirements.txt
+    pip install --no-deps --require-hashes -r securedrop/requirements/python3/develop-requirements.txt
 
 
 Running the Config Tests
@@ -41,14 +41,14 @@ libvirt:
 
 .. code:: sh
 
-   molecule verify -s libvirt-staging
+   molecule verify -s libvirt-staging-xenial
 
 virtualbox:
 ~~~~~~~~~~~
 
 .. code:: sh
 
-   molecule verify -s virtualbox-staging
+   molecule verify -s virtualbox-staging-xenial
 
 .. tip:: To run only a single test, set ``PYTEST_ADDOPTS="-k name_of_test"``
          in your environment.
@@ -58,7 +58,7 @@ about the specific test that triggered the error. Molecule
 will also exit with a non-zero status code.
 
 .. note:: To build and test the VMs with one command, use the Molecule ``test``
-  action: ``molecule test -s libvirt-staging --destroy=never``, or ``molecule test -s virtualbox-staging --destroy=never``.
+  action: ``molecule test -s libvirt-staging-xenial --destroy=never``, or ``molecule test -s virtualbox-staging-xenial --destroy=never``.
 
 Updating the Config Tests
 -------------------------

--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/main.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: Install SecureDrop Python requirements in container
   shell: |
-    pip3 install --no-binary :all: --require-hashes -r {{ securedrop_app_code_prep_dir }}/requirements.txt
+    pip3 install --no-deps --no-binary :all: --require-hashes -r {{ securedrop_app_code_prep_dir }}/requirements.txt
   tags:
     - pip
 

--- a/install_files/securedrop-app-code/debian/rules
+++ b/install_files/securedrop-app-code/debian/rules
@@ -30,6 +30,7 @@ override_dh_virtualenv:
 		--setuptools \
 		--extra-pip-arg "--verbose" \
 		--extra-pip-arg "--ignore-installed" \
+		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-binary=:all:" \
 		--extra-pip-arg "--no-cache-dir"
 

--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -49,9 +49,9 @@ RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckod
 
 COPY requirements requirements
 RUN python3 -m venv /opt/venvs/securedrop-app-code && \
-    /opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/docker-requirements.txt && \
-    /opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/securedrop-app-code-requirements.txt && \
-    /opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/test-requirements.txt
+    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/docker-requirements.txt && \
+    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/securedrop-app-code-requirements.txt && \
+    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/test-requirements.txt
 
 RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi && \
     cp -r /root/.local /tmp/ && chmod +x /tmp/.local/tbb/tor-browser_en-US/Browser/firefox && chmod -R 777 /tmp/.local && \


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Addresses #5109 - adds `--no-deps` flag to `pip` invocations

- adds `--no-deps` as an extra pip arg to dh_virtualenv config
- adds `--no-deps` to direct invocations of pip in Ansible tasks and Dockerfiles
- updates documentation to reference `--no-deps` arg in all pip commands.

## Testing
on this branch:
- [ ] set up a virtualenv, use the--no-deps flag when adding development requirements, verify that it completes successfully
- [ ] run `make dev`, verify that the environment comes up and SI and JI are available
- run `make build-debs`:
  - [ ] verify that the expected packages are built
  - [ ] verify that the version of (pip, setuptools) in place in `/opt/venvs/securedrop-app-code/lib/python3.5/site-packages/` are (20.0.2, 45.2.0).
- [ ] (optional) verify that the developer documentation references the `--no-deps` flag 

## Deployment

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally