### PR TITLE
Get CI parallelization of translation tests working again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
 
   translation-tests:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202007-01
       enabled: true
     environment:
       DOCKER_API_VERSION: 1.23
@@ -137,7 +137,7 @@ jobs:
             BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^i18n")
             if ! [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
             sudo apt update && sudo apt install python-sh python-pybabel
-            export LOCALE="$(/usr/bin/python2 securedrop/i18n_tool.py list-locales --lines | circleci tests split | tr '\n' ' ')"
+            export LOCALES="$(/usr/bin/python2 securedrop/i18n_tool.py list-locales --lines | circleci tests split | tr '\n' ' ')"
             fromtag=$(docker images | grep securedrop-test-xenial-py3 | head -n1 | awk '{print $2}')
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-xenial-py3:${fromtag:-latest}" make translation-test
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ update-python3-requirements:  ## Update Python 3 requirements with pip-compile.
 		--output-file requirements/python3/test-requirements.txt \
 		requirements/python3/test-requirements.in
 	@$(DEVSHELL) pip-compile --generate-hashes \
-                --allow-unsafe \
+				--allow-unsafe \
 		--output-file requirements/python3/securedrop-app-code-requirements.txt \
 		requirements/python3/securedrop-app-code-requirements.in
 	@$(DEVSHELL) pip-compile --generate-hashes \
@@ -292,7 +292,7 @@ translate:  ## Update POT files from translated strings in source code.
 .PHONY: translation-test
 translation-test:  ## Run page layout tests in all supported languages.
 	@echo "Running translation tests..."
-	@$(DEVSHELL) $(SDBIN)/translation-test "$${LOCALE:-$(./i18n_tool.py list-locales)}"
+	@$(DEVSHELL) $(SDBIN)/translation-test $${LOCALES}
 	@echo
 
 .PHONY: list-translators


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The out-of-date Ubuntu image couldn't get through an apt update because of the Google Chrome repo, so python-sh couldn't get installed, which broke the invocation of i18n_tool.py to list locales for CircleCI splitting.

This updates the machine image, and also improves the locale argument handling in the translation-test Makefile target.

## Testing

Check the CI logs for the translation-tests job. Each of the 20 containers spun up should test a different locale, not the entire set.

## Deployment

This only affects CI.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
