### PR TITLE
Add 1.2.1 upgrade testing boxes

### DIFF
--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -89,6 +89,17 @@
         }
       ],
       "version": "1.1.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "652d4b10825e2fa7d1f9cabdace79d842cd6b6b8a22dcb5668f9d33b24613f71",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_1.2.1.box"
+        }
+      ],
+      "version": "1.2.1"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -89,6 +89,17 @@
         }
       ],
       "version": "1.1.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "78c6b5e777f5517315e44cbbfdeb527ef1f38369091432b8c1ce02653ce219dc",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_1.2.1.box"
+        }
+      ],
+      "version": "1.2.1"
     }
   ]
 }


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds 1.2.1 upgrade testing boxes.

Closes #5121.

## Testing
- Checkout `develop`
- `make build-debs`
- Check out this branch
- `make upgrade-start` (will take a while as it needs to fetch the boxes)
- [x] source interface shows SecureDrop version 1.2.1
- [x] `make upgrade-test-local` completes without error
- [x] source interface shows SecureDrop version 1.3.0~rc1

## Deployment

Dev only.

## Checklist


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
