### PR TITLE
Update qa_loader for crypto_util changes

### DIFF
--- a/securedrop/qa_loader.py
+++ b/securedrop/qa_loader.py
@@ -188,7 +188,10 @@ class QaLoader(object):
         fname = "{}-{}-reply.gpg".format(source.interaction_count, source.journalist_filename)
         current_app.crypto_util.encrypt(
             next(replies),
-            [current_app.crypto_util.getkey(source.filesystem_id), sdconfig.JOURNALIST_KEY],
+            [
+                current_app.crypto_util.get_fingerprint(source.filesystem_id),
+                sdconfig.JOURNALIST_KEY
+            ],
             current_app.storage.path(source.filesystem_id, fname),
         )
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The old `CryptoUtil.getkey` method, which actually returned a fingerprint, was renamed to `get_fingerprint`, so `qa_loader.py` needs an update.

## Testing

- Run `make test TESTFILES="tests/test_qa_loader.py"` on `develop` -- it should fail because of the mismatched method name.
- Run `make test TESTFILES="tests/test_qa_loader.py"` on the `fix-qa-loader-new-reply` branch -- it should pass because of the matched method name.

## Deployment

Dev-only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
