### PR TITLE
Add SecureDrop 1.3.0->1.4.0 docs, OSSEC alert guidance

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -422,10 +422,9 @@ There are two primary reasons why you may want to update the system configuratio
 
 - to change SecureDrop server configuration options. **Example:** You want to change
   the time of day at which the servers are automatically rebooted (default: 4:00 AM).
-- to fix a problem with the configuration state of your *Application* and/or
-  *Monitor Server*. **Example:** An administrator unfamiliar with the system has
-  directly modified the iptables rules, and you want to reinstate the correct
-  rules.
+- to restore a valid configuration state on your servers. **Example:** Another admin
+  has directly modified the iptables rules during troubleshooting, and you want
+  to reinstate the correct rules.
 
 In both cases, follow these steps:
 

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -194,9 +194,9 @@ Passphrases and Two-Factor Resets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning:: Both of these operations will lock a user out of their
-   SecureDrop accounts. We recommend having users be physically present when
+   SecureDrop account. We recommend having users be physically present when
    resetting their passphrase or two-factor authentication. If this is not
-   possible, store passphrases and/or two-factor authentication secret in
+   possible, store the passphrase and/or two-factor authentication secret in
    your own password manager before securely transmitting them to the user
    in question, and delete them once the user has confirmed they can
    successfully log in.
@@ -423,8 +423,9 @@ There are two primary reasons why you may want to update the system configuratio
 - to change SecureDrop server configuration options. **Example:** You want to change
   the time of day at which the servers are automatically rebooted (default: 4:00 AM).
 - to fix a problem with the configuration state of your *Application* and/or
-  *Monitor Server*. **Example:** An administrator has locally modified your iptables
-  rules, and you want to reinstate the SecureDrop defaults.
+  *Monitor Server*. **Example:** An administrator unfamiliar with the system has
+  directly modified the iptables rules, and you want to reinstate the correct
+  rules.
 
 In both cases, follow these steps:
 

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -191,14 +191,14 @@ possession when they attempt to log in to SecureDrop.
 
 
 Passphrases and Two-Factor Resets
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning:: Both of these operations will lock a user out of their
    SecureDrop accounts. We recommend having users be physically present when
    resetting their passphrase or two-factor authentication. If this is not
-   possible, store passphrases and/or two-factor authentication secret in 
-   your own password manager before securely transmitting them to the user 
-   in question, and delete them once the user has confirmed they can 
+   possible, store passphrases and/or two-factor authentication secret in
+   your own password manager before securely transmitting them to the user
+   in question, and delete them once the user has confirmed they can
    successfully log in.
 
 While we publish some :ref:`passphrase best practices <passphrase_best_practices>`,
@@ -418,33 +418,42 @@ Updating System Configuration
 
 .. _update-system-configuration:
 
-If you want to update the system configuration, you should use the
-``securedrop-admin`` tool on the *Admin Workstation*. From
-``~/Persistent/securedrop``, run:
+There are two primary reasons why you may want to update the system configuration:
 
-.. code:: sh
+- to change SecureDrop server configuration options. **Example:** You want to change
+  the time of day at which the servers are automatically rebooted (default: 4:00 AM).
+- to fix a problem with the configuration state of your *Application* and/or
+  *Monitor Server*. **Example:** An administrator has locally modified your iptables
+  rules, and you want to reinstate the SecureDrop defaults.
 
-  ./securedrop-admin sdconfig
+In both cases, follow these steps:
 
-This will give you the opportunity to edit any variable. Answer the prompts with values
-that match your environment. An example of one such prompt would be to set the ``daily reboot time``.
-To minimize the presence/duration of plaintext in memory, the servers are rebooted every 24 hours
-to periodically wipe the memory. As an admin, you can configure this automatic reboot time.
-By default, it is set at 4:00 a.m. and you can change it to suit your timing. Next, you will need to
-apply the changes to the servers. Again from ``~/Persistent/securedrop``:
+1. Boot the *Admin Workstation* and unlock its persistent volume.
+2. Open a terminal and type ``cd ~/Persistent/securedrop``.
+3. Run ``git status``. If the output includes ``HEAD detached at``
+   followed by the version number displayed in the footer of your *Source Interface*,
+   you are running the applicable version of the SecureDrop code on your
+   workstation, and can proceed to the next step.
 
