### PR TITLE
Disable v2 onion addresses on restore on Focal

### DIFF
--- a/install_files/ansible-base/roles/restore/files/compare_torrc.py
+++ b/install_files/ansible-base/roles/restore/files/compare_torrc.py
@@ -49,6 +49,10 @@ if __name__ == "__main__":
         print("The Tor configuration in the backup matches the server.")
         sys.exit(0)
 
+    if (3 in server_versions) and (3 in backup_versions):
+        print("V3 services detected in backup and server - proceeding with v3-only restore")
+        sys.exit(0)
+
     print(
         "The Tor configuration on the app server offers version {} services.".format(
             strset(server_versions)

--- a/install_files/ansible-base/roles/restore/files/disable_v2.py
+++ b/install_files/ansible-base/roles/restore/files/disable_v2.py
@@ -73,7 +73,6 @@ def filter_v2(filename):
                         i += 1
                         continue
 
-
         result.append(line)
         i += 1
 

--- a/install_files/ansible-base/roles/restore/files/disable_v2.py
+++ b/install_files/ansible-base/roles/restore/files/disable_v2.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# To execute on prod:
+# python3 disable_v2.py /etc/tor/torrc /etc/tor/torrc
+# To execute for testing locally:
+# python3 disable_v2.py /etc/tor/torrc /tmp/dumytorrc
+import sys
+
+
+def filter_v2(filename):
+    # Read the file
+    with open(filename) as f:
+        data = f.readlines()
+    # We will store the filtered lines to result
+    result = []
+
+    i = 0
+    while i < len(data):
+        line = data[i]
+        if line == "HiddenServiceDir /var/lib/tor/services/source\n":
+            i += 1
+            while data[i].strip() == "":
+                i += 1
+            line = data[i]
+            if line == "HiddenServiceVersion 2\n":
+                i += 1
+                line = data[i]
+                while data[i].strip() == "":
+                    i += 1
+                line = data[i]
+                if line == "HiddenServicePort 80 127.0.0.1:80\n":
+                    i += 1
+                    continue
+        # Now check for journalist
+        if line == "HiddenServiceDir /var/lib/tor/services/journalist\n":
+            i += 1
+            while data[i].strip() == "":
+                i += 1
+            line = data[i]
+            if line == "HiddenServiceVersion 2\n":
+                i += 1
+                line = data[i]
+                while data[i].strip() == "":
+                    i += 1
+                line = data[i]
+                if line == "HiddenServicePort 80 127.0.0.1:8080\n":
+                    i += 1
+                    line = data[i]
+                    while data[i].strip() == "":
+                        i += 1
+                    line = data[i]
+                    if line == "HiddenServiceAuthorizeClient stealth journalist\n":
+                        i += 1
+                        continue
+        # Now the v2 ssh access
+        if line == "HiddenServiceDir /var/lib/tor/services/ssh\n":
+            i += 1
+            while data[i].strip() == "":
+                i += 1
+            line = data[i]
+            if line == "HiddenServiceVersion 2\n":
+                i += 1
+                line = data[i]
+                while data[i].strip() == "":
+                    i += 1
+                line = data[i]
+                if line == "HiddenServicePort 22 127.0.0.1:22\n":
+                    i += 1
+                    line = data[i]
+                    while data[i].strip() == "":
+                        i += 1
+                    line = data[i]
+                    if line == "HiddenServiceAuthorizeClient stealth admin\n":
+                        i += 1
+                        continue
+
+
+        result.append(line)
+        i += 1
+
+    # Now return the result
+    return result
+
+
+if __name__ == "__main__":
+    filename = sys.argv[1]
+    outputfilename = sys.argv[2]
+    result = filter_v2(filename)
+    with open(outputfilename, "w") as fobj:
+        for line in result:
+            fobj.write(line)

--- a/install_files/ansible-base/roles/restore/tasks/main.yml
+++ b/install_files/ansible-base/roles/restore/tasks/main.yml
@@ -73,6 +73,34 @@
     name: apache2
     state: reloaded
 
+- name: Copy disable_v2.py script for Focal
+  copy:
+    src: "{{ role_path }}/files/disable_v2.py"
+    dest: /opt/disable_v2.py
+  when: ansible_distribution_release == 'focal'
+
+- name: Execute disable_v2 script on Focal
+  command: python3 /opt/disable_v2.py /etc/tor/torrc /etc/tor/torrc
+  when: ansible_distribution_release == 'focal'
+
+- name: Remove v2 tor source directory
+  file:
+    state: absent
+    path: /var/lib/tor/services/source
+  when: ansible_distribution_release == 'focal'
+
+- name: Remove v2 tor journalist directory
+  file:
+    state: absent
+    path: /var/lib/tor/services/journalist
+  when: ansible_distribution_release == 'focal'
+
+- name: Remove disable_v2.py script on Focal
+  file:
+    state: absent
+    path: /opt/disable_v2.py
+  when: ansible_distribution_release == 'focal'
+
 - name: Reload Tor service
   service:
     name: tor

--- a/install_files/ansible-base/roles/restore/tasks/main.yml
+++ b/install_files/ansible-base/roles/restore/tasks/main.yml
@@ -32,6 +32,7 @@
   connection: local
   become: no
   command: "python {{ role_path }}/files/compare_torrc.py {{ torrc_check_dir.path }}"
+  register: compare_result
 
 - name: Remove temporary directory for Tor configuration check
   connection: local
@@ -52,7 +53,17 @@
     dest: /
     remote_src: yes
     src: "/tmp/{{ restore_file}}"
-  when: restore_skip_tor is not defined
+  when: (restore_skip_tor is not defined) and
+        ("V3 services detected" not in compare_result.stdout)
+
+- name: Extract backup, using v3 services only
+  unarchive:
+    dest: /
+    remote_src: yes
+    src: "/tmp/{{ restore_file}}"
+    exclude: "var/lib/tor/services/source,var/lib/tor/services/journalist,var/lib/tor/services/ssh"
+  when: (restore_skip_tor is not defined) and
+        ("V3 services detected" in compare_result.stdout)
 
 - name: Extract backup, skipping tor service configuration
   unarchive:
@@ -77,11 +88,13 @@
   copy:
     src: "{{ role_path }}/files/disable_v2.py"
     dest: /opt/disable_v2.py
-  when: ansible_distribution_release == 'focal'
+  when: (ansible_distribution_release == 'focal') or
+        ("V3 services detected" in compare_result.stdout)
 
 - name: Execute disable_v2 script on Focal
   command: python3 /opt/disable_v2.py /etc/tor/torrc /etc/tor/torrc
-  when: ansible_distribution_release == 'focal'
+  when: (ansible_distribution_release == 'focal') or
+        ("V3 services detected" in compare_result.stdout)
 
 - name: Remove v2 tor source directory
   file:


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #5676 , towards https://github.com/freedomofpress/securedrop/issues/5731

We filter out any v2 onion address related line from /etc/tor/torrc
and also the directories from /var/lib/tor/services. This will
happen only on Focal. On Xenial, everything stays the same.

## Testing

- [ ] Checkout this branch in Tails
- [ ] Restore a v2 + v3 backup into a Xenial prod, nothing should change
- [ ] Create a Focal prod vm following steps at https://github.com/freedomofpress/securedrop/pull/5669 with both v2+v3
- [ ] Restore the same backup from tails to the Focal VM.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
