### PR TITLE
adds playbook to switch a production instance to use the staging apt repo

### DIFF
--- a/install_files/ansible-base/securedrop-qa.yml
+++ b/install_files/ansible-base/securedrop-qa.yml
@@ -1,0 +1,48 @@
+---
+# Playbook to update SecureDrop VMs configured with the latest stable release
+# to use the release candiate packages from apt-test.freedom.press (rather
+# than apt.freedom.press). Updates the apt repo pubkey with a testing pubkey,
+# and alters the apt source lists to point to the test server.
+#
+# Steps to use this playbook from an Admin Workstation:
+#
+#   1. Check out the current production release tag.
+#   2. Provision a SecureDrop instance (hardware or VMs).
+#   4. Run `./securedrop-admin tailsconfig`
+#   5. Run `source admin/.venv3/bin/activate` (so ansible commands work)
+#   6. Run `cd install_files/ansible-base`
+#   7. Run `ansible-playbook -vv --diff securedrop-qa.yml`
+#   8. `ssh app` # start interactive session
+#   9. On the Application Server, run `sudo cron-apt -i -s`
+#   10. Repeat steps 8 & 9 on the Monitor server
+
+- name: Configure prod host to accept Release Candidate packages.
+  environment:
+    LC_ALL: C
+  max_fail_percentage: 0
+  any_errors_fatal: yes
+  hosts: securedrop
+  vars:
+    apt_files_to_modify:
+      - /etc/apt/sources.list.d/apt_freedom_press.list
+      - /etc/apt/security.list
+  tasks:
+    - name: Add apt public key for release-candidate repo.
+      apt_key:
+        data: "{{ lookup('file', 'roles/install-fpf-repo/files/apt-test-signing-key.pub') }}"
+        state: present
+
+    - name: Switch apt repo URLs to staging.
+      replace:
+        dest: "{{ item }}"
+        replace: "apt-test.freedom.press"
+        regexp: 'apt\.freedom\.press'
+        backup: yes
+      with_items: "{{ apt_files_to_modify }}"
+      notify: update apt cache
+
+  handlers:
+    - name: update apt cache
+      apt:
+        update_cache: yes
+  become: yes


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #3792 .

Updates and adds the playbook formerly available at https://gist.githubusercontent.com/conorsch/e7556624df59b2a0f8b81f7c0c4f9b7d/raw/294294cc4fb243569e121d93350fdee2b2e0920d/securedrop-qa.yml, allowing devs and testers to test the upgrade scenario with release candidate versions..

## Testing

- set up a production instance (VMs or HW) using the current release version.
- check out this branch
- follow the instructions in `~/Persistent/securedrop/install_files/ansible-base/securedrop-qa.yml` to run the playbook
- log on to `app` and `mon` and verify that
  - [ ] the testing apt key has been added, with the command `sudo apt-key list 2211B03C`
  - [ ] the files `/etc/apt/security.list` and `/etc/apt/sources.list.d/apt_freedom_press.list` reference apt-test.freedom.press, not apt.freedom.press
  - [ ] the command `apt-cache policy securedrop-keyring` includes apt-test.freedom.press versions in the version table

## Deployment
No special requirements