### PR TITLE
Adds upgrade boxes for SecureDrop 1.5.0

### DIFF
--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -155,6 +155,17 @@
         }
       ],
       "version": "1.4.1"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "3fc53176b6f0ef18fa720b05192371301711276530e32878cbd53971e4dbc39b",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_1.5.0.box"
+        }
+      ],
+      "version": "1.5.0"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -155,6 +155,17 @@
         }
       ],
       "version": "1.4.1"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "2f2657811d77f90604c6f7d51a7f8d1e6ffd7adbe4e87cecd207aa597355d645",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_1.5.0.box"
+        }
+      ],
+      "version": "1.5.0"
     }
   ]
 }


### PR DESCRIPTION
## Status
Ready for review

## Description of Changes

Closes #5368   


- Adds references to new "upgrade" scenario boxes (already uploaded to S3)

## Testing

- Checkout `develop`
- `make build-debs`
- Check out this branch
- `make upgrade-start` (will take a while as it needs to fetch the boxes)
- [x] source interface shows SecureDrop version 1.5.0
- [x] `make upgrade-test-local` completes without error
- [x] source interface shows SecureDrop version 1.6.0~rc1

## Deployment

Dev only
