### PR TITLE
Consistent usage of "onion services" terminology

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -24,7 +24,7 @@ older submissions in the *Journalist Interface*. As a general practice, you shou
 encourage Journalists to delete regularly unneeded submissions from the *Journalist
 Interface*.
 
-.. tip:: Although it varies, the average throughput of a Tor Hidden Service is
+.. tip:: Although it varies, the average throughput of an onion service is
          about 150 kB/s, or roughly 4 hours for 2GB. Plan your backup and
          restore accordingly.
 

--- a/docs/configure_admin_workstation_post_install.rst
+++ b/docs/configure_admin_workstation_post_install.rst
@@ -22,15 +22,10 @@ but are only accessible to users who possess a shared secret
 (``auth-cookie`` in the Tor documentation) that is generated during the onion
 service setup process.
 
-In order to access an authenticated onion service, you need to add one or more
-"auth-cookie" values to your Tor configuration file (``torrc``) and restart Tor.
-Doing this manually is annoying and error-prone, so SecureDrop includes a set of
-scripts in ``./tails_files`` that can set up a Tails instance to automatically
-configure Tor to access a set of authenticated onion services. In order to
-persist these changes across reboots, the Tails instance must have persistence
-enabled (specifically, the "dotfiles persistence").
-
-.. note:: Starting in version 0.3.7, SecureDrop requires Tails 2.x or greater.
+In order to access an authenticated onion service, you require its authentication
+secret. SecureDrop includes a set of scripts to configure Tails access to the
+authenticated onion services. In order to persist these changes across reboots,
+persistence must be enabled in Tails.
 
 To install the auto-connect configuration, start by navigating to the directory
 with these scripts (``~/Persistent/securedrop/``), and run the install script:
@@ -62,7 +57,7 @@ using the *Admin Workstation* and are unable to connect to any
 of the authenticated onion services, restart Tails and make
 sure to enable persistence.
 
-.. _authenticated onion services: https://tb-manual.torproject.org/onion-services/#onion-service-authentication
+.. _authenticated onion services: https://community.torproject.org/onion-services/advanced/client-auth/
 
 Back Up the Workstations
 ------------------------

--- a/docs/configure_admin_workstation_post_install.rst
+++ b/docs/configure_admin_workstation_post_install.rst
@@ -3,8 +3,8 @@ Configure the Admin Workstation Post-Install and Create Backups
 
 .. _auto-connect ATHS:
 
-Auto-connect to the Authenticated Tor Onion Services
------------------------------------------------------
+Auto-connect to the Authenticated Onion Services
+------------------------------------------------
 
 The SecureDrop installation process adds multiple layers of authentication to
 protect access to the most sensitive assets in the SecureDrop system:
@@ -16,19 +16,19 @@ protect access to the most sensitive assets in the SecureDrop system:
 #. SSH on the *Monitor Server*
 
 The installation process blocks direct access to each of these assets, and sets
-up `Authenticated Tor Onion Services`_ (ATHS) to provide authenticated access
-instead. Authenticated Tor Onion Services share the benefits of Tor Hidden
-Services, but are only accessible to users who possess a shared secret
-(``auth-cookie`` in the Tor documentation) that is generated during the hidden
+up `authenticated onion services`_ to provide authenticated access
+instead. Authenticated onion services share the benefits of regular onion services,
+but are only accessible to users who possess a shared secret
+(``auth-cookie`` in the Tor documentation) that is generated during the onion
 service setup process.
 
-In order to access an ATHS, you need to add one or more "auth-cookie" values
-to your Tor configuration file (``torrc``) and restart Tor. Doing this manually
-is annoying and error-prone, so SecureDrop includes a set of scripts in
-``./tails_files`` that can set up a Tails instance to automatically
-configure Tor to access a set of ATHS. In order to persist these changes across
-reboots, the Tails instance must have persistence enabled (specifically, the
-"dotfiles persistence").
+In order to access an authenticated onion service, you need to add one or more
+"auth-cookie" values to your Tor configuration file (``torrc``) and restart Tor.
+Doing this manually is annoying and error-prone, so SecureDrop includes a set of
+scripts in ``./tails_files`` that can set up a Tails instance to automatically
+configure Tor to access a set of authenticated onion services. In order to
+persist these changes across reboots, the Tails instance must have persistence
+enabled (specifically, the "dotfiles persistence").
 
 .. note:: Starting in version 0.3.7, SecureDrop requires Tails 2.x or greater.
 
@@ -59,10 +59,10 @@ beginning of every session, and sets up SSH host aliases for the servers.
 The only thing you need to remember to do is enable
 persistence when you boot the *Admin Workstation*. If you are
 using the *Admin Workstation* and are unable to connect to any
-of the authenticated Onion Services, restart Tails and make
+of the authenticated onion services, restart Tails and make
 sure to enable persistence.
 
-.. _Authenticated Tor Onion Services: https://www.torproject.org/docs/tor-manual.html.en#HiddenServiceAuthorizeClient
+.. _authenticated onion services: https://tb-manual.torproject.org/onion-services/#onion-service-authentication
 
 Back Up the Workstations
 ------------------------

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -97,7 +97,7 @@ organization for both technical and legal reasons:
   the context of SecureDrop, this means that the provider could
   access extremely sensitive information, such as the plaintext of
   submissions or the encryption keys used to identify and access
-  the Tor Onion Services.
+  the onion services.
 
 * In addition, attackers with legal authority such as law
   enforcement agencies may (depending on the jurisdiction) be able

