### PR TITLE
Re-enables code coverage analysis via CodeCov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+codecov:
+  disable_default_path_fixes: false
+ignore:
+  - "securedrop/upload-screenshots.py"
+  - "securedrop/qa_loader.py"
+  - "securedrop/create-dev-data.py"
+  - "securedrop/specialstrings.py"

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -59,9 +59,16 @@ function docker_run() {
         echo "************************************************************"
     fi
 
+    # If this is a CI run, pass CodeCov settings into the container.
+    if [ -n "${CIRCLE_BRANCH:-}" ] ; then
+        ci_env=$(bash <(curl -s https://codecov.io/env))
+    else
+        ci_env=""
+    fi
+
     # The --shm-size argument sets up dedicated shared memory for the
     # container. Our tests can fail with the default of 64m.
-    docker run \
+    docker run $ci_env \
            --shm-size 2g \
            --rm \
            -p "127.0.0.1:${SD_HOSTPORT_VNC}:5909" \
@@ -72,6 +79,7 @@ function docker_run() {
            -e LANG=C.UTF-8 \
            -e PAGE_LAYOUT_LOCALES \
            -e PATH \
+           -e BASE_OS=$BASE_OS \
            --user "${USER:-root}" \
            --volume "${TOPLEVEL}:${TOPLEVEL}" \
            --workdir "${TOPLEVEL}/securedrop" \

--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -26,7 +26,7 @@ if [ -n "${CIRCLE_BRANCH:-}" ] ; then
     touch tests/log/firefox.log
     function finish {
         cp tests/log/firefox.log ../test-results
-        bash <(curl -s https://codecov.io/bash)
+        bash <(curl -s https://codecov.io/bash -cF "$BASE_OS")
     }
     trap finish EXIT
 fi


### PR DESCRIPTION
Ready for review

## Description

- adds required environmental settings for CodeCov upload script to Docker container when run in CircleCI
- adds `codecov.yml` to fix up file paths in report and exclude unpackaged code from metrics 

## Testing
- [ ] CI passes
- [ ] When CI runs, a report is generated at https://codecov.io/gh/freedomofpress/securedrop
- [ ] When `make test` is run locally (ie not in CircleCI) a report is *not* generated.
