### PR TITLE
Add 1.2.1 upgrade testing boxes

### DIFF
--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -100,6 +100,17 @@
         }
       ],
       "version": "1.2.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "652d4b10825e2fa7d1f9cabdace79d842cd6b6b8a22dcb5668f9d33b24613f71",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_1.2.1.box"
+        }
+      ],
+      "version": "1.2.1"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -100,6 +100,17 @@
         }
       ],
       "version": "1.2.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "78c6b5e777f5517315e44cbbfdeb527ef1f38369091432b8c1ce02653ce219dc",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_1.2.1.box"
+        }
+      ],
+      "version": "1.2.1"
     }
   ]
 }


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5141.

Backports the 1.2.1 upgrade testing box changes.

(cherry picked from commit 2f33828595492ca1ff5be143166950741a779180)

## Testing

Run through the upgrade testing scenario, confirm that the starting point is 1.2.1 and the upgrade takes you to 1.3.0~rc1.

## Deployment

Dev only.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
