### PR TITLE
Fixes #5507 marks grsec kernel as default on Focal

### DIFF
--- a/install_files/securedrop-grsec/DEBIAN/postinst
+++ b/install_files/securedrop-grsec/DEBIAN/postinst
@@ -15,14 +15,21 @@ set -x
 #          <conflicting-package> <version>
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
+GRSEC_VERSION='4.14.188-grsec'
+
+# Sets default grub boot parameter to the kernel version specified
+# by $GRSEC_VERSION. The debian buster default kernel is 4.19, thus
+# supersedes this 4.14.x series grsecurity kernel at boot-time
+set_grub_default() {
+    GRUB_OPT="'Advanced options for Debian GNU/Linux>Debian GNU/Linux, with Linux $GRSEC_VERSION'"
+    perl -pi -e "s|^GRUB_DEFAULT=.*|GRUB_DEFAULT=$GRUB_OPT|" /etc/default/grub
+}
 
 case "$1" in
     configure)
 
-    # Replace the default GRUB boot option with 0, which defaults to the
-    # highest kernel version. Any kernel provided by apt.freedom.press must
-    # suprecede the ones provided by Ubuntu.
-    sed -i '/^GRUB_DEFAULT=/s/=.*/=0/' /etc/default/grub
+    # Force latest hardened kernel for next boot
+    set_grub_default
     # When using CONFIG_PAX_KERNEXEC, the grsecurity team recommends the kernel
     # is booted with "noefi" on the kernel command line if "CONFIG_EFI" is
     # enabled, as EFI runtime services are necessarily mapped as RWX.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5507

Marking the current version of the grsec kernel as the default
on Focal. We will have to update the version string when we releae
new kernel.

## Testing

**NOTE** If I manually install the freshly built `securedrop-grsec` metapackage on the vms, it behaves as it should. But, otherwise it installs the package from the apt repo (instead of the local one). Any tips? @conorsch @emkll ?

- [ ] `make build-debs-focal`
- [ ] `molecule converge -s libvirt-staging-focal`
- [ ] reboot both the vms
- [ ] login and check if both the vms are running `grsec` kernel
- [ ] `molecule destroy -s libvirt-staging-focal`
- [ ] `make build-debs`
- [ ] `molecule converge -s libvirt-staging-xenial`
- [ ] reboot both the vms
- [ ] login and check if both the vms are running `grsec` kernel


## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
