### PR TITLE
update targeted Tor version to 0.4.3.6

### DIFF
--- a/molecule/fetch-tor-packages/playbook.yml
+++ b/molecule/fetch-tor-packages/playbook.yml
@@ -12,7 +12,7 @@
     tor_repo_pubkey: "{{ sd_repo_root + '/install_files/ansible-base/roles/tor-hidden-services/files/tor-signing-key.pub' }}"
     tor_repo_url: "deb https://deb.torproject.org/torproject.org {{ ansible_distribution_release }} main"
     # Used to fetch a precise version; must also be updated in the test vars
-    tor_version: "0.4.3.5-1~xenial+1"
+    tor_version: "0.4.3.6-1~xenial+1"
 
   tasks:
     - name: Add Tor apt repo pubkey

--- a/molecule/fetch-tor-packages/tests/test_tor_packages.py
+++ b/molecule/fetch-tor-packages/tests/test_tor_packages.py
@@ -8,7 +8,7 @@ TOR_PACKAGES = [
     {"name": "tor", "arch": "amd64"},
     {"name": "tor-geoipdb", "arch": "all"},
 ]
-TOR_VERSION = "0.4.3.5-1~xenial+1"
+TOR_VERSION = "0.4.3.6-1~xenial+1"
 
 
 def test_tor_apt_repo(host):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updates the desired version of Tor packages to 0.4.3.6.

Fixes #5362.

## Testing

Run `make fetch-tor-packages` and see that `tor_0.4.3.6-1~xenial+1_amd64.deb` and `tor-geoipdb_0.4.3.6-1~xenial+1_all.deb` are downloaded to the `build/xenial` directory.

Package checksum verification will be done in https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/50.