### PR TITLE
Ask cryptography to please keep using Xenial's OpenSSL

### DIFF
--- a/install_files/ansible-base/roles/app-test/files/source.wsgi.logging
+++ b/install_files/ansible-base/roles/app-test/files/source.wsgi.logging
@@ -1,6 +1,9 @@
 #!/usr/bin/python
 
+import os
 import sys
+
+os.environ["CRYPTOGRAPHY_ALLOW_OPENSSL_102"] = "True"
 sys.path.insert(0,"/var/www/securedrop")
 
 import logging

--- a/install_files/securedrop-app-code/var/www/journalist.wsgi
+++ b/install_files/securedrop-app-code/var/www/journalist.wsgi
@@ -1,7 +1,9 @@
 #!/opt/venvs/securedrop-app-code/bin/python
 
+import os
 import sys
 
+os.environ["CRYPTOGRAPHY_ALLOW_OPENSSL_102"] = "True"
 sys.path.insert(0, "/var/www/securedrop")
 
 import logging

--- a/install_files/securedrop-app-code/var/www/source.wsgi
+++ b/install_files/securedrop-app-code/var/www/source.wsgi
@@ -1,7 +1,9 @@
 #!/opt/venvs/securedrop-app-code/bin/python
 
+import os
 import sys
 
+os.environ["CRYPTOGRAPHY_ALLOW_OPENSSL_102"] = "True"
 sys.path.insert(0, "/var/www/securedrop")
 
 # import logging

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.in
@@ -1,7 +1,15 @@
 alembic
 argon2_cffi>=20.1.0
 cffi>=1.14.2
+
+# The next release of cryptography after 3.2.1 will remove support for
+# OpenSSL 1.0.2, which is what we have on Xenial. If we're not on
+# Focal the next time the following requirement needs to be updated,
+# we will have to consider bundling a binary wheel of cryptography in
+# the securedrop-app-code package, so it includes a supported version
+# of OpenSSL.
 cryptography>=3.2
+
 Flask-Assets
 Flask-Babel
 Flask-SQLAlchemy


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5622.

Sets the `CRYPTOGRAPHY_ALLOW_OPENSSL_102` environment variable in `/var/www/journalist.wsgi` and `/var/www/source.wsgi` (and the logging version of that used in staging), so that `cryptography` will deign to use Xenial's manky old OpenSSL library. 

Adds a note to the `securedrop-app-code` requirements file about what we'll have to do if we need another `cryptography` update before we're on Focal.

## Testing

- Build a staging environment from `develop`: `make build-debs; make staging`
- Check that submitting a file through the source interface results in a server error.
- Rebuild staging from this branch:
  - `git checkout -b fix-5622 origin/fix-5622`
  - `make build-debs; make staging`
- Submitting a file should now work.

## Deployment

This will prevent the `cryptography` update from #5612 from breaking file submission in all production instances with our next release. 

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation