### PR TITLE
Handle case of deleted journalists

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -132,6 +132,10 @@ password manager. Then, you will select whether you would like them to also be
 an admin (this allows them to add or delete other journalist accounts), and
 whether they will be using FreeOTP or a YubiKey for two-factor authentication.
 
+.. note::
+  We don't allow the username **deleted** as we use it to mark the
+  journalist which are deleted from the system.
+
 FreeOTP
 ^^^^^^^
 

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -134,7 +134,7 @@ whether they will be using FreeOTP or a YubiKey for two-factor authentication.
 
 .. note::
   We don't allow the username **deleted** as we use it to mark the
-  journalist which are deleted from the system.
+  journalists which are deleted from the system.
 
 FreeOTP
 ^^^^^^^

--- a/securedrop/journalist_app/forms.py
+++ b/securedrop/journalist_app/forms.py
@@ -40,7 +40,7 @@ def name_length_validation(form, field):
 def check_invalid_usernames(form, field):
     if field.data in Journalist.INVALID_USERNAMES:
         raise ValidationError(gettext(
-            "Invalid username"))
+            "This username is invalid because it is reserved for internal use by the software."))
 
 
 class NewUserForm(FlaskForm):

--- a/securedrop/journalist_app/forms.py
+++ b/securedrop/journalist_app/forms.py
@@ -37,10 +37,16 @@ def name_length_validation(form, field):
             .format(max_chars=Journalist.MAX_NAME_LEN)))
 
 
+def check_username_deleted(form, field):
+    if field.data == 'deleted':
+        raise ValidationError(gettext(
+            "Invalid username '{}'".format(field.data)))
+
+
 class NewUserForm(FlaskForm):
     username = StringField('username', validators=[
         InputRequired(message=gettext('This field is required.')),
-        minimum_length_validation
+        minimum_length_validation, check_username_deleted
     ])
     first_name = StringField('first_name', validators=[name_length_validation, Optional()])
     last_name = StringField('last_name', validators=[name_length_validation, Optional()])

--- a/securedrop/journalist_app/forms.py
+++ b/securedrop/journalist_app/forms.py
@@ -38,10 +38,9 @@ def name_length_validation(form, field):
 
 
 def check_invalid_usernames(form, field):
-    invalid_usernames = ['deleted']
-    if field.data in invalid_usernames:
+    if field.data in Journalist.INVALID_USERNAMES:
         raise ValidationError(gettext(
-            "Invalid username '{}'".format(field.data)))
+            "Invalid username"))
 
 
 class NewUserForm(FlaskForm):

--- a/securedrop/journalist_app/forms.py
+++ b/securedrop/journalist_app/forms.py
@@ -37,8 +37,9 @@ def name_length_validation(form, field):
             .format(max_chars=Journalist.MAX_NAME_LEN)))
 
 
-def check_username_deleted(form, field):
-    if field.data == 'deleted':
+def check_invalid_usernames(form, field):
+    invalid_usernames = ['deleted']
+    if field.data in invalid_usernames:
         raise ValidationError(gettext(
             "Invalid username '{}'".format(field.data)))
 
@@ -46,7 +47,7 @@ def check_username_deleted(form, field):
 class NewUserForm(FlaskForm):
     username = StringField('username', validators=[
         InputRequired(message=gettext('This field is required.')),
-        minimum_length_validation, check_username_deleted
+        minimum_length_validation, check_invalid_usernames
     ])
     first_name = StringField('first_name', validators=[name_length_validation, Optional()])
     last_name = StringField('last_name', validators=[name_length_validation, Optional()])

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -414,6 +414,7 @@ class Journalist(db.Model):
     MIN_USERNAME_LEN = 3
     MIN_NAME_LEN = 0
     MAX_NAME_LEN = 100
+    INVALID_USERNAMES = ['deleted']
 
     def __init__(self,
                  username: str,
@@ -642,17 +643,16 @@ class Journalist(db.Model):
               password: str,
               token: str) -> 'Journalist':
 
-        invalid_usernames = ['deleted']
-
         try:
             user = Journalist.query.filter_by(username=username).one()
         except NoResultFound:
             raise InvalidUsernameException(
                 "invalid username '{}'".format(username))
 
