### PR TITLE
Add note on creating virtualenv and Fedora install docs

### DIFF
--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -13,19 +13,21 @@ To get started editing the docs:
 
 .. _clone_the_rep:
 
-#. Clone the SecureDrop repository:
+1. Clone the SecureDrop repository:
 
    .. code:: sh
 
       git clone https://github.com/freedomofpress/securedrop.git
 
-#. Install the dependencies:
+2. Install the dependencies:
 
    .. code:: sh
 
       pip install --no-deps --require-hashes -r securedrop/requirements/python3/develop-requirements.txt
 
-#. Build the docs for viewing in your web browser:
+.. include:: ../includes/virtualenv.txt   
+
+3. Build the docs for viewing in your web browser:
 
    .. code:: sh
 
@@ -150,10 +152,10 @@ called ``securedrop``. This ``securedrop`` directory also contains a
 
      .
      ├── securedrop
-     │   │
-     │  ...
-     │   ├── securedrop
-    ... ...
+     │   │
+     │  ...
+     │   ├── securedrop
+    ... ...
 
 To avoid confusion, paths to files anywhere inside the SecureDrop git repository
 should be written as ``./some_dir/file``, where ``.`` is the top level directory

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -20,7 +20,8 @@ Quick Start
 The Docker based environment is suitable for developing the web application
 and updating the documentation.
 
-Follow the instructions below to install the requirements for the Docker-based environment for your operating system.
+Follow the instructions below to install the requirements for the Docker-based
+environment for your operating system.
 
 Ubuntu or Debian GNU/Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -40,8 +41,8 @@ be installed via the official documentation links:
 Make sure to follow the `post-installation steps for Linux`_.
 
 
-Fedora and Other Linux Distributions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fedora Linux
+~~~~~~~~~~~~
 .. note:: To install Docker Engine, you need the 64-bit version of Fedora 30 or higher.
 
 Run the following command to update the package index and to install Git and ``make``:

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -3,8 +3,8 @@ Setting Up the Development Environment
 
 .. include:: ../includes/docs-branches.txt
 
-Prerequisites
--------------
+Overview
+--------
 
 SecureDrop is a multi-machine design. To make development and testing
 easy, we provide a set of virtual environments, each tailored for a
@@ -20,9 +20,11 @@ Quick Start
 The Docker based environment is suitable for developing the web application
 and updating the documentation.
 
+Follow the instructions below to install the requirements for the Docker-based environment for your operating system.
 
 Ubuntu or Debian GNU/Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+Run the following commands to update the package index and to install Git and ``make``:
 
 .. code:: sh
 
@@ -35,11 +37,32 @@ be installed via the official documentation links:
 * `Docker CE for Ubuntu`_
 * `Docker CE for Debian`_
 
-Make sure to follow the `Post-installation steps for Linux`_, as well.
+Make sure to follow the `post-installation steps for Linux`_.
 
-.. _`Docker CE for Ubuntu`: https://docs.docker.com/install/linux/docker-ce/ubuntu/
-.. _`Docker CE for Debian`: https://docs.docker.com/install/linux/docker-ce/debian/
-.. _`Post-installation steps for Linux`: https://docs.docker.com/install/linux/linux-postinstall/
+
+Fedora and Other Linux Distributions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. note:: To install Docker Engine, you need the 64-bit version of Fedora 30 or higher.
+
+Run the following command to update the package index and to install Git and ``make``:
+
+.. code:: sh
+
+   sudo dnf install -y make git
+
+
+We recommend using the stable version of Docker CE (Community Edition) which can
+be installed via the official documentation link:
+
+* `Docker CE for Fedora`_
+
+Make sure to follow the `post-installation steps for Linux`_.
+
+.. _`Docker CE for Ubuntu`: https://docs.docker.com/engine/install/ubuntu/
+.. _`Docker CE for Debian`: https://docs.docker.com/engine/install/debian/
+.. _`Docker CE for Fedora`: https://docs.docker.com/engine/install/fedora/
+.. _`post-installation steps for Linux`: https://docs.docker.com/engine/install/linux-postinstall/
+
 
 macOS
 ~~~~~
@@ -62,7 +85,7 @@ the following in ``dom0``:
    qvm-start sd-dev
    qvm-sync-appmenus sd-dev
 
-The commands above will created a new StandaloneVM, boot it, then update
+The commands above create a new StandaloneVM, boot it, and then update
 the Qubes menus with applications within that VM. Open a terminal in
 ``sd-dev``, and proceed with installing `Docker CE for Debian`_.
 

--- a/docs/includes/virtualenv.txt
+++ b/docs/includes/virtualenv.txt
@@ -1,0 +1,5 @@
+.. note:: You can install, upgrade, and remove Python packages using ``pip``, the Python package installer. By default, ``pip`` will attempt to install packages system-wide. Use ``venv`` or ``virtualenv`` to avoid installing Python packages globally and to isolate the installation of dependencies of a specific application.
+          
+          Run the command ``python3 -m venv .venv`` to create and manage your virtual environment. To begin using the virtual environment, use the command ``source .venv/bin/activate`` to activate.   
+        
+          You can also use `virtualenvwrapper <https://virtualenvwrapper.readthedocs.io/en/latest/install.html>`_ which provides the ``mkvirtualenv`` shell function and is a set of extensions to the ``virtualenv`` tool. The extensions include wrappers for creating and deleting virtual environments and otherwise managing your development workflow. 

--- a/docs/includes/virtualenv.txt
+++ b/docs/includes/virtualenv.txt
@@ -1,5 +1,15 @@
-.. note:: You can install, upgrade, and remove Python packages using ``pip``, the Python package installer. By default, ``pip`` will attempt to install packages system-wide. Use ``venv`` or ``virtualenv`` to avoid installing Python packages globally and to isolate the installation of dependencies of a specific application.
-          
-          Run the command ``python3 -m venv .venv`` to create and manage your virtual environment. To begin using the virtual environment, use the command ``source .venv/bin/activate`` to activate.   
-        
-          You can also use `virtualenvwrapper <https://virtualenvwrapper.readthedocs.io/en/latest/install.html>`_ which provides the ``mkvirtualenv`` shell function and is a set of extensions to the ``virtualenv`` tool. The extensions include wrappers for creating and deleting virtual environments and otherwise managing your development workflow. 
+.. note:: You can install, upgrade, and remove Python packages using ``pip``,
+          the Python package installer. By default, ``pip`` will attempt to
+          install packages system-wide. Use ``venv`` or ``virtualenv`` to avoid
+          installing Python packages globally and to isolate the installation of
+          dependencies of a specific application.
+
+          Run the command ``python3 -m venv .venv`` to create and manage your
+          virtual environment. To begin using the virtual environment, use the
+          command ``source .venv/bin/activate`` to activate.
+
+          You can also use `virtualenvwrapper <https://virtualenvwrapper.readthedocs.io/en/latest/install.html>`_
+          which provides the ``mkvirtualenv`` shell function and is a set of
+          extensions to the ``virtualenv`` tool. The extensions include wrappers
+          for creating and deleting virtual environments and otherwise managing
+          your development workflow.


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes
Changes proposed in this pull request: Adds docs on installing in Fedora and other Linux distributions. Also, adds a note on creating a `virtulalenv` in Python3.  

This employs changes discussed in the [PR 5459](https://github.com/freedomofpress/securedrop/pull/5459)

Fixes #5438 .

Changes proposed in this pull request:

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [x] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
