### PR TITLE
Ensure that generated journalist designation doesn't conflict with existing ones

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -176,23 +176,19 @@ class CryptoUtil:
     def display_id(self):
         """Generate random journalist_designation until we get an unused one"""
 
-        used_journalist_designation_hits = 0
-        matching_journalist_designation = '123'
-        journalist_designation = ''
+        tries = 0
 
-        while len(matching_journalist_designation) != 0:
-            if used_journalist_designation_hits >= 50:
-                raise ValueError("Too many duplicate journalist_designation hits")
+        while tries < 50:
+            new_designation = ' '.join([random.choice(self.adjectives),
+                                        random.choice(self.nouns)])
 
-            journalist_designation = ' '.join([random.choice(self.adjectives),
-                                               random.choice(self.nouns)])
+            collisions = Source.query.filter(Source.journalist_designation == new_designation)
+            if collisions.count() == 0:
+                return new_designation
 
-            matching_journalist_designation = Source.query.filter(
-                Source.journalist_designation == journalist_designation).all()
+            tries += 1
 
-            used_journalist_designation_hits = used_journalist_designation_hits + 1
-
-        return journalist_designation
+        raise ValueError("Could not generate unique journalist designation for new source")
 
     def hash_codename(self, codename, salt=None):
         """Salts and hashes a codename using scrypt.

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -16,6 +16,8 @@ from redis import Redis
 
 import rm
 
+from models import Source
+
 import typing
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
 if typing.TYPE_CHECKING:
@@ -172,8 +174,16 @@ class CryptoUtil:
                         for x in range(words_in_random_id))
 
     def display_id(self):
-        return ' '.join([random.choice(self.adjectives),
-                         random.choice(self.nouns)])
+        """Generate random journalist_designation until we get an unused one"""
+        while True:
+            journalist_designation = ' '.join([random.choice(self.adjectives),
+                                               random.choice(self.nouns)])
+
+            matching_journalist_designation = Source.query.filter(
+                Source.journalist_designation == journalist_designation).all()
+
+            if len(matching_journalist_designation) == 0:
+                return journalist_designation
 
     def hash_codename(self, codename, salt=None):
         """Salts and hashes a codename using scrypt.

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -175,15 +175,24 @@ class CryptoUtil:
 
     def display_id(self):
         """Generate random journalist_designation until we get an unused one"""
-        while True:
+
+        used_journalist_designation_hits = 0
+        matching_journalist_designation = '123'
+        journalist_designation = ''
+
+        while len(matching_journalist_designation) != 0:
+            if used_journalist_designation_hits >= 50:
+                raise ValueError("Too many duplicate journalist_designation hits")
+
             journalist_designation = ' '.join([random.choice(self.adjectives),
                                                random.choice(self.nouns)])
 
             matching_journalist_designation = Source.query.filter(
                 Source.journalist_designation == journalist_designation).all()
 
-            if len(matching_journalist_designation) == 0:
-                return journalist_designation
+            used_journalist_designation_hits = used_journalist_designation_hits + 1
+
+        return journalist_designation
 
     def hash_codename(self, codename, salt=None):
         """Salts and hashes a codename using scrypt.

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -77,7 +77,7 @@ def make_blueprint(config):
             except ValueError as e:
                 current_app.logger.error(e)
                 flash(
-                    gettext("There was a temporary problem creating you account. "
+                    gettext("There was a temporary problem creating your account. "
                             "Please try again."
                             ),
                     'error'

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -72,8 +72,18 @@ def make_blueprint(config):
             del session['codenames']
 
             filesystem_id = current_app.crypto_util.hash_codename(codename)
+            try:
+                source = Source(filesystem_id, current_app.crypto_util.display_id())
+            except ValueError as e:
+                current_app.logger.error(e)
+                flash(
+                    gettext("There was a temporary problem creating you account. "
+                            "Please try again."
+                            ),
+                    'error'
+                )
+                return redirect(url_for('.index'))
 
-            source = Source(filesystem_id, current_app.crypto_util.display_id())
             db.session.add(source)
             try:
                 db.session.commit()

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -76,6 +76,8 @@ class FunctionalTest(object):
     driver_retry_count = 3
     driver_retry_interval = 5
 
+    journalist_designation_collision_test = False
+
     def _unused_port(self):
         s = socket.socket()
         s.bind(("127.0.0.1", 0))
@@ -260,6 +262,10 @@ class FunctionalTest(object):
                     }
 
                     self.admin_user["totp"] = pyotp.TOTP(self.admin_user["secret"])
+
+                    if self.journalist_designation_collision_test:
+                        self.source_app.crypto_util.adjectives = self.source_app.crypto_util.adjectives[:1]
+                        self.source_app.crypto_util.nouns = self.source_app.crypto_util.nouns[:1]
 
                     def start_source_server(app):
                         config.SESSION_EXPIRATION_MINUTES = self.session_expiration / 60.0

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -76,8 +76,6 @@ class FunctionalTest(object):
     driver_retry_count = 3
     driver_retry_interval = 5
 
-    journalist_designation_collision_test = False
-
     def _unused_port(self):
         s = socket.socket()
         s.bind(("127.0.0.1", 0))
@@ -187,6 +185,11 @@ class FunctionalTest(object):
         if hasattr(self, 'torbrowser_driver'):
             disable_js(self.torbrowser_driver)
 
+    def start_source_server(self, app, source_port):
+        config.SESSION_EXPIRATION_MINUTES = self.session_expiration / 60.0
+
+        app.run(port=source_port, debug=True, use_reloader=False, threaded=True)
+
     @pytest.fixture(autouse=True)
     def set_default_driver(self):
         logging.info("Creating default web driver: %s", self.default_driver_name)
@@ -263,21 +266,11 @@ class FunctionalTest(object):
 
                     self.admin_user["totp"] = pyotp.TOTP(self.admin_user["secret"])
 
-                    if self.journalist_designation_collision_test:
-                        self.source_app.crypto_util.adjectives = \
-                            self.source_app.crypto_util.adjectives[:1]
-                        self.source_app.crypto_util.nouns = self.source_app.crypto_util.nouns[:1]
-
-                    def start_source_server(app):
-                        config.SESSION_EXPIRATION_MINUTES = self.session_expiration / 60.0
-
-                        app.run(port=source_port, debug=True, use_reloader=False, threaded=True)
-
                     def start_journalist_server(app):
                         app.run(port=journalist_port, debug=True, use_reloader=False, threaded=True)
 
                     self.source_process = Process(
-                        target=lambda: start_source_server(self.source_app)
+                        target=lambda: self.start_source_server(self.source_app, source_port)
                     )
 
                     self.journalist_process = Process(

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -185,10 +185,10 @@ class FunctionalTest(object):
         if hasattr(self, 'torbrowser_driver'):
             disable_js(self.torbrowser_driver)
 
-    def start_source_server(self, app, source_port):
+    def start_source_server(self, source_port):
         config.SESSION_EXPIRATION_MINUTES = self.session_expiration / 60.0
 
-        app.run(port=source_port, debug=True, use_reloader=False, threaded=True)
+        self.source_app.run(port=source_port, debug=True, use_reloader=False, threaded=True)
 
     @pytest.fixture(autouse=True)
     def set_default_driver(self):
@@ -270,7 +270,7 @@ class FunctionalTest(object):
                         app.run(port=journalist_port, debug=True, use_reloader=False, threaded=True)
 
                     self.source_process = Process(
-                        target=lambda: self.start_source_server(self.source_app, source_port)
+                        target=lambda: self.start_source_server(source_port)
                     )
 
                     self.journalist_process = Process(

--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -264,7 +264,8 @@ class FunctionalTest(object):
                     self.admin_user["totp"] = pyotp.TOTP(self.admin_user["secret"])
 
                     if self.journalist_designation_collision_test:
-                        self.source_app.crypto_util.adjectives = self.source_app.crypto_util.adjectives[:1]
+                        self.source_app.crypto_util.adjectives = \
+                            self.source_app.crypto_util.adjectives[:1]
                         self.source_app.crypto_util.nouns = self.source_app.crypto_util.nouns[:1]
 
                     def start_source_server(app):

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -123,15 +123,7 @@ class SourceNavigationStepsMixin:
 
         self.wait_for(submit_page_loaded)
 
-    def _source_chooses_to_submit_documents_with_colliding_journalist_designation(self):
-        self.safe_click_by_id("submit-documents-button")
-        self.wait_for(lambda: self.driver.find_element_by_id("continue-button"))
-        self.safe_click_by_id("continue-button")
-        self.wait_for(lambda: self.driver.find_element_by_id("logout"))
-        self.safe_click_by_id("logout")
-        self.driver.get(self.source_location)
-        self.safe_click_by_id("submit-documents-button")
-        self.wait_for(lambda: self.driver.find_element_by_id("continue-button"))
+    def _source_continues_to_submit_page_with_colliding_journalist_designation(self):
         self.safe_click_by_id("continue-button")
 
         self.wait_for(lambda: self.driver.find_element_by_css_selector(".error"))

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -123,6 +123,24 @@ class SourceNavigationStepsMixin:
 
         self.wait_for(submit_page_loaded)
 
+    def _source_chooses_to_submit_documents_with_colliding_journalist_designation(self):
+        self.source_app.crypto_util.adjectives = self.source_app.crypto_util.adjectives[0]
+        self.source_app.crypto_util.nouns = self.source_app.crypto_util.nouns[0]
+
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_logs_out()
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+
+        def make_source_with_colliding_journalist_designation():
+            self._source_continues_to_submit_page()
+            flash_error = self.driver.find_element_by_class_name("flash error")
+            assert "There was a temporary problem creating your account. Please try again" \
+                   == flash_error.text
+
+        self.wait_for(make_source_with_colliding_journalist_designation)
+
     def _source_submits_a_file(self):
         with tempfile.NamedTemporaryFile() as file:
             file.write(self.secret_message.encode("utf-8"))

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -124,9 +124,6 @@ class SourceNavigationStepsMixin:
         self.wait_for(submit_page_loaded)
 
     def _source_chooses_to_submit_documents_with_colliding_journalist_designation(self):
-        self.source_app.crypto_util.adjectives = self.source_app.crypto_util.adjectives[0]
-        self.source_app.crypto_util.nouns = self.source_app.crypto_util.nouns[0]
-
         self.safe_click_by_id("submit-documents-button")
         self.wait_for(lambda: self.driver.find_element_by_id("continue-button"))
         self.safe_click_by_id("continue-button")
@@ -139,7 +136,7 @@ class SourceNavigationStepsMixin:
 
         self.wait_for(lambda: self.driver.find_element_by_css_selector(".error"))
         flash_error = self.driver.find_element_by_css_selector(".error")
-        assert "There was a temporary problem creating your account. Please try again" \
+        assert "There was a temporary problem creating your account. Please try again." \
                == flash_error.text
 
     def _source_submits_a_file(self):

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -127,19 +127,20 @@ class SourceNavigationStepsMixin:
         self.source_app.crypto_util.adjectives = self.source_app.crypto_util.adjectives[0]
         self.source_app.crypto_util.nouns = self.source_app.crypto_util.nouns[0]
 
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_logs_out()
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
+        self.safe_click_by_id("submit-documents-button")
+        self.wait_for(lambda: self.driver.find_element_by_id("continue-button"))
+        self.safe_click_by_id("continue-button")
+        self.wait_for(lambda: self.driver.find_element_by_id("logout"))
+        self.safe_click_by_id("logout")
+        self.driver.get(self.source_location)
+        self.safe_click_by_id("submit-documents-button")
+        self.wait_for(lambda: self.driver.find_element_by_id("continue-button"))
+        self.safe_click_by_id("continue-button")
 
-        def make_source_with_colliding_journalist_designation():
-            self._source_continues_to_submit_page()
-            flash_error = self.driver.find_element_by_class_name("flash error")
-            assert "There was a temporary problem creating your account. Please try again" \
-                   == flash_error.text
-
-        self.wait_for(make_source_with_colliding_journalist_designation)
+        self.wait_for(lambda: self.driver.find_element_by_css_selector(".error"))
+        flash_error = self.driver.find_element_by_css_selector(".error")
+        assert "There was a temporary problem creating your account. Please try again" \
+               == flash_error.text
 
     def _source_submits_a_file(self):
         with tempfile.NamedTemporaryFile() as file:

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -1,22 +1,28 @@
 from . import source_navigation_steps, journalist_navigation_steps
 from . import functional_test
+from sdconfig import config
 
 
 class TestSourceInterfaceDesignationCollision(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationStepsMixin):
 
-    @classmethod
-    def setup_class(cls):
-        functional_test.FunctionalTest.journalist_designation_collision_test = True
+    def start_source_server(self, app, source_port):
+        self.source_app.crypto_util.adjectives = \
+            self.source_app.crypto_util.adjectives[:1]
+        self.source_app.crypto_util.nouns = self.source_app.crypto_util.nouns[:1]
+        config.SESSION_EXPIRATION_MINUTES = self.session_expiration / 60.0
 
-    @classmethod
-    def teardown_class(cls):
-        functional_test.FunctionalTest.journalist_designation_collision_test = False
+        app.run(port=source_port, debug=True, use_reloader=False, threaded=True)
 
     def test_display_id_designation_collisions(self):
         self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents_with_colliding_journalist_designation()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_logs_out()
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page_with_colliding_journalist_designation()
 
 
 class TestSourceInterface(

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -18,6 +18,10 @@ class TestSourceInterface(
         self._source_proceeds_to_login()
         self._source_sees_no_codename()
 
+    def test_journalist_designation_collides(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents_with_colliding_journalist_designation()
+
 
 class TestDownloadKey(
         functional_test.FunctionalTest,

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -7,13 +7,13 @@ class TestSourceInterfaceDesignationCollision(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationStepsMixin):
 
-    def start_source_server(self, app, source_port):
+    def start_source_server(self, source_port):
         self.source_app.crypto_util.adjectives = \
             self.source_app.crypto_util.adjectives[:1]
         self.source_app.crypto_util.nouns = self.source_app.crypto_util.nouns[:1]
         config.SESSION_EXPIRATION_MINUTES = self.session_expiration / 60.0
 
-        app.run(port=source_port, debug=True, use_reloader=False, threaded=True)
+        self.source_app.run(port=source_port, debug=True, use_reloader=False, threaded=True)
 
     def test_display_id_designation_collisions(self):
         self._source_visits_source_homepage()

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -2,6 +2,23 @@ from . import source_navigation_steps, journalist_navigation_steps
 from . import functional_test
 
 
+class TestSourceInterfaceDesignationCollision(
+        functional_test.FunctionalTest,
+        source_navigation_steps.SourceNavigationStepsMixin):
+
+    @classmethod
+    def setup_class(cls):
+        functional_test.FunctionalTest.journalist_designation_collision_test = True
+
+    @classmethod
+    def teardown_class(cls):
+        functional_test.FunctionalTest.journalist_designation_collision_test = False
+
+    def test_display_id_designation_collisions(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents_with_colliding_journalist_designation()
+
+
 class TestSourceInterface(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationStepsMixin):
@@ -17,10 +34,6 @@ class TestSourceInterface(
         self._source_chooses_to_login()
         self._source_proceeds_to_login()
         self._source_sees_no_codename()
-
-    def test_journalist_designation_collides(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents_with_colliding_journalist_designation()
 
 
 class TestDownloadKey(

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -201,19 +201,17 @@ def test_display_id(source_app):
 
 
 def test_display_id_designation_collisions(source_app):
-    source_app.crypto_util.adjectives = source_app.crypto_util.adjectives[0]
-    source_app.crypto_util.nouns = source_app.crypto_util.nouns[0]
     with source_app.test_client() as app:
         app.get(url_for('main.generate'))
-        source_app.crypto_util.adjectives = source_app.crypto_util.adjectives[0]
-        source_app.crypto_util.nouns = source_app.crypto_util.nouns[0]
+        source_app.crypto_util.adjectives = source_app.crypto_util.adjectives[:1]
+        source_app.crypto_util.nouns = source_app.crypto_util.nouns[:1]
         tab_id = next(iter(session['codenames'].keys()))
         app.post(url_for('main.create'), data={'tab_id': tab_id}, follow_redirects=True)
 
-    with pytest.raises(ValueError) as err:
-        source_app.crypto_util.display_id()
+        with pytest.raises(ValueError) as err:
+            source_app.crypto_util.display_id()
 
-    assert 'Could not generate unique journalist designation for new source' in str(err)
+        assert 'Could not generate unique journalist designation for new source' in str(err)
 
 
 def test_genkeypair(source_app):

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -7,6 +7,8 @@ import os
 import pytest
 import re
 
+from flask import url_for, session
+
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 import crypto_util
 import models
@@ -196,6 +198,22 @@ def test_display_id(source_app):
     assert len(id_words) == 2
     assert id_words[0] in source_app.crypto_util.adjectives
     assert id_words[1] in source_app.crypto_util.nouns
+
+
+def test_display_id_designation_collisions(source_app):
+    source_app.crypto_util.adjectives = source_app.crypto_util.adjectives[0]
+    source_app.crypto_util.nouns = source_app.crypto_util.nouns[0]
+    with source_app.test_client() as app:
+        app.get(url_for('main.generate'))
+        source_app.crypto_util.adjectives = source_app.crypto_util.adjectives[0]
+        source_app.crypto_util.nouns = source_app.crypto_util.nouns[0]
+        tab_id = next(iter(session['codenames'].keys()))
+        app.post(url_for('main.create'), data={'tab_id': tab_id}, follow_redirects=True)
+
+    with pytest.raises(ValueError) as err:
+        source_app.crypto_util.display_id()
+
+    assert 'Could not generate unique journalist designation for new source' in str(err)
 
 
 def test_genkeypair(source_app):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2043 

Changes proposed in this pull request:

Added a while loop in crypto_util.display_id() similar to the loop in [source_app.utils.generate_unique_codename()](https://github.com/freedomofpress/securedrop/blob/develop/securedrop/source_app/utils.py#L38) to make sure we keep on generating a new `journalist_designation` until we find one not used already. 

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

No.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally