### PR TITLE
Add 1.2.1 changes to changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ## 1.3.0~rc1
 
+## 1.2.1
+
+### Web Applications
+
+* Updated Tor Browser user agent detection (#5087)
+* Added caching of source keys (#5100)
+* Removed the ability to change source codenames/designations (#5119)
+
 ## 1.2.0
 
 ### Web Applications
@@ -24,7 +32,7 @@
 
 * Added SECURITY.md to the repository (#4994).
 * Fixed Journalist Interface functional tests that require specific Tor Browser security settings (#4987, #4995).
-* Added developer quickstart instructions to the repository README (#4983, #4984). 
+* Added developer quickstart instructions to the repository README (#4983, #4984).
 * Fixed admin pip requirements updater (#4955).
 * Added an environmental variable to control Docker build verbosity (#4943, #4974).
 * Increased libvirt prod VM memory to 1024MB (#4918).
@@ -251,7 +259,7 @@
 ### Operations
 
 * Ensured WiFi related packages are not installed on Xenial on upgrade (#4163)
-* Try harder to attach to a `tmux` session on upgrade (#4221) 
+* Try harder to attach to a `tmux` session on upgrade (#4221)
 * Control locale during Ansible runs (#4252)
 
 ### Tails Environment
@@ -374,7 +382,7 @@
 
 * Updated OSSEC to 3.0.0 and use GPG signatures for verifying sources (#3701)
 * Update paramiko to 2.4.2 (#3861)
-* Enforce use of the latest grsecurity-patched kernel on servers (#3842) 
+* Enforce use of the latest grsecurity-patched kernel on servers (#3842)
 
 ### Development
 
@@ -423,7 +431,7 @@ https://github.com/freedomofpress/securedrop/milestone/44
 
 ### Web Applications
 
-* Adds a new supported language: Swedish (#3570) 
+* Adds a new supported language: Swedish (#3570)
 * Replace PyCryptodome with pyca/cryptography (#3458)
 * Add explanatory text to source interface screensaver (#3439, #3455)
 * Rename "Delete collection" on journalist interface for clarity (#2419)
@@ -529,7 +537,7 @@ https://github.com/freedomofpress/securedrop/milestones/0.7.
 
 * Add commands to check for and apply updates to the securedrop-admin CLI (#2976).
 
-### Developer Workflow 
+### Developer Workflow
 
 * Make the Docker-based development environment the default (#2902).
 * Rebase branches prior to running CI jobs (#2934).
@@ -748,12 +756,12 @@ https://github.com/freedomofpress/securedrop/milestones/0.4.1.
 The issues for this release were tracked in the 0.4 milestone on Github:
 https://github.com/freedomofpress/securedrop/milestones/0.4.
 
-This changelog shows major changes below. Please diff the tags to see the full list of changes. 
+This changelog shows major changes below. Please diff the tags to see the full list of changes.
 
 ### Deployment
 
 * Enable optional HTTPS on the source interface (#1605).
-* Standardize SecureDrop server installation on a single username (#1796). 
+* Standardize SecureDrop server installation on a single username (#1796).
 * Add `securedrop-admin` script and update version of Ansible running in the workstation (#1146, #1885).
 * Add validation of user-provided values during SecureDrop installation (#1663, #749, #1257).
 * Removes `prod-specific.yml` configuration file (#1758).
@@ -766,10 +774,10 @@ This changelog shows major changes below. Please diff the tags to see the full l
 ### Developer Workflow
 
 * Reconciles divergent master and develop branches (#1559).
-* Increases unit test coverage to from 65% to 92%. 
-* Adds testinfra system configuration test suite (#1580). 
+* Increases unit test coverage to from 65% to 92%.
+* Adds testinfra system configuration test suite (#1580).
 * Removes unnecessary test wrappers (#1412).
-* Major improvements to SecureDrop CI and testing flow including adding the staging environment to CI (#1067). 
+* Major improvements to SecureDrop CI and testing flow including adding the staging environment to CI (#1067).
 
 ### Web App: Source
 
@@ -786,10 +794,10 @@ This changelog shows major changes below. Please diff the tags to see the full l
 * Adds minimum password length requirements for new journalist accounts (#980).
 * Delete submissions that have had their sources deleted (#1188).
 * Bugfix: Empty replies can no longer be sent to a source (#1715).
-* Bugfix: Handle non hexadecimal digits for the 2FA secret (#1869). 
+* Bugfix: Handle non hexadecimal digits for the 2FA secret (#1869).
 * Bugfix: Handle token reuse for the 2FA secret on /admin/2fa (#1687).
-* Bugfix: Handle attempts to make duplicate user accounts (#1693). 
-* Bugfix: Fix confusing UI on message/reply icons (#1258). 
+* Bugfix: Handle attempts to make duplicate user accounts (#1693).
+* Bugfix: Fix confusing UI on message/reply icons (#1258).
 
 ### Tails Environment
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updates the changelog for 1.2.1.

## Testing

Compare the 1.2.1 section of `changelog.md` to the [release/1.2.1 version](https://github.com/freedomofpress/securedrop/blob/release/1.2.1/changelog.md). The list should be the same.

