### PR TITLE
Fixes #5206 Delete Source Confirmation Modal

### DIFF
--- a/securedrop/journalist_templates/_confirmation_modal.html
+++ b/securedrop/journalist_templates/_confirmation_modal.html
@@ -4,6 +4,9 @@
     <a href="#close" title="{{ gettext('Close') }}" class="close">X</a>
     <h2>{{ modal_data.modal_header }}</h2>
     <p>{{ modal_data.modal_body }}</p>
+    {% if modal_data.modal_warning %}
+      <p><em>{{ modal_data.modal_warning }}</em></p>
+    {% endif %}
     <a href="#close" id="{{ modal_data.cancel_id }}" title="{{ gettext('Cancel') }}" class="btn upper">{{ gettext('Cancel') }}</a>
     <button type="submit" id="{{ modal_data.submit_id }}" name="action" value="delete" class="{{ modal_data.submit_btn_type }} upper">{{ modal_data.submit_btn_text }}</button>
   </div>

--- a/securedrop/journalist_templates/_confirmation_modal.html
+++ b/securedrop/journalist_templates/_confirmation_modal.html
@@ -4,7 +4,7 @@
     <a href="#close" title="{{ gettext('Close') }}" class="close">X</a>
     <h2>{{ modal_data.modal_header }}</h2>
     <p>{{ modal_data.modal_body }}</p>
-    {% if modal_data.modal_warning %}
+    {% if modal_data.modal_warning is defined %}
       <p><em>{{ modal_data.modal_warning }}</em></p>
     {% endif %}
     <a href="#close" id="{{ modal_data.cancel_id }}" title="{{ gettext('Cancel') }}" class="btn upper">{{ gettext('Cancel') }}</a>

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -45,6 +45,7 @@
                               "modal_id": "delete-confirmation-modal",
                               "modal_header": gettext('Delete Confirmation'),
                               "modal_body": gettext('Are you sure you want to delete the selected collections?'),
+                              "modal_warning": gettext('Warning: If you do this, the files seen here will be unrecoverable and the source will no longer be able to login using their previous codename.'),
                               "cancel_id": "cancel-collections-deletions",
                               "submit_id": "delete-collections",
                               "submit_btn_type": "danger",

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -45,7 +45,7 @@
                               "modal_id": "delete-confirmation-modal",
                               "modal_header": gettext('Delete Confirmation'),
                               "modal_body": gettext('Are you sure you want to delete the selected collections?'),
-                              "modal_warning": gettext('Warning: If you do this, the files seen here will be unrecoverable and the source will no longer be able to login using their previous codename.'),
+                              "modal_warning": gettext('Warning: If you do this, all files for the selected sources will be unrecoverable, and the sources will no longer be able to log in using their previous codename.'),
                               "cancel_id": "cancel-collections-deletions",
                               "submit_id": "delete-collections",
                               "submit_btn_type": "danger",


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5206.

Added `modal_warning to journalist_templates/_confirmation_modal.html` to display emphasized text of any warnings.

Changed `journalist_templates/index.html` to add warning text to `modal_warning`. (This text is identical to the one in `col.html`, line 104: "If you do this...")

## Deployment

We need to add the translation for the modal_warning, but this isn't very difficult because the text is already translated, just not specifically for this page.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

