### PR TITLE
added version information to docs index page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -138,3 +138,8 @@ anonymous sources.
   threat_model/threat_model.rst
   threat_model/dataflow.rst
   threat_model/mitigations.rst
+
+Two versions of this documentation are available:
+
+- ``latest`` - built from the ``develop`` branch of the SecureDrop repository, containing updates that have been tested but not yet released.
+- ``master`` - built from the ``master`` branch of the SecureDrop repository, and up to date with the most recent release, |version|.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Optional update to #5081.

Adds  information on docs versions to the docs index page, including the latest release version number.

## Testing

- Docs-only - review for clarity and correctness.

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
