### PR TITLE
Remove unused/disabled source onion service info files

### DIFF
--- a/install_files/ansible-base/roles/app/tasks/copy_tor_url_info_to_app_dir.yml
+++ b/install_files/ansible-base/roles/app/tasks/copy_tor_url_info_to_app_dir.yml
@@ -15,7 +15,7 @@
   failed_when: false
   when: v3_onion_services
 
-- name: Expose Tor v2 Onion URL info to app
+- name: Expose source v2 onion service info to app
   copy:
     dest: /var/lib/securedrop/source_v2_url
     owner: www-data
@@ -25,7 +25,13 @@
       {{ v2_onion_url_lookup_result.stdout|default('') }}
   when: v2_onion_services
 
-- name: Expose Tor v3 Onion URL info to app
+- name: Remove source v2 onion service info if not enabled
+  file:
+    path: /var/lib/securedrop/source_v2_url
+    state: absent
+  when: not v2_onion_services
+
+- name: Expose source v3 onion service info to app
   copy:
     dest: /var/lib/securedrop/source_v3_url
     owner: www-data
@@ -34,3 +40,9 @@
     content: |
       {{ v3_onion_url_lookup_result.stdout|default('') }}
   when: v3_onion_services
+
+- name: Remove source v3 onion service info if not enabled
+  file:
+    path: /var/lib/securedrop/source_v3_url
+    state: absent
+  when: not v3_onion_services


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5400.

If a site disables v2 onion services, remove the file used to decide to show the deprecation warning.

The v3 equivalent is also removed if v3 services are disabled, though downgrading to v2-only is not really possible -- more work would be needed in the playbooks, and that's probably not something we should support at this point.

## Testing

- Start with a deployment that has v2 onion services enabled. VM or hardware is most straightforward at this point, but I'll see if it can be tested in a staging environment.
- Run `securedrop-admin sdconfig` to enable v3 and disable v2 onion services.
- Run `securedrop-admin install`. This should complete successfully, and in the Ansible output you should see `Remove source v2 onion service info if not enabled` followed by `Expose source v3 onion service info to app`.
- Log in to the app server and list the contents of `/var/lib/securedrop`. There should  be no `source_v2_url`, just `source_v3_url`. 
- Run `securedrop-admin tailsconfig`. 
- Log in to the journalist interface. There should be no v2 deprecation warning.

## Deployment

This enables admins to disable v2 onion services and remove the deprecation warning from the journalist interface.

## Checklist

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR
