### PR TITLE
Updates CI box image stretch -> buster

### DIFF
--- a/devops/gce-nested/gce-start.sh
+++ b/devops/gce-nested/gce-start.sh
@@ -22,10 +22,10 @@ function create_gce_ssh_key() {
 # Value will be used in the create call.
 function find_latest_ci_image() {
     #gcloud_call compute images list \
-    #    --filter="family:fpf-securedrop AND name ~ ^ci-nested-virt-stretch" \
+    #    --filter="family:fpf-securedrop AND name ~ ^ci-nested-virt" \
     #    --sort-by=~Name --limit=1 --format="value(Name)"
     # Return hardcoded image id to prevent newer builds from breaking CI
-    echo "ci-nested-virt-stretch-1564072828"
+    echo "ci-nested-virt-buster-1594062724"
 }
 
 # Call out to GCE API and start a new instance, designating


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #5294 

Changes proposed in this pull request:

Updates the GCP image used in the staging-with-rebase CI job, porting the base OS from Debian 9 Stretch to Debian 10 Buster.

## Testing

Re-ran the CI on this PR, while it was in draft state, several times, in order to observe working builds. Documented the following times:

1. 40m37s
2. 41m59s 
3. 42m57s

If you have CircleCI access, you can view the build info at  https://app.circleci.com/pipelines/github/freedomofpress/securedrop/452/workflows/0ed92bf5-974f-46e7-9895-531ce2029908/jobs/41906 If not, here's a screenshot for you:

![sd-ci-buster-box-working-well](https://user-images.githubusercontent.com/657862/86851201-6496f280-c067-11ea-81c1-5bab52aefb73.png)

That's good enough for me. If you agree this looks stable, let's merge.


## Deployment
CI-only.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
