### PR TITLE
Update CI docker images with CircleCI python images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,9 +225,9 @@ jobs:
 
   admin-tests:
     docker:
-      - image: gcr.io/cloud-builders/docker
+      - image: cimg/python:3.7
     steps:
-      - run: apt-get install -y make jq
+      - run: sudo apt update && sudo apt-get install -y make jq
       - checkout
       - setup_remote_docker
       - run:
@@ -239,9 +239,9 @@ jobs:
 
   fetch-tor-debs:
     docker:
-      - image: gcr.io/cloud-builders/docker
+      - image: cimg/python:3.7
     steps:
-      - run: apt-get install -y make virtualenv python3-pip enchant jq
+      - run: sudo apt-get update && sudo apt-get install -y make virtualenv python3-pip enchant jq rsync
       - checkout
       - setup_remote_docker
       - run:
@@ -369,12 +369,12 @@ jobs:
 
   deb-tests:
     docker:
-      - image: gcr.io/cloud-builders/docker
+      - image: cimg/python:3.7
     environment:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     steps:
-      - run: apt-get install -y make virtualenv enchant jq python3-dev build-essential
+      - run: sudo apt-get update && sudo apt-get install -y make virtualenv enchant jq python3-dev build-essential rsync
       - checkout
       - setup_remote_docker
       - run:
@@ -386,12 +386,12 @@ jobs:
 
   deb-tests-focal:
     docker:
-      - image: gcr.io/cloud-builders/docker
+      - image: cimg/python:3.7
     environment:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     steps:
-      - run: apt-get install -y make virtualenv enchant jq python3-dev build-essential
+      - run: sudo apt-get update && sudo apt-get install -y make virtualenv enchant jq python3-dev build-essential rsync
       - checkout
       - setup_remote_docker
       - run:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5719 

The container image provided by GCPs cloud-builders now recommends in its README the use of other docker containers, and is still running on Xenial. Since they are essentially swappable in place, here we use the containers that are maintained by the CI provider [2]

[1] https://github.com/GoogleCloudPlatform/cloud-builders
[2] https://circleci.com/developer/images/image/cimg/python


## Testing

- [x] CI is passing on this branch
- [x] CI is passing on the https://github.com/freedomofpress/securedrop/tree/5719-ci-containers-test branch which is running fetch-tor-debs

## Deployment

Test/CI only
