### PR TITLE
Update Tor Browser, Firefox, geckodriver

### DIFF
--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -21,9 +21,9 @@ RUN gem install sass -v 3.4.23
 # Current versions of the test browser software. Tor Browser is based
 # on a specific version of Firefox, noted in Help > About Tor Browser.
 # Ideally we'll keep those in sync.
-ENV FF_VERSION 78.4.0esr
-ENV GECKODRIVER_VERSION v0.27.0
-ENV TBB_VERSION 10.0.6
+ENV FF_VERSION 78.6.1esr
+ENV GECKODRIVER_VERSION v0.28.0
+ENV TBB_VERSION 10.0.8
 
 # Import Tor release signing key
 ENV TOR_RELEASE_KEY_FINGERPRINT "EF6E286DDA85EA2A4BA7DE684E2C6E8793298290"

--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -21,9 +21,9 @@ RUN gem install sass -v 3.4.23
 # Current versions of the test browser software. Tor Browser is based
 # on a specific version of Firefox, noted in Help > About Tor Browser.
 # Ideally we'll keep those in sync.
-ENV FF_VERSION 78.4.0esr
-ENV GECKODRIVER_VERSION v0.27.0
-ENV TBB_VERSION 10.0.6
+ENV FF_VERSION 78.6.1esr
+ENV GECKODRIVER_VERSION v0.28.0
+ENV TBB_VERSION 10.0.8
 
 # Import Tor release signing key
 ENV TOR_RELEASE_KEY_FINGERPRINT "EF6E286DDA85EA2A4BA7DE684E2C6E8793298290"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This updates the versions of Tor Browser, Firefox and geckodriver used in the dev containers, so we can use those during the 1.7.0 release, continue to have a functional demo site for translators, and so on.

This always seems to happen at a very inconvenient time. Let's move #5586 up the priority list.

## Testing

- `git checkout -b update-tbb origin/tbb`
- `make dev` and verify the dev server works

### Optional (I've done it. It's fine.)
- `LOCALES="ar en_US" make translation-test`
- Check the screenshots under `tests/pageslayout/screenshots`.

## Deployment

dev only

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
