### PR TITLE
Ensure the test config is valid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ update-python3-requirements:  ## Update Python 3 requirements with pip-compile.
 		--output-file requirements/python3/test-requirements.txt \
 		requirements/python3/test-requirements.in
 	@$(DEVSHELL) pip-compile --generate-hashes \
-                --allow-unsafe \
+				--allow-unsafe \
 		--output-file requirements/python3/securedrop-app-code-requirements.txt \
 		requirements/python3/securedrop-app-code-requirements.in
 	@$(DEVSHELL) pip-compile --generate-hashes \
@@ -176,7 +176,7 @@ securedrop/config.py: ## Generate the test SecureDrop application config.
 		 ctx.update(dict((k, {"stdout":v}) for k,v in os.environ.items())); \
 		 ctx = open("config.py", "w").write(env.get_template("config.py.example").render(ctx))'
 	@echo >> securedrop/config.py
-	@echo "SUPPORTED_LOCALES = $$(if test -f /opt/venvs/securedrop-app-code/bin/python3; then ./securedrop/i18n_tool.py list-locales --python; else DOCKER_BUILD_VERBOSE=false $(DEVSHELL) ./i18n_tool.py list-locales --python; fi)" >> securedrop/config.py
+	@echo "SUPPORTED_LOCALES = $$(if test -f /opt/venvs/securedrop-app-code/bin/python3; then ./securedrop/i18n_tool.py list-locales --python; else DOCKER_BUILD_VERBOSE=false $(DEVSHELL) ./i18n_tool.py list-locales --python; fi)" | sed 's/\r//' >> securedrop/config.py
 	@echo
 
 .PHONY: test-config

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -17,7 +17,7 @@ get_port_offset() {
     while true
     do
         tries=$((tries + 1))
-	port_offset=$((tries * 100))
+    port_offset=$((tries * 100))
         vnc=$((port_offset + 5909))
         nc -z localhost "$vnc" || break
     done
@@ -48,13 +48,16 @@ function docker_run() {
     SD_HOSTPORT_SI=$((port_offset + 8080))
     SD_HOSTPORT_VNC=$((port_offset + 5909))
 
-    echo "************************************************************"
-    echo "Exposed Docker ports will be available on localhost with"
-    echo "Port offset: $port_offset"
-    echo "Source interface: $SD_HOSTPORT_SI"
-    echo "Journalist interface: $SD_HOSTPORT_JI"
-    echo "VNC: $SD_HOSTPORT_VNC"
-    echo "************************************************************"
+    if [ "${DOCKER_BUILD_VERBOSE:-'false'}" = "true" ]
+    then
+        echo "************************************************************"
+        echo "Exposed Docker ports will be available on localhost with"
+        echo "Port offset: $port_offset"
+        echo "Source interface: $SD_HOSTPORT_SI"
+        echo "Journalist interface: $SD_HOSTPORT_JI"
+        echo "VNC: $SD_HOSTPORT_VNC"
+        echo "************************************************************"
+    fi
 
     # The --shm-size argument sets up dedicated shared memory for the
     # container. Our tests can fail with the default of 64m.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

If the dev shell prints the Docker port info, it breaks the `SUPPORTED_LOCALES` setting produced by `i18n_tool.py "list-locales".

## Testing

- Remove any local `securedrop/config.py`.
- Run `make test-config`
- Confirm that `SUPPORTED_LOCALES` is set to a simple, valid list of locales, without the port information printed by `dev-shell`.

## Deployment

dev-only

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
