### PR TITLE
Fix source_app.utils.normalize_timestamps

### DIFF
--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -97,15 +97,15 @@ def async_genkey(crypto_util_: CryptoUtil,
 
 def normalize_timestamps(filesystem_id: str) -> None:
     """
-    Update the timestamps on all of the source's submissions to match that of
-    the latest submission. This minimizes metadata that could be useful to
-    investigators. See #301.
+    Update the timestamps on all of the source's submissions. This
+    minimizes metadata that could be useful to investigators. See
+    #301.
     """
     sub_paths = [current_app.storage.path(filesystem_id, submission.filename)
                  for submission in g.source.submissions]
     if len(sub_paths) > 1:
-        args = ["touch"]
-        args.extend(sub_paths[:-1])
+        args = ["touch", "--no-create"]
+        args.extend(sub_paths)
         rc = subprocess.call(args)
         if rc != 0:
             current_app.logger.warning(


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Upon each new submission, [`source_app.utils.normalize_timestamp`](https://github.com/freedomofpress/securedrop/blob/cbcc894c961201dd8ca0cda93bcf959160f2f4bb/securedrop/source_app/utils.py#L98) is called to update the timestamps of all the source's submissions. It currently uses the `touch` command to do this, which means if a file has gone missing, it will be recreated empty. This could mask problems that would otherwise be detected by the daily check for disconnected submissions. The function is also omitting the most recent submission from the arguments, assuming that `touch` is going to give the previous submissions the same timestamp as the new one, which might not be true if it's not processed instantaneously.

This changes the function to call `touch` with the `--no-create` flag and all of the source's submissions.

## Testing

- `make dev`
- Log in to the source interface as a new source.  Submit one message.
- run `docker exec -it securedrop-dev-0 bash`
- in the container, navigate to the source's directory under `/var/lib/securedrop/store` and delete the file of the message you just submitted.
- Back in the source interface, submit another two messages, waiting a few seconds between them.
- Back in the container shell, verify that the source's directory only contains two files (`2-...` and `3-...`) and that their timestamps match.

## Deployment

No special considerations.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
