### PR TITLE
Fix test_rm.py::test_secure_delete_capability

### DIFF
--- a/securedrop/tests/test_rm.py
+++ b/securedrop/tests/test_rm.py
@@ -13,11 +13,11 @@ def test_secure_delete_capability(config):
 
     path = os.environ["PATH"]
     try:
-        os.environ["PATH"] = "{}:{}".format("/sbin", config.TEMP_DIR)
+        os.environ["PATH"] = "{}".format(config.TEMP_DIR)
         assert rm.check_secure_delete_capability() is False
         fakeshred = os.path.join(config.TEMP_DIR, "shred")
         with open(fakeshred, "w") as f:
-            f.write("#!/bin/bash\nexit1\n")
+            f.write("#!/bin/bash\nexit 1\n")
         os.chmod(fakeshred, 0o700)
         assert rm.check_secure_delete_capability() is False
     finally:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

When testing what happens when the `shred` command is not found, the `PATH` environment variable shouldn't contain any location where it could ever exist, as just happened in the upgrade from Xenial to Focal. The test script also had a typo.

## Testing

CI should be green.

## Deployment

Test only.

## Checklist

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation