### PR TITLE
Add 1.2.1->1.2.2 upgrade guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,7 @@ anonymous sources.
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/1.2.1_to_1.2.2.rst
    upgrade/1.2.0_to_1.2.1.rst
    upgrade/1.1.0_to_1.2.0.rst
    upgrade/1.0.0_to_1.1.0.rst

--- a/docs/upgrade/1.2.1_to_1.2.2.rst
+++ b/docs/upgrade/1.2.1_to_1.2.2.rst
@@ -1,0 +1,75 @@
+Upgrade from 1.2.1 to 1.2.2
+===========================
+
+Updating Workstations to SecureDrop 1.2.2
+-----------------------------------------
+
+Using the graphical updater
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+On the next boot of your SecureDrop *Journalist* and *Admin Workstations*,
+the *SecureDrop Workstation Updater* will alert you to workstation updates. You
+must have `configured an administrator password <https://tails.boum.org/doc/first_steps/startup_options/administration_password/>`_
+on the Tails welcome screen in order to use the graphical updater.
+
+Perform the update to 1.2.2 by clicking "Update Now":
+
+.. image:: ../images/securedrop-updater.png
+
+Performing a manual update
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+If the graphical updater fails and you want to perform a manual update instead,
+first delete the graphical updater's temporary flag file, if it exists (the
+``.`` before ``securedrop`` is not a typo): ::
+
+  rm ~/Persistent/.securedrop/securedrop_update.flag
+
+This will prevent the graphical updater from attempting to re-apply the failed
+update and has no bearing on future updates. You can now perform a manual
+update by  running the following commands: ::
+
+  cd ~/Persistent/securedrop
+  git fetch --tags
+  gpg --keyserver hkps://keys.openpgp.org --recv-key \
+   "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
+  git tag -v 1.2.2
+
+The output should include the following two lines: ::
+
+    gpg:                using RSA key 22245C81E3BAEB4138B36061310F561200F4AD77
+    gpg: Good signature from "SecureDrop Release Signing Key"
+
+Please verify that each character of the fingerprint above matches what
+on the screen of your workstation. If it does, you can check out the
+new release: ::
+
+    git checkout 1.2.2
+
+.. important:: If you do see the warning "refname '1.2.2' is ambiguous" in the
+  output, we recommend that you contact us immediately at securedrop@freedom.press
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
+
+Finally, run the following commands: ::
+
+  ./securedrop-admin setup
+  ./securedrop-admin tailsconfig
+
+Upgrading Tails
+---------------
+If you have already upgraded your workstations to Tails 4, follow the graphical
+prompts to update to the latest version.
+
+.. important::
+
+   If you are still running Tails 3.x on any workstation, we urge you to update
+   to the Tails 4 series as soon as possible. Tails 3.x is no longer receiving
+   security updates, and is no longer supported by the SecureDrop team.
+   Please see our
+   :ref:`instructions for upgrading to Tails 4 <upgrade_to_tails_4>`.
+
+Getting Support
+---------------
+
+Should you require further support with your SecureDrop installation, we are
+happy to help!
+
+.. include:: ../includes/getting-support.txt


### PR DESCRIPTION
## Description

Standard update docs, but added a bit about removing the updater flag file before manual update, since that's likely to come up for some folks due to previous update failures.

## Status

Ready for review

## Checklint
- [x] `make docs-lint` is not raising a ruckus