### PR TITLE
Remove libvirt-share target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,13 +194,6 @@ testinfra:  ## Run infra tests against a local staging environment.
 	@MOLECULE_ACTION=verify $(SDROOT)/devops/scripts/create-staging-env
 	@echo
 
-.PHONY: libvirt-share
-libvirt-share:  ## Configure ACLs to allow RWX for libvirt VM (e.g. Admin Workstation).
-	@echo "███ Configuring ACLs for admin workstation..."
-	@find "$(SDROOT)" -type d -and -user $$USER -exec setfacl -m u:libvirt-qemu:rwx {} +
-	@find "$(SDROOT)" -type f -and -user $$USER -exec setfacl -m u:libvirt-qemu:rw {} +
-	@echo
-
 .PHONY: self-signed-https-certs
 self-signed-https-certs:  ## Generate self-signed certs for testing the HTTPS config.
 	@echo "███ Generating self-signed HTTPS certs for testing..."


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Removed Makefile target `libvirt-share` used for mounting host folder in a Tails VM. We're not using it in practice and are removing it from the docs (https://github.com/freedomofpress/securedrop-docs/pull/33). Marking as draft until docs PR is merged, but can be reviewed/approved in draft state.