### PR TITLE
Update bandit to 1.7.0

### DIFF
--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -48,9 +48,9 @@ attrs==20.2.0 \
     --hash=sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594 \
     --hash=sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc \
     # via pytest
-bandit==1.4.0 \
-    --hash=sha256:cb977045497f83ec3a02616973ab845c829cdab8144ce2e757fe031104a9abd4 \
-    --hash=sha256:de4cc19d6ba32d6f542c6a1ddadb4404571347d83ef1ed1e7afb7d0b38e0c25b \
+bandit==1.7.0 \
+    --hash=sha256:216be4d044209fa06cf2a3e51b319769a51be8318140659719aa7a115c35ed07 \
+    --hash=sha256:8a4c7415254d75df8ff3c3b15cfe9042ecee628a1e40b44c15a98890fbfc2608 \
     # via -r requirements/python3/develop-requirements.in
 bcrypt==3.1.3 \
     --hash=sha256:05b35b9842b009b44496fa5433ce462f69966291e50fbd471dbb427f399f748f \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The 322 test was not yet deprecated in our last pinned version (1.4.0) so removing it from the skip list in #5670 broke in local environments in which bandit wasn't upgraded (as is done each run in CI).

Also, 1.4.0 didn't yet support glob patterns in bandit's `--exclude` option, so running it locally would take forever as the `.venv` directory was scanned.

## Testing

### Verify current problems

- `rm -rf .venv && make venv && . .venv/bin/activate`
- `make bandit`: It should take forever and complain about test 322.

### Verify fix
- check out this branch with `git checkout -b upgrade-bandit origin/upgrade-bandit`
- create a virtualenv with new bandit: `rm -rf .venv && make venv && . .venv/bin/activate`
- run `make bandit`: It should only check 76 files, finish quickly, and not complain about test 322.

## Deployment

dev only.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation