### PR TITLE
Removes deprecated 322 test from bandit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,9 +141,9 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 bandit: test-config ## Run bandit with medium level excluding test-related folders.
 	@command -v bandit || (echo "Please run 'pip install -U bandit'."; exit 1)
 	@echo "███ Running bandit..."
-	@bandit -ll --skip B322 --exclude ./admin/.tox,./admin/.venv,./admin/.eggs,./molecule,./testinfra,./securedrop/tests,./.tox,./.venv*,securedrop/config.py --recursive .
+	@bandit -ll --exclude ./admin/.tox,./admin/.venv,./admin/.eggs,./molecule,./testinfra,./securedrop/tests,./.tox,./.venv*,securedrop/config.py --recursive .
 	@echo "███ Running bandit on securedrop/config.py..."
-	@bandit -ll --skip B108,B322 securedrop/config.py
+	@bandit -ll --skip B108 securedrop/config.py
 	@echo
 
 #############


### PR DESCRIPTION


## Status

Ready for review 

## Description of Changes

Removes old https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html?highlight=B322#b322-input check from bandit.

## Testing

- [ ] CI should be green.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
