### PR TITLE
Bump Tor Browser version to 9.5

### DIFF
--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -LO https://ftp.mozilla.org/pub/firefox/releases/${FF_ESR_VER}/linux-x8
 
 COPY ./tor_project_public.pub /opt/
 
-ENV TBB_VERSION 9.0.9
+ENV TBB_VERSION 9.5
 RUN gpg --import /opt/tor_project_public.pub && \
     wget  https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \


### PR DESCRIPTION
## Description

Tor 9.5 was [released](https://blog.torproject.org/new-release-tor-browser-95) today; this PR updated the version in our Docker container accordingly to fix CI issues like [this one](https://app.circleci.com/pipelines/github/freedomofpress/securedrop/237/workflows/69159665-5b51-4745-93c4-380f045427b6/jobs/40834/steps).

## Status

Ready for review