### PR TITLE
Prevent IntegrityError on repeated reset of journalist password

### DIFF
--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -472,6 +472,11 @@ def cleanup_expired_revoked_tokens() -> None:
 
 
 def revoke_token(user: Journalist, auth_token: str) -> None:
-    revoked_token = RevokedToken(token=auth_token, journalist_id=user.id)
-    db.session.add(revoked_token)
-    db.session.commit()
+    try:
+        revoked_token = RevokedToken(token=auth_token, journalist_id=user.id)
+        db.session.add(revoked_token)
+        db.session.commit()
+    except IntegrityError as e:
+        db.session.rollback()
+        if "UNIQUE constraint failed: revoked_tokens.token" not in str(e):
+            raise e


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5617.

Instead of breaking down and making everyone uncomfortable when encountering `IntegrityError` while revoking a journalist's two-factor token during a password reset, roll with it, take it in stride, demonstrating resilience, class, even aplomb.

## Testing

Follow the STR in #5617 on `develop`. Then `git checkout -b fix-5617 origin/fix-5617` and repeat. You should now be able to reset a password for the rest of your days error-free, if that seems a good alternative to whatever else 2020 is handing you.

## Deployment

It's probably fine. It's better than it was, anyway. With the new error handling in place, the admin doesn't encounter an error, the journalist gets a new password, everyone's happy.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
