### PR TITLE
[1.3.0] added Ansible parameter to use legacy password prompt text

### DIFF
--- a/install_files/ansible-base/ansible.cfg
+++ b/install_files/ansible-base/ansible.cfg
@@ -8,6 +8,9 @@ timeout=120
 # from site-specific vars, or Onion URLs for SSH over ATHS.
 inventory=inventory-dynamic
 
+[privilege_escalation]
+agnostic_become_prompt=False
+
 [ssh_connection]
 scp_if_ssh=True
 ssh_args = -o ControlMaster=auto -o ControlPersist=1200


### PR DESCRIPTION
(cherry picked from commit c03651e8260d5bee84dd11d57248a722af343639)

## Status

Ready for review

## Description of Changes

backports #5255 - fixes Ansible BECOME prompt to use pre-2.8 behaviour.



## Testing

- [ ] CI is passing
- [ ] base is `release/1.3.0`
- [ ] commits are the same as those in #5255
