### PR TITLE
Remove the cloud-init package during server installation

### DIFF
--- a/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
+++ b/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
@@ -21,6 +21,14 @@
       SecureDrop cannot be installed. For details, see
       https://github.com/freedomofpress/securedrop/issues/4058
 
+- name: Remove cloud-init
+  apt:
+    name: cloud-init
+    state: absent
+    purge: yes
+  tags:
+    - apt
+
 - name: Install python and packages required by installer
   raw: apt install -y python apt-transport-https dnsutils
   register: _apt_install_prereqs_results

--- a/molecule/testinfra/common/test_system_hardening.py
+++ b/molecule/testinfra/common/test_system_hardening.py
@@ -141,6 +141,7 @@ def test_no_ecrypt_messages_in_logs(host, logfile):
 
 
 @pytest.mark.parametrize('package', [
+    'cloud-init',
     'libiw30',
     'wpasupplicant',
     'wireless-tools',


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards https://github.com/freedomofpress/securedrop/issues/5663

We don't want Ubuntu's `cloud-init` package on the servers, not least because it can make them take ten minutes or more to boot, apparently while waiting for `systemd-random-seed` to initialize.

## Testing

1. Prepare two fresh Ubuntu Focal servers.
2. On your admin workstation, check out this branch and run the installation:
    - `git fetch --all`
    - `git checkout -b remove-cloud-init origin/remove-cloud-init`
    - `./securedrop-admin install`
3. Observe that the installation does not fail because of timeouts waiting ten minutes for the servers to reboot.
4. Verify that `cloud-init` is no longer installed on either server.
5. Run the configuration tests:
    - `./securedrop-admin tailsconfig`
    - `./securedrop-admin verify`
    - The `common/test_system_hardening.py::test_unused_packages_are_removed` test should pass.

## Deployment

We don't have `cloud-init` on existing Xenial instances, and this change means we also won't on new Focal systems.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation