### PR TITLE
Update and add annotations to sshd config for servers

### DIFF
--- a/install_files/ansible-base/roles/restrict-direct-access/templates/sshd_config
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/sshd_config
@@ -5,8 +5,6 @@ HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 
-# Enforce privilege separation by creating unprivileged child process
-UsePrivilegeSeparation yes
 KeyRegenerationInterval 3600
 ServerKeyBits 4096
 
@@ -39,7 +37,7 @@ UseDNS no
 
 # Cipher selection
 
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr
+Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr
 # Don't use SHA1 for kex
 KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
 # Don't use SHA1 for hashing, don't use encrypt-and-MAC mode

--- a/install_files/ansible-base/roles/restrict-direct-access/templates/sshd_config
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/sshd_config
@@ -2,6 +2,7 @@ Port 22
 ListenAddress {{ ssh_listening_address }}:22
 Protocol 2
 HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 
 # Enforce privilege separation by creating unprivileged child process
@@ -39,7 +40,6 @@ UseDNS no
 # Cipher selection
 
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr
-HostKeyAlgorithms ssh-ed25519,rsa-sha2-256,rsa-sha2-512
 # Don't use SHA1 for kex
 KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
 # Don't use SHA1 for hashing, don't use encrypt-and-MAC mode

--- a/install_files/ansible-base/roles/restrict-direct-access/templates/sshd_config
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/sshd_config
@@ -2,18 +2,29 @@ Port 22
 ListenAddress {{ ssh_listening_address }}:22
 Protocol 2
 HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
-HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Enforce privilege separation by creating unprivileged child process
 UsePrivilegeSeparation yes
 KeyRegenerationInterval 3600
 ServerKeyBits 4096
+
+# Logging options
+
 SyslogFacility AUTH
 LogLevel INFO
+
+# Authentication options
+
 LoginGraceTime 120
 PermitRootLogin no
 StrictModes yes
 RSAAuthentication yes
 PubkeyAuthentication yes
+PasswordAuthentication no
+# Only users in the ssh group to authenticate
+AllowGroups ssh
+# Don't use host-based authentication
 IgnoreRhosts yes
 RhostsRSAAuthentication no
 HostbasedAuthentication no
@@ -22,20 +33,34 @@ ChallengeResponseAuthentication no
 KerberosAuthentication no
 KerberosGetAFSToken no
 GSSAPIAuthentication no
+UsePAM no
+UseDNS no
+
+# Cipher selection
+
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr
+HostKeyAlgorithms ssh-ed25519,rsa-sha2-256,rsa-sha2-512
+# Don't use SHA1 for kex
+KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+# Don't use SHA1 for hashing, don't use encrypt-and-MAC mode
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
+
+# Network
+
+ClientAliveInterval 300
+ClientAliveCountMax 0
+# Do not allow remote port forwarding to bind to non-loopback addresses
+GatewayPorts no
+# DisableX11 and agent forwarding, tunnelling
+AllowTcpForwarding no
+AllowAgentForwarding no
+PermitTunnel no
 X11Forwarding no
 X11DisplayOffset 10
+
+# Misc configuration
+
 PrintMotd no
 PrintLastLog yes
 TCPKeepAlive yes
 AcceptEnv LANG LC_*
-UsePAM no
-UseDNS no
-ClientAliveInterval 300
-ClientAliveCountMax 0
-Ciphers aes256-gcm@openssh.com,aes256-ctr,chacha20-poly1305@openssh.com
-KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
-MACs hmac-sha2-256,hmac-sha2-512
-GatewayPorts no
-AllowGroups ssh
-AllowTcpForwarding no
-PasswordAuthentication no

--- a/molecule/testinfra/common/test_system_hardening.py
+++ b/molecule/testinfra/common/test_system_hardening.py
@@ -110,6 +110,11 @@ def test_twofactor_disabled_on_tty(host):
   ('PasswordAuthentication', 'no'),
   ('PubkeyAuthentication', 'yes'),
   ('RSAAuthentication', 'yes'),
+  ('AllowGroups', 'ssh'),
+  ('AllowTcpForwarding', 'no'),
+  ('AllowAgentForwarding', 'no'),
+  ('PermitTunnel', 'no'),
+  ('X11Forwarding', 'no'),
 ])
 def test_sshd_config(host, sshd_opts):
     """


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #5660 

- Update supported algorthms
- Disable some agent forwarding and tunnelling options
- Annotate and reorder configuration for readability

Sources:
- https://github.com/dev-sec/ansible-ssh-hardening
- https://github.com/arthepsy/ssh-audit / https://github.com/jtesta/ssh-audit/

## Testing

- [ ] provided config is good / adheres to best practices
- [ ] provided config is adequately annotated
- [ ] provided config eliminates log message described in #5660 
- [ ] on an existing Xenial install the config is applied properly when an Ansible run occurs (I have tested this)
## Deployment

#### New installs

The sshd configuration will be applied on new installs via Ansible

#### Existing installs

Existing installs will not be updated unattended, but applied when an Ansible run occurs

## Checklist


- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
