### PR TITLE
Fix type hints in models, qa_loader

### DIFF
--- a/securedrop/qa_loader.py
+++ b/securedrop/qa_loader.py
@@ -107,8 +107,8 @@ class QaLoader:
         self.source_star_fraction = source_star_fraction
         self.source_reply_fraction = source_reply_fraction
 
-        self.journalists = []  # type: List[Journalist]
-        self.sources = []  # type: List[Source]
+        self.journalists = []  # type: List[int]
+        self.sources = []  # type: List[int]
 
     def new_journalist(self) -> None:
         # Make a diceware-like password


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Corrects some type hinting problems in `models.py` and `qa_loader.py`.

## Testing

CI is green. Run `make lint` if you feel like it. 

## Deployment

Dev only, 'cause type hints don't actually do anything.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
