### PR TITLE
configure OSSEC server gnupg directory permissions in securedrop-osse…

### DIFF
--- a/install_files/ansible-base/roles/ossec/tasks/configure_server.yml
+++ b/install_files/ansible-base/roles/ossec/tasks/configure_server.yml
@@ -20,44 +20,6 @@
   tags:
     - gpg
 
-- name: Check if GPG homedir already exists.
-  stat:
-    path: /var/ossec/.gnupg
-  register: gpg_homedir_status
-  tags:
-    - gpg
-
-- name: Ensure correct permissions on OSSEC GPG homedir if it exists.
-  file:
-    state: directory
-    path: /var/ossec/.gnupg
-    mode: "0700"
-    owner: ossec
-    group: "{{ ossec_group }}"
-  when: gpg_homedir_status.stat.exists
-  tags:
-    - gpg
-
-- name: Check if .gpg files have been created yet in the GPG homedir.
-  stat:
-    path: "/var/ossec/.gnupg/{{ item }}"
-  with_items: "{{ gpg_keyring_files }}"
-  register: gpg_keyring_status
-  tags:
-    - gpg
-
-- name: Ensure correct permissions on contents of OSSEC GPG homedir.
-  file:
-    state: file
-    path: "/var/ossec/.gnupg/{{ item.item }}"
-    mode: "0600"
-    owner: ossec
-    group: "{{ ossec_group }}"
-  with_items: "{{ gpg_keyring_status.results }}"
-  when: item.stat.exists
-  tags:
-    - gpg
-
 - name: Add the OSSEC GPG public key to the OSSEC manager keyring.
   # multiline format for command module, since this is a long command
   command: >

--- a/install_files/securedrop-ossec-server/DEBIAN/postinst
+++ b/install_files/securedrop-ossec-server/DEBIAN/postinst
@@ -29,6 +29,10 @@ case "$1" in
         chown root:${GROUP} ${OSSEC_HOME}/rules/local_rules.xml
         chmod 440 ${OSSEC_HOME}/rules/local_rules.xml
 
+	# Ensure correct gnupg directory permissions
+	find ${OSSEC_HOME}/.gnupg -type f -exec chmod 600 {} \;
+	find ${OSSEC_HOME}/.gnupg -type d -exec chmod 700 {} \;
+      	
         # Replace localhost with 127.0.0.1 for smtp_server due to
         #  https://github.com/ossec/ossec-hids/issues/1145
         sed -i -e "s/<smtp_server>localhost<\/smtp_server>/<smtp_server>127.0.0.1<\/smtp_server>/g" /var/ossec/etc/ossec.conf

--- a/install_files/securedrop-ossec-server/DEBIAN/postinst
+++ b/install_files/securedrop-ossec-server/DEBIAN/postinst
@@ -28,10 +28,11 @@ case "$1" in
 
         chown root:${GROUP} ${OSSEC_HOME}/rules/local_rules.xml
         chmod 440 ${OSSEC_HOME}/rules/local_rules.xml
-
-	# Ensure correct gnupg directory permissions
-	find ${OSSEC_HOME}/.gnupg -type f -exec chmod 600 {} \;
-	find ${OSSEC_HOME}/.gnupg -type d -exec chmod 700 {} \;
+        
+        # Ensure correct gnupg directory permissions and ownership
+        chown -R ossec:${GROUP} ${OSSEC_HOME}/.gnupg
+        find ${OSSEC_HOME}/.gnupg -type f -exec chmod 600 {} \;
+        find ${OSSEC_HOME}/.gnupg -type d -exec chmod 700 {} \;
       	
         # Replace localhost with 127.0.0.1 for smtp_server due to
         #  https://github.com/ossec/ossec-hids/issues/1145


### PR DESCRIPTION
Configure OSSEC server gnupg directory permissions in `securedrop-ossec-server` post-installation script. Remove permissions configuration from `configure_server` task.

## Status

Ready for Review

## Description of Changes

Fixes #5265.

Changes proposed in this pull request:
Remove OSSEC directory permission configuration steps from configure_server task and set them in `securedrop-ossec-server` post-installation script. 
Modify OSSEC `/var/ossec/.gnupg` directory permission, and sub-directories if existing (required for `private-keys.d` if ever created) to 700, and files in `/var/ossec/.gnupg/*` to 600.  

## Testing
### Staging
Check out this branch and `make build-debs`.

**Clean install prereqs** 
- `make staging`

**Upgrade scenario prereqs** 
- `make upgrade-start`
- [ ] observe 700 permissions on `/var/ossec/.gnupg` and 550 permissions on `/var/ossec/.gnupg/*` 
- `make upgrade-test-local`

**On both:**
- [ ] observe 700 permissions on `/var/ossec/.gnupg` 
- [ ] observe 600 permissions on `var/ossec/.gnupg/*`
- [ ] observe no unusual OSSEC errors in `/var/ossec/logs/alerts/alerts.log`
- Trigger a 'test' journalist alert from the journalist interface, then return to OSSEC logs (above) and observe OSSEC alert for a level 7 "Apache application error" with details "[...] This is a test OSSEC alert" , or observe test alert 
- [ ] Additional unusual OSSEC errors not present in `/var/ossec/logs/alerts/alerts.log`
- [ ] No references to  `gpg: Permission denied`, `trustdb not writable`, or `Executing "/var/ossec/send_encrypted_alarm.sh,ossec"` in `/var/log/procmail.log` 

### Prod/Release testing
- Include a check of the permissions on `/var/ossec/.gnupg` in the cron-apt upgrade scenario for QA 

## Deployment 

1. No special considerations for existing installs--permissions will be upgraded as `securedrop-ossec-server` package is upgraded
2. No special considerations for new instances.

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass (Tests have passed on CircleCI. Testinfra tests don't pass on Qubes staging.)