### PR TITLE
Make fixture independent of contents of storage directory

### DIFF
--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -101,11 +101,8 @@ class TestJournalistMissingFile(
 
         # Remove the message file from the store
         filesystem_id = self.source_app.crypto_util.hash_codename(self.source_name)
-        storage_path = Path(self.journalist_app.storage.storage_path)
-        msg_files = [
-            p for p in storage_path.rglob("*")
-            if p.is_file() and filesystem_id in p.parts
-        ]
+        storage_path = Path(self.journalist_app.storage.storage_path) / filesystem_id
+        msg_files = [p for p in storage_path.glob("*-msg.gpg")]
         assert len(msg_files) == 1
         msg_files[0].unlink()
 

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -100,8 +100,12 @@ class TestJournalistMissingFile(
         self._source_logs_out()
 
         # Remove the message file from the store
+        filesystem_id = self.source_app.crypto_util.hash_codename(self.source_name)
         storage_path = Path(self.journalist_app.storage.storage_path)
-        msg_files = [p for p in storage_path.rglob("*") if p.is_file()]
+        msg_files = [
+            p for p in storage_path.rglob("*")
+            if p.is_file() and filesystem_id in p.parts
+        ]
         assert len(msg_files) == 1
         msg_files[0].unlink()
 


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #5633 

Changes proposed in this pull request:

Make the fixture for the functional tests with missing files in the store independent from the presence of additional files in the storage directory.

Use the source's `filesystem_id` to select the proper file to remove from the store.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

Trigger the **focal-app-tests** CI job to run multiple times. Ensure the tests in `tests/functional/test_journalist.py::TestJournalistMissingFiles` pass each time.

**Note** The failing tests already passed 4/4 times, see [CircleCi Dashboard](https://app.circleci.com/pipelines/github/freedomofpress/securedrop?branch=pull%2F5634). Two of the four runs were cancelled **after** all the tests using the improved fixture passed.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
