### PR TITLE
Refactor scrypt hashing and source app session mgmt pt 1/3

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -211,6 +211,7 @@
   /var/www/securedrop/sdconfig.py r,
   /var/www/securedrop/secure_tempfile.py r,
   /var/www/securedrop/source.py r,
+  /var/www/securedrop/source_user.py r,
   /var/www/securedrop/source_app/ r,
   /var/www/securedrop/source_app/__init__.py r,
   /var/www/securedrop/source_app/api.py r,

--- a/securedrop/crypto_util.py
+++ b/securedrop/crypto_util.py
@@ -27,6 +27,8 @@ from passphrases import DicewarePassphrase
 
 # monkey patch to work with Focal gnupg.
 # https://github.com/isislovecruft/python-gnupg/issues/250
+from source_user import SourceUser
+
 gnupg._parsers.Verify.TRUST_LEVELS["DECRYPTION_COMPLIANCE_MODE"] = 23
 
 # to fix GPG error #78 on production
@@ -151,6 +153,7 @@ class CryptoUtil:
 
         raise ValueError("Could not generate unique journalist designation for new source")
 
+    # TODO(AD): This will be removed in my next PR and replaced by SourceUser
     def hash_codename(self, codename: DicewarePassphrase, salt: Optional[str] = None) -> str:
         """Salts and hashes a codename using scrypt.
 
@@ -162,33 +165,14 @@ class CryptoUtil:
             salt = self.scrypt_id_pepper
         return b32encode(scrypt.hash(codename, salt, **self.scrypt_params)).decode('utf-8')
 
-    def genkeypair(self, name: str, secret: DicewarePassphrase) -> gnupg._parsers.GenKey:
-        """Generate a GPG key through batch file key generation. A source's
-        codename is salted with SCRYPT_GPG_PEPPER and hashed with scrypt to
-        provide the passphrase used to encrypt their private key. Their name
-        should be their filesystem id.
-
-        >>> if not gpg.list_keys(hash_codename('randomid')):
-        ...     genkeypair(hash_codename('randomid'), 'randomid').type
-        ... else:
-        ...     u'P'
-        u'P'
-
-        :param name: The source's filesystem id (their codename, salted
-                         with SCRYPT_ID_PEPPER, and hashed with scrypt).
-        :param secret: The source's codename.
-        :returns: a :class:`GenKey <gnupg._parser.GenKey>` object, on which
-                  the ``__str__()`` method may be called to return the
-                  generated key's fingeprint.
-
+    def genkeypair(self, source_user: SourceUser) -> gnupg._parsers.GenKey:
+        """Generate a GPG key through batch file key generation.
         """
