### PR TITLE
Creates a symlink to the .so file in postint for mod_wsgi

### DIFF
--- a/install_files/securedrop-app-code/debian/postinst
+++ b/install_files/securedrop-app-code/debian/postinst
@@ -93,6 +93,14 @@ function adjust_wsgi_configuration {
             perl -pi -e 's/^WSGIProcessGroup journalist.*\n//' "$journalist_conf"
         fi
     fi
+    # Create the WSGI so file link if only on Python3.8
+    wsgi_so_link="/opt/venvs/securedrop-app-code/lib/python3.8/site-packages/mod_wsgi/server/mod_wsgi-py38.so"
+    wsgi_so="/opt/venvs/securedrop-app-code/lib/python3.8/site-packages/mod_wsgi/server/mod_wsgi-py38.cpython-38-x86_64-linux-gnu.so"
+    if test -f "/usr/bin/python3.8"; then
+        if test ! -L  $wsgi_so_link; then
+            ln -s $wsgi_so $wsgi_so_link
+        fi
+    fi
 }
 
 # Manage PaX flags for web app, only required under Xenial.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes  in part of #4768 

On Focal, mod_wsgi expects a shared library for the python module at:

```
$VENV/lib/python3.8/site-packages/mod_wsgi/server/mod_wsgi-py38.so
```
But, the real shared library path is

```
$VENV/lib/python3.8/site-packages/mod_wsgi/server/mod_wsgi-py38.cpython-38-x86_64-linux-gnu.so"
```

So we are creating a symlink with the proper path if we are using Python 3.8 (that is on Focal)

## Testing

- [ ] `make build-deps` on this branch
- [ ] `make staging` to create a fresh staging environment from the debian packages. There should not be any error in the postinstall section
- [ ] Login to app `molecule -s libvirt-staging-xenial -h app-staging` (on mac point to virtualbox) and see that the following file does not exist.

```
/opt/venvs/securedrop-app-code/lib/python3.8/site-packages/mod_wsgi/server/mod_wsgi-py38.so
```

- [ ] `sudo touch /usr/bin/python3.8` to emulate a python3.8 env in focal
- [ ] reinstall the `securedrop-app-code` package or reconfigure it, it should create a symlink as mentioned above.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
