### PR TITLE
Updated references to Tails Terminal menu item with 4.6 location

### DIFF
--- a/docs/backup_workstations.rst
+++ b/docs/backup_workstations.rst
@@ -107,7 +107,7 @@ Create the backup using Rsync
 |Backup and TailsData Mounted|
 
 Open a terminal by going to
-**Applications** ▸ **Favorites** ▸ **Terminal**.
+**Applications** ▸ **System Tools** ▸ **Terminal**.
 
 
 Next, create a directory on the Backup USB for the device to be backed up - the
@@ -189,7 +189,7 @@ name ``TailsData`` will appear in the lefthand column.
 Copy the Backup to the New Workstation USB's Persistent Volume
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Open a terminal by navigating to **Applications** ▸ **Favorites**
+Open a terminal by navigating to **Applications** ▸ **System Tools**
 ▸ **Terminal** . Next, use the ``rsync`` command to copy the appropriate backup
 folder to the new workstation USB's persistent volume. For example, if the
 backup folder to be copied is named ``admin-backup``, run the following command:

--- a/docs/generate_submission_key.rst
+++ b/docs/generate_submission_key.rst
@@ -21,7 +21,7 @@ stick, with persistence enabled.
 Create the Key
 --------------
 
-#. Navigate to **Applications ▸ Terminal** to open a terminal |Terminal|.
+#. Navigate to **Applications > System Tools > Terminal** to open a terminal |Terminal|.
 #. In the terminal, run ``gpg --full-generate-key``:
 
    |GPG generate key|

--- a/docs/rebuild_admin.rst
+++ b/docs/rebuild_admin.rst
@@ -52,7 +52,7 @@ the KeePassXC database <set_up_admin_tails>`.
 
 The *Admin Workstation* uses SSH with key authentication to connect to the servers,
 so you'll need to create a new SSH keypair for your SecureDrop instance. To do so,
-open a terminal by navigating to **Applications>Favorites>Terminal**,  and run 
+open a terminal by navigating to **Applications > System Tools > Terminal**,  and run 
 the following command:
 
 .. code:: sh

--- a/docs/v3_services.rst
+++ b/docs/v3_services.rst
@@ -84,7 +84,7 @@ Workstation* with ``./securedrop-admin tailsconfig``.
 
 - First, boot into the *Admin Workstation* with the persistent volume unlocked
   and an admin password set.
-- Next, open a terminal via **Applications > Favorites > Terminal** and change
+- Next, open a terminal via **Applications > System Tools > Terminal** and change
   the working directory to the Securedrop application directory:
 
   .. code:: sh
@@ -190,7 +190,7 @@ Journalist Workstation:
 
  - Then, boot into the *Journalist Workstation* to be updated, with the persistent 
    volume unlocked and an admin password set.
- - Next, open a terminal via **Applications > Favorites > Terminal** and change
+ - Next, open a terminal via **Applications > System Tools > Terminal** and change
    the working directory to the Securedrop application directory:
 
    .. code:: sh
@@ -236,7 +236,7 @@ Admin Workstation:
 
  - Then, boot into the *Admin Workstation* to be updated, with the persistent 
    volume unlocked and an admin password set.
- - Next, open a terminal via **Applications > Favorites > Terminal** and change
+ - Next, open a terminal via **Applications > System Tools > Terminal** and change
    the working directory to the Securedrop application directory:
 
    .. code:: sh


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5234 

Updates references to the Terminal menu location to the correct new location for Tails 4.6, **Applications > System Tools > Terminal**.

## Testing

Docs-only PR:
- [ ] all references to the menu location are updated
- [ ] does CI pass?


## Checklist

### If you made changes to the system configuration:


### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
