### PR TITLE
Use cron-apt instead of apt upgrade molecule upgrade testing scenario

### DIFF
--- a/install_files/ansible-base/roles/app-test/tasks/modern_gettext.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/modern_gettext.yml
@@ -2,7 +2,7 @@
 - name: Install gettext
   apt:
     name: gettext
-    state: latest
     update_cache: yes
+    cache_valid_time: 3600
   tags:
     - apt

--- a/install_files/ansible-base/roles/app-test/tasks/modern_gettext.yml
+++ b/install_files/ansible-base/roles/app-test/tasks/modern_gettext.yml
@@ -3,5 +3,6 @@
   apt:
     name: gettext
     state: latest
+    update_cache: yes
   tags:
     - apt

--- a/molecule/upgrade/side_effect.yml
+++ b/molecule/upgrade/side_effect.yml
@@ -3,6 +3,12 @@
   hosts: securedrop
   become: yes
   tasks:
+    - name: Add apt-test to install non-local packages referenced by metapackages (linux images)
+      lineinfile:
+        path: /etc/apt/security.list
+        line: "deb [arch=amd64] https://apt-test.freedom.press xenial main"
+      become: yes
+
     - name: Perform cron-apt upgrade
       command: cron-apt -i -s
       become: yes

--- a/molecule/upgrade/side_effect.yml
+++ b/molecule/upgrade/side_effect.yml
@@ -3,10 +3,17 @@
   hosts: securedrop
   become: yes
   tasks:
-    - name: Perform safe upgrade
-      apt:
-        update_cache: yes
-        upgrade: yes
+    - name: Perform cron-apt upgrade
+      command: cron-apt -i -s
+      become: yes
+
+    # cron-apt will always return 0, even if packages are held back.
+    # Here, we should manually check to see if packages were kept back with security.list
+    - name: Check to see if packages were kept back
+      command: "apt-get upgrade -y -o Dir::Etc::SourceList=security.list"
+      become: yes
+      register: apt_upgrade_output
+      failed_when: "'The following packages have been kept back' in apt_upgrade_output.stdout"
 
 - name: Lay out app testing deps
   hosts: securedrop_application_server


### PR DESCRIPTION
## Status
Work in progress

The challenge here will be mostly to deal with packages on the apt server that are not tracked locally: the kernel images, tor packages, and now ossec dependencies.

For these reasons, introduced a commit to append apt-test.freedom.press to `security.list` prior to running cron-apt, to ensure kernel images referred to my the metapackage are pulled in during the upgrade.

Feedback is welcome, as I am not sure this is the best approach (though it seems like an easy/quick fix that will help prevent future regressions when it comes to apt dependencies).

## Description of Changes

Fixes #4659 

Changes proposed in this pull request:

## Testing
#### Local packages
- `make upgrade-start`
- [ ] make `upgrade-test-local` completes successfully
#### Apt-test packages
- `make upgrade-qa-start`
- [ ] `make upgrade-test-qa`
## Deployment

Test only
## Checklist


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

