### PR TITLE
Restart Apache during installation when onion service version configuration changes

### DIFF
--- a/install_files/ansible-base/roles/app/tasks/copy_tor_url_info_to_app_dir.yml
+++ b/install_files/ansible-base/roles/app/tasks/copy_tor_url_info_to_app_dir.yml
@@ -23,12 +23,16 @@
     mode: "0644"
     content: |
       {{ v2_onion_url_lookup_result.stdout|default('') }}
+  notify:
+    - restart apache2
   when: v2_onion_services
 
 - name: Remove source v2 onion service info if not enabled
   file:
     path: /var/lib/securedrop/source_v2_url
     state: absent
+  notify:
+    - restart apache2
   when: not v2_onion_services
 
 - name: Expose source v3 onion service info to app
@@ -39,10 +43,14 @@
     mode: "0644"
     content: |
       {{ v3_onion_url_lookup_result.stdout|default('') }}
+  notify:
+    - restart apache2
   when: v3_onion_services
 
 - name: Remove source v3 onion service info if not enabled
   file:
     path: /var/lib/securedrop/source_v3_url
     state: absent
+  notify:
+    - restart apache2
   when: not v3_onion_services


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5715.

If the configuration of v2 and v3 services is modified, Apache needs to be restarted for the app config to reflect the changes, so that migration warnings are accurate.

## Testing

- check out `develop`
- enable both v2 and v3 onion services by running `securedrop-admin sdconfig` or editing `site-specific`
- `securedrop-admin install`
- create admin user, visit JI, confirm v2 warning is shown
- disable v2, reinstall
- visit JI and confirm warning is still shown
- `git checkout -b fix-5715 origin/fix-5715`
- reenable v2, reinstall
- visit JI and confirm v2 warning is shown
- disable v2, reinstall
- visit JI and confirm v2 warning is no longer shown

## Deployment

No special considerations.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
