### PR TITLE
Ensure functional test assertions are evaluated

### DIFF
--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -822,13 +822,12 @@ class JournalistNavigationStepsMixin:
     def _visit_edit_hotp_secret(self):
         self._visit_edit_secret(
             "hotp",
-            "Reset two-factor authentication for security keys like Yubikey")
+            "Reset two-factor authentication for security keys, like a YubiKey")
 
     def _visit_edit_totp_secret(self):
         self._visit_edit_secret(
             "totp",
-            "Reset two-factor authentication for mobile apps such as FreeOTP or "
-            "Google Authenticator"
+            "Reset two-factor authentication for mobile apps, such as FreeOTP"
         )
 
     def _admin_visits_add_user(self):
@@ -896,7 +895,9 @@ class JournalistNavigationStepsMixin:
             assert tip_opacity == "1"
 
             if not self.accept_languages:
-                assert tip_text == "Reset two-factor authentication for security keys like Yubikey"
+                assert (
+                    tip_text == "Reset two-factor authentication for security keys, like a YubiKey"
+                )
 
             self.safe_click_by_id("button-reset-two-factor-hotp")
 
@@ -927,8 +928,7 @@ class JournalistNavigationStepsMixin:
             assert tip_opacity == "1"
             if not self.accept_languages:
                 expected_text = (
-                    "Reset two-factor authentication for mobile apps such as FreeOTP "
-                    "or Google Authenticator"
+                    "Reset two-factor authentication for mobile apps, such as FreeOTP"
                 )
                 assert tip_text == expected_text
 

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -153,7 +153,7 @@ class JournalistNavigationStepsMixin:
         self._journalist_clicks_on_modal("delete-collections")
 
         def collection_deleted():
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 flash_msg = self.driver.find_element_by_css_selector(".flash")
                 assert "1 collection deleted" in flash_msg.text
 
@@ -163,7 +163,7 @@ class JournalistNavigationStepsMixin:
         self._journalist_clicks_on_modal("delete-selected")
 
         def submission_deleted():
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 flash_msg = self.driver.find_element_by_css_selector(".flash")
                 assert "Submission deleted." in flash_msg.text
 
@@ -275,7 +275,7 @@ class JournalistNavigationStepsMixin:
         self.safe_click_by_id("submit-logo-update")
 
         def updated_image():
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 flash_msg = self.driver.find_element_by_css_selector(".flash")
                 assert "Image updated." in flash_msg.text
 
@@ -327,7 +327,7 @@ class JournalistNavigationStepsMixin:
 
         self.wait_for(lambda: self.driver.find_element_by_id("username"))
 
-        if not hasattr(self, "accept_languages"):
+        if not self.accept_languages:
             # The add user page has a form with an "ADD USER" button
             btns = self.driver.find_elements_by_tag_name("button")
             assert "ADD USER" in [el.text for el in btns]
@@ -349,7 +349,7 @@ class JournalistNavigationStepsMixin:
 
         self.wait_for(lambda: self.driver.find_element_by_id("username"))
 
-        if not hasattr(self, "accept_languages"):
+        if not self.accept_languages:
             # The add user page has a form with an "ADD USER" button
             btns = self.driver.find_elements_by_tag_name("button")
             assert "ADD USER" in [el.text for el in btns]
@@ -364,7 +364,7 @@ class JournalistNavigationStepsMixin:
                        last_name=self.new_user['last_name'],
                        is_admin=is_admin)
 
-        if not hasattr(self, "accept_languages"):
+        if not self.accept_languages:
             # Clicking submit on the add user form should redirect to
             # the FreeOTP page
             h1s = [h1.text for h1 in self.driver.find_elements_by_tag_name("h1")]
@@ -380,7 +380,7 @@ class JournalistNavigationStepsMixin:
         self.safe_click_by_css_selector("button[type=submit]")
 
         def user_token_added():
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 # Successfully verifying the code should redirect to the admin
                 # interface, and flash a message indicating success
                 flash_msg = self.driver.find_elements_by_css_selector(".flash")
@@ -403,7 +403,7 @@ class JournalistNavigationStepsMixin:
                 logging.info("Selenium has failed to click yet again; retrying.")
 
         def user_deleted():
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 flash_msg = self.driver.find_element_by_css_selector(".flash")
                 assert "Deleted user" in flash_msg.text
 
@@ -414,7 +414,7 @@ class JournalistNavigationStepsMixin:
         alert_button.click()
 
         def test_alert_sent():
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 flash_msg = self.driver.find_element_by_css_selector(".flash")
                 assert "Test alert sent. Please check your email." in flash_msg.text
 
@@ -566,7 +566,7 @@ class JournalistNavigationStepsMixin:
         self.safe_click_by_css_selector("button[type=submit]")
 
         def user_edited():
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 flash_msg = self.driver.find_element_by_css_selector(".flash")
                 assert "Invalid username" in flash_msg.text
 
@@ -608,7 +608,7 @@ class JournalistNavigationStepsMixin:
         self.safe_click_by_css_selector("button[type=submit]")
 
         def user_edited():
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 flash_msg = self.driver.find_element_by_css_selector(".flash")
                 assert "Account updated." in flash_msg.text
 
@@ -676,7 +676,7 @@ class JournalistNavigationStepsMixin:
         assert 0 != len(code_names), code_names
         assert 1 <= len(code_names), code_names
 
-        if not hasattr(self, "accept_languages"):
+        if not self.accept_languages:
             # There should be a "1 unread" span in the sole collection entry
             unread_span = self.driver.find_element_by_css_selector("span.unread")
             assert "1 unread" in unread_span.text
@@ -776,7 +776,7 @@ class JournalistNavigationStepsMixin:
         self.driver.find_element_by_id("reply-button").click()
 
         def reply_stored():
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 assert "Thanks. Your reply has been stored." in self.driver.page_source
 
         self.wait_for(reply_stored)
@@ -805,7 +805,7 @@ class JournalistNavigationStepsMixin:
             explanatory_tooltip_opacity = explanatory_tooltip.value_of_css_property("opacity")
             assert explanatory_tooltip_opacity == "1"
 
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 assert explanatory_tooltip.text == tooltip_text
 
         self.wait_for(explanatory_tooltip_is_correct)
@@ -895,7 +895,7 @@ class JournalistNavigationStepsMixin:
 
             assert tip_opacity == "1"
 
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 assert tip_text == "Reset two-factor authentication for security keys like Yubikey"
 
             self.safe_click_by_id("button-reset-two-factor-hotp")
@@ -925,7 +925,7 @@ class JournalistNavigationStepsMixin:
                 "#button-reset-two-factor-totp span")[0].text
 
             assert tip_opacity == "1"
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 expected_text = (
                     "Reset two-factor authentication for mobile apps such as FreeOTP "
                     "or Google Authenticator"

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -109,7 +109,7 @@ class SourceNavigationStepsMixin:
     def _source_hits_cancel_at_submit_page(self):
         self.driver.find_element_by_id("cancel").click()
 
-        if not hasattr(self, "accept_languages"):
+        if not self.accept_languages:
             headline = self.driver.find_element_by_class_name("headline")
             assert "Submit Files or Messages" == headline.text
 
@@ -117,7 +117,7 @@ class SourceNavigationStepsMixin:
         self.safe_click_by_id("continue-button")
 
         def submit_page_loaded():
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 headline = self.driver.find_element_by_class_name("headline")
                 assert "Submit Files or Messages" == headline.text
 
@@ -144,7 +144,7 @@ class SourceNavigationStepsMixin:
             self.wait_for_source_key(self.source_name)
 
             def file_submitted():
-                if not hasattr(self, "accept_languages"):
+                if not self.accept_languages:
                     notification = self.driver.find_element_by_css_selector(".success")
                     expected_notification = "Thank you for sending this information to us"
                     assert expected_notification in notification.text
@@ -160,7 +160,7 @@ class SourceNavigationStepsMixin:
         self._source_clicks_submit_button_on_submission_page()
 
         def message_submitted():
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 notification = self.driver.find_element_by_css_selector(".success")
                 assert "Thank" in notification.text
 
@@ -198,7 +198,7 @@ class SourceNavigationStepsMixin:
         confirm_button.click()
 
         def reply_deleted():
-            if not hasattr(self, "accept_languages"):
+            if not self.accept_languages:
                 notification = self.driver.find_element_by_class_name("notification")
                 assert "Reply deleted" in notification.text
 
@@ -228,7 +228,7 @@ class SourceNavigationStepsMixin:
     def _source_sees_session_timeout_message(self):
         notification = self.driver.find_element_by_css_selector(".important")
 
-        if not hasattr(self, "accept_languages"):
+        if not self.accept_languages:
             expected_text = "You were logged out due to inactivity."
             assert expected_text in notification.text
 
@@ -242,13 +242,13 @@ class SourceNavigationStepsMixin:
     def _source_sees_already_logged_in_in_other_tab_message(self):
         notification = self.driver.find_element_by_css_selector(".notification")
 
-        if not hasattr(self, "accepted_languages"):
+        if not self.accept_languages:
             expected_text = "You are already logged in."
             assert expected_text in notification.text
 
     def _source_sees_redirect_already_logged_in_message(self):
         notification = self.driver.find_element_by_css_selector(".notification")
 
-        if not hasattr(self, "accepted_languages"):
+        if not self.accept_languages:
             expected_text = "You were redirected because you are already logged in."
             assert expected_text in notification.text

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -113,13 +113,16 @@ class SourceNavigationStepsMixin:
             headline = self.driver.find_element_by_class_name("headline")
             assert "Submit Files or Messages" == headline.text
 
-    def _source_continues_to_submit_page(self):
+    def _source_continues_to_submit_page(self, files_allowed=True):
         self.safe_click_by_id("continue-button")
 
         def submit_page_loaded():
             if not self.accept_languages:
                 headline = self.driver.find_element_by_class_name("headline")
-                assert "Submit Files or Messages" == headline.text
+                if files_allowed:
+                    assert "Submit Files or Messages" == headline.text
+                else:
+                    assert "Submit Messages" == headline.text
 
         self.wait_for(submit_page_loaded)
 

--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -83,7 +83,7 @@ class TestAdminInterface(
 
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
+        self._source_continues_to_submit_page(files_allowed=False)
         self._source_does_not_sees_document_attachment_item()
 
     def test_allow_file_submission(self):


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #5607

Changes proposed in this pull request:

* Ensure functional tests assertions are evaluated by changing the guard clause that prevented them from being evaluated.
* Fix tests that fail after change of guard clause.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

No specific testing beyond code review and running unit tests.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
