### PR TITLE
Adds CI job for deb package builds on Focal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,6 +277,21 @@ jobs:
             if ! [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
             make ci-deb-tests
 
+  deb-tests-focal:
+    docker:
+      - image: gcr.io/cloud-builders/docker
+    environment:
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
+    steps:
+      - run: apt-get install -y make virtualenv enchant jq python3-dev build-essential
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Test Debian package build on Focal
+          command: |
+            make ci-deb-tests-focal
+
   docs-linkcheck:
     docker:
       - image: circleci/python:3.5
@@ -358,6 +373,15 @@ workflows:
                 - /update-builder-.*/
           requires:
             - lint
+      - deb-tests-focal:
+          filters:
+            branches:
+              ignore:
+                - stable
+                - /docs-.*/
+                - /i18n-.*/
+          requires:
+            - lint
 
   nightly:
     triggers:
@@ -380,6 +404,7 @@ workflows:
                 - develop
     jobs:
       - deb-tests
+      - deb-tests-focal
       - translation-tests
       - docs-linkcheck
       - fetch-tor-debs

--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,14 @@ ci-deb-tests:  ## Test SecureDrop Debian packages in CI environment.
 	@$(SDROOT)/devops/scripts/test-built-packages.sh
 	@echo
 
+.PHONY: ci-deb-tests-focal
+ci-deb-tests-focal:  ## Test SecureDrop Debian packages in CI environment.
+	@echo "███ Running Debian package tests in CI..."
+	@$(SDROOT)/devops/scripts/test-built-packages.sh focal
+	@echo
+
+
+
 .PHONY: build-gcloud-docker
 build-gcloud-docker:  ## Build Docker container for Google Cloud SDK.
 	@echo "Building Docker container for Google Cloud SDK..."

--- a/devops/scripts/test-built-packages.sh
+++ b/devops/scripts/test-built-packages.sh
@@ -5,9 +5,9 @@
 
 set -e
 set -o pipefail
-
+TARGET_PLATFORM="${1:-xenial}"
 . ./devops/scripts/boot-strap-venv.sh
 
 virtualenv_bootstrap
 
-molecule test -s builder-xenial
+molecule test -s "builder-${TARGET_PLATFORM}"


### PR DESCRIPTION


## Status

Ready for review 

## Description of Changes

Fixes #5494 

Builds debian packages on Focal for every branch other than
- stable
- docs-*
- i18n-*

Changes proposed in this pull request:

## Testing

- [ ] CI should have a new job on building packages on Focal

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
