### PR TITLE
[1.7.0] Backport 5726 to 1.7.0 

### DIFF
--- a/install_files/ansible-base/roles/app/tasks/copy_tor_url_info_to_app_dir.yml
+++ b/install_files/ansible-base/roles/app/tasks/copy_tor_url_info_to_app_dir.yml
@@ -23,12 +23,16 @@
     mode: "0644"
     content: |
       {{ v2_onion_url_lookup_result.stdout|default('') }}
+  notify:
+    - restart apache2
   when: v2_onion_services
 
 - name: Remove source v2 onion service info if not enabled
   file:
     path: /var/lib/securedrop/source_v2_url
     state: absent
+  notify:
+    - restart apache2
   when: not v2_onion_services
 
 - name: Expose source v3 onion service info to app
@@ -39,10 +43,14 @@
     mode: "0644"
     content: |
       {{ v3_onion_url_lookup_result.stdout|default('') }}
+  notify:
+    - restart apache2
   when: v3_onion_services
 
 - name: Remove source v3 onion service info if not enabled
   file:
     path: /var/lib/securedrop/source_v3_url
     state: absent
+  notify:
+    - restart apache2
   when: not v3_onion_services


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Backports the changes from #5726 to the 1.7.0 release branch

## Testing
- [ ] changes identical to #5726 
- [ ] target branch is `release/1.7.0`


## Deployment

For both new and existing installs, these changes will be handled in Ansible
