### PR TITLE
Qubes staging env: handle reboots automatically

### DIFF
--- a/docs/development/qubes_staging.rst
+++ b/docs/development/qubes_staging.rst
@@ -299,12 +299,6 @@ environment. In from the root of the SecureDrop project in ``sd-dev``, run:
 
    make staging
 
-One limitation of Qubes is that the reboot handlers which run during 
-provisioning can shut down the VMs, but not start them again. When you see the
-message ``RUNNING HANDLER [common : Wait for server to come back.]`` you must 
-start the VMs again manually from ``dom0`` with the command 
-``qvm-start sd-staging-app && qvm-start sd-staging-mon``.
-
 The ``make staging`` command invokes the ``qubes-staging`` Molecule scenario. 
 You can also run constituent Molecule actions directly, rather than using
 the Makefile target: 

--- a/install_files/ansible-base/tasks/reboot.yml
+++ b/install_files/ansible-base/tasks/reboot.yml
@@ -3,3 +3,23 @@
   reboot:
   tags:
     - reboot
+  when: not securedrop_staging_qubes_env|default(False)
+
+- name: Gracefully halt Qubes staging VM
+  command: qvm-shutdown --wait {{ "sd-staging-app" if "app" in inventory_hostname else "sd-staging-mon" }}
+  become: no
+  delegate_to: localhost
+  when: securedrop_staging_qubes_env|default(False)
+  tags:
+    - reboot
+
+- name: Boot Qubes staging VM
+  shell: >
+    qvm-start
+    {{ "sd-staging-app" if "app" in inventory_hostname else "sd-staging-mon" }}
+    && sleep 30
+  become: no
+  delegate_to: localhost
+  when: securedrop_staging_qubes_env|default(False)
+  tags:
+    - reboot

--- a/molecule/qubes-staging/create.yml
+++ b/molecule/qubes-staging/create.yml
@@ -9,7 +9,9 @@
   tasks:
 
     - name: Clone base image for staging VMs
-      command: qvm-clone {{ item.vm_base }} {{ item.vm_name }}
+      # The "ignore-errors" flag sidesteps an issue with qvm-sync-appmenus. We don't need
+      # app menus for the SD VMs, so an error there need not block provisioning.
+      command: qvm-clone {{ item.vm_base }} {{ item.vm_name }} --ignore-errors
       register: clone_result
       failed_when: >-
         clone_result.rc != 0 and "qvm-clone: error: VM "+item.vm_name+" already exists" not in clone_result.stderr_lines

--- a/molecule/qubes-staging/create.yml
+++ b/molecule/qubes-staging/create.yml
@@ -7,6 +7,12 @@
     molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
+    - name: Check that Qubes admin tools are installed
+      shell: >
+        which qvm-clone
+        || { echo 'qvm-clone not found, install qubes-core-admin-client';
+        exit 1; }
+      changed_when: false
 
     - name: Clone base image for staging VMs
       # The "ignore-errors" flag sidesteps an issue with qvm-sync-appmenus. We don't need

--- a/molecule/qubes-staging/destroy.yml
+++ b/molecule/qubes-staging/destroy.yml
@@ -9,6 +9,13 @@
     molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
     molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
   tasks:
+    - name: Check that Qubes admin tools are installed
+      shell: >
+        which qvm-clone
+        || { echo 'qvm-clone not found, install qubes-core-admin-client';
+        exit 1; }
+      changed_when: false
+
     - name: Halt molecule instance(s)
       command: qvm-shutdown --wait "{{ item.vm_name }}"
       register: server

--- a/molecule/qubes-staging/qubes-vars.yml
+++ b/molecule/qubes-staging/qubes-vars.yml
@@ -23,3 +23,7 @@ remote_host_ref: >-
   }}
 
 securedrop_staging_install_target_distro: xenial
+
+# Inform the Ansible logic we're targeting Qubes staging VMs,
+# helps to customize the reboot logic.
+securedrop_staging_qubes_env: True


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #3936. 
Fixes #3629

Changes proposed in this pull request:

* Uses `--ignore-errors` on the `qvm-clone` action, closing #3936
* Adds a helpful "hey you need to install something" message during qubes-staging env failures
* Handles reboots of Qubes staging VMs automatically, same as the other environments, via the admin API. Accordingly, updates the docs to match. Closes #3629

## Testing
You must have a Qubes machine to test in!

```
make staging
```

That should get you all the way to the end, without any manual futzing with `qvm-start`. I noticed there are some testinfra tests failing under Qubes, but those aren't related, and the changes presented here should make it easier to clean those up if we want to.

## Deployment
Was careful to keep these changes dev-env only, so no prod side-effects.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
