### PR TITLE
[docs] Qubes development documentation fixes

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -268,6 +268,7 @@ The version of rsync installed by default on macOS is extremely out-of-date, as 
 .. _Homebrew: https://brew.sh/
 .. _homebrew-cask: http://sourabhbajaj.com/mac-setup/Vagrant/README.html
 
+
 Fork & Clone the Repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -292,3 +293,13 @@ Ensure your virtualenv is activated and install the packages.
     pip install --no-deps --require-hashes -r securedrop/requirements/python3/develop-requirements.txt
 
 .. note:: You will need to run this everytime new packages are added.
+
+Qubes
+~~~~~
+
+To configure a multi-machine evironment in Qubes, follow the Quick Start instructions above to
+create a standalone VM named ``sd-dev``, then follow the Linux instructions above to install the
+required packages, *omitting* Virtualbox.
+
+Then, complete the steps described in :doc:`qubes_staging`.
+

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -51,7 +51,9 @@ Debian packages on the staging machines:
    ./manage.py add-admin
    pytest -v tests/
 
-To rebuild the local packages for the app code and update on Xenial staging: ::
+To rebuild the local packages for the app code and update on Xenial staging: 
+
+.. code:: sh
 
    make build-debs
    make staging


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

- Reference Qubes Staging docs in Developer Environment setup guide, small changes to Qubes staging setup docs 
- Add documentation on using auth_private file with Whonix VMs on Qubes 
- Small fix to Qubes RPC policy notation in docs
- Small typo fix

Changes proposed in this pull request:

docs-only

## Testing

manual review

## Deployment

n/a

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally

