### PR TITLE
Fixes `./securedrop-admin verify` command

### DIFF
--- a/devops/scripts/run_prod_testinfra
+++ b/devops/scripts/run_prod_testinfra
@@ -8,6 +8,14 @@
 set -e
 set -o pipefail
 
+function cleanup {
+    deactivate
+    echo "--------"
+    echo "Verification complete - to restore the default workstation environment, remove ~/Persistent/securedrop/admin/.venv3 and run 'cd ~/Persistent/securedrop && ./securedrop-admin setup'"
+}
+trap cleanup EXIT
+
+
 # Are we in Tails?
 if [ -f "/home/amnesia/Persistent/.securedrop/securedrop_init.py" ]
 then
@@ -22,7 +30,3 @@ source admin/.venv3/bin/activate
 
 cd molecule/testinfra
 CI_SD_ENV=${TEST_ENV:-prod} SECUREDROP_TESTINFRA_TARGET_HOST=${TEST_ENV:-prod} py.test -v -n 2 --disable-warnings -m "not skip_in_prod" 
-
-deactivate
-echo "--------"
-echo "Testinfra run complete - restore your workstation virtualenv by removing ~/Persistent/securedrop/admin/.venv3 and running 'cd ~/Persistent/securedrop && ./securedrop-admin setup'"

--- a/molecule/testinfra/conftest.py
+++ b/molecule/testinfra/conftest.py
@@ -28,7 +28,16 @@ def securedrop_import_testinfra_vars(hostname, with_header=False):
     with io.open(filepath, 'r') as f:
         hostvars = yaml.safe_load(f)
 
-    if os.environ.get("MOLECULE_SCENARIO_NAME").endswith("focal"):
+    # Testing against both Focal and Xenial must be supported for now in both
+    # staging scenarios, and in prod via `USE_FOCAL=1 ./securedrop-admin verify`
+    testing_focal = False
+    scenario_env = "MOLECULE_SCENARIO_NAME"
+    if scenario_env in os.environ and os.environ.get(scenario_env).endswith("focal"):
+        testing_focal = True
+    if "USE_FOCAL" in os.environ:
+        testing_focal = True
+
+    if testing_focal:
         hostvars['securedrop_venv_site_packages'] = hostvars["securedrop_venv_site_packages"].format("3.8")  # noqa: E501
         hostvars['python_version'] = "3.8"
     else:

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -13,7 +13,7 @@ wanted_apache_headers:
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"
-securedrop_venv_site_packages: "/opt/venvs/securedrop-app-code/lib/python3.5/site-packages"
+securedrop_venv_site_packages: /opt/venvs/securedrop-app-code/lib/python{}/site-packages
 securedrop_code: /var/www/securedrop
 securedrop_data: /var/lib/securedrop
 securedrop_user: www-data


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #5659 

Improves testinfra molecule scenario check and adds option to run `./securedrop-admin verify` against a Focal prod environment

Changes proposed in this pull request:

## Testing

## libvirt staging scenarios
- [x] `molecule test -s libvirt-staging-focal` completes successfully
- [x] `molecule test -s libvirt-staging-xenial` completes successfully

## prod VMs (with admin virtualenv set up with ./securedrop-admin setup -t)
### Focal VMs
- [x] `USE_FOCAL=1 ./securedrop-admin verify` completes with expected 8 errors (IP/iptables mismatches) only 
- [x] `./securedrop-admin verify` completes with 13 or more errors (IP/iptables mismatches and Python versions)  
- [x] Post-verification message with instructions on restoring non-verification virtualenv is displayed in both cases
 
### Xenial VMs
- [x] `./securedrop-admin verify` completes with expected 8 or fewer errors (IP/iptables mismatches) only 
- [x] Post-verification message with instructions on restoring non-verification virtualenv is displayed in both cases

## Deployment

No concerns

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation