### PR TITLE
Fixes #5378, adds more checks for invalid username

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -484,6 +484,10 @@ class Journalist(db.Model):
             raise InvalidUsernameException(
                         'Username "{}" must be at least {} characters long.'
                         .format(username, cls.MIN_USERNAME_LEN))
+        if username in cls.INVALID_USERNAMES:
+            raise InvalidUsernameException(
+                    "This username is invalid because it is reserved "
+                    "for internal use by the software.")
 
     @classmethod
     def check_name_acceptable(cls, name):

--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -15,6 +15,13 @@ class TestAdminInterface(
         self._new_user_can_log_in()
         self._admin_can_edit_new_user()
 
+    def test_admin_edit_invalid_username(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_adds_a_user()
+        self._new_user_can_log_in()
+        self._admin_editing_invalid_username()
+
     def test_admin_edits_hotp_secret(self):
         # Toggle security slider to force prefs change
         self.set_tbb_securitylevel(ft.TBB_SECURITY_HIGH)

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -820,6 +820,29 @@ def test_admin_edits_user_invalid_username(
                 'error')
 
 
+def test_admin_edits_user_invalid_username_deleted(
+        journalist_app, test_admin, test_journo):
+    """Test expected error message when admin attempts to change a user's
+    username to deleted"""
+    new_username = "deleted"
+    with journalist_app.test_client() as app:
+        _login_user(app, test_admin['username'], test_admin['password'],
+                    test_admin['otp_secret'])
+
+        with InstrumentedApp(journalist_app) as ins:
+            app.post(
+                url_for('admin.edit_user', user_id=test_admin['id']),
+                data=dict(username=new_username,
+                          first_name='',
+                          last_name='',
+                          is_admin=None))
+
+            ins.assert_message_flashed(
+                    'Invalid username: This username is invalid because it '
+                    'is reserved for internal use by the software.',
+                    'error')
+
+
 def test_admin_resets_user_hotp_format_non_hexa(
         journalist_app, test_admin, test_journo):
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #5378 

In #5284 we made sure that the username `deleted` is not not allowed
to be added in the system via the admin section of the journalist web
application. But, one could still edit any existing user and change
the name to `deleted`. Or, an admin can add a new user via `manage.py`
in command line.

In PR adds checks to make sure that addiving a new user via `manage.py`
will fail if you try to set the username as `deleted`, it also blocks
editing any existing username to `deleted`.

The PR also includes unit and functional tests.

## Testing

- [ ] `make build-debs`
- [ ] `make staging`
- [ ] Run `create-dev-data.py` in the `app-staging` vm for 2 journalists accounts.
- [ ]  Try to add a new user called `deleted` via `manage.py`, this should fail.
- [ ] Login as `journalist` and then try to change the username `dellsberg`  to `deleted`, this should flash an error about "Invalid username" 

![invalid_username_error_sd](https://user-images.githubusercontent.com/272303/87659766-a9174200-c77b-11ea-811c-cb48821348c0.png)


## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
