### PR TITLE
fix: Handle case of disconnected replies

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -307,7 +307,7 @@ def make_blueprint(config):
     def get_all_replies():
         replies = Reply.query.all()
         return jsonify(
-            {'replies': [reply.to_json() for reply in replies]}), 200
+            {'replies': [reply.to_json() for reply in replies if reply.source]}), 200
 
     @api.route('/user', methods=['GET'])
     @token_required

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -285,10 +285,10 @@ class Reply(db.Model):
             uuid = self.journalist.uuid
         json_submission = {
             'source_url': url_for('api.single_source',
-                                  source_uuid=self.source.uuid),
+                                  source_uuid=self.source.uuid) if self.source else None,
             'reply_url': url_for('api.single_reply',
                                  source_uuid=self.source.uuid,
-                                 reply_uuid=self.uuid),
+                                 reply_uuid=self.uuid) if self.source else None,
             'filename': self.filename,
             'size': self.size,
             'journalist_username': username,

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -415,6 +415,20 @@ def test_authorized_user_can_get_single_submission(journalist_app,
             test_submissions['source'].submissions[0].size
 
 
+def test_authorized_user_can_get_all_replies_with_disconnected_replies(journalist_app,
+                                                                       test_files,
+                                                                       journalist_api_token):
+    with journalist_app.test_client() as app:
+        db.session.execute(
+            "DELETE FROM sources WHERE id = :id",
+            {"id": test_files["source"].id}
+        )
+        response = app.get(url_for('api.get_all_replies'),
+                           headers=get_api_headers(journalist_api_token))
+
+        assert response.status_code == 200
+
+
 def test_authorized_user_can_get_all_replies(journalist_app, test_files,
                                              journalist_api_token):
     with journalist_app.test_client() as app:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5349 

Handled the case of disconnected replies and added a test for the same.

A similar case and more discussion why we decided not to return the disconnected resources altogether can be found here: #5345 

## Checklist

### If you made changes to the server application code:

- [X] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [X] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [X] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [X] Doc linting (`make docs-lint`) passed locally
