### PR TITLE
Hardcodes CI image id in scripts

### DIFF
--- a/devops/gce-nested/gce-start.sh
+++ b/devops/gce-nested/gce-start.sh
@@ -25,7 +25,7 @@ function find_latest_ci_image() {
     #    --filter="family:fpf-securedrop AND name ~ ^ci-nested-virt-stretch" \
     #    --sort-by=~Name --limit=1 --format="value(Name)"
     # Return hardcoded image id to prevent newer builds from breaking CI
-    echo "ci-nested-virt-stretch-1557975808"
+    echo "ci-nested-virt-stretch-1564072828"
 }
 
 # Call out to GCE API and start a new instance, designating

--- a/devops/gce-nested/gce-start.sh
+++ b/devops/gce-nested/gce-start.sh
@@ -21,9 +21,11 @@ function create_gce_ssh_key() {
 # Lookup the latest GCE image available for use with SD CI.
 # Value will be used in the create call.
 function find_latest_ci_image() {
-    gcloud_call compute images list \
-        --filter="family:fpf-securedrop AND name ~ ^ci-nested-virt-stretch" \
-        --sort-by=~Name --limit=1 --format="value(Name)"
+    #gcloud_call compute images list \
+    #    --filter="family:fpf-securedrop AND name ~ ^ci-nested-virt-stretch" \
+    #    --sort-by=~Name --limit=1 --format="value(Name)"
+    # Return hardcoded image id to prevent newer builds from breaking CI
+    echo "ci-nested-virt-stretch-1557975808"
 }
 
 # Call out to GCE API and start a new instance, designating


### PR DESCRIPTION
## Status

Ready for review .

## Description of Changes

Towards #5294 

Rather than looking up via dynamic logic, explicitly declare which image
is being used. The smart lookup logic makes it difficult to build new
boxes and exclude them from affecting CI, so let's pin it and update 
versions after testing. 

Surprisingly, the smart lookup logic wasn't even guaranteed to use the _most recent_ image as intended:
```
$  gcloud --project securedrop-ci compute images list --filter="family:fpf-securedrop AND name ~ ^ci-nested-virt-stretch" --limit=1
NAME                               PROJECT        FAMILY          DEPRECATED  STATUS
ci-nested-virt-stretch-1557975808  securedrop-ci  fpf-securedrop              READY
$
NAME                               PROJECT        FAMILY          DEPRECATED  STATUS
ci-nested-virt-stretch-1557975808  securedrop-ci  fpf-securedrop              READY
ci-nested-virt-stretch-1564072828  securedrop-ci  fpf-securedrop              READY
```

After it's pinned, we'll be able to build new boxes willy-nilly without breaking CI.

## Testing
1. Is CI passing, particularing the `staging-test-with-rebase` job?
2. Click through into the `staging-test-with-rebase` job: did it perform a full run, with Ansible output and VMs rebooting at the end?

## Deployment

None, CI only. As intended, this change is effectively a no-op, even for CI: it reuses the same image we're _already_ using.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
