### PR TITLE
Disables LTS upgrade prompt for Focal

### DIFF
--- a/install_files/securedrop-config-focal/DEBIAN/postinst
+++ b/install_files/securedrop-config-focal/DEBIAN/postinst
@@ -4,8 +4,17 @@
 set -e
 set -x
 
+# Issue #5782
+# Set Prompt=never for distro upgrades
+update_release_prompt() {
+    set -e
+    upgrade_config='/etc/update-manager/release-upgrades'
+    sed -i 's/Prompt=.*/Prompt=never/' "$upgrade_config"
+}
+
 case "$1" in
     configure)
+    update_release_prompt
     # Configuration required for unattended-upgrades
     cp /opt/securedrop/20auto-upgrades /etc/apt/apt.conf.d/
     cp /opt/securedrop/50unattended-upgrades /etc/apt/apt.conf.d/


### PR DESCRIPTION


## Status
Work in progress

## Description of Changes

We don't want the OS to nag admins, since we want to ensure the next LTS
is fully supported by SecureDrop before recommending an in-place
upgrade. Disable the prompt on Focal, same as we've done for Xenial in
the past.

Closes #5782.

## Testing
Still need to update the testinfra tests. 

## Deployment
TK
