### PR TITLE
Add new CI job for app tests on Focal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,49 @@ common-steps:
       paths:
         - /caches/layers.tar
 
+  - &focalcreatecachedir
+    run:
+      name: Ensure cache dir exists and permissions are good
+      command: |
+        sudo mkdir -p /focalcaches && sudo chown circleci: -R /focalcaches
+
+  - &focalrestorecache
+    restore_cache:
+      key: v1-sd-layers-{{ checksum "securedrop/dockerfiles/focal/python3/Dockerfile" }}
+      paths:
+        - /focalcaches/layers.tar.gz
+
+  - &focalloadimagelayers
+    run:
+      name: Load image layer cache on Focal
+      command: |
+        set +o pipefail
+        docker load -i /focalcaches/layers.tar || true
+
+  - &focaldockerimagebuild
+    run:
+      name: Build Docker images for Focal
+      command: |
+        set +o pipefail
+        docker images
+        fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
+        cd securedrop && DOCKER_BUILD_VERBOSE=true DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" BASE_OS=focal ./bin/dev-shell true
+
+  - &focalsaveimagelayers
+    run:
+      name: Save Docker image layer cache on Focal
+      command: |
+        docker images
+        docker save -o /focalcaches/layers.tar securedrop-test-focal-py3:latest
+
+  - &focalsavecache
+    save_cache:
+      key: v1-sd-layers-{{ checksum "securedrop/dockerfiles/focal/python3/Dockerfile" }}
+      paths:
+        - /focalcaches/layers.tar
+
+
+
 version: 2
 jobs:
   lint:
@@ -79,6 +122,39 @@ jobs:
       - run:
           name: Run shellcheck
           command: make shellcheck
+
+  focal-app-tests:
+    machine:
+      enabled: true
+    environment:
+      DOCKER_API_VERSION: 1.23
+      BASE_OS: focal
+    parallelism: 3
+    steps:
+      - checkout
+      - *rebaseontarget
+      - *focalcreatecachedir
+      - *focalrestorecache
+      - *focalloadimagelayers
+      - *focaldockerimagebuild
+      - *focalsaveimagelayers
+      - *focalsavecache
+
+      - run:
+          name: Run tests on Focal
+          command: |
+            BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|update-builder)")
+            if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
+            export TESTFILES=$(cd securedrop; circleci tests glob 'tests/test*py' 'tests/**/test*py' |circleci tests split --split-by=timings |xargs echo)
+            fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
+            DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" make test-focal
+          no_output_timeout: 15m
+
+      - store_test_results:
+          path: ~/project/test-results-focal
+
+      - store_artifacts:
+          path: ~/project/test-results-focal
 
   app-tests:
     machine:
@@ -298,6 +374,14 @@ workflows:
     jobs:
       - lint
       - app-tests:
+          filters:
+            branches:
+              ignore:
+                - /i18n-.*/
+                - /update-builder-.*/
+          requires:
+            - lint
+      - focal-app-tests:
           filters:
             branches:
               ignore:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5524

This adds related CI steps for app tests on Focal

## Testing

- [ ] CI should have a new job for app tests on `Focal`.  
 
## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
