### PR TITLE
5433 replace platform.linux distribution

### DIFF
--- a/securedrop/source_app/api.py
+++ b/securedrop/source_app/api.py
@@ -8,7 +8,7 @@ import version
 
 
 with open("/etc/lsb-release", "r") as f:
-    server_os = f.readlines()[1].split("=")[1]
+    server_os = f.readlines()[1].split("=")[1].strip("\n")
 
 
 def make_blueprint(config):

--- a/securedrop/source_app/api.py
+++ b/securedrop/source_app/api.py
@@ -1,11 +1,14 @@
 import json
-import platform
 
 from flask import Blueprint, current_app, make_response
 
 from source_app.utils import get_sourcev2_url, get_sourcev3_url
 
 import version
+
+
+with open("/etc/lsb-release", "r") as f:
+    server_os = f.readlines()[1].split("=")[1]
 
 
 def make_blueprint(config):
@@ -17,7 +20,7 @@ def make_blueprint(config):
             'allow_document_uploads': current_app.instance_config.allow_document_uploads,
             'gpg_fpr': config.JOURNALIST_KEY,
             'sd_version': version.__version__,
-            'server_os': platform.linux_distribution()[1],
+            'server_os': server_os,
             'supported_languages': config.SUPPORTED_LOCALES,
             'v2_source_url': get_sourcev2_url(),
             'v3_source_url': get_sourcev3_url()

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -583,8 +583,7 @@ def test_why_journalist_key(source_app):
 
 
 def test_metadata_route(config, source_app):
-    with patch.object(source_app_api.platform, "linux_distribution") as mocked_platform:
-        mocked_platform.return_value = ("Ubuntu", "16.04", "xenial")
+    with patch.object(source_app_api, "server_os", new="16.04"):
         with source_app.test_client() as app:
             resp = app.get(url_for('api.metadata'))
             assert resp.status_code == 200


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #5433 

Changes proposed in this pull request:

- Replace the deprecated `platform.linux_distribution` function by reading the os version directly from `/etc/lsb-release`.
- Update mock in `tests/test_source.py::test_metadata_route` to reflect new server_os variable.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

1. Run tests with `make tests`. The `server_os` value returned by the `/metadata` endpoint is verified in `tests/functional/test_source_metadata.py::TestInstanceMetadata::test_instance_metadata`.
1. Run `make dev` and verify the `server_os` parameter on `/metadata` equals "16.04".
1. Test in "focal" staging environment.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container
N/A.

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
N/A.

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR
N/A. Already covered by functional test.

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally
N/A.

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
N/A.
