### PR TITLE
Increase timeout on OSSEC fetch tasks

### DIFF
--- a/install_files/ansible-base/roles/build-ossec-deb-pkg/tasks/main.yml
+++ b/install_files/ansible-base/roles/build-ossec-deb-pkg/tasks/main.yml
@@ -34,11 +34,13 @@
     url: "{{ ossec_tarball_url }}"
     dest: "{{ build_path }}/{{ ossec_tarball_filename }}"
     checksum: "{{ ossec_source_checksum }}"
+    timeout: "30"
 
 - name: Download OSSEC signature.
   get_url:
     url: "{{ ossec_signature_url }}"
     dest: "{{ build_path }}/{{ ossec_signature_filename }}"
+    timeout: "30"
 
 - name: Copy OSSEC archive GPG key.
   copy: src=../files/OSSEC-ARCHIVE-KEY.asc dest=/tmp/OSSEC-ARCHIVE-KEY.asc


### PR DESCRIPTION

## Status

Ready for review 

## Description of Changes

Fixes #5540 

Affects the build logic. We saw CI failures related to the timeout being
reached. Default timeout is only 10s, so let's bump that up to 30s in an
attempt to make the build process more durable.



## Testing
Is CI passing? If so, visual review is sufficient. 

## Deployment

Only affects build/CI environments, no direct implications for prod deploys.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
