### PR TITLE
Fix test_rm failure on Focal

### DIFF
--- a/securedrop/tests/test_rm.py
+++ b/securedrop/tests/test_rm.py
@@ -13,7 +13,7 @@ def test_secure_delete_capability(config):
 
     path = os.environ["PATH"]
     try:
-        os.environ["PATH"] = "{}:{}".format("/bin", config.TEMP_DIR)
+        os.environ["PATH"] = "{}:{}".format("/sbin", config.TEMP_DIR)
         assert rm.check_secure_delete_capability() is False
         fakeshred = os.path.join(config.TEMP_DIR, "shred")
         with open(fakeshred, "w") as f:


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #5601 

On Focal `/bin/shred` exists, that was reason for the failure. `/sbin`
does not contain the `shred` executable in both Xenial and Focal.

## Testing

- [ ] CI should be green
- [ ] To test on focal, first create a local dummy branch from `dev_focal` and rebase on top of #5585 
- [ ] `git rebase -i updates_pytest_pluggy_testinfra_molecule_and_the_universe`
- [ ] `BASE_OS=focal securedrop/bin/dev-shell bin/run-test -s -v tests/test_rm.py`

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
