### PR TITLE
fix download error handling when files are missing

### DIFF
--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -153,7 +153,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
     @view.route('/bulk', methods=('POST',))
     def bulk() -> Union[str, werkzeug.Response]:
         action = request.form['action']
-
+        error_redirect = url_for('col.col', filesystem_id=g.filesystem_id)
         doc_names_selected = request.form.getlist('doc_names_selected')
         selected_docs = [doc for doc in g.source.collection
                          if doc.filename in doc_names_selected]
@@ -164,11 +164,13 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             elif action in ('delete', 'confirm_delete'):
                 flash(gettext("No collections selected for deletion."),
                       "error")
-            return redirect(url_for('col.col', filesystem_id=g.filesystem_id))
+            return redirect(error_redirect)
 
         if action == 'download':
             source = get_source(g.filesystem_id)
-            return download(source.journalist_filename, selected_docs)
+            return download(
+                source.journalist_filename, selected_docs, on_error_redirect=error_redirect
+            )
         elif action == 'delete':
             return bulk_delete(g.filesystem_id, selected_docs)
         elif action == 'confirm_delete':

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -3,7 +3,6 @@ import binascii
 import datetime
 import os
 from typing import Optional, List, Union, Any
-from urllib.parse import urlparse
 
 import flask
 import werkzeug
@@ -187,7 +186,11 @@ def mark_seen(targets: List[Union[Submission, Reply]], user: Journalist) -> None
             raise
 
 
-def download(zip_basename: str, submissions: List[Union[Submission, Reply]]) -> werkzeug.Response:
+def download(
+    zip_basename: str,
+    submissions: List[Union[Submission, Reply]],
+    on_error_redirect: Optional[str] = None
+) -> werkzeug.Response:
     """Send client contents of ZIP-file *zip_basename*-<timestamp>.zip
     containing *submissions*. The ZIP-file, being a
     :class:`tempfile.NamedTemporaryFile`, is stored on disk only
@@ -208,8 +211,9 @@ def download(zip_basename: str, submissions: List[Union[Submission, Reply]]) -> 
             ),
             "error"
         )
-        referrer = urlparse(str(request.referrer)).path
-        return redirect(referrer)
+        if on_error_redirect is None:
+            on_error_redirect = url_for('main.index')
+        return redirect(on_error_redirect)
 
     attachment_filename = "{}--{}.zip".format(
         zip_basename, datetime.datetime.utcnow().strftime("%Y-%m-%d--%H-%M-%S")


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

With the changes from #5573, when a journalist tries to download a submission for which the file is not available, the error handling is building a redirect using the referrer header, but that isn't available with our production Apache configuration, which contains `Header set Referrer-Policy "no-referrer"`. This changes `journalist_app.utils.download` to accept a URL to which the journalist will be redirected in case of error.

Fixes #5721.
Fixes #5722.

## Testing

Follow the steps to reproduce for #5721 and #5722 in an environment using Apache and this branch -- staging will suffice, but the dev server will not. Running `make build-debs; make staging` on this branch will be easiest.

You should not get any 500 or 404 errors with this change in place.

## Deployment

This changes error handling when submission files are missing. If wrong, journalists could be redirected to an unexpected location.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
