### PR TITLE
Fixes #5605 alembic migration errors on Focal

### DIFF
--- a/securedrop/alembic/versions/2d0ce3ee5bdc_added_passphrase_hash_column_to_.py
+++ b/securedrop/alembic/versions/2d0ce3ee5bdc_added_passphrase_hash_column_to_.py
@@ -23,7 +23,8 @@ def upgrade():
 def downgrade():
     # sqlite has no `drop column` command, so we recreate the original table
     # then load it from a temp table
-
+    conn = op.get_bind()
+    conn.execute("PRAGMA legacy_alter_table=ON")
     op.rename_table("journalists", "journalists_tmp")
 
     op.create_table(
@@ -43,7 +44,6 @@ def downgrade():
         sa.UniqueConstraint("username"),
     )
 
-    conn = op.get_bind()
     conn.execute(
         """
         INSERT INTO journalists

--- a/securedrop/alembic/versions/3d91d6948753_create_source_uuid_column.py
+++ b/securedrop/alembic/versions/3d91d6948753_create_source_uuid_column.py
@@ -18,6 +18,8 @@ depends_on = None
 
 
 def upgrade():
+    conn = op.get_bind()
+    conn.execute("PRAGMA legacy_alter_table=ON")
     # Schema migration
     op.rename_table("sources", "sources_tmp")
 
@@ -25,7 +27,6 @@ def upgrade():
     op.add_column("sources_tmp", sa.Column("uuid", sa.String(length=36)))
 
     # Add UUIDs to sources_tmp table.
-    conn = op.get_bind()
     sources = conn.execute(sa.text("SELECT * FROM sources_tmp")).fetchall()
 
     for source in sources:

--- a/securedrop/alembic/versions/60f41bb14d98_add_session_nonce_to_journalist.py
+++ b/securedrop/alembic/versions/60f41bb14d98_add_session_nonce_to_journalist.py
@@ -17,6 +17,8 @@ depends_on = None
 
 
 def upgrade():
+    conn = op.get_bind()
+    conn.execute("PRAGMA legacy_alter_table=ON")
     # Save existing journalist table.
     op.rename_table('journalists', 'journalists_tmp')
 
@@ -24,7 +26,6 @@ def upgrade():
     op.add_column('journalists_tmp', sa.Column('session_nonce', sa.Integer()))
 
     # Populate nonce column.
-    conn = op.get_bind()
     journalists = conn.execute(
         sa.text("SELECT * FROM journalists_tmp")).fetchall()
 
@@ -57,7 +58,6 @@ def upgrade():
         sa.UniqueConstraint('uuid')
     )
 
-    conn = op.get_bind()
     conn.execute('''
         INSERT INTO journalists
         SELECT id, uuid, username, first_name, last_name, pw_salt, pw_hash,

--- a/securedrop/alembic/versions/6db892e17271_add_reply_uuid.py
+++ b/securedrop/alembic/versions/6db892e17271_add_reply_uuid.py
@@ -18,6 +18,8 @@ depends_on = None
 
 
 def upgrade():
+    conn = op.get_bind()
+    conn.execute("PRAGMA legacy_alter_table=ON")
     # Schema migration
     op.rename_table("replies", "replies_tmp")
 
@@ -25,7 +27,6 @@ def upgrade():
     op.add_column("replies_tmp", sa.Column("uuid", sa.String(length=36)))
 
     # Populate new column in replies_tmp table.
-    conn = op.get_bind()
     replies = conn.execute(sa.text("SELECT * FROM replies_tmp")).fetchall()
 
     for reply in replies:

--- a/securedrop/alembic/versions/e0a525cbab83_add_column_to_track_source_deletion_of_.py
+++ b/securedrop/alembic/versions/e0a525cbab83_add_column_to_track_source_deletion_of_.py
@@ -17,6 +17,8 @@ depends_on = None
 
 
 def upgrade():
+    conn = op.get_bind()
+    conn.execute("PRAGMA legacy_alter_table=ON")
     # Schema migration
     op.rename_table("replies", "replies_tmp")
 
@@ -24,7 +26,6 @@ def upgrade():
     op.add_column("replies_tmp", sa.Column("deleted_by_source", sa.Boolean()))
 
     # Populate deleted_by_source column in replies_tmp table.
-    conn = op.get_bind()
     replies = conn.execute(sa.text("SELECT * FROM replies_tmp")).fetchall()
 
     for reply in replies:

--- a/securedrop/alembic/versions/f2833ac34bb6_add_uuid_column_for_users_table.py
+++ b/securedrop/alembic/versions/f2833ac34bb6_add_uuid_column_for_users_table.py
@@ -18,6 +18,8 @@ depends_on = None
 
 
 def upgrade():
+    conn = op.get_bind()
+    conn.execute("PRAGMA legacy_alter_table=ON")
     # Save existing journalist table.
     op.rename_table("journalists", "journalists_tmp")
 
@@ -25,7 +27,6 @@ def upgrade():
     op.add_column("journalists_tmp", sa.Column("uuid", sa.String(length=36)))
 
     # Add UUIDs to journalists_tmp table.
-    conn = op.get_bind()
     journalists = conn.execute(sa.text("SELECT * FROM journalists_tmp")).fetchall()
 
     for journalist in journalists:
@@ -57,7 +58,6 @@ def upgrade():
         sa.UniqueConstraint("uuid"),
     )
 
-    conn = op.get_bind()
     conn.execute(
         """
         INSERT INTO journalists

--- a/securedrop/alembic/versions/fccf57ceef02_create_submission_uuid_column.py
+++ b/securedrop/alembic/versions/fccf57ceef02_create_submission_uuid_column.py
@@ -18,6 +18,8 @@ depends_on = None
 
 
 def upgrade():
+    conn = op.get_bind()
+    conn.execute("PRAGMA legacy_alter_table=ON")
     # Schema migration
     op.rename_table("submissions", "submissions_tmp")
 
@@ -25,7 +27,6 @@ def upgrade():
     op.add_column("submissions_tmp", sa.Column("uuid", sa.String(length=36)))
 
     # Add UUIDs to submissions_tmp table.
-    conn = op.get_bind()
     submissions = conn.execute(sa.text("SELECT * FROM submissions_tmp")).fetchall()
 
     for submission in submissions:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5605

Due to SQLite3 upgrade in Focal, our previous migration scripts
were failing.

From SQLite website https://sqlite.org/lang_altertable.html:

``` Compatibility Note: The behavior of ALTER TABLE when renaming a table was
enhanced in versions 3.25.0 (2018-09-15) and 3.26.0 (2018-12-01) in order to
carry the rename operation forward into triggers and views that reference the
renamed table. This is considered an improvement. Applications that depend on
the older (and arguably buggy) behavior can use the PRAGMA legacy_alter_table=ON
statement or the SQLITE_DBCONFIG_LEGACY_ALTER_TABLE configuration parameter on
sqlite3_db_config() interface to make ALTER TABLE RENAME behave as it did prior
to version 3.25.0.
```

As @rmol [suggestied](https://github.com/freedomofpress/securedrop/issues/5605#issuecomment-719059509), this PR is only using the `PRAGMA` calls where we are doing `rename_table` operations. 

## Testing

- [ ] `make test` should pass all tests
- [ ] `make test-focal` (after rebasing) on the `dev_focal` branch should not have any `Alembic` test failures
- [ ] CI should be green 

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
