### PR TITLE
added functionality to load test data during staging provisioning

### DIFF
--- a/devops/scripts/create-staging-env
+++ b/devops/scripts/create-staging-env
@@ -17,6 +17,16 @@ set -o pipefail
 
 securedrop_staging_scenario="$(./devops/scripts/select-staging-env)"
 
+if [ -z "$TEST_DATA_FILE" ]
+then
+    EXTRA_ANSIBLE_ARGS=()
+else
+    if [ "${MOLECULE_ACTION:-converge}" = 'converge' ]
+    then
+        EXTRA_ANSIBLE_ARGS=(-- --extra-vars test_data_file"=""${TEST_DATA_FILE}")
+    fi
+fi
+
 printf "Creating staging environment via '%s'...\n" "${securedrop_staging_scenario}"
 
 # Run it!
@@ -25,5 +35,5 @@ virtualenv_bootstrap
 if [ "$USER" = "sdci" ]; then
     molecule test -s "${securedrop_staging_scenario}"
 else
-    molecule "${MOLECULE_ACTION:-converge}" -s "${securedrop_staging_scenario}"
+    molecule "${MOLECULE_ACTION:-converge}" -s "${securedrop_staging_scenario}" "${EXTRA_ANSIBLE_ARGS[@]}"
 fi

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -140,6 +140,21 @@ Direct SSH access is available for staging hosts, so you can use
 is either ``virtualbox-staging-xenial`` or ``libvirt-staging-xenial``, depending
 on your environment.
 
+By default, the staging environments are created with an empty submissions database. If you want to set up a staging environment with a preexisting submissions database, you can do so using a SecureDrop backup file as follows:
+
+- Create a directory ``install_files/ansible-base/test-data``.
+- Copy the backup file to the directory above.
+- Define an environmental variable ``TEST_DATA_FILE`` whose value is the name  of the backup file - for example ``sd-backup.tar.gz`` - and run ``make staging``:
+  
+  .. code:: sh
+
+    TEST_DATA_FILE="sd-backup.tar.gz" make staging
+
+A staging environment will be created using the submissions and account data from the backup, but ignoring the backup file's Tor configuration data.
+
+.. note:: It is not recommended to use backup data from a live SecureDrop installation in staging, as the backup may contain sensitive information and the staging environment should not be considered secure.
+
+
 When finished with the Staging environment, run ``molecule destroy -s <scenario>``
 to clean up the VMs. If the host machine has been rebooted since the Staging
 environment was created, Molecule will fail to find the VM info, as it's stored

--- a/install_files/ansible-base/securedrop-staging.yml
+++ b/install_files/ansible-base/securedrop-staging.yml
@@ -34,6 +34,36 @@
   roles:
     - { role: prepare-servers }
 
+- name: Extract test data
+  hosts: app-staging
+  environment:
+    LC_ALL: C
+  become: yes
+  max_fail_percentage: 0
+  any_errors_fatal: yes
+  tasks:
+    - name: Clear existing application data
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - /var/lib/securedrop
+        - /var/www/securedrop
+      when: test_data_file is defined
+    - name: Copy test data to application server
+      synchronize:
+        src: "test-data/{{ test_data_file }}"
+        dest: /tmp/{{ test_data_file }}
+        partial: yes
+      when: test_data_file is defined
+    - name: Extract test data
+      unarchive:
+        dest: /
+        remote_src: yes
+        src: "/tmp/{{ test_data_file }}"
+        exclude: "var/lib/tor,etc/tor/torrc"
+      when: test_data_file is defined
+
 - name: Add FPF apt repository and install base packages.
   hosts: staging
   environment:


### PR DESCRIPTION
## Status
Ready for review

## Description of Changes

Fixes #5140 .

Adds option to provision a staging environment using instance data from a backup file.

## Testing

Using an existing SecureDrop backup tarball (say, `sd-backup.tar.gz`):
- checkout this branch 
- create a directory `install_files/ansible-base/test-data` and copy the backup file there.
- [ ] run `make build-debs && make staging`, verify that it completes successfully
- [ ] create an admin account, log into the JI, and verify that there are no sources or other journalist accounts on the instance
- [ ] run `TEST_DATA_FILE="sd-backup.tar.gz" make staging` and verify that it completes successfully
- [ ] verify that the SI and JI addresses remain unchanged from the initial run, and have not been set to those in the backup tarball
- [ ] create an admin account, log into the JI, and verify that the sources and journalist accounts on the instance match those from the backup tarball
- [ ] verify that source login and submission, and journalist reply processes work correctly.


## Deployment

Development/QA-only change

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