-        if user.username in invalid_usernames and user.uuid in invalid_usernames:
+        if user.username in Journalist.INVALID_USERNAMES and \
+                user.uuid in Journalist.INVALID_USERNAMES:
             raise InvalidUsernameException(
-                "Invalid username '{}'".format(username))
+                "Invalid username")
 
         if LOGIN_HARDENING:
             cls.throttle_login(user)

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -647,6 +647,10 @@ class Journalist(db.Model):
             raise InvalidUsernameException(
                 "invalid username '{}'".format(username))
 
+        if user.username == 'deleted' and user.uuid == 'deleted':
+            raise InvalidUsernameException(
+                "Invalid username '{}'".format(username))
+
         if LOGIN_HARDENING:
             cls.throttle_login(user)
 

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -641,13 +641,16 @@ class Journalist(db.Model):
               username: str,
               password: str,
               token: str) -> 'Journalist':
+
+        invalid_usernames = ['deleted']
+
         try:
             user = Journalist.query.filter_by(username=username).one()
         except NoResultFound:
             raise InvalidUsernameException(
                 "invalid username '{}'".format(username))
 
-        if user.username == 'deleted' and user.uuid == 'deleted':
+        if user.username in invalid_usernames and user.uuid in invalid_usernames:
             raise InvalidUsernameException(
                 "Invalid username '{}'".format(username))
 

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -341,7 +341,7 @@ class JournalistNavigationStepsMixin:
         self.wait_for(lambda: self.driver.find_element_by_css_selector(".form-validation-error"))
 
         error_msg = self.driver.find_element_by_css_selector(".form-validation-error")
-        assert "Invalid username '{}'".format(invalid_username) in error_msg.text
+        assert "Invalid username" in error_msg.text
 
     def _admin_adds_a_user(self, is_admin=False, new_username=""):
         self.safe_click_by_id("add-user")

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -338,6 +338,8 @@ class JournalistNavigationStepsMixin:
 
         self.safe_click_by_css_selector("button[type=submit]")
 
+        self.wait_for(lambda: self.driver.find_element_by_css_selector(".form-validation-error"))
+
         error_msg = self.driver.find_element_by_css_selector(".form-validation-error")
         assert "Invalid username '{}'".format(invalid_username) in error_msg.text
 

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -322,6 +322,25 @@ class JournalistNavigationStepsMixin:
 
         self.wait_for(lambda: self.driver.find_element_by_id("check-token"))
 
+    def _admin_adds_a_user_with_invalid_username(self):
+        self.safe_click_by_id("add-user")
+
+        self.wait_for(lambda: self.driver.find_element_by_id("username"))
+
+        if not hasattr(self, "accept_languages"):
+            # The add user page has a form with an "ADD USER" button
+            btns = self.driver.find_elements_by_tag_name("button")
+            assert "ADD USER" in [el.text for el in btns]
+
+        invalid_username = 'deleted'
+
+        self.safe_send_keys_by_css_selector('input[name="username"]', invalid_username)
+
+        self.safe_click_by_css_selector("button[type=submit]")
+
+        error_msg = self.driver.find_element_by_css_selector(".form-validation-error")
+        assert "Invalid username '{}'".format(invalid_username) in error_msg.text
+
     def _admin_adds_a_user(self, is_admin=False, new_username=""):
         self.safe_click_by_id("add-user")
 

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -341,7 +341,7 @@ class JournalistNavigationStepsMixin:
         self.wait_for(lambda: self.driver.find_element_by_css_selector(".form-validation-error"))
 
         error_msg = self.driver.find_element_by_css_selector(".form-validation-error")
-        assert "Invalid username" in error_msg.text
+        assert "This username is invalid because it is reserved for internal use by the software." in error_msg.text
 
     def _admin_adds_a_user(self, is_admin=False, new_username=""):
         self.safe_click_by_id("add-user")

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -341,7 +341,8 @@ class JournalistNavigationStepsMixin:
         self.wait_for(lambda: self.driver.find_element_by_css_selector(".form-validation-error"))
 
         error_msg = self.driver.find_element_by_css_selector(".form-validation-error")
