### PR TITLE
Provides first-run custom kernel support for Focal

### DIFF
--- a/install_files/ansible-base/roles/common/vars/Ubuntu_focal.yml
+++ b/install_files/ansible-base/roles/common/vars/Ubuntu_focal.yml
@@ -2,3 +2,4 @@
 securedrop_kernel_packages_to_remove:
   - linux-virtual
   - linux-generic
+  - 'linux-image-.*generic'

--- a/install_files/ansible-base/roles/grsecurity/defaults/main.yml
+++ b/install_files/ansible-base/roles/grsecurity/defaults/main.yml
@@ -11,3 +11,8 @@ grsec_sysctl_flags:
     # exist otherwise.
   - name: "vm.heap_stack_gap"
     value: "1048576"
+
+# Lookup table for how to create PaX flags, depending on OS.
+paxctl_header_type:
+  xenial: C
+  focal: c

--- a/install_files/ansible-base/roles/grsecurity/tasks/paxctl.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/paxctl.yml
@@ -21,7 +21,8 @@
     - /usr/bin/grub-script-check
 
 - name: Adjust paxctl headers on grub binaries.
-  command: paxctl -zCE {{ item.item }}
+  command: paxctl -z{{ paxctl_header_type[ansible_distribution_release] }}E {{ item.item }}
   with_items: "{{ paxctl_grub_header_check.results }}"
-  when: "item.stdout != '- PaX flags: --------E--- [{{ item.item }}]' or
-         item.rc != 0"
+  when: >
+    item.stdout != '- PaX flags: --------E--- ['+item.item+']'
+    or item.rc != 0


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Updates the `paxctl` commands to use slightly different logic depending on whether the host is running Xenial or Focal. Notably this _only_ alters the Ansible logic, and ignores the same flags in the `securedrop-grsec` metapackage. Therefore I'm only saying "refs #5495" since technically there's a bit more follow-up required there (possibly switching to paxctld #4134). 

Also updating the package patterns so that non-grsec kernels are succesfully removed during first install. I've only tested in this in libvirt staging VMs running focal, but it's enough. More durable forcing of the hardened kernels is tracked in  #5507. Therefore, closes #5508. 



## Testing

You must use a Linux machine with libvirt support.

```
make build-debs-focal # if you don't already have them
molecule converge -s libvirt-staging-focal
```

Confirm that the install completes without error, and the app is functional. The testinfra tests are not yet passing for Focal, so don't expect the "verify" action to work.

## Deployment

The changes aim to preserve identical behavior under Xenial. Still, the CI checks for staging will confirm that the paxctl commands are not broken under Xenial. I don't think we need additional functional testing beyond that, outside of standard pre-release QA.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
