### PR TITLE
Improve admin workstation updater GUI error handling

### DIFF
--- a/journalist_gui/journalist_gui/strings.py
+++ b/journalist_gui/journalist_gui/strings.py
@@ -25,12 +25,15 @@ update_failed_sig_failure = ("WARNING: Signature verification failed. "
                              "Contact your SecureDrop administrator "
                              "or securedrop@freedom.press immediately.")
 tailsconfig_failed_sudo_password = ('Administrator password incorrect. '
-                                    'Exiting upgrade - '
-                                    'click Update Now to try again.')
+                                    'Click Update Now to try again.')
 tailsconfig_failed_generic_reason = ("Tails workstation configuration failed. "
                                      "Contact your administrator. "
                                      "If you are an administrator, contact "
                                      "securedrop@freedom.press.")
+tailsconfig_failed_timeout = ("Tails workstation configuration took too long. "
+                              "Contact your administrator. "
+                              "If you are an administrator, contact "
+                              "securedrop@freedom.press.")
 install_update_button = 'Update Now'
 install_later_button = 'Update Later'
 sudo_password_text = ("Enter the Tails Administrator password you "

--- a/journalist_gui/test_gui.py
+++ b/journalist_gui/test_gui.py
@@ -206,6 +206,18 @@ class WindowTestCase(AppTestCase):
     def test_tailsconfigThread_sudo_password_is_wrong(self, pt):
         child = pt()
         before = MagicMock()
+        before.decode.return_value = "stuff[sudo via ansible, key=blahblahblah"
+        child.before = before
+        self.window.tails_thread.run()
+        self.assertNotIn("failed=0", self.window.output)
+        self.assertEqual(self.window.update_success, False)
+        self.assertEqual(self.window.failure_reason,
+                         strings.tailsconfig_failed_sudo_password)
+
+    @mock.patch('pexpect.spawn')
+    def test_tailsconfigThread_timeout(self, pt):
+        child = pt()
+        before = MagicMock()
         before.decode.side_effect = ["some data",
                                      pexpect.exceptions.TIMEOUT(1)]
         child.before = before
@@ -213,7 +225,7 @@ class WindowTestCase(AppTestCase):
         self.assertNotIn("failed=0", self.window.output)
         self.assertEqual(self.window.update_success, False)
         self.assertEqual(self.window.failure_reason,
-                         strings.tailsconfig_failed_sudo_password)
+                         strings.tailsconfig_failed_timeout)
 
     @mock.patch('pexpect.spawn')
     def test_tailsconfigThread_some_other_subprocess_error(self, pt):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Increase the time it will wait for tailsconfig to run.

Don't say the admin password was wrong on tailsconfig timeout. Instead, look for sudo in the output to determine if an incorrect password was given.

Add a new message explaining that tailsconfig took too long, and don't say "Exiting upgrade" when an incorrect admin password was given, as the updater is not exiting, and in fact we're telling the admin to try again.

Make sure the failure reason was cleared on each attempt.

Fixes #3642.

## Testing

For those about to curse, we salute you. Ah, it's not that bad, but a bit manual.

- Fire up an admin workstation, making sure to enable the persistent volume and set an admin password.
- Start a terminal.
- `cd Persistent/securedrop`
- `git fetch --all`
- `git diff origin/develop..origin/gui-updater-error-handling > ../updater.patch`
- `git checkout 1.2.1`
- `git apply ../updater.patch`

Now bounce your network, most easily via the taskbar menu. After the network is reconnected and Tor restarts, the updater should pop up. 

- Click `Update Now`.
- When prompted, enter a wrong password. You should get a dialog saying `Administrator password incorrect.`
- Close the dialog, click `Update Now` again, and enter the correct password. It should work this time. Close the updater.

Now back in the terminal:

- `git checkout 1.2.1`
- Edit `journalist_gui/journalist_gui/SecureDropUpdater.py` to change the timeout on line 137 from 120 to 1.
- Bounce the network. 
- When the updater appears, click `Update Now`.
- Enter the correct password when the dialog appears.
- You should see a dialog saying `Tails workstation configuration took too long.`.
- Close the updater.
- If you like, clean up your repo with `git reset --hard HEAD`.

## Deployment

This doesn't change anything on the servers, just prevents a misleading error shown to admins.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
