### PR TITLE
Fix Tor Browser capitalisation for readability (source interface)

### DIFF
--- a/securedrop/source_templates/logout.html
+++ b/securedrop/source_templates/logout.html
@@ -4,5 +4,5 @@
   </a>
   <br class="clearfix">
   <h1>{{ gettext('One more thing...') }}</h1>
-  <p id="click-new-identity-tor"> {{ gettext('Click the <img src={icon} alt="broom icon" width="16" height="16">&nbsp;<strong>New Identity</strong> button in your Tor browser\'s toolbar. This will clear your Tor browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom-black.png'))  }}</p>
+  <p id="click-new-identity-tor"> {{ gettext('Click the <img src={icon} alt="broom icon" width="16" height="16">&nbsp;<strong>New Identity</strong> button in your Tor Browser\'s toolbar. This will clear your Tor Browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom-black.png'))  }}</p>
 {% endblock %}

--- a/securedrop/source_templates/session_timeout.html
+++ b/securedrop/source_templates/session_timeout.html
@@ -2,5 +2,5 @@
   <strong>{{ gettext('Important') }}</strong>
 </div>
 <div class="localized" dir="{{ g.text_direction }}">
-    <p>{{ gettext('You were logged out due to inactivity. Click the <img src={icon} alt="broom icon" width="16" height="16">&nbsp;<strong>New Identity</strong> button in your Tor browser\'s toolbar before moving on. This will clear your Tor browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom-coral.png'))  }}</p>
+    <p>{{ gettext('You were logged out due to inactivity. Click the <img src={icon} alt="broom icon" width="16" height="16">&nbsp;<strong>New Identity</strong> button in your Tor Browser\'s toolbar before moving on. This will clear your Tor Browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom-coral.png'))  }}</p>
 </div>

--- a/securedrop/source_templates/tor2web-warning.html
+++ b/securedrop/source_templates/tor2web-warning.html
@@ -3,5 +3,5 @@
 <h1>{{ gettext('Why is there a warning about Tor2Web?') }}</h1>
 <p>{{ gettext('Using Tor2Web to connect to SecureDrop will not protect your anonymity.') }}</p>
 <p>{{ gettext('It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you.') }}</p>
-<p>{{ gettext('We <strong>strongly advise</strong> you to use the <a href="www.torproject.org/projects/torbrowser.html">Tor browser</a> instead.') }}</p>
+<p>{{ gettext('We <strong>strongly advise</strong> you to use the <a href="www.torproject.org/projects/torbrowser.html">Tor Browser</a> instead.') }}</p>
 {% endblock %}

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -255,7 +255,7 @@ def test_login_and_logout(source_app):
 
         # This is part of the logout page message instructing users
         # to click the 'New Identity' icon
-        assert 'This will clear your Tor browser activity data' in text
+        assert 'This will clear your Tor Browser activity data' in text
 
 
 def test_user_must_log_in_for_protected_views(source_app):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

When reviewing the usage of user-facing strings borrowed from the Tor Browser ([context][ctx]), I noticed that sometimes the English source would read `Tor browser` (lowercase). The three occurrences in this PR belong to the _source_ interface.

I propose using `Tor Browser` instead, primarily to make the instructions more readable to _sources_.

  [ctx]: https://forum.securedrop.org/t/spanish-es-locales-for-securedrop-in-relation-to-tor-browser/1352/4?u=gonzalo-bulnes

**Considerations**

- "Tor browser" has legitimate uses. While "Tor Browser" the name of one such product, you could browse the Tor network with a different browser.
- However, the three sets of instructions make reference specifically to _the_ Tor Browser.
- Using consistently "Tor Browser" as a product name takes advantage of our sensitivity to brands in order to reduce cognitive load of the _sources_. ("Which browser is this about? Ah! _The_ Tor Browser, I've seen that name!")
- There are other instances where "Tor Browser" is written as a product name, so this would also increase consistency.

## Testing

- [ ] Strings don't change length so this change should be very straightforward as far as the UI is concerned.
- [ ] Check for misspellings. 

## Deployment

 - [ ] These strings are internationalized. _I didn't modify the `.pot` file because I assumed strings would be extracted following a dedicated process._