### PR TITLE
Ignore shellcheck warning 2230

### DIFF
--- a/devops/scripts/boot-strap-venv.sh
+++ b/devops/scripts/boot-strap-venv.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC2230
 # Shared logic to be sourced for bootstrapping a development virtualenv
 
 set -eo pipefail

--- a/devops/scripts/match-ci-branch.sh
+++ b/devops/scripts/match-ci-branch.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2230
 
 #
 # Checks the given regular expression against the branch names

--- a/devops/scripts/vnc-docker-connect.sh
+++ b/devops/scripts/vnc-docker-connect.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC2086
+# shellcheck disable=SC2086,SC2230
 #
 #
 # Connect to a docker test instance's VNC session

--- a/install_files/securedrop-keyring/DEBIAN/preinst
+++ b/install_files/securedrop-keyring/DEBIAN/preinst
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2230
 
 set -e
 

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC2230
+
 ## Usage: ./update_version.sh <version>
 
 set -e


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Ignores SC2230. Fixes #5170.

## Testing

Check out this branch and run `make lint` locally, with a version of `shellcheck` between 0.5.0 and 0.7.0. The version included with Debian Buster will do the trick. You should not get the SC2230 errors you would on `develop`.

## Deployment

Dev only.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
