### PR TITLE
Fix sentence about onion services v2

### DIFF
--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -21,7 +21,7 @@
     {% if g.user %}
       {% if g.show_v2_onion_eol_warning %}
       <div id="v2-onion-eol" class="warning-banner">
-        {{ gettext('<strong>Update Required:</strong> Your SecureDrop servers are still running v2 Onion Services, which are being phased out for security reasons. In February 2021, v2 Onion Services will be disabled, and your SecureDrop servers may become unreachable. <a href="//securedrop.org/v2-onion-eol" rel="noreferrer">Learn More</a>') }}
+        {{ gettext('<strong>Update Required:</strong>Your SecureDrop servers are running onion services v2, which will be deprecated February 2021. Your SecureDrop servers may become unreachable. <a href="//securedrop.org/v2-onion-eol" rel="noreferrer">Learn More</a>') }}
       </div>
       {% endif %}
 

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -21,7 +21,7 @@
     {% if g.user %}
       {% if g.show_v2_onion_eol_warning %}
       <div id="v2-onion-eol" class="warning-banner">
-        {{ gettext('<strong>Update Required:</strong>Your SecureDrop servers are running onion services v2, which will be deprecated February 2021. Your SecureDrop servers may become unreachable. <a href="//securedrop.org/v2-onion-eol" rel="noreferrer">Learn More</a>') }}
+        {{ gettext('<strong>Update Required:</strong>Your SecureDrop servers are running v2 onion services, which will be deprecated for security reasons come February 2021. Your SecureDrop servers may become unreachable. <a href="//securedrop.org/v2-onion-eol" rel="noreferrer">Learn More</a>') }}
       </div>
       {% endif %}
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #.

https://weblate.securedrop.org/translate/securedrop/securedrop/en/?checksum=8bf29e52aaf6db39#comments

Changes proposed in this pull request:

## Testing

How should the reviewer test this PR?

See https://blog.torproject.org/v2-deprecation-timeline check whether SecureDrop deprecation differs from Tor plan.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
