### PR TITLE
Updates references to "journalists" in Source Interface to more neutral "team"

### DIFF
--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -7,7 +7,7 @@
   <p>{{ gettext('Please either write this codename down and keep it in a safe place, or memorize it.') }}</p>
 </aside>
 
-<p class="explanation">{{ gettext('This codename is what you will use in future visits to receive messages from our journalists in response to what you submit on the next screen.') }}</p>
+<p class="explanation">{{ gettext('This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen.') }}</p>
 
 <hr class="no-line">
 

--- a/securedrop/source_templates/why-journalist-key.html
+++ b/securedrop/source_templates/why-journalist-key.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body %}
-<h1>{{ gettext("Why download the journalist's public key?") }}</h1>
+<h1>{{ gettext("Why download the team's public key?") }}</h1>
 <p>{{ gettext("SecureDrop encrypts files and messages after they are submitted. Encrypting messages and files before submission can provide an extra layer of security before your data reaches the SecureDrop server.") }}</p>
 <p>{{ gettext("If you are already familiar with the GPG encryption software, you may wish to encrypt your submissions yourself. To do so:") }}
 <ol>

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -550,7 +550,7 @@ def test_why_journalist_key(source_app):
         resp = app.get(url_for('info.why_download_journalist_pubkey'))
         assert resp.status_code == 200
         text = resp.data.decode('utf-8')
-        assert "Why download the journalist's public key?" in text
+        assert "Why download the team's public key?" in text
 
 
 def test_metadata_route(config, source_app):


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Closes #5146.

- Replaces instances of the phrase "our journalist[s]" with the phrase "our team", to reduce possible confusion when a source encounters a non-newsroom SecureDrop instance.


## Testing

Observe the changed strings in the source interface's templates.


## Deployment

No special considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container