### PR TITLE
Fixes #5128 removes snappy from the default installation

### DIFF
--- a/install_files/ansible-base/roles/common/defaults/main.yml
+++ b/install_files/ansible-base/roles/common/defaults/main.yml
@@ -49,3 +49,4 @@ unused_packages:
   - libiw30
   - wireless-tools
   - wpasupplicant
+  - snapd

--- a/install_files/ansible-base/roles/common/tasks/remove_unused_packages.yml
+++ b/install_files/ansible-base/roles/common/tasks/remove_unused_packages.yml
@@ -3,6 +3,7 @@
   apt:
     name: "{{ unused_packages }}"
     state: absent
+    purge: yes
   tags:
     - apt
     - hardening

--- a/install_files/ansible-base/roles/common/tasks/remove_unused_packages.yml
+++ b/install_files/ansible-base/roles/common/tasks/remove_unused_packages.yml
@@ -7,6 +7,12 @@
     - apt
     - hardening
 
+# Remove the apparmor config file for snapd
+- name: Remove snapd config for apparmor
+  file:
+    path: /etc/apparmor.d/usr.lib.snapd.snap-confine.real
+    state: absent
+
 # After installing securedrop-grsec, remove
 # old generic kernels to avoid accidental
 # boots into a less secure environment.

--- a/install_files/ansible-base/roles/common/tasks/remove_unused_packages.yml
+++ b/install_files/ansible-base/roles/common/tasks/remove_unused_packages.yml
@@ -7,12 +7,6 @@
     - apt
     - hardening
 
-# Remove the apparmor config file for snapd
-- name: Remove snapd config for apparmor
-  file:
-    path: /etc/apparmor.d/usr.lib.snapd.snap-confine.real
-    state: absent
-
 # After installing securedrop-grsec, remove
 # old generic kernels to avoid accidental
 # boots into a less secure environment.

--- a/molecule/testinfra/common/test_system_hardening.py
+++ b/molecule/testinfra/common/test_system_hardening.py
@@ -148,8 +148,9 @@ def test_no_ecrypt_messages_in_logs(host, logfile):
 @pytest.mark.parametrize('package', [
     'cloud-init',
     'libiw30',
-    'wpasupplicant',
+    'snapd',
     'wireless-tools',
+    'wpasupplicant',
 ])
 def test_unused_packages_are_removed(host, package):
     """ Check if unused package is present """
@@ -165,3 +166,10 @@ def test_iptables_packages(host):
         assert host.package("iptables-persistent").is_installed
     else:
         assert not host.package("iptables-persistent").is_installed
+
+
+def test_snapd_absent(host):
+    assert not host.file("/lib/systemd/system/snapd.service").exists
+    assert not host.file("/etc/apparmor.d/usr.lib.snapd.snap-confine.real").exists
+    assert not host.file("/usr/bin/snap").exists
+    assert not host.file("/var/lib/snapd/snaps").exists


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5128 

Removes snappy and also removes the related apparmor configuration.

## Testing
- [x] `molecule converge -s libvirt-staging-focal`
- [x] `molecule login -s libvirt-staging-focal app-staging`
- [x] check `snapd` package is not present
- [x] repeat the same for mon-staging
- [x] Now repeat the steps for `Xenial` 

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
