### PR TITLE
Ignore tmp files in /var/lib/securedrop/shredder

### DIFF
--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -53,7 +53,9 @@
     <ignore>/var/lib/securedrop/db.sqlite</ignore>
 
     <ignore>/var/lib/securedrop/submissions_today.txt</ignore>
-
+    
+    <ignore type="sregex">/var/lib/securedrop/shredder/tmp</ignore>
+    
     <ignore>/var/securedrop/store</ignore>
 
     <ignore>/var/ossec/queue</ignore>


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Changes proposed in this pull request:

Ossec syscheck tends to generate noise about missing shredder tmp files when submissions are deleted between two rounds of syscheck.  Proposing ignoring anything in /var/lib/securedrop/shredder starting with tmp

## Testing
Delete submission between two rounds of ossec syscheck.

## Deployment
[TBD]

## Checklist
- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass