### PR TITLE
Minor fix miswording in list of unacceptable behavior

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -105,7 +105,7 @@ following behaviors:
   - Unwelcome sexual attention
   - Posting (or threatening to post) other people's personally identifying
     information ("doxing")
-  - Respect people's stated personal boundaries
+  - Violation of people's stated personal boundaries
 
 - Following the letter of this Code of Conduct while disregarding its spirit.
   When judging whether certain behavior represents a violation of this code, we


### PR DESCRIPTION
##  Status

Ready for review

## Description of Changes

"Respect people's stated personal boundaries" was listed as unacceptable behavior.

The intent was clear but given the list is introduced as a list of behaviors people are expected to _never_ engage into, the meaning was the opposite of the intention.

To limit changes in formatting, reworded the entry so that it belongs in the list.

## Testing

- [ ] Proof-read the paragraph please.

## Deployment

_No special considerations for deployment._

## Checklist

- [x] Verified that the new list entry fits among the existing ones.
