### PR TITLE
Adds upgrade boxes for SecureDrop 1.6.0

### DIFF
--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -166,6 +166,17 @@
         }
       ],
       "version": "1.5.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "b7208208febdaca0682afe60fac0709cf284c643dc9c5459a729e1df5584ec38",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_1.6.0.box"
+        }
+      ],
+      "version": "1.6.0"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -166,6 +166,17 @@
         }
       ],
       "version": "1.5.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "e003896cc3b53fafa7f43a60b78cfac0a3a9587bc7ae0d5e581d3e0dbb479c03",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_1.6.0.box"
+        }
+      ],
+      "version": "1.6.0"
     }
   ]
 }


### PR DESCRIPTION
## Status

Ready for review

## Description
Closes #5501 , adds upgrade boxes for SecureDrop 1.6.0

## Testing

- Check out this branch
- `make build-debs`
- `make upgrade-start` (will take a while as it needs to fetch the boxes)
- [ ] source interface shows SecureDrop version 1.6.0
- [ ] `make upgrade-test-local` completes without error
- [ ] source interface shows SecureDrop version 1.7.0~rc1

## Deployment

Dev only