### PR TITLE
fix: Only run docs linting/linkcheck tests in master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,7 @@ workflows:
             branches:
               only:
                 - master
-      - lint
+      - lint:
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ jobs:
             if ! [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
             make ci-deb-tests
 
-  docs-linkcheck:
+  docs-lint-linkcheck:
     docker:
       - image: circleci/python:3.5
     steps:
@@ -297,7 +297,7 @@ workflows:
   version: 2
   securedrop_ci:
     jobs:
-      - docs-linkcheck:
+      - docs-lint-linkcheck:
           filters:
             branches:
               only:
@@ -390,5 +390,5 @@ workflows:
     jobs:
       - deb-tests
       - translation-tests
-      - docs-linkcheck
+      - docs-lint-linkcheck
       - fetch-tor-debs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
           name: Run all linters but shellcheck
           command: |
             fromtag=$(docker images |grep securedrop-test-xenial-py3 |head -n1 |awk '{print $2}')
-            DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" securedrop/bin/dev-shell bash -c "/opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/develop-requirements.txt && make -C .. ansible-config-lint app-lint docs-lint flake8 html-lint typelint yamllint"
+            DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" securedrop/bin/dev-shell bash -c "/opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/develop-requirements.txt && make -C .. ansible-config-lint app-lint flake8 html-lint typelint yamllint"
 
       - run:
           name: Run shellcheck
@@ -297,11 +297,21 @@ workflows:
   version: 2
   securedrop_ci:
     jobs:
+      - docs-linkcheck:
+          filters:
+            branches:
+              only:
+                - master
       - lint
+          filters:
+            branches:
+              ignore:
+                - master
       - app-tests:
           filters:
             branches:
               ignore:
+                - master
                 - /docs-.*/
                 - /i18n-.*/
                 - /update-builder-.*/
@@ -311,6 +321,7 @@ workflows:
           filters:
             branches:
               ignore:
+                - master
                 - /docs-.*/
                 - /i18n-.*/
                 - /update-builder-.*/
@@ -320,23 +331,33 @@ workflows:
           filters:
             branches:
               ignore:
+                - master
                 - /docs-.*/
                 - /i18n-.*/
                 - /update-builder-.*/
           requires:
             - lint
       - static-analysis-and-no-known-cves:
+          filters:
+            branches:
+              ignore:
+                - master
           requires:
             - lint
       - staging-test-with-rebase:
           filters:
             branches:
               ignore:
+                - master
                 - /docs-.*/
                 - /i18n-.*/
           requires:
             - lint
       - translation-tests:
+          filters:
+            branches:
+              ignore:
+                - master
           requires:
             - lint
       - deb-tests:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

As `master` branch is only used for the purpose of building documentation, we should modify the jobs that are run on that branch to only those that are relevant for documentation purposes, which is the lint job only, as it runs the docs linting. We may even want to restrict further and only run the docs linting on master.

Fixes #5264 

Changes proposed in this pull request:

Ignored jobs other than `docs-linkcheck` for master branch. Also, configured `docs-linkcheck` to only run if changes are done in master branch.