### PR TITLE
Fix session expiry message

### DIFF
--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -124,7 +124,8 @@ def create_app(config: SDConfig) -> Flask:
         if 'expires' in session and datetime.utcnow() >= session['expires']:
             msg = render_template('session_timeout.html')
 
-            # Show expiration message only if the user was in the codename generation flow or was logged in
+            # Show expiration message only if the user was
+            # either in the codename generation flow or logged in
             show_expiration_message = any([
                 session.get('show_expiration_message'),
                 logged_in(),
@@ -134,7 +135,7 @@ def create_app(config: SDConfig) -> Flask:
             # clear the session after we render the message so it's localized
             session.clear()
 
-            # Persist this properety across sessions to distinguish users whose sessions actually expired
+            # Persist this properety across sessions to distinguish users whose sessions expired
             # from users who never logged in or generated a codename
             session['show_expiration_message'] = show_expiration_message
 

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -121,7 +121,7 @@ def create_app(config: SDConfig) -> Flask:
     def setup_g() -> Optional[werkzeug.Response]:
         """Store commonly used values in Flask's special g object"""
 
-        if 'expires' in session and datetime.utcnow() >= session['expires']:
+        if 'expires' in session and datetime.utcnow() >= session['expires'] and logged_in():
             msg = render_template('session_timeout.html')
 
             # clear the session after we render the message so it's localized

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -257,7 +257,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                 current_app.logger.info("generating key, entropy: {}".format(
                     entropy_avail))
             else:
-                current_app.logger.warn(
+                current_app.logger.warning(
                         "skipping key generation. entropy: {}".format(
                                 entropy_avail))
 

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -20,8 +20,10 @@ from sdconfig import SDConfig
 if typing.TYPE_CHECKING:
     from typing import Optional  # noqa: F401
 
+
 def was_in_generate_flow() -> bool:
     return 'codenames' in session
+
 
 def logged_in() -> bool:
     return 'logged_in' in session

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -20,6 +20,8 @@ from sdconfig import SDConfig
 if typing.TYPE_CHECKING:
     from typing import Optional  # noqa: F401
 
+def was_in_generate_flow() -> bool:
+    return 'codenames' in session
 
 def logged_in() -> bool:
     return 'logged_in' in session

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -758,6 +758,24 @@ def test_source_session_expiration_create(config, source_app):
         assert 'You were logged out due to inactivity' in text
 
 
+def test_source_no_session_expiration_message_when_not_logged_in(config, source_app):
+    """If sources never logged in, no message should be displayed
+    after SESSION_EXPIRATION_MINUTES."""
+
+    with source_app.test_client() as app:
+        seconds_session_expire = 1
+        config.SESSION_EXPIRATION_MINUTES = seconds_session_expire / 60.
+
+        resp = app.get(url_for('main.index'))
+        assert resp.status_code == 200
+
+        time.sleep(seconds_session_expire + 1)
+
+        refreshed_resp = app.get(url_for('main.index'), follow_redirects=True)
+        text = refreshed_resp.data.decode('utf-8')
+        assert 'You were logged out due to inactivity' not in text
+
+
 def test_csrf_error_page(config, source_app):
     source_app.config['WTF_CSRF_ENABLED'] = True
     with source_app.test_client() as app:

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -727,6 +727,8 @@ def test_source_session_expiration(config, source_app):
         # which is always present and 'csrf_token' which leaks no info)
         session.pop('expires', None)
         session.pop('csrf_token', None)
+        session.pop('generate_flow_record', None)
+        session.pop('login_record', None)
         assert not session
 
         text = resp.data.decode('utf-8')
@@ -752,6 +754,8 @@ def test_source_session_expiration_create(config, source_app):
         # which is always present and 'csrf_token' which leaks no info)
         session.pop('expires', None)
         session.pop('csrf_token', None)
+        session.pop('generate_flow_record', None)
+        session.pop('login_record', None)
         assert not session
 
         text = resp.data.decode('utf-8')

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -727,8 +727,7 @@ def test_source_session_expiration(config, source_app):
         # which is always present and 'csrf_token' which leaks no info)
         session.pop('expires', None)
         session.pop('csrf_token', None)
-        session.pop('generate_flow_record', None)
-        session.pop('login_record', None)
+        session.pop('show_expiration_message', None)
         assert not session
 
         text = resp.data.decode('utf-8')
@@ -754,8 +753,7 @@ def test_source_session_expiration_create(config, source_app):
         # which is always present and 'csrf_token' which leaks no info)
         session.pop('expires', None)
         session.pop('csrf_token', None)
-        session.pop('generate_flow_record', None)
-        session.pop('login_record', None)
+        session.pop('show_expiration_message', None)
         assert not session
 
         text = resp.data.decode('utf-8')


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

Fixes #5197 

- Use two new properties (generate_flow_record and login_record) to distinguish users who have logged in before or those who have gone through the codename generation flow.

## Testing

- Added a test to check session timeout messages aren't displayed after `SESSION_EXPIRATION_MINUTES`.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR