### PR TITLE
Use WTForm for source interface submission form

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -184,6 +184,8 @@ class Source(db.Model):
 
 
 class Submission(db.Model):
+    MAX_MESSAGE_LEN = 100000
+
     __tablename__ = 'submissions'
     id = Column(Integer, primary_key=True)
     uuid = Column(String(36), unique=True, nullable=False)

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -54,12 +54,12 @@
 {% if allow_document_uploads %}
     <div class="attachment grid-item center">
       <img class="center" id="upload-icon" src="{{ url_for('static', filename='i/arrow-upload-large.png') }}" width="56" height="56">
-      <input type="file" name="fh" autocomplete="off">
+      {{ form.fh() }}
       <p class="center" id="max-file-size">{{ gettext('Maximum upload size: 500 MB') }}</p>
     </div>
 {% endif %}
     <div class="message grid-item{% if not allow_document_uploads %} wide{% endif %}">
-      <textarea name="msg" class="fill-parent" placeholder="{{ gettext('Write a message.') }}"></textarea>
+        {{ form.msg(class="fill-parent") }}
     </div>
   </div>
 

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -352,11 +352,9 @@ def test_submit_empty_message(source_app):
 
 
 def test_submit_big_message(source_app):
-    '''
-    When the message is larger than 512KB it's written to disk instead of
-    just residing in memory. Make sure the different return type of
-    SecureTemporaryFile is handled as well as BytesIO.
-    '''
+    """
+    Test the message size limit.
+    """
     with source_app.test_client() as app:
         new_codename(app, session)
         _dummy_submission(app)
@@ -366,7 +364,7 @@ def test_submit_big_message(source_app):
             follow_redirects=True)
         assert resp.status_code == 200
         text = resp.data.decode('utf-8')
-        assert "Thanks! We received your message" in text
+        assert "Message text too long." in text
 
 
 def test_submit_file(source_app):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds `SubmissionForm` to `securedrop/source_app/forms.py`, supporting validation of the source submission form. Rework `lookup.html` to use it: some presentation (the placeholder) had to be moved to the form, because the translated message couldn't be interpolated into the `SubmissionForm` construction in the template.

Note that this change does *not* add the `maxlength` attribute to the message textarea, as Firefox doesn't limit the text length accurately when it includes newlines and can submit a message longer than the validator limit.

## Testing

- Check out the `source-submission-wtform` branch.
- Run `make dev`
- Navigate to the source submission page. 
- Copy more than 100000 bytes of text, paste it into the message textarea, submit, and confirm that you get an error saying `Message text too long. Large blocks of text must be uploaded as a file, not copied and pasted.`
- Submit a short message and confirm that there is no validation error.
- Confirm that you can still upload a file larger than 100000 bytes.
- Navigate to the journalist interface, under the instance config admin page, and disable uploads.
- Retry the large paste test, and confirm that the message is simply `Message text too long.`

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

