### PR TITLE
Updates kernel version to 4.14.188

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -40,5 +40,5 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder-xenial/tests/vars.yml
 securedrop_pkg_grsec:
-  ver: "4.14.175"
-  depends: "linux-image-4.14.175-grsec-securedrop,linux-image-4.14.154-grsec-securedrop,intel-microcode"
+  ver: "4.14.188"
+  depends: "linux-image-4.14.188-grsec-securedrop,linux-image-4.14.175-grsec-securedrop,intel-microcode"

--- a/molecule/builder-xenial/tests/vars.yml
+++ b/molecule/builder-xenial/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "1.5.0~rc1"
 ossec_version: "3.6.0"
 keyring_version: "0.1.4"
 config_version: "0.1.3"
-grsec_version: "4.14.175"
+grsec_version: "4.14.188"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/staging/vars/staging.yml
+++ b/molecule/testinfra/staging/vars/staging.yml
@@ -197,4 +197,4 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
-grsec_version: "4.14.175"
+grsec_version: "4.14.188"


### PR DESCRIPTION
## Status

Ready for review.

Closes #5359.

## Description of Changes

Changes proposed in this pull request:

Bumps server kernel version 4.14.175 -> 4.14.188. 

## Testing

- [x] Review and merge freedomofpress/ansible-role-grsecurity-build#60
- [x] Review and merge freedomofpress/securedrop-dev-packages-lfs#49
- [x] Restart full CI run for this PR: https://app.circleci.com/pipelines/github/freedomofpress/securedrop/498/workflows/ccf9cb71-1537-4460-900c-c5eb15c177a6/jobs/42205/steps
- [ ] Review and merge this PR

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