-.. code:: sh
+   If not, **it is not not safe to proceed**. Follow the upgrade instructions
+   associated with the `release notes for the most recent release of
+   SecureDrop <https://securedrop.org/news/release-announcement/>`__. Apply all
+   available updates, including for the Tails operating system.
+4. Run ``./securedrop-admin sdconfig``. This will display the current
+   configuration, one line at a time, and allow you to change it. At this point,
+   any changes you make are only saved on this *Admin Workstation*, to the
+   following file:
 
-  ./securedrop-admin install
+   ``~/Persistent/securedrop/install_files/ansible-base/group_vars/all/site-specific``
+
+5. Run ``./securedrop-admin install``. This will apply the configuration to your
+   *Application* and *Monitor Server*, and enforce the canonical state of the
+   server configuration.
+
+If there is more than one administrator on your team, please also see the
+following section.
 
 .. include:: includes/rerun-install-is-safe.txt
-
-Once the install command has successfully completed, the changes are applied.
-Read the next section if you have multiple admins.
-
-.. note::
-  Server configuration is stored on the *Admin Workstation* in
-  ``~/Persistent/securedrop/install_files/ansible-base/group_vars/all/site-specific``.
 
 Managing ``site-specific`` Updates On Teams With Multiple Admins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,7 @@ anonymous sources.
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/1.3.0_to_1.4.0.rst
    upgrade/1.2.2_to_1.3.0.rst
    upgrade/1.2.1_to_1.2.2.rst
    upgrade/1.2.0_to_1.2.1.rst

--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -530,10 +530,29 @@ securedrop@freedom.press for help.
 Uncommon OSSEC Alerts
 ~~~~~~~~~~~~~~~~~~~~~
 
+.. _uncommon_alerts:
+
 SecureDrop also runs automatic checks for submission data integrity
 problems. For example, secure deletion of large submissions could
 potentially be interrupted, resulting in an alert recommending steps
 to :ref:`clean them up <submission-cleanup>`.
+
+In addition, SecureDrop performs a daily configuration check to ensure that
+the iptables rules configured on the *Application* and *Monitor Server* match
+the expected configuration. If they do not, you may receive a level 12 alert
+like the following: ::
+
+      Received From: (app) 10.20.2.2->/var/ossec/checksdconfig.py
+      Rule: 400900 fired (level 12) ->
+      "Indicates a problem with the configuration of the SecureDrop servers."
+      Portion of the log(s):
+      ossec: output: '/var/ossec/checksdconfig.py': System configuration error:
+      The iptables default drop rules are incorrect.
+
+Alternatively, the error text may say: ``The iptables rules have not been configured.``
+
+To resolve the issue, you can reinstate the standard iptables
+rules by :ref:`updating the system configuration <update-system-configuration>`.
 
 If you believe that the system is behaving abnormally, you should
 contact us at the `SecureDrop Support Portal`_ or securedrop@freedom.press for

--- a/docs/upgrade/1.3.0_to_1.4.0.rst
+++ b/docs/upgrade/1.3.0_to_1.4.0.rst
@@ -30,13 +30,16 @@ first delete the graphical updater's temporary flag file, if it exists (the
 
 This will prevent the graphical updater from attempting to re-apply the failed
 update and has no bearing on future updates. You can now perform a manual
-update by  running the following commands: ::
+update by running the following commands: ::
 
   cd ~/Persistent/securedrop
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
   git tag -v 1.4.0
+
+.. important:: Do not skip the ``gpg`` step. This release includes an update
+   of the release key. The old release key is set to expire on June 30, 2020.
 
 The output should include the following two lines: ::
 

--- a/docs/upgrade/1.3.0_to_1.4.0.rst
+++ b/docs/upgrade/1.3.0_to_1.4.0.rst
@@ -1,0 +1,97 @@
+Upgrade from 1.3.0 to 1.4.0
+===========================
+
+Automatic server upgrades
+-------------------------
+As with previous releases, your servers will be upgraded to the latest version
+of SecureDrop automatically within 24 hours of the release.
+
+Updating Workstations to SecureDrop 1.4.0
+-----------------------------------------
+
+Using the graphical updater
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+On the next boot of your SecureDrop *Journalist* and *Admin Workstations*,
+the *SecureDrop Workstation Updater* will alert you to workstation updates. You
+must have `configured an administrator password <https://tails.boum.org/doc/first_steps/startup_options/administration_password/>`_
+on the Tails welcome screen in order to use the graphical updater.
+
+Perform the update to 1.4.0 by clicking "Update Now":
+
+.. image:: ../images/securedrop-updater.png
+
+Performing a manual update
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+If the graphical updater fails and you want to perform a manual update instead,
+first delete the graphical updater's temporary flag file, if it exists (the
+``.`` before ``securedrop`` is not a typo): ::
+
+  rm ~/Persistent/.securedrop/securedrop_update.flag
+
+This will prevent the graphical updater from attempting to re-apply the failed
+update and has no bearing on future updates. You can now perform a manual
+update by  running the following commands: ::
+
+  cd ~/Persistent/securedrop
+  git fetch --tags
+  gpg --keyserver hkps://keys.openpgp.org --recv-key \
+   "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
+  git tag -v 1.4.0
+
+The output should include the following two lines: ::
+
+    gpg:                using RSA key 22245C81E3BAEB4138B36061310F561200F4AD77
+    gpg: Good signature from "SecureDrop Release Signing Key"
+
+Please verify that each character of the fingerprint above matches what is
+on the screen of your workstation. If it does, you can check out the
+new release: ::
+
+    git checkout 1.4.0
+
+.. important:: If you do see the warning "refname '1.4.0' is ambiguous" in the
+  output, we recommend that you contact us immediately at securedrop@freedom.press
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
+
+Finally, run the following commands: ::
+
+  ./securedrop-admin setup
+  ./securedrop-admin tailsconfig
+
+Upgrading Tails
+---------------
+If you have already upgraded your workstations to the Tails 4 series, follow the
+graphical prompts to update to the latest version.
+
+.. important::
+
+   If you are still running Tails 3.x on any workstation, we urge you to update
+   to the Tails 4 series as soon as possible. Tails 3.x is no longer receiving
+   security updates, and is no longer supported by the SecureDrop team.
+   Please see our
+   :ref:`instructions for upgrading to Tails 4 <upgrade_to_tails_4>`.
+
+   These instructions will be removed from a future version of this
+   documentation.
+
+.. include:: ../includes/always-backup.txt
+
+New OSSEC alert for iptables misconfigurations
+----------------------------------------------
+This release of SecureDrop introduces a new level 12 alert for detecting
+misconfigurations of the iptables rules on the *Application* and
+*Monitor Servers*. iptables functions as a software firewall, providing defense
+in depth in addition to the rules configured in your hardware firewall.
+
+We recommend that you check your OSSEC alerts carefully in the days after this
+release, to ensure iptables is configured correctly. Please see our guide to
+:ref:`uncommon OSSEC alerts <uncommon_alerts>` for an example of this alert,
+and for information on how to reinstate the correct configuration.
+
+Getting Support
+---------------
+
+Should you require further support with your SecureDrop installation, we are
+happy to help!
+
+.. include:: ../includes/getting-support.txt


### PR DESCRIPTION
## Status

Ready for review

## Description
- Adds our standard upgrade guidance, as well as specific docs pertaining to #5287. In the process, generalizes our docs for updating the system configuration a bit further, and adds standard guidance for ensuring you're running the correct version of the playbook
- Notes that Tails 4 upgrade docs may go away soon
- Resolves #5310

## Checklint

- [x] Linter says "Nothing to see here. Move along, folks"