### PR TITLE
Docs upgrade links to use https where possible

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -29,7 +29,7 @@ headers below) apply only to the /securedrop request URI. This can be done
 in Apache by the encapsulating these settings within a
 `<Location> <https://httpd.apache.org/docs/2.4/mod/core.html#location>`__
 block, which can be defined similarly in nginx by using the
-`location {} <http://nginx.org/en/docs/http/ngx_http_core_module.html#location>`__
+`location {} <https://nginx.org/en/docs/http/ngx_http_core_module.html#location>`__
 directive.
 
 HTTPS Only (No Mixed Content)

--- a/docs/deployment/whole_site_changes.rst
+++ b/docs/deployment/whole_site_changes.rst
@@ -21,7 +21,7 @@ analysis.
 #. Print the link, URL and info block on the dead trees (the paper),
    as others have suggested.
 #. Add `HSTS headers
-   <http://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security>`__.
+   <https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security>`__.
 
 Suggested
 ---------

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -30,7 +30,7 @@ The SecureDrop system includes `Flask`_-based web applications for sources and
 journalists. It is deployed across multiple machines with `Ansible`_. Most of
 SecureDrop's code is written in `Python`_.
 
-.. _`Flask`: http://flask.pocoo.org/
+.. _`Flask`: https://flask.palletsprojects.com/
 .. _`Ansible`: https://github.com/ansible/ansible
 .. _`Python`: https://github.com/freedomofpress/securedrop/search?l=python
 

--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -117,13 +117,13 @@ easier to maintain in the long run by explicitly specifying the expected input/o
 types of various functions.
 
 Any pull request with Python code in SecureDrop should have corresponding type hints
-for all the functions. Type hints and function annotations are defined in 
+for all the functions. Type hints and function annotations are defined in
 `PEP 484 <https://www.python.org/dev/peps/pep-0484>`_ and in `PEP 3107
 <https://www.python.org/dev/peps/pep-3107>`_. We also use the `mypy <https://github.com/python/mypy>`_
 tool in our CI to find bugs in our Python code.
 
 If you are new to Python type hinting, please read the above mentioned PEP documents,
-and then go through the examples in the 
+and then go through the examples in the
 `mypy documentation <https://mypy.readthedocs.io/en/stable/builtin_types.html>`_.
 Some type annotations are included as code comments due to SecureDrop being Python 2 only when
 they were added, but any annotation syntax supported in Python 3.5 is allowed (i.e. function but not
@@ -170,7 +170,7 @@ Example of Type Hint
     if __name__ == '__main__':
         main()
 
-The above example shows how to do a conditional import of ``Dict`` class from 
+The above example shows how to do a conditional import of ``Dict`` class from
 ``typing`` module. ``typing.TYPE_CHECKING`` will only be true when we use mypy
 to check type annotations.
 

--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -63,7 +63,7 @@ root of the repository:
 Python
 ~~~~~~
 
-All Python code should be `flake8 <http://flake8.pycqa.org/en/latest/>`__
+All Python code should be `flake8 <https://flake8.pycqa.org/en/latest/>`__
 compliant. You can run ``flake8`` locally via:
 
   .. code:: sh
@@ -140,7 +140,7 @@ Example of Type Hint
         # flake8 can not understand type annotation yet.
         # That is why all type annotation relative import
         # statements has to be marked as noqa.
-        # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401
+        # https://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401
         from typing import Dict  # noqa: F401
 
     class Config(object):

--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -119,7 +119,7 @@ types of various functions.
 Any pull request with Python code in SecureDrop should have corresponding type hints
 for all the functions. Type hints and function annotations are defined in 
 `PEP 484 <https://www.python.org/dev/peps/pep-0484>`_ and in `PEP 3107
-<https://www.python.org/dev/peps/pep-3107>`_. We also use the `mypy <http://mypy-lang.org>`_
+<https://www.python.org/dev/peps/pep-3107>`_. We also use the `mypy <https://github.com/python/mypy>`_
 tool in our CI to find bugs in our Python code.
 
 If you are new to Python type hinting, please read the above mentioned PEP documents,

--- a/docs/development/database_migrations.rst
+++ b/docs/development/database_migrations.rst
@@ -4,7 +4,7 @@ Database Migrations
 SecureDrop uses Alembic_ for database schema migrations. This guide is not a complete explanation of
 what ``alembic`` is or how it is used, so the original documentation should be read.
 
-.. _Alembic: http://alembic.zzzcomputing.com/
+.. _Alembic: https://alembic.sqlalchemy.org/en/latest/
 
 Migration Files
 ---------------

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -6,7 +6,7 @@ and is built by and hosted on `Read the Docs`_ (RTD). The
 documentation files are stored in the primary SecureDrop git
 repository under the ``docs/`` directory.
 
-.. _ReStructuredText: http://sphinx-doc.org/rest.html
+.. _ReStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 .. _Read the Docs: https://docs.readthedocs.org/en/latest/index.html
 
 To get started editing the docs:
@@ -91,7 +91,7 @@ https://docs.securedrop.org. We use a `webhook`_ to rebuild the documentation
 automatically when commits get pushed to the branch.
 
 .. _upstream Git repository: https://github.com/freedomofpress/securedrop
-.. _webhook: http://docs.readthedocs.org/en/latest/webhooks.html
+.. _webhook: https://docs.readthedocs.io/en/latest/webhooks.html
 
 Style Guide
 -----------

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -18,7 +18,7 @@ code. A Python example:
 In this code, the string ``You must enter a message or choose a file to
 submit.`` can be automatically extracted for translation. The
 ``gettext`` function to which it is passed is used as a marker by
-`pybabel <http://babel.pocoo.org/>`__ or similar tools to collect the
+`pybabel <https://babel.pocoo.org/en/latest/>`__ or similar tools to collect the
 strings to be translated and store them into a `.pot`_ file at
 ``securedrop/translations/messages.pot``. For instance:
 
@@ -456,7 +456,7 @@ with a release looming, the server can be rebooted.
 .. _`.pot`: https://www.gnu.org/software/gettext/manual/gettext.html#index-files_002c-_002epot
 .. _`.po`: https://www.gnu.org/software/gettext/manual/gettext.html#PO-Files
 .. _`.mo`: https://www.gnu.org/software/gettext/manual/gettext.html#MO-Files
-.. _`pybabel`: http://babel.pocoo.org/
+.. _`pybabel`: https://babel.pocoo.org/en/latest/
 .. _`Weblate`: http://weblate.securedrop.org/
 .. _`SecureDrop git repository`: https://github.com/freedomofpress/securedrop
 .. _`Weblate SecureDrop branch`: https://github.com/freedomofpress/securedrop-i18n

--- a/docs/development/l10n.rst
+++ b/docs/development/l10n.rst
@@ -298,7 +298,7 @@ In those cases, please feel free to correct the existing translation.
 .. _`Weblate dashboard`: https://weblate.securedrop.org/
 .. _`translation category of the SecureDrop forum`: https://forum.securedrop.org/c/translations
 .. _`SecureDrop instant messaging channel`: https://gitter.im/freedomofpress/securedrop
-.. _`Weblate documentation`: http://docs.weblate.org/
+.. _`Weblate documentation`: https://docs.weblate.org/
 .. _`EFF Surveillance Self-Defense glossary`: https://ssd.eff.org/en/glossary/
 
 

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -217,7 +217,7 @@ same as the version in your distro's repos, or may at some point flux out of
 sync. For this reason, and also just as a good general development practice, we
 recommend using a Python virtual environment to install Ansible and other
 development-related tooling. Using `virtualenvwrapper
-<http://virtualenvwrapper.readthedocs.io/en/stable/>`_:
+<https://virtualenvwrapper.readthedocs.io/en/stable/>`_:
 
 .. code:: sh
 
@@ -266,7 +266,7 @@ The version of rsync installed by default on macOS is extremely out-of-date, as 
 .. _VirtualBox: https://www.virtualbox.org/wiki/Downloads
 .. _Ansible: http://docs.ansible.com/intro_installation.html
 .. _Homebrew: https://brew.sh/
-.. _homebrew-cask: http://sourabhbajaj.com/mac-setup/Vagrant/README.html
+.. _homebrew-cask: https://sourabhbajaj.com/mac-setup/Vagrant/README.html
 
 
 Fork & Clone the Repository

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -140,7 +140,7 @@ If you need to generate the six digit two-factor code, use the TOTP secret in
 combination with an authenticator application that implements
 `RFC 6238 <https://tools.ietf.org/html/rfc6238>`__, such as
 `FreeOTP <https://freeotp.github.io/>`__ (Android and iOS) or
-`oathtool <http://www.nongnu.org/oath-toolkit/oathtool.1.html>`__
+`oathtool <https://www.nongnu.org/oath-toolkit/oathtool.1.html>`__
 (command line tool, multiple platforms). Instead of typing the TOTP code, you
 can simply scan the following QR code:
 

--- a/docs/development/testing_continuous_integration.rst
+++ b/docs/development/testing_continuous_integration.rst
@@ -5,7 +5,7 @@ Testing: CI
 
 The SecureDrop project uses CircleCI_ for running automated test suites on code changes.
 
-.. _CircleCI: http://circleci.com/gh/freedomofpress/securedrop/
+.. _CircleCI: https://circleci.com/gh/freedomofpress/securedrop
 
 The relevant files for configuring the CI tests are the ``Makefile`` in
 the main repo, the configuration file at ``.circleci/config.yml``, and

--- a/docs/development/testing_continuous_integration.rst
+++ b/docs/development/testing_continuous_integration.rst
@@ -75,7 +75,7 @@ Source the setup script using the following command:
 
 You will be prompted for the values of the required environment variables. There
 are some defaults set that you may want to change. You will need to export
-``GOOGLE_CREDENTIALS`` with authentication details for your GCP account, 
+``GOOGLE_CREDENTIALS`` with authentication details for your GCP account,
 which is outside the scope of this guide.
 
 Use Makefile to Provision Hosts

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -432,7 +432,7 @@ support is preferable, since you want neither WiFi nor Bluetooth.
 
 .. note:: If you encounter issues booting Ubuntu on the NUCs, try
 	  updating the BIOS according to `these instructions
-	  <http://arstechnica.com/gadgets/2014/02/new-intel-nuc-bios-update-fixes-steamos-other-linux-booting-problems/>`__.
+	  <https://arstechnica.com/gadgets/2014/02/new-intel-nuc-bios-update-fixes-steamos-other-linux-booting-problems/>`__.
 
 2014 Mac Minis
 ~~~~~~~~~~~~~~

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -43,16 +43,16 @@ Alternatively, you can use the command line:
 .. code:: sh
 
    cd ~/Persistent
-   torify curl -OOO http://releases.ubuntu.com/16.04.6/{ubuntu-16.04.6-server-amd64.iso,SHA256SUMS{,.gpg}}
+   torify curl -OOO https://releases.ubuntu.com/16.04.6/{ubuntu-16.04.6-server-amd64.iso,SHA256SUMS{,.gpg}}
 
 .. note:: Downloading Ubuntu on the *Admin Workstation* can take a while
    because Tails does everything over Tor, and Tor is typically slow relative
    to the speed of your upstream Internet connection.
 
-.. _Ubuntu Releases page: http://releases.ubuntu.com/
-.. _ubuntu-16.04.6-server-amd64.iso: http://releases.ubuntu.com/16.04.6/ubuntu-16.04.6-server-amd64.iso
-.. _SHA256SUMS: http://releases.ubuntu.com/16.04.6/SHA256SUMS
-.. _SHA256SUMS.gpg: http://releases.ubuntu.com/16.04.6/SHA256SUMS.gpg
+.. _Ubuntu Releases page: https://releases.ubuntu.com/
+.. _ubuntu-16.04.6-server-amd64.iso: https://releases.ubuntu.com/16.04.6/ubuntu-16.04.6-server-amd64.iso
+.. _SHA256SUMS: https://releases.ubuntu.com/16.04.6/SHA256SUMS
+.. _SHA256SUMS.gpg: https://releases.ubuntu.com/16.04.6/SHA256SUMS.gpg
 
 Verify the Ubuntu Installation Media
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Upgrade links in the docs to use HTTPS where possible.

Based on the output of [`make docs-linkcheck`](https://docs.securedrop.org/en/master/development/documentation_guidelines.html#testing-documentation-changes). Most of these links were permanently redirected to their HTTPS counterpart already, some others were not but we verified that the HTTPS versions were correct manually.

## Testing

- [ ] Check that the changes seem reasonable _Note: there are few domain changes, the output of `make docs-linkcheck` can help but it is likely quicker to visit the old links and observe the redirect._
- [ ] Check that all the new links work as expected

## Deployment

_No special considerations for deployment._

## Checklist

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
