### PR TITLE
fix: Internationalize "Show Password" on Journalist Interface

### DIFF
--- a/securedrop/journalist_templates/login.html
+++ b/securedrop/journalist_templates/login.html
@@ -7,7 +7,7 @@
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   <p><input class="login-username" type="text" name="username" autocomplete="off" placeholder="{{ gettext('Username') }}" autofocus></p>
   <p><input class="login-password" id="login-form-password" type="password" name="password" placeholder="{{ gettext('Password') }}"></p>
-  <p class="show-password-checkbox-container"><label><input id="show-password-check" type="checkbox">Show password</label></p>
+  <p class="show-password-checkbox-container"><label><input id="show-password-check" type="checkbox">{{ gettext('Show password') }}</label></p>
   <p><input class="login-token" name="token" id="token" type="text" placeholder="{{ gettext('Two-factor Code') }}"></p>
   <button type="submit">{{ gettext('LOG IN') }}</button>
 </form>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5462 

Changes proposed in this pull request:

Internationalized "Show password" on Journalist Interface.

## Checklist

### If you made changes to the server application code:

- [X] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [X] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [X] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [X] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [X] Doc linting (`make docs-lint`) passed locally