### PR TITLE
fix: Proper exception handling of InvalidPasswordLength

### DIFF
--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -12,7 +12,8 @@ import i18n
 from db import db
 from models import (get_one_or_else, Source, Journalist, InvalidUsernameException,
                     WrongPasswordException, FirstOrLastNameError, LoginThrottledException,
-                    BadTokenException, SourceStar, PasswordError, Submission, RevokedToken)
+                    BadTokenException, SourceStar, PasswordError, Submission, RevokedToken,
+                    InvalidPasswordLength)
 from store import add_checksum_for_file
 
 import typing
@@ -77,7 +78,8 @@ def validate_user(username, password, token, error_message=None):
     except (InvalidUsernameException,
             BadTokenException,
             WrongPasswordException,
-            LoginThrottledException) as e:
+            LoginThrottledException,
+            InvalidPasswordLength) as e:
         current_app.logger.error("Login for '{}' failed: {}".format(
             username, e))
         if not error_message:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

When entering passphrase of more than 128 (max_limit) characters, the user lands to the Internal Server Error Page.

Fixes #5145 

Changes proposed in this pull request:

Handle the exception properly so that the server returns with the flashed error message.


## Testing

- check out this branch
- [x] Run `make dev` - it completes successfully
- Attempt to log into the journalist interface on `localhost:8081` with a valid username `<userName>` and TOTP code, and a password longer than 127 characters:
  - [x] Login fails with `Login failed. Please wait for a new code from your two-factor mobile app or security key before trying again` message.
  - [x] Error recorded in Docker output with contents: `[<timestamp>] ERROR in utils: Login for '<userName>' failed: invalid password`
- Attempt to log in to the JI with valid username, TOTP, and password:
  - [x] Login succeeds.

## Deployment

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
