### PR TITLE
Use confirmation modal when Admin deletes a user

### DIFF
--- a/securedrop/journalist_templates/_confirmation_modal.html
+++ b/securedrop/journalist_templates/_confirmation_modal.html
@@ -10,7 +10,7 @@
     <center>
       <div class="btn-row">
         <a href="#close" id="{{ modal_data.cancel_id }}" title="{{ gettext('Cancel') }}" class="btn cancel small">{{ gettext('Cancel') }}</a>
-        <button type="submit" id="{{ modal_data.submit_id }}" name="action" value="delete" class="btn small {{ modal_data.submit_btn_type }}">{{ modal_data.submit_btn_text }}</button>
+        <button type="submit" id="{{ modal_data.submit_id }}" name="action" value="delete" {% if modal_data.modal_action is defined %} formaction="{{ modal_data.modal_action }}" {% endif %} class="btn small {{ modal_data.submit_btn_type }}">{{ modal_data.submit_btn_text }}</button>
       </div>
     </center>
   </div>

--- a/securedrop/journalist_templates/admin.html
+++ b/securedrop/journalist_templates/admin.html
@@ -38,12 +38,14 @@
         </td>
 	{% else %}
         <td>
-          <button type="submit" class="plain delete-user" formaction="/admin/delete/{{ user.id }}" data-username="{{ user.username}}">
-            <i title="{{ gettext('Delete user {username}').format(username=user.username) }}">
-              <img src="{{ url_for('static', filename='icons/trash.png') }}" class="off-hover" width="14" height="16" alt="{{ gettext('Delete user {username}').format(username=user.username) }}">
-              <img src="{{ url_for('static', filename='icons/trash-hover-red.png') }}" class="on-hover" width="14" height="16" alt="{{ gettext('Delete user {username}').format(username=user.username) }}">
-            </i>
-          </button>
+          <a href="?user_id={{ user.id }}#delete-user-confirmation-modal">
+            <button type="button" class="plain delete-user" data-username="{{ user.username}}">
+              <i title="{{ gettext('Delete user {username}').format(username=user.username) }}">
+                <img src="{{ url_for('static', filename='icons/trash.png') }}" class="off-hover" width="14" height="16" alt="{{ gettext('Delete user {username}').format(username=user.username) }}">
+                <img src="{{ url_for('static', filename='icons/trash-hover-red.png') }}" class="on-hover" width="14" height="16" alt="{{ gettext('Delete user {username}').format(username=user.username) }}">
+              </i>
+            </button>
+          </a>
         </td>
 	{% endif %}
         <td><time class="date" title="{{ user.created_on }}">{{ user.created_on|rel_datetime_format(relative=True) }}</time></td>
@@ -55,6 +57,23 @@
       </tr>
     {% endfor %}
   </table>
+
+  <!-- Delete Confirmation modal for user -->
+  {% with %}
+    {% set modal_data = {
+                          "modal_id": "delete-user-confirmation-modal",
+                          "modal_header": gettext('Delete Confirmation'),
+                          "modal_body": gettext('Are you sure you want to delete this user?'),
+                          "modal_action": "/admin/delete/" + request.args.get('user_id') if request.args.get('user_id') else "",
+                          "cancel_id": "cancel-selected-deletions",
+                          "submit_id": "delete-selected",
+                          "submit_btn_type": "danger",
+                          "submit_btn_text": gettext('DELETE')
+                        }
+    %}
+    {% include '_confirmation_modal.html' %}
+  {% endwith %}
+
 </form>
 {% else %}
 <p>{{ gettext('No users to display') }}</p>

--- a/securedrop/journalist_templates/js-strings.html
+++ b/securedrop/journalist_templates/js-strings.html
@@ -4,7 +4,6 @@
   <div id="select-all-string" hidden>{{ gettext('Select All') }}</div>
   <div id="select-unread-string" hidden>{{ gettext('Select Unread') }}</div>
   <div id="select-none-string" hidden>{{ gettext('Select None') }}</div>
-  <div id="delete-user-confirm-string" hidden>{{ gettext('Are you sure you want to delete the user {username}?') }}</div>
   <div id="reset-user-mfa-confirm-string" hidden>{{ gettext('Are you sure you want to reset two-factor authentication for {username}?') }}</div>
   <div id="sources-selected" hidden>{{ gettext('Sources selected: ') }}</div>
 </div>

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -164,19 +164,6 @@ ready(function() {
     filter_codenames(filterInput.value);
   }
 
-  // Confirm before deleting user on admin page
-  let deleteUser = document.querySelector('button.delete-user');
-  if (deleteUser) {
-    deleteUser.addEventListener('click', function(evt) {
-      let username = this.dataset.username;
-      let confirmed = confirm(get_string("delete-user-confirm-string").supplant({ username: username }));
-      if (!confirmed) {
-        evt.preventDefault();
-      }
-      return confirmed;
-    });
-  };
-
   // Confirm before resetting multifactor authentication on edit user page
   let resetTwoFactorForms = document.querySelectorAll('form.reset-two-factor');
   for (let i = 0; i < resetTwoFactorForms.length; i++) {

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -468,6 +468,10 @@ class JournalistNavigationStepsMixin:
         for i in range(CLICK_ATTEMPTS):
             try:
                 self.safe_click_by_css_selector(".delete-user")
+                self.wait_for(
+                    lambda: expected_conditions.element_to_be_clickable((By.ID, "delete-selected"))
+                )
+                self.safe_click_by_id("delete-selected")
                 self.alert_wait()
                 self.alert_accept()
                 break


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #4649 

Changes proposed in this pull request:
This PR removes the logic of only JS supported confirmation modal when Admin deletes a User and replaces it with the confirmation modal which works without JS. 

## Testing

How should the reviewer test this PR?
Login as Admin and try deleting a user. Try out the confirmation modal. Should also work with Safest Setting for Tor Browser (i.e, without JS).

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [X] These changes do not require documentation
