### PR TITLE
Add system configuration check script to securedrop-ossec packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,6 @@ lib/
 lib64/
 parts/
 sdist/
-var/
 wheels/
 *.egg-info/
 .installed.cfg

--- a/install_files/securedrop-ossec-agent/var/ossec/checksdconfig.py
+++ b/install_files/securedrop-ossec-agent/var/ossec/checksdconfig.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import argparse
+import subprocess
+import sys
+
+
+IPTABLES_RULES_UNCONFIGURED = {
+    "all": ["-P INPUT ACCEPT", "-P FORWARD ACCEPT", "-P OUTPUT ACCEPT"]
+}
+
+
+IPTABLES_RULES_DEFAULT_DROP = {
+    "policies": [
+        "-P INPUT DROP",
+        "-P FORWARD DROP",
+        "-P OUTPUT DROP",
+    ],
+    "input": [
+        '-A INPUT -m comment --comment "Drop and log all other incoming traffic" -j LOGNDROP',
+    ],
+    "output": [
+        '-A OUTPUT -m comment --comment "Drop all other outgoing traffic" -j DROP',
+    ],
+    "logndrop": [
+        (
+            "-A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-tcp-options --log-ip-options "
+            "--log-uid"
+        ),
+        "-A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-ip-options --log-uid",
+        "-A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-ip-options --log-uid",
+        "-A LOGNDROP -j DROP",
+    ]
+}
+
+
+def list_iptables_rules():
+    result = subprocess.run(
+        ["iptables", "-S"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    rules = result.stdout.decode("utf-8").splitlines()
+    policies = [r for r in rules if r.startswith("-P")]
+    input_rules = [r for r in rules if r.startswith("-A INPUT")]
+    output_rules = [r for r in rules if r.startswith("-A OUTPUT")]
+    logndrop_rules = [r for r in rules if r.startswith("-A LOGNDROP")]
+    return {
+        "all": rules,
+        "policies": policies,
+        "input": input_rules,
+        "output": output_rules,
+        "logndrop": logndrop_rules,
+    }
+
+
+def check_iptables_are_default(rules):
+    if rules["all"] == IPTABLES_RULES_UNCONFIGURED:
+        raise ValueError("The iptables rules have not been configured.")
+
+
+def check_iptables_default_drop(rules):
+    for chain, chain_rules in IPTABLES_RULES_DEFAULT_DROP.items():
+        for i, rule in enumerate(reversed(chain_rules), 1):
+            try:
+                if rules[chain][-i] != rule:
+                    raise ValueError("The iptables default drop rules are incorrect.")
+            except (KeyError, IndexError):
+                raise ValueError("The iptables default drop rules are incorrect.")
+
+
+def check_iptables_rules():
+    rules = list_iptables_rules()
+    check_iptables_are_default(rules)
+    check_iptables_default_drop(rules)
+
+
+def check_system_configuration(args):
+    print("Checking system configuration...")
+    try:
+        check_iptables_rules()
+    except ValueError as e:
+        print("System configuration error:", e)
+        sys.exit(1)
+    print("System configuration checks were successful.")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='SecureDrop server configuration check')
+    args = parser.parse_args()
+    check_system_configuration(args)

--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -140,6 +140,12 @@
   </localfile>
 
   <localfile>
+    <log_format>command</log_format>
+    <command>/var/ossec/checksdconfig.py</command>
+    <frequency>90000</frequency>
+  </localfile>
+
+  <localfile>
     <log_format>syslog</log_format>
     <location>/var/log/kern.log</location>
   </localfile>

--- a/install_files/securedrop-ossec-server/var/ossec/checksdconfig.py
+++ b/install_files/securedrop-ossec-server/var/ossec/checksdconfig.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import argparse
+import subprocess
+import sys
+
+
+IPTABLES_RULES_UNCONFIGURED = {
+    "all": ["-P INPUT ACCEPT", "-P FORWARD ACCEPT", "-P OUTPUT ACCEPT"]
+}
+
+
+IPTABLES_RULES_DEFAULT_DROP = {
+    "policies": [
+        "-P INPUT DROP",
+        "-P FORWARD DROP",
+        "-P OUTPUT DROP",
+    ],
+    "input": [
+        '-A INPUT -m comment --comment "Drop and log all other incoming traffic" -j LOGNDROP',
+    ],
+    "output": [
+        '-A OUTPUT -m comment --comment "Drop all other outgoing traffic" -j DROP',
+    ],
+    "logndrop": [
+        (
+            "-A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-tcp-options --log-ip-options "
+            "--log-uid"
+        ),
+        "-A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-ip-options --log-uid",
+        "-A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-ip-options --log-uid",
+        "-A LOGNDROP -j DROP",
+    ]
+}
+
+
+def list_iptables_rules():
+    result = subprocess.run(
+        ["iptables", "-S"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    rules = result.stdout.decode("utf-8").splitlines()
+    policies = [r for r in rules if r.startswith("-P")]
+    input_rules = [r for r in rules if r.startswith("-A INPUT")]
+    output_rules = [r for r in rules if r.startswith("-A OUTPUT")]
+    logndrop_rules = [r for r in rules if r.startswith("-A LOGNDROP")]
+    return {
+        "all": rules,
+        "policies": policies,
+        "input": input_rules,
+        "output": output_rules,
+        "logndrop": logndrop_rules,
+    }
+
+
+def check_iptables_are_default(rules):
+    if rules["all"] == IPTABLES_RULES_UNCONFIGURED:
+        raise ValueError("The iptables rules have not been configured.")
+
+
+def check_iptables_default_drop(rules):
+    for chain, chain_rules in IPTABLES_RULES_DEFAULT_DROP.items():
+        for i, rule in enumerate(reversed(chain_rules), 1):
+            try:
+                if rules[chain][-i] != rule:
+                    raise ValueError("The iptables default drop rules are incorrect.")
+            except (KeyError, IndexError):
+                raise ValueError("The iptables default drop rules are incorrect.")
+
+
+def check_iptables_rules():
+    rules = list_iptables_rules()
+    check_iptables_are_default(rules)
+    check_iptables_default_drop(rules)
+
+
+def check_system_configuration(args):
+    print("Checking system configuration...")
+    try:
+        check_iptables_rules()
+    except ValueError as e:
+        print("System configuration error:", e)
+        sys.exit(1)
+    print("System configuration checks were successful.")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='SecureDrop server configuration check')
+    args = parser.parse_args()
+    check_system_configuration(args)

--- a/install_files/securedrop-ossec-server/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-server/var/ossec/etc/ossec.conf
@@ -98,6 +98,12 @@
     <command>last -n 5</command>
   </localfile>
 
+  <localfile>
+    <log_format>command</log_format>
+    <command>/var/ossec/checksdconfig.py</command>
+    <frequency>90000</frequency>
+  </localfile>
+
   <reports>
     <group>authentication_success</group>
     <user type="relation">srcip</user>
@@ -142,6 +148,14 @@
     <email_to>root@localhost</email_to>
     <group>sd_data_problems</group>
     <rule_id>400800, 400801</rule_id>
+    <do_not_delay />
+    <do_not_group />
+  </email_alerts>
+
+  <email_alerts>
+    <email_to>root@localhost</email_to>
+    <group>system_configuration</group>
+    <rule_id>400900</rule_id>
     <do_not_delay />
     <do_not_group />
   </email_alerts>

--- a/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
+++ b/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
@@ -224,3 +224,13 @@
     <description>Indicates that there are files in the submission area without corresponding submissions in the database.</description>
   </rule>
 </group>
+
+<group name="system_configuration">
+  <rule id="400900" level="12" >
+    <if_sid>530</if_sid>
+    <options>alert_by_email</options> <!-- force email to be sent -->
+    <match>ossec: output: '/var/ossec/checksdconfig.py'</match>
+    <regex>System configuration error:</regex>
+    <description>Indicates a problem with the configuration of the SecureDrop servers.</description>
+  </rule>
+</group>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Add checksdconfig.py to both securedrop-ossec-agent and securedrop-ossec-server, so that the configuration of both app and mon servers can be checked.

## Testing

- `make build-debs && make staging`
- as root on each server:
  - edit `/var/ossec/etc/ossec.conf` to change the frequency at which `checksdconfig.py` is run to 30 seconds
  - restart OSSEC with `systemctl restart ossec`
  -  run `iptables --rename-chain LOGNDROP FOO`
- wait 30 seconds, then as root on the mon server, verify that `/var/ossec/logs/alerts/alerts.log` contains level 12 alerts saying that there are system configuration errors on both servers, saying  `The iptables default drop rules are incorrect.` .

## Deployment

This adds a new script for checking the system configuration of both app and mon servers, with corresponding alerts that could be sent to the SecureDrop administrators.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
