### PR TITLE
Modify journalist 2fa TOTP secret style

### DIFF
--- a/securedrop/sass/modules/_shared-secret.sass
+++ b/securedrop/sass/modules/_shared-secret.sass
@@ -1,6 +1,8 @@
 =shared-secret
   span#shared-secret
-    background-color: #FFFD9E
+    background-color: $color_grey_light
     color: #555
-    padding: 4px
-    border: 1px solid $color_grey_medium
+    padding: 8px 16px
+    font-family: monospace
+    font-size: 1.15em
+    font-weight: bold


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #1598 

Changes proposed in this pull request:

Change styling of journalist 2FA TOTP secret text:
- Change background color to light grey
- Remove border
- Increase lateral and vertical padding
- Use monospace font
- Increase font size
- Use bold font weight

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

1. Run `make dev`.
1. In journalist interface, create a new user.
1. On the `/admin/2fa` page, check the style of the TOTP secret text. The expected style is shown in the screenshot below.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

### If you made changes to documentation:

- [ ] Doc linting (`make docs-lint`) passed locally

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
