### PR TITLE
adds daily OSSEC check/alert for v2 onion service config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 codecov:
   disable_default_path_fixes: false
 ignore:
+  - "securedrop/loaddata.py"
   - "securedrop/upload-screenshots.py"
   - "securedrop/qa_loader.py"
   - "securedrop/create-dev-data.py"

--- a/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-agent/var/ossec/etc/ossec.conf
@@ -145,6 +145,13 @@
   </localfile>
 
   <localfile>
+    <log_format>command</log_format>
+    <command>grep "HiddenServiceVersion 2" /etc/tor/torrc | head -1</command>
+    <alias>v2_service_check</alias>
+    <frequency>86400</frequency>
+  </localfile>
+
+  <localfile>
     <log_format>syslog</log_format>
     <location>/var/log/kern.log</location>
   </localfile>

--- a/install_files/securedrop-ossec-server/var/ossec/etc/ossec.conf
+++ b/install_files/securedrop-ossec-server/var/ossec/etc/ossec.conf
@@ -104,6 +104,13 @@
     <frequency>90000</frequency>
   </localfile>
 
+  <localfile>
+    <log_format>command</log_format>
+    <command>grep "HiddenServiceVersion 2" /etc/tor/torrc | head -1</command>
+    <alias>v2_service_check</alias>
+    <frequency>86400</frequency>
+  </localfile>
+
   <reports>
     <group>authentication_success</group>
     <user type="relation">srcip</user>
@@ -156,6 +163,14 @@
     <email_to>root@localhost</email_to>
     <group>system_configuration</group>
     <rule_id>400900</rule_id>
+    <do_not_delay />
+    <do_not_group />
+  </email_alerts>
+
+  <email_alerts>
+    <email_to>root@localhost</email_to>
+    <group>system_configuration</group>
+    <rule_id>400901</rule_id>
     <do_not_delay />
     <do_not_group />
   </email_alerts>

--- a/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
+++ b/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
@@ -233,4 +233,11 @@
     <regex>System configuration error:</regex>
     <description>Indicates a problem with the configuration of the SecureDrop servers.</description>
   </rule>
+  <rule id="400901" level="12" >
+    <if_sid>530</if_sid>
+    <options>alert_by_email</options> <!-- force email to be sent -->
+    <match>ossec: output: 'v2_service_check'</match>
+    <regex>HiddenServiceVersion 2</regex>
+    <description>v2 onion services are still enabled. Support for v2 onion services is deprecated and will be removed starting in February 2021. To preserve access to SecureDrop, you must migrate to v3 onion services: https://securedrop.org/v2-onion-eol</description>
+  </rule>
 </group>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5673.

Adds a daily OSSEC check for "HiddenServiceVersion 2" matches in the `/etc/tor/torrc` files on the app and mon servers.

## Testing:

### Prod: 

- install latest prod version with only v2 onion services enabled
- build debs from this branch
- install built `securedrop-ossec-agent` .deb on app, `securedrop-ossec-server` .deb on mon and restart OSSEC on both servers with the command `sudo systemctl restart ossec`
- [ ] observe the `/var/ossec/logs/alerts/alerts.log` file on mon and confirm there are `v2_service_check` alerts generated for both app and mon
- [ ] if configured, the OSSEC alert email address receives both the alerts above
- install latest prod version with both v2 and v3 onion services enabled
- build debs from this branch
- install built `securedrop-ossec-agent` .deb on app, `securedrop-ossec-server` .deb on mon and restart OSSEC on both servers with the command `sudo systemctl restart ossec`
- [ ] observe the `/var/ossec/logs/alerts/alerts.log` file on mon and confirm there are `v2_service_check` alerts generated for both app and mon
- [ ] if configured, the OSSEC alert email address receives both the alerts above

- update the last prod install to use v3 onion services only via `./securedrop-admin sdconfig && ./securedrop-admin install`
- reinstall the built debs if overwritten and restart OSSEC as above
- [ ] observe the `/var/ossec/logs/alerts/alerts.log` file on mon and confirm there are no`v2_service_check` alerts generated for both app and mon
- [ ] confirm no `v2_service_check` alert emails are sent.

## Checklist

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR 

Choose one of the following:

- [x] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation
