### PR TITLE
Fix docs lint error and correct/tweak CI rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,21 +297,12 @@ workflows:
   version: 2
   securedrop_ci:
     jobs:
-      - docs-linkcheck:
-          filters:
-            branches:
-              only:
-                - master
-      - lint:
-          filters:
-            branches:
-              ignore:
-                - master
+      - lint
       - app-tests:
           filters:
             branches:
               ignore:
-                - master
+                - stable
                 - /docs-.*/
                 - /i18n-.*/
                 - /update-builder-.*/
@@ -321,7 +312,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
+                - stable
                 - /docs-.*/
                 - /i18n-.*/
                 - /update-builder-.*/
@@ -331,7 +322,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
+                - stable
                 - /docs-.*/
                 - /i18n-.*/
                 - /update-builder-.*/
@@ -341,14 +332,14 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
+                - stable
           requires:
             - lint
       - staging-test-with-rebase:
           filters:
             branches:
               ignore:
-                - master
+                - stable
                 - /docs-.*/
                 - /i18n-.*/
           requires:
@@ -357,7 +348,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
+                - stable
           requires:
             - lint
       - deb-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
           name: Run all linters but shellcheck
           command: |
             fromtag=$(docker images |grep securedrop-test-xenial-py3 |head -n1 |awk '{print $2}')
-            DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" securedrop/bin/dev-shell bash -c "/opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/develop-requirements.txt && make -C .. ansible-config-lint app-lint flake8 html-lint typelint yamllint"
+            DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" securedrop/bin/dev-shell bash -c "/opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/develop-requirements.txt && make -C .. ansible-config-lint app-lint flake8 html-lint typelint yamllint docs-lint"
 
       - run:
           name: Run shellcheck
@@ -277,7 +277,7 @@ jobs:
             if ! [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
             make ci-deb-tests
 
-  docs-lint-linkcheck:
+  docs-linkcheck:
     docker:
       - image: circleci/python:3.5
     steps:
@@ -290,14 +290,14 @@ jobs:
           command: sudo pip3 install -U -r securedrop/requirements/python3/develop-requirements.txt
 
       - run:
-          name: Run documentation linting
-          command: make docs-lint && make docs-linkcheck
+          name: Run documentation linkcheck
+          command: make docs-linkcheck
 
 workflows:
   version: 2
   securedrop_ci:
     jobs:
-      - docs-lint-linkcheck:
+      - docs-linkcheck:
           filters:
             branches:
               only:
@@ -390,5 +390,5 @@ workflows:
     jobs:
       - deb-tests
       - translation-tests
-      - docs-lint-linkcheck
+      - docs-linkcheck
       - fetch-tor-debs

--- a/docs/development/client.rst
+++ b/docs/development/client.rst
@@ -26,7 +26,7 @@ into our `Gitter chat channel for the project <https://gitter.im/freedomofpress/
 
 Every non-public holiday weekday (except Fridays) at 10am (Pacific Time) we
 take part in a public daily stand-up, usually via a
-`meeting on Google Meet https://meet.google.com/ekb-kkhf-mrk`_
+`meeting on Google Meet <https://meet.google.com/ekb-kkhf-mrk>`_
 (although the details of each daily meeting are published on the Gitter channel
 five minutes before the start of the meeting). All are welcome to contribute.
 


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

- Fixes lint error in #5429 
- Corrects CI rules, which accidentally removed `docs-lint` from the standard lint checks in #5266 (https://github.com/freedomofpress/securedrop/pull/5266/files#diff-1d37e48f9ceff6d8030570cd36286a61R77). 
- Updates branch filters to `stable`, which is now the canonical docs branch (was `master`)
- Tweaks weekly job to only run link check, not linter (which already runs on each PR)
- Updates branch exclusion rules (there's no reason to exempt `stable` from the lint run, nor to run the link check specifically on the `stable` branch -- that's what the weekly run is for)

## Test plan

- Review the CircleCI rules and inspect the detailed output for this PR against `develop` to ensure there are no regressions.