### PR TITLE
Updated Tor Browser UA matches to include recent MacOS versions

### DIFF
--- a/securedrop/static/js/source.js
+++ b/securedrop/static/js/source.js
@@ -1,4 +1,4 @@
-const TBB_UA_REGEX = /Mozilla\/5\.0 \((Windows NT 10\.0|X11; Linux x86_64|Macintosh; Intel Mac OS X 10\.14|Windows NT 10\.0; Win64; x64); rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/;
+const TBB_UA_REGEX = /Mozilla\/5\.0 \((Windows NT 10\.0|X11; Linux x86_64|Macintosh; Intel Mac OS X 10\.[0-9]{2}|Windows NT 10\.0; Win64; x64|Android; Mobile); rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/
 const ORFOX_UA_REGEX = /Mozilla\/5\.0 \(Android; Mobile; rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/;
 
 function fadeIn(el, duration = 200, displayStyle = "block") {


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5626 .

Adds @harrislapiroff's update to the TBB User Agent regex to include versions of MacOS from 00 to 99 :)

## Testing

- `make dev` on this branch on a MacOS system with the latest Tor Browser
- Open Tor Browser and update the config: open `about:config`
- Update the proxy settings to allow localhost requests by searching for `network.proxy.no_proxies_on` and updating its value to `127.0.0.1`
- [ ] Open `127.0.0.1:8080` and confirm that the Source Interface appears with no TBB warning. 
- [ ] Open `127.0.0.1:8080` in a different browser and confirm that the warning does appear

- [ ] If available, repeat the steps above on a non-MacOS system and confirm consistent behaviour. 

## Deployment
Will be deployed with next release after merge.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