--- a/docs/https_source_interface.rst
+++ b/docs/https_source_interface.rst
@@ -1,8 +1,8 @@
 HTTPS on the *Source Interface*
 ===============================
 
-The SecureDrop *Source Interface* is served over a Tor Hidden Service,
-requiring a ``*.onion`` URL to access it. While Tor Onion Services provide
+The SecureDrop *Source Interface* is served as an onion service with an ``.onion``
+URL, requiring Tor Browser to access it. While onion services provide
 end-to-end encryption by default, as well as strong anonymity, there are
 several reasons why you might want to consider deploying an additional layer of
 encryption and authentication via HTTPS:
@@ -15,10 +15,10 @@ encryption and authentication via HTTPS:
   they are communicating with the intended organization when they access a
   given Source Interface.
 
-* SecureDrop supports v3 onion services, which use updated cryptographic 
-  primitives that provide better transport-layer encryption than those used 
+* SecureDrop supports v3 onion services, which use updated cryptographic
+  primitives that provide better transport-layer encryption than those used
   by v2 onion services. It is **strongly** recommended that you configure your
-  instance to use :doc:`v3 onion services <v3_services>`, but if you cannot 
+  instance to use :doc:`v3 onion services <v3_services>`, but if you cannot
   switch your instance to v3, using HTTPS on the source interface will provide
   an extra layer of encryption for data in transit.
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -89,8 +89,8 @@ Admins
 The SecureDrop servers are managed by a systems admin; for larger
 newsrooms, there may be a team of systems admins. The admin
 uses a dedicated *Admin Workstation* running `Tails <https://tails.boum.org>`__,
-connects to the *Application* and *Monitor Servers* over authenticated `Tor Onion Services
-<https://www.torproject.org/docs/hidden-services.html>`__, and manages them
+connects to the *Application* and *Monitor Servers* over  `authenticated onion services
+<https://tb-manual.torproject.org/onion-services/>`__, and manages them
 using `Ansible <http://www.ansible.com/>`__.
 
 Sources
@@ -98,7 +98,7 @@ Sources
 
 A source submits documents and messages by using `Tor Browser
 <https://www.torproject.org/projects/torbrowser.html>`__ (or Tails) to access
-the *Source Interface*: a public Tor Hidden Service. Submissions are encrypted
+the *Source Interface*: a public onion service. Submissions are encrypted
 in place on the *Application Server* as they are uploaded.
 
 Journalists
@@ -106,7 +106,7 @@ Journalists
 
 Journalists working in the newsroom use two machines to interact with
 SecureDrop. First, they use a *Journalist Workstation* running Tails to connect
-to the *Journalist Interface*, an authenticated Tor Hidden Service. Journalists
+to the *Journalist Interface*, an authenticated onion service. Journalists
 download `GPG <https://www.gnupg.org/>`__-encrypted submissions and copy them
 to a *Transfer Device* (a thumb drive or DVD). Those submissions are then
 connected to the airgapped *Secure Viewing Station* (*SVS*) which holds the key

--- a/docs/passphrase_best_practices.rst
+++ b/docs/passphrase_best_practices.rst
@@ -53,7 +53,7 @@ We have tried to minimize the number of credentials that Journalists and
 admins actually have to *remember* by automating the storage and entry
 of credentials on the Tails workstations wherever possible. For example,
 shortcut icons are created on the Desktop of each Tails workstation to make it
-easy to access the Tor Onion Services without having to look up their
+easy to access the onion services without having to look up their
 ``.onion`` addresses every time.
 
 Ideally, each admin would only have to:

--- a/docs/passphrases.rst
+++ b/docs/passphrases.rst
@@ -37,7 +37,7 @@ passphrases:
    -  The admin's personal GPG public key, if you want to potentially encrypt
       sensitive files to it for further analysis.
    -  The account details for the destination email address for OSSEC alerts.
-   -  The Onion Services values required to connect to the *Application* and
+   -  The onion services values required to connect to the *Application* and
       *Monitor Servers*.
 
 
@@ -60,11 +60,7 @@ will require the following set of passphrases:
 
 -  A master passphrase for the persistent volume on the Tails device.
 -  A master passphrase for the KeePassXC password manager, which unlocks
-   passphrases to:
-
-   -  The Hidden Service value required to connect to the Journalist
-      Interface.
-   -  The *Journalist Interface*.
+   the passphrase for logging into the *Journalist Interface*.
 
 The journalist will also need to have a two-factor authenticator, such
 as an Android or iOS device with FreeOTP installed, or a

--- a/docs/rebuild_admin.rst
+++ b/docs/rebuild_admin.rst
@@ -1,24 +1,24 @@
 Rebuilding an *Admin Workstation* USB
 -------------------------------------
 
-.. note:: These instructions refer to a SecureDrop instance using v2 onion 
+.. note:: These instructions refer to a SecureDrop instance using v2 onion
           services. If your instance uses v3 onion services and you need to
           rebuild your *Admin Workstation*, please contact FPF through the
-          `SecureDrop Support Portal`_.                            
-                                                                                
+          `SecureDrop Support Portal`_.
+
 .. _SecureDrop Support Portal: https://securedrop-support.readthedocs.io/en/latest/
 
 
 In cases where an *Admin Workstation* USB stick has been lost or destroyed, and no
 backup exists, it is possible to rebuild one. In order to do so, you'll need
- 
+
  - physical access to the SecureDrop servers
  - 2 USB sticks:
 
    - Tails Master USB
    - 1 replacement *Admin Workstation* USB (USB3 and 16GB or better recommended)
 
-The process requires experience with the Linux command line and Tails, and 
+The process requires experience with the Linux command line and Tails, and
 can take up to 3 hours. If a backup of the SecureDrop application server is available,
 reinstalling the instance may be simpler. An outline of the steps involved in
 rebuilding an *Admin Workstation* is as follows:
@@ -34,7 +34,7 @@ rebuilding an *Admin Workstation* is as follows:
  #. Complete post-rebuild tasks.
 
 
-.. important:: The rebuild process involves temporarily removing ``iptables`` 
+.. important:: The rebuild process involves temporarily removing ``iptables``
                rules on the *Application* and *Monitor Servers*, weakening their
                security. Because of this, it's important to complete the rebuild
                process promptly, to avoid leaving the servers in an insecure state.
@@ -43,16 +43,16 @@ rebuilding an *Admin Workstation* is as follows:
 Step 1: Prepare the USB sticks
 ==============================
 
-First, :ref:`create a new Admin Workstation USB <setup_install_tails>` 
+First, :ref:`create a new Admin Workstation USB <setup_install_tails>`
 and set up a persistent volume with a strong passphrase.
 
-Once persistence has been set up, start up the *Admin Workstation* with 
+Once persistence has been set up, start up the *Admin Workstation* with
 persistence enabled, :ref:`install the SecureDrop application code, and set up
 the KeePassXC database <set_up_admin_tails>`.
 
 The *Admin Workstation* uses SSH with key authentication to connect to the servers,
 so you'll need to create a new SSH keypair for your SecureDrop instance. To do so,
-open a terminal by navigating to **Applications ▸ System Tools ▸ Terminal**,  and run 
+open a terminal by navigating to **Applications ▸ System Tools ▸ Terminal**,  and run
 the following command:
 
 .. code:: sh
@@ -68,10 +68,10 @@ Step 2: (Optional) Boot the servers in single-user mode
 If you do not have the original password for the shell admin account on the
 *Application* and *Monitor Servers*, you'll need to reset the password on each
 server by booting in single user mode. In order to do so, you'll need physical
-access to the server, a keyboard, and a monitor. 
+access to the server, a keyboard, and a monitor.
 
 First, connect a monitor and keyboard to the *Monitor Server*. Then reboot the server.
-When the GRUB menu appears, make sure the **Ubuntu** entry is highlighted, and 
+When the GRUB menu appears, make sure the **Ubuntu** entry is highlighted, and
 press **e** to edit boot options.
 In the boot options for Ubuntu, find the line that starts with ``linux`` and ends
 with ``ro``. Add ``single`` after ``ro``, separated by a space, and press
@@ -81,12 +81,12 @@ Reset the SecureDrop admin user's password
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Once the root prompt appears, you'll need to reset the password for the
 SecureDrop admin user. By default this user is named `sdadmin` and has UID 1000.
-However it may have been named differently during the installation of your 
+However it may have been named differently during the installation of your
 instance. You can use the command ``getent passwd 1000`` to check the username
 corresponding to UID 1000. Once you have the correct username, reset its password
 using the `passwd` command, for example:
 
-.. code:: sh 
+.. code:: sh
 
  passwd sdadmin
 
@@ -97,8 +97,8 @@ using the `passwd` command, for example:
 Finally, reboot the *Monitor Server* and verify that you can log in at the console
 using the new password.
 
-Repeat the process for the *Application Server*. Use the same username and 
-password as for the *Monitor Server* - this is required in order for the 
+Repeat the process for the *Application Server*. Use the same username and
+password as for the *Monitor Server* - this is required in order for the
 ``./securedrop-admin install`` command to work correctly.
 
 Step 3: Set up *Admin Workstation* access
@@ -117,7 +117,7 @@ address for the *Admin Workstation*, and you are using a recommended pfSense-bas
 *Hardware Firewall*, you can retrieve the address by loggging into its admin
 interface and checking the settings under **Firewall ▸ Aliases**.
 
-.. note:: If you do not have login credentials for your pfSense firewall, check 
+.. note:: If you do not have login credentials for your pfSense firewall, check
  its user manual for instructions on resetting the administration password.
 
 Next, determine whether your instance was set up to allow adminstrative access
@@ -126,9 +126,9 @@ chosen, you can check as follows:
 
  #. Log in to the *Application Server* via the console using the adminstration username
     and password.
- #. Check to see if an SSH hidden proxy service exists, using the command 
+ #. Check to see if an SSH hidden proxy service exists, using the command
     ``sudo cat /var/lib/tor/services/ssh/hostname``. If this file exists and
-    includes an Onion URL and authorization token, your instance is set up 
+    includes an Onion URL and authorization token, your instance is set up
     to use SSH over Tor and you should configure temporary SSH access
     using :ref:`these instructions <rebuild_ssh_over_tor>`.
     If not, your instance is set up to use SSH over LAN, and you should follow
@@ -150,25 +150,25 @@ commands, substituting the *Admin Workstation's* static IP for ``<admin_static_i
 
   sudo iptables -I INPUT -p tcp --dport 22 -s <admin_static_ip> \
     -m state --state NEW,ESTABLISHED -j ACCEPT
