### PR TITLE
Remove traces of obsolete dependences from virtualenv

### DIFF
--- a/install_files/securedrop-app-code/debian/postinst
+++ b/install_files/securedrop-app-code/debian/postinst
@@ -17,7 +17,8 @@ set -o pipefail
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-SDBIN=/opt/venvs/securedrop-app-code/bin
+SDVE="/opt/venvs/securedrop-app-code"
+SDBIN="${SDVE}/bin"
 
 database_migration() {
     database_dir='/var/lib/securedrop'
@@ -65,7 +66,7 @@ database_migration() {
     fi
 }
 
-function adjust_wsgi_configuration {
+adjust_wsgi_configuration() {
     journalist_conf="/etc/apache2/sites-available/journalist.conf"
     if test -f $journalist_conf; then
         # Supports passing authorization headers for the SecureDrop API.
@@ -93,6 +94,14 @@ function adjust_wsgi_configuration {
             perl -pi -e 's/^WSGIProcessGroup journalist.*\n//' "$journalist_conf"
         fi
     fi
+}
+
+#
+# Remove any existing byte code files from the virtualenv, to ensure
+# that obsolete dependencies can't linger after they've been removed.
+#
+remove_bytecode() {
+    find "${SDVE}" -name '*.py[co]' -delete
 }
 
 # Manage PaX flags for web app, only required under Xenial.
@@ -174,6 +183,9 @@ case "$1" in
 
     # Munge Apache config while service is stopped.
     adjust_wsgi_configuration
+
+    # Remove Python bytecode from virtualenv
+    remove_bytecode
 
     # Restart apache so it loads with the apparmor profiles in enforce mode.
     service apache2 restart


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

After removing a dependency from the securedrop-app-code requirements, its byte code files could be left behind after installation of the updated package. This adds a function in postinst to clean those up.

Fixes #856.

## Testing

- Check out the `856-clean-env` branch.
- Build a staging environment. 
- Once complete, log in to the app server and list the contents of a requirement which we'll delete:
`ls -alR /opt/venvs/securedrop-app-code/lib/python3.5/site-packages/psutil`
  There should be `.pyc` files there.
- Back in your working copy, comment out the `psutil` lines in `securedrop/requirements/python3/securedrop-app-code-requirements.txt`, rerun `make build-debs` and `make staging`.
- On the app server, list the `psutil` path above. There should be no `.pyc` files.

## Deployment

This removes all Python byte code from the virtualenv, to purge obsolete requirements. 

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