-        _validate_name_for_diceware(name)
-        hashed_secret = self.hash_codename(secret, salt=self.scrypt_gpg_pepper)
         genkey_obj = self.gpg.gen_key(self.gpg.gen_key_input(
             key_type=self.GPG_KEY_TYPE,
             key_length=self.__gpg_key_length,
-            passphrase=hashed_secret,
-            name_email=name,
+            passphrase=source_user.gpg_secret,
+            name_email=source_user.filesystem_id,
             name_real="Source Key",
             creation_date=self.DEFAULT_KEY_CREATION_DATE.isoformat(),
             expire_date=self.DEFAULT_KEY_EXPIRATION_DATE
@@ -309,9 +293,3 @@ class CryptoUtil:
         data = self.gpg.decrypt(ciphertext, passphrase=hashed_codename).data
 
         return data.decode('utf-8')
-
-
-def _validate_name_for_diceware(name: str) -> None:
-    for char in name:
-        if char not in DICEWARE_SAFE_CHARS:
-            raise CryptoException("invalid input: {0}".format(name))

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -3,7 +3,6 @@ import binascii
 import datetime
 import base64
 import os
-import scrypt
 import pyotp
 import qrcode
 # Using svg because it doesn't require additional dependencies
@@ -11,6 +10,8 @@ import qrcode.image.svg
 import uuid
 from io import BytesIO
 
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.kdf import scrypt
 from flask import current_app, url_for
 from flask_babel import gettext, ngettext
 from itsdangerous import TimedJSONWebSignatureSerializer, BadData
@@ -452,10 +453,17 @@ class Journalist(db.Model):
             self.username,
             " [admin]" if self.is_admin else "")
 
-    _LEGACY_SCRYPT_PARAMS = dict(N=2**14, r=8, p=1)
-
     def _scrypt_hash(self, password: str, salt: bytes) -> bytes:
-        return scrypt.hash(str(password), salt, **self._LEGACY_SCRYPT_PARAMS)
+        backend = default_backend()
+        scrypt_instance = scrypt.Scrypt(
+            length=64,
+            salt=salt,
+            n=2**14,
+            r=8,
+            p=1,
+            backend=backend,
+        )
+        return scrypt_instance.derive(password.encode("utf-8"))
 
     MAX_PASSWORD_LEN = 128
     MIN_PASSWORD_LEN = 14

--- a/securedrop/passphrases.py
+++ b/securedrop/passphrases.py
@@ -13,7 +13,7 @@ from sdconfig import config
 DicewarePassphrase = NewType("DicewarePassphrase", str)
 
 
-_current_generator = None  # type: Optional["PassphraseGenerator"]
+_default_generator = None  # type: Optional["PassphraseGenerator"]
 
 
 class InvalidWordListError(Exception):
@@ -52,7 +52,9 @@ class PassphraseGenerator:
                 raise InvalidWordListError(
                     "The word list for language '{}' only contains {} long-enough words;"
                     " minimum required is {} words.".format(
-                        language, word_list_size, self._WORD_LIST_MINIMUM_SIZE,
+                        language,
+                        word_list_size,
+                        self._WORD_LIST_MINIMUM_SIZE,
                     )
                 )
 
@@ -98,11 +100,11 @@ class PassphraseGenerator:
 
     @classmethod
     def get_default(cls) -> "PassphraseGenerator":
-        global _current_generator
-        if _current_generator is None:
+        global _default_generator
+        if _default_generator is None:
             language_to_words = _parse_available_words_list(Path(config.SECUREDROP_ROOT))
-            _current_generator = cls(language_to_words)
-        return _current_generator
+            _default_generator = cls(language_to_words)
+        return _default_generator
 
     @property
     def available_languages(self) -> Set[str]:

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -9,11 +9,9 @@ import re
 
 from crypto_util import CryptoException
 from models import Source
-from passphrases import PassphraseGenerator, DicewarePassphrase
-from sdconfig import SDConfig
 
 if typing.TYPE_CHECKING:
-    from typing import Optional  # noqa: F401
+    from typing import Optional
 
 
 def was_in_generate_flow() -> bool:
@@ -35,21 +33,6 @@ def valid_codename(codename: str) -> bool:
 
     source = Source.query.filter_by(filesystem_id=filesystem_id).first()
     return source is not None
-
-
-def generate_unique_codename(config: SDConfig) -> DicewarePassphrase:
-    """Generate random codenames until we get an unused one"""
-    while True:
-        passphrase = PassphraseGenerator.get_default().generate_passphrase(
-            preferred_language=g.localeinfo.language
-        )
-        # scrypt (slow)
-        filesystem_id = current_app.crypto_util.hash_codename(passphrase)
-
-        matching_sources = Source.query.filter(
-            Source.filesystem_id == filesystem_id).all()
-        if len(matching_sources) == 0:
-            return passphrase
 
 
 def normalize_timestamps(filesystem_id: str) -> None:

--- a/securedrop/source_user.py
+++ b/securedrop/source_user.py
@@ -1,0 +1,120 @@
+import os
+from base64 import b32encode
+from typing import TYPE_CHECKING
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.kdf import scrypt
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+import models
+
+if TYPE_CHECKING:
+    from crypto_util import CryptoUtil
+    from passphrases import DicewarePassphrase
+    from store import Storage
+
+
+class SourceUser:
+    """A source user and their associated data derived from their passphrase."""
+
+    def __init__(self, db_record: models.Source, filesystem_id: str, gpg_secret: str) -> None:
+        self.gpg_secret = gpg_secret
+        self.filesystem_id = filesystem_id
+        self.db_record_id = db_record.id  # We don't store the actual record to force a refresh
+
+    def get_db_record(self) -> models.Source:
+        return models.Source.query.get(self.db_record_id)
+
+
+class SourcePassphraseCollisionError(Exception):
+    """Tried to create a Source with a passphrase already used by another Source."""
+
+
+class SourceDesignationCollisionError(Exception):
+    """Tried to create a Source with a journalist designation already used by another Source."""
+
+
+def create_source_user(
+    db_session: Session,
+    source_passphrase: "DicewarePassphrase",
+    source_app_crypto_util: "CryptoUtil",
+    source_app_storage: "Storage",
+) -> SourceUser:
+    # Derive the source's info from their passphrase
+    # TODO(AD): This will be updated in my next PR to not take params from the CryptoUtil instance
+    scrypt_manager = _SourceScryptManager(
+        salt_for_gpg_secret=source_app_crypto_util.scrypt_gpg_pepper.encode(),
+        salt_for_filesystem_id=source_app_crypto_util.scrypt_id_pepper.encode(),
+        scrypt_n=source_app_crypto_util.scrypt_params["N"],
+        scrypt_r=source_app_crypto_util.scrypt_params["r"],
+        scrypt_p=source_app_crypto_util.scrypt_params["p"],
+    )
+    filesystem_id = scrypt_manager.derive_source_filesystem_id(source_passphrase)
+    gpg_secret = scrypt_manager.derive_source_gpg_secret(source_passphrase)
+
+    # Create a designation for the source
+    try:
+        journalist_designation = source_app_crypto_util.display_id()
+    except ValueError:
+        raise SourceDesignationCollisionError()
+
+    # Store the source in the DB
+    source_db_record = models.Source(filesystem_id, journalist_designation)
+    db_session.add(source_db_record)
+    try:
+        db_session.commit()
+    except IntegrityError:
+        db_session.rollback()
+        raise SourcePassphraseCollisionError(
+            "Passphrase already used by another Source (filesystem_id {})".format(filesystem_id)
+        )
+    # Create the source's folder
+    os.mkdir(source_app_storage.path(filesystem_id))
+
+    # All done
+    return SourceUser(source_db_record, filesystem_id, gpg_secret)
+
+
+class _SourceScryptManager:
+    def __init__(
+        self,
+        salt_for_gpg_secret: bytes,
+        salt_for_filesystem_id: bytes,
+        scrypt_n: int,
+        scrypt_r: int,
+        scrypt_p: int,
+    ) -> None:
+        if salt_for_gpg_secret == salt_for_filesystem_id:
+            raise ValueError("scrypt_id_pepper == scrypt_gpg_pepper")
+
+        self._salt_for_gpg_secret = salt_for_gpg_secret
+        self._salt_for_filesystem_id = salt_for_filesystem_id
+        self._scrypt_n = scrypt_n
+        self._scrypt_r = scrypt_r
+        self._scrypt_p = scrypt_p
+        self._backend = default_backend()
+
+    def derive_source_gpg_secret(self, source_passphrase: "DicewarePassphrase") -> str:
+        scrypt_for_gpg_secret = scrypt.Scrypt(
+            length=64,
+            salt=self._salt_for_gpg_secret,
+            n=self._scrypt_n,
+            r=self._scrypt_r,
+            p=self._scrypt_p,
+            backend=self._backend,
+        )
+        hashed_passphrase = scrypt_for_gpg_secret.derive(source_passphrase.encode("utf-8"))
+        return b32encode(hashed_passphrase).decode("utf-8")
+
+    def derive_source_filesystem_id(self, source_passphrase: "DicewarePassphrase") -> str:
+        scrypt_for_filesystem_id = scrypt.Scrypt(
+            length=64,
+            salt=self._salt_for_filesystem_id,
+            n=self._scrypt_n,
+            r=self._scrypt_r,
+            p=self._scrypt_p,
+            backend=self._backend,
+        )
+        hashed_passphrase = scrypt_for_filesystem_id.derive(source_passphrase.encode("utf-8"))
+        return b32encode(hashed_passphrase).decode("utf-8")

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -17,7 +17,6 @@ from mock import patch, ANY
 import pytest
 
 import crypto_util
-import source
 from passphrases import PassphraseGenerator
 from . import utils
 import server_os
@@ -151,28 +150,24 @@ def test_generate(source_app):
 
 
 def test_create_duplicate_codename_logged_in_not_in_session(source_app):
-    with patch.object(source.app.logger, 'error') as logger:
-        with source_app.test_client() as app:
-            resp = app.get(url_for('main.generate'))
-            assert resp.status_code == 200
-            tab_id = next(iter(session['codenames'].keys()))
+    with source_app.test_client() as app:
+        resp = app.get(url_for('main.generate'))
+        assert resp.status_code == 200
+        tab_id = next(iter(session['codenames'].keys()))
 
-            # Create a source the first time
-            resp = app.post(url_for('main.create'), data={'tab_id': tab_id}, follow_redirects=True)
-            assert resp.status_code == 200
-            codename = session['codename']
+        # Create a source the first time
+        resp = app.post(url_for('main.create'), data={'tab_id': tab_id}, follow_redirects=True)
+        assert resp.status_code == 200
+        codename = session['codename']
 
-        with source_app.test_client() as app:
-            # Attempt to add the same source
-            with app.session_transaction() as sess:
-                sess['codenames'] = {tab_id: codename}
-            resp = app.post(url_for('main.create'), data={'tab_id': tab_id}, follow_redirects=True)
-            logger.assert_called_once()
-            assert ("Attempt to create a source with duplicate codename"
-                    in logger.call_args[0][0])
-            assert resp.status_code == 500
-            assert 'codename' not in session
-            assert 'logged_in' not in session
+    with source_app.test_client() as app:
+        # Attempt to add the same source
+        with app.session_transaction() as sess:
+            sess['codenames'] = {tab_id: codename}
+        resp = app.post(url_for('main.create'), data={'tab_id': tab_id}, follow_redirects=True)
+        assert resp.status_code == 200
+        assert 'codename' not in session
+        assert 'logged_in' not in session
 
 
 def test_create_duplicate_codename_logged_in_in_session(source_app):

--- a/securedrop/tests/test_source_user.py
+++ b/securedrop/tests/test_source_user.py
@@ -1,0 +1,93 @@
+from unittest import mock
+
+import pytest
+
+from db import db
+from passphrases import PassphraseGenerator
+from source_user import SourceDesignationCollisionError
+from source_user import SourcePassphraseCollisionError
+from source_user import _SourceScryptManager
+from source_user import create_source_user
+
+
+TEST_SALT_GPG_SECRET = "YrPAwKMyWN66Y2WNSt+FS1KwfysMHwPISG0wmpb717k="
+TEST_SALT_FOR_FILESYSTEM_ID = "mEFXIwvxoBqjyxc/JypLdvgMRNRjApoaM0OBNrxJM2E="
+
+
+class TestSourceUser:
+    def test_create_source_user(self, source_app):
+        # Given a passphrase
+        passphrase = PassphraseGenerator.get_default().generate_passphrase()
+
+        # When trying to create a new source user with this passphrase, it succeeds
+        source_user = create_source_user(
+            db_session=db.session,
+            source_passphrase=passphrase,
+            source_app_crypto_util=source_app.crypto_util,
+            source_app_storage=source_app.storage,
+        )
+        assert source_user
+        assert source_user.get_db_record()
+
+    def test_create_source_user_passphrase_collision(self, source_app):
+        # Given a source in the DB
+        passphrase = PassphraseGenerator.get_default().generate_passphrase()
+        create_source_user(
+            db_session=db.session,
+            source_passphrase=passphrase,
+            source_app_crypto_util=source_app.crypto_util,
+            source_app_storage=source_app.storage,
+        )
+
+        # When trying to create another with the same passphrase, it fails
+        with pytest.raises(SourcePassphraseCollisionError):
+            create_source_user(
+                db_session=db.session,
+                source_passphrase=passphrase,
+                source_app_crypto_util=source_app.crypto_util,
+                source_app_storage=source_app.storage,
+            )
+
+    def test_create_source_user_designation_collision(self, source_app):
+        # Given a source in the DB
+        create_source_user(
+            db_session=db.session,
+            source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
+            source_app_crypto_util=source_app.crypto_util,
+            source_app_storage=source_app.storage,
+        )
+
+        # And the next generated journalist designation will be identical to this source's
+        with mock.patch.object(source_app.crypto_util, "display_id", side_effect=ValueError):
+            # When trying to create another source, it fails, because the designation is the same
+            with pytest.raises(SourceDesignationCollisionError):
+                create_source_user(
+                    db_session=db.session,
+                    source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
+                    source_app_crypto_util=source_app.crypto_util,
+                    source_app_storage=source_app.storage,
+                )
+
+
+class TestSourceScryptManager:
+    def test(self):
+        # Given a passphrase
+        passphrase = "rehydrate flaring study raven fence extenuate linguist"
+
+        # When deriving the passphrase's filesystem ID and GPG secret
+        scrypt_mgr = _SourceScryptManager(
+            salt_for_gpg_secret=TEST_SALT_GPG_SECRET.encode(),
+            salt_for_filesystem_id=TEST_SALT_FOR_FILESYSTEM_ID.encode(),
+            scrypt_n=2 ** 1,
+            scrypt_r=1,
+            scrypt_p=1,
+        )
+        filesystem_id = scrypt_mgr.derive_source_filesystem_id(passphrase)
+        gpg_secret = scrypt_mgr.derive_source_gpg_secret(passphrase)
+
+        # It succeeds and the right values are returned
+        expected_filesystem_id = "7A7N4GSAB6NRZLUYOTHVYWJGOYIFS24TRC5FQQUSSXCWTF7MJQ7W3QTQLHUFHTKHYO3ONKJ6RSWPS6OI2PFCIW3KI4UZVKGZ3GAIKXI="  # noqa: E501
+        assert expected_filesystem_id == filesystem_id
+
+        expected_gpg_secret = "AWCRZVPA6YTQ2A3552LZJW3VO7L3ZONDFT6A6VPRGPGQQSNENRLA3EVRW4LZYNSUV5QIKNFZMJ2BMOVORG43ZETV5ZCRQKLJNOC2BXY="  # noqa: E501
+        assert expected_gpg_secret == gpg_secret

--- a/securedrop/tests/test_store.py
+++ b/securedrop/tests/test_store.py
@@ -7,6 +7,9 @@ import re
 import stat
 import zipfile
 
+from passphrases import PassphraseGenerator
+from source_user import create_source_user
+
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 from . import utils
 
@@ -217,7 +220,13 @@ def test_add_checksum_for_file(config, db_model):
 
     with app.app_context():
         db.create_all()
-        source, _ = utils.db_helper.init_source_without_keypair()
+        source_user = create_source_user(
+            db_session=db.session,
+            source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
+            source_app_crypto_util=app.crypto_util,
+            source_app_storage=app.storage,
+        )
+        source = source_user.get_db_record()
         target_file_path = app.storage.path(source.filesystem_id, '1-foo-msg.gpg')
         test_message = b'hash me!'
         expected_hash = 'f1df4a6d8659471333f7f6470d593e0911b4d487856d88c83d2d187afa195927'
@@ -259,7 +268,13 @@ def test_async_add_checksum_for_file(config, db_model):
 
     with app.app_context():
         db.create_all()
-        source, _ = utils.db_helper.init_source_without_keypair()
+        source_user = create_source_user(
+            db_session=db.session,
+            source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
+            source_app_crypto_util=app.crypto_util,
+            source_app_storage=app.storage,
+        )
+        source = source_user.get_db_record()
         target_file_path = app.storage.path(source.filesystem_id, '1-foo-msg.gpg')
         test_message = b'hash me!'
         expected_hash = 'f1df4a6d8659471333f7f6470d593e0911b4d487856d88c83d2d187afa195927'


### PR DESCRIPTION
## Status

Ready.

## Description of Changes

This PR started with the goal of refactoring **CryptoUtil.hash_codename()** to move it out of CryptoUtil (for #5599).

However, I ran into some problems as I was trying to do this, and saw some opportunities for larger improvements. The downside is that the changes are bigger, so I split them into 3 PRs so they're a bit easier to review. While I know big changes are annoying to review, merge and ultimately deal with, I think these ones are important and worth it.

Overall I felt that a crucial concept was "missing"/invisible in the code base: a user who is currently logged into the source application. 

So the main change of these PRs is the introduction of a **SourceUser** class, which ties it all together: how a user's session is managed (when they create an account, login, etc.), how the user's crypto works (filesystem_id, gpg_secret, etc.), and the user's corresponding "Source" record in the DB. 

My overall goal is to make all this logic self-documenting so it is clear to the reader how these users (and more generally the source app) work. Currently, this logic is spread throughout the code base and also repeated a lot, which makes it hard to understand and hard to change. The main example of this is how hash_codename() is used in a lot of code locations, but in each of them it is hard to understand what is getting hashed, and why.

While I split the changes into 3 PRs, each PR brings something useful independently of the other ones:

* 1/3: This PR: Implement SourceUser and create_source_user() to consolidate source creation (More details below)
* 2/3: https://github.com/freedomofpress/securedrop/pull/5694 Remove CryptoUtil.hash_codename(), scrypt Python dependency, and refactor session management in the source app.
* 3/3: https://github.com/freedomofpress/securedrop/pull/5695 Remove usage of flask.g in the source app and fix tests.

If everything gets merged, the following issues will be completed or will see progress: #5455, #5599, #5613. I also think the source app's code base will be significantly easier to approach, understand, and maintain (at least that's the main goal).

**About this PR which is part 1/3:**

* Implement SourceUser and create_source_user() to consolidate source creation. In the current code base there is some duplicate code (in the tests, the apps, etc.) for creating a new source. This PR replaces all of them with a call to create_source_user() so there's one consistent way of creating a source.
* Fixes https://github.com/freedomofpress/securedrop/issues/5455.