### PR TITLE
Added 30sec delay for post-reboot checks.

### DIFF
--- a/install_files/ansible-base/tasks/reboot.yml
+++ b/install_files/ansible-base/tasks/reboot.yml
@@ -1,6 +1,7 @@
 ---
 - name: Reboot if required due to security updates.
   reboot:
+    post_reboot_delay: 30
   tags:
     - reboot
   when: not securedrop_staging_qubes_env|default(False)


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes

Addresses #5401.

CI frequently fails due to the Ansible reboot module's post-reboot checks timing out
against one or both staging servers. Adding a small delay to hopefully alleviate
this.

## Testing

- [ ] on a prod install, `./securedrop-admin install` completes without error
- [ ] `make staging` completes without error
- [ ] CI passes without a failure in the `staging-test-with-rebase` job
