### PR TITLE
Bump securedrop-grsec-focal metapackage to 5.4.88

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -38,6 +38,10 @@ enable_ssh_over_tor: true
 securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder-xenial/tests/vars.yml
-securedrop_pkg_grsec:
+securedrop_pkg_grsec_xenial:
   ver: "4.14.188"
   depends: "linux-image-4.14.188-grsec-securedrop,linux-image-4.14.175-grsec-securedrop,intel-microcode"
+
+securedrop_pkg_grsec_focal:
+  ver: "5.4.88"
+  depends: "linux-image-5.4.88-grsec-securedrop,linux-image-4.14.188-grsec-securedrop,intel-microcode"

--- a/install_files/ansible-base/roles/build-generic-pkg/tasks/main.yml
+++ b/install_files/ansible-base/roles/build-generic-pkg/tasks/main.yml
@@ -29,7 +29,7 @@
 
 - name: Create any necessary parent directories for jinja files
   file:
-    path: "{{ build_path }}/{{ item.path | dirname |regex_replace('^\\/.*'+package_name, '') }}"
+    path: "{{ build_path }}/{{ item.path | dirname |regex_replace('^\\/.*'+package_dirname, '') }}"
     state: directory
   with_items: "{{ jinja_files_found.files }}"
 

--- a/install_files/ansible-base/roles/grsecurity/tasks/from_local_pkg_install_grsec.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/from_local_pkg_install_grsec.yml
@@ -1,7 +1,11 @@
 ---
+- name: Get the grsec version of the current scenario
+  set_fact:
+    grsec_version: "{% if ansible_distribution_release == 'xenial' %}{{ securedrop_pkg_grsec_xenial.ver }}{% else %}{{ securedrop_pkg_grsec_focal.ver }}{% endif %}"
+
 - name: Copy locally built securedrop-grsec metapackage
   copy:
-    src: "../../build/{{ securedrop_target_distribution }}/securedrop-grsec-{{ securedrop_pkg_grsec.ver }}+{{ securedrop_target_distribution }}-amd64.deb"
+    src: "../../build/{{ securedrop_target_distribution }}/securedrop-grsec-{{ grsec_version }}+{{ securedrop_target_distribution }}-amd64.deb"
     dest: /root/securedrop-grsec.deb
 
 - name: Install locally built securedrop-grsec metapackage

--- a/install_files/securedrop-grsec-focal/DEBIAN/control.j2
+++ b/install_files/securedrop-grsec-focal/DEBIAN/control.j2
@@ -1,9 +1,9 @@
 Package: securedrop-grsec
 Source: securedrop-grsec
-Version: {{ securedrop_pkg_grsec.ver }}+{{ securedrop_target_distribution }}
+Version: {{ securedrop_pkg_grsec_focal.ver }}+{{ securedrop_target_distribution }}
 Architecture: amd64
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Depends: {{ securedrop_pkg_grsec.depends }},paxctld
+Depends: {{ securedrop_pkg_grsec_focal.depends }},paxctld
 Section: admin
 Priority: optional
 Homepage: https://securedrop.org

--- a/install_files/securedrop-grsec-focal/DEBIAN/postinst.j2
+++ b/install_files/securedrop-grsec-focal/DEBIAN/postinst.j2
@@ -17,7 +17,7 @@ set -x
 # the debian-policy package
 
 # Pin current version of custom kernel
-GRSEC_VERSION="{{ securedrop_pkg_grsec.ver }}-grsec-securedrop"
+GRSEC_VERSION="{{ securedrop_pkg_grsec_focal.ver }}-grsec-securedrop"
 
 # Sets default grub boot parameter to the kernel version specified
 # by $GRSEC_VERSION.

--- a/install_files/securedrop-grsec/DEBIAN/control.j2
+++ b/install_files/securedrop-grsec/DEBIAN/control.j2
@@ -1,9 +1,9 @@
 Package: securedrop-grsec
 Source: securedrop-grsec
-Version: {{ securedrop_pkg_grsec.ver }}+{{ securedrop_target_distribution }}
+Version: {{ securedrop_pkg_grsec_xenial.ver }}+{{ securedrop_target_distribution }}
 Architecture: amd64
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Depends: {{ securedrop_pkg_grsec.depends }}
+Depends: {{ securedrop_pkg_grsec_xenial.depends }}
 Section: admin
 Priority: optional
 Homepage: https://securedrop.org

--- a/molecule/builder-xenial/tests/test_securedrop_deb_package.py
+++ b/molecule/builder-xenial/tests/test_securedrop_deb_package.py
@@ -61,10 +61,17 @@ def make_deb_paths() -> Dict[str, Path]:
     Jinja-based evaluation of the YAML files (so we can't trivially
     reuse vars in other var values, as is the case with Ansible).
     """
-    grsec_version = "{}+{}".format(
-        securedrop_test_vars["grsec_version"],
-        SECUREDROP_TARGET_DISTRIBUTION
-    )
+
+    if SECUREDROP_TARGET_DISTRIBUTION == "xenial":
+        grsec_version = "{}+{}".format(
+            securedrop_test_vars["grsec_version_xenial"],
+            SECUREDROP_TARGET_DISTRIBUTION
+        )
+    else:
+        grsec_version = "{}+{}".format(
+            securedrop_test_vars["grsec_version_focal"],
+            SECUREDROP_TARGET_DISTRIBUTION
+        )
 
     substitutions = dict(
         securedrop_version=securedrop_test_vars["securedrop_version"],

--- a/molecule/builder-xenial/tests/vars.yml
+++ b/molecule/builder-xenial/tests/vars.yml
@@ -3,7 +3,8 @@ securedrop_version: "1.8.0~rc1"
 ossec_version: "3.6.0"
 keyring_version: "0.1.4"
 config_version: "0.1.4"
-grsec_version: "4.14.188"
+grsec_version_xenial: "4.14.188"
+grsec_version_focal: "5.4.88"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/common/test_grsecurity.py
+++ b/molecule/testinfra/common/test_grsecurity.py
@@ -223,7 +223,7 @@ def test_wireless_disabled_in_kernel_config(host, kernel_opts):
         kernel_config = host.file(kernel_config_path).content_string
 
         line = "# CONFIG_{} is not set".format(kernel_opts)
-        assert line in kernel_config
+        assert line in kernel_config or kernel_opts not in kernel_config
 
 
 @pytest.mark.parametrize('kernel_opts', [

--- a/molecule/testinfra/common/test_grsecurity.py
+++ b/molecule/testinfra/common/test_grsecurity.py
@@ -4,10 +4,6 @@ import re
 import testutils
 
 sdvars = testutils.securedrop_test_vars
-if host.system_info.codename == "xenial":
-    KERNEL_VERSION = sdvars.grsec_version_xenial
-else:
-    KERNEL_VERSION = sdvars.grsec_version_focal
 testinfra_hosts = [sdvars.app_hostname, sdvars.monitor_hostname]
 
 
@@ -22,7 +18,7 @@ def test_ssh_motd_disabled(host):
 
 
 @pytest.mark.parametrize("package", [
-    'linux-image-{}-grsec-securedrop'.format(KERNEL_VERSION),
+    'linux-image-{}-grsec-securedrop',
     'paxctl',
     'securedrop-grsec',
 ])
@@ -32,6 +28,12 @@ def test_grsecurity_apt_packages(host, package):
     Includes the FPF-maintained metapackage, as well as paxctl, for managing
     PaX flags on binaries.
     """
+    if host.system_info.codename == "xenial":
+        KERNEL_VERSION = sdvars.grsec_version_xenial
+    else:
+        KERNEL_VERSION = sdvars.grsec_version_focal
+    if package.startswith("linux-image"):
+        package = package.format(KERNEL_VERSION)
     assert host.package(package).is_installed
 
 
@@ -75,6 +77,10 @@ def test_grsecurity_kernel_is_running(host):
     """
     Make sure the currently running kernel is specific grsec kernel.
     """
+    if host.system_info.codename == "xenial":
+        KERNEL_VERSION = sdvars.grsec_version_xenial
+    else:
+        KERNEL_VERSION = sdvars.grsec_version_focal
     c = host.run('uname -r')
     assert c.stdout.strip().endswith('-grsec-securedrop')
     assert c.stdout.strip() == '{}-grsec-securedrop'.format(KERNEL_VERSION)
@@ -208,6 +214,10 @@ def test_wireless_disabled_in_kernel_config(host, kernel_opts):
     remove wireless support from the kernel. Let's make sure wireless is
     disabled in the running kernel config!
     """
+    if host.system_info.codename == "xenial":
+        KERNEL_VERSION = sdvars.grsec_version_xenial
+    else:
+        KERNEL_VERSION = sdvars.grsec_version_focal
     with host.sudo():
         kernel_config_path = "/boot/config-{}-grsec-securedrop".format(KERNEL_VERSION)
         kernel_config = host.file(kernel_config_path).content_string
@@ -226,6 +236,10 @@ def test_kernel_options_enabled_config(host, kernel_opts):
     Tests kernel config for options that should be enabled
     """
 
+    if host.system_info.codename == "xenial":
+        KERNEL_VERSION = sdvars.grsec_version_xenial
+    else:
+        KERNEL_VERSION = sdvars.grsec_version_focal
     with host.sudo():
         kernel_config_path = "/boot/config-{}-grsec-securedrop".format(KERNEL_VERSION)
         kernel_config = host.file(kernel_config_path).content_string

--- a/molecule/testinfra/common/test_grsecurity.py
+++ b/molecule/testinfra/common/test_grsecurity.py
@@ -4,7 +4,10 @@ import re
 import testutils
 
 sdvars = testutils.securedrop_test_vars
-KERNEL_VERSION = sdvars.grsec_version
+if host.system_info.codename == "xenial":
+    KERNEL_VERSION = sdvars.grsec_version_xenial
+else:
+    KERNEL_VERSION = sdvars.grsec_version_focal
 testinfra_hosts = [sdvars.app_hostname, sdvars.monitor_hostname]
 
 

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -197,4 +197,5 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
-grsec_version: "4.14.188"
+grsec_version_xenial: "4.14.188"
+grsec_version_focal: "5.4.88"


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #5479 and towards https://github.com/freedomofpress/securedrop/issues/4768

Updates the kernel metapackage version to 5.4.88 for Focal installs.

See https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/89 

## Testing

- [ ] Focal metapackage pulls in 5.4.88 kernel image
- [ ] Xenial metapackage pulls in 4.14.188 kernel image
## Deployment

For new and existing installs, these changes will be distributed via deb packages through apt.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

