### PR TITLE
code owners: remove heartsucker (due to inactivity)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 # application code
-/securedrop/ @redshiftzero @heartsucker @kushaldas
+/securedrop/ @redshiftzero @kushaldas
 
 # updater GUI
 /journalist_gui/ @redshiftzero @kushaldas
 
 # admin CLI
-/admin/ @redshiftzero @kushaldas @emkll @heartsucker
+/admin/ @redshiftzero @kushaldas @emkll
 
 # docs
 /docs/ @zenmonkeykstop @redshiftzero @kushaldas @emkll


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Heartsucker is no longer a maintainer (:cry:) as he's moved on to other projects for now, so let's remove him from the code owners file. 