### PR TITLE
Clarify release roles, new package upload/signing workflow

### DIFF
--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -260,6 +260,11 @@ Release Process
    ``apt.freedom.press``.
 #. The reviewer must delete the ``release`` branch so that it can be re-created
    during the next release.
+#. Issue a PR in the ``securedrop`` repository to merge the release branch
+   changes into ``master``. Once the PR is merged, verify that the
+   `public documentation <https://docs.securedrop.org/>`_
+   refers to the new release version. If not, log in to ReadTheDocs and start a
+   build of the ``master`` version.
 #. Create a `release
    <https://github.com/freedomofpress/securedrop/releases>`_ on GitHub
    with a brief summary of the changes in this release.

--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -17,6 +17,8 @@ roles for a SecureDrop release:
 - **Localization Manager:** to manage outreach to the translator community, and
   to coordinate translation updates of existing strings.
 
+- **Deputy LM:** like the RM, this role is backed up by another team member.
+
 - **Communications Manager:** to prepare and distribute pre-release and
   release messaging (including standard upgrade instructions, release notes,
   social media posts, and support portal announcements)

--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -228,11 +228,11 @@ Release Process
    #. Build logs should be saved and published according to the `build
       log guidelines
       <https://github.com/freedomofpress/securedrop/wiki/Build-logs>`_.
-#. Step through the signing ceremony for the ``Release`` file(s)
-   (there may be multiple if Tor is also updated along with the
-   SecureDrop release).
-#. Coordinate with the Infrastructure team to put signed Debian
-   packages on ``apt-qa.freedom.press``:
+#. In a clone of the private
+   `securedrop-debian-packages-lfs <https://github.com/freedomofpress/securedrop-debian-packages-lfs>`_
+   repository, create a branch from ``master`` called ``release``.
+#. In your local branch, commit the built packages to the ``core/xenial``
+   directory.
 
    * If the release includes a Tor update, make sure to include the
      new Tor Debian packages.
@@ -240,17 +240,26 @@ Release Process
      corresponding grsecurity-patched kernel packages, including both
      ``linux-image-*`` and ``linux-firmware-image-*`` packages as
      appropriate.
-
+#. Run the ``tools/publish`` script. This will create the ``Release`` file.
+#. Commit the changes made by the ``tools/publish`` script.
+#. Push your commits to the remote ``release`` branch. This will trigger an
+   automatic upload of the packages to ``apt-qa.freedom.press``, but the
+   packages will not yet be installable.
+#. Create a `draft PR <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests>`__
+   from ``release`` into ``master``. Make sure to include a link to the build
+   logs in the PR description.
+#. A reviewer must verify the build logs, obtain and sign the generated ``Release``
+   file, and append the detached signature to the PR. The PR should remain in
+   draft mode. The packages on ``apt-qa.freedom.press`` are now installable.
 #. Coordinate with one or more team members to confirm a successful
    clean install in production VMs using the packages on
    ``apt-qa.freedom.press``.
-#. Ask Infrastructure to perform the DNS cutover to switch
-   ``apt-qa.freedom.press`` to ``apt.freedom.press``. Once complete,
-   the release is live.
-#. Issue a PR to merge the release branch changes into ``master``. Once the PR is
-   merged, verify that the `public documentation <https://docs.securedrop.org/>`_
-   refers to the new release version. If not, log in to ReadTheDocs and start a
-   build of the ``master`` version.
+#. If no issues are discovered in final QA, promote the packaging PR out of draft
+   mode.
+#. A reviewer must merge the packaging PR. This will publish the packages on
+   ``apt.freedom.press``.
+#. The reviewer must delete the ``release`` branch so that it can be re-created
+   during the next release.
 #. Create a `release
    <https://github.com/freedomofpress/securedrop/releases>`_ on GitHub
    with a brief summary of the changes in this release.
@@ -258,6 +267,8 @@ Release Process
 #. Make sure that the release is announced from the SecureDrop Twitter account.
 #. Make sure that members of `the support portal
    <https://support.freedom.press>`_ are notified about the release.
+#. Make sure that version string monitored by FPF's Icinga monitoring system
+   is updated by the infrastructure team.
 #. Update the upgrade testing boxes following this process:
    :ref:`updating_upgrade_boxes`.
 

--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -8,6 +8,27 @@ must be done by people that have special privileges to do specific tasks
 but even if the **Release Manager** does not have those privileges, they should
 coordinate with the person that does to make sure the task is completed.
 
+In addition to the Release Manager, we typically recognize the following
+roles for a SecureDrop release:
+
+- **Deputy RM:** for additional time zone coverage, to delegate specific tasks,
+  and to act as backup in case of the RM becomes unavailable for any reason.
+
+- **Localization Manager:** to manage outreach to the translator community, and
+  to coordinate translation updates of existing strings.
+
+- **Communications Manager:** to prepare and distribute pre-release and
+  release messaging (including standard upgrade instructions, release notes,
+  social media posts, and support portal announcements)
+
+During the full release cycle, we also recognize the following role:
+
+- **Community Manager:** to engage with community contributors, offer initial
+  responses to new issues and Pull Requests, and follow up with other SecureDrop
+  team members as appropriate.
+
+We aim to rotate membership in these roles regularly.
+
 Pre-Release
 -----------
 
@@ -15,8 +36,8 @@ Pre-Release
    Keep this issue updated as you proceed through the release process for
    transparency.
 
-#. Check if there is a new stable release of Tor that can be QAed and released as part of the 
-   SecureDrop release. You can find stable releases by checking the `Tor blog 
+#. Check if there is a new stable release of Tor that can be QAed and released as part of the
+   SecureDrop release. You can find stable releases by checking the `Tor blog
    <https://blog.torproject.org/category/tags/stable-release>`_. If we can upgrade, file an issue
    and upgrade Tor following these steps:
 
@@ -24,7 +45,7 @@ Pre-Release
          <https://github.com/freedomofpress/securedrop/blob/develop/molecule/fetch-tor-packages/
          playbook.yml>`_ and open a PR.
 
-      b. Run ``make fetch-tor-packages`` to download the new debs. The script uses 
+      b. Run ``make fetch-tor-packages`` to download the new debs. The script uses
          apt under the hood, so the Release file on the tor packages is verified according
          to Tor's signature, ensuring package integrity.
 
@@ -35,14 +56,14 @@ Pre-Release
          packages will be resigned with our an FPF-managed test-only signing key, replacing the Tor
          signature, and served from ``apt-test.freedom.press``.
 
-#. Check if a new release or release candidate for Tails has been added to the `Tails apt repo 
+#. Check if a new release or release candidate for Tails has been added to the `Tails apt repo
    <https://deb.tails.boum.org/dists/>`_. If so, request
    people participating in QA to use the latest release candidate.
 
-#. Work with the Communications Manager assigned for the release to prepare a pre-release 
-   announcement that will be shared on the support.freedom.press support portal, securedrop.org 
-   website, and Twitter. Wait until the day of the release before including an announcmement for a 
-   SecureDrop security update. For a point release, you may be able to skip the pre-release 
+#. Work with the Communications Manager assigned for the release to prepare a pre-release
+   announcement that will be shared on the support.freedom.press support portal, securedrop.org
+   website, and Twitter. Wait until the day of the release before including an announcmement for a
+   SecureDrop security update. For a point release, you may be able to skip the pre-release
    announcement depending on how small the point release is.
 
 #. Create a release branch.
@@ -61,27 +82,27 @@ Pre-Release
 #. For each release candidate, update the version and changelog.
 
    a. Collect a list of important changes from the `SecureDrop milestones
-      <https://github.com/freedomofpress/securedrop/milestones>`_ for the release, including 
-      GitHub issues or PR numbers for each change. You will add these changes to the changelog in 
+      <https://github.com/freedomofpress/securedrop/milestones>`_ for the release, including
+      GitHub issues or PR numbers for each change. You will add these changes to the changelog in
       the next step.
 
    #. Run ``update_version.sh`` in the dev shell to update the version and changelog. The script
-      will open both the main repository changelog (``changelog.md``) and the one used for Debian 
-      packaging in an editor, giving you a chance to add the changes you collected. In the Debian 
+      will open both the main repository changelog (``changelog.md``) and the one used for Debian
+      packaging in an editor, giving you a chance to add the changes you collected. In the Debian
       changelog, we typically just refer the reader to the ``changelog.md`` file. When you run the
-      script, you will need to pass it the new version in the format 
+      script, you will need to pass it the new version in the format
       ``<major>.<minor>.<patch>~rcN``::
 
         securedrop/bin/dev-shell ../update_version.sh <major>.<minor>.<patch>~rcN
 
       .. note:: A tilde is used in the version number passed to ``update_version.sh`` to match
-                the format specified in the `Debian docs 
-                <https://www.debian.org/doc/manuals/maint-guide/first.en.html#namever>`_ on how to 
-                name and version a package, whereas a dash is used in the tag version number 
-                since `git does not support the use of tilde 
-                <https://git-scm.com/docs/git-check-ref-format#_description>`_. 
+                the format specified in the `Debian docs
+                <https://www.debian.org/doc/manuals/maint-guide/first.en.html#namever>`_ on how to
+                name and version a package, whereas a dash is used in the tag version number
+                since `git does not support the use of tilde
+                <https://git-scm.com/docs/git-check-ref-format#_description>`_.
 
-   #. Disregard the script-generated ``.tag`` file since this is only used when we need to sign the 
+   #. Disregard the script-generated ``.tag`` file since this is only used when we need to sign the
       final release tag (see `Release Process`_ section).
 
    #. Sign the commit that was added by the ``update_version.sh`` script::
@@ -92,7 +113,7 @@ Pre-Release
 
         git push origin release/<major>.<minor>.<patch>
 
-   #. Push the unsigned tag (only the final release tag needs to be signed, see 
+   #. Push the unsigned tag (only the final release tag needs to be signed, see
       `Release Process`_ section)::
 
         git push origin <major>.<minor>.<patch>-rcN
@@ -104,14 +125,14 @@ Pre-Release
    #. Build logs should be saved and published according to the `build
       log guidelines
       <https://github.com/freedomofpress/securedrop/wiki/Build-logs>`_.
-   #. Open a PR on `securedrop-dev-packages-lfs  
+   #. Open a PR on `securedrop-dev-packages-lfs
       <https://github.com/freedomofpress/securedrop-dev-packages-lfs>`_ that targets the `master`
       branch. Changes merged to this branch will be published to ``apt-test.freedom.press``
       within 15 minutes.
 
-   .. warning:: Only commit packages with an incremented version number: do not clobber existing 
-                packages.  That is, if there is already a deb called e.g. 
-                ``ossec-agent-3.6.0-amd64.deb`` in ``master``, do not commit a new version of this 
+   .. warning:: Only commit packages with an incremented version number: do not clobber existing
+                packages.  That is, if there is already a deb called e.g.
+                ``ossec-agent-3.6.0-amd64.deb`` in ``master``, do not commit a new version of this
                 deb.
 
    .. note:: If the release contains other packages not created by
@@ -119,9 +140,9 @@ Pre-Release
           sure that they also get pushed to
           ``apt-test.freedom.press``.
 
-#. Write a test plan that focuses on the new functionality introduced in the release. Post for 
+#. Write a test plan that focuses on the new functionality introduced in the release. Post for
    feedback and make changes based on suggestions from the community. Once it's ready, publish the
-   test plan in the `wiki <https://github.com/freedomofpress/securedrop/wiki>`_ and link to it in 
+   test plan in the `wiki <https://github.com/freedomofpress/securedrop/wiki>`_ and link to it in
    the **Release SecureDrop <major>.<minor>.<patch>** issue.
 
 #. Create a new QA matrix spreadsheet by copying the google spreadsheet from the last release and
@@ -248,15 +269,15 @@ Now it's time to backport the changelog from the release branch into the ``devel
 the SecureDrop version so that it's ready for the next round of QA testing.
 
 We backport the changelog by cherry-picking any commits that modified ``changelog.md`` during the
-release. You can look at the file history by checking out the release branch and running: 
-``git log --pretty=oneline changelog.md``. The output will contain the commit hashes associated with 
+release. You can look at the file history by checking out the release branch and running:
+``git log --pretty=oneline changelog.md``. The output will contain the commit hashes associated with
 the release. Create a new branch based on ``develop`` and cherry-pick these commits using the
 ``-x`` flag.
 
 Now you're ready to bump the SecureDrop version on your new branch. There are a bunch of version
 files that'll need to be updated in order to set up the upgrade test for the next release. We do
 this by running the version-updater script and specifying the new version number, which will be the
-next minor version with ``~rc1`` appended. For example, if the release is 1.3.0, then you'll run: 
+next minor version with ``~rc1`` appended. For example, if the release is 1.3.0, then you'll run:
 ``securedrop/bin/dev-shell ../update_version.sh 1.4.0~rc1``  (``dev-shell`` is a script that starts
 a container so that we can ensure ``dch`` is installed). Accept all the default changes from the
 ``update_version.sh`` script. You'll only need to add your commit message. Once you're done, sign
@@ -264,4 +285,4 @@ your commit and make a PR to merge these changes into ``develop``.
 
 The only thing left to do is to monitor the `FPF support portal <https://support.freedom.press>`_
 and the `SecureDrop community support forum <https://forum.securedrop.org/c/support>`_ for any new
-user issues related to the release. 
+user issues related to the release.


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

- Documents our rotating release management responsibilities.
- Documents the revised workflow for uploading and signing packages using the LFS repo.
- Includes trailing whitespace cleanup.

## Checklint
- [x] `make docs-lint` has examined this PR and reached a state of blissful transcendence