### PR TITLE
Adds upgrade boxes for v1.4.1

### DIFF
--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -144,6 +144,17 @@
         }
       ],
       "version": "1.4.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "bcc366e11b54a53e6b6be193edb8a977b0624c56b430fce717998c2b28bb1daa",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_1.4.1.box"
+        }
+      ],
+      "version": "1.4.1"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -144,6 +144,17 @@
         }
       ],
       "version": "1.4.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "551d8ea7323aeafe03010a63181857f8d546ed897e686efbb2c8f2a268201555",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_1.4.1.box"
+        }
+      ],
+      "version": "1.4.1"
     }
   ]
 }


### PR DESCRIPTION
## Status
Ready for review

## Description of Changes

Closes #5338  

Changes proposed in this pull request:

- Adds references to new "upgrade" scenario boxes (already uploaded to S3)

## Testing

- Checkout `develop`
- `make build-debs`
- Check out this branch
- `make upgrade-start` (will take a while as it needs to fetch the boxes)
- [x] source interface shows SecureDrop version 1.4.1
- [x] `make upgrade-test-local` completes without error
- [x] source interface shows SecureDrop version 1.5.0~rc1

## Deployment

Dev only