-        assert "This username is invalid because it is reserved for internal use by the software." in error_msg.text
+        assert "This username is invalid because it is reserved for internal use " \
+               "by the software." in error_msg.text
 
     def _admin_adds_a_user(self, is_admin=False, new_username=""):
         self.safe_click_by_id("add-user")

--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -56,6 +56,12 @@ class TestAdminInterface(
         self._admin_visits_system_config_page()
         self._admin_can_send_test_alert()
 
+    def test_admin_adds_user_with_invalid_username(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        # Add an user with invalid username
+        self._admin_adds_a_user_with_invalid_username()
+
     def test_admin_adds_admin_user(self):
         self._admin_logs_in()
         self._admin_visits_admin_interface()

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1076,6 +1076,23 @@ def test_admin_add_user(journalist_app, test_admin):
                                                uid=new_user.id))
 
 
+def test_admin_add_user_with_invalid_username(journalist_app, test_admin):
+    username = 'deleted'
+
+    with journalist_app.test_client() as app:
+        _login_user(app, test_admin['username'], test_admin['password'], test_admin['otp_secret'])
+
+        with InstrumentedApp(journalist_app) as ins:
+            resp = app.post(url_for('admin.add_user'),
+                            data=dict(username=username,
+                                      first_name='',
+                                      last_name='',
+                                      password=VALID_PASSWORD,
+                                      is_admin=None))
+
+    assert "Invalid username '{}'".format(username) in resp.data.decode('utf-8')
+
+
 def test_admin_add_user_without_username(journalist_app, test_admin):
     with journalist_app.test_client() as app:
         _login_user(app, test_admin['username'], test_admin['password'],

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1082,13 +1082,12 @@ def test_admin_add_user_with_invalid_username(journalist_app, test_admin):
     with journalist_app.test_client() as app:
         _login_user(app, test_admin['username'], test_admin['password'], test_admin['otp_secret'])
 
-        with InstrumentedApp(journalist_app) as ins:
-            resp = app.post(url_for('admin.add_user'),
-                            data=dict(username=username,
-                                      first_name='',
-                                      last_name='',
-                                      password=VALID_PASSWORD,
-                                      is_admin=None))
+        resp = app.post(url_for('admin.add_user'),
+                        data=dict(username=username,
+                                  first_name='',
+                                  last_name='',
+                                  password=VALID_PASSWORD,
+                                  is_admin=None))
 
     assert "Invalid username '{}'".format(username) in resp.data.decode('utf-8')
 

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1089,7 +1089,7 @@ def test_admin_add_user_with_invalid_username(journalist_app, test_admin):
                                   password=VALID_PASSWORD,
                                   is_admin=None))
 
-    assert "Invalid username '{}'".format(username) in resp.data.decode('utf-8')
+    assert "Invalid username" in resp.data.decode('utf-8')
 
 
 def test_deleted_user_cannot_login(journalist_app):

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1089,7 +1089,8 @@ def test_admin_add_user_with_invalid_username(journalist_app, test_admin):
                                   password=VALID_PASSWORD,
                                   is_admin=None))
 
-    assert "Invalid username" in resp.data.decode('utf-8')
+    assert "This username is invalid because it is reserved for internal use by the software." \
+           in resp.data.decode('utf-8')
 
 
 def test_deleted_user_cannot_login(journalist_app):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5232 

Changes proposed in this pull request:

Because of #5178, deleted journalist `username` and `uuid` is set to `deleted`. We should not allow the deleted journalist to login. Also, we can differentiate it from other not deleted journalists whose username is deleted by comparing both the `username` and `uuid` rather than just username. Also, we should not allow adding new journalist with username `deleted` for less confusion. 

## Testing

How should the reviewer test this PR?

Make a test journalist with username `deleted`, it would fail (due to changes in `form.py` file). Undo those changes and make a new journalist with username `deleted` and try logging in using credentials of that journalist, it should succeed. Change `uuid` of that journalist to `deleted`, it should fail to login again for that journalist.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR