### PR TITLE
Provide end-of life messaging and disable on source interface after Xenial EOL

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -1,4 +1,3 @@
-# Last Modified: Wed Oct 29 08:16:32 2014
 #include <tunables/global>
 
 /usr/sbin/apache2 {
@@ -336,6 +335,7 @@
   /var/www/securedrop/template_filters.py r,
   /var/www/securedrop/translations/ r,
   /var/www/securedrop/translations/** r,
+  /var/www/securedrop/server_os.py r,
   /var/www/securedrop/version.py r,
   /var/www/securedrop/wordlists/ r,
   /var/www/securedrop/wordlists/** r,

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -56,12 +56,6 @@ def create_app(config: 'SDConfig') -> Flask:
     def _url_exists(u: str) -> bool:
         return path.exists(path.join(config.SECUREDROP_DATA_ROOT, u))
 
-    v2_enabled = _url_exists('source_v2_url') or ((not _url_exists('source_v2_url'))
-                                                  and (not _url_exists('source_v3_url')))
-    v3_enabled = _url_exists('source_v3_url')
-
-    app.config.update(V2_ONION_ENABLED=v2_enabled, V3_ONION_ENABLED=v3_enabled)
-
     # TODO: Attaching a Storage dynamically like this disables all type checking (and
     # breaks code analysis tools) for code that uses current_app.storage; it should be refactored
     app.storage = Storage(config.STORE_DIR,
@@ -162,12 +156,6 @@ def create_app(config: 'SDConfig') -> Flask:
             g.organization_name = app.instance_config.organization_name
         else:
             g.organization_name = gettext('SecureDrop')
-
-        if app.config['V2_ONION_ENABLED'] and not app.config['V3_ONION_ENABLED']:
-            g.show_v2_onion_eol_warning = True
-
-        if app.config['V2_ONION_ENABLED'] and app.config['V3_ONION_ENABLED']:
-            g.show_v2_onion_migration_warning = True
 
         if request.path.split('/')[1] == 'api':
             pass  # We use the @token_required decorator for the API endpoints

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -19,18 +19,6 @@
   <body>
 
     {% if g.user %}
-      {% if g.show_v2_onion_eol_warning %}
-      <div id="v2-onion-eol" class="alert-banner">
-        <img src="{{ url_for('static', filename='i/bang-circle.png') }}" width="20" height="20"> {{ gettext('<strong>Update Required</strong>&nbsp;&nbsp;Set up v3 Onion Services before April 30 to keep your SecureDrop servers online. Please contact your administrator. <a href="//securedrop.org/v2-onion-eol" rel="noreferrer">Learn More</a>') }}
-      </div>
-      {% endif %}
-
-      {% if g.show_v2_onion_migration_warning %}
-      <div id="v2-complete-migration" class="alert-banner">
-        <img src="{{ url_for('static', filename='i/bang-circle.png') }}" width="20" height="20"> {{ gettext('<strong>Update Required</strong>&nbsp;&nbsp;Complete the v3 Onion Services setup before April 30. Please contact your administrator. <a href="//securedrop.org/v2-onion-eol" rel="noreferrer">Learn More</a>') }}
-      </div>
-      {% endif %}
-
     <div id="logout">
       {{ gettext('Logged on as') }} <a href="{{ url_for('account.edit') }}" id="link-edit-account">{{ g.user.username }}</a> |
       {% if g.user and g.user.is_admin %}

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -19,6 +19,16 @@
   <body>
 
     {% if g.user %}
+    {% if g.show_os_past_eol_warning %}
+    <div id="os-past-eol" class="alert-banner">
+      <img src="{{ url_for('static', filename='i/bang-circle.png') }}" width="20" height="20"> {{ gettext ('<strong>Critical Security:</strong>&nbsp;&nbsp;The operating system used by your SecureDrop servers has reached its end-of-life. A manual update is required to re-enable the Source Interface and remain safe. Please contact your administrator. <a href="//securedrop.org/xenial-eol" rel="noreferrer">Learn More</a>') }}
+    </div>
+    {% elif g.show_os_near_eol_warning %}
+    <div id="os-near-eol" class="alert-banner">
+      <img src="{{ url_for('static', filename='i/bang-circle.png') }}" width="20" height="20"> {{ gettext ('<strong>Critical Security:</strong>&nbsp;&nbsp;The operating system used by your SecureDrop servers will reach its end-of-life on April 30, 2021. A manual update is urgently required to remain safe. Please contact your adminstrator. <a href="//securedrop.org/xenial-eol" rel="noreferrer">Learn More</a>') }}
+    </div>
+    {% endif %}
+
     <div id="logout">
       {{ gettext('Logged on as') }} <a href="{{ url_for('account.edit') }}" id="link-edit-account">{{ g.user.username }}</a> |
       {% if g.user and g.user.is_admin %}

--- a/securedrop/server_os.py
+++ b/securedrop/server_os.py
@@ -1,0 +1,25 @@
+from datetime import date
+
+FOCAL_VERSION = "20.04"
+XENIAL_EOL_DATE = date(2021, 4, 30)
+
+with open("/etc/lsb-release", "r") as f:
+    installed_version = f.readlines()[1].split("=")[1].strip("\n")
+
+
+def is_os_past_eol() -> bool:
+    """
+    Assumption: Any OS that is not Focal is an earlier version of the OS.
+    """
+    if installed_version != FOCAL_VERSION and date.today() > XENIAL_EOL_DATE:
+        return True
+    return False
+
+
+def is_os_near_eol() -> bool:
+    """
+    Assumption: Any OS that is not Focal is an earlier version of the OS.
+    """
+    if installed_version != FOCAL_VERSION and date.today() <= XENIAL_EOL_DATE:
+        return True
+    return False

--- a/securedrop/source_app/decorators.py
+++ b/securedrop/source_app/decorators.py
@@ -22,7 +22,7 @@ def ignore_static(f: Callable) -> Callable:
     a static resource."""
     @wraps(f)
     def decorated_function(*args: Any, **kwargs: Any) -> Any:
-        if request.path.startswith('/static'):
+        if request.path.startswith("/static") or request.path == "/org-logo":
             return  # don't execute the decorated function
         return f(*args, **kwargs)
     return decorated_function

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -28,6 +28,11 @@
         {% endblock %}
 
         <div class="panel selected">
+          {% if g.show_offline_message %}
+          <h1>{{ gettext("We're sorry, our SecureDrop is currently offline.") }}</h1>
+          <p>{{ gettext("Please try again later. Check our website for more information.") }}</p>
+          {% else %}
+
           {% if 'logged_in' in session %}
             <a href="{{ url_for('main.logout') }}" class="btn pull-right" id="logout">{{ gettext('LOG OUT') }}</a>
           {% endif %}
@@ -36,8 +41,9 @@
             <hr class="no-line">
           {% endif %}
 
-          {% block body %}{% endblock %}
+          {% endif %}
 
+          {% block body %}{% endblock %}
         </div>
       </div>
 

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -64,54 +64,6 @@ def _login_user(app, username, password, otp_secret):
     assert hasattr(g, 'user')  # ensure logged in
 
 
-def test_user_sees_v2_eol_warning_if_only_v2_is_enabled(config, journalist_app, test_journo):
-    journalist_app.config.update(V2_ONION_ENABLED=True, V3_ONION_ENABLED=False)
-    with journalist_app.test_client() as app:
-        _login_user(
-            app,
-            test_journo['username'],
-            test_journo['password'],
-            test_journo['otp_secret'])
-
-        resp = app.get(url_for('main.index'))
-
-    text = resp.data.decode('utf-8')
-    assert 'id="v2-onion-eol"' in text, text
-    assert 'id="v2-complete-migration"' not in text, text
-
-
-def test_user_sees_v2_eol_warning_if_both_v2_and_v3_enabled(config, journalist_app, test_journo):
-    journalist_app.config.update(V2_ONION_ENABLED=True, V3_ONION_ENABLED=True)
-    with journalist_app.test_client() as app:
-        _login_user(
-            app,
-            test_journo['username'],
-            test_journo['password'],
-            test_journo['otp_secret'])
-
-        resp = app.get(url_for('main.index'))
-
-    text = resp.data.decode('utf-8')
-    assert 'id="v2-onion-eol"' not in text, text
-    assert 'id="v2-complete-migration"' in text, text
-
-
-def test_user_does_not_see_v2_eol_warning_if_only_v3_enabled(config, journalist_app, test_journo):
-    journalist_app.config.update(V2_ONION_ENABLED=False, V3_ONION_ENABLED=True)
-    with journalist_app.test_client() as app:
-        _login_user(
-            app,
-            test_journo['username'],
-            test_journo['password'],
-            test_journo['otp_secret'])
-
-        resp = app.get(url_for('main.index'))
-
-    text = resp.data.decode('utf-8')
-    assert 'id="v2-onion-eol"' not in text, text
-    assert 'id="v2-complete-migration"' not in text, text
-
-
 def test_user_with_whitespace_in_username_can_login(journalist_app):
     # Create a user with whitespace at the end of the username
     with journalist_app.app_context():


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Resolves https://github.com/freedomofpress/securedrop/issues/5688

Needs review of messaging to admins/source/journalists.

Changes proposed in this pull request:

## Testing

1. build both xenial and focal `securedrop-app-code` debs off of this pr branch with the edit from step 1 
2. install one on your home server to make sure app armor changes are working and install the other on a staging vm
3. log into the journalist interface
   - [x] for xenial, confirm you see the critical eol warning + mention of April 30, 2021 date + learn more link that takes you to: https://securedrop.org/news/securedrop-advisory-end-life-v2-onion-services-and-ubuntu-1604/
   - [x] for focal, confirm you do not see the critical eol warning
   - [x] for both, confirm you do not see any v2 warning
4. visit the source interface
   - [x] for xenial, confirm you see that the interface is disabled
   - [x] for focal, confirm you see that the interface is enabled
5. change the dates in `source_app/disable.py` and `jouranlist_app/os_eol.py` to year 2020 instead of 2021
6. build the debs and install again
7. log into the journalist interface
   - [x] for xenial, confirm you see the critical eol warning + mention of Source Interface being disabled + learn more link that takes you to: https://securedrop.org/news/securedrop-advisory-end-life-v2-onion-services-and-ubuntu-1604/
   - [x] for focal, confirm you do not see the critical eol warning
   - [x] for both, confirm you do not see any v2 warning
8. visit the source interface
   - [x] for xenial, confirm you see that the interface is disabled
   - [x] for focal, confirm you see that the interface is enabled

## New test

1. log into the source interface on a dev server
2. change EOL date so that the source interface is disabled
3. try hitting endpoints while source interface is disabled
   - [x] you see a message about securedrop being unavailable
   - [x] no logout button shows up
4. change EOL date so that the source interface is not longer disabled
5. try hitting endpoints
   - [x] verify that you have to log in again

## Checklist
- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have updated AppArmor rules to include the change
