### PR TITLE
update pre-release docs - part 3

### DIFF
--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -11,7 +11,7 @@ coordinate with the person that does to make sure the task is completed.
 Pre-Release
 -----------
 
-1. Open a **Release SecureDrop 1.x.y** issue to track release-related activity.
+1. Open a **Release SecureDrop <major>.<minor>.<patch>** issue to track release-related activity.
    Keep this issue updated as you proceed through the release process for
    transparency.
 #. Check if there is a new stable release of Tor that can be QAed and released
@@ -76,47 +76,64 @@ Pre-Release
      ``release/1.x.y`` branch, and push the signed tag once the PR is
      merged.
 
-#. Build Debian packages and place them on
-   ``apt-test.freedom.press``. This is currently done by making a PR
-   into `a git-lfs repo here
-   <https://github.com/freedomofpress/securedrop-dev-packages-lfs>`_.
-   Only commit packages with an incremented version number: do not
-   clobber existing packages.  That is, if there is already a deb
-   called e.g. ``ossec-agent-3.6.0-amd64.deb`` in ``master``, do not
-   commit a new version of this deb. Changes merged to ``master`` in
-   this repo will be published within 15 minutes.
+#. Build Debian packages:
+
+   a. Check out the tag for the release candidate.
+   #. Build the packages with ``make build-debs``.
+   #. Build logs should be saved and published according to the `build
+      log guidelines
+      <https://github.com/freedomofpress/securedrop/wiki/Build-logs>`_.
+   #. Open a PR on `securedrop-dev-packages-lfs  
+      <https://github.com/freedomofpress/securedrop-dev-packages-lfs>`_ that targets the `master`
+      branch. Changes merged to this branch will be published to ``apt-test.freedom.press``
+      within 15 minutes.
+
+   .. warning:: Only commit packages with an incremented version number: do not clobber existing 
+                packages.  That is, if there is already a deb called e.g. 
+                ``ossec-agent-3.6.0-amd64.deb`` in ``master``, do not commit a new version of this 
+                deb.
 
    .. note:: If the release contains other packages not created by
           ``make build-debs``, such as Tor or kernel updates, make
           sure that they also get pushed to
           ``apt-test.freedom.press``.
 
-#. Build logs from the above debian package builds should be saved and
-   published according to the `build log guidelines
-   <https://github.com/freedomofpress/securedrop/wiki/Build-logs>`_.
-#. Write a test plan that focuses on the new functionality introduced
-   in the release. Post for feedback and make changes based on
-   suggestions from the community.
-#. Encourage QA participants to QA the release on production VMs and
-   hardware. They should post their QA reports in the release issue
-   such that it is clear what was and what was not tested. It is the
-   responsibility of the release manager to ensure that sufficient QA
-   is done on the release candidate prior to final release.
-#. Triage bugs as they are reported. If a bug must be fixed before the
-   release, it's the release manager's responsibility to either fix it
-   or find someone who can.
-#. Backport release QA fixes merged into ``develop`` into the release
-   branch using ``git cherry-pick -x <commit>`` to clearly indicate
-   where the commit originated from.
-#. At your discretion -- for example when a significant fix is merged
-   -- prepare additional release candidates and have fresh Debian
-   packages prepared for testing.
-#. For a regular release, the string freeze will be declared by the
-   translation administrator one week prior to the release. After this
-   is done, ensure that no changes involving string changes are
-   backported into the release branch.
-#. Ensure that a draft of the release notes are prepared and shared
-   with the community for feedback.
+#. Write a test plan that focuses on the new functionality introduced in the release. Post for 
+   feedback and make changes based on suggestions from the community. Once it's ready, publish the
+   test plan in the `wiki <https://github.com/freedomofpress/securedrop/wiki>`_ and link to it in 
+   the **Release SecureDrop <major>.<minor>.<patch>** issue.
+
+#. Create a new QA matrix spreadsheet by copying the google spreadsheet from the last release and
+   adding a new row for testing new functionality specific to the release candidate. Link to this
+   in the **Release SecureDrop <major>.<minor>.<patch>** issue.
+
+#. At this point, QA can begin. During the QA period:
+
+   * Encourage QA participants to QA the release on production VMs and
+     hardware. They should post their QA reports in the release issue
+     such that it is clear what was and what was not tested. It is the
+     responsibility of the release manager to ensure that sufficient QA
+     is done on the release candidate prior to final release.
+
+   * Triage bugs as they are reported. If a bug must be fixed before the
+     release, it's the release manager's responsibility to either fix it
+     or find someone who can.
+
+   * Backport release QA fixes merged into ``develop`` into the release
+     branch using ``git cherry-pick -x <commit>`` to clearly indicate
+     where the commit originated from.
+
+   * At your discretion -- for example when a significant fix is merged
+     -- prepare additional release candidates and have fresh Debian
+     packages prepared for testing.
+
+   * For a regular release, the string freeze will be declared by the
+     translation administrator one week prior to the release. After this
+     is done, ensure that no changes involving string changes are
+     backported into the release branch.
+
+   * Ensure that a draft of the release notes are prepared and shared
+     with the community for feedback.
 
 Release Process
 ---------------


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Update RM docs to include details around the beginning steps of the pre-release process.

## Testing

Someone who's familiar with release management should make sure the changes are accurate and helpful.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
