### PR TITLE
Updates SI to render /lookup even if reply files are missing from storage

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -129,6 +129,9 @@ def make_blueprint(config):
             except UnicodeDecodeError:
                 current_app.logger.error("Could not decode reply %s" %
                                          reply.filename)
+            except FileNotFoundError:
+                current_app.logger.error("Reply file missing: %s" %
+                                         reply.filename)
             else:
                 reply.date = datetime.utcfromtimestamp(
                     os.stat(reply_path).st_mtime)


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #5402 

Adds exception handling to cover the case when a source has replies in the db
whose corresponding files are missing from disk. Previously the /lookup path
would fail, preventing the source from viewing replies or uploading submissions.

## Testing
### dev environment:
- check out this branch and run `make dev`
- note the codename and  journalist designation in the docker output for one of the sources created with 2 reply files in the docker output
- run `docker ps` in a separate terminal to determine the ID for the dev container
- run `docker exec -it <dockerID> bash` to connect to the dev container
- find and delete one of the reply files for the source identified above, under `/var/lib/securedrop/store`.
- open the source interface at `localhost:8080` and log in with the source codename:
  - [ ] The login is successful and the `/lookup` page is displayed
  - [ ] One reply is displayed
  - [ ] An error message like `[2020-09-15 17:49:31,400] ERROR in main: Reply file missing: 3-blameless_fumble-reply.gpg` is printed in the docker output.

### staging environment:
- check out this branch and run `make staging`
- log in to the source interface and submit a message,  note the codename, then log out.
- log into the journalist interface and reply to a message
- log back into the SI and verify that the reply is visible, then logout
- log into the `app` staging serve, andr find and delete the reply file for the source, under `/var/lib/securedrop/store`.
- log into the source interface with the source codename:
  - [ ] The login is successful and the `/lookup` page is displayed
  - [ ] No replies are displayed.
  - [ ] An error message like `Reply file missing: 3-blameless_fumble-reply.gpg` is printed in the source error log on the app server.

## Deployment

No special deployment requirements.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR