### PR TITLE
Monkey-patch pretty-bad-protocol to work with Focal gnupg

### DIFF
--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -23,6 +23,9 @@ import rm
 
 from models import Source
 
+# monkey patch to work with Focal gnupg.
+# https://github.com/isislovecruft/python-gnupg/issues/250
+gnupg._parsers.Verify.TRUST_LEVELS["DECRYPTION_COMPLIANCE_MODE"] = 23
 
 # to fix GPG error #78 on production
 os.environ['USERNAME'] = 'www-data'


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5592.

To work with recent gnupg, the pretty-bad-protocol package needs an update it seems unlikely to get, so we're gonna monkey-patch it until we can find a viable replacement.

https://github.com/isislovecruft/python-gnupg/issues/250

## Testing

- [ ] CI should be green.
- [ ] `make test-focal` should pass.
- [ ] In the source interface, submit a message and a file.
- [ ] Confirm that you can download those from the journalist interface and decrypt them.
- [ ] Send a reply to the source, and confirm that it's readable in the source interface.


## Deployment

This modifies the unmaintained library we're using for encrypting submissions and replies so that it will work on Focal. It shouldn't negatively affect Xenial. 

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation