### PR TITLE
Fetches tor packages for Focal

### DIFF
--- a/molecule/fetch-tor-packages/create.yml
+++ b/molecule/fetch-tor-packages/create.yml
@@ -7,14 +7,12 @@
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
-    # Use same container image as the Xenial build scenario
-    image_hash: "{{ lookup('pipe', 'egrep -v ^# ../builder-xenial/image_hash') }}"
   tasks:
     - name: Create molecule instance(s)
       docker_container:
         name: "{{ item.name }}"
-        # Use same container image as the Xenial build scenario
-        image: "quay.io/freedomofpress/sd-docker-builder-xenial@sha256:{{ image_hash }}"
+        # Use same container image as the build scenario
+        image: "{{ item.image }}@sha256:{{ lookup('pipe', 'egrep -v ^# ../builder-'+item.distro+'/image_hash') }}"
         state: started
         recreate: False
         command: "{{ item.command | default('sleep infinity') }}"

--- a/molecule/fetch-tor-packages/molecule.yml
+++ b/molecule/fetch-tor-packages/molecule.yml
@@ -7,6 +7,12 @@ lint:
   name: yamllint
 platforms:
   - name: tor-package-fetcher-xenial
+    image: "quay.io/freedomofpress/sd-docker-builder-xenial"
+    distro: xenial
+
+  - name: tor-package-fetcher-focal
+    image: "quay.io/freedomofpress/sd-docker-builder-focal"
+    distro: focal
 
 provisioner:
   name: ansible

--- a/molecule/fetch-tor-packages/playbook.yml
+++ b/molecule/fetch-tor-packages/playbook.yml
@@ -12,7 +12,7 @@
     tor_repo_pubkey: "{{ sd_repo_root + '/install_files/ansible-base/roles/tor-hidden-services/files/tor-signing-key.pub' }}"
     tor_repo_url: "deb https://deb.torproject.org/torproject.org {{ ansible_distribution_release }} main"
     # Used to fetch a precise version; must also be updated in the test vars
-    tor_version: "0.4.3.6-1~xenial+1"
+    tor_version: "0.4.3.6-1~{{ ansible_distribution_release }}+1"
 
   tasks:
     - name: Add Tor apt repo pubkey

--- a/molecule/fetch-tor-packages/prepare.yml
+++ b/molecule/fetch-tor-packages/prepare.yml
@@ -4,4 +4,4 @@
   gather_facts: no
   tasks:
     - name: Install python
-      raw: apt-get update && apt-get install -qq python-minimal apt-transport-https
+      raw: apt-get update && apt-get install -qq python3 apt-transport-https


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Updates the `fetch-tor-packages` to pull tor packages for both Xenial &
Focal, so we can begin hosting the latter, possible since
https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/57

Closes #5428 


## Testing

1. On the develop branch, run `make fetch-tor-packages` and note the checksums for `build/xenial/tor*`. 
2.. On this branch, run `make fetch-tor-packages` and confirm no errors.
3. Inspect the two (2) tor debs inside `build/xenial/`. Confirm their checksums match those from step 1.
4. Inspect the two (2) tor debs inside `build/focal/`. Confirm they match byte-for-byte what's found in https://deb.torproject.org/torproject.org/pool/main/t/tor/ 

Once you've approved these changes, please take a gander at https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/60, which includes the focal packages fetched via this logic.

## Deployment



## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
