### PR TITLE
Fix functional test flake at two-factor tooltip check

### DIFF
--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -720,15 +720,20 @@ class JournalistNavigationStepsMixin:
         # Also, confirm the text on the tooltip is the correct one.
         reset_button.location_once_scrolled_into_view
         ActionChains(self.driver).move_to_element(reset_button).perform()
-        time.sleep(1)
-        explanatory_tooltip_opacity = self.driver.find_elements_by_css_selector(
-            "#button-reset-two-factor-" + otp_type + " span")[0].value_of_css_property("opacity")
-        explanatory_tooltip_content = self.driver.find_elements_by_css_selector(
-            "#button-reset-two-factor-" + otp_type + " span")[0].text
 
-        assert explanatory_tooltip_opacity == "1"
-        if not hasattr(self, "accept_languages"):
-            assert explanatory_tooltip_content == tooltip_text
+        def explanatory_tooltip_is_correct():
+            explanatory_tooltip = self.driver.find_element_by_css_selector(
+                "#button-reset-two-factor-" + otp_type + " span"
+            )
+
+            explanatory_tooltip_opacity = explanatory_tooltip.value_of_css_property("opacity")
+            assert explanatory_tooltip_opacity == "1"
+
+            if not hasattr(self, "accept_languages"):
+                assert explanatory_tooltip.text == tooltip_text
+
+        self.wait_for(explanatory_tooltip_is_correct)
+
         reset_form.submit()
 
         alert = self.driver.switch_to_alert()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5271.

The check of the explanatory tooltip shown when editing two-factor secrets needed to be made more tolerant of CI performance.

## Testing

The flakiness only presented in CI, but it was failing more often than not, so if CI is green, this is probably ready to go.
