### PR TITLE
Prevent CI failure due to checking private repo link, other broken links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -309,4 +309,5 @@ linkcheck_ignore = [
   r'http://localhost(:\d+)?/?',
   'https://forum.securedrop.org/admin/users/list/active',
   'https://weblate.securedrop.org/projects/securedrop/securedrop/#repository',
+  'https://github.com/freedomofpress/securedrop-debian-packages-lfs',
 ]

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -351,20 +351,20 @@ Two weeks before the release: string freeze
 When features for a new SecureDrop release are frozen, the localization manager for the release will:
 
 * :ref:`merge_develop_to_weblate`.
+* Update the `i18n timeline`_ in the translation section of the forum.
 * Post an announcement `to the translation section of the forum <https://forum.securedrop.org/c/translations>`__ (see `an example  <https://forum.securedrop.org/t/4-securedrop-strings-need-work-march-2018-string-freeze/461>`__).
-* Add a prominent Weblate whiteboard announcement that reads `The X.Y.Z deadline is Month day, year at midnight US/Pacific time. String freeze is in effect: no source strings will be modified before the release.`.
-* Remind all developers about the string freeze, in the `chat room <https://gitter.im/freedomofpress/securedrop>`__.
+* Remind all developers about the string freeze in `Gitter <https://gitter.im/freedomofpress/securedrop>`__.
+* Add a `Weblate announcement`_ with the translation timeline for the release.
 * Create a pull request for every source string suggestion coming from translators.
-* Update the `i18n timeline`_ and `Weblate whiteboard`_.
 
 Release day
 ^^^^^^^^^^^
 
 * :ref:`merge_weblate_to_develop`.
 * :ref:`Update the screenshots <updating_screenshots>`.
-* Remove the prominent Weblate whiteboard announcement.
+* Remove the `Weblate announcement`_ about this release's translation timeline.
 * Provide translator credits to add to the SecureDrop release announcement.
-* Update the `i18n timeline`_ and `Weblate whiteboard`_.
+* Update the `i18n timeline`_ in the forum.
 
 Translator credits
 ^^^^^^^^^^^^^^^^^^
@@ -466,7 +466,7 @@ with a release looming, the server can be rebooted.
 .. _`Weblate translation creation page`: https://weblate.securedrop.org/new-lang/securedrop/securedrop/
 .. _`Weblate desktop translation creation page`: https://weblate.securedrop.org/new-lang/securedrop/desktop/
 .. _`i18n timeline`: https://forum.securedrop.org/t/about-the-translations-category/16
-.. _`Weblate whiteboard`: https://weblate.securedrop.org/admin/trans/whiteboardmessage/6/change/
+.. _`Weblate announcement`: https://weblate.securedrop.org/admin/trans/announcement
 
 .. |Weblate commit Lock| image:: ../images/weblate/admin-lock.png
 .. |Weblate commit Locked| image:: ../images/weblate/admin-locked.png

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -434,10 +434,6 @@ support is preferable, since you want neither WiFi nor Bluetooth.
 	  updating the BIOS according to `these instructions
 	  <http://arstechnica.com/gadgets/2014/02/new-intel-nuc-bios-update-fixes-steamos-other-linux-booting-problems/>`__.
 
-.. caution:: Some older NUC BIOS versions will cause the server to `brick itself <https://communities.intel.com/message/359708>`__ if the device
-    attempts to suspend. This has `since been fixed <https://communities.intel.com/message/432692>`__
-    in a BIOS update. See these `release notes <https://downloadmirror.intel.com/29454/eng/RY_0384_ReleaseNotes.pdf>`__ (PDF) for more details.
-
 2014 Mac Minis
 ~~~~~~~~~~~~~~
 

--- a/docs/includes/update-gui.txt
+++ b/docs/includes/update-gui.txt
@@ -8,4 +8,4 @@ in the updater to perform the update.
   do so, you will need to reboot to enable it.
 
 .. _`Tails Administrator
-   password`: https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/index.en.html
+   password`: https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/

--- a/docs/set_up_transfer_and_export_device.rst
+++ b/docs/set_up_transfer_and_export_device.rst
@@ -232,7 +232,7 @@ mitigate that risk.
 
 One option is to restrict write access to the *Export Device* before it is
 plugged into a device other than the *Secure Viewing Station*. Some USB flash
-drives come with a physical write protection switch, and `write blockers <https://www.forensicswiki.org/wiki/Write_Blockers>`__
+drives come with a physical write protection switch, and `write blockers <https://forensicswiki.xyz/wiki/index.php?title=Write_Blockers>`__
 are used in forensics to ensure storage media are not modified during
 examination.
 

--- a/docs/tails_printing_guide.rst
+++ b/docs/tails_printing_guide.rst
@@ -41,7 +41,7 @@ Installing and Printing via the Tails GUI
 
 Let's look at the flow in Tails 4 for installing a USB-connected printer.
 On the Tails welcome screen, unlock your persistent volume, and
-`set an admin password <https://tails.boum.org/doc/first_steps/startup_options/administration_password/index.en.html>`__.
+`set an admin password <https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/>`__.
 This ensures that you won't have to reinstall the printer each time you start
 Tails.
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5367.

## Testing

- Check out the `fix-5367` branch.
- Run `make docs-linkcheck`. 
- Verify that there is no error `broken link: https://github.com/freedomofpress/securedrop-debian-packages-lfs (404 Client Error: Not Found for url: https://github.com/freedomofpress/securedrop-debian-packages-lfs)` or any other similar link error.