### PR TITLE
Removed submission preference alert from top of config page

### DIFF
--- a/securedrop/journalist_templates/flashed.html
+++ b/securedrop/journalist_templates/flashed.html
@@ -1,7 +1,7 @@
 {% with messages = get_flashed_messages(with_categories=true) %}
 {% if messages %}
   {% for category, message in messages %}
-    {% if category != "banner-warning" and category != "logo-success" and category != "logo-error"%}
+    {% if category != "banner-warning" and category != "logo-success" and category != "logo-error" and category != "submission-preferences-success" %}
       <div class="flash {{ category }}">
         {% if category == "notification" %}
         <img src="{{ url_for('static', filename='i/font-awesome/info-circle-black.png') }}" height="16" width="20">


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #5220

Adds document submission flash message to the list of messages *not* displayed at the top of pages, similarly to the handling for the logo form on the instance config page. (It was being displayed unstyled due to the message category not having a corresponding css style)

## Testing

- checkout this branch and run `make dev`
- log into the journalist interface using the test credentials, and navigate to the config section: `/admin/config`
- change the submissions preference at the bottom of the page
- [ ] the config page is re-rendered *without* a flash message at the top of the page, and *with* the "Preferences saved" message rendered correctly in the Submissions Preferences section.

## Deployment

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