-  sudo iptables -I OUTPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT 
+  sudo iptables -I OUTPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
 
 Next, edit the file ``/etc/ssh/sshd_config``, changing the line:
 
 .. code-block:: none
 
-  ListenAddress 127.0.0.1:22                                    
+  ListenAddress 127.0.0.1:22
 
 to:
- 
-.. code-block:: none
-
-  ListenAddress 0.0.0.0:22                                   
-
-and deleting the line: 
 
 .. code-block:: none
 
-  PasswordAuthentication no                                         
+  ListenAddress 0.0.0.0:22
+
+and deleting the line:
+
+.. code-block:: none
+
+  PasswordAuthentication no
 
 Then, restart ``sshd`` using the command ``sudo service sshd restart``.
 
@@ -186,12 +186,12 @@ the new Admin Workstation <enabling_access_from_admin>`.
 Configuring access for an SSH-over-LAN instance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-First, log on to the *Application Server* via the console and edit the file 
+First, log on to the *Application Server* via the console and edit the file
 ``/etc/ssh/sshd_config``, deleting the line:
 
 .. code-block:: none
 
-  PasswordAuthentication no                                         
+  PasswordAuthentication no
 
 Then, restart ``sshd`` using the command ``sudo service sshd restart``.
 
@@ -206,21 +206,21 @@ network settings as well.
 Enabling access from the new *Admin Workstation*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-From the *Admin Workstation*, open a terminal and copy the *Admin Workstation's* 
+From the *Admin Workstation*, open a terminal and copy the *Admin Workstation's*
 SSH public key to the servers, substituting the values for the server administration
-username and server IP addresses in the commands below and entering the admin account's 
+username and server IP addresses in the commands below and entering the admin account's
 password when prompted:
 
 .. code:: sh
 
   ssh-copy-id <admin-username>@<application-server-ip>
   ssh-copy-id <admin-username>@<monitor-server-ip>
-  
+
 Next, create a file ``~/.ssh/config`` with contents as below, again substituting
 the appropriate values for your servers:
 
 .. code-block:: none
- 
+
   Host app
     User <admin-username>
     Hostname <application-server-ip>
@@ -232,7 +232,7 @@ the appropriate values for your servers:
     ProxyCommand none
 
 
-Finally, test direct SSH access from the terminal, using the commands ``ssh app`` and 
+Finally, test direct SSH access from the terminal, using the commands ``ssh app`` and
 ``ssh mon``. It should be possible to connect without entering a password.
 
 Step 4: Retrieve SecureDrop configuration info from the servers
@@ -249,7 +249,7 @@ so far, you'll need to retrieve the following files and info:
 Retrieve Onion Service info
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to connect to the Tor Onion Services used by your instance, you will
+In order to connect to the onion services used by your instance, you will
 need to copy their details to the *Admin Workstation*. To do so, run the following
 commands from a Terminal window:
 
@@ -260,17 +260,17 @@ commands from a Terminal window:
     > app-journalist-aths
  echo "$(ssh app sudo cat /var/lib/tor/services/source/hostname)" > app-source-ths
 
-If your instance was set up to use SSH over TOR, you'll also need to copy over the details 
-of the SSH proxy Onion Services, by running the following commands:
+If your instance was set up to use SSH over TOR, you'll also need to copy over the details
+of the SSH proxy onion services, by running the following commands:
 
 .. code:: sh
 
  echo "HidServAuth $(ssh app sudo cat /var/lib/tor/services/ssh/hostname)" > app-ssh-aths
  echo "HidServAuth $(ssh mon sudo cat /var/lib/tor/services/ssh/hostname)" > mon-ssh-aths
 
-Retrieve GPG Public Keys 
+Retrieve GPG Public Keys
 ~~~~~~~~~~~~~~~~~~~~~~~~
-There are 2 GPG public keys required by the instance configuration, that you will need to 
+There are 2 GPG public keys required by the instance configuration, that you will need to
 copy to the new *Admin Workstation*.
 
 To copy the *Submission Public Key*, download it from the *Source Interface* and import
@@ -282,7 +282,7 @@ it locally using the following commands:
  curl http://$(cat app-source-ths)/journalist-key > SecureDrop.asc
  gpg --import SecureDrop.asc
 
-Validate that the imported key's fingerprint matches the one on your 
+Validate that the imported key's fingerprint matches the one on your
 SecureDrop install. You can do this by first running the command:
 
 .. code:: sh
@@ -299,27 +299,27 @@ using the command:
 To copy the OSSEC alert public key, first list available keys on the monitor server:
 
 .. code:: sh
- 
+
  ssh mon sudo gpg --homedir=/var/ossec/.gnupg  -k
 
-Look for the key corresponding to the destination email address for OSSEC alerts. 
-Then, import it locally using the following commands (substituting the 
+Look for the key corresponding to the destination email address for OSSEC alerts.
+Then, import it locally using the following commands (substituting the
 appropriate email address for ``alerts@example.com``):
 
 .. code:: sh
 
  ssh mon sudo gpg --homedir=/var/ossec/.gnupg --export --armor alerts@example.com > ossec.pub
  gpg --import ossec.pub
- 
+
 You will be prompted for the fingerprints for both keys during the next step. To view their fingerprints, use the command:
 
 .. code:: sh
- 
+
  gpg -k --fingerprint
 
 Retrieve OSSEC alert configuration details
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In addition to the OSSEC alert GPG key you retrieved above, you'll also need 
+In addition to the OSSEC alert GPG key you retrieved above, you'll also need
 the following configuration information:
 
  - SMTP server
@@ -337,11 +337,11 @@ To retrieve these values, use the following command in the terminal:
 This will return a line like:
 
 .. code:: sh
- 
+
  [smtp.gmail.com]:587 testossec@gmail.com:AwfulPassword
 
 In this example, ``smtp.gmail.com`` is the SMTP server, ``587`` is the SMTP port,
-``testossec`` is the SASL username, ``gmail.com`` is the SASL domain, and 
+``testossec`` is the SASL username, ``gmail.com`` is the SASL domain, and
 ``AwfulPassword`` is the SASL password.
 
 (Optional) Retrieve HTTPS certificate files
@@ -354,19 +354,19 @@ To retrieve these files, use the commands:
 .. code:: sh
 
    cd ~/Persistent/securedrop/install_files/ansible-base
-   ssh app sudo tar -c -C /var/lib ssl/  | tar xvf - 
+   ssh app sudo tar -c -C /var/lib ssl/  | tar xvf -
 
-These commands will create a directory named 
+These commands will create a directory named
 ``~/Persistent/securedrop/install_files/ansible-base/ssl``
-on the *Admin Workstation*, containing your instance's SSL certificate, 
+on the *Admin Workstation*, containing your instance's SSL certificate,
 certificate key, and chain file. When prompted for the names of these files
-during the next step, you should specify them relative to the 
+during the next step, you should specify them relative to the
 ``install_files/ansible-base`` directory, i.e. as ``ssl/mydomain.crt``.
 
 Step 5: Configure and back up the application
 =============================================
 
-Next, configure the application using the files and info retrieved in the 
+Next, configure the application using the files and info retrieved in the
 previous steps. To do so, connect to the Tor network on the
 *Admin Workstation*, open a Terminal and run the following commands:
 
@@ -390,10 +390,10 @@ Once complete, configure the *Admin Workstation* using the command:
 This will set up desktop shortcuts for the *Source* and *Journalist Interfaces*,
 and configure adminstrative access to the servers.
 
-Once the ``./securedrop-admin tailsconfig`` command is complete: 
- - verify that the ``Hostname`` references in ``~/.ssh/config`` have been updated 
+Once the ``./securedrop-admin tailsconfig`` command is complete:
+ - verify that the ``Hostname`` references in ``~/.ssh/config`` have been updated
    to refer to Onion URLs instead of direct IP addresses,
- - verify that you can connect to 
+ - verify that you can connect to
    the servers using ``ssh app`` and ``ssh mon``, accepting the host verification
    prompt if necessary,
  - and verify that the desktop shortcuts for the *Source* and *Journalist Interfaces*
@@ -401,8 +401,8 @@ Once the ``./securedrop-admin tailsconfig`` command is complete:
 
 Next, back up the servers by running the following command in the terminal:
 
-.. code:: sh 
- 
+.. code:: sh
+
  ./securedrop-admin backup
 
 
@@ -410,7 +410,7 @@ Step 6: Run the ``./securedrop-admin install`` command
 ======================================================
 
 After the ``./securedrop-admin backup`` command completes successfully, you should
-undo the changes made to enable temporary local SSH access, by running the following 
+undo the changes made to enable temporary local SSH access, by running the following
 command:
 
 .. code:: sh
@@ -422,7 +422,7 @@ for use. To revert the changes made to enable temporary local SSH access, you
 should reboot the servers, by issuing the following commands in a terminal:
 
 .. code:: sh
- 
+
  ssh app sudo reboot
  ssh mon sudo reboot
 
@@ -433,15 +433,15 @@ We recommend completing the following tasks after the rebuild:
 
  - Set up a new administration account on the *Journalist Interface*, by following
    :doc:`these instructions <create_admin_account>`
- - Verify that submissions can be decrypted, by going through the decryption 
+ - Verify that submissions can be decrypted, by going through the decryption
    workflow with a new submission.
- - Back up your *Admin Workstation* using the process 
+ - Back up your *Admin Workstation* using the process
    :ref:`documented here <backup_workstations>`.
  - Delete invalid admin accounts in the *Journalist Interface*.
- - Restrict SSH access to the *Application* and *Monitor Servers* to valid 
+ - Restrict SSH access to the *Application* and *Monitor Servers* to valid
    *Admin Workstions*. If your new *Admin Workstation* USB stick
-   is the only one that should have SSH access to the servers, you can remove 
-   access for any previous *Admin Workstations* from the terminal,  using the 
+   is the only one that should have SSH access to the servers, you can remove
+   access for any previous *Admin Workstations* from the terminal,  using the
    commands:
 
    .. code:: sh
@@ -450,10 +450,9 @@ We recommend completing the following tasks after the rebuild:
      ./securedrop-admin reset_admin_access
 
    You can also selectively remove invalid keys by logging on to the *Application*
-   and *Monitor Servers* and editing the file ``~/.ssh/authorized_keys``, making 
+   and *Monitor Servers* and editing the file ``~/.ssh/authorized_keys``, making
    sure not to remove the public key belonging to your new *Admin Workstation*.
- - Optionally, set up :ref:`daily journalist alerts <daily_journalist_alerts>`, 
+ - Optionally, set up :ref:`daily journalist alerts <daily_journalist_alerts>`,
    by running ``./securedrop-admin sdconfig`` and providing a valid
    GPG key and fingerprint, along with the corresponding destination email address, then
    running ``./securedrop-admin install`` again to update the server configuration.
-     

--- a/docs/threat_model/mitigations.rst
+++ b/docs/threat_model/mitigations.rst
@@ -155,7 +155,7 @@ Countermeasures Against Vulnerabilities in Tor
 -  A cron job ensures that automatic nightly security updates are applied for OS packages, including Tor
 -  Grsecurity/PaX linux patches prevent the exploitation of certain memory-corruption attacks
 -  AppArmor profiles further reduce process capabilities through Mandatory Access Control
--  Hidden Service authentication is used as a complementary authentication and only used for defense-in-depth/attack surface reduction
+-  Onion service authentication is used as a complementary authentication and only used for defense-in-depth/attack surface reduction
 
 Countermeasures Against Malicious apt Installs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -170,7 +170,7 @@ Countermeasures Against Vulnerabilities in the Hardware Firewall
 -  SecureDrop `Admin Guide <https://docs.securedrop.org/en/stable/admin.html>`__ informs administrators to update the hardware firewall and provides a very restrictive policy for accessing the administrative interface (blocked on app and mon ports of the firewall).
 -  Alert emails are sent out to admins when there are critical pfSense vulnerabilities.
 -  *Application* and *Monitor Servers* use IPTables as host-based firewall for defense-in-depth
--  All application traffic is over Tor Hidden services (end-to-end encrypted) and all software packages are signed. Only DNS and NTP are transmitted over HTTP (unauthenticated and in cleartext)
+-  All application traffic is over Tor onion services (end-to-end encrypted) and all software packages are signed. Only DNS and NTP are transmitted over HTTP (unauthenticated and in cleartext)
 
 Network Infrastructure — FPF Infrastructure or Organization Corporate Network
 -----------------------------------------------------------------------------
@@ -232,6 +232,6 @@ Countermeasures in User Behavior Recommendations
 -  `Journalist Guide <https://docs.securedrop.org/en/stable/journalist.html>`__ informs users of malware risks, the importance of strict comparmentalization of SecureDrop-related activities
 -  `SecureDrop Deployment Guide <https://docs.securedrop.org/en/stable/deployment_practices.html>`__ gives best practices for proper administration of the SecureDrop system, and its public-facing properties like the Landing Page
 -  `Admin Guide <https://docs.securedrop.org/en/stable/admin.html>`__ gives instructions for long-term maintenance of the technical properties of the SecureDrop system, as well as operations to support Journalists
--  All Admin tasks are completed over Tor/Tor authenticated Onion Services after installation
+-  All Admin tasks are completed over Tor/Tor authenticated onion services after installation
 -  Any Journalist/Admin password/2FA credentials resets can only be done by an Admin with password-protected SSH capability or authenticated Onion Service credentials.
 -  Persistent storage on the Admin Workstation is protected with LUKS/dm-crypt encryption

--- a/docs/threat_model/threat_model.rst
+++ b/docs/threat_model/threat_model.rst
@@ -193,7 +193,7 @@ Assumptions About the World
    valid.
 -  The security assumptions of scrypt with randomly-generated salts are
    valid.
--  The security/anonymity assumptions of Tor and the Hidden Service
+-  The security/anonymity assumptions of Tor and the onion service
    protocol are valid.
 -  The security assumptions of the Tails operating system are valid.
 -  The security assumptions of SecureDrop dependencies, specifically
@@ -241,9 +241,9 @@ What a Compromise of the *Application Server* Can Surrender
 -  The server sees the plaintext submissions of every source.
 -  The server sees the plaintext communication between journalists and
    their sources.
--  The server stores the Tor Hidden Service private key for the source interface.
--  The server stores the Tor Hidden Service private key and ATHS token for the
-   Journalist interface.
+-  The server stores the onion service private key for the source interface.
+-  The server stores the onion service private key and authentication token for
+   the Journalist interface.
 -  The server stores and (optional) TLS private key and certificate (if HTTPS
    is enabled on the source interface)
 -  The server stores hashes of codenames, created with scrypt and
@@ -293,7 +293,7 @@ What a Compromise of the Workstations Can Surrender
    for the *Application Server*, the *Monitor Server*, and the GPG key the
    *Monitor Server* will encrypt OSSEC alerts to.
 -  The *Journalist Workstation* requires Tails with a persistent
-   volume, which stores information such as the Hidden Service value
+   volume, which stores information such as the onion service value
    required to connect to the *Journalist Interface*, as well as a :doc:`database
    with passphrases <../passphrases>` for the
    *Journalist Interface*.
@@ -369,7 +369,7 @@ What Compromise of the Admin's Property Can Surrender
    *Monitor Server*, the attacker needs to obtain the admin's login
    credentials and the admin's two-factor authentication device. Unless
    the attacker has physical access to the servers, the attacker will
-   also need to obtain the Hidden Service values for the Interface and
+   also need to obtain the onion service values for the Interface and
    the servers. This information is stored in a password-protected
    database in a persistent volume on the admin's Tails device. The
    volume is protected by a passphrase. If the admin's two-factor
@@ -384,7 +384,7 @@ What Compromise of the Admin's Property Can Surrender
    Tails device can:
 
    -  Add, modify, and delete files on the volume.
-   -  Access the Hidden Service values used by the Interfaces and the
+   -  Access the onion service values used by the Interfaces and the
       servers.
    -  Access SSH keys and passphrases for the *Application Server* and the
       *Monitor Server*.
@@ -455,7 +455,7 @@ What a Compromise of the Journalist's Property Can Achieve
 -  To access the *Journalist Interface*, the attacker needs to obtain the
    journalist's login credentials and the journalist's two-factor
    authentication device or seed. Unless the attacker has physical access to the
-   server, the attacker will also need to obtain the Hidden Service
+   server, the attacker will also need to obtain the onion service
    value for the Interface. This information is stored in a
    password-protected database in a persistent volume on the
    journalist's Tails device. The volume is protected by a passphrase.
@@ -470,7 +470,7 @@ What a Compromise of the Journalist's Property Can Achieve
    journalist's Tails device can:
 
    -  Add, modify, and delete files on the volume.
-   -  Access the Hidden Service values used by the *Journalist Interface*.
+   -  Access the onion service values used by the *Journalist Interface*.
    -  Access SSH keys and passphrases for the *Application Server* and the
       *Monitor Server*.
 

--- a/docs/training_schedule.rst
+++ b/docs/training_schedule.rst
@@ -128,7 +128,7 @@ Participants: admins
 -  Adding/removing users
 -  Enabling logging
 -  Sending logs to FPF
--  Generating new Tor Onion Services
+-  Generating new Tor onion services
 -  Updating application's GPG key
 -  Re-IP'ing
 -  Backups

--- a/docs/v3_services.rst
+++ b/docs/v3_services.rst
@@ -1,4 +1,4 @@
-SecureDrop v3 Onion Services
+SecureDrop V3 Onion Services
 ============================
 Tor onion services provide anonymous inbound connections to websites and other
 servers exclusively over the Tor network. For example, SecureDrop uses onion services
@@ -16,7 +16,7 @@ SecureDrop will remove support for v2 onion services as part of its 2.0.0
 release, planned for **February 2021**. If you are currently using v2 onion services,
 they will become unreachable at that point.
 
-The unique identifier in V3 onion addresses is 56 characters long - for example:
+The unique identifier in v3 onion addresses is 56 characters long - for example:
 
 .. code-block:: none
 
@@ -37,8 +37,7 @@ such as:
 
    There is no downgrade path from v3 to v2 using the ``securedrop-admin``
    tool. We recommend that you follow the v2+v3 migration path below, and test v3
-   functionality thoroughly before disabling
-   v2 services.
+   functionality thoroughly before :ref:`disabling v2 onion services <disable_v2>`.
 
 Migrating from v2 to v3 only or v2+v3
 -------------------------------------
@@ -284,6 +283,8 @@ You'll find the new *Source Interface* address in the file:
 
   ~/Persistent/securedrop/install_files/ansible-base/app-sourcev3-ths
 
+
+.. _disable_v2:
 
 Disabling v2 onion services
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/install_files/ansible-base/group_vars/securedrop_application_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_application_server.yml
@@ -12,7 +12,7 @@ local_deb_packages:
   - "{{ securedrop_app_code_deb }}.deb"
   - "ossec-agent-3.6.0-amd64.deb"
 
-# Configuring the tor Onion Services
+# Configuring the tor onion services
 tor_instances:
   - "{{ {'service': 'ssh', 'filename': 'app-ssh-aths'} if enable_ssh_over_tor else [] }}"
   - service: source

--- a/install_files/ansible-base/group_vars/securedrop_monitor_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_monitor_server.yml
@@ -11,7 +11,7 @@ local_deb_packages:
   - "securedrop-ossec-server-3.6.0+{{ securedrop_app_code_version }}-amd64.deb"
   - ossec-server-3.6.0-amd64.deb
 
-# Configure the tor Onion Services. The Monitor server has only one,
+# Configure the tor onion services. The Monitor server has only one,
 # for SSH, since no web interfaces.
 tor_instances: "{{ [{ 'service': 'ssh', 'filename': 'mon-ssh-aths'}] if enable_ssh_over_tor else [] }}"
 tor_instances_v3: "{{ [{ 'service': 'sshv3', 'filename': 'mon-ssh.auth_private'}] if enable_ssh_over_tor else [] }}"

--- a/install_files/ansible-base/inventory-dynamic
+++ b/install_files/ansible-base/inventory-dynamic
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Dynamic inventory script for connecting to a Tor Hidden Service
+Dynamic inventory script for connecting to a Tor onion service
 for SSH. The THS must already be provisioned on the target host.
 """
 import json
@@ -38,8 +38,8 @@ class ConfigurationError(Exception):
 def lookup_local_ipv4_address(hostname):
     """
     Extract local IPv4 addresses from site vars for first-run config.
-    After running the playbooks, SSH access is restricted to Authenticated
-    Tor Onion Services.
+    After running the playbooks, SSH access is restricted to authenticated
+    onion services.
     """
     try:
         with io.open(SECUREDROP_SITE_VARS, 'r') as f:

--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/fetch_tor_config.yml
@@ -1,5 +1,5 @@
 ---
-- name: Wait for all Tor Onion Services hostname files.
+- name: Wait for all Tor onion services hostname files.
   wait_for:
     state: present
     path: "{{ tor_hidden_services_parent_dir }}/{{ item.service }}/hostname"

--- a/install_files/ansible-base/roles/tails-config/files/65-configure-tor-for-securedrop.sh
+++ b/install_files/ansible-base/roles/tails-config/files/65-configure-tor-for-securedrop.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # appends HidServAuth values needed for SecureDrop
-# authenticated Onion Services to /etc/tor/torrc
+# authenticated onion services to /etc/tor/torrc
 # and reloads Tor
 
 # Run only when the interace is not "lo":

--- a/install_files/ansible-base/roles/tor-hidden-services/tasks/check_tor_service_config_for_admins.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/tasks/check_tor_service_config_for_admins.yml
@@ -25,10 +25,10 @@
     that: >
       not (not v3_onion_services and true in _v3_services_state_info)
     msg: >
-      ERROR. The 'sdconfig' settings do not specify v3 Onion Services,
-      but v3 Onion Services were found on the server. If your SecureDrop
+      ERROR. The 'sdconfig' settings do not specify v3 onion services,
+      but v3 onion services were found on the server. If your SecureDrop
       instance has multiple Administrators, contact the other Administrators
-      to request the Tor v3 Onion Service config information. You must copy
+      to request the Tor v3 onion service config information. You must copy
       the 'tor_v3_keys.json' and '*.auth_private' files to this workstation,
       then re-run the install action.
   when:

--- a/install_files/ansible-base/roles/tor-hidden-services/tasks/configure_tor_hidden_services.yml
+++ b/install_files/ansible-base/roles/tor-hidden-services/tasks/configure_tor_hidden_services.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create parent directory for Tor Onion Services.
+- name: Create parent directory for onion services.
   file:
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}"
@@ -9,7 +9,7 @@
   tags:
     - tor
 
-- name: Create directories for Tor Onion Services.
+- name: Create directories for onion services.
   file:
     state: directory
     dest: "{{ tor_hidden_services_parent_dir }}/{{ item.service }}"

--- a/molecule/testinfra/staging/app/test_tor_config.py
+++ b/molecule/testinfra/staging/app/test_tor_config.py
@@ -39,7 +39,7 @@ def test_tor_torrc_options(host, torrc_option):
     These options should be present regardless of machine role,
     meaning both Application and Monitor server will have them.
 
-    Separate tests will check for specific Onion Services.
+    Separate tests will check for specific onion services.
     """
     f = host.file("/etc/tor/torrc")
     assert f.is_file

--- a/molecule/testinfra/staging/app/test_tor_hidden_services.py
+++ b/molecule/testinfra/staging/app/test_tor_hidden_services.py
@@ -22,9 +22,9 @@ def test_tor_service_directories(host, tor_service):
 @pytest.mark.parametrize('tor_service', sdvars.tor_services)
 def test_tor_service_hostnames(host, tor_service):
     """
-    Check contents of tor service hostname file. For normal Onion Services,
-    the file should contain only hostname (.onion URL). For Authenticated
-    Onion Services, it should also contain the HidServAuth cookie.
+    Check contents of tor service hostname file. For normal onion services,
+    the file should contain only hostname (.onion URL). For authenticated
+    onion services, it should also contain the HidServAuth cookie.
     """
     # Declare regex only for THS; we'll build regex for ATHS only if
     # necessary, since we won't have the required values otherwise.
@@ -65,13 +65,13 @@ def test_tor_service_hostnames(host, tor_service):
 @pytest.mark.parametrize('tor_service', sdvars.tor_services)
 def test_tor_services_config(host, tor_service):
     """
-    Ensure torrc file contains relevant lines for Hidden Service declarations.
-    All Onion Services must include:
+    Ensure torrc file contains relevant lines for onion service declarations.
+    All onion services must include:
 
       * HiddenServiceDir
       * HiddenServicePort
 
-    Only v2 authenticated Onion Services must also include:
+    Only v2 authenticated onion services must also include:
 
       * HiddenServiceAuthorizeClient
 

--- a/molecule/vagrant-packager/side_effect.yml
+++ b/molecule/vagrant-packager/side_effect.yml
@@ -7,7 +7,7 @@
       pause:
         seconds: 120
 
-- name: Strip away configured tor Onion Services files
+- name: Strip away configured onion services files
   hosts: securedrop
   become: yes
   tasks:

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -21,7 +21,7 @@
     {% if g.user %}
       {% if g.show_v2_onion_eol_warning %}
       <div id="v2-onion-eol" class="warning-banner">
-        {{ gettext('<strong>Update Required:</strong> Your SecureDrop servers are still running v2 Onion Services, which are being phased out for security reasons. In February 2021, v2 Onion Services will be disabled, and your SecureDrop servers may become unreachable. <a href="//securedrop.org/v2-onion-eol" rel="noreferrer">Learn More</a>') }}
+        {{ gettext('<strong>Update Required:</strong> Your SecureDrop servers are still running v2 onion services, which are being phased out for security reasons. In February 2021, v2 onion services will be disabled, and your SecureDrop servers may become unreachable. <a href="//securedrop.org/v2-onion-eol" rel="noreferrer">Learn More</a>') }}
       </div>
       {% endif %}
 

--- a/tails_files/torrc_additions
+++ b/tails_files/torrc_additions
@@ -1,1 +1,1 @@
-# HidServAuth lines for SecureDrop's authenticated Onion Services
+# HidServAuth lines for SecureDrop's authenticated onion services


### PR DESCRIPTION
- "Hidden Services" begone, retire "ATHS" abbreviation
- Lower case throughout except in titles, per typical Tor project usage
- Retire "ATHS" abbreviation
- Address https://github.com/freedomofpress/securedrop/pull/5373/files#r454731330
- Whitespace fixes

## Status

Ready for review

## Checklint

- [x] Linter is stressed out by the size and scope of this change but is not noticing anything to complain about