### PR TITLE
Add missing static/icons directory to debian package

### DIFF
--- a/securedrop/.rsync-filter
+++ b/securedrop/.rsync-filter
@@ -38,6 +38,8 @@ include static/i/font-awesome/
 include static/i/font-awesome/**
 include static/i/tipbox/
 include static/i/tipbox/**
+include static/icons/
+include static/icons/**
 include static/js/
 include static/js/*.js
 include static/js/libs/


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #5625 

Changes proposed in this pull request:

Add missing `static/icons` directory to  `securedrop-app-code` Debian package. The directory was added in #5593 but not included in `securedrop/.rsync-filter`.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

1. Run `make build-debs`.
1. Check the icons are included by running the command below and verify the output equals 22.
    ```
    dpkg --contents build/xenial/securedrop-app-code_1.7.0~rc1+xenial_amd64.deb | \
        grep -e static/icons/.*\.png | wc -l
    ```
1. Run `make staging`, visit the Journalist Interface and verify that the icons are displayed correctly.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
