### PR TITLE
Updates builder image for 2020-06-17

### DIFF
--- a/molecule/builder-xenial/image_hash
+++ b/molecule/builder-xenial/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2020_05_13
-ae19eb949b26cdd7e81f94dcd71ceac334c3ed8e9ea4f7c3f1e7713a7c9d5985
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2020_06_17
+918f618085a22adb3259c090a019736b72912bb951fe41d03c0dc3ceeb6dbd26


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Related to #5289. Updates the Docker image used for building SecureDrop packages.

## Testing

Run `make build-debs`. The tests should not complain about the image needing apt updates.
