### PR TITLE
Update grsecurity kernels to 4.14.175

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -38,7 +38,7 @@ enable_ssh_over_tor: true
 # the many roles of the current prod playbook
 securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
-# If you bump this, also remember to bump in molecule/builder/tests/vars.yml
+# If you bump this, also remember to bump in molecule/builder-xenial/tests/vars.yml
 securedrop_pkg_grsec:
-  ver: "4.14.154"
-  depends: "linux-image-4.14.154-grsec-securedrop,linux-image-4.4.182-grsec,linux-firmware-image-4.4.182-grsec,intel-microcode"
+  ver: "4.14.175"
+  depends: "linux-image-4.14.175-grsec-securedrop,linux-image-4.4.182-grsec,linux-firmware-image-4.4.182-grsec,intel-microcode"

--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -41,4 +41,4 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 # If you bump this, also remember to bump in molecule/builder-xenial/tests/vars.yml
 securedrop_pkg_grsec:
   ver: "4.14.175"
-  depends: "linux-image-4.14.175-grsec-securedrop,linux-image-4.4.182-grsec,linux-firmware-image-4.4.182-grsec,intel-microcode"
+  depends: "linux-image-4.14.175-grsec-securedrop,linux-image-4.14.154-grsec-securedrop,intel-microcode"

--- a/molecule/builder-xenial/tests/vars.yml
+++ b/molecule/builder-xenial/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "1.3.0~rc1"
 ossec_version: "3.0.0"
 keyring_version: "0.1.3"
 config_version: "0.1.3"
-grsec_version: "4.14.154"
+grsec_version: "4.14.175"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/staging/common/test_grsecurity.py
+++ b/molecule/testinfra/staging/common/test_grsecurity.py
@@ -185,12 +185,12 @@ def test_wireless_disabled_in_kernel_config(host, kernel_opts):
     remove wireless support from the kernel. Let's make sure wireless is
     disabled in the running kernel config!
     """
+    with host.sudo():
+        kernel_config_path = "/boot/config-{}-grsec-securedrop".format(KERNEL_VERSION)
+        kernel_config = host.file(kernel_config_path).content_string
 
-    kernel_config_path = "/boot/config-{}-grsec-securedrop".format(KERNEL_VERSION)
-    kernel_config = host.file(kernel_config_path).content_string
-
-    line = "# CONFIG_{} is not set".format(kernel_opts)
-    assert line in kernel_config
+        line = "# CONFIG_{} is not set".format(kernel_opts)
+        assert line in kernel_config
 
 
 @pytest.mark.parametrize('kernel_opts', [
@@ -203,11 +203,12 @@ def test_kernel_options_enabled_config(host, kernel_opts):
     Tests kernel config for options that should be enabled
     """
 
-    kernel_config_path = "/boot/config-{}-grsec-securedrop".format(KERNEL_VERSION)
-    kernel_config = host.file(kernel_config_path).content_string
+    with host.sudo():
+        kernel_config_path = "/boot/config-{}-grsec-securedrop".format(KERNEL_VERSION)
+        kernel_config = host.file(kernel_config_path).content_string
 
-    line = "{}=y".format(kernel_opts)
-    assert line in kernel_config
+        line = "{}=y".format(kernel_opts)
+        assert line in kernel_config
 
 
 def test_mds_mitigations_and_smt_disabled(host):
@@ -216,7 +217,8 @@ def test_mds_mitigations_and_smt_disabled(host):
     see https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html
     """
 
-    grub_config_path = "/boot/grub/grub.cfg"
-    grub_config = host.file(grub_config_path)
+    with host.sudo():
+        grub_config_path = "/boot/grub/grub.cfg"
+        grub_config = host.file(grub_config_path)
 
-    assert grub_config.contains("mds=full,nosmt")
+        assert grub_config.contains("mds=full,nosmt")

--- a/molecule/testinfra/staging/vars/staging.yml
+++ b/molecule/testinfra/staging/vars/staging.yml
@@ -195,4 +195,4 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
-grsec_version: "4.14.154"
+grsec_version: "4.14.175"

--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -LO https://ftp.mozilla.org/pub/firefox/releases/${FF_ESR_VER}/linux-x8
 
 COPY ./tor_project_public.pub /opt/
 
-ENV TBB_VERSION 9.0.7
+ENV TBB_VERSION 9.0.9
 RUN gpg --import /opt/tor_project_public.pub && \
     wget  https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \


### PR DESCRIPTION
Closes #5111

## Status

Work  in progress

## Description of Changes

Fixes #4989, towards #4992 upgrades SecureDrop kernels to 4.14.184

## Testing
- [x] Review and merge https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/57
- [x] Review and merge https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/37
- [x] Restart full CI run for this PR https://circleci.com/workflow-run/1449b8c6-d239-432b-bff0-7b05b50f37fe
- [x] Review and merge this PR

## Deployment

New and existing installs will be updated via deb packages and unattended upgrades via cron-apt

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
