### PR TITLE
Minor fix development docs to prevent deprecation warning

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -103,11 +103,11 @@ To get started, you can try the following:
 
 .. code:: sh
 
-   cd securedrop/securedrop
-   make dev                                    # run development servers
-   make test                                   # run tests
-   bin/dev-shell bin/run-test tests/functional # functional tests only
-   bin/dev-shell bash                          # shell inside the container
+   cd securedrop
+   make dev                                               # run development servers
+   make test                                              # run tests
+   securedrop/bin/dev-shell bin/run-test tests/functional # functional tests only
+   securedrop/bin/dev-shell bash                          # shell inside the container
 
 .. tip:: The interactive shell in the container does not run
          ``redis``, ``Xvfb`` etc.  However you can import shell helper
@@ -302,4 +302,3 @@ create a standalone VM named ``sd-dev``, then follow the Linux instructions abov
 required packages, *omitting* Virtualbox.
 
 Then, complete the steps described in :doc:`qubes_staging`.
-


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Running tests from the `securedrop/securedrop` directory prints a deprecation warning:

> `►►► securedrop/Makefile is deprecated. Run 'make test' in the repo root. ◀◀◀`

This PR applies the suggestion of running the tests from the `securedrop` directory instead.

### Considerations

The `bin/dev-shell` script sets `TOPLEVEL` from Git output and doesn't depend on the current directory, so there is no need to change directory before running the `bin/dev-shell` examples.

The lines become longer, but still fit the width of the Read the Docs code block in all orientations of an iPad-sized device, and readability remains unchanged. (Smaller devices already required horizontal scrolling.)

## Testing

- [ ] Run the 5 commands in the code block successively. All must succeed.

## Deployment

_No special considerations for deployment._

## Checklist

- [x] Doc linting (`make docs-lint`) passed locally 

:warning: I may have a different version of Pygments because I ran into an error (unrelated to the changes in this PR): `securedrop/docs/kernel_troubleshooting.rst:110:Cannot analyze code. No Pygments lexer found for "none".` (I worked around it.)

