### PR TITLE
Add v2 onion deprecation warning to securedrop-admin

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -410,7 +410,9 @@ class SiteConfig(object):
              str.split,
              lambda config: True],
             ['v2_onion_services', self.check_for_v2_onion(), bool,
-             'Do you want to enable v2 onion services (recommended only for SecureDrop instances installed before 1.0.0)?',  # noqa: E501
+             'WARNING: For security reasons, support for v2 onion services ' +
+             'will be removed in February 2021. ' +
+             'Do you want to enable v2 onion services?',
              SiteConfig.ValidateYesNo(),
              lambda x: x.lower() == 'yes',
              lambda config: True],

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -340,7 +340,7 @@ def verify_locales_prompt(child):
 
 
 def verify_v2_onion_for_first_time(child):
-    child.expect(rb' installed before 1.0.0\)\?\:', timeout=2)  # noqa: E501
+    child.expect(rb'Do you want to enable v2 onion services\?\:', timeout=2)  # noqa: E501
     assert ANSI_ESCAPE.sub('', child.buffer.decode("utf-8")).strip() == 'no'  # noqa: E501
 
 


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #5361

Adds a simple deprecation warning for the v2 setting, regardless of the current value.

## Test plan

- Check out this branch in a real or virtualized Tails Admin Workstation
- Run `./securedrop-admin sdconfig`
- [ ] Observe that the output is clean and understandable, and that the tool works as before

## Checklist

- [x] `make -C admin test` passes locally