### PR TITLE
Updated references to 'master' branch to refer to renamed branches in…

### DIFF
--- a/docs/development/client.rst
+++ b/docs/development/client.rst
@@ -14,7 +14,7 @@ The source code, and related issues are `hosted on GitHub <https://github.com/fr
 Developer Setup
 ---------------
 
-You may find developer setup instructions in the `SecureDrop Client README <https://github.com/freedomofpress/securedrop-client/blob/master/README.md>`_.
+You may find developer setup instructions in the `SecureDrop Client README <https://github.com/freedomofpress/securedrop-client/blob/main/README.md>`_.
 
 How to Find Help
 ----------------
@@ -107,7 +107,7 @@ abide by it.
 
 Before submitting a pull request, make sure the test suite passes
 (``make check``), because our CI tools will flag broken tests before we're able
-to merge your code into ``master``.
+to merge your code into ``main``.
 
 Most of all, please don't hesitate to get in touch if you need help, advice or
 would like guidance.

--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -128,13 +128,13 @@ Pre-Release
       log guidelines
       <https://github.com/freedomofpress/securedrop/wiki/Build-logs>`_.
    #. Open a PR on `securedrop-dev-packages-lfs
-      <https://github.com/freedomofpress/securedrop-dev-packages-lfs>`_ that targets the `master`
+      <https://github.com/freedomofpress/securedrop-dev-packages-lfs>`_ that targets the `main`
       branch. Changes merged to this branch will be published to ``apt-test.freedom.press``
       within 15 minutes.
 
    .. warning:: Only commit packages with an incremented version number: do not clobber existing
                 packages.  That is, if there is already a deb called e.g.
-                ``ossec-agent-3.6.0-amd64.deb`` in ``master``, do not commit a new version of this
+                ``ossec-agent-3.6.0-amd64.deb`` in ``main``, do not commit a new version of this
                 deb.
 
    .. note:: If the release contains other packages not created by
@@ -232,7 +232,7 @@ Release Process
       <https://github.com/freedomofpress/securedrop/wiki/Build-logs>`_.
 #. In a clone of the private
    `securedrop-debian-packages-lfs <https://github.com/freedomofpress/securedrop-debian-packages-lfs>`_
-   repository, create a branch from ``master`` called ``release``.
+   repository, create a branch from ``main`` called ``release``.
 #. In your local branch, commit the built packages to the ``core/xenial``
    directory.
 
@@ -248,7 +248,7 @@ Release Process
    automatic upload of the packages to ``apt-qa.freedom.press``, but the
    packages will not yet be installable.
 #. Create a `draft PR <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests>`__
-   from ``release`` into ``master``. Make sure to include a link to the build
+   from ``release`` into ``main``. Make sure to include a link to the build
    logs in the PR description.
 #. A reviewer must verify the build logs, obtain and sign the generated ``Release``
    file, and append the detached signature to the PR. The PR should remain in
@@ -263,10 +263,10 @@ Release Process
 #. The reviewer must delete the ``release`` branch so that it can be re-created
    during the next release.
 #. Issue a PR in the ``securedrop`` repository to merge the release branch
-   changes into ``master``. Once the PR is merged, verify that the
+   changes into ``stable``. Once the PR is merged, verify that the
    `public documentation <https://docs.securedrop.org/>`_
    refers to the new release version. If not, log in to ReadTheDocs and start a
-   build of the ``master`` version.
+   build of the ``stable`` version.
 #. Create a `release
    <https://github.com/freedomofpress/securedrop/releases>`_ on GitHub
    with a brief summary of the changes in this release.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -144,4 +144,4 @@ anonymous sources.
 Two versions of this documentation are available:
 
 - ``latest`` - built from the ``develop`` branch of the SecureDrop repository, containing updates that have been tested but not yet released.
-- ``master`` - built from the ``master`` branch of the SecureDrop repository, and up to date with the most recent release, |version|.
+- ``stable`` - built from the ``stable`` branch of the SecureDrop repository, and up to date with the most recent release, |version|.


### PR DESCRIPTION
…stead

## Status

Ready for review 

## Description of Changes

- Updates references to core docs branch to `stable` from `master`.
- Updates references to `master` to `main` in docs for other repos that have changed default branches.


## Testing

Docs-only PR

- [ ] are the changes clear and correct?
- [ ] does CI pass?

## Checklist


### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
