### PR TITLE
Tell pylint to use more processes

### DIFF
--- a/securedrop/pylintrc
+++ b/securedrop/pylintrc
@@ -18,7 +18,7 @@ ignore-patterns=
 #init-hook=
 
 # Use multiple processes to speed up Pylint.
-jobs=1
+jobs=0
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes `jobs=1` to `jobs=0` in pylintrc so it will use multiple processes. Speeds up `make app-lint` by ~40%, reducing the time it takes from ~40-45 seconds to ~25 on my T480.

Obviously not a priority for review. It can sit with little risk of conflict. :slightly_smiling_face: 

## Testing

- `git checkout develop`
- `time make app-lint`
- `git checkout -b parallel-pylint origin/parallel-pylint`
- `time make app-lint`

## Deployment

dev only

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation