### PR TITLE
Clarify ordering of a few operations in release management docs

### DIFF
--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -14,98 +14,109 @@ Pre-Release
 1. Open a **Release SecureDrop 1.x.y** issue to track release-related activity.
    Keep this issue updated as you proceed through the release process for
    transparency.
-2. Check if there is a new stable release of Tor that can be QAed and released
+#. Check if there is a new stable release of Tor that can be QAed and released
    as part of the SecureDrop release. If so, file an issue.
-3. Check if a release candidate for the Tails release is prepared. If so, request
+#. Check if a release candidate for the Tails release is prepared. If so, request
    people participating in QA to use the latest release candidate.
-4. Prepare a changelog describing the changes in the release.
-5. Ensure that a pre-release announcement is prepared and shared with the community
+#. Ensure that a pre-release announcement is prepared and shared with the community
    for feedback. Once the announcement is ready, coordinate with other team members to
    send them to current administrators, post on the SecureDrop blog, and tweet
    out a link.
-6. For a regular release for version 1.x.0, branch off ``develop``:
-
-  ::
+#. For a regular release for version 1.x.0, branch off ``develop``::
 
      git checkout develop
      git checkout -b release/1.x
 
-.. warning:: For new branches, please ask a ``freedomofpress`` organization
-  administrator to enable branch protection on the release branch. We want to
-  require CI to be passing as well as at least one approving review prior to
-  merging into the release branch.
+   .. warning:: For new branches, please ask a ``freedomofpress``
+                organization administrator to enable branch protection
+                on the release branch. We want to require CI to be
+                passing as well as at least one approving review prior
+                to merging into the release branch.
 
-7. Prepare each release candidate where ``rcN`` is the Nth release candidate
-   using this script:
+#. For each release candidate, update the version and
+   changelog. Collect a list of the important changes in the release,
+   including their GitHub issues or PR numbers, then run the
+   ``update_version.sh`` script, passing it the new version in the
+   format ``major.minor.patch~rcN``, e.g.::
 
-  ::
+     securedrop/bin/dev-shell ../update_version.sh 1.3.0~rc1
 
-     securedrop/bin/dev-shell ../update_version.sh 1.x.y~rcN
+   The script will open both the main repository changelog
+   (``changelog.md``) and the one used for Debian packaging in an
+   editor, giving you a chance to add the changes you collected. In
+   the Debian changelog, we typically just refer the reader to the
+   ``changelog.md`` file.
 
-8. If you would like to sign the release commit, you will need to do so manually:
+#. If you would like to sign the release commit, you will need to do so manually:
 
-    a. Create a new signed commit and verify the signature:
+   a. Create a new signed commit and verify the signature::
 
-      ::
+        git reset HEAD~1
+        git commit -aS
+        git log --show-signature
 
-         git reset HEAD~1
-         git commit -aS
-         git log --show-signature
+   #. Ensure the new commit is signed, take note of the commit hash.
 
-    b. Ensure the new commit is signed, take note of the commit hash.
+   #. Edit ``1.x.y-rcN.tag`` and replace the commit hash with the new
+      (signed) commit hash.
 
-    c. Edit ``1.x.y-rcN.tag`` and replace the commit hash with the new (signed) commit
-       hash.
-
-    d. Delete the old tag and create a new one based on the tag file edited above:
-
-      ::
+   #. Delete the old tag and create a new one based on the tag file
+      edited above::
 
          git tag -d 1.x.y-rcN
          git mktag < 1.x.y-rcN.tag > .git/refs/tags/1.x.y-rcN
 
-9. Push the branch and tags:
+#. Push the branch and tags:
 
-    a. For ``1.x.y~rc1``, push the ``release/1.x.y`` branch and ``1.x.y-rc1``
-       tag directly.
+   * For ``1.x.y~rc1``, push the ``release/1.x.y`` branch and
+     ``1.x.y-rc1`` tag directly.
 
-    b. For subsequent release candidates and the final release version, issue
-       a PR with changelog and version changes into the ``release/1.x.y`` branch,
-       and push the signed tag once the PR is merged.
+   * For subsequent release candidates and the final release version,
+     issue a PR with changelog and version changes into the
+     ``release/1.x.y`` branch, and push the signed tag once the PR is
+     merged.
 
-10. Build Debian packages and place them on ``apt-test.freedom.press``. This is currently done
-    by making a PR into `a git-lfs repo here <https://github.com/freedomofpress/securedrop-dev-packages-lfs>`_.
-    Only commit packages with an incremented version number: do not clobber existing packages.
-    That is, if there is already a deb called e.g. ``ossec-agent-3.0.0-amd64.deb`` in ``master``, do
-    not commit a new version of this deb. Changes merged to ``master`` in this repo will be published within 15 minutes.
+#. Build Debian packages and place them on
+   ``apt-test.freedom.press``. This is currently done by making a PR
+   into `a git-lfs repo here
+   <https://github.com/freedomofpress/securedrop-dev-packages-lfs>`_.
+   Only commit packages with an incremented version number: do not
+   clobber existing packages.  That is, if there is already a deb
+   called e.g. ``ossec-agent-3.0.0-amd64.deb`` in ``master``, do not
+   commit a new version of this deb. Changes merged to ``master`` in
+   this repo will be published within 15 minutes.
 
-.. note:: If the release contains other packages not created by ``make build-debs``,
-          such as Tor or kernel updates, make sure that they also get pushed to 
+   .. note:: If the release contains other packages not created by
+          ``make build-debs``, such as Tor or kernel updates, make
+          sure that they also get pushed to
           ``apt-test.freedom.press``.
 
-11. Build logs from the above debian package builds should be saved and published according to the
-    `build log guidelines <https://github.com/freedomofpress/securedrop/wiki/Build-logs>`_.
-12. Write a test plan that focuses on the new functionality introduced in the release.
-    Post for feedback and make changes based on suggestions from the community.
-13. Encourage QA participants to QA the release on production VMs and hardware. They
-    should post their QA reports in the release issue such that it is clear what
-    was and what was not tested. It is the responsibility of the release manager
-    to ensure that sufficient QA is done on the release candidate prior to
-    final release.
-14. Triage bugs as they are reported, if a bug is important to fix and does not
-    receive attention, you should fix the bug yourself or find someone who agrees
-    to work on a fix.
-15. Backport release QA fixes merged into ``develop`` into the
-    release branch using ``git cherry-pick -x <commit>`` to clearly indicate
-    where the commit originated from.
-16. At your discretion - for example when a significant fix is merged - prepare
-    additional release candidates and have fresh Debian packages prepared for
-    testing.
-17. For a regular release, the string freeze will be declared by the
-    translation administrator one week prior to the release. After this is done, ensure
-    that no changes involving string changes are backported into the release branch.
-18. Ensure that a draft of the release notes are prepared and shared with the
-    community for feedback.
+#. Build logs from the above debian package builds should be saved and
+   published according to the `build log guidelines
+   <https://github.com/freedomofpress/securedrop/wiki/Build-logs>`_.
+#. Write a test plan that focuses on the new functionality introduced
+   in the release. Post for feedback and make changes based on
+   suggestions from the community.
+#. Encourage QA participants to QA the release on production VMs and
+   hardware. They should post their QA reports in the release issue
+   such that it is clear what was and what was not tested. It is the
+   responsibility of the release manager to ensure that sufficient QA
+   is done on the release candidate prior to final release.
+#. Triage bugs as they are reported. If a bug must be fixed before the
+   release, it's the release manager's responsibility to either fix it
+   or find someone who can.
+#. Backport release QA fixes merged into ``develop`` into the release
+   branch using ``git cherry-pick -x <commit>`` to clearly indicate
+   where the commit originated from.
+#. At your discretion -- for example when a significant fix is merged
+   -- prepare additional release candidates and have fresh Debian
+   packages prepared for testing.
+#. For a regular release, the string freeze will be declared by the
+   translation administrator one week prior to the release. After this
+   is done, ensure that no changes involving string changes are
+   backported into the release branch.
+#. Ensure that a draft of the release notes are prepared and shared
+   with the community for feedback.
 
 Release Process
 ---------------
@@ -116,92 +127,97 @@ Release Process
    :ref:`i18n documentation <i18n_release>` for more information about the i18n
    release process. Note that you *must* manually inspect each line in the diff
    to ensure no malicious content is introduced.
-2. Prepare the final release commit and tag. Do not push the tag file.
-3. Step through the signing ceremony for the tag file. If you do not have
-   permissions to do so, coordinate with someone that does.
-4. Once the tag is signed, append the detached signature to the unsigned tag:
-
-  ::
+#. Prepare the final release commit and tag. Do not push the tag file.
+#. Step through the signing ceremony for the tag file. If you do not
+   have permissions to do so, coordinate with someone that does.
+#. Once the tag is signed, append the detached signature to the unsigned tag::
 
     cat 1.x.y.tag.sig >> 1.x.y.tag
 
-5. Delete the original unsigned tag:
-
-  ::
+#. Delete the original unsigned tag::
 
     git tag -d 1.x.y
 
-6. Make the signed tag:
-
-  ::
+#. Make the signed tag::
 
     git mktag < 1.x.y.tag > .git/refs/tags/1.x.y
 
-7. Verify the signed tag:
-
-  ::
+#. Verify the signed tag::
 
     git tag -v 1.x.y
 
-8. Push the signed tag:
-
-  ::
+#. Push the signed tag::
 
     git push origin 1.x.y
 
-9. Ensure there are no local changes (whether tracked, untracked or git ignored)
+#. Ensure there are no local changes (whether tracked, untracked or git ignored)
    prior to building the debs. If you did not freshly clone the repository, you
    can use git clean:
 
-   Dry run (it will list the files/folders that will be deleted):
-
-   ::
+   Dry run (it will list the files/folders that will be deleted)::
 
       git clean -ndfx
 
-   Actually delete the files:
-
-   ::
+   Actually delete the files::
 
       git clean -dfx
 
-10. Build Debian packages. People building Debian packages should verify and build
-    off the signed tag. Build logs should be saved and published according to the
-    `build log guidelines <https://github.com/freedomofpress/securedrop/wiki/Build-logs>`_.
-11. Step through the signing ceremony for the ``Release``
-    file(s) (there may be multiple if Tor is also updated along
-    with the SecureDrop release).
-12. Coordinate with the Infrastructure team to put signed Debian packages on
-    ``apt-qa.freedom.press``:
+#. Build Debian packages:
 
-  * If the release includes a Tor update, make sure to include the new Tor
-    Debian packages.
-  * If the release includes a kernel update, make sure to add the
-    corresponding grsecurity-patched kernel packages, including both
-    ``linux-image-*`` and ``linux-firmware-image-*`` packages as appropriate.
+   a. Verify and check out the signed tag for the release.
+   #. Build the packages with ``make build-debs``.
+   #. Build logs should be saved and published according to the `build
+      log guidelines
+      <https://github.com/freedomofpress/securedrop/wiki/Build-logs>`_.
+#. Step through the signing ceremony for the ``Release`` file(s)
+   (there may be multiple if Tor is also updated along with the
+   SecureDrop release).
+#. Coordinate with the Infrastructure team to put signed Debian
+   packages on ``apt-qa.freedom.press``:
 
-13. Coordinate with one or more team members to confirm a successful clean install
-    in production VMs using the packages on ``apt-qa.freedom.press``.
-14. Ask Infrastructure to perform the DNS cutover to switch ``apt-qa.freedom.press`` to
-    ``apt.freedom.press``. Once complete, the release is live.
-15. Make sure that the default branch of documentation is being built off the tip
-    of the release branch. Building from the branch instead of a given tag enables
-    us to more easily add documentation changes after release. You should:
+   * If the release includes a Tor update, make sure to include the
+     new Tor Debian packages.
+   * If the release includes a kernel update, make sure to add the
+     corresponding grsecurity-patched kernel packages, including both
+     ``linux-image-*`` and ``linux-firmware-image-*`` packages as
+     appropriate.
 
