### PR TITLE
Check user's id before calling "admin/bootstrap.py"

### DIFF
--- a/securedrop-admin
+++ b/securedrop-admin
@@ -7,7 +7,7 @@ set -eo pipefail
 
 u=$(id -u)
 if test "$u" = "0"; then
-    echo "Please do not run this script directly as root."
+    echo "Please do not run \"$0\" directly as root."
     exit 1
 fi
 

--- a/securedrop-admin
+++ b/securedrop-admin
@@ -5,9 +5,10 @@
 # the top level of the SecureDrop repository
 set -eo pipefail
 
+b=$(basename "$0")
 u=$(id -u)
 if test "$u" = "0"; then
-    echo "Please do not run \"$0\" directly as root."
+    echo "Please do not run \"$b\" directly as root."
     exit 1
 fi
 

--- a/securedrop-admin
+++ b/securedrop-admin
@@ -5,6 +5,11 @@
 # the top level of the SecureDrop repository
 set -eo pipefail
 
+u=$(id -u)
+if test "$u" = "0"; then
+    exit 1
+fi
+
 d=$(dirname "$0")
 if test "$1" = "setup" || test "$2" = "setup"; then
    if test "$1" = "setup"; then

--- a/securedrop-admin
+++ b/securedrop-admin
@@ -6,8 +6,8 @@
 set -eo pipefail
 
 b=$(basename "$0")
-u=$(id -u)
-if test "$u" = "0"; then
+u=$(whoami)
+if test "$u" = "root"; then
     echo "Please do not run \"$b\" directly as root."
     exit 1
 fi

--- a/securedrop-admin
+++ b/securedrop-admin
@@ -7,6 +7,7 @@ set -eo pipefail
 
 u=$(id -u)
 if test "$u" = "0"; then
+    echo "Please do not run this script directly as root."
     exit 1
 fi
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:

  - Avoid running "secure-admin" directly as root;
      - future calls made by its child processes will use `sudo` anyway
      - `admin/bootstrap.py#L130` (9eb2cdb)
      - print a clear message before exiting the script
      - replace term 'this script' by $0 (which represents script's basename)

## Testing

How should the reviewer test this PR?

#### Environment:

```
Linux amnesia 5.8.0-2-amd64 #1 SMP Debian 5.8.10-1 (2020-09-19) x86_64 GNU/Linux

$ grep -i tails /etc/os-release
TAILS_PRODUCT_NAME="Tails"
TAILS_VERSION_ID="4.13"
TAILS_DISTRIBUTION="unstable"
```

#### This must return `1` and exit:

```
root@amnesia:~# id
uid=0(root) gid=0(root) groups=0(root)
root@amnesia:~# /mnt/_/securedrop/securedrop-admin
Please do not run "securedrop-admin" directly as root.
```

#### This must work as expected:

```
amnesia@amnesia:~$ id
uid=1000(amnesia) gid=1000(amnesia) groups=1000(amnesia),7(lp),20(dialout),24(cdrom),25(floppy),44(video),46(plugdev),109(netdev),115(lpadmin),116(scanner),119(vboxsf)
amnesia@amnesia:~$ /mnt/_/securedrop/securedrop-admin
ERROR: Please run "securedrop-admin setup".
```
```
amnesia@amnesia:~$ /mnt/_/securedrop/securedrop-admin setup
INFO: Installing SecureDrop Admin dependencies
INFO: You'll be prompted for the temporary Tails admin password, which was set on Tails login screen
[sudo] password for amnesia:
```

## Deployment

Any special considerations for deployment?

1. Trivial change for new installs (setup, sdconfig, install);
2. **Nothing** changed under `securedrop-admin`