### PR TITLE
Updates tor to 0.4.2.7

### DIFF
--- a/molecule/fetch-tor-packages/playbook.yml
+++ b/molecule/fetch-tor-packages/playbook.yml
@@ -12,7 +12,7 @@
     tor_repo_pubkey: "{{ sd_repo_root + '/install_files/ansible-base/roles/tor-hidden-services/files/tor-signing-key.pub' }}"
     tor_repo_url: "deb https://deb.torproject.org/torproject.org {{ ansible_distribution_release }} main"
     # Used to fetch a precise version; must also be updated in the test vars
-    tor_version: "0.4.1.6-1~xenial+1"
+    tor_version: "0.4.2.7-1~xenial+1"
 
   tasks:
     - name: Add Tor apt repo pubkey

--- a/molecule/fetch-tor-packages/tests/test_tor_packages.py
+++ b/molecule/fetch-tor-packages/tests/test_tor_packages.py
@@ -8,7 +8,7 @@ TOR_PACKAGES = [
     {"name": "tor", "arch": "amd64"},
     {"name": "tor-geoipdb", "arch": "all"},
 ]
-TOR_VERSION = "0.4.1.6-1~xenial+1"
+TOR_VERSION = "0.4.2.7-1~xenial+1"
 
 
 def test_tor_apt_repo(host):


### PR DESCRIPTION
## Status
Ready for review.

## Description of Changes


Changes proposed in this pull request:

Includes package version bumps in the fetch logic, which unbreaks the
associated nightly CI job. Test vars have been updated to expect the new
version info.

Fixes #5070

## Testing
So far, I've performed simple spot testing of the Source Interface, v2 & v3, and observed no problems. More vigorous testing is required to confirm no problems with these new packages.

1. Fetch the new proposed packages from https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/38
2. Run the staging environment locally
3. Copy in the new deb packages and install them with `sudo dpkg -i *.deb`
4. Perform manual interactive testing of the source & journalist interfaces, both v2 & v3. Confirm you can submit, download & decrypt, reply, and read the reply as the source. 

If no problems are found, then we can proceed with publishing the packages to apt-test, and using them in staging environments going forward. Next steps:

1. Review and merge https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/38 
2. Rerun CI on this PR, confirm passing

## Deployment
Significant implications. All prod instances will be updated to this new version of tor, when released as part of SecureDrop 1.3.0. 

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
