### PR TITLE
Add update docs for 1.4.0->1.4.1 (boilerplate)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,6 +91,7 @@ anonymous sources.
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/1.4.0_to_1.4.1.rst
    upgrade/1.3.0_to_1.4.0.rst
    upgrade/1.2.2_to_1.3.0.rst
    upgrade/1.2.1_to_1.2.2.rst

--- a/docs/upgrade/1.4.0_to_1.4.1.rst
+++ b/docs/upgrade/1.4.0_to_1.4.1.rst
@@ -1,0 +1,83 @@
+Upgrade from 1.4.0 to 1.4.1
+===========================
+
+Automatic server upgrades
+-------------------------
+As with previous releases, your servers will be upgraded to the latest version
+of SecureDrop automatically within 24 hours of the release.
+
+Updating Workstations to SecureDrop 1.4.1
+-----------------------------------------
+
+Using the graphical updater
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+On the next boot of your SecureDrop *Journalist* and *Admin Workstations*,
+the *SecureDrop Workstation Updater* will alert you to workstation updates. You
+must have `configured an administrator password <https://tails.boum.org/doc/first_steps/startup_options/administration_password/>`_
+on the Tails welcome screen in order to use the graphical updater.
+
+Perform the update to 1.4.1 by clicking "Update Now":
+
+.. image:: ../images/securedrop-updater.png
+
+Performing a manual update
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+If the graphical updater fails and you want to perform a manual update instead,
+first delete the graphical updater's temporary flag file, if it exists (the
+``.`` before ``securedrop`` is not a typo): ::
+
+  rm ~/Persistent/.securedrop/securedrop_update.flag
+
+This will prevent the graphical updater from attempting to re-apply the failed
+update and has no bearing on future updates. You can now perform a manual
+update by running the following commands: ::
+
+  cd ~/Persistent/securedrop
+  git fetch --tags
+  gpg --keyserver hkps://keys.openpgp.org --recv-key \
+   "2224 5C81 E3BA EB41 38B3 6061 310F 5612 00F4 AD77"
+  git tag -v 1.4.1
+
+The output should include the following two lines: ::
+
+    gpg:                using RSA key 22245C81E3BAEB4138B36061310F561200F4AD77
+    gpg: Good signature from "SecureDrop Release Signing Key"
+
+Please verify that each character of the fingerprint above matches what is
+on the screen of your workstation. If it does, you can check out the
+new release: ::
+
+    git checkout 1.4.1
+
+.. important:: If you do see the warning "refname '1.4.1' is ambiguous" in the
+  output, we recommend that you contact us immediately at securedrop@freedom.press
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
+
+Finally, run the following commands: ::
+
+  ./securedrop-admin setup
+  ./securedrop-admin tailsconfig
+
+Upgrading Tails
+---------------
+If you have already upgraded your workstations to the Tails 4 series, follow the
+graphical prompts to update to the latest version.
+
+.. important::
+
+   If you are still running Tails 3.x on any workstation, we urge you to update
+   to the Tails 4 series as soon as possible. Tails 3.x is no longer receiving
+   security updates, and is no longer supported by the SecureDrop team.
+   Please see our
+   :ref:`instructions for upgrading to Tails 4 <upgrade_to_tails_4>`.
+
+   These instructions will be removed from a future version of this
+   documentation.
+
+Getting Support
+---------------
+
+Should you require further support with your SecureDrop installation, we are
+happy to help!
+
+.. include:: ../includes/getting-support.txt


### PR DESCRIPTION
## Status

Ready for review

## Description

Standard update docs. Omitting backup reminder for point release, but keeping Tails 4 reminder for a bit longer.

## Checklint

- [x] `make docs-lint` is neither coughing nor sneezing, but wearing a mask