### PR TITLE
Update builder image

### DIFF
--- a/molecule/builder-xenial/image_hash
+++ b/molecule/builder-xenial/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2019_12_03
-1e61e825bd7bc221eacb071ae200924f99fb1728e736d9a707fd183d22f0dfcb
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2020_02_19
+e1a0d8ba0248997cb5b6dd22a703e4b2cb0e356dde7f31f31e33bbce3bb7ec1e


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updates the Docker image used for building SecureDrop packages.

## Testing

Run `make build-debs`. The tests should not complain about the image needing apt updates.
