### PR TITLE
Enable no_implicit_optional in mypy config

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 ignore_missing_imports = True
+no_implicit_optional = True
 python_version = 3.5
 
 [mypy-config]

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -82,8 +82,8 @@ class Source(db.Model):
     MAX_CODENAME_LEN = 128
 
     def __init__(self,
-                 filesystem_id: Optional[str] = None,
-                 journalist_designation: Optional[str] = None) -> None:
+                 filesystem_id: 'Optional[str]' = None,
+                 journalist_designation: 'Optional[str]' = None) -> None:
         self.filesystem_id = filesystem_id
         self.journalist_designation = journalist_designation
         self.uuid = str(uuid.uuid4())

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -82,8 +82,8 @@ class Source(db.Model):
     MAX_CODENAME_LEN = 128
 
     def __init__(self,
-                 filesystem_id: str = None,
-                 journalist_designation: str = None) -> None:
+                 filesystem_id: Optional[str] = None,
+                 journalist_designation: Optional[str] = None) -> None:
         self.filesystem_id = filesystem_id
         self.journalist_designation = journalist_designation
         self.uuid = str(uuid.uuid4())

--- a/securedrop/worker.py
+++ b/securedrop/worker.py
@@ -11,7 +11,7 @@ from rq.registry import StartedJobRegistry
 from sdconfig import config
 
 
-def create_queue(name: str = None, timeout: int = 3600) -> Queue:
+def create_queue(name: Optional[str] = None, timeout: int = 3600) -> Queue:
     """
     Create an rq ``Queue`` named ``name`` with default timeout ``timeout``.
 
@@ -52,7 +52,7 @@ def worker_for_job(job_id: str) -> Optional[Worker]:
     return None
 
 
-def requeue_interrupted_jobs(queue_name: str = None) -> None:
+def requeue_interrupted_jobs(queue_name: Optional[str] = None) -> None:
     """
     Requeues jobs found in the given queue's started job registry.
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

To help with #4399 , this PR adds `no_implicit_optional = True` to the mypy config and then fixes the few type errors triggered by this change. 
This will eventually be the default setting in mypy ( https://github.com/python/mypy/issues/9091 ) and seemed easy enough to add to Securedrop now, before a lot of non-compatible type annotations get added.

