### PR TITLE
Practical fix for securedrop-client#1025 Faster sync for all source

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -14,6 +14,7 @@ from models import (Journalist, Reply, Source, Submission,
                     LoginThrottledException, InvalidUsernameException,
                     BadTokenException, WrongPasswordException)
 from store import NotEncrypted
+import smallapi
 
 
 TOKEN_EXPIRATION_MINS = 60 * 8
@@ -135,9 +136,9 @@ def make_blueprint(config):
     @api.route('/sources', methods=['GET'])
     @token_required
     def get_all_sources():
-        sources = Source.query.filter_by(pending=False).all()
+        sources = smallapi.get_all_sources()
         return jsonify(
-            {'sources': [source.to_json() for source in sources]}), 200
+            {'sources': sources}), 200
 
     @api.route('/sources/<source_uuid>', methods=['GET', 'DELETE'])
     @token_required

--- a/securedrop/smallapi.py
+++ b/securedrop/smallapi.py
@@ -1,0 +1,78 @@
+from flask import url_for, current_app
+import datetime
+from collections import defaultdict
+from db import db
+from sqlalchemy import text
+
+
+def get_all_sources():
+    sql = text("SELECT filename, source_id FROM submissions")
+    results = db.engine.execute(sql)
+
+    # A dictionary of all source_ids and their submission names in a list as value
+    submissions = defaultdict(list)
+    for res in results:
+        submissions[res["source_id"]].append(res["filename"])
+
+    sql = text("SELECT source_id, starred FROM source_stars")
+    results = db.engine.execute(sql)
+
+    stars = {res["source_id"]: res["starred"] for res in results}
+
+    sql = text(
+        "SELECT id, uuid, filesystem_id, journalist_designation, flagged,"
+        "last_updated, pending, interaction_count FROM sources"
+    )
+    sources = db.engine.execute(sql)
+
+    # this is the final result list
+    result = []
+    for source in sources:
+        source_id = source["id"]
+        if source["last_updated"]:
+            timestamp = source["last_updated"] + "Z"
+        else:
+            timestamp = datetime.datetime.utcnow().isoformat() + "Z"
+
+        starred = False
+        if source_id in stars:
+            starred = bool(stars[source_id])
+
+        messages = 0
+        documents = 0
+
+        subs = submissions.get(source_id, [])
+        for sub in subs:
+            if sub.endswith("msg.gpg"):
+                messages += 1
+            elif sub.endswith("doc.gz.gpg") or sub.endswith("doc.zip.gpg"):
+                documents += 1
+
+        json_source = {
+            "uuid": source["uuid"],
+            "url": url_for("api.single_source", source_uuid=source["uuid"]),
+            "journalist_designation": source["journalist_designation"],
+            "is_flagged": source["flagged"],
+            "is_starred": starred,
+            "last_updated": timestamp,
+            "interaction_count": source["interaction_count"],
+            "key": {
+                "type": "PGP",
+                "public": current_app.crypto_util.get_pubkey(source["filesystem_id"]),
+                "fingerprint": current_app.crypto_util.get_fingerprint(
+                    source["filesystem_id"]
+                ),
+            },
+            "number_of_documents": documents,
+            "number_of_messages": messages,
+            "submissions_url": url_for(
+                "api.all_source_submissions", source_uuid=source["uuid"]
+            ),
+            "add_star_url": url_for("api.add_star", source_uuid=source["uuid"]),
+            "remove_star_url": url_for("api.remove_star", source_uuid=source["uuid"]),
+            "replies_url": url_for(
+                "api.all_source_replies", source_uuid=source["uuid"]
+            ),
+        }
+        result.append(json_source)
+    return result


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes freedomofpress/securedrop-client#1025

Reimplements  the `get_sources` call. On a staging system, direct calls using exposed port gave us the following numbers. Key size: `1024`, all keys and fingerprints are in redis cache.

1461 sources, 50 submissions, and 20 replies for each.

This is the pure python implementation (as in this PR).

```
1.61 s ± 38.5 ms per loop (mean ± std. dev. of 3 runs, 50 loops each)
```

I also tested the same logic in a complied Rust extension just to see the difference.

Python module written in Rust on mod_wsgi-express

```
1.11 s ± 47.3 ms per loop (mean ± std. dev. of 3 runs, 50 loops each)
```

Python module written in Rust on our apache2

```
1.44 s ± 114 ms per loop (mean ± std. dev. of 3 runs, 50 loops each)
```

## Testing

How should the reviewer test this PR?

- [ ] `make staging` 
- [ ] Run the client against this server.
- [ ] CI is green

I am waiting for the CI :)

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
