### PR TITLE
Handle FileNotFoundError on download of messages

### DIFF
--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -95,13 +95,16 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         if '..' in fn or fn.startswith('/'):
             abort(404)
 
-        file_ = current_app.storage.path(filesystem_id, fn)
-        if not Path(file_).is_file():
+        file = current_app.storage.path(filesystem_id, fn)
+        if not Path(file).is_file():
             flash(
-                gettext("An unexpected error occurred! Please inform your admin."),
+                gettext(
+                    "An error occured: file not found. "
+                    + "An admin can find more information in the system logs."
+                ),
                 "error"
             )
-            current_app.logger.error("File {} could not be found.".format(file_))
+            current_app.logger.error("File {} not found".format(file))
             return redirect(url_for("col.col", filesystem_id=filesystem_id))
 
         # mark as seen by the current user

--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+
 from flask import (
     Blueprint,
     abort,
@@ -92,6 +94,15 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         """
         if '..' in fn or fn.startswith('/'):
             abort(404)
+
+        file_ = current_app.storage.path(filesystem_id, fn)
+        if not Path(file_).is_file():
+            flash(
+                gettext("An unexpected error occurred! Please inform your admin."),
+                "error"
+            )
+            current_app.logger.error("File {} could not be found.".format(file_))
+            return redirect(url_for("col.col", filesystem_id=filesystem_id))
 
         # mark as seen by the current user
         try:

--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -99,8 +99,8 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         if not Path(file).is_file():
             flash(
                 gettext(
-                    "An error occured: file not found. "
-                    + "An admin can find more information in the system logs."
+                    "Your download failed because a file could not be found. An admin can find "
+                    + "more information in the system and monitoring logs."
                 ),
                 "error"
             )

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -207,8 +207,8 @@ def download(zip_basename: str, submissions: List[Union[Submission, Reply]]) -> 
     except FileNotFoundError:
         flash(
             gettext(
-                "An error occured: file not found. "
-                + "An admin can find more information in the system logs."
+                "Your download failed because a file could not be found. An admin can find "
+                + "more information in the system and monitoring logs."
             ),
             "error"
         )

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -191,7 +191,7 @@ def mark_seen(targets: List[Union[Submission, Reply]], user: Journalist) -> None
             raise
 
 
-def download(zip_basename: str, submissions: List[Union[Submission, Reply]]) -> flask.Response:
+def download(zip_basename: str, submissions: List[Union[Submission, Reply]]) -> werkzeug.Response:
     """Send client contents of ZIP-file *zip_basename*-<timestamp>.zip
     containing *submissions*. The ZIP-file, being a
     :class:`tempfile.NamedTemporaryFile`, is stored on disk only

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -212,7 +212,7 @@ def download(zip_basename: str, submissions: List[Union[Submission, Reply]]) -> 
 
         current_app.logger.error("File {} could not be found.".format(e.filename))
 
-        referrer = urlparse(request.referrer).path
+        referrer = urlparse(str(request.referrer)).path
         return redirect(referrer)
 
     attachment_filename = "{}--{}.zip".format(

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -204,14 +204,14 @@ def download(zip_basename: str, submissions: List[Union[Submission, Reply]]) -> 
     """
     try:
         zf = current_app.storage.get_bulk_archive(submissions, zip_directory=zip_basename)
-    except FileNotFoundError as e:
+    except FileNotFoundError:
         flash(
-            gettext("An unexpected error occurred! Please inform your admin."),
+            gettext(
+                "An error occured: file not found. "
+                + "An admin can find more information in the system logs."
+            ),
             "error"
         )
-
-        current_app.logger.error("File {} could not be found.".format(e.filename))
-
         referrer = urlparse(str(request.referrer)).path
         return redirect(referrer)
 

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -1114,8 +1114,8 @@ class JournalistNavigationStepsMixin:
 
         if self.accept_languages is None:
             expected_text = (
-                "An error occured: file not found. "
-                + "An admin can find more information in the system logs."
+                "Your download failed because a file could not be found. An admin can find "
+                + "more information in the system and monitoring logs."
             )
             assert expected_text == notification.text
 

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -753,6 +753,17 @@ class JournalistNavigationStepsMixin:
 
         assert self.secret_message == submission
 
+    def _journalist_downloads_message_missing_file(self):
+        self._journalist_selects_the_first_source()
+
+        self.wait_for(lambda: self.driver.find_element_by_css_selector("ul#submissions"))
+
+        submissions = self.driver.find_elements_by_css_selector("#submissions a")
+        assert 1 == len(submissions)
+
+        file_link = submissions[0]
+        file_link.click()
+
     def _journalist_composes_reply(self):
         reply_text = (
             "Thanks for the documents. Can you submit more " "information about the main program?"
@@ -1097,3 +1108,39 @@ class JournalistNavigationStepsMixin:
         for checkbox in checkboxes:
             classes = checkbox.get_attribute("class")
             assert "unread-cb" in classes
+
+    def _journalist_sees_unexpected_error_message(self):
+        notification = self.driver.find_element_by_css_selector(".error")
+
+        if not hasattr(self, "accept_languages"):
+            expected_text = "An unexpected error occurred! Please inform your admin."
+            assert expected_text in notification.text
+
+    def _journalist_is_on_collection_page(self):
+        return self.wait_for(
+            lambda: self.driver.find_element_by_css_selector("div.journalist-view-single")
+        )
+
+    def _journalist_clicks_source_unread(self):
+        self.driver.find_element_by_css_selector("span.unread a").click()
+
+    def _journalist_selects_first_source_then_download_all(self):
+        checkboxes = self.driver.find_elements_by_name("cols_selected")
+        assert len(checkboxes) == 1
+        checkboxes[0].click()
+
+        self.driver.find_element_by_xpath("//button[@value='download-all']").click()
+
+    def _journalist_selects_first_source_then_download_unread(self):
+        checkboxes = self.driver.find_elements_by_name("cols_selected")
+        assert len(checkboxes) == 1
+        checkboxes[0].click()
+
+        self.driver.find_element_by_xpath("//button[@value='download-unread']").click()
+
+    def _journalist_selects_message_then_download_selected(self):
+        checkboxes = self.driver.find_elements_by_name("doc_names_selected")
+        assert len(checkboxes) == 1
+        checkboxes[0].click()
+
+        self.driver.find_element_by_xpath("//button[@value='download']").click()

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -1109,12 +1109,15 @@ class JournalistNavigationStepsMixin:
             classes = checkbox.get_attribute("class")
             assert "unread-cb" in classes
 
-    def _journalist_sees_unexpected_error_message(self):
+    def _journalist_sees_missing_file_error_message(self):
         notification = self.driver.find_element_by_css_selector(".error")
 
-        if not hasattr(self, "accept_languages"):
-            expected_text = "An unexpected error occurred! Please inform your admin."
-            assert expected_text in notification.text
+        if self.accept_languages is None:
+            expected_text = (
+                "An error occured: file not found. "
+                + "An admin can find more information in the system logs."
+            )
+            assert expected_text == notification.text
 
     def _journalist_is_on_collection_page(self):
         return self.wait_for(

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -116,7 +116,7 @@ class TestJournalistMissingFile(
         journalist home page."""
         self._journalist_logs_in()
         self._journalist_clicks_source_unread()
-        self._journalist_sees_unexpected_error_message()
+        self._journalist_sees_missing_file_error_message()
         self._is_on_journalist_homepage()
 
     def test_select_source_and_download_all(self, missing_msg_file):
@@ -124,7 +124,7 @@ class TestJournalistMissingFile(
         from the journalist home page."""
         self._journalist_logs_in()
         self._journalist_selects_first_source_then_download_all()
-        self._journalist_sees_unexpected_error_message()
+        self._journalist_sees_missing_file_error_message()
         self._is_on_journalist_homepage()
 
     def test_select_source_and_download_unread(self, missing_msg_file):
@@ -132,7 +132,7 @@ class TestJournalistMissingFile(
         button from the journalist home page."""
         self._journalist_logs_in()
         self._journalist_selects_first_source_then_download_unread()
-        self._journalist_sees_unexpected_error_message()
+        self._journalist_sees_missing_file_error_message()
         self._is_on_journalist_homepage()
 
     def test_download_message(self, missing_msg_file):
@@ -141,7 +141,7 @@ class TestJournalistMissingFile(
         self._journalist_logs_in()
         self._journalist_checks_messages()
         self._journalist_downloads_message_missing_file()
-        self._journalist_sees_unexpected_error_message()
+        self._journalist_sees_missing_file_error_message()
         self._journalist_is_on_collection_page()
 
     def test_select_message_and_download_selected(self, missing_msg_file):
@@ -150,5 +150,5 @@ class TestJournalistMissingFile(
         self._journalist_logs_in()
         self._journalist_selects_the_first_source()
         self._journalist_selects_message_then_download_selected()
-        self._journalist_sees_unexpected_error_message()
+        self._journalist_sees_missing_file_error_message()
         self._journalist_is_on_collection_page()


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #4787 

Changes proposed in this pull request:

Handle the `FileNotFoundError` on download of message in the JI where the corresponding file is missing on the filesystem.
- Display a flash message to the journalist.
- Add a log entry reporting the error.
- Redirect to the page from which the download was attempted.

Also added functional test for flash message and redirect and tests for logging of the error.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

**Setup**

1. Run `make dev`.
1. Log in the Source Interface and submit two messages.
1. Log in the app server Docker container with `docker exec -it securedrop-dev-0 bash` and delete the first message (filename `1-something_something-msg.gpg`) from the source's directory in `/var/lib/securedrop/store`.

**Scenario 1 - Download via "n unread" button on `/`**
1. Log in the Journalist Interface.
1. Click the "2 unread" button of the first source.
    - [ ] Verify that a flash error message is displayed
    - [ ] Verify that the page remains unchanged (journalist homepage)
    - [ ] Verify that the source's number of unread message is unchanged (2)

**Scenario 2 - Download via "Download Unread" button on `/`**
1. Log in the Journalist Interface.
1. Check the first source's checkbox.
1. Click the "Download Unread" button.
    - [ ] Verify that a flash error message is displayed
    - [ ] Verify that the page remains unchanged (journalist homepage)
    - [ ] Verify that the source's number of unread message is unchanged (2)

**Scenario 3 - Download via "Download" button on `/`**
1. Log in the Journalist Interface.
1. Check the first source's checkbox.
1. Click the "Download" button.
    - [ ] Verify that a flash error message is displayed
    - [ ] Verify that the page remains unchanged (journalist homepage)
    - [ ] Verify that the source's number of unread message is unchanged (2)

**Scenario 4 - Download via "Download Selected" button on `/col/<filesystem_id>`**
1. Log in the Journalist Interface.
1. Click the first source's code name.
1. Click the "Select All" button
1. Click the "Download Selected" button.
    - [ ] Verify that a flash error message is displayed
    - [ ] Verify that the page remains unchanged (source collection page)
    - [ ] Verify that the first message remains unread

**Scenario 5 - Direct message download from `/col/<filesystem_id>`**
1. Log in the Journalist Interface.
1. Click the first source's code name.
1. Click first message.
    - [ ] Verify that a flash error message is displayed
    - [ ] Verify that the page remains unchanged (source collection page)
    - [ ] Verify that the first message remains unread

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
Test plan above + added unit/functional tests.

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
