### PR TITLE
Revert the case change in the v2 onion service deprecation warning

### DIFF
--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -21,7 +21,7 @@
     {% if g.user %}
       {% if g.show_v2_onion_eol_warning %}
       <div id="v2-onion-eol" class="warning-banner">
-        {{ gettext('<strong>Update Required:</strong> Your SecureDrop servers are still running v2 onion services, which are being phased out for security reasons. In February 2021, v2 onion services will be disabled, and your SecureDrop servers may become unreachable. <a href="//securedrop.org/v2-onion-eol" rel="noreferrer">Learn More</a>') }}
+        {{ gettext('<strong>Update Required:</strong> Your SecureDrop servers are still running v2 Onion Services, which are being phased out for security reasons. In February 2021, v2 Onion Services will be disabled, and your SecureDrop servers may become unreachable. <a href="//securedrop.org/v2-onion-eol" rel="noreferrer">Learn More</a>') }}
       </div>
       {% endif %}
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This change wasn't pushed to the i18n repo, so didn't get translated for 1.5.0. For this release, we'll revert the capitalization change (so that the warning will actually be translated in the UI), and it will be made in 1.6.0.

## Testing

Confirm that the warning says "Onion Services" instead of "onion services". Once the i18n-merge branch is rebased, we'll have to verify that translation of the warning is working.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