-  * Log into readthedocs.
-  * Navigate to **Projects** → **securedrop** → **Versions** → **Inactive Versions** → **release/branch** → **Edit**.
-  * Mark the branch as Active by checking the box and save your changes. This will kick off a new docs build.
-  * Once the documentation has built, it will appear in the version selector at the bottom of the column of the.
-  * Now set this new release as default by navigating to **Admin** → **Advanced Settings** → **Global Settings** → **Default Version**.
-  * Select ``release/branch`` from the dropdown menu and save the changes.
-  * Verify that docs.securedrop.org redirects users to the documentation built from the release branch.
+#. Coordinate with one or more team members to confirm a successful
+   clean install in production VMs using the packages on
+   ``apt-qa.freedom.press``.
+#. Ask Infrastructure to perform the DNS cutover to switch
+   ``apt-qa.freedom.press`` to ``apt.freedom.press``. Once complete,
+   the release is live.
+#. Make sure that the default branch of documentation is being built
+   off the tip of the release branch. Building from the branch instead
+   of a given tag enables us to more easily add documentation changes
+   after release. You should:
 
-16. Create a `release <https://github.com/freedomofpress/securedrop/releases>`_
-    on GitHub with a brief summary of the changes in this release.
-17. Make sure that release notes are written and posted on the SecureDrop blog.
-18. Make sure that the release is announced from the SecureDrop Twitter account.
-19. Make sure that members of `the support portal <https://support.freedom.press>`_
-    are notified about the release.
+   a. Log into readthedocs.
+   #. Navigate to **Projects** → **securedrop** → **Versions** →
+      **Inactive Versions** → **release/branch** → **Edit**.
+   #. Mark the branch as Active by checking the box and save your
+      changes. This will kick off a new docs build.
+   #. Once the documentation has built, it will appear in the version
+      selector at the bottom of the column of the.
+   #. Now set this new release as default by navigating to **Admin** →
+      **Advanced Settings** → **Global Settings** → **Default
+      Version**.
+   #. Select ``release/branch`` from the dropdown menu and save the
+      changes.
+   #. Verify that docs.securedrop.org redirects users to the
+      documentation built from the release branch.
+
+#. Create a `release
+   <https://github.com/freedomofpress/securedrop/releases>`_ on GitHub
+   with a brief summary of the changes in this release.
+#. Make sure that release notes are written and posted on the SecureDrop blog.
+#. Make sure that the release is announced from the SecureDrop Twitter account.
+#. Make sure that members of `the support portal
+   <https://support.freedom.press>`_ are notified about the release.
+#. Update the upgrade testing boxes following this process:
+   :ref:`updating_upgrade_boxes`.
+
 
 Post-Release
 ------------

--- a/docs/development/upgrade_testing.rst
+++ b/docs/development/upgrade_testing.rst
@@ -116,6 +116,8 @@ Log back into the *Application Server*, and repeat the previous commands:
 Navigate to the Source Interface URL again, and confirm you see the upgraded
 version in the footer. Then proceed with testing the new version.
 
+.. _updating_upgrade_boxes:
+
 Updating the base boxes used for upgrade testing
 ------------------------------------------------
 
@@ -124,10 +126,10 @@ new VM images, to enable testing against that base version in future upgrade
 testing. The procedure is as follows:
 
 1. ``make clean`` to remove any previous artifacts (which would also be pushed)
-2. ``git checkout <version>`` (if a point release, ``git checkout develop``)
-3. ``make vagrant-package``
-4. ``cd molecule/vagrant-packager && ./push.yml`` to upload to S3
-5. Commit the local changes to JSON files and open a PR.
+#. ``git checkout <version>``
+#. ``make vagrant-package``
+#. ``cd molecule/vagrant-packager && ./push.yml`` to upload to S3
+#. Commit the local changes to JSON files and open a PR.
 
 Subsequent invocations of ``make upgrade-start`` will pull the latest
 version of the box.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5137.

The old instruction to `Prepare a changelog describing the changes in the release` sounded like you should be updating the changelog files at that point, when that happens automatically during the execution of `update_version.sh`.

Also improved some indentation to clarify flow, and switched to auto-enumerated lists to avoid having to renumber when steps are added or deleted.

For upgrade testing, removed the suggestion to build upgrade boxes on develop for point releases.

## Testing

- Check out this branch
- Run `make docs`
- Review the changes in [Release Management](http://localhost:8000/development/release_management.html) and [updating upgrade boxes](http://localhost:8000/development/upgrade_testing.html#updating-upgrade-boxes).

## Deployment

Just docs.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
