### PR TITLE
Added SSH option to fix upgrade scenario when user has too many SSH keys

### DIFF
--- a/molecule/upgrade/local_apt_with_debs.yml
+++ b/molecule/upgrade/local_apt_with_debs.yml
@@ -8,6 +8,7 @@
   synchronize:
     src: "{{ molecule_dir }}/../../build/{{ rep_dist }}/"
     dest: /var/repos/debs/
+    use_ssh_args: yes
     delete: yes
 
 - name: Establish config

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -64,6 +64,8 @@ provisioner:
       pipelining: True
   playbooks:
     side_effect: side_effect.yml
+  connection_options:
+    ansible_ssh_common_args: -o IdentitiesOnly=yes
 
 scenario:
   name: upgrade


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5653 .

Adds `-o IdentitiesOnly=yes` SSH option in the Molecule upgrade scenario, to work around connection failures when a user has more than 6 SSH keys

## Testing
- Add more than 6 SSH private keys in your `.ssh` directory
- Check out this branch
- [x] Run `make build-debs && make upgrade-start && make upgrade-test`` - verify that it completes without error.

## Deployment

Dev-only.

## Checklist

### If you made changes to the server application code:
### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

