### PR TITLE
Upgrade boxes for SecureDrop 1.7.1

### DIFF
--- a/molecule/upgrade/side_effect.yml
+++ b/molecule/upgrade/side_effect.yml
@@ -30,6 +30,8 @@
 
     - name: Insert journalist test user
       command: /var/www/securedrop/loaddata.py
+      environment:
+        CRYPTOGRAPHY_ALLOW_OPENSSL_102: "True"
       args:
         chdir: /var/www/securedrop
   become: yes

--- a/molecule/vagrant-packager/box_files/app_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/app_xenial_metadata.json
@@ -177,6 +177,17 @@
         }
       ],
       "version": "1.6.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "63fa462c1990312c25c4b4ff3cfbbf8bb443c42bf050aa524ec9938689f79625",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/app-staging-xenial_1.7.1.box"
+        }
+      ],
+      "version": "1.7.1"
     }
   ]
 }

--- a/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
+++ b/molecule/vagrant-packager/box_files/mon_xenial_metadata.json
@@ -177,6 +177,17 @@
         }
       ],
       "version": "1.6.0"
+    },
+    {
+      "providers": [
+        {
+          "checksum": "33068aab60f86e996625a0305f4620e5d31ad8379e87bfac2fb38c3b35434ffb",
+          "checksum_type": "sha256",
+          "name": "libvirt",
+          "url": "https://dev-bin.ops.securedrop.org/vagrant/mon-staging-xenial_1.7.1.box"
+        }
+      ],
+      "version": "1.7.1"
     }
   ]
 }


### PR DESCRIPTION
## Status
Ready for Review

## Description of Changes

Closes #5758

Changes proposed in this pull request:


## Testing

- Check out this branch
-  `make build-debs`
- `make upgrade-start` (will take a while as it needs to fetch the boxes)
- [ ] source interface shows SecureDrop version 1.7.1
- [ ] `make upgrade-test-local` completes without error
- [ ] source interface shows SecureDrop version 1.8.0~rc1

## Deployment

Dev only


