### PR TITLE
[1.3.0] backports update of pylint from 2.4.4 to 2.5.0, astroid from 2.3.3 to 2.4.0

### DIFF
--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -19,7 +19,7 @@ pip==19.1
 pip-tools>=4.0.0
 psutil>=5.6.6
 pyenchant
-pylint>=2.4.4
+pylint>=2.5.0
 pytest-xdist
 python-vagrant
 pyyaml>=5.3.1

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -36,9 +36,9 @@ aspy.yaml==1.3.0 \
     --hash=sha256:463372c043f70160a9ec950c3f1e4c3a82db5fca01d334b6bc89c7164d744bdc \
     --hash=sha256:e7c742382eff2caed61f87a39d13f99109088e5e93f04d76eb8d4b28aa143f45 \
     # via pre-commit
-astroid==2.3.3 \
-    --hash=sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a \
-    --hash=sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42 \
+astroid==2.4.0 \
+    --hash=sha256:29fa5d46a2404d01c834fcb802a3943685f1fc538eb2a02a161349f5505ac196 \
+    --hash=sha256:2fecea42b20abb1922ed65c7b5be27edfba97211b04b2b6abc6a43549a024ea6 \
     # via pylint
 babel==2.4.0 \
     --hash=sha256:8c98f5e5f8f5f088571f2c6bd88d530e331cbbcb95a7311a0db69d3dca7ec563 \
@@ -455,9 +455,9 @@ pygments==2.2.0 \
     --hash=sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d \
     --hash=sha256:dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc \
     # via sphinx
-pylint==2.4.4 \
-    --hash=sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd \
-    --hash=sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4
+pylint==2.5.0 \
+    --hash=sha256:588e114e3f9a1630428c35b7dd1c82c1c93e1b0e78ee312ae4724c5e1a1e0245 \
+    --hash=sha256:bd556ba95a4cf55a1fc0004c00cf4560b1e70598a54a74c6904d933c8f3bd5a8
 pynacl==1.1.2 \
     --hash=sha256:123c41df1db119397f2e26e9c63ca2ea853d3663e26b1c389bd3859dc1b7178a \
     --hash=sha256:1b4938a557b32e5c6b27fac79a94cf1abb70753b5462a0b577bd2a77e09dacd0 \
@@ -601,7 +601,7 @@ testinfra==3.2.0 \
 toml==0.10.0 \
     --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
     --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
-    # via pre-commit
+    # via pre-commit, pylint
 tornado==4.5.1 \
     --hash=sha256:0a6894559e62a186d6cc20f1c0e7318f83ae8e28922d75c4b6f83d42cc91d8b1 \
     --hash=sha256:2b4618010625bcf01f187eec3148c6a3db76a2a900f7dde416330fc413274df1 \


### PR DESCRIPTION
(cherry picked from commit 4e768674bc604af764d739972b0efe58e3200be3)

## Status

Ready for review 

## Description of Changes

Backports #5219 

Updates pylint to 2.5.0, astroid to 2.4.0

## Testing

Does this PR contain the same commits as #5219?

## Deployment

Dev-only

