### PR TITLE
Clarify in CoC that any team member can be contacted individually.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -137,6 +137,8 @@ Currently the Community Team consists of:
 - Jen Helsby (`@redshiftzero`) - Principal Research Engineer - [jen@freedom.press](mailto:jen@freedom.press)
 - Mickael E. (`@emkll`) - Lead Engineer - [mickael@freedom.press](mailto:mickael@freedom.press)
 
+You can contact the whole Community Team or members individually.
+
 You should contact the Community Team if you have questions or concerns about
 the Code of Conduct (including improvements) or if you feel that you have
 witnessed a Code of Conduct violation. In the even of a violation either


### PR DESCRIPTION
This language was removed in 56c89ed18fd2cdd17ecdbf239aff66b8a9f76cdb when the size of the community team was reduced to 1, but with more than 1 member, it makes sense again.

## Status

Ready for review 