### PR TITLE
update make target fetch-tor-packages to download 0.4.3.5

### DIFF
--- a/molecule/fetch-tor-packages/playbook.yml
+++ b/molecule/fetch-tor-packages/playbook.yml
@@ -12,7 +12,7 @@
     tor_repo_pubkey: "{{ sd_repo_root + '/install_files/ansible-base/roles/tor-hidden-services/files/tor-signing-key.pub' }}"
     tor_repo_url: "deb https://deb.torproject.org/torproject.org {{ ansible_distribution_release }} main"
     # Used to fetch a precise version; must also be updated in the test vars
-    tor_version: "0.4.2.7-1~xenial+1"
+    tor_version: "0.4.3.5-1~xenial+1"
 
   tasks:
     - name: Add Tor apt repo pubkey

--- a/molecule/fetch-tor-packages/tests/test_tor_packages.py
+++ b/molecule/fetch-tor-packages/tests/test_tor_packages.py
@@ -8,7 +8,7 @@ TOR_PACKAGES = [
     {"name": "tor", "arch": "amd64"},
     {"name": "tor-geoipdb", "arch": "all"},
 ]
-TOR_VERSION = "0.4.2.7-1~xenial+1"
+TOR_VERSION = "0.4.3.5-1~xenial+1"
 
 
 def test_tor_apt_repo(host):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes https://github.com/freedomofpress/securedrop/issues/5291

Bumps tor version from `0.4.2.7-1~xenial+1` to `0.4.3.5-1~xenial+1` in our `fetch-tor-packages` make target.

As followup, I plan to add notes about this process to our pre-release docs when I make a pre-release docs PR after running through the process from start to finish.

Changes proposed in this pull request:

## Testing

Run `make fetch-tor-packages` and see that the new debs are downloaded to the build/xenial directory.

Checksum verification will be done here: https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/43