### PR TITLE
Fixes #5176 Adds code+test to return replies without a journalist

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -278,10 +278,10 @@ class Reply(db.Model):
 
     def to_json(self):
         # type: () -> Dict[str, Union[str, int, bool]]
-        username = ""
+        username = "deleted"
         first_name = ""
         last_name = ""
-        uuid = ""
+        uuid = "deleted"
         if self.journalist:
             username = self.journalist.username
             first_name = self.journalist.first_name

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -278,6 +278,15 @@ class Reply(db.Model):
 
     def to_json(self):
         # type: () -> Dict[str, Union[str, int, bool]]
+        username = ""
+        first_name = ""
+        last_name = ""
+        uuid = ""
+        if self.journalist:
+            username = self.journalist.username
+            first_name = self.journalist.first_name
+            last_name = self.journalist.last_name
+            uuid = self.journalist.uuid
         json_submission = {
             'source_url': url_for('api.single_source',
                                   source_uuid=self.source.uuid),
@@ -286,10 +295,10 @@ class Reply(db.Model):
                                  reply_uuid=self.uuid),
             'filename': self.filename,
             'size': self.size,
-            'journalist_username': self.journalist.username,
-            'journalist_first_name': self.journalist.first_name,
-            'journalist_last_name': self.journalist.last_name,
-            'journalist_uuid': self.journalist.uuid,
+            'journalist_username': username,
+            'journalist_first_name': first_name,
+            'journalist_last_name': last_name,
+            'journalist_uuid': uuid,
             'uuid': self.uuid,
             'is_deleted_by_source': self.deleted_by_source,
         }

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -219,6 +219,23 @@ def test_files(journalist_app, test_journo):
 
 
 @pytest.fixture(scope='function')
+def test_files_deleted_journalist(journalist_app, test_journo):
+    with journalist_app.app_context():
+        source, codename = utils.db_helper.init_source()
+        utils.db_helper.submit(source, 2)
+        test_journo['journalist']
+        juser, _ = utils.db_helper.init_journalist("f", "l", is_admin=False)
+        utils.db_helper.reply(juser, source, 1)
+        utils.db_helper.delete_journalist(juser)
+        return {'source': source,
+                'codename': codename,
+                'filesystem_id': source.filesystem_id,
+                'uuid': source.uuid,
+                'submissions': source.submissions,
+                'replies': source.replies}
+
+
+@pytest.fixture(scope='function')
 def journalist_api_token(journalist_app, test_journo):
     with journalist_app.test_client() as app:
         valid_token = TOTP(test_journo['otp_secret']).now()

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -477,6 +477,31 @@ def test_authorized_user_can_get_single_reply(journalist_app, test_files,
             test_files['source'].replies[0].size
 
 
+def test_reply_of_deleted_journalist(journalist_app,
+                                     test_files_deleted_journalist,
+                                     journalist_api_token):
+    with journalist_app.test_client() as app:
+        reply_uuid = test_files_deleted_journalist['source'].replies[0].uuid
+        uuid = test_files_deleted_journalist['source'].uuid
+        response = app.get(url_for('api.single_reply',
+                                   source_uuid=uuid,
+                                   reply_uuid=reply_uuid),
+                           headers=get_api_headers(journalist_api_token))
+
+        assert response.status_code == 200
+
+        assert response.json['uuid'] == reply_uuid
+        assert response.json['journalist_username'] == ""
+        assert response.json['journalist_uuid'] == ""
+        assert response.json['journalist_first_name'] == ""
+        assert response.json['journalist_last_name'] == ""
+        assert response.json['is_deleted_by_source'] is False
+        assert response.json['filename'] == \
+            test_files_deleted_journalist['source'].replies[0].filename
+        assert response.json['size'] == \
+            test_files_deleted_journalist['source'].replies[0].size
+
+
 def test_authorized_user_can_delete_single_submission(journalist_app,
                                                       test_submissions,
                                                       journalist_api_token):

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -491,8 +491,8 @@ def test_reply_of_deleted_journalist(journalist_app,
         assert response.status_code == 200
 
         assert response.json['uuid'] == reply_uuid
-        assert response.json['journalist_username'] == ""
-        assert response.json['journalist_uuid'] == ""
+        assert response.json['journalist_username'] == "deleted"
+        assert response.json['journalist_uuid'] == "deleted"
         assert response.json['journalist_first_name'] == ""
         assert response.json['journalist_last_name'] == ""
         assert response.json['is_deleted_by_source'] is False

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -39,6 +39,17 @@ def init_journalist(first_name=None, last_name=None, is_admin=False):
     return user, user_pw
 
 
+def delete_journalist(journalist):
+    """Deletes a journalist from the database.
+
+    :param models.Journalist journalist: The journalist to delete
+
+    :returns: None
+    """
+    db.session.delete(journalist)
+    db.session.commit()
+
+
 def reply(journalist, source, num_replies):
     """Generates and submits *num_replies* replies to *source*
     from *journalist*. Returns reply objects as a list.


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #5176
Fixes #5177

We can safely return a reply by a journalist who is deleted from
the system. This patch also includes a test case, and dev-data
generation script also now adds a reply and then deletes the
journalist.

## Testing

- [ ] `create-dev-data.py` will add the first source with a journalist and then deletes the journalist
- [ ] https://github.com/freedomofpress/securedrop-sdk/blob/master/sdclientapi/__init__.py#L675 the list of replies for the first source can be fetched without any error

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
