### PR TITLE
Add /users endpoint

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -66,6 +66,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
     def get_endpoints() -> Tuple[flask.Response, int]:
         endpoints = {'sources_url': '/api/v1/sources',
                      'current_user_url': '/api/v1/user',
+                     'all_users_url': '/api/v1/users',
                      'submissions_url': '/api/v1/submissions',
                      'replies_url': '/api/v1/replies',
                      'auth_token_url': '/api/v1/token'}
@@ -322,6 +323,13 @@ def make_blueprint(config: SDConfig) -> Blueprint:
     def get_current_user() -> Tuple[flask.Response, int]:
         user = _authenticate_user_from_auth_header(request)
         return jsonify(user.to_json()), 200
+
+    @api.route('/users', methods=['GET'])
+    @token_required
+    def get_all_users() -> Tuple[flask.Response, int]:
+        users = Journalist.query.all()
+        return jsonify(
+            {'users': [user.to_json(all_info=False) for user in users]}), 200
 
     @api.route('/logout', methods=['POST'])
     @token_required

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -710,15 +710,25 @@ class Journalist(db.Model):
 
         return Journalist.query.get(data['id'])
 
-    def to_json(self) -> 'Dict[str, Union[str, bool, str]]':
+    def to_json(self, all_info: bool = True) -> 'Dict[str, Union[str, bool, str]]':
+        """Returns a JSON representation of the journalist user. If all_info is
+           False, potentially sensitive or extraneous fields are excluded. Note
+           that both representations do NOT include credentials."""
+
         json_user = {
             'username': self.username,
-            'last_login': self.last_access.isoformat() + 'Z',
-            'is_admin': self.is_admin,
             'uuid': self.uuid,
             'first_name': self.first_name,
             'last_name': self.last_name
         }
+
+        if all_info is True:
+            json_user['is_admin'] = self.is_admin
+            try:
+                json_user['last_login'] = self.last_access.isoformat() + 'Z'
+            except AttributeError:
+                json_user['last_login'] = None
+
         return json_user
 
 


### PR DESCRIPTION
Resolves #5490
## Description

Adds the `/users` endpoint as described in the issue and subsequent comments, enumerating non-sensitive information for all users.

Documentation PR dependent on this one:
https://github.com/freedomofpress/securedrop-docs/pull/3

## Status

Ready for review.

## Test plan

Spin up a development environment from this PR.

- [ ] Observe that you see this endpoint listed on http://localhost:8081/api/v1
- [ ] Observe that you cannot access this endpoint at http://localhost:8081/api/v1/users without an authentication token
- [ ] Observe that you can access the list of users when providing a valid authentication token as part of the request (see example below)
- [ ] Observe that the list of users only includes the expected fields (UUID, username, first name, last name)

## Token usage example (curl)

```bash
$ curl -X POST -H "Content-Type: application/json" \ 
  -d '{"username":"journalist", "passphrase":"correct horse battery staple profanity oil chewy", "one_time_code": "123456"}' \ 
  'http://localhost:8081/api/v1/token'

$ curl -H "Authorization: Token TOKEN_HERE" http://localhost:8081/api/v1/users
```

## Checklist
- [x] Linting (`make lint`) and tests (`make test`) pass in the development container (tested for API tests)

