### PR TITLE
Check for updates before most securedrop-admin commands

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -24,6 +24,7 @@ instances.
 """
 
 import argparse
+import functools
 import ipaddress
 import logging
 import os
@@ -45,6 +46,9 @@ import yaml
 from pkg_resources import parse_version
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import x25519
+
+from typing import cast
+
 from typing import List
 
 from typing import Set
@@ -80,6 +84,11 @@ class JournalistAlertEmailException(Exception):
 
 # The type of each entry within SiteConfig.desc
 _T = TypeVar('_T', bound=Union[int, str, bool])
+
+# The function type used for the @update_check_required decorator; see
+# https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
+_FuncT = TypeVar('_FuncT', bound=Callable[..., Any])
+
 # (var, default, type, prompt, validator, transform, condition)
 _DescEntryType = Tuple[str, _T, Type[_T], str, Optional[Validator], Optional[Callable], Callable]
 
@@ -516,7 +525,7 @@ class SiteConfig:
                 self._config_in_progress[var] = ''
                 continue
             self._config_in_progress[var] = self.user_prompt_config_one(desc,
-                                                            self.config.get(var))  # noqa: E501
+                                                                        self.config.get(var))  # noqa: E501
         return self._config_in_progress
 
     def user_prompt_config_one(
@@ -690,6 +699,45 @@ def setup_logger(verbose: bool = False) -> None:
     sdlog.addHandler(stdout)
 
 
+def update_check_required(cmd_name: str) -> Callable[[_FuncT], _FuncT]:
+    """
+    This decorator can be added to any subcommand that is part of securedrop-admin
+    via `@update_check_required("name_of_subcommand")`. It forces a check for
+    updates, and aborts if the locally installed code is out of date. It should
+    be generally added to all subcommands that make modifications on the
+    server or on the Admin Workstation.
+
+    The user can override this check by specifying the --force argument before
+    any subcommand.
+    """
+    def decorator_update_check(func: _FuncT) -> _FuncT:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            cli_args = args[0]
+            if cli_args.force:
+                sdlog.info("Skipping update check because --force argument was provided.")
+                return func(*args, **kwargs)
+
+            update_status, latest_tag = check_for_updates(cli_args)
+            if update_status is True:
+                sdlog.error("You are not running the most recent signed SecureDrop release "
+                            "on this workstation.")
+                sdlog.error("Latest available version: {}".format(latest_tag))
+                sdlog.error("Running outdated or mismatched code can cause significant "
+                            "technical issues.")
+                sdlog.error("If you are certain you want to proceed, run:\n\n\t"
+                            "./securedrop-admin --force {}\n".format(cmd_name))
+                sdlog.error("To apply the latest updates, run:\n\n\t"
+                            "./securedrop-admin update\n")
+                sdlog.error("If this fails, see the latest upgrade guide on "
+                            "https://docs.securedrop.org/ for instructions.")
+                sys.exit(1)
+            return func(*args, **kwargs)
+        return cast(_FuncT, wrapper)
+    return decorator_update_check
+
+
+@update_check_required("sdconfig")
 def sdconfig(args: argparse.Namespace) -> int:
     """Configure SD site settings"""
     SiteConfig(args).load_and_update_config(validate=False)
@@ -752,8 +800,10 @@ def find_or_generate_new_torv3_keys(args: argparse.Namespace) -> int:
     return 0
 
 
+@update_check_required("install")
 def install_securedrop(args: argparse.Namespace) -> int:
     """Install/Update SecureDrop"""
+
     SiteConfig(args).load_and_update_config(prompt=False)
 
     sdlog.info("Now installing SecureDrop on remote servers.")
@@ -767,6 +817,7 @@ def install_securedrop(args: argparse.Namespace) -> int:
     )
 
 
+@update_check_required("verify")
 def verify_install(args: argparse.Namespace) -> int:
     """Run configuration tests against SecureDrop servers"""
 
@@ -776,6 +827,7 @@ def verify_install(args: argparse.Namespace) -> int:
                                  cwd=os.getcwd())
 
 
+@update_check_required("backup")
 def backup_securedrop(args: argparse.Namespace) -> int:
     """Perform backup of the SecureDrop Application Server.
     Creates a tarball of submissions and server config, and fetches
@@ -789,6 +841,7 @@ def backup_securedrop(args: argparse.Namespace) -> int:
     return subprocess.check_call(ansible_cmd, cwd=args.ansible_path)
 
 
+@update_check_required("restore")
 def restore_securedrop(args: argparse.Namespace) -> int:
     """Perform restore of the SecureDrop Application Server.
     Requires a tarball of submissions and server config, created via
@@ -825,6 +878,7 @@ def restore_securedrop(args: argparse.Namespace) -> int:
     return subprocess.check_call(ansible_cmd, cwd=args.ansible_path)
 
 
+@update_check_required("tailsconfig")
 def run_tails_config(args: argparse.Namespace) -> int:
     """Configure Tails environment post SD install"""
     sdlog.info("Configuring Tails workstation environment")
@@ -972,6 +1026,7 @@ def update(args: argparse.Namespace) -> int:
     return 0
 
 
+@update_check_required("logs")
 def get_logs(args: argparse.Namespace) -> int:
     """Get logs for forensics and debugging purposes"""
     sdlog.info("Gathering logs for forensics and debugging")
@@ -998,6 +1053,7 @@ def set_default_paths(args: argparse.Namespace) -> argparse.Namespace:
     return args
 
 
+@update_check_required("reset_admin_access")
 def reset_admin_access(args: argparse.Namespace) -> int:
     """Resets SSH access to the SecureDrop servers, locking it to
     this Admin Workstation."""
@@ -1021,6 +1077,8 @@ def parse_argv(argv: List[str]) -> argparse.Namespace:
                         help="Increase verbosity on output")
     parser.add_argument('-d', action='store_true', default=False,
                         help="Developer mode. Not to be used in production.")
+    parser.add_argument('--force', action='store_true', required=False,
+                        help="force command execution without update check")
     parser.add_argument('--root', required=True,
                         help="path to the root of the SecureDrop repository")
     parser.add_argument('--site-config',

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -359,7 +359,7 @@ def verify_install_has_valid_config():
     Checks that securedrop-admin install validates the configuration.
     """
     cmd = os.path.join(os.path.dirname(CURRENT_DIR), 'securedrop_admin/__init__.py')
-    child = pexpect.spawn('python {0} --root {1} install'.format(cmd, SD_DIR))
+    child = pexpect.spawn('python {0} --force --root {1} install'.format(cmd, SD_DIR))
     child.expect(b"SUDO password:", timeout=5)
     child.close()
 
@@ -369,7 +369,7 @@ def test_install_with_no_config():
     Checks that securedrop-admin install complains about a missing config file.
     """
     cmd = os.path.join(os.path.dirname(CURRENT_DIR), 'securedrop_admin/__init__.py')
-    child = pexpect.spawn('python {0} --root {1} install'.format(cmd, SD_DIR))
+    child = pexpect.spawn('python {0} --force --root {1} install'.format(cmd, SD_DIR))
     child.expect(b'ERROR: Please run "securedrop-admin sdconfig" first.', timeout=5)
     child.expect(pexpect.EOF, timeout=5)
     child.close()
@@ -380,7 +380,7 @@ def test_install_with_no_config():
 def test_sdconfig_on_first_run():
     cmd = os.path.join(os.path.dirname(CURRENT_DIR),
                        'securedrop_admin/__init__.py')
-    child = pexpect.spawn('python {0} --root {1} sdconfig'.format(cmd, SD_DIR))
+    child = pexpect.spawn('python {0} --force --root {1} sdconfig'.format(cmd, SD_DIR))
     verify_username_prompt(child)
     child.sendline('')
     verify_reboot_prompt(child)
@@ -444,7 +444,7 @@ def test_sdconfig_on_first_run():
 def test_sdconfig_both_v2_v3_true():
     cmd = os.path.join(os.path.dirname(CURRENT_DIR),
                        'securedrop_admin/__init__.py')
-    child = pexpect.spawn('python {0} --root {1} sdconfig'.format(cmd, SD_DIR))
+    child = pexpect.spawn('python {0} --force --root {1} sdconfig'.format(cmd, SD_DIR))
     verify_username_prompt(child)
     child.sendline('')
     verify_reboot_prompt(child)
@@ -508,7 +508,7 @@ def test_sdconfig_both_v2_v3_true():
 def test_sdconfig_only_v2_true():
     cmd = os.path.join(os.path.dirname(CURRENT_DIR),
                        'securedrop_admin/__init__.py')
-    child = pexpect.spawn('python {0} --root {1} sdconfig'.format(cmd, SD_DIR))
+    child = pexpect.spawn('python {0} --force --root {1} sdconfig'.format(cmd, SD_DIR))
     verify_username_prompt(child)
     child.sendline('')
     verify_reboot_prompt(child)
@@ -572,7 +572,7 @@ def test_sdconfig_only_v2_true():
 def test_sdconfig_enable_journalist_alerts():
     cmd = os.path.join(os.path.dirname(CURRENT_DIR),
                        'securedrop_admin/__init__.py')
-    child = pexpect.spawn('python {0} --root {1} sdconfig'.format(cmd, SD_DIR))
+    child = pexpect.spawn('python {0} --force --root {1} sdconfig'.format(cmd, SD_DIR))
     verify_username_prompt(child)
     child.sendline('')
     verify_reboot_prompt(child)
@@ -641,7 +641,7 @@ def test_sdconfig_enable_journalist_alerts():
 def test_sdconfig_enable_https_on_source_interface():
     cmd = os.path.join(os.path.dirname(CURRENT_DIR),
                        'securedrop_admin/__init__.py')
-    child = pexpect.spawn('python {0} --root {1} sdconfig'.format(cmd, SD_DIR))
+    child = pexpect.spawn('python {0} --force --root {1} sdconfig'.format(cmd, SD_DIR))
     verify_username_prompt(child)
     child.sendline('')
     verify_reboot_prompt(child)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5317 

Provides a new decorator, `@update_check_required`, and adds it to `securedrop-admin` subcommands which make significant modifications on the workstation or the server. If the update check detects a need to update (using the existing logic in `securedrop-admin`), it will display a message explaining how to update. A `--force` option is provided in case the user wishes to intentionally run a subcommand with a playbook version that differs from the most recent signed release tag (e.g., during QA).

## Testing

This change is best tested on a real or virtualized *Admin Workstation* in Tails. 

1. Create a backup copy of your `~/Persistent/securedrop` as warranted.
2. Fetch all updates with `git fetch --all` and check out git tag `1.7.1`
3. Apply the changes from this branch via `git cherry-pick -n 75249c2ef9dc9ad383fa02e6c1fe9a3a4117b38d && git cherry-pick -n 26e608723fed7e7a0f166caed3d2e395583a02f1` . This will stage the changes for commit -- you can verify this via `git diff --cached`.
4. Run `securedrop-admin check_for_updates`
- [ ] Observe that the command reports "All updates applied"
5. Run `securedrop-admin logs`
- [ ] Observe that securedrop-admin checks for updates before running the playbook
- [ ] Observe that securedrop-admin attempts to run the logs playbook
6. Switch to an older tag (you may need to discard re-apply the changes)
7. Run `securedrop-admin logs`
- [ ] Observe that securedrop-admin checks for updates and reports that updates are available
- [ ] Observe that securedrop-admin fails to complete due to a version mismatch
- [ ] Observe that securedrop-admin reports the checked out tag as `Current branch status`
8. Run `securedrop-admin --force logs`
- [ ] Observe that securedrop-admin now skips the update check and runs the logs playbook
9. Check out the `develop` branch and repeat steps 7 and 8 and the associated checks.
10. Bounce the network connection in Tails.
- [ ] Observe that the graphical updater runs to completion and puts you back on the 1.7.1 tag.
- [ ] (Optional) Test and observe that all `securedrop-admin` subcommands annotated via the decorator (see diff) run the update check and produce the expected help output
11. Discard the unstaged changes with `git reset --hard`.

## Deployment

Note that this will only be available to users _after_ the next workstation update.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

### Docs

While this change is largely self-documenting and does not conflict with previous guidance, I intend to add a brief explanation to the documentation, in particular https://docs.securedrop.org/en/stable/admin.html#the-securedrop-admin-utility