### PR TITLE
Add seen tables and update seen status based on downloads in JI

### DIFF
--- a/securedrop/alembic/versions/48a75abc0121_add_seen_tables.py
+++ b/securedrop/alembic/versions/48a75abc0121_add_seen_tables.py
@@ -1,0 +1,57 @@
+"""add seen tables
+
+Revision ID: 48a75abc0121
+Revises: 35513370ba0d
+Create Date: 2020-09-15 22:34:50.116403
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "48a75abc0121"
+down_revision = "35513370ba0d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "seen_files",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("file_id", sa.Integer(), nullable=False),
+        sa.Column("journalist_id", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("file_id", "journalist_id"),
+        sa.ForeignKeyConstraint(["file_id"], ["submissions.id"]),
+        sa.ForeignKeyConstraint(["journalist_id"], ["journalists.id"]),
+    )
+
+    op.create_table(
+        "seen_messages",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("message_id", sa.Integer(), nullable=False),
+        sa.Column("journalist_id", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("message_id", "journalist_id"),
+        sa.ForeignKeyConstraint(["message_id"], ["submissions.id"]),
+        sa.ForeignKeyConstraint(["journalist_id"], ["journalists.id"]),
+    )
+
+    op.create_table(
+        "seen_replies",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("reply_id", sa.Integer(), nullable=False),
+        sa.Column("journalist_id", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("reply_id", "journalist_id"),
+        sa.ForeignKeyConstraint(["reply_id"], ["replies.id"]),
+        sa.ForeignKeyConstraint(["journalist_id"], ["journalists.id"]),
+    )
+
+
+def downgrade():
+    op.drop_table("seen_files")
+    op.drop_table("seen_messages")
+    op.drop_table("seen_replies")

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -185,18 +185,11 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             {'submissions': [submission.to_json() for
                              submission in source.submissions]}), 200
 
-    @api.route('/sources/<source_uuid>/submissions/<submission_uuid>/download',  # noqa
-               methods=['GET'])
+    @api.route("/sources/<source_uuid>/submissions/<submission_uuid>/download", methods=["GET"])
     @token_required
     def download_submission(source_uuid: str, submission_uuid: str) -> flask.Response:
         get_or_404(Source, source_uuid, column=Source.uuid)
-        submission = get_or_404(Submission, submission_uuid,
-                                column=Submission.uuid)
-
-        # Mark as downloaded
-        submission.downloaded = True
-        db.session.commit()
-
+        submission = get_or_404(Submission, submission_uuid, column=Submission.uuid)
         return utils.serve_file_with_etag(submission)
 
     @api.route('/sources/<source_uuid>/replies/<reply_uuid>/download',

--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -1,7 +1,17 @@
 # -*- coding: utf-8 -*-
 
-from flask import (g, Blueprint, redirect, url_for, render_template, flash,
-                   request, abort, send_file, current_app)
+from flask import (
+    Blueprint,
+    abort,
+    current_app,
+    flash,
+    g,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    url_for,
+)
 from flask_babel import gettext
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
@@ -74,33 +84,33 @@ def make_blueprint(config):
 
     @view.route('/<filesystem_id>/<fn>')
     def download_single_file(filesystem_id, fn):
-        """Sends a client the contents of a single file, either a submission
-        or a journalist reply"""
+        """
+        Marks the file being download (the file being downloaded is either a submission message,
+        submission file attachement, or journalist reply) as seen by the current logged-in user and
+        send the file to a client to be saved or opened.
+        """
         if '..' in fn or fn.startswith('/'):
             abort(404)
 
-        # mark as seen by the current user and update downloaded for submissions
-        journalist_id = g.get('user').id
+        # mark as seen by the current user
         try:
-            if fn.endswith('reply.gpg'):
+            journalist_id = g.get("user").id
+            if fn.endswith("reply.gpg"):
                 reply = Reply.query.filter(Reply.filename == fn).one()
                 seen_reply = SeenReply(reply_id=reply.id, journalist_id=journalist_id)
                 db.session.add(seen_reply)
-            elif fn.endswith('-doc.gz.gpg') or fn.endswith("doc.zip.gpg"):
+            elif fn.endswith("-doc.gz.gpg") or fn.endswith("doc.zip.gpg"):
                 file = Submission.query.filter(Submission.filename == fn).one()
                 seen_file = SeenFile(file_id=file.id, journalist_id=journalist_id)
                 db.session.add(seen_file)
-                Submission.query.filter(Submission.filename == fn).one().downloaded = True
             else:
                 message = Submission.query.filter(Submission.filename == fn).one()
                 seen_message = SeenMessage(message_id=message.id, journalist_id=journalist_id)
                 db.session.add(seen_message)
-                Submission.query.filter(Submission.filename == fn).one().downloaded = True
 
             db.session.commit()
         except NoResultFound as e:
-            current_app.logger.error(
-                "Could not mark " + fn + " as downloaded: %s" % (e,))
+            current_app.logger.error("Could not mark {} as seen: {}".format(fn, e))
         except IntegrityError:
             pass  # expected not to store that a file was seen by the same user multiple times
 

--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from flask import (Blueprint, redirect, url_for, render_template, flash,
+from flask import (g, Blueprint, redirect, url_for, render_template, flash,
                    request, abort, send_file, current_app)
 from flask_babel import gettext
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
 from db import db
-from models import Submission
+from models import Reply, SeenFile, SeenMessage, SeenReply, Submission
 from journalist_app.forms import ReplyForm
 from journalist_app.utils import (make_star_true, make_star_false, get_source,
                                   delete_collection, col_download_unread,
@@ -78,15 +79,30 @@ def make_blueprint(config):
         if '..' in fn or fn.startswith('/'):
             abort(404)
 
-        # only mark as read when it's a submission (and not a journalist reply)
-        if not fn.endswith('reply.gpg'):
-            try:
-                Submission.query.filter(
-                    Submission.filename == fn).one().downloaded = True
-                db.session.commit()
-            except NoResultFound as e:
-                current_app.logger.error(
-                    "Could not mark " + fn + " as downloaded: %s" % (e,))
+        # mark as seen by the current user and update downloaded for submissions
+        journalist_id = g.get('user').id
+        try:
+            if fn.endswith('reply.gpg'):
+                reply = Reply.query.filter(Reply.filename == fn).one()
+                seen_reply = SeenReply(reply_id=reply.id, journalist_id=journalist_id)
+                db.session.add(seen_reply)
+            elif fn.endswith('-doc.gz.gpg') or fn.endswith("doc.zip.gpg"):
+                file = Submission.query.filter(Submission.filename == fn).one()
+                seen_file = SeenFile(file_id=file.id, journalist_id=journalist_id)
+                db.session.add(seen_file)
+                Submission.query.filter(Submission.filename == fn).one().downloaded = True
+            else:
+                message = Submission.query.filter(Submission.filename == fn).one()
+                seen_message = SeenMessage(message_id=message.id, journalist_id=journalist_id)
+                db.session.add(seen_message)
+                Submission.query.filter(Submission.filename == fn).one().downloaded = True
+
+            db.session.commit()
+        except NoResultFound as e:
+            current_app.logger.error(
+                "Could not mark " + fn + " as downloaded: %s" % (e,))
+        except IntegrityError:
+            pass  # expected not to store that a file was seen by the same user multiple times
 
         return send_file(current_app.storage.path(filesystem_id, fn),
                          mimetype="application/pgp-encrypted")

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -9,16 +9,29 @@ import werkzeug
 from flask import (g, flash, current_app, abort, send_file, redirect, url_for,
                    render_template, Markup, sessions, request)
 from flask_babel import gettext, ngettext
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.sql.expression import false
 
 import i18n
 
 from db import db
-from models import (get_one_or_else, Source, Journalist, InvalidUsernameException,
-                    WrongPasswordException, FirstOrLastNameError, LoginThrottledException,
-                    BadTokenException, SourceStar, PasswordError, SeenFile, SeenMessage, SeenReply,
-                    Submission, RevokedToken, InvalidPasswordLength, Reply)
+from models import (
+    BadTokenException,
+    FirstOrLastNameError,
+    InvalidPasswordLength,
+    InvalidUsernameException,
+    Journalist,
+    LoginThrottledException,
+    PasswordError,
+    Reply,
+    RevokedToken,
+    SeenFile,
+    SeenMessage,
+    SeenReply,
+    Source,
+    SourceStar,
+    Submission,
+    WrongPasswordException,
+    get_one_or_else,
+)
 from store import add_checksum_for_file
 
 from sdconfig import SDConfig
@@ -161,34 +174,43 @@ def download(zip_basename: str, submissions: List[Union[Submission, Reply]]) -> 
     :param list submissions: A list of :class:`models.Submission`s to
                              include in the ZIP-file.
     """
-    zf = current_app.storage.get_bulk_archive(submissions,
-                                              zip_directory=zip_basename)
+    zf = current_app.storage.get_bulk_archive(submissions, zip_directory=zip_basename)
     attachment_filename = "{}--{}.zip".format(
-        zip_basename, datetime.datetime.utcnow().strftime("%Y-%m-%d--%H-%M-%S"))
+        zip_basename, datetime.datetime.utcnow().strftime("%Y-%m-%d--%H-%M-%S")
+    )
 
-    # mark as seen by the current user and update downloaded for submissions
-    journalist_id = g.get('user').id
+    # mark as seen by the current user
+    journalist_id = g.get("user").id
     for item in submissions:
-        try:
-            if item.filename.endswith('reply.gpg'):
+        if item.filename.endswith("reply.gpg"):
+            already_seen = SeenReply.query.filter_by(
+                reply_id=item.id, journalist_id=journalist_id
+            ).one_or_none()
+            if not already_seen:
                 seen_reply = SeenReply(reply_id=item.id, journalist_id=journalist_id)
                 db.session.add(seen_reply)
-            elif item.filename.endswith('-doc.gz.gpg'):
+        elif item.filename.endswith("-doc.gz.gpg"):
+            already_seen = SeenFile.query.filter_by(
+                file_id=item.id, journalist_id=journalist_id
+            ).one_or_none()
+            if not already_seen:
                 seen_file = SeenFile(file_id=item.id, journalist_id=journalist_id)
                 db.session.add(seen_file)
-                item.downloaded = True
-            else:
+        else:
+            already_seen = SeenMessage.query.filter_by(
+                message_id=item.id, journalist_id=journalist_id
+            ).one_or_none()
+            if not already_seen:
                 seen_message = SeenMessage(message_id=item.id, journalist_id=journalist_id)
                 db.session.add(seen_message)
-                item.downloaded = True
+        db.session.commit()
 
-            db.session.commit()
-        except IntegrityError:
-            pass  # expected not to store that a file was seen by the same user multiple times
-
-    return send_file(zf.name, mimetype="application/zip",
-                     attachment_filename=attachment_filename,
-                     as_attachment=True)
+    return send_file(
+        zf.name,
+        mimetype="application/zip",
+        attachment_filename=attachment_filename,
+        as_attachment=True,
+    )
 
 
 def delete_file_object(file_object: Union[Submission, Reply]) -> None:
@@ -354,19 +376,25 @@ def set_diceware_password(user: Journalist, password: Optional[str]) -> bool:
 
 
 def col_download_unread(cols_selected: List[str]) -> werkzeug.Response:
-    """Download all unread submissions from all selected sources."""
-    submissions = []  # type: List[Union[Source, Submission]]
+    """
+    Download all unseen submissions from all selected sources.
+    """
+    unseen_submissions = []  # type: List[Union[Source, Submission]]
+
     for filesystem_id in cols_selected:
-        id = Source.query.filter(Source.filesystem_id == filesystem_id) \
-                         .filter_by(deleted_at=None).one().id
-        submissions += Submission.query.filter(
-            Submission.downloaded == false(),
-            Submission.source_id == id).all()
-    if submissions == []:
-        flash(gettext("No unread submissions in selected collections."),
-              "error")
-        return redirect(url_for('main.index'))
-    return download("unread", submissions)
+        source = (
+            Source.query.filter(Source.filesystem_id == filesystem_id)
+            .filter_by(deleted_at=None)
+            .one()
+        )
+        submissions = Submission.query.filter_by(source_id=source.id).all()
+        unseen_submissions += [s for s in submissions if not s.seen]
+
+    if not unseen_submissions:
+        flash(gettext("No unread submissions in selected collections."), "error")
+        return redirect(url_for("main.index"))
+
+    return download("unread", unseen_submissions)
 
 
 def col_download_all(cols_selected: List[str]) -> werkzeug.Response:

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -21,7 +21,7 @@
 
       <ul id="submissions" class="plain submissions">
         {% for doc in source.collection %}
-          <li class="submission {% if not doc.downloaded and not doc.filename.endswith('reply.gpg') %}unread{% endif %}">
+          <li class="submission {% if not doc.seen and not doc.filename.endswith('reply.gpg') %}unread{% endif %}">
             {% if doc.filename.endswith('reply.gpg') %}
               {% if not doc.deleted_by_source %}
                 <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
@@ -30,14 +30,14 @@
                 <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
                 <span title="{{ gettext('Read') }}" class="icon"><i class="fa fa-check"></i></span>
               {% endif %}
-            {% elif not doc.downloaded %}
+            {% elif not doc.seen %}
               <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
               <span title="{{ gettext('Unread') }}" class="icon"><i class="fa fa-envelope"></i></span>
             {% else %}
               <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
               <span title="{{ gettext('Read') }}" class="icon"><i class="fa fa-envelope-open"></i></span>
             {% endif %}
-            <a class="file {% if not doc.downloaded and not doc.filename.endswith('reply.gpg') %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_file', filesystem_id=filesystem_id, fn=doc.filename) }}">
+            <a class="file {% if not doc.seen and not doc.filename.endswith('reply.gpg') %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_file', filesystem_id=filesystem_id, fn=doc.filename) }}">
               <span class="filename">{{ doc.filename }}</span>
             </a>
             <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat() }}</span></span>

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -722,6 +722,40 @@ class Journalist(db.Model):
         return json_user
 
 
+class SeenFile(db.Model):
+    __tablename__ = "seen_files"
+    __table_args__ = (db.UniqueConstraint("file_id", "journalist_id"),)
+    id = Column(Integer, primary_key=True)
+    file_id = Column(Integer, ForeignKey("submissions.id"), nullable=False)
+    journalist_id = Column(Integer, ForeignKey("journalists.id"), nullable=True)
+    file = relationship(
+        "Submission", backref=backref("seen_files", cascade="all,delete")
+    )
+    journalist = relationship("Journalist", backref=backref("seen_files"))
+
+
+class SeenMessage(db.Model):
+    __tablename__ = "seen_messages"
+    __table_args__ = (db.UniqueConstraint("message_id", "journalist_id"),)
+    id = Column(Integer, primary_key=True)
+    message_id = Column(Integer, ForeignKey("submissions.id"), nullable=False)
+    journalist_id = Column(Integer, ForeignKey("journalists.id"), nullable=True)
+    message = relationship(
+        "Submission", backref=backref("seen_messages", cascade="all,delete")
+    )
+    journalist = relationship("Journalist", backref=backref("seen_messages"))
+
+
+class SeenReply(db.Model):
+    __tablename__ = "seen_replies"
+    __table_args__ = (db.UniqueConstraint("reply_id", "journalist_id"),)
+    id = Column(Integer, primary_key=True)
+    reply_id = Column(Integer, ForeignKey("replies.id"), nullable=False)
+    journalist_id = Column(Integer, ForeignKey("journalists.id"), nullable=True)
+    reply = relationship("Reply", backref=backref("seen_replies", cascade="all,delete"))
+    journalist = relationship("Journalist", backref=backref("seen_replies"))
+
+
 class JournalistLoginAttempt(db.Model):
 
     """This model keeps track of journalist's login attempts so we can

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -229,6 +229,17 @@ class Submission(db.Model):
         }
         return json_submission
 
+    @property
+    def seen(self) -> bool:
+        """
+        If the submission has been downloaded or seen by any journalist, then the submssion is
+        considered seen.
+        """
+        if self.downloaded or self.seen_files.count() or self.seen_messages.count():
+            return True
+
+        return False
+
 
 class Reply(db.Model):
     __tablename__ = "replies"
@@ -729,7 +740,7 @@ class SeenFile(db.Model):
     file_id = Column(Integer, ForeignKey("submissions.id"), nullable=False)
     journalist_id = Column(Integer, ForeignKey("journalists.id"), nullable=True)
     file = relationship(
-        "Submission", backref=backref("seen_files", cascade="all,delete")
+        "Submission", backref=backref("seen_files", lazy="dynamic", cascade="all,delete")
     )
     journalist = relationship("Journalist", backref=backref("seen_files"))
 
@@ -741,7 +752,7 @@ class SeenMessage(db.Model):
     message_id = Column(Integer, ForeignKey("submissions.id"), nullable=False)
     journalist_id = Column(Integer, ForeignKey("journalists.id"), nullable=True)
     message = relationship(
-        "Submission", backref=backref("seen_messages", cascade="all,delete")
+        "Submission", backref=backref("seen_messages", lazy="dynamic", cascade="all,delete")
     )
     journalist = relationship("Journalist", backref=backref("seen_messages"))
 

--- a/securedrop/tests/migrations/migration_48a75abc0121.py
+++ b/securedrop/tests/migrations/migration_48a75abc0121.py
@@ -1,0 +1,382 @@
+# -*- coding: utf-8 -*-
+
+import random
+import string
+
+import pytest
+from db import db
+from journalist_app import create_app
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from uuid import uuid4
+
+from .helpers import (
+    bool_or_none,
+    random_bool,
+    random_bytes,
+    random_chars,
+    random_datetime,
+    random_username,
+)
+
+random.seed("ᕕ( ᐛ )ᕗ")
+
+
+class Helper:
+
+    @staticmethod
+    def add_source():
+        filesystem_id = random_chars(96) if random_bool() else None
+        params = {
+            'uuid': str(uuid4()),
+            "filesystem_id": filesystem_id,
+            "journalist_designation": random_chars(50),
+            "flagged": bool_or_none(),
+            "last_updated": random_datetime(nullable=True),
+            "pending": bool_or_none(),
+            "interaction_count": random.randint(0, 1000),
+        }
+        sql = """
+        INSERT INTO sources (
+            uuid,
+            filesystem_id,
+            journalist_designation,
+            flagged,
+            last_updated,
+            pending,
+            interaction_count
+        )
+        VALUES (
+            :uuid,
+            :filesystem_id,
+            :journalist_designation,
+            :flagged,
+            :last_updated,
+            :pending,
+            :interaction_count
+        )
+        """
+        db.engine.execute(text(sql), **params)
+
+    @staticmethod
+    def add_journalist():
+        if random_bool():
+            otp_secret = random_chars(16, string.ascii_uppercase + "234567")
+        else:
+            otp_secret = None
+
+        is_totp = random_bool()
+        if is_totp:
+            hotp_counter = 0 if random_bool() else None
+        else:
+            hotp_counter = random.randint(0, 10000) if random_bool() else None
+
+        last_token = random_chars(6, string.digits) if random_bool() else None
+
+        params = {
+            "uuid": str(uuid4()),
+            "username": random_username(),
+            "session_nonce": 0,
+            "pw_salt": random_bytes(1, 64, nullable=True),
+            "pw_hash": random_bytes(32, 64, nullable=True),
+            "is_admin": bool_or_none(),
+            "otp_secret": otp_secret,
+            "is_totp": is_totp,
+            "hotp_counter": hotp_counter,
+            "last_token": last_token,
+            "created_on": random_datetime(nullable=True),
+            "last_access": random_datetime(nullable=True),
+        }
+        sql = """
+        INSERT INTO journalists (
+            uuid,
+            username,
+            session_nonce,
+            pw_salt,
+            pw_hash,
+            is_admin,
+            otp_secret,
+            is_totp,
+            hotp_counter,
+            last_token,
+            created_on,
+            last_access
+        )
+        VALUES (
+            :uuid,
+            :username,
+            :session_nonce,
+            :pw_salt,
+            :pw_hash,
+            :is_admin,
+            :otp_secret,
+            :is_totp,
+            :hotp_counter,
+            :last_token,
+            :created_on,
+            :last_access
+        );
+        """
+        db.engine.execute(text(sql), **params)
+
+    @staticmethod
+    def add_reply(journalist_id, source_id):
+        params = {
+            "uuid": str(uuid4()),
+            "journalist_id": journalist_id,
+            "source_id": source_id,
+            "filename": random_chars(50),
+            "size": random.randint(0, 1024 * 1024 * 500),
+            "deleted_by_source": 0
+        }
+        sql = """
+        INSERT INTO replies (uuid, journalist_id, source_id, filename, size, deleted_by_source)
+        VALUES (:uuid, :journalist_id, :source_id, :filename, :size, :deleted_by_source)
+        """
+        db.engine.execute(text(sql), **params)
+
+    @staticmethod
+    def add_message(source_id):
+        params = {
+            "uuid": str(uuid4()),
+            "source_id": source_id,
+            "filename": random_chars(50) + "-msg.gpg",
+            "size": random.randint(0, 1024 * 1024 * 500),
+            "downloaded": random.choice([True, False])
+        }
+        sql = """
+        INSERT INTO submissions (uuid, source_id, filename, size, downloaded)
+        VALUES (:uuid, :source_id, :filename, :size, :downloaded)
+        """
+        db.engine.execute(text(sql), **params)
+
+    @staticmethod
+    def add_file(source_id):
+        params = {
+            "uuid": str(uuid4()),
+            "source_id": source_id,
+            "filename": random_chars(50) + "-doc.gz.gpg",
+            "size": random.randint(0, 1024 * 1024 * 500),
+            "downloaded": random.choice([True, False]),
+            "checksum": "sha256:" + random_chars(64)
+        }
+        sql = """
+        INSERT INTO submissions (uuid, source_id, filename, size, downloaded, checksum)
+        VALUES (:uuid, :source_id, :filename, :size, :downloaded, :checksum)
+        """
+        db.engine.execute(text(sql), **params)
+
+    @staticmethod
+    def mark_reply_as_seen(reply_id, journalist_id):
+        params = {
+            "reply_id": reply_id,
+            "journalist_id": journalist_id,
+        }
+        sql = """
+        INSERT INTO seen_replies (reply_id, journalist_id)
+        VALUES (:reply_id, :journalist_id)
+        """
+        try:
+            db.engine.execute(text(sql), **params)
+        except IntegrityError:
+            pass
+
+    @staticmethod
+    def mark_file_as_seen(file_id, journalist_id):
+        params = {
+            "file_id": file_id,
+            "journalist_id": journalist_id,
+        }
+        sql = """
+        INSERT INTO seen_files (file_id, journalist_id)
+        VALUES (:file_id, :journalist_id)
+        """
+        try:
+            db.engine.execute(text(sql), **params)
+        except IntegrityError:
+            pass
+
+    @staticmethod
+    def mark_message_as_seen(message_id, journalist_id):
+        params = {
+            "message_id": message_id,
+            "journalist_id": journalist_id,
+        }
+        sql = """
+        INSERT INTO seen_messages (message_id, journalist_id)
+        VALUES (:message_id, :journalist_id)
+        """
+        try:
+            db.engine.execute(text(sql), **params)
+        except IntegrityError:
+            pass
+
+
+class UpgradeTester(Helper):
+    """
+    This migration verifies that the seen_files, seen_messages, and seen_replies association tables
+    now exist, and that the data migration completes successfully.
+    """
+
+    JOURNO_NUM = 20
+    SOURCE_NUM = 20
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            for _ in range(self.SOURCE_NUM):
+                self.add_source()
+
+            for _ in range(self.JOURNO_NUM):
+                self.add_journalist()
+
+            for i in range(self.SOURCE_NUM):
+                # add 1-3 messages from each source, some messages are set to downloaded
+                for _ in range(random.randint(1, 3)):
+                    self.add_message(i)
+                # add 0-2 files from each source, some files are set to downloaded
+                for _ in range(random.randint(0, 2)):
+                    self.add_file(i)
+
+            # add 30 replies from randomly-selected journalists to randomly-selected sources
+            for i in range(30):
+                selected_journo = random.randint(0, self.JOURNO_NUM)
+                selected_source = random.randint(0, self.SOURCE_NUM)
+                self.add_reply(selected_journo, selected_source)
+
+    def check_upgrade(self):
+        with self.app.app_context():
+            sql = "SELECT * FROM submissions"
+            submissions = db.engine.execute(text(sql)).fetchall()
+
+            sql = "SELECT * FROM replies"
+            replies = db.engine.execute(text(sql)).fetchall()
+
+            # Now seen tables exist, so you should be able to mark some files, messages, and replies
+            # as seen
+            for submission in submissions:
+                if submission.filename.endswith('-doc.gz.gpg') and random.choice([0, 1]):
+                    selected_journo_id = random.randint(0, self.JOURNO_NUM)
+                    self.mark_file_as_seen(submission.id, selected_journo_id)
+                elif random.choice([0, 1]):
+                    selected_journo_id = random.randint(0, self.JOURNO_NUM)
+                    self.mark_message_as_seen(submission.id, selected_journo_id)
+            for reply in replies:
+                if random.choice([0, 1]):
+                    selected_journo_id = random.randint(0, self.JOURNO_NUM)
+                    self.mark_reply_as_seen(reply.id, selected_journo_id)
+
+            # Check unique constraint on (reply_id, journalist_id)
+            params = {"reply_id": 100, "journalist_id": 100}
+            sql = """
+            INSERT INTO seen_replies (reply_id, journalist_id)
+            VALUES (:reply_id, :journalist_id);
+            """
+            db.engine.execute(text(sql), **params)
+            with pytest.raises(IntegrityError):
+                db.engine.execute(text(sql), **params)
+
+            # Check unique constraint on (message_id, journalist_id)
+            params = {"message_id": 100, "journalist_id": 100}
+            sql = """
+            INSERT INTO seen_messages (message_id, journalist_id)
+            VALUES (:message_id, :journalist_id);
+            """
+            db.engine.execute(text(sql), **params)
+            with pytest.raises(IntegrityError):
+                db.engine.execute(text(sql), **params)
+
+            # Check unique constraint on (file_id, journalist_id)
+            params = {"file_id": 101, "journalist_id": 100}
+            sql = """
+            INSERT INTO seen_files (file_id, journalist_id)
+            VALUES (:file_id, :journalist_id);
+            """
+            db.engine.execute(text(sql), **params)
+            with pytest.raises(IntegrityError):
+                db.engine.execute(text(sql), **params)
+
+
+class DowngradeTester(Helper):
+    """
+    This migration verifies that the seen_files, seen_messages, and seen_replies association tables
+    are removed.
+    """
+
+    JOURNO_NUM = 20
+    SOURCE_NUM = 20
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            for _ in range(self.SOURCE_NUM):
+                self.add_source()
+
+            for _ in range(self.JOURNO_NUM):
+                self.add_journalist()
+
+            for i in range(self.SOURCE_NUM):
+                # add 1-3 messages from each source, some messages are set to downloaded
+                for _ in range(random.randint(1, 3)):
+                    self.add_message(i)
+                # add 0-2 files from each source, some files are set to downloaded
+                for _ in random.randint(0, 2):
+                    self.add_file(i)
+
+            # add 30 replies from randomly-selected journalists to randomly-selected sources
+            for i in range(30):
+                selected_journo = random.randint(0, self.JOURNO_NUM)
+                selected_source = random.randint(0, self.SOURCE_NUM)
+                self.add_reply(selected_journo, selected_source)
+
+            # mark some files, messages, and replies as seen
+            sql = "SELECT * FROM submissions"
+            submissions = db.engine.execute(text(sql)).fetchall()
+            for submission in submissions:
+                if submission.filename.endswith('-doc.gz.gpg') and random.choice([0, 1]):
+                    selected_journo_id = random.randint(0, self.JOURNO_NUM)
+                    self.mark_file_as_seen(submission.id, selected_journo_id)
+                elif random.choice([0, 1]):
+                    self.mark_message_as_seen(submission.id, selected_journo_id)
+
+            sql = "SELECT * FROM replies"
+            replies = db.engine.execute(text(sql)).fetchall()
+            for reply in replies:
+                if random.choice([0, 1]):
+                    selected_journo_id = random.randint(0, self.JOURNO_NUM)
+                    self.mark_reply_as_seen(reply.id, selected_journo_id)
+
+            # Mark some files, messages, and replies as seen
+            for submission in submissions:
+                if submission.filename.endswith('-doc.gz.gpg') and random.choice([0, 1]):
+                    selected_journo_id = random.randint(0, self.JOURNO_NUM)
+                    self.mark_file_as_seen(submission.id, selected_journo_id)
+                elif random.choice([0, 1]):
+                    selected_journo_id = random.randint(0, self.JOURNO_NUM)
+                    self.mark_message_as_seen(submission.id, selected_journo_id)
+            for reply in replies:
+                if random.choice([0, 1]):
+                    selected_journo_id = random.randint(0, self.JOURNO_NUM)
+                    self.mark_reply_as_seen(reply.id, selected_journo_id)
+
+    def check_downgrade(self):
+        with self.app.app_context():
+            # Check that seen tables no longer exist
+            params = {"table_name": "seen_files"}
+            sql = "SELECT name FROM sqlite_master WHERE type='table' AND name=:table_name;"
+            seen_files_exists = db.engine.execute(text(sql), **params).fetchall()
+            assert not seen_files_exists
+            params = {"table_name": "seen_messages"}
+            sql = "SELECT name FROM sqlite_master WHERE type='table' AND name=:table_name;"
+            seen_messages_exists = db.engine.execute(text(sql), **params).fetchall()
+            assert not seen_messages_exists
+            params = {"table_name": "seen_replies"}
+            sql = "SELECT name FROM sqlite_master WHERE type='table' AND name=:table_name;"
+            seen_replies_exists = db.engine.execute(text(sql), **params).fetchall()
+            assert not seen_replies_exists

--- a/securedrop/tests/migrations/migration_48a75abc0121.py
+++ b/securedrop/tests/migrations/migration_48a75abc0121.py
@@ -326,7 +326,7 @@ class DowngradeTester(Helper):
                 for _ in range(random.randint(1, 3)):
                     self.add_message(i)
                 # add 0-2 files from each source, some files are set to downloaded
-                for _ in random.randint(0, 2):
+                for _ in range(random.randint(0, 2)):
                     self.add_file(i)
 
             # add 30 replies from randomly-selected journalists to randomly-selected sources
@@ -343,6 +343,7 @@ class DowngradeTester(Helper):
                     selected_journo_id = random.randint(0, self.JOURNO_NUM)
                     self.mark_file_as_seen(submission.id, selected_journo_id)
                 elif random.choice([0, 1]):
+                    selected_journo_id = random.randint(0, self.JOURNO_NUM)
                     self.mark_message_as_seen(submission.id, selected_journo_id)
 
             sql = "SELECT * FROM replies"

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -10,7 +10,16 @@ from flask import current_app, url_for
 from itsdangerous import TimedJSONWebSignatureSerializer
 
 from db import db
-from models import Journalist, Reply, Source, SourceStar, Submission, RevokedToken
+from models import (
+    Journalist,
+    Reply,
+    Source,
+    SeenFile,
+    SeenMessage,
+    SourceStar,
+    Submission,
+    RevokedToken,
+)
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 from .utils.api_helper import get_api_headers
@@ -585,17 +594,16 @@ def test_authorized_user_can_download_submission(journalist_app,
         submission_uuid = test_submissions['source'].submissions[0].uuid
         uuid = test_submissions['source'].uuid
 
-        response = app.get(url_for('api.download_submission',
-                                   source_uuid=uuid,
-                                   submission_uuid=submission_uuid),
-                           headers=get_api_headers(journalist_api_token))
+        response = app.get(
+            url_for(
+                "api.download_submission",
+                source_uuid=uuid,
+                submission_uuid=submission_uuid,
+            ),
+            headers=get_api_headers(journalist_api_token),
+        )
 
         assert response.status_code == 200
-
-        # Submission should now be marked as downloaded in the database
-        submission = Submission.query.get(
-            test_submissions['source'].submissions[0].id)
-        assert submission.downloaded
 
         # Response should be a PGP encrypted download
         assert response.mimetype == 'application/pgp-encrypted'

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -3,23 +3,21 @@ import json
 import os
 import random
 
-from pyotp import TOTP
-from uuid import UUID, uuid4
-
 from flask import current_app, url_for
 from itsdangerous import TimedJSONWebSignatureSerializer
+from pyotp import TOTP
+from uuid import UUID, uuid4
 
 from db import db
 from models import (
     Journalist,
     Reply,
     Source,
-    SeenFile,
-    SeenMessage,
     SourceStar,
     Submission,
     RevokedToken,
 )
+
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 from .utils.api_helper import get_api_headers

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -3,37 +3,40 @@
 filesystem) interaction.
 """
 import datetime
-import mock
+import math
 import os
+import random
+from typing import Dict, List
 
+import mock
 from flask import current_app
 
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-from sdconfig import config
-import models
-
 from db import db
+from models import Journalist, Reply, SeenFile, SeenMessage, SeenReply, Source, Submission
+from sdconfig import config
 
-# models.{Journalist, Reply}
+os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 
 
 def init_journalist(first_name=None, last_name=None, is_admin=False):
     """Initialize a journalist into the database. Return their
-    :class:`models.Journalist` object and password string.
+    :class:`Journalist` object and password string.
 
     :param bool is_admin: Whether the user is an admin.
 
-    :returns: A 2-tuple. The first entry, an :obj:`models.Journalist`
+    :returns: A 2-tuple. The first entry, an :obj:`Journalist`
               corresponding to the row just added to the database. The
               second, their password string.
     """
     username = current_app.crypto_util.genrandomid()
     user_pw = current_app.crypto_util.genrandomid()
-    user = models.Journalist(username=username,
-                             password=user_pw,
-                             first_name=first_name,
-                             last_name=last_name,
-                             is_admin=is_admin)
+    user = Journalist(
+        username=username,
+        password=user_pw,
+        first_name=first_name,
+        last_name=last_name,
+        is_admin=is_admin
+    )
     db.session.add(user)
     db.session.commit()
     return user, user_pw
@@ -42,7 +45,7 @@ def init_journalist(first_name=None, last_name=None, is_admin=False):
 def delete_journalist(journalist):
     """Deletes a journalist from the database.
 
-    :param models.Journalist journalist: The journalist to delete
+    :param Journalist journalist: The journalist to delete
 
     :returns: None
     """
@@ -54,14 +57,14 @@ def reply(journalist, source, num_replies):
     """Generates and submits *num_replies* replies to *source*
     from *journalist*. Returns reply objects as a list.
 
-    :param models.Journalist journalist: The journalist to write the
+    :param Journalist journalist: The journalist to write the
                                      reply from.
 
-    :param models.Source source: The source to send the reply to.
+    :param Source source: The source to send the reply to.
 
     :param int num_replies: Number of random-data replies to make.
 
-    :returns: A list of the :class:`models.Reply`s submitted.
+    :returns: A list of the :class:`Reply`s submitted.
     """
     assert num_replies >= 1
     replies = []
@@ -75,7 +78,7 @@ def reply(journalist, source, num_replies):
              config.JOURNALIST_KEY],
             current_app.storage.path(source.filesystem_id, fname))
 
-        reply = models.Reply(journalist, source, fname)
+        reply = Reply(journalist, source, fname)
         replies.append(reply)
         db.session.add(reply)
 
@@ -90,7 +93,7 @@ def mock_verify_token(testcase):
     :param unittest.TestCase testcase: The test case for which to patch
                                        TOTP verification.
     """
-    patcher = mock.patch('models.Journalist.verify_token')
+    patcher = mock.patch('Journalist.verify_token')
     testcase.addCleanup(patcher.stop)
     testcase.mock_journalist_verify_token = patcher.start()
     testcase.mock_journalist_verify_token.return_value = True
@@ -99,7 +102,7 @@ def mock_verify_token(testcase):
 def mark_downloaded(*submissions):
     """Mark *submissions* as downloaded in the database.
 
-    :param models.Submission submissions: One or more submissions that
+    :param Submission submissions: One or more submissions that
                                       should be marked as downloaded.
     """
     for submission in submissions:
@@ -107,21 +110,21 @@ def mark_downloaded(*submissions):
     db.session.commit()
 
 
-# models.{Source,Submission}
+# {Source,Submission}
 
 def init_source_without_keypair():
     """Initialize a source: create their database record and the
     filesystem directory that stores their submissions & replies.
     Return a source object and their codename string.
 
-    :returns: A 2-tuple. The first entry, the :class:`models.Source`
+    :returns: A 2-tuple. The first entry, the :class:`Source`
     initialized. The second, their codename string.
     """
     # Create source identity and database record
     codename = current_app.crypto_util.genrandomid()
     filesystem_id = current_app.crypto_util.hash_codename(codename)
     journalist_filename = current_app.crypto_util.display_id()
-    source = models.Source(filesystem_id, journalist_filename)
+    source = Source(filesystem_id, journalist_filename)
     db.session.add(source)
     db.session.commit()
     # Create the directory to store their submissions and replies
@@ -136,7 +139,7 @@ def init_source():
     and their GPG key encrypted with their codename. Return a source
     object and their codename string.
 
-    :returns: A 2-tuple. The first entry, the :class:`models.Source`
+    :returns: A 2-tuple. The first entry, the :class:`Source`
     initialized. The second, their codename string.
     """
     source, codename = init_source_without_keypair()
@@ -147,16 +150,16 @@ def init_source():
 
 def submit(source, num_submissions):
     """Generates and submits *num_submissions*
-    :class:`models.Submission`s on behalf of a :class:`models.Source`
+    :class:`Submission`s on behalf of a :class:`Source`
     *source*.
 
-    :param models.Source source: The source on who's behalf to make
+    :param Source source: The source on who's behalf to make
                              submissions.
 
     :param int num_submissions: Number of random-data submissions
                                 to make.
 
-    :returns: A list of the :class:`models.Submission`s submitted.
+    :returns: A list of the :class:`Submission`s submitted.
     """
     assert num_submissions >= 1
     source.last_updated = datetime.datetime.utcnow()
@@ -171,7 +174,7 @@ def submit(source, num_submissions):
             source.journalist_filename,
             str(os.urandom(1))
         )
-        submission = models.Submission(source, fpath)
+        submission = Submission(source, fpath)
         submissions.append(submission)
         db.session.add(source)
         db.session.add(submission)
@@ -187,3 +190,81 @@ def new_codename(client, session):
     tab_id, codename = next(iter(session['codenames'].items()))
     client.post('/create', data={'tab_id': tab_id})
     return codename
+
+
+def mark_replies_seen(journalist_id: int, replies: List[Reply]):
+    """
+    Mark replies as seen.
+    """
+    for reply in replies:
+        seen_reply = SeenReply(journalist_id=journalist_id, reply_id=reply.id)
+        db.session.add(seen_reply)
+    db.session.commit()
+
+
+def mark_messages_seen(journalist_id: int, messages: List[Submission]):
+    """
+    Mark messages as seen.
+    """
+    for message in messages:
+        message.downloaded = True
+        seen_message = SeenMessage(journalist_id=journalist_id, message_id=message.id)
+        db.session.add(seen_message)
+    db.session.commit()
+
+
+def mark_files_seen(journalist_id: int, files: List[Submission]):
+    """
+    Mark files as seen.
+    """
+    for file in files:
+        file.downloaded = True
+        seen_file = SeenFile(journalist_id=journalist_id, file_id=file.id)
+        db.session.add(seen_file)
+    db.session.commit()
+
+
+def bulk_setup_for_seen_only(journo) -> List[Dict]:
+    """
+    Create some sources with some seen submissions that are not marked as 'downloaded' in the
+    database and some seen replies from journo.
+    """
+
+    setup_collection = []
+
+    for i in range(random.randint(2, 4)):
+        collection = {}
+
+        source, _ = init_source()
+
+        submissions = submit(source, random.randint(2, 4))
+        half = math.ceil(len(submissions) / 2)
+        messages = submissions[half:]
+        files = submissions[:half]
+        replies = reply(journo, source, random.randint(1, 3))
+
+        seen_files = random.sample(files, math.ceil(len(files) / 2))
+        seen_messages = random.sample(messages, math.ceil(len(messages) / 2))
+        seen_replies = random.sample(replies, math.ceil(len(replies) / 2))
+
+        mark_files_seen(journo.id, seen_files)
+        mark_messages_seen(journo.id, seen_messages)
+        mark_replies_seen(journo.id, seen_replies)
+
+        unseen_files = list(set(files).difference(set(seen_files)))
+        unseen_messages = list(set(messages).difference(set(seen_messages)))
+        unseen_replies = list(set(replies).difference(set(seen_replies)))
+        not_downloaded = list(set(files + messages).difference(set(seen_files + seen_messages)))
+
+        collection['source'] = source
+        collection['seen_files'] = seen_files
+        collection['seen_messages'] = seen_messages
+        collection['seen_replies'] = seen_replies
+        collection['unseen_files'] = unseen_files
+        collection['unseen_messages'] = unseen_messages
+        collection['unseen_replies'] = unseen_replies
+        collection['not_downloaded'] = not_downloaded
+
+        setup_collection.append(collection)
+
+    return setup_collection


### PR DESCRIPTION
# Description of Changes

Fixes https://github.com/freedomofpress/securedrop/issues/5474
Also fixes a bug found while working on this PR, see "Change 3"

## Change 1

Adds association tables so we know which journalists have seen a file, message, or reply:
  * seen_files
  * seen_replies
  * seen_messages

There has been significant consideration around journalist account deletion. While research is ongoing, we are going to continue to support keeping submissions as downloaded/seen even if the journalist who downloaded/saw the submission was deleted. And this will apply to replies as well. 

<details><summary>Note about unique constraints in sqlite</summary>
<p>
In sqlite, null is the absence of a value, so it is never equal to other null values and not considered a duplicate value. This means that it's possible to insert rows that appear to be duplicates if one of the values is null. So if we have:

```
id  message_id  journalist_id
---------------------------------
1   12                  7
2   12                  8
3   13                  8
4   13                  5
```

and then `journalist_id=8` is deleted, we would then have:

```
id  message_id  journalist_id
---------------------------------
1   12                  7
2   12                  
3   13                  
4   13                  5
```

and then `journalist_id=5` is deleted, we would then have:

```
id  message_id  journalist_id
---------------------------------
1   12                  7
2   12                  
3   13                  
4   13                  
```

Once/if we create a global "deleted" account in the db, we will have to do a data migration to aggregate these duplicate rows and update journalist_id to the journalist_id of the global deleted account.

</p>
</details>

<details><summary>More info about deletion</summary>
<p>

Currently, SecureDrop provides a global inbox, so we preserve journalist replies even when journalist accounts are deleted. The replies are no longer attributed to the journalist, but other journalists will still be able to read the source conversation (which may have replies from multiple journalists) until the conversation is deleted with the source. Currently, we set 'journalist_id' to null in the replies table if the journalist is deleted, which should violate the foreign key constraint on the 'replies' table for 'journalist_id', but due to this issue the constraint is not currently enforced: https://github.com/freedomofpress/securedrop/issues/5503. Also, we lose information about how unique individuals sent those replies that we are persisting without their accounts.

We're also considering full-deletion of journalists, meaning deleting the account and the replies made from that journalist. The issue I see with this is that there are other people sharing the same global inbox and viewing the same source conversations those replies are part of. Removing a journalist's replies when their account is deleted means altering the conversations that other people see. Deleting all the historical data connected to a journalist would also make any global features more challenging. Take global read/unread (aka seen/unseen, the current feature we're working on implementing) for instance. If a journalist was the primary person checking securedrop for a long time and then their account was deleted, potentially many old outdated sources would get bumped up to the top of the list as "unread" if they were the only journalists who read these messages.

As mentioned already, https://github.com/freedomofpress/securedrop/issues/5503 for referential integrity.

Another issue for debate is switching to using uuids as our primary keys. This would remove redundancy and hide sequential ordering of ids tied to account creation. If using ids has made significant performance improvements, I'd be interested in seeing the results. Otherwise, I'd be interested in benchmarking so that we know the tradeoffs.

So here were a couple ideas that were considered when designing the seen tables.

Idea 1:

```py
class SeenFile(db.Model):
    __tablename__ = "seen_files"
    file_id = Column(Integer, ForeignKey("submissions.id"), primary_key=True)
    journalist_id = Column(Integer, ForeignKey("journalists.id"), primary_key=True)
    file = relationship("Submission", backref="seen_files", cascade="delete")
    journalist = relationship("Journalist", backref="seen_files")
```

The association tables declare the foreign keys as primary keys so that the join operations are fast and prevent duplicate records of (journalist_id, message_id), (journalist_id, reply_id), and (journalist_id, file_id). This would require us to implement a global "deleted" journalist account, but there would be work involved in deciding when the "deleted" account should be created (upon first account deletion? by default?) and to be complete and organized about it, we would also want to do a data migration for replies with null journalist_ids. Also, there is some work around catching exceptions when journalists are deleted and making sure we re-attribute replies and seen records to the global "deleted" user. This third point would not be necessary if we implement https://github.com/freedomofpress/securedrop/issues/5467 (which I am in favor of doing in the future).

Idea 2 (the winner):

```py
class SeenFile(db.Model):
    __tablename__ = "seen_files"
    __table_args__ = (
        db.UniqueConstraint('file_id', 'journalist_id'),
    )
    id = Column(Integer, primary_key=True)
    file_id = Column(Integer, ForeignKey("submissions.id"), nullable=False)
    journalist_id = Column(Integer, ForeignKey("journalists.id"), nullable=True)
    file = relationship("Submission", backref="seen_files", cascade="delete")
    journalist = relationship("Journalist", backref="seen_files")
```

We still have the same foreign keys but there is a new sequential 'id' column that is the primary key and a unique constraint on (file_id, journalist_id) to prevent duplicate records. Also, journalist_id can now be null. This is a workaround solution for allowing null 'journalist_id' (once we turn on foreign key support we will have to update this table along with replies) to support deleted accounts.

</p>
</details>

## Change 2

The journalist interface no longer marks submissions as 'downloaded' and instead makes entries into the seen tables when:
  * files, messages, or replies are downloaded via the "Download Selected" button, by clicking on the filename link, and by clicking on the "<count> unread" link from the "Sources" page
  * files are downloaded from the client

The submissions table now has a `seen` property that is set if 'downloaded' is set or there is a corresponding 'seen' entry in the database. This is for backwards compatibility.

<details><summary>Note about design choice</summary>
<p>
With a preference for avoiding fake/ special numbers and accounts, it made the most sense to keep the 'downloaded' column in the 'submissions' table and to leave the data there. 'downloaded' can now be used for historical data where we don’t know which journalist saw a submission. Other options considered were:
  * data migration using a fake 'journalist_id' of a very large number in the 'seen_files' table and removal of 'downloaded'
  * data migration using a special journalist account to represent an "unknown" user, as distinct from "deleted", and removal of 'downloaded'
</p>
</details>

## Change 3

Fixed a bug where we were marking all files and messages as downloaded when the client opens from the JI endpoint `/sources/<source_uuid>/submissions/<submission_uuid>/download`, which is used in the background by the client just to get the latest messages and used to download files per user request. We now no longer mark files and messages as 'downloaded'.

Once we start using the new seen endpoints in the client we will be able to mark source messages as seen when a user clicks on the source and files as seen when a user clicks to open a file.

# Testing

## New tables and account deletion [Change 1]
0. Make sure alembic upgrade and downgrade work as expected (you can just check that tests pass as well
1. Check out this branch
2. `make dev`
3. `docker exec -it securedrop-dev-0 bash`
4. `sqlite3 /var/lib/securedrop/db.sqlite`
5. Check existence of tables
     - [ ] verify 'seen_replies', 'seen_files', and 'seen_messages' exist
6. Check deletion of a journalist
     -  Log in from JI as dellsberg and download a message
     - [ ] verify record exists in seen_messages table
     - Log in from JI as test-user and download the same message
     - [ ] verify new record exists in seen_messages table
     - Log in as journalist and delete dellsberg and test-user
     - [ ] verify journalist_id is now null for both records
7. Check unique constraints for non-nulls
     - `insert into seen_files (file_id, journalist_id) values (1, 1);` twice
     - [ ] verify constraint does not allow this
     - repeat for 'seen_messages' and 'seen_replies'
8. Check deletion of a file/message/reply
     - Send a file attachment from the source interface
     - Download it from the JI
     - [ ] verify seen record exists for this file
     - Now delete the file from the JI
     - [ ] verify record is deleted in the seen_files table
     - repeat for replies and messages
9. Check deletion of a source
     - Delete a source with seen records for replies, files, and messages
     - [ ] verify seen records no longer exist

## Behavior has not changed in the JI [Change 2]
1. Check out this branch
2. `make dev`
3. `docker exec -it securedrop-dev-0 bash`
4. `sqlite3 /var/lib/securedrop/db.sqlite`
5. Check x-unread link
     - Click on the "<x> unread" link for the source at the top of the list
     - [ ] verify JI works the same as before
     - [ ] verify the correct entries were added to the 'seen_messages' table for submissions
     - [ ] verify 'downloaded' was not set in the db
     - Repeat for files
6. Check "Download Unread" button
     - Send a file and message
     - Select the source with the unread file and message and click "Download Unread"
     - [ ] verify JI works the same as before
     - Select the source again with no unread files and messages and click "Download Unread"
     - [ ] verify that you get error message "No unread submissions in selected collections."
     - Send a couple files
     - Select all sources in the source list and click "Download Unread"
     - [ ] verify JI works the same as before
7. Check "Download Selected" button
     - Send a file, message, and reply
     - Select all conversation items for this source and click "Download Selected"
     - [ ] verify JI works the same as before
     - [ ] verify the correct entries were added to the 'seen_*' table
     - [ ] verify 'downloaded' was not set in the db
8. Check filename-link
     - Send a file
     - Click on the filename of that file from the JI
     - [ ] verify JI works the same as before
     - [ ] verify the correct entry was added to the 'seen_files' table
     - [ ] verify 'downloaded' was not set in the db
     - Repeat for message
9. Check unique constraint exception handling
     - [ ] verify that downloading the same file, message, or reply again and again works and that there is only one seen entry for each
10. Check that sending a reply as a journalist creates seen record
     - [ ] Send a reply to a source
     - [ ] Verify seen record exists in the seen_replies table

## New behavior in the JI [Change 3]
1. Restart `make dev`
2. Send 2 file attachments from the source interface as a new source
3. Visit JI to confirm that there are unread files
4. Log into the client
     - [ ] verify no files or messages are marked as read in the JI due to logging into the client
5. Download one file from the client
     - [ ] verify the file is not marked as read in the JI
     - [ ] verify 'downloaded' was not set in the db
6. Check that you can download a file that was seen via the JI
     - [ ] Download the unread file from the JI
     - [ ] Download the same file from the client
     - [ ] verify download was successful

## Migration testing

**Note:** the migration is in the postinst of the package

(test on staging or dev)
1. On your server running the latest securedrop, download some messages and files from the JI
2. Checkout this branch, rebuild, and restart the server (for staging: build the debs and make staging, for dev: run make dev)
3. Run `manage.py init-db` to apply the migration (Either ssh to your staging server or `docker exec -it securedrop-dev-0 bash` if you're testing on a dev server)
4. Revisit the JI and see that the same files and messages are still downloaded
5. Download some new messages, files, and replies (these will be marked as seen in the new seen tables)
6. From the latest release branch, either a) build the debs and make staging, or b) make dev
7. Checkout the latest release branch, rebuild, and restart the server (for staging: build the debs and make staging, for dev: run make dev)
8. Revisit the JI and see that only the messages and files you downloaded from step 2 are still downloaded
9. Download some more stuff to make sure nothing went horribly wrong during the downgrade

Or, instead of all the steps above, you can just do: https://docs.securedrop.org/en/stable/development/upgrade_testing.html?highlight=upgrade%20testing#upgrade-testing-using-molecule

## QA Testing

Remember to follow https://docs.securedrop.org/en/stable/development/database_migrations.html?highlight=alembic#release-testing-migrations during QA testing

# Upgrading existing production instances

N/A since database migrations are applied postinst