### PR TITLE
Add upgrade boxes for 1.4.0

### DIFF
--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -133,6 +133,17 @@
         }
       ],
       "version": "1.3.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "364916d4f48f2786da6d672e88862afb9badcf7f9c1bc601061a550ddcbddff7",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_1.4.0.box"
+        }
+      ],
+      "version": "1.4.0"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -133,6 +133,17 @@
         }
       ],
       "version": "1.3.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "7b8f58292297f6ab8a004f8925451e1d93bb99a71611852d72eff9d6e221bad7",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_1.4.0.box"
+        }
+      ],
+      "version": "1.4.0"
     }
   ]
 }


### PR DESCRIPTION
## Status
Ready for review

- [x] #5328 should be reviewed and merged, then this PR should be rebased, to facilitate testing. 

## Description of Changes

Towards #5289. 

Changes proposed in this pull request:

- Adds references to new "upgrade" scenario boxes (already uploaded to S3)

## Testing

- Checkout `develop`
- `make build-debs`
- Check out this branch
- `make upgrade-start` (will take a while as it needs to fetch the boxes)
- [ ] source interface shows SecureDrop version 1.4.0
- [ ] `make upgrade-test-local` completes without error
- [ ] source interface shows SecureDrop version 1.5.0~rc1

## Deployment

Dev only

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
