### PR TITLE
Update ossec service files to start after the local network is online

### DIFF
--- a/install_files/ansible-base/roles/build-ossec-deb-pkg/files/ossec-agent.service
+++ b/install_files/ansible-base/roles/build-ossec-deb-pkg/files/ossec-agent.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=OSSEC service for agent
+After=network.target
 
 [Service]
 Type=forking

--- a/install_files/ansible-base/roles/build-ossec-deb-pkg/files/ossec-agent.service
+++ b/install_files/ansible-base/roles/build-ossec-deb-pkg/files/ossec-agent.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=OSSEC service for agent
-After=network.target
+Wants=network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=forking

--- a/install_files/ansible-base/roles/build-ossec-deb-pkg/files/ossec.service
+++ b/install_files/ansible-base/roles/build-ossec-deb-pkg/files/ossec.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=OSSEC service
-After=network.target
+Wants=network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=forking

--- a/install_files/ansible-base/roles/build-ossec-deb-pkg/files/ossec.service
+++ b/install_files/ansible-base/roles/build-ossec-deb-pkg/files/ossec.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=OSSEC service
+After=network.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5778 

Updates the ossec service files to start after the network is online

## Testing
### Xenial testing
- make build-debs
- molecule converge -s libvirt-staging
- ssh into `app` and run `sudo su` to trigger ossec alert
- [ ] email is received or `/var/ossec/log/alerts/alert.log` contains alert:
```
** Alert 1612988276.2414638: - syslog,sudo                             
2021 Feb 10 20:17:56 (app-staging) 10.0.1.2->/var/log/auth.log           
Rule: 5402 (level 3) -> 'Successful sudo to ROOT executed'
User: vagrant                                                            Feb 10 20:17:56 app-staging sudo:  vagrant : TTY=pts/1 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/su      
```
- log into journalist interface, navigate to admin -> instance config and click on send ossec alert
- [ ]  email is received or `/var/ossec/log/alerts/alert.log` contains alert
```
** Alert 1612988346.2416758: mail  - Apache logs
2021 Feb 10 20:19:06 (app-staging) 10.0.1.2->/var/log/apache2/journalist-error.log                           
Rule: 400700 (level 7) -> 'Apache application error.'                    
[Wed Feb 10 20:19:05.505528 2021] [wsgi:error] [pid 807:tid 126394263918336] [remote 127.0.0.1:59230] ERROR:flask.app:This is a test OSSEC alert               
```
### Focal testing
- make build-debs focal
- molecule converge -s libvirt-staging-focal
- ssh into `app` and run `sudo su` to trigger ossec alert
- [ ] email is received or `/var/ossec/log/alerts/alert.log` contains alert:
```
** Alert 1612988276.2414638: - syslog,sudo                             
2021 Feb 10 20:17:56 (app-staging) 10.0.1.2->/var/log/auth.log           
Rule: 5402 (level 3) -> 'Successful sudo to ROOT executed'
User: vagrant                                                            Feb 10 20:17:56 app-staging sudo:  vagrant : TTY=pts/1 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/su      
```
- log into journalist interface, navigate to admin -> instance config and click on send ossec alert
- [ ]  email is received or `/var/ossec/log/alerts/alert.log` contains alert
```
** Alert 1612988346.2416758: mail  - Apache logs
2021 Feb 10 20:19:06 (app-staging) 10.0.1.2->/var/log/apache2/journalist-error.log                           
Rule: 400700 (level 7) -> 'Apache application error.'                    
[Wed Feb 10 20:19:05.505528 2021] [wsgi:error] [pid 807:tid 126394263918336] [remote 127.0.0.1:59230] ERROR:flask.app:This is a test OSSEC alert               
```
## Deployment

These changes will be to new and existing instances via the ossec-agent package

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
