### PR TITLE
Add upgrade boxes for 1.2.2

### DIFF
--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -111,6 +111,17 @@
         }
       ],
       "version": "1.2.1"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "d38973ea121a96b40927cf6684812bac35ebcce17c5215e42874ad65a9b6ddd8",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_1.2.2.box"
+        }
+      ],
+      "version": "1.2.2"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -111,6 +111,17 @@
         }
       ],
       "version": "1.2.1"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "156253981849acb027d4ec081c6ec42d0d3475e37ab936d389823d2d2fb8ef6f",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_1.2.2.box"
+        }
+      ],
+      "version": "1.2.2"
     }
   ]
 }


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Closes #5156

Changes proposed in this pull request:

## Testing
on this branch:
- [ ] `make upgrade-start` : Source interface indicates version 1.2.2 (this will take a while)
- [ ] `make upgrade-test-local`: upgrade completes successfully and source interface version string indicates 1.3.0~rc1

## Deployment

Dev env only

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

