### PR TITLE
Updates Focal kernel to 5.4.97

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -43,5 +43,5 @@ securedrop_pkg_grsec_xenial:
   depends: "linux-image-4.14.188-grsec-securedrop,linux-image-4.14.175-grsec-securedrop,intel-microcode"
 
 securedrop_pkg_grsec_focal:
-  ver: "5.4.88"
-  depends: "linux-image-5.4.88-grsec-securedrop,linux-image-4.14.188-grsec-securedrop,intel-microcode"
+  ver: "5.4.97"
+  depends: "linux-image-5.4.97-grsec-securedrop,linux-image-4.14.188-grsec-securedrop,intel-microcode"

--- a/molecule/builder-xenial/tests/vars.yml
+++ b/molecule/builder-xenial/tests/vars.yml
@@ -4,7 +4,7 @@ ossec_version: "3.6.0"
 keyring_version: "0.1.4"
 config_version: "0.1.4"
 grsec_version_xenial: "4.14.188"
-grsec_version_focal: "5.4.88"
+grsec_version_focal: "5.4.97"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -199,5 +199,5 @@ log_events_with_ossec_alerts:
 fpf_apt_repo_url: "https://apt-test.freedom.press"
 
 grsec_version_xenial: "4.14.188"
-grsec_version_focal: "5.4.88"
+grsec_version_focal: "5.4.97"
 

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -199,4 +199,4 @@ log_events_with_ossec_alerts:
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
 grsec_version_xenial: "4.14.188"
-grsec_version_focal: "5.4.88"
+grsec_version_focal: "5.4.97"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Refs #5479 and towards https://github.com/freedomofpress/securedrop/issues/4768

Updates the kernel metapackage version to 5.4.97 for Focal installs. Uses the newfangled build logic in https://github.com/freedomofpress/kernel-builder 

https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/91

## Testing

- [x] Focal metapackage pulls in 5.4.97 kernel image
- [x] Xenial metapackage pulls in 4.14.188 kernel image (unchanged)
- [x] CI is failing on this PR before https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/91 is merged
- [x] After merge of https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/91, CI passes here

## Deployment

For new and existing installs, these changes will be distributed via deb packages through apt.
