### PR TITLE
Add Weblate screenshot update to release tasks

### DIFF
--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -376,6 +376,7 @@ Two weeks before the release: string freeze
 When features for a new SecureDrop release are frozen, the localization manager for the release will:
 
 * :ref:`merge_develop_to_weblate`.
+* `Update Weblate screenshots`_ so translators can see new or modified source strings in context.
 * Update the `i18n timeline`_ in the translation section of the forum.
 * Post an announcement `to the translation section of the forum <https://forum.securedrop.org/c/translations>`__ (see `an example  <https://forum.securedrop.org/t/4-securedrop-strings-need-work-march-2018-string-freeze/461>`__).
 * Remind all developers about the string freeze in `Gitter <https://gitter.im/freedomofpress/securedrop>`__.
@@ -386,7 +387,7 @@ Release day
 ^^^^^^^^^^^
 
 * :ref:`merge_weblate_to_develop`.
-* :ref:`Update the screenshots <updating_screenshots>`.
+* :ref:`Update the documentation screenshots <updating_screenshots>`.
 * Remove the `Weblate announcement`_ about this release's translation timeline.
 * Provide translator credits to add to the SecureDrop release announcement.
 * Update the `i18n timeline`_ in the forum.

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -355,6 +355,10 @@ generate using this command in the base directory:
 
     $ LOCALES=en_US make translation-test
 
+Inspect the screenshots in the directory ``securedrop/tests/pageslayout/screenshots/en_US``
+and make sure that their content corresponds to the expected version of the
+codebase.
+
 `Obtain your API key <https://weblate.securedrop.org/accounts/profile/#api>`__
 in Weblate. Export the token to the environment variable ``WEBLATE_API_TOKEN``.
 You can now run this command to perform an upload:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5463.

Adds Weblate screenshot updating to the localization manager release duties.

## Testing

Run `make docs` on this branch, proofread the addition and confirm it links properly to the instructions for updating the Weblate screenshots.

## Deployment

Documentation only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally
