### PR TITLE
added Ansible parameter to use legacy password prompt text

### DIFF
--- a/install_files/ansible-base/ansible.cfg
+++ b/install_files/ansible-base/ansible.cfg
@@ -8,6 +8,9 @@ timeout=120
 # from site-specific vars, or Onion URLs for SSH over ATHS.
 inventory=inventory-dynamic
 
+[privilege_escalation]
+agnostic_become_prompt=False
+
 [ssh_connection]
 scp_if_ssh=True
 ssh_args = -o ControlMaster=auto -o ControlPersist=1200


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5254.

Sets `agnostic_become_prompt` to `False` in `ansible.cfg`. This sets the password prompt when ansible is called with `--ask-become-pass` to `SUDO password:`. When set to `True`, the prompt is set as `BECOME password:`. 

The default value was switched in Ansible 2.8, but the GUI updater expects the `False` and `SUDO password` version, so it needs to be set explicitly.

## Testing
In a prod instance (VMs or hardware):
- check out this branch in an Admin Workstation
- [ ] run `./securedrop-admin setup` - it completes without error
- follow the installation guide and verify that:
  - [ ] the password prompt for `./securedrop-admin install` is `SUDO password:`
  - [ ] the password prompt for `./securedrop-admin tailsconfig` is `SUDO password:`
  - [ ] both commands complete successfully.


## Deployment
This will be deployed with the next production release after merge - as it preserves existing behaviour it should not have any impact on the GUI updater.

## Checklist
### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR


