### PR TITLE
Update Tor package version to 0.4.4.x series

### DIFF
--- a/molecule/fetch-tor-packages/playbook.yml
+++ b/molecule/fetch-tor-packages/playbook.yml
@@ -12,7 +12,7 @@
     tor_repo_pubkey: "{{ sd_repo_root + '/install_files/ansible-base/roles/tor-hidden-services/files/tor-signing-key.pub' }}"
     tor_repo_url: "deb https://deb.torproject.org/torproject.org {{ ansible_distribution_release }} main"
     # Used to fetch a precise version; must also be updated in the test vars
-    tor_version: "0.4.3.6-1~{{ ansible_distribution_release }}+1"
+    tor_version: "0.4.4.5-1~{{ ansible_distribution_release }}+1"
 
   tasks:
     - name: Add Tor apt repo pubkey

--- a/molecule/fetch-tor-packages/tests/test_tor_packages.py
+++ b/molecule/fetch-tor-packages/tests/test_tor_packages.py
@@ -12,7 +12,7 @@ TOR_PACKAGES = [
     {"name": "tor-geoipdb", "arch": "all"},
 ]
 # The '{}' will be replaced with platform, e.g. Focal
-TOR_VERSION_TEMPLATE = "0.4.3.6-1~{}+1"
+TOR_VERSION_TEMPLATE = "0.4.4.5-1~{}+1"
 
 
 def test_tor_apt_repo(host):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #5500.

## Testing

- [ ] `make fetch-tor-debs` is passing locally, and the artifacts fetched are the same as the ones in https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/63
- [ ] https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/63 is reviewed and merged
- [ ] Review and merge this PR

## Deployment
New and existing installs will be updated via unattended apt upgrades.
## Checklist


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR


