### PR TITLE
API changes for listing/marking source conversation items that have been seen by journalists

### DIFF
--- a/securedrop/create-dev-data.py
+++ b/securedrop/create-dev-data.py
@@ -15,7 +15,7 @@ import journalist_app
 
 from sdconfig import config
 from db import db
-from models import Journalist, Reply, Source, Submission
+from models import Journalist, Reply, SeenReply, Source, Submission
 from specialstrings import strings
 
 
@@ -138,6 +138,9 @@ def create_source_and_submissions(
             journalist = journalist_who_replied
         reply = Reply(journalist, source, fname)
         db.session.add(reply)
+        db.session.flush()
+        seen_reply = SeenReply(reply_id=reply.id, journalist_id=journalist.id)
+        db.session.add(seen_reply)
 
     db.session.commit()
 

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -16,8 +16,7 @@ from werkzeug.exceptions import default_exceptions
 
 from db import db
 from journalist_app import utils
-from models import (Journalist, Reply, SeenFile, SeenMessage,
-                    SeenReply, Source, Submission,
+from models import (Journalist, Reply, SeenReply, Source, Submission,
                     LoginThrottledException, InvalidUsernameException,
                     BadTokenException, WrongPasswordException)
 from sdconfig import SDConfig

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -317,44 +317,13 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         return jsonify(
             {'replies': [reply.to_json() for reply in replies if reply.source]}), 200
 
-    @api.route("/seen", methods=["GET", "POST"])
+    @api.route("/seen", methods=["POST"])
     @token_required
     def seen() -> Tuple[flask.Response, int]:
         """
         Lists or marks the source conversation items that the journalist has seen.
         """
         user = _authenticate_user_from_auth_header(request)
-
-        if request.method == "GET":
-            seen_files = [
-                {
-                    "file_uuid": f.file.uuid,
-                    "journalist_uuid": f.journalist.uuid if f.journalist_id else None
-                }
-                for f in SeenFile.query.all()
-            ]
-            seen_messages = [
-                {
-                    "message_uuid": f.message.uuid,
-                    "journalist_uuid": f.journalist.uuid if f.journalist_id else None
-                }
-                for f in SeenMessage.query.all()
-            ]
-            seen_replies = [
-                {
-                    "reply_uuid": f.reply.uuid,
-                    "journalist_uuid": f.journalist.uuid if f.journalist_id else None
-                }
-                for f in SeenReply.query.all()
-            ]
-
-            return jsonify(
-                {
-                    "files": seen_files,
-                    "messages": seen_messages,
-                    "replies": seen_replies,
-                }
-            ), 200
 
         if request.method == "POST":
             if request.json is None or not isinstance(request.json, collections.abc.Mapping):

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -1,7 +1,8 @@
+import collections.abc
 import json
 
 from datetime import datetime, timedelta
-from typing import Tuple, Callable, Any
+from typing import Tuple, Callable, Any, Set, Union
 
 import flask
 import werkzeug
@@ -15,7 +16,8 @@ from werkzeug.exceptions import default_exceptions
 
 from db import db
 from journalist_app import utils
-from models import (Journalist, Reply, Source, Submission,
+from models import (Journalist, Reply, SeenFile, SeenMessage,
+                    SeenReply, Source, Submission,
                     LoginThrottledException, InvalidUsernameException,
                     BadTokenException, WrongPasswordException)
 from sdconfig import SDConfig
@@ -69,6 +71,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                      'all_users_url': '/api/v1/users',
                      'submissions_url': '/api/v1/submissions',
                      'replies_url': '/api/v1/replies',
+                     'seen_url': '/api/v1/seen',
                      'auth_token_url': '/api/v1/token'}
         return jsonify(endpoints), 200
 
@@ -268,6 +271,9 @@ def make_blueprint(config: SDConfig) -> Blueprint:
 
             try:
                 db.session.add(reply)
+                db.session.flush()
+                seen_reply = SeenReply(reply_id=reply.id, journalist_id=user.id)
+                db.session.add(seen_reply)
                 db.session.add(source)
                 db.session.commit()
             except IntegrityError as e:
@@ -310,6 +316,80 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         replies = Reply.query.all()
         return jsonify(
             {'replies': [reply.to_json() for reply in replies if reply.source]}), 200
+
+    @api.route("/seen", methods=["GET", "POST"])
+    @token_required
+    def seen() -> Tuple[flask.Response, int]:
+        """
+        Lists or marks the source conversation items that the journalist has seen.
+        """
+        user = _authenticate_user_from_auth_header(request)
+
+        if request.method == "GET":
+            seen_files = [
+                {
+                    "file_uuid": f.file.uuid,
+                    "journalist_uuid": f.journalist.uuid if f.journalist_id else None
+                }
+                for f in SeenFile.query.all()
+            ]
+            seen_messages = [
+                {
+                    "message_uuid": f.message.uuid,
+                    "journalist_uuid": f.journalist.uuid if f.journalist_id else None
+                }
+                for f in SeenMessage.query.all()
+            ]
+            seen_replies = [
+                {
+                    "reply_uuid": f.reply.uuid,
+                    "journalist_uuid": f.journalist.uuid if f.journalist_id else None
+                }
+                for f in SeenReply.query.all()
+            ]
+
+            return jsonify(
+                {
+                    "files": seen_files,
+                    "messages": seen_messages,
+                    "replies": seen_replies,
+                }
+            ), 200
+
+        if request.method == "POST":
+            if request.json is None or not isinstance(request.json, collections.abc.Mapping):
+                abort(400, "Please send requests in valid JSON.")
+
+            if not any(map(request.json.get, ["files", "messages", "replies"])):
+                abort(400, "Please specify the resources to mark seen.")
+
+            # gather everything to be marked seen. if any don't exist,
+            # reject the request.
+            targets = set()  # type: Set[Union[Submission, Reply]]
+            for file_uuid in request.json.get("files", []):
+                f = Submission.query.filter(Submission.uuid == file_uuid).one_or_none()
+                if f is None or not f.is_file:
+                    abort(404, "file not found: {}".format(file_uuid))
+                targets.add(f)
+
+            for message_uuid in request.json.get("messages", []):
+                m = Submission.query.filter(Submission.uuid == message_uuid).one_or_none()
+                if m is None or not m.is_message:
+                    abort(404, "message not found: {}".format(message_uuid))
+                targets.add(m)
+
+            for reply_uuid in request.json.get("replies", []):
+                r = Reply.query.filter(Reply.uuid == reply_uuid).one_or_none()
+                if r is None:
+                    abort(404, "reply not found: {}".format(reply_uuid))
+                targets.add(r)
+
+            # now mark everything seen.
+            utils.mark_seen(list(targets), user)
+
+            return jsonify({"message": "resources marked seen"}), 200
+
+        abort(405)
 
     @api.route('/user', methods=['GET'])
     @token_required

--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -1,17 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from flask import (
-    Blueprint,
-    abort,
-    current_app,
-    flash,
-    g,
-    redirect,
-    render_template,
-    request,
-    send_file,
-    url_for,
-)
+from flask import (g, Blueprint, redirect, url_for, render_template, flash,
+                   request, abort, send_file, current_app)
 from flask_babel import gettext
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
@@ -92,25 +82,28 @@ def make_blueprint(config):
         if '..' in fn or fn.startswith('/'):
             abort(404)
 
-        # mark as seen by the current user
+        # mark as seen by the current user and update downloaded for submissions
+        journalist_id = g.get('user').id
         try:
-            journalist_id = g.get("user").id
-            if fn.endswith("reply.gpg"):
+            if fn.endswith('reply.gpg'):
                 reply = Reply.query.filter(Reply.filename == fn).one()
                 seen_reply = SeenReply(reply_id=reply.id, journalist_id=journalist_id)
                 db.session.add(seen_reply)
-            elif fn.endswith("-doc.gz.gpg") or fn.endswith("doc.zip.gpg"):
+            elif fn.endswith('-doc.gz.gpg') or fn.endswith("doc.zip.gpg"):
                 file = Submission.query.filter(Submission.filename == fn).one()
                 seen_file = SeenFile(file_id=file.id, journalist_id=journalist_id)
                 db.session.add(seen_file)
+                Submission.query.filter(Submission.filename == fn).one().downloaded = True
             else:
                 message = Submission.query.filter(Submission.filename == fn).one()
                 seen_message = SeenMessage(message_id=message.id, journalist_id=journalist_id)
                 db.session.add(seen_message)
+                Submission.query.filter(Submission.filename == fn).one().downloaded = True
 
             db.session.commit()
         except NoResultFound as e:
-            current_app.logger.error("Could not mark {} as seen: {}".format(fn, e))
+            current_app.logger.error(
+                "Could not mark " + fn + " as downloaded: %s" % (e,))
         except IntegrityError:
             pass  # expected not to store that a file was seen by the same user multiple times
 

--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -1,7 +1,17 @@
 # -*- coding: utf-8 -*-
 
-from flask import (g, Blueprint, redirect, url_for, render_template, flash,
-                   request, abort, send_file, current_app)
+from flask import (
+    Blueprint,
+    abort,
+    current_app,
+    flash,
+    g,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    url_for,
+)
 from flask_babel import gettext
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
@@ -82,28 +92,25 @@ def make_blueprint(config):
         if '..' in fn or fn.startswith('/'):
             abort(404)
 
-        # mark as seen by the current user and update downloaded for submissions
-        journalist_id = g.get('user').id
+        # mark as seen by the current user
         try:
-            if fn.endswith('reply.gpg'):
+            journalist_id = g.get("user").id
+            if fn.endswith("reply.gpg"):
                 reply = Reply.query.filter(Reply.filename == fn).one()
                 seen_reply = SeenReply(reply_id=reply.id, journalist_id=journalist_id)
                 db.session.add(seen_reply)
-            elif fn.endswith('-doc.gz.gpg') or fn.endswith("doc.zip.gpg"):
+            elif fn.endswith("-doc.gz.gpg") or fn.endswith("doc.zip.gpg"):
                 file = Submission.query.filter(Submission.filename == fn).one()
                 seen_file = SeenFile(file_id=file.id, journalist_id=journalist_id)
                 db.session.add(seen_file)
-                Submission.query.filter(Submission.filename == fn).one().downloaded = True
             else:
                 message = Submission.query.filter(Submission.filename == fn).one()
                 seen_message = SeenMessage(message_id=message.id, journalist_id=journalist_id)
                 db.session.add(seen_message)
-                Submission.query.filter(Submission.filename == fn).one().downloaded = True
 
             db.session.commit()
         except NoResultFound as e:
-            current_app.logger.error(
-                "Could not mark " + fn + " as downloaded: %s" % (e,))
+            current_app.logger.error("Could not mark {} as seen: {}".format(fn, e))
         except IntegrityError:
             pass  # expected not to store that a file was seen by the same user multiple times
 

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -208,7 +208,7 @@ def test_submissions(journalist_app):
 def test_files(journalist_app, test_journo):
     with journalist_app.app_context():
         source, codename = utils.db_helper.init_source()
-        utils.db_helper.submit(source, 2)
+        utils.db_helper.submit(source, 2, submission_type="file")
         utils.db_helper.reply(test_journo['journalist'], source, 1)
         return {'source': source,
                 'codename': codename,

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -2293,12 +2293,6 @@ def test_download_all_selected_sources(journalist_app, test_journo):
             source = i["source"]
             selected.append(source.filesystem_id)
 
-        # Download all submissions from all sources selected
-        resp = app.post(
-            url_for("col.process"),
-            data=dict(action="download-all", cols_selected=selected),
-        )
-
     # The download request was succesful, and the app returned a zipfile
     assert resp.status_code == 200
     assert resp.content_type == "application/zip"

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -2293,6 +2293,12 @@ def test_download_all_selected_sources(journalist_app, test_journo):
             source = i["source"]
             selected.append(source.filesystem_id)
 
+        # Download all submissions from all sources selected
+        resp = app.post(
+            url_for("col.process"),
+            data=dict(action="download-all", cols_selected=selected),
+        )
+
     # The download request was succesful, and the app returned a zipfile
     assert resp.status_code == 200
     assert resp.content_type == "application/zip"

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -18,6 +18,7 @@ from sqlalchemy.sql.expression import func
 
 import crypto_util
 import journalist_app as journalist_app_module
+from journalist_app.utils import mark_seen
 import models
 from db import db
 from models import (
@@ -1847,11 +1848,11 @@ def test_delete_collection_updates_db(journalist_app, test_journo, test_source):
         source = Source.query.get(test_source["id"])
         journo = Journalist.query.get(test_journo["id"])
         files = utils.db_helper.submit(source, 2)
-        utils.db_helper.mark_files_seen(journo.id, files)
+        mark_seen(files, journo)
         messages = utils.db_helper.submit(source, 2)
-        utils.db_helper.mark_messages_seen(journo.id, messages)
+        mark_seen(messages, journo)
         replies = utils.db_helper.reply(journo, source, 2)
-        utils.db_helper.mark_replies_seen(journo.id, replies)
+        mark_seen(replies, journo)
 
         journalist_app_module.utils.delete_collection(test_source["filesystem_id"])
 
@@ -2074,9 +2075,7 @@ def test_download_selected_submissions_and_replies_previously_seen(
     db.session.add(seen_file)
     seen_message = SeenMessage(message_id=selected_submissions[1].id, journalist_id=journo.id)
     db.session.add(seen_message)
-    for reply in selected_replies:
-        seen_reply = SeenReply(reply_id=reply.id, journalist_id=journo.id)
-        db.session.add(seen_reply)
+    mark_seen(selected_replies, journo)
     db.session.commit()
 
     with journalist_app.test_client() as app:

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -1051,13 +1051,6 @@ def test_seen(journalist_app, journalist_api_token, test_files, test_journo, tes
         submissions_url = url_for('api.get_all_submissions')
         headers = get_api_headers(journalist_api_token)
 
-        # check that /seen reports no submissions, but one reply
-        response = app.get(seen_url, headers=headers)
-        assert response.status_code == 200
-        assert len(response.json["files"]) == 0
-        assert len(response.json["messages"]) == 0
-        assert len(response.json["replies"]) == 1
-
         # check that /submissions contains no seen items
         response = app.get(submissions_url, headers=headers)
         assert response.status_code == 200
@@ -1080,32 +1073,6 @@ def test_seen(journalist_app, journalist_api_token, test_files, test_journo, tes
         response = app.post(seen_url, data=json.dumps(data), headers=headers)
         assert response.status_code == 200
         assert response.json["message"] == "resources marked seen"
-
-        # and check that they are now reported seen
-        response = app.get(seen_url, headers=headers)
-        assert response.status_code == 200
-
-        expected_data = {
-            "files": [
-                {
-                    "file_uuid": file_uuid,
-                    "journalist_uuid": test_journo["uuid"]
-                }
-            ],
-            "messages": [
-                {
-                    "message_uuid": msg_uuid,
-                    "journalist_uuid": test_journo["uuid"]
-                }
-            ],
-            "replies": [
-                {
-                    "reply_uuid": reply_uuid,
-                    "journalist_uuid": test_journo["uuid"]
-                }
-            ],
-        }
-        assert expected_data == response.json
 
         # check that /submissions now contains the seen items
         response = app.get(submissions_url, headers=headers)
@@ -1156,13 +1123,6 @@ def test_seen_bad_requests(journalist_app, journalist_api_token):
     with journalist_app.test_client() as app:
         seen_url = url_for('api.seen')
         headers = get_api_headers(journalist_api_token)
-
-        response = app.get(seen_url, headers=headers)
-        assert response.status_code == 200
-
-        assert len(response.json["files"]) == 0
-        assert len(response.json["messages"]) == 0
-        assert len(response.json["replies"]) == 0
 
         # invalid JSON
         data = "not a mapping"

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -13,7 +13,8 @@ import mock
 from flask import current_app
 
 from db import db
-from models import Journalist, Reply, SeenFile, SeenMessage, SeenReply, Source, Submission
+from journalist_app.utils import mark_seen
+from models import Journalist, Reply, SeenReply, Source, Submission
 from sdconfig import config
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
@@ -205,38 +206,6 @@ def new_codename(client, session):
     return codename
 
 
-def mark_replies_seen(journalist_id: int, replies: List[Reply]):
-    """
-    Mark replies as seen.
-    """
-    for reply in replies:
-        seen_reply = SeenReply(journalist_id=journalist_id, reply_id=reply.id)
-        db.session.add(seen_reply)
-    db.session.commit()
-
-
-def mark_messages_seen(journalist_id: int, messages: List[Submission]):
-    """
-    Mark messages as seen.
-    """
-    for message in messages:
-        message.downloaded = True
-        seen_message = SeenMessage(journalist_id=journalist_id, message_id=message.id)
-        db.session.add(seen_message)
-    db.session.commit()
-
-
-def mark_files_seen(journalist_id: int, files: List[Submission]):
-    """
-    Mark files as seen.
-    """
-    for file in files:
-        file.downloaded = True
-        seen_file = SeenFile(journalist_id=journalist_id, file_id=file.id)
-        db.session.add(seen_file)
-    db.session.commit()
-
-
 def bulk_setup_for_seen_only(journo) -> List[Dict]:
     """
     Create some sources with some seen submissions that are not marked as 'downloaded' in the
@@ -260,9 +229,9 @@ def bulk_setup_for_seen_only(journo) -> List[Dict]:
         seen_messages = random.sample(messages, math.ceil(len(messages) / 2))
         seen_replies = random.sample(replies, math.ceil(len(replies) / 2))
 
-        mark_files_seen(journo.id, seen_files)
-        mark_messages_seen(journo.id, seen_messages)
-        mark_replies_seen(journo.id, seen_replies)
+        mark_seen(seen_files, journo)
+        mark_seen(seen_messages, journo)
+        mark_seen(seen_replies, journo)
 
         unseen_files = list(set(files).difference(set(seen_files)))
         unseen_messages = list(set(messages).difference(set(seen_messages)))


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes
    
Add new API endpoint for listing or marking source conversation items that have been seen by a journalist.
    
Add utility method to mark a heterogeneous collection of Submission and Reply objects seen.
    
Add Submission.is_file and Submission.is_message to encapsulate the characterization based on filename.

Fixes #5475.

## Testing

- Run the dev server with `make dev`.

- Get an API token as the `journalist` user:
  ```
  export TOKEN=$(curl -o- -X POST -H "Content-Type: application/json" --data '{"username":"journalist","passphrase":"correct horse battery staple profanity oil chewy","one_time_code":"047889"}' http://localhost:8081/api/v1/token | jq -r .token)
  ```

- List current submissions: 
  ```
  curl -X GET -H "Content-Type: application/json" -H "Authorization: Token $TOKEN" http://localhost:8081/api/v1/submissions
  ```
  All should have a `seen_by` property, currently an empty list.

- Mark a message seen:
  ```
  curl -X POST -H "Content-Type: application/json" -H "Authorization: Token $TOKEN" --data '{"messages": ["e711d29d-d0a1-440f-80e4-6642b77ec3ea"]}' http://localhost:8081/api/v1/seen
  ```
  Replace the UUID with one from one of the messages in the response from the `/submissions` endpoint, of course.
- Mark the same message seen again. There should be no error.
- Retrieve `/submissions` again. The message's `seen_by` list should now contain your journalist account's UUID.
- Visit the source of that message in the journalist interface. The message you marked should not be listed in bold text. Clicking "Select unread" should not select that message.
- Visit the source list in the journalist interface. Select the source of the message you marked and click "Download Unread". The zip file you receive should not contain the seen message.

- Via the source interface, upload a file, then retrieve `/submissions` again, and mark the file seen:
  ```
  curl -X POST -H "Content-Type: application/json" -H "Authorization: Token $TOKEN" --data '{"files": ["4fe4b7f5-3031-4651-9092-888951681cf7"]}' http://localhost:8081/api/v1/seen
  ```
  Replace the UUID with that of the file you just uploaded, of course.
- Repeat the checks in the journalist interface that you performed for a seen message, confirming that the file you marked seen is always considered read.

- Get another API token, this time as the `dellsberg` journalist account.
- Retrieve the list of all replies:
  ```
  curl -X GET -H "Content-Type: application/json" -H "Authorization: Token $TOKEN" http://localhost:8081/api/v1/replies
  ```
- Mark one of them read: 
  ```
  curl -X POST -H "Content-Type: application/json" -H "Authorization: Token $TOKEN" --data '{"replies": ["8924a691-3b0f-45c1-bfed-b0b91e264855"]}' http://localhost:8081/api/v1/seen
  ```
- Hit `/replies` again and confirm that the `dellsberg` account UUID appears in the reply's `seen_by` list.

## Deployment

Depends on the database changes in #5505.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
