### PR TITLE
Fixes #5522 no typing module required on Focal

### DIFF
--- a/securedrop/requirements/python3/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.in
@@ -22,5 +22,5 @@ scrypt
 setuptools>=46.0.0
 sh
 SQLAlchemy>=1.3.0
-typing
+typing;python_version<"3.8"
 Werkzeug>=0.15.3

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.txt
@@ -208,7 +208,7 @@ six==1.11.0 \
     # via argon2-cffi, cryptography, python-dateutil, qrcode
 sqlalchemy==1.3.3 \
     --hash=sha256:91c54ca8345008fceaec987e10924bf07dcab36c442925357e5a467b36a38319
-typing==3.6.4 \
+typing==3.6.4 ; python_version < "3.8" \
     --hash=sha256:3a887b021a77b292e151afb75323dea88a7bc1b3dfa92176cff8e44c8b68bddf \
     --hash=sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8 \
     --hash=sha256:d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #5522 

We need the typing module only on Xenial, but not on Focal.

## Testing

- [x] CI is green
- [x] `make build-debs-focal && molecule converge -s libvirt-staging-focal`
- [x] login to the app-staging and check if any systemctl service is failing

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
