### PR TITLE
Remove duplicated route

### DIFF
--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -216,23 +216,6 @@ def make_blueprint(config):
         return render_template("edit_account.html", user=user,
                                password=password)
 
-    @view.route('/edit/<int:user_id>/new-password', methods=('POST',))
-    @admin_required
-    def set_password(user_id):
-        try:
-            user = Journalist.query.get(user_id)
-        except NoResultFound:
-            abort(404)
-
-        password = request.form.get('password')
-        if set_diceware_password(user, password) is not False:
-            if user.last_token is not None:
-                revoke_token(user, user.last_token)
-            user.session_nonce += 1
-            db.session.commit()
-
-        return redirect(url_for('admin.edit_user', user_id=user_id))
-
     @view.route('/delete/<int:user_id>', methods=('POST',))
     @admin_required
     def delete_user(user_id):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Removes an unintentionally duplicated route. No test implications as far as I can tell, as the method is not tested via a unit test.

Resolves #5434

## Test plan

1. Build a development environment from this branch
2. Log in as an admin user
3. Attempt to change an existing user's password (not your own) using the web-based "Admin" interface. Note down the new password.
- [ ] Observe that the password change is completed successfully.
- [ ] Observe that you can log in as the user whose password you changed.

## Checklist
- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
