### PR TITLE
Testinfra fixes for dual distro

### DIFF
--- a/molecule/libvirt-staging-focal/molecule.yml
+++ b/molecule/libvirt-staging-focal/molecule.yml
@@ -67,7 +67,7 @@ verifier:
   name: testinfra
   lint:
     name: flake8
-  directory: ../testinfra/staging/
+  directory: ../testinfra/
   options:
     n: auto
     v: 2

--- a/molecule/testinfra/app-code/test_securedrop_app_code.py
+++ b/molecule/testinfra/app-code/test_securedrop_app_code.py
@@ -5,6 +5,7 @@ securedrop_test_vars = pytest.securedrop_test_vars
 testinfra_hosts = [securedrop_test_vars.app_hostname]
 python_version = securedrop_test_vars.python_version
 
+
 def test_apache_default_docroot_is_absent(host):
     """
     Ensure that the default docroot for Apache, containing static HTML

--- a/molecule/testinfra/app-code/test_securedrop_app_code.py
+++ b/molecule/testinfra/app-code/test_securedrop_app_code.py
@@ -3,7 +3,7 @@ import pytest
 
 securedrop_test_vars = pytest.securedrop_test_vars
 testinfra_hosts = [securedrop_test_vars.app_hostname]
-
+python_version = securedrop_test_vars.python_version
 
 def test_apache_default_docroot_is_absent(host):
     """
@@ -21,7 +21,7 @@ def test_apache_default_docroot_is_absent(host):
     'gnupg2',
     'haveged',
     'libapache2-mod-xsendfile',
-    'libpython3.5',
+    'libpython{}'.format(python_version),
     'paxctld',
     'python3',
     'redis-server',

--- a/molecule/testinfra/common/test_platform.py
+++ b/molecule/testinfra/common/test_platform.py
@@ -4,8 +4,8 @@ test_vars = pytest.securedrop_test_vars
 testinfra_hosts = [test_vars.app_hostname, test_vars.monitor_hostname]
 
 # We expect Ubuntu Xenial
-SUPPORTED_CODENAMES = ('xenial')
-SUPPORTED_RELEASES = ('16.04')
+SUPPORTED_CODENAMES = ('xenial', 'focal')
+SUPPORTED_RELEASES = ('16.04', '20.04')
 
 
 def test_ansible_version(host):
@@ -23,7 +23,7 @@ def test_ansible_version(host):
 
 def test_platform(host):
     """
-    SecureDrop requires Ubuntu Ubuntu 16.04 LTS.
+    SecureDrop requires Ubuntu Ubuntu 16.04 or 20.04 LTS
     """
     assert host.system_info.type == "linux"
     assert host.system_info.distribution == "ubuntu"

--- a/molecule/testinfra/common/test_release_upgrades.py
+++ b/molecule/testinfra/common/test_release_upgrades.py
@@ -13,6 +13,7 @@ def test_release_manager_upgrade_channel(host):
     """
     expected_channels = {
         "xenial": "never",
+        "focal": "never",
     }
 
     config_path = "/etc/update-manager/release-upgrades"

--- a/molecule/testinfra/conftest.py
+++ b/molecule/testinfra/conftest.py
@@ -10,7 +10,6 @@ import io
 import os
 import yaml
 
-
 # The config tests target staging by default. It's possible to override
 # for e.g. prod, but the associated vars files are not yet ported.
 target_host = os.environ.get('SECUREDROP_TESTINFRA_TARGET_HOST', 'staging')
@@ -27,6 +26,13 @@ def securedrop_import_testinfra_vars(hostname, with_header=False):
     filepath = os.path.join(os.path.dirname(__file__), "vars", hostname+".yml")
     with io.open(filepath, 'r') as f:
         hostvars = yaml.safe_load(f)
+
+    if os.environ.get("MOLECULE_SCENARIO_NAME").endswith("focal"):
+        hostvars['securedrop_venv_site_packages'] = hostvars["securedrop_venv_site_packages"].format("3.8")
+        hostvars['python_version'] = "3.8"
+    else:
+        hostvars['securedrop_venv_site_packages'] = hostvars["securedrop_venv_site_packages"].format("3.5")
+        hostvars['python_version'] = "3.5"
 
     if with_header:
         hostvars = dict(securedrop_test_vars=hostvars)

--- a/molecule/testinfra/conftest.py
+++ b/molecule/testinfra/conftest.py
@@ -28,10 +28,10 @@ def securedrop_import_testinfra_vars(hostname, with_header=False):
         hostvars = yaml.safe_load(f)
 
     if os.environ.get("MOLECULE_SCENARIO_NAME").endswith("focal"):
-        hostvars['securedrop_venv_site_packages'] = hostvars["securedrop_venv_site_packages"].format("3.8")
+        hostvars['securedrop_venv_site_packages'] = hostvars["securedrop_venv_site_packages"].format("3.8")  # noqa: E501
         hostvars['python_version'] = "3.8"
     else:
-        hostvars['securedrop_venv_site_packages'] = hostvars["securedrop_venv_site_packages"].format("3.5")
+        hostvars['securedrop_venv_site_packages'] = hostvars["securedrop_venv_site_packages"].format("3.5")  # noqa: E501
         hostvars['python_version'] = "3.5"
 
     if with_header:

--- a/molecule/testinfra/vars/app-staging.yml
+++ b/molecule/testinfra/vars/app-staging.yml
@@ -13,7 +13,7 @@ wanted_apache_headers:
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: /opt/venvs/securedrop-app-code/bin
-securedrop_venv_site_packages: /opt/venvs/securedrop-app-code/lib/python3.5/site-packages
+securedrop_venv_site_packages: /opt/venvs/securedrop-app-code/lib/python{}/site-packages
 securedrop_code: /var/www/securedrop
 securedrop_data: /var/lib/securedrop
 securedrop_user: www-data

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -13,7 +13,7 @@ wanted_apache_headers:
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: /opt/venvs/securedrop-app-code/bin
-securedrop_venv_site_packages: /opt/venvs/securedrop-app-code/lib/python3.5/site-packages
+securedrop_venv_site_packages: /opt/venvs/securedrop-app-code/lib/python{}/site-packages
 securedrop_code: /var/www/securedrop
 securedrop_data: /var/lib/securedrop
 securedrop_user: www-data


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #5509 
- Adds `focal` as distribution value for the `testinfra` tests.
- Uses dynamic Python version value in the `testinfra` tests

## Testing

- [ ] `molecule test -s libvirt-staging-focal` now should have only 6 test failures :)

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
