### PR TITLE
Fix Focal source key deletion

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -267,7 +267,7 @@ class CryptoUtil:
 
         # Always delete keys without invoking pinentry-mode = loopback
         # see: https://lists.gnupg.org/pipermail/gnupg-users/2016-May/055965.html
-        temp_gpg = gnupg.GPG(binary='gpg2', homedir=self.gpg_key_dir)
+        temp_gpg = gnupg.GPG(binary='gpg2', homedir=self.gpg_key_dir, options=["--yes"])
 
         # The subkeys keyword argument deletes both secret and public keys.
         temp_gpg.delete_keys(fingerprint, secret=True, subkeys=True)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5579.

Adds `--yes` to gnupg options when deleting source keypairs.

This is the smallest fix, but I also experimented with adding `--yes` to the [options of `CryptoUtil.gpg`](https://github.com/freedomofpress/securedrop/blob/6807447f7451f2aa192bffa5654377ec4302687a/securedrop/crypto_util.py#L115) and dispensing with the [special `GPG` instance](https://github.com/freedomofpress/securedrop/blob/6807447f7451f2aa192bffa5654377ec4302687a/securedrop/crypto_util.py#L270) used in `delete_keys`, and that works too -- on Focal. On Xenial, with gpg 2.1.11, `--pinentry-mode loopback` still breaks key deletion.

I read through the [mailing list thread](https://lists.gnupg.org/pipermail/gnupg-users/2016-May/055965.html) linked in the [comment](https://github.com/freedomofpress/securedrop/blob/6807447f7451f2aa192bffa5654377ec4302687a/securedrop/crypto_util.py#L268) in `delete_keys` and I'm not sure it's still relevant as of gpg 2.2.19, which is what we have on Focal.

So when we drop Xenial, we should be able to drop the extra GPG object too.

## Testing

Follow STR from #5579. The source keys should be deleted.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
