### PR TITLE
Update Qubes docs references to debian-10; add tip re: aufs-dkms

### DIFF
--- a/docs/development/qubes_staging.rst
+++ b/docs/development/qubes_staging.rst
@@ -15,7 +15,7 @@ Standalone (HVM) Qubes VMs for use with staging:
 - ``sd-staging-app-base``, a base VM for the *SecureDrop Application Server*
 - ``sd-staging-mon-base``, a base VM for the *SecureDrop Monitor Server*
 
-While the development VM, ``sd-dev``, is based on Debian 9, the other VMs
+While the development VM, ``sd-dev``, is based on Debian 10, the other VMs
 will be based on Ubuntu Xenial.
 
 .. note:: The staging server VM names were recently changed from ``sd-app`` and

--- a/docs/development/qubes_staging.rst
+++ b/docs/development/qubes_staging.rst
@@ -299,9 +299,9 @@ environment. In from the root of the SecureDrop project in ``sd-dev``, run:
 
    make staging
 
-The ``make staging`` command invokes the ``qubes-staging`` Molecule scenario. 
+The ``make staging`` command invokes the ``qubes-staging`` Molecule scenario.
 You can also run constituent Molecule actions directly, rather than using
-the Makefile target: 
+the Makefile target:
 
 .. code:: sh
 
@@ -309,11 +309,11 @@ the Makefile target:
    molecule converge -s qubes-staging
    molecule test -s qubes-staging
 
-.. note:: 
+.. note::
 
-  If the Molecule converge scenario fails with an error like ``"stderr": 
-  "app: Failed to clone appmenus, qvm-appmenus missing\`` you may be running 
-  into a bug in Qubes that prevents non-dom0 VMs from cloning new VMs. A 
+  If the Molecule converge scenario fails with an error like ``"stderr":
+  "app: Failed to clone appmenus, qvm-appmenus missing\`` you may be running
+  into a bug in Qubes that prevents non-dom0 VMs from cloning new VMs. A
   workaround is described `here <https://github.com/freedomofpress/securedrop/issues/3936>`_.
 
 That's it. You should now have a running, configured SecureDrop staging instance
@@ -324,4 +324,3 @@ to provision staging VMs on-demand. To remove the staging instance, use the Mole
 .. code:: sh
 
    molecule destroy -s qubes-staging
-

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -52,19 +52,23 @@ Install Docker_.
 Qubes
 ~~~~~
 
-Create a StandaloneVM based on Debian 9, called ``sd-dev``.
+Create a StandaloneVM based on Debian 10, called ``sd-dev``.
 You can use the **Q** menu to configure a new VM, or run
 the following in ``dom0``:
 
 .. code:: sh
 
-   qvm-clone --class StandaloneVM debian-9 sd-dev
+   qvm-clone --class StandaloneVM debian-10 sd-dev
    qvm-start sd-dev
    qvm-sync-appmenus sd-dev
 
 The commands above will created a new StandaloneVM, boot it, then update
 the Qubes menus with applications within that VM. Open a terminal in
 ``sd-dev``, and proceed with installing `Docker CE for Debian`_.
+
+.. tip:: If you experience an error with the ``aufs-dkms`` dependency when
+   installing Docker CE, you can safely skip that package using the
+   ``--no-install-recommends`` argument for ``apt``.
 
 Fork & Clone the Repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -224,8 +224,8 @@ Log out, then log in again. Verify that libvirt is installed and KVM is availabl
    kvm-ok
 
 
-Debian 9 setup
-^^^^^^^^^^^^^^
+Debian stable setup
+^^^^^^^^^^^^^^^^^^^
 
 Install Vagrant, libvirt, QEMU, and their dependencies:
 


### PR DESCRIPTION
## Description

The Qubes dev/staging docs still reference `debian-9`; we have since transitioned to `debian-10`. Also added a tip regarding the `aufs-dkms` dependency which can bite users when setting up Docker due to Qubes' custom kernel.

I did not attempt to resolve #4965 because we've not discussed that change as a team yet.

## Status

Ready for review

## Checklint
- [x] Linter says "ship it, fine with me!"