### PR TITLE
Updates CI boxes for staging tests

### DIFF
--- a/devops/gce-nested/gce-start.sh
+++ b/devops/gce-nested/gce-start.sh
@@ -25,7 +25,7 @@ function find_latest_ci_image() {
     #    --filter="family:fpf-securedrop AND name ~ ^ci-nested-virt" \
     #    --sort-by=~Name --limit=1 --format="value(Name)"
     # Return hardcoded image id to prevent newer builds from breaking CI
-    echo "ci-nested-virt-buster-1594062724"
+    echo "ci-nested-virt-buster-1606755081"
 }
 
 # Call out to GCE API and start a new instance, designating


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes
Related to #5642 

Pins the Vagrant box versions inside the Buster GCP box,
as described in [0]:

  * 16.04 - 202008.16.0
  * 20.04 - 202008.16.0

[0] https://github.com/freedomofpress/securedrop/issues/5642#issuecomment-734369056


## Testing

1. Is CI passing? That's good enough
2. Optionally we can rebase PR https://github.com/freedomofpress/securedrop/pull/5638 to verify, but I'm fine merging now, rebasing 5638, and following up with more box changes if required.

## Deployment
No, CI only.
