### PR TITLE
Restore lost `SDConfig.env` attribute

### DIFF
--- a/securedrop/sdconfig.py
+++ b/securedrop/sdconfig.py
@@ -53,7 +53,8 @@ class SDConfig:
 
         self.WORKER_PIDFILE = _config.WORKER_PIDFILE  # type: str
 
-        if _config.env == 'test':
+        self.env = getattr(_config, 'env', 'prod')  # type: str
+        if self.env == 'test':
             self.RQ_WORKER_NAME = 'test'  # type: str
         else:
             self.RQ_WORKER_NAME = 'default'


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5594.

## Testing

- `git checkout -b 5594-fix-lost-sdconfig-env origin/5594-fix-lost-sdconfig-env`
- Run `make dev`
- Change `securedrop/journalist_app/main.py` to trigger a reload, and confirm that the change is detected.

## Deployment

This is simply restoring old logic lost in the refactoring for #5532; it should not change production configurations.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
