### PR TITLE
Server OS can be 16.04 or 20.04

### DIFF
--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -29,7 +29,7 @@ class SourceNavigationStepsMixin:
     def _source_checks_instance_metadata(self):
         self.driver.get(self.source_location + "/metadata")
         j = json.loads(self.driver.find_element_by_tag_name("body").text)
-        assert j["server_os"] == "16.04"
+        assert j["server_os"] in ["16.04", "20.04"]
         assert j["sd_version"] == self.source_app.jinja_env.globals["version"]
         assert j["gpg_fpr"] != ""
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5603 

The Server OS version can be either 16.04 or 20.04

## Testing

- [ ] CI should be green
- [ ] To test on focal, first create a local dummy branch from `dev_focal` and rebase on top of #5585 
- [ ] `git rebase -i updates_pytest_pluggy_testinfra_molecule_and_the_universe`
- [ ] `BASE_OS=focal securedrop/bin/dev-shell bin/run-test -s -v tests/functional/source_navigation_steps.py`

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
