### PR TITLE
Adds error handling for file deletion operations.

### DIFF
--- a/devops/scripts/shellcheck.sh
+++ b/devops/scripts/shellcheck.sh
@@ -4,7 +4,7 @@ set -e
 
 
 function run_native_or_in_docker () {
-    EXCLUDE_RULES="SC1091,SC2001,SC2064,SC2181,SC1117"
+    EXCLUDE_RULES="SC1090,SC1091,SC2001,SC2064,SC2181,SC1117"
     if [ "$(command -v shellcheck)" ]; then
         shellcheck -x --exclude="$EXCLUDE_RULES" "$1"
     else

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -244,10 +244,8 @@ def bulk_delete(
                        num=len(items_selected)),
                    len(items_selected)), "notification")
     if deletion_errors > 0:
-        flash(ngettext("An error occured during deletion - contact an administrator",
-                       "{num} errors occured during deletion - contact an administrator.".format(
-                           num=deletion_errors),
-                       deletion_errors), "error")
+        current_app.logger.error("Disconnected submission entries (%d) were detected",
+                                 deletion_errors)
     return redirect(url_for('col.col', filesystem_id=filesystem_id))
 
 


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

Fixes #4787 
Fixes #5543 (kindof a dupe of #4787 tbh tho against new shredder-enhanced code)

Changes proposed in this pull request:
- added exception handling around the delete_file_object function, to catch errors caused by missing files in instance storage
- disabled shellcheck for SC1090 errors, which were being triggered by a shell script outside of the SecureDrop codebase

## Testing

- run `make dev` or` make staging`
- on the Source interface, submit multiple messages (3+) as a source
- on the Journalist interface, reply to the source
- log into app server (if dev, with `docker exec -it securedrop-dev-0 bash`), and delete the reply file and the first  message (with filename `1-something-something-msg.gpg`) from the source's directory in `/var/lib/securedrop/store`
- in the Journalist interface, on the source's collection page, select the reply, the first message, and one other message, and click **Delete Selected** and then **Delete** in the modal:
  - [ ] Deletion completes with all selected submissions removed from the list
  - [ ] in staging, errors are logged in /var/log/apache2/journalist-error.log for both missing files
  - [ ] In staging, an error is logged listing the total  number of disconnected db enrties
- click **Delete Source and Submissions** and then **Delete** in the modal
  - the source collection is deleted and the source is no longer listed in the `all sources` page
  - the source directory no longer exists in `/var/lib/securedrop/store`

## Deployment


## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
