### PR TITLE
Add upgrade boxes for 1.3.0

### DIFF
--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -122,6 +122,17 @@
         }
       ],
       "version": "1.2.2"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "32865fc67110bc3dd4d98bd61d1b54207bebae75fec5b0df9e3935b70d107467",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_1.3.0.box"
+        }
+      ],
+      "version": "1.3.0"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -122,6 +122,17 @@
         }
       ],
       "version": "1.2.2"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "2cd099eb7c8ac45381ec106f8de3412f39dad15d3f4cc663b284e021a8605b83",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_1.3.0.box"
+        }
+      ],
+      "version": "1.3.0"
     }
   ]
 }


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Last item on 1.3.0 release checklist, therefore closes #5205 

Changes proposed in this pull request:

* Adds references to new "upgrade" scenario boxes (already uploaded to S3) 

## Testing

- Checkout `develop`
- `make build-debs`
- Check out this branch
- `make upgrade-start` (will take a while as it needs to fetch the boxes)
- [ ] source interface shows SecureDrop version 1.3.0
- [ ] `make upgrade-test-local` completes without error
- [ ] source interface shows SecureDrop version 1.4.0~rc1

## Deployment

Dev only

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
