### PR TITLE
Remove Redis database file created in dev/test containers

### DIFF
--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -19,6 +19,7 @@ function run_xvfb() {
 }
 
 function run_redis() {
+    rm -f "${REPOROOT}/securedrop/dump.rdb"
     setsid redis-server >& /tmp/redis.out || cat /tmp/redis.out
 }
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The `securedrop/dump.rdb` file, which could be created when Redis was run long enough in a container, was never being removed, and format differences between the versions of Redis used in different supported Ubuntu releases could result in the file being unreadable by an earlier release, causing errors.

Fixes #5557.

## Testing

- `rm -f securedrop/dump.rdb`
- Run `make dev-focal` or `make test-focal` until `securedrop/dump.rdb` exists.
- Run `make dev`. You should get the error described in #5557.
- `git checkout -b clean-dev-redis-db origin/clean-dev-redis-db`
- Run `make dev`. There should be no error.

## Deployment

This only affects dev/test environments.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
