### PR TITLE
Added Makefile and requirements changes to allow `make safety` to pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 	@echo "███ Running safety..."
 	@for req_file in `find . -type f -name '*requirements.txt'`; do \
 		echo "Checking file $$req_file" \
-		&& safety check --full-report -r $$req_file \
+		&& safety check --ignore 39252 --full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \
 	done

--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -26,6 +26,7 @@ pip-tools==4.5.1
 psutil>=5.6.6
 pyenchant
 pylint>=2.5.0
+py>=1.10.0
 pytest>=6.1.1
 pytest-xdist>=2.1.0
 python-vagrant

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -459,10 +459,10 @@ ptyprocess==0.5.2 \
     --hash=sha256:e64193f0047ad603b71f202332ab5527c5e52aa7c8b609704fc28c0dc20c4365 \
     --hash=sha256:e8c43b5eee76b2083a9badde89fd1bbce6c8942d1045146e100b7b5e014f4f1a \
     # via pexpect
-py==1.9.0 \
-    --hash=sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2 \
-    --hash=sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342 \
-    # via pytest, pytest-forked
+py==1.10.0 \
+    --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3 \
+    --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a \
+    # via -r requirements/python3/develop-requirements.in, pytest, pytest-forked
 pycodestyle==2.5.0 \
     --hash=sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56 \
     --hash=sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c \

--- a/securedrop/requirements/python3/test-requirements.in
+++ b/securedrop/requirements/python3/test-requirements.in
@@ -8,7 +8,7 @@ mock
 pathlib2
 pillow>=7.2.0
 pip-tools==4.5.1
-py
+py>=1.10.0
 pytest>=6.1.1
 pytest-xdist>=2.1.0
 pluggy>=0.13.1

--- a/securedrop/requirements/python3/test-requirements.txt
+++ b/securedrop/requirements/python3/test-requirements.txt
@@ -197,9 +197,9 @@ pluggy==0.13.1 \
     --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \
     --hash=sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d \
     # via -r requirements/python3/test-requirements.in, pytest
-py==1.9.0 \
-    --hash=sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2 \
-    --hash=sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342 \
+py==1.10.0 \
+    --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3 \
+    --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a \
     # via -r requirements/python3/test-requirements.in, pytest, pytest-forked
 pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \


### PR DESCRIPTION

## Status

Ready for review 

## Description of Changes

Fixes #5685.

- Added `--ignore 39252` flag for check related to unused functionality in cryptography 3.2.1
- Updated `py` dependency in develop and test requirements to 1.10.0

## Testing

- [x] CI passes on this branch
- [x] `make safety` passes locally
- [x] Only dependency updates are to `py` from 1.9.0 to 1.10.0 in develop and test requirements.

## Deployment

CI & development only 

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
