### PR TITLE
Updated references to Tails Terminal menu item with 4.6 location

### DIFF
--- a/docs/backup_workstations.rst
+++ b/docs/backup_workstations.rst
@@ -51,7 +51,7 @@ Preparing the Backup Device
 
 First you must boot the *primary Tails USB* drive. Ensure you set an
 administrator password set at the login screen. Then navigate to
-**Applications** ▸ **Utilities** ▸ **Disks**.
+**Applications ▸ Utilities ▸ Disks**.
 
 |Applications Utilities Disks|
 
@@ -89,7 +89,7 @@ Once completed, you will see two partitions appear:
 |Two Partitions Appear|
 
 Now that you made the backup device, plug in the device you want to backup.
-Then, browse to **Places** ▸ **Computer**:
+Then, browse to **Places ▸ Computer**:
 
 |Browse to Places Computer|
 
@@ -107,7 +107,7 @@ Create the backup using Rsync
 |Backup and TailsData Mounted|
 
 Open a terminal by going to
-**Applications** ▸ **System Tools** ▸ **Terminal**.
+**Applications ▸ System Tools ▸ Terminal**.
 
 
 Next, create a directory on the Backup USB for the device to be backed up - the
@@ -177,7 +177,7 @@ Open the Backup USB and new Tails Persistent Volume
 First, boot up the host Tails USB on the airgapped machine, making sure to set
 an administration password on the Tails Greeter dialog.
 
-Then, navigate to **Places** ▸ **Computer** to open the file manager, and insert
+Then, navigate to **Places ▸ Computer** to open the file manager, and insert
 the Backup USB. Click its entry in the lefthand column and enter its decryption
 passphrase when prompted. Its volume name (``Backup`` in the instructions above)
 will appear in place of the generic ``N.M GB Encrypted`` name.
@@ -189,8 +189,8 @@ name ``TailsData`` will appear in the lefthand column.
 Copy the Backup to the New Workstation USB's Persistent Volume
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Open a terminal by navigating to **Applications** ▸ **System Tools**
-▸ **Terminal** . Next, use the ``rsync`` command to copy the appropriate backup
+Open a terminal by navigating to **Applications ▸ System Tools
+▸ Terminal** . Next, use the ``rsync`` command to copy the appropriate backup
 folder to the new workstation USB's persistent volume. For example, if the
 backup folder to be copied is named ``admin-backup``, run the following command:
 

--- a/docs/backup_workstations.rst
+++ b/docs/backup_workstations.rst
@@ -107,7 +107,7 @@ Create the backup using Rsync
 |Backup and TailsData Mounted|
 
 Open a terminal by going to
-**Applications** ▸ **Favorites** ▸ **Terminal**.
+**Applications** ▸ **System Tools** ▸ **Terminal**.
 
 
 Next, create a directory on the Backup USB for the device to be backed up - the
@@ -189,7 +189,7 @@ name ``TailsData`` will appear in the lefthand column.
 Copy the Backup to the New Workstation USB's Persistent Volume
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Open a terminal by navigating to **Applications** ▸ **Favorites**
+Open a terminal by navigating to **Applications** ▸ **System Tools**
 ▸ **Terminal** . Next, use the ``rsync`` command to copy the appropriate backup
 folder to the new workstation USB's persistent volume. For example, if the
 backup folder to be copied is named ``admin-backup``, run the following command:

--- a/docs/generate_submission_key.rst
+++ b/docs/generate_submission_key.rst
@@ -21,7 +21,7 @@ stick, with persistence enabled.
 Create the Key
 --------------
 
-#. Navigate to **Applications > System Tools > Terminal** to open a terminal |Terminal|.
+#. Navigate to **Applications ▸ System Tools ▸ Terminal** to open a terminal |Terminal|.
 #. In the terminal, run ``gpg --full-generate-key``:
 
    |GPG generate key|

--- a/docs/generate_submission_key.rst
+++ b/docs/generate_submission_key.rst
@@ -21,7 +21,7 @@ stick, with persistence enabled.
 Create the Key
 --------------
 
-#. Navigate to **Applications ▸ Terminal** to open a terminal |Terminal|.
+#. Navigate to **Applications > System Tools > Terminal** to open a terminal |Terminal|.
 #. In the terminal, run ``gpg --full-generate-key``:
 
    |GPG generate key|

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -449,8 +449,8 @@ Tails 4 replaces MAT with MAT2, which is usable via the command line and via a
 context menu in the **Files** application (called ``nautilus`` on the command
 line).
 
-You can use MAT2 via the **Files** application by browsing to **Places** ▸
-**(Your file's location)** and right-clicking on your file. In the context
+You can use MAT2 via the **Files** application by browsing to **Places ▸
+(Your file's location)** and right-clicking on your file. In the context
 menu, select **Remove metadata**.
 
 |mat2 context menu|

--- a/docs/rebuild_admin.rst
+++ b/docs/rebuild_admin.rst
@@ -52,7 +52,7 @@ the KeePassXC database <set_up_admin_tails>`.
 
 The *Admin Workstation* uses SSH with key authentication to connect to the servers,
 so you'll need to create a new SSH keypair for your SecureDrop instance. To do so,
-open a terminal by navigating to **Applications>Favorites>Terminal**,  and run 
+open a terminal by navigating to **Applications > System Tools > Terminal**,  and run 
 the following command:
 
 .. code:: sh

--- a/docs/rebuild_admin.rst
+++ b/docs/rebuild_admin.rst
@@ -52,7 +52,7 @@ the KeePassXC database <set_up_admin_tails>`.
 
 The *Admin Workstation* uses SSH with key authentication to connect to the servers,
 so you'll need to create a new SSH keypair for your SecureDrop instance. To do so,
-open a terminal by navigating to **Applications > System Tools > Terminal**,  and run 
+open a terminal by navigating to **Applications ▸ System Tools ▸ Terminal**,  and run 
 the following command:
 
 .. code:: sh

--- a/docs/tails_printing_guide.rst
+++ b/docs/tails_printing_guide.rst
@@ -48,8 +48,8 @@ Tails.
 Connect the printer to your Tails-booted computer via USB, then turn the printer
 on.
 
-Now, you'll want to single-click your way through **Applications** ▸
-**System Tools** ▸ **Settings** ▸ **Devices** ▸ **Printers**. The screenshot
+Now, you'll want to single-click your way through **Applications ▸
+System Tools ▸ Settings**, then select **Devices ▸ Printers**. The screenshot
 below highlights the "Devices" section in which the printer settings can be
 found:
 

--- a/docs/update_bios.rst
+++ b/docs/update_bios.rst
@@ -38,7 +38,7 @@ Proceed to the Intel Download Centre to download the correct file. Each make and
 
   .. warning:: Do not download BIOS updates from anywhere other than the manufacturer's website. Be sure that you are `on the correct website`_ and that it has a valid SSL Certificate. Intel's SSL Certificate is issued to \*.intel.com and signed by DigiCert. Be sure you download the files specific to the model of your servers.
 
-Intel provides an md5 checksum on the download page. Once you have downloaded the ``.bio file``, using the **Files** application, browse to the file, right click and select **Properties** ▸ **Digests**, select MD5, and click Hash. Compare the result in the Digest column to the md5 sum listed on Intel's website. If these two values do not match, do not proceed, and contact support@freedom.press. Tails `provides a detailed explanation of this process`_. (Note that the hash in the screenshot below is an example only, and will not match your specific ``.bio`` file.)
+Intel provides an md5 checksum on the download page. Once you have downloaded the ``.bio file``, using the **Files** application, browse to the file, right click and select **Properties ▸ Digests**, select MD5, and click Hash. Compare the result in the Digest column to the md5 sum listed on Intel's website. If these two values do not match, do not proceed, and contact support@freedom.press. Tails `provides a detailed explanation of this process`_. (Note that the hash in the screenshot below is an example only, and will not match your specific ``.bio`` file.)
 
 |gtkhash tails|
 

--- a/docs/v3_services.rst
+++ b/docs/v3_services.rst
@@ -84,7 +84,7 @@ Workstation* with ``./securedrop-admin tailsconfig``.
 
 - First, boot into the *Admin Workstation* with the persistent volume unlocked
   and an admin password set.
-- Next, open a terminal via **Applications > Favorites > Terminal** and change
+- Next, open a terminal via **Applications > System Tools > Terminal** and change
   the working directory to the Securedrop application directory:
 
   .. code:: sh
@@ -190,7 +190,7 @@ Journalist Workstation:
 
  - Then, boot into the *Journalist Workstation* to be updated, with the persistent 
    volume unlocked and an admin password set.
- - Next, open a terminal via **Applications > Favorites > Terminal** and change
+ - Next, open a terminal via **Applications > System Tools > Terminal** and change
    the working directory to the Securedrop application directory:
 
    .. code:: sh
@@ -236,7 +236,7 @@ Admin Workstation:
 
  - Then, boot into the *Admin Workstation* to be updated, with the persistent 
    volume unlocked and an admin password set.
- - Next, open a terminal via **Applications > Favorites > Terminal** and change
+ - Next, open a terminal via **Applications > System Tools > Terminal** and change
    the working directory to the Securedrop application directory:
 
    .. code:: sh

--- a/docs/v3_services.rst
+++ b/docs/v3_services.rst
@@ -84,7 +84,7 @@ Workstation* with ``./securedrop-admin tailsconfig``.
 
 - First, boot into the *Admin Workstation* with the persistent volume unlocked
   and an admin password set.
-- Next, open a terminal via **Applications > System Tools > Terminal** and change
+- Next, open a terminal via **Applications ▸ System Tools ▸ Terminal** and change
   the working directory to the Securedrop application directory:
 
   .. code:: sh
@@ -190,7 +190,7 @@ Journalist Workstation:
 
  - Then, boot into the *Journalist Workstation* to be updated, with the persistent 
    volume unlocked and an admin password set.
- - Next, open a terminal via **Applications > System Tools > Terminal** and change
+ - Next, open a terminal via **Applications ▸ System Tools ▸ Terminal** and change
    the working directory to the Securedrop application directory:
 
    .. code:: sh
@@ -236,7 +236,7 @@ Admin Workstation:
 
  - Then, boot into the *Admin Workstation* to be updated, with the persistent 
    volume unlocked and an admin password set.
- - Next, open a terminal via **Applications > System Tools > Terminal** and change
+ - Next, open a terminal via **Applications ▸ System Tools ▸ Terminal** and change
    the working directory to the Securedrop application directory:
 
    .. code:: sh


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5234 

- Updates references to the Terminal menu location to the correct new location for Tails 4.6, **Applications ▸ System Tools ▸ Terminal**
- standardizes references to menu locations in docs on format above.

## Testing

Docs-only PR:
- [ ] all references to the menu location are updated
- [ ] does CI pass?


## Checklist

### If you made changes to the system configuration:


### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
