### PR TITLE
Added quick data update option for staging environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # test files with the development containers
 test-results
 
+# ignore the test-data directory, used to store backup tarballs for testing
+install_files/ansible-base/test-data
+
 # ignore the production config files that don't end in .example
 securedrop-app-conf.yml
 securedrop-mon-conf.yml

--- a/devops/scripts/create-staging-env
+++ b/devops/scripts/create-staging-env
@@ -17,15 +17,22 @@ set -o pipefail
 
 securedrop_staging_scenario="$(./devops/scripts/select-staging-env)"
 
-if [ -z "$TEST_DATA_FILE" ]
+if [ ! -z "$TEST_DATA_FILE" ]
 then
-    EXTRA_ANSIBLE_ARGS=()
-else
     if [ "${MOLECULE_ACTION:-converge}" = 'converge' ]
     then
-        EXTRA_ANSIBLE_ARGS=(-- --extra-vars test_data_file"=""${TEST_DATA_FILE}")
+        EXTRA_ANSIBLE_ARGS=(-- --extra-vars test_data_file"=""${TEST_DATA_FILE}" )
     fi
 fi
+
+if [ ! -z "$UPDATE_DATA_FILE" ]
+then
+    if [ "${MOLECULE_ACTION:-converge}" = 'converge' ]
+    then
+        EXTRA_ANSIBLE_ARGS=(-- --extra-vars test_data_file"=""${UPDATE_DATA_FILE}" --tags extract-data)
+    fi
+fi
+
 
 printf "Creating staging environment via '%s'...\n" "${securedrop_staging_scenario}"
 

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -152,7 +152,14 @@ By default, the staging environments are created with an empty submissions datab
 
 A staging environment will be created using the submissions and account data from the backup, but ignoring the backup file's Tor configuration data.
 
+You can also update the database in a running staging environment, without rebuilding it, using the ``UPDATE_DATA_FILE`` environmental variable as follows:
+
+  .. code:: sh
+  
+    UPDATE_DATA_FILE="sd-backup.tar.gz" make staging
+
 .. note:: It is not recommended to use backup data from a live SecureDrop installation in staging, as the backup may contain sensitive information and the staging environment should not be considered secure.
+
 
 
 When finished with the Staging environment, run ``molecule destroy -s <scenario>``

--- a/install_files/ansible-base/securedrop-staging.yml
+++ b/install_files/ansible-base/securedrop-staging.yml
@@ -34,36 +34,6 @@
   roles:
     - { role: prepare-servers }
 
-- name: Extract test data
-  hosts: app-staging
-  environment:
-    LC_ALL: C
-  become: yes
-  max_fail_percentage: 0
-  any_errors_fatal: yes
-  tasks:
-    - name: Clear existing application data
-      file:
-        path: "{{ item }}"
-        state: absent
-      with_items:
-        - /var/lib/securedrop
-        - /var/www/securedrop
-      when: test_data_file is defined
-    - name: Copy test data to application server
-      synchronize:
-        src: "test-data/{{ test_data_file }}"
-        dest: /tmp/{{ test_data_file }}
-        partial: yes
-      when: test_data_file is defined
-    - name: Extract test data
-      unarchive:
-        dest: /
-        remote_src: yes
-        src: "/tmp/{{ test_data_file }}"
-        exclude: "var/lib/tor,etc/tor/torrc"
-      when: test_data_file is defined
-
 - name: Add FPF apt repository and install base packages.
   hosts: staging
   environment:
@@ -113,6 +83,60 @@
     - { role: app, tags: app }
     - { role: app-test, tags: app-test }
   become: yes
+
+- name: Extract test data
+  tags: extract-data
+  hosts: app-staging
+  environment:
+    LC_ALL: C
+  become: yes
+  max_fail_percentage: 0
+  any_errors_fatal: yes
+  tasks:
+    - name: Clear existing application data
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - /var/lib/securedrop
+        - /var/www/securedrop/config.py
+        - /var/www/securedrop/static/i/logo.png
+      when: test_data_file is defined
+    - name: Copy test data to application server
+      synchronize:
+        src: "test-data/{{ test_data_file }}"
+        dest: /tmp/{{ test_data_file }}
+        partial: yes
+      when: test_data_file is defined
+    - name: Extract test data
+      unarchive:
+        dest: /
+        remote_src: yes
+        src: "/tmp/{{ test_data_file }}"
+        exclude: "var/lib/tor,etc/tor/torrc"
+      when: test_data_file is defined
+
+
+- name: Reconfigure application after data update
+  tags: extract-data
+  hosts: app-staging
+  environment:
+    LC_ALL: C
+  become: yes
+  max_fail_percentage: 0
+  any_errors_fatal: yes
+  tasks:
+    - name: Reconfigure securedrop-app-code
+      command: dpkg-reconfigure -fnoninteractive securedrop-app-code
+      when: test_data_file is defined
+    - name: Reconfigure securedrop-config
+      command: dpkg-reconfigure -fnoninteractive securedrop-config
+      when: test_data_file is defined
+    - name: Reload Apache service
+      service:
+        name: apache2
+        state: reloaded
+      when: test_data_file is defined
 
   # Set iptables rules with exemptions for staging that permit direct access for SSH.
   # The overrides that permit direct access are managed in group_vars/staging.yml,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #5186.

Adds an option to update a staging environment with a backup tarball without running the full staging playbook. When run as `make staging`, the staging playbook runs with its default behaviour, creating a staging environment. When run as `TEST_DATA_FILE=foo.tar.gz make staging`, the playbook creates a staging environment and populates it with data from the `foo.tar.gz` backup tarball. When run as `UPDATE_DATA_FILE=foo.tar.gz make staging`, the playbook updates a staging environment with data from the `foo.tar.gz` backup tarball, running only the data extraction tasks.

## Testing
(2 distinct valid sd backup tarballs are required for testing.)
- check out this branch and run `make build-debs` to create packages for installation
- [ ] run `make staging` - the staging environment is created with a blank database
- [ ] run `molecule destroy -s libvirt-staging-xenial` if testing on non-Qubes or `molecule destroy -s qubes-staging` if running on Qubes, then run `make clean` - the staging environment  is wiped.
- run `make build-debs` again to create packages for installation
- create a directory `install_files/ansible-base/test-data/` and copy 2 backup tarballs into place as `foo.tar.gz` and `bar.tar.gz`
- [ ] run `TEST_DATA_FILE=foo.tar.gz make staging` - the staging environment is set up with the data from `foo.tar.gz` and newly-created onion addresses.
- [ ] run `UPDATE_DATA_FILE=bar.tar.gz make staging` - the staging environment is updated with the data from `bar.tar.gz`, the onion addresses are unchanged, and only the data extraction and app reconfiguration tasks are run.

## Deployment
Development-only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally

