### PR TITLE
fix: Handle case of disconnected submissions

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -300,7 +300,7 @@ def make_blueprint(config):
     def get_all_submissions():
         submissions = Submission.query.all()
         return jsonify({'submissions': [submission.to_json() for
-                                        submission in submissions]}), 200
+                                        submission in submissions if submission.source]}), 200
 
     @api.route('/replies', methods=['GET'])
     @token_required

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -215,17 +215,17 @@ class Submission(db.Model):
     def to_json(self) -> 'Dict[str, Union[str, int, bool]]':
         json_submission = {
             'source_url': url_for('api.single_source',
-                                  source_uuid=self.source.uuid),
+                                  source_uuid=self.source.uuid) if self.source else None,
             'submission_url': url_for('api.single_submission',
                                       source_uuid=self.source.uuid,
-                                      submission_uuid=self.uuid),
+                                      submission_uuid=self.uuid) if self.source else None,
             'filename': self.filename,
             'size': self.size,
             'is_read': self.downloaded,
             'uuid': self.uuid,
             'download_url': url_for('api.download_submission',
                                     source_uuid=self.source.uuid,
-                                    submission_uuid=self.uuid),
+                                    submission_uuid=self.uuid) if self.source else None,
         }
         return json_submission
 
@@ -285,10 +285,10 @@ class Reply(db.Model):
             uuid = self.journalist.uuid
         json_submission = {
             'source_url': url_for('api.single_source',
-                                  source_uuid=self.source.uuid),
+                                  source_uuid=self.source.uuid) if self.source else None,
             'reply_url': url_for('api.single_reply',
                                  source_uuid=self.source.uuid,
-                                 reply_uuid=self.uuid),
+                                 reply_uuid=self.uuid) if self.source else None,
             'filename': self.filename,
             'size': self.size,
             'journalist_username': username,

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -215,17 +215,17 @@ class Submission(db.Model):
     def to_json(self) -> 'Dict[str, Union[str, int, bool]]':
         json_submission = {
             'source_url': url_for('api.single_source',
-                                  source_uuid=self.source.uuid) if self.source else None,
+                                  source_uuid=self.source.uuid),
             'submission_url': url_for('api.single_submission',
                                       source_uuid=self.source.uuid,
-                                      submission_uuid=self.uuid) if self.source else None,
+                                      submission_uuid=self.uuid),
             'filename': self.filename,
             'size': self.size,
             'is_read': self.downloaded,
             'uuid': self.uuid,
             'download_url': url_for('api.download_submission',
                                     source_uuid=self.source.uuid,
-                                    submission_uuid=self.uuid) if self.source else None,
+                                    submission_uuid=self.uuid),
         }
         return json_submission
 
@@ -285,10 +285,10 @@ class Reply(db.Model):
             uuid = self.journalist.uuid
         json_submission = {
             'source_url': url_for('api.single_source',
-                                  source_uuid=self.source.uuid) if self.source else None,
+                                  source_uuid=self.source.uuid),
             'reply_url': url_for('api.single_reply',
                                  source_uuid=self.source.uuid,
-                                 reply_uuid=self.uuid) if self.source else None,
+                                 reply_uuid=self.uuid),
             'filename': self.filename,
             'size': self.size,
             'journalist_username': username,

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -215,17 +215,17 @@ class Submission(db.Model):
     def to_json(self) -> 'Dict[str, Union[str, int, bool]]':
         json_submission = {
             'source_url': url_for('api.single_source',
-                                  source_uuid=self.source.uuid),
+                                  source_uuid=self.source.uuid) if self.source else None,
             'submission_url': url_for('api.single_submission',
                                       source_uuid=self.source.uuid,
-                                      submission_uuid=self.uuid),
+                                      submission_uuid=self.uuid) if self.source else None,
             'filename': self.filename,
             'size': self.size,
             'is_read': self.downloaded,
             'uuid': self.uuid,
             'download_url': url_for('api.download_submission',
                                     source_uuid=self.source.uuid,
-                                    submission_uuid=self.uuid),
+                                    submission_uuid=self.uuid) if self.source else None,
         }
         return json_submission
 

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -376,6 +376,20 @@ def test_authorized_user_can_get_all_submissions(journalist_app,
         assert observed_submissions == expected_submissions
 
 
+def test_authorized_user_get_all_submissions_with_disconnected_submissions(journalist_app,
+                                                                           test_submissions,
+                                                                           journalist_api_token):
+    with journalist_app.test_client() as app:
+        source_id = test_submissions['submissions'][0].source_id
+        source = Source.query.filter(Source.id == source_id).one()
+        db.session.delete(source)
+        db.session.commit()
+        response = app.get(url_for('api.get_all_submissions'),
+                           headers=get_api_headers(journalist_api_token))
+
+        assert response.status_code == 200
+
+
 def test_authorized_user_get_source_submissions(journalist_app,
                                                 test_submissions,
                                                 journalist_api_token):

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -380,8 +380,10 @@ def test_authorized_user_get_all_submissions_with_disconnected_submissions(journ
                                                                            test_submissions,
                                                                            journalist_api_token):
     with journalist_app.test_client() as app:
-        db.session.delete(test_submissions['source'])
-        db.session.commit()
+        db.session.execute(
+            "DELETE FROM sources WHERE id = :id",
+            {"id": test_submissions["source"].id}
+        )
         response = app.get(url_for('api.get_all_submissions'),
                            headers=get_api_headers(journalist_api_token))
 

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -380,9 +380,7 @@ def test_authorized_user_get_all_submissions_with_disconnected_submissions(journ
                                                                            test_submissions,
                                                                            journalist_api_token):
     with journalist_app.test_client() as app:
-        source_id = test_submissions['submissions'][0].source_id
-        source = Source.query.filter(Source.id == source_id).one()
-        db.session.delete(source)
+        db.session.delete(test_submissions['source'])
         db.session.commit()
         response = app.get(url_for('api.get_all_submissions'),
                            headers=get_api_headers(journalist_api_token))


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

Fixes #5315 .

Changes proposed in this pull request:

Handled the case of disconnected submissions and added a test for the same.

## Checklist

### If you made changes to the server application code:

- [X] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [X] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [X] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [X] Doc linting (`make docs-lint`) passed locally
