### PR TITLE
Only configure v2 ssh service when v2 services are enabled

### DIFF
--- a/install_files/ansible-base/roles/tor-hidden-services/templates/torrc
+++ b/install_files/ansible-base/roles/tor-hidden-services/templates/torrc
@@ -16,7 +16,7 @@ HiddenServicePort 80 127.0.0.1:8080
 HiddenServiceAuthorizeClient stealth journalist
 {% endif %}
 
-{% if enable_ssh_over_tor %}
+{% if enable_ssh_over_tor and v2_onion_services %}
 HiddenServiceDir /var/lib/tor/services/ssh
 HiddenServiceVersion 2
 HiddenServicePort 22 127.0.0.1:22


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #5717 

Updates the torrc template to conditionally add the ssh config for v2 onion services

## Testing

0. Make sure the underlying issue is reproducible
- [ ] I can reproduce the issue described in #5717 

1. Install from develop (or 1.7.0-rc2) using staging or prod scenarios, with the following config:
* enable_ssh_over_tor: true
* v2_onion_services: true
* v3_onion_services: true

2. Confirm that you receive the alert:
- [ ] An email alert is received indicating v2 services are enabled
- [ ] /var/ossec/logs/alerts/alert.log contains rule 4000901 triggered

3. Check out this branch, set `v2_onion_services: false` and run `./securedrop-admin install`
4. Confirm the changes work as expected
- [ ] `/var/ossec/logs/alerts.log` does not contain a new rule 4000901 that was triggered
- [ ] `/etc/tor/torrc` does not contain occurrences of `HiddenServiceVersion 2` on both app and mon
 
## Deployment

New and existing installs will be configured using Ansible. For orgs which have already updated to disable v2, they will need to run the playbook again to ensure v2 onion services for ssh are properly disabled.

Disabling v2 and enabling v3 in a single pass might prove problematic if provisioning over Tor, but the documentation appears sufficiently clear that one should enable v2+v3 first, then disable v2: https://docs.securedrop.org/en/stable/v3_services.html#disabling-v2-onion-services

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
