### PR TITLE
Remove paths that are no longer in use

### DIFF
--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -10,7 +10,6 @@
     <directories realtime="yes" check_all="yes" report_changes="yes">/etc,/usr/bin,/usr/sbin</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/bin,/sbin</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/ossec</directories>
-    <directories realtime="yes" check_all="yes" report_changes="yes">/var/securedrop</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/www</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/securedrop</directories>
     <directories realtime="yes" check_all="yes" report_changes="yes">/var/lib/tor/services/source/hostname</directories>
@@ -53,11 +52,9 @@
     <ignore>/var/lib/securedrop/db.sqlite</ignore>
 
     <ignore>/var/lib/securedrop/submissions_today.txt</ignore>
-    
+
     <ignore type="sregex">/var/lib/securedrop/shredder/tmp</ignore>
     
-    <ignore>/var/securedrop/store</ignore>
-
     <ignore>/var/ossec/queue</ignore>
     <ignore>/var/ossec/logs</ignore>
     <ignore>/var/ossec/stats</ignore>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes
Removes paths that are no longer in use from OSSEC monitoring. As far as I can tell, the last trace of `/var/securedrop` use was removed in #4622.

## Testing/Deployment
Are there any reasons we want to continue to monitor those paths? If not, visual review and double-checking for any remaining references to those paths should be sufficient.