### PR TITLE
Correct message when logged-in source logs in

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -61,7 +61,7 @@ def make_blueprint(config):
     @view.route('/create', methods=['POST'])
     def create():
         if session.get('logged_in', False):
-            flash(gettext("You are already logged in. Please verify your codename below as it " +
+            flash(gettext("You are already logged in. Please verify your codename above as it " +
                           "may differ from the one displayed on the previous page."),
                   'notification')
         else:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5215.

The "show codename" tool is now above the message flashed when a logged-in source logs in again, not below. This PR corrects the message.

## Testing

Follow #5125 steps to reproduce. The message should be correct for the current page layout.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
