### PR TITLE
Prod vms on focal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,9 @@ securedrop/static/.webassets-cache
 # https://github.com/mitchellh/vagrant/issues/6705
 .bundle
 
+# Vagrant-added ansible-galaxy roles
+.galaxy_roles
+
 # ignore ansible retry files
 *.retry
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,7 +71,11 @@ Vagrant.configure("2") do |config|
       config.ssh.port = 22
     end
     prod.vm.hostname = "mon-prod"
-    prod.vm.box = "bento/ubuntu-16.04"
+    if ENV['USE_FOCAL']
+      prod.vm.box = "bento/ubuntu-20.04"
+    else
+      prod.vm.box = "bento/ubuntu-16.04"
+    end
     prod.vm.network "private_network", ip: "10.0.1.5", virtualbox__intnet: internal_network_name
     prod.vm.synced_folder './', '/vagrant', disabled: true
     prod.vm.provider "libvirt" do |lv, override|
@@ -86,7 +90,11 @@ Vagrant.configure("2") do |config|
       config.ssh.port = 22
     end
     prod.vm.hostname = "app-prod"
-    prod.vm.box = "bento/ubuntu-16.04"
+    if ENV['USE_FOCAL']
+      prod.vm.box = "bento/ubuntu-20.04"
+    else
+      prod.vm.box = "bento/ubuntu-16.04"
+    end
     prod.vm.network "private_network", ip: "10.0.1.4", virtualbox__intnet: internal_network_name
     prod.vm.synced_folder './', '/vagrant', disabled: true
     prod.vm.provider "virtualbox" do |v|

--- a/devops/apt-local.yml
+++ b/devops/apt-local.yml
@@ -1,0 +1,48 @@
+---
+- name: Confirm local debs present
+  hosts: localhost
+  gather_facts: no
+  tasks:
+      # Before running apt-server logic, confirm we have local
+      # debs built.
+    - name: Find local deb files
+      find:
+        paths: "../build/focal/"
+        patterns: "*.deb"
+      register: _find_debs_result
+
+    - name: Ensure debs were found
+      assert:
+        that:
+          - "_find_debs_result.files|length >= 8"
+        msg: "No local debs found, run 'make build-debs-focal'"
+
+- name: Configure apt-server
+  hosts: apt-local
+  become: yes
+  tasks:
+    - import_tasks: ../molecule/upgrade/local_apt_mirror.yml
+    - import_tasks: ../molecule/upgrade/local_apt_with_debs.yml
+
+  vars:
+    QA_APTTEST: False
+    rep_dist: "focal"
+    molecule_dir: "../molecule/upgrade"
+    dpkg_dir: /var/repos/debs
+    rep_component: main
+    rep_arch: i386 amd64
+    release_file: "/var/repos/base/dists/{{ rep_dist }}/Release"
+    nginx_sites:
+      default:
+        - listen 80
+        - root "/var/repos/base"
+        - location / { autoindex on; }
+        - location /gpg { alias /var/repos/base/; }
+      encrypted:
+        - listen 443 ssl
+        - server_name apt.freedom.press
+        - ssl_certificate /etc/ssl/certs/apt_freedom_press.pem
+        - ssl_certificate_key /etc/ssl/private/apt_freedom_press.priv
+        - root "/var/repos/base"
+        - location / { autoindex on; }
+

--- a/install_files/ansible-base/securedrop-apt-local.yml
+++ b/install_files/ansible-base/securedrop-apt-local.yml
@@ -1,0 +1,33 @@
+---
+# Playbook to update SecureDrop VMs to install Focal packages from a local repo
+#
+# Steps to use this playbook:
+#
+#   1. On host machine, build packages with `make build-debs-focal`
+#   2. On host machine, provision local apt repo with `vagrant up apt-local`
+#   3. Switch to Admin Workstation
+#   3. Continue with prod provisioning as far as `./securedrop-admin sdconfig`
+#   5. Run `source admin/.venv3/bin/activate` (so ansible commands work)
+#   6. Run `cd install_files/ansible-base`
+#   7. Run `ansible-playbook -vv --diff securedrop-apt-local.yml`
+#   8. Proceed with `./securedrop-admin install`
+
+- name: Configure prod host to prioritize local packages.
+  environment:
+    LC_ALL: C
+  max_fail_percentage: 0
+  any_errors_fatal: yes
+  hosts: securedrop
+  tasks:
+    - name: Add apt public key for local repo.
+      apt_key:
+        data: "{{ lookup('file', '../../molecule/upgrade/files/apt-test.pub') }}"
+        state: present
+
+    - name: Add local repo
+      apt_repository:
+        repo: deb [arch=amd64] http://10.0.1.7 focal main
+        state: present
+        update_cache: yes
+  become: yes
+

--- a/molecule/upgrade/local_apt_with_debs.yml
+++ b/molecule/upgrade/local_apt_with_debs.yml
@@ -31,5 +31,5 @@
   changed_when: false
 
 - name: Sign release file
-  command: "gpg -b -u C5D5CD3B6D65484B -o {{ release_file }}.gpg {{ release_file }}"
+  command: "gpg --armor -b -u C5D5CD3B6D65484B -o {{ release_file }}.gpg {{ release_file }}"
   changed_when: false


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #5668 .

Adds functionality to do a Focal production install using local deb packages and the `focal` dist on `apt-test.freedom.press`.

## Testing


- on dev box:
    - check out this branch
    - add the `bento/ubuntu-20.04` Vagrant box if not already present
    - set up prod focal base vms with `USE_FOCAL=true vagrant up --no-provision /prod/`
    - build focal debs with `make build-debs-focal`
    - set up local apt repo with `vagrant up apt-local`
- in admin workstation:
    - proceed with prod provisioning as normal as far as `./securedrop-admin sdconfig`
    - follow instructions in `install_files/ansible-base/securedrop-apt-local.yml` to add local repo on VMs
    - update `install-fpf-repo` defaults to point to apt-test+test key
    - do `./securedrop-admin install`

- [ ] installation completes successfully on Focal prod VMs
- [ ] `apt-cache policy securedrop-app-code` lists the local apt server as the source
- [ ] Source and Journalist Interface are accessible and version matches local deb version.




## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
