### PR TITLE
Installs release-upgrader in prepare-servers role

### DIFF
--- a/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
+++ b/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
@@ -21,6 +21,11 @@
       SecureDrop cannot be installed. For details, see
       https://github.com/freedomofpress/securedrop/issues/4058
 
+- name: Install python and packages required by installer
+  raw: apt install -y python3 apt-transport-https dnsutils ubuntu-release-upgrader-core
+  register: _apt_install_prereqs_results
+  changed_when: "'0 upgraded, 0 newly installed, 0 to remove' not in _apt_install_prereqs_results.stdout"
+
 - name: Remove cloud-init
   apt:
     name: cloud-init
@@ -28,8 +33,3 @@
     purge: yes
   tags:
     - apt
-
-- name: Install python and packages required by installer
-  raw: apt install -y python apt-transport-https dnsutils
-  register: _apt_install_prereqs_results
-  changed_when: "'0 upgraded, 0 newly installed, 0 to remove' not in _apt_install_prereqs_results.stdout"

--- a/molecule/testinfra/common/test_release_upgrades.py
+++ b/molecule/testinfra/common/test_release_upgrades.py
@@ -4,6 +4,16 @@ test_vars = testutils.securedrop_test_vars
 testinfra_hosts = [test_vars.app_hostname, test_vars.monitor_hostname]
 
 
+def test_release_manager_installed(host):
+    """
+    The securedrop-config package munges `do-release-upgrade` settings
+    that assume the release-upgrader logic is installed. On hardware
+    installs of Ubuntu, it is, but the VM images we use in CI may
+    remove it to make the boxes leaner.
+    """
+    assert host.package("ubuntu-release-upgrader-core").is_installed
+
+
 def test_release_manager_upgrade_channel(host):
     """
     Ensures that the `do-release-upgrade` command will not

--- a/molecule/testinfra/common/test_system_hardening.py
+++ b/molecule/testinfra/common/test_system_hardening.py
@@ -148,6 +148,7 @@ def test_no_ecrypt_messages_in_logs(host, logfile):
 @pytest.mark.parametrize('package', [
     'cloud-init',
     'libiw30',
+    'python-is-python2',
     'snapd',
     'wireless-tools',
     'wpasupplicant',


### PR DESCRIPTION

## Status

Ready for review  

## Description of Changes

Closes #5781. Adds the package to an early run, mostly
to satisfy dev/testing environments where deb packages are installed
directly as part of test runs.

Also updates the "python" -> "python3" in the same task, since on Focal
the former would result in (EOL'd) python2 being unnecessarily installed.
Updated tests to match.

## Testing

Make sure you use the newest Vagrant boxes available, preferably libvirt. At least `202102.02.0` should exhibit the problem.
Run `make staging`. Observe it passes. 

Optionally we can update the boxes used in CI, which would shave a few minutes off each staging-with-rebase run, but not doing that now since the motivation here is to unbreak dev environments.

## Deployment
None, we expect this package to be installed on hardware, and it indeed always have been. Dev-focused.