### PR TITLE
Postfix fix for focal

### DIFF
--- a/install_files/ansible-base/roles/postfix/templates/main.cf
+++ b/install_files/ansible-base/roles/postfix/templates/main.cf
@@ -62,3 +62,7 @@ maximal_queue_lifetime = 14d
 # Used to remap outbound from address in emails
 smtp_generic_maps = hash:/etc/postfix/generic
 {% endif %}
+{% if ansible_distribution_release == 'focal' %}
+# Restriction for client RCPT TO command, details at http://www.postfix.org/postconf.5.html#smtpd_recipient_restrictions
+smtpd_recipient_restrictions = reject_unauth_destination
+{% endif %}

--- a/molecule/testinfra/mon/test_postfix.py
+++ b/molecule/testinfra/mon/test_postfix.py
@@ -37,6 +37,12 @@ def test_postfix_generic_maps(host):
     """
     assert not host.file("/etc/postfix/generic").exists
     assert not host.file("/etc/postfix/main.cf").contains("^smtp_generic_maps")
+    if host.system_info.codename == "focal":
+        assert host.file("/etc/postfix/main.cf").contains(
+                         "^smtpd_recipient_restrictions = reject_unauth_destination")
+    if host.system_info.codename == "xenial":
+        assert not host.file("/etc/postfix/main.cf").contains(
+                             "^smtpd_recipient_restrictions = reject_unauth_destination")
 
 
 def test_postfix_service(host):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5775 

Adds postfix configuration for `Focal` based on http://www.postfix.org/postconf.5.html#smtpd_recipient_restrictions

## Testing

- [ ] Create Focal prod VMs 
- [ ] ssh into both and do `sudo apt install ubuntu-release-upgrader-core` because the latest Bento box does not have that.
- [ ] Apply the following the patch on your tails vm, and then do `./securedrop-admin install` to install SecureDrop on `Focal`.

```diff
diff --git a/install_files/ansible-base/roles/install-fpf-repo/defaults/main.yml b/install_files/ansible-base/roles/install-fpf-repo/defaults/main.yml
index d186993df..6354113fa 100644
--- a/install_files/ansible-base/roles/install-fpf-repo/defaults/main.yml
+++ b/install_files/ansible-base/roles/install-fpf-repo/defaults/main.yml
@@ -10,7 +10,7 @@
 #
 # For testing/QA, set this URL to another apt server. You must also update
 # the associated public key for the apt repo for testing/QA.
-apt_repo_url: https://apt.freedom.press
+apt_repo_url: https://apt-test.freedom.press
 
 # By default, install packages from the apt-repo, but under
 # staging hosts we'll prefer locally-built deb packages
@@ -20,7 +20,7 @@ install_local_packages: False
 # May be overridden in staging to install from a test/QA server,
 # the Release file for which will *not* be signed with the prod key.
 apt_repo_pubkey_files:
-  - fpf-signing-key.pub
+  - apt-test-signing-key.pub
 
 # Enabling support for xenial by default.
 apt_repo_target_distro: "{{ ansible_distribution_release }}"

```

- [ ] login to the mon server and check for any postfix error in the `/var/log/syslog` file.


## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
