### PR TITLE
Remove aptitude, disable install-recommends

### DIFF
--- a/install_files/ansible-base/roles/common/tasks/apt_upgrade.yml
+++ b/install_files/ansible-base/roles/common/tasks/apt_upgrade.yml
@@ -10,21 +10,30 @@
   tags:
     - apt
 
-- name: Install aptitude.
+- name: Configure apt preferences
+  template:
+    src: 80securedrop.j2
+    dest: /etc/apt/apt.conf.d/80securedrop
+    mode: 0644
+    owner: root
+    group: root
+  tags:
+    - apt
+
+- name: Remove aptitude.
   apt:
     name: aptitude
-    state: present
+    state: absent
   tags: apt
 
 - name: Check whether tor will be upgraded.
-  command: aptitude search '~U' --display-format '%p' --disable-columns
+  shell: apt list --upgradable -a | perl -F/ -lanE 'print $F[0]' | grep -v ^Listing | sort -u
   register: tor_upgradable_result
   changed_when: false
-  # aptitude >= 0.7.6 will exit non-zero if no hits
   failed_when: false
 
 - name: Hold tor package to prevent upgrade breaking SSH connection.
-  command: aptitude hold tor
+  command: apt-mark hold tor
   register: tor_hold_package_result
   when:
     - "'tor' in tor_upgradable_result.stdout_lines"
@@ -33,21 +42,20 @@
     # If we're connecting to an Onion URL, then it's over Tor.
     - (ansible_host|default(ansible_host)).endswith('.onion')
 
-- name: Perform safe upgrade to ensure all the packages are updated.
+- name: Perform dist upgrade to ensure all the packages are updated.
   apt:
-    upgrade: safe
+    upgrade: dist
   tags:
     - apt
     - apt-upgrade
 
 - name: Remove hold on tor package, to permit automatic upgrades.
-  command: aptitude unhold tor
+  command: apt-mark unhold tor
   # Report changed status if we marked the package as held previously.
   # Not using a conditional `when` to control task execution because
   # we want to ensure the hold is removed, otherwise nightly upgrades
   # will not install security patches.
   changed_when: tor_hold_package_result is changed
-
 
   # Ansible doesn't support notifying handlers based on file existence, results,
   # e.g. via registered `stat` results, only only on changed=true task results,

--- a/install_files/ansible-base/roles/common/tasks/main.yml
+++ b/install_files/ansible-base/roles/common/tasks/main.yml
@@ -5,6 +5,8 @@
   when:
     - ansible_distribution_release == "focal"
 
+- include: apt_upgrade.yml
+
 - include: install_packages.yml
 
 - include: post_ubuntu_install_checks.yml
@@ -28,8 +30,6 @@
     - reboot
 
 - include: remove_unused_packages.yml
-
-- include: apt_upgrade.yml
 
 - include: sysctl.yml
 

--- a/install_files/ansible-base/roles/common/tasks/unattended_upgrades.yml
+++ b/install_files/ansible-base/roles/common/tasks/unattended_upgrades.yml
@@ -2,17 +2,6 @@
 # Configuration for unattended upgrades is almost exclusively managed by the
 # securedrop-config package under Focal.
 
-- name: Configure unattended-upgrades to reboot daily at the scheduled time.
-  template:
-    src: 80securedrop.j2
-    dest: /etc/apt/apt.conf.d/80securedrop
-    mode: 0644
-    owner: root
-    group: root
-  tags:
-    - apt
-    - unattended-upgrades
-
 - name: Ensure apt-daily and apt-daily-upgrade services are unmasked, started and enabled.
   systemd:
     name: "{{ item }}"

--- a/install_files/ansible-base/roles/common/templates/80securedrop.j2
+++ b/install_files/ansible-base/roles/common/templates/80securedrop.j2
@@ -1,4 +1,9 @@
+{% if ansible_distribution_release == "focal" %}
 // If automatic reboot is enabled and needed, reboot at the specific
 // time instead of immediately
 //  Default: "now"
 Unattended-Upgrade::Automatic-Reboot-Time "{{ daily_reboot_time }}:00";
+{% endif %}
+// Don't install packages from "Recommends" field, we'll manage dependencies
+// explicitly to avoid pulling in packages from e.g. universe.
+APT::Install-Recommends "false";

--- a/install_files/ansible-base/roles/common/vars/Ubuntu_focal.yml
+++ b/install_files/ansible-base/roles/common/vars/Ubuntu_focal.yml
@@ -8,7 +8,6 @@ resolvconf_target_filepath: /etc/resolv.conf
 
 securedrop_common_packages:
   - apt-transport-https
-  - aptitude
   - iptables-persistent
   - unattended-upgrades
   - ntp

--- a/install_files/ansible-base/roles/common/vars/Ubuntu_xenial.yml
+++ b/install_files/ansible-base/roles/common/vars/Ubuntu_xenial.yml
@@ -12,7 +12,6 @@ resolvconf_target_filepath: /etc/resolvconf/resolv.conf.d/base
 
 securedrop_common_packages:
   - apt-transport-https
-  - aptitude
   - cron-apt
   - ntp
   - ntpdate

--- a/install_files/ansible-base/roles/install-local-packages/tasks/hold_debs.yml
+++ b/install_files/ansible-base/roles/install-local-packages/tasks/hold_debs.yml
@@ -1,5 +1,5 @@
 ---
-# The Ansible config runs an aptitude safe-upgrade on every playbook invocation,
+# The Ansible config runs an apt-get dist-upgrade on every playbook invocation,
 # which will clobber the locally built packages with prod packages from the apt
 # repo. Let's set the packages to "hold" so they don't auto-upgrade.
 
@@ -9,10 +9,7 @@
   changed_when: false
   with_items: "{{ local_deb_packages }}"
 
-# Using apt-mark only applies to `apt` or `apt-get` actions, so we'll use a two-pass
-# approach to hold the locally built packages, so that neither apt nor aptitude
-# tries to upgrade them on subsequent playbook runs.
-
+# Using apt-mark applies to both `apt` or `apt-get` actions.
 - name: Mark packages as held, so they aren't upgraded automatically (via apt).
   command: apt-mark hold {{ item.stdout }}
   register: apt_mark_hold_result
@@ -21,11 +18,4 @@
   # to the value prior to installation.
   changed_when: item.stdout not in apt_mark_showhold_result.stdout_lines
   when: item.stdout not in apt_mark_showhold_result.stdout_lines
-  with_items: "{{ local_deb_packages_name_check.results }}"
-
-- name: Mark packages as held, so they aren't upgraded automatically (via aptitude).
-  command: aptitude hold {{ item.stdout }}
-  # `aptitude hold <package>` doesn't give any meaningful output to handle idempotence,
-  # so let's mark the task as no changes.
-  changed_when: false
   with_items: "{{ local_deb_packages_name_check.results }}"

--- a/molecule/builder-focal/Dockerfile
+++ b/molecule/builder-focal/Dockerfile
@@ -8,7 +8,6 @@ LABEL image_name="focal-sd-builder-app"
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         apache2-dev \
-        aptitude \
         coreutils \
         debhelper \
         devscripts \

--- a/molecule/builder-xenial/Dockerfile
+++ b/molecule/builder-xenial/Dockerfile
@@ -7,7 +7,6 @@ LABEL image_name="xenial-sd-builder-app"
 
 RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         apache2-dev \
-        aptitude \
         coreutils \
         debhelper \
         devscripts \

--- a/molecule/builder-xenial/tests/test_build_dependencies.py
+++ b/molecule/builder-xenial/tests/test_build_dependencies.py
@@ -28,7 +28,7 @@ def test_build_all_packages_updated(host):
     all upgrades, security and otherwise, have been applied to the VM
     used to build packages.
     """
-    c = host.run('aptitude --simulate -y dist-upgrade')
+    c = host.run('apt-get --simulate -y dist-upgrade')
     assert c.rc == 0
     assert "No packages will be installed, upgraded, or removed." in c.stdout
 

--- a/molecule/testinfra/common/test_system_hardening.py
+++ b/molecule/testinfra/common/test_system_hardening.py
@@ -146,9 +146,11 @@ def test_no_ecrypt_messages_in_logs(host, logfile):
 
 
 @pytest.mark.parametrize('package', [
+    'aptitude',
     'cloud-init',
     'libiw30',
     'snapd',
+    'torsocks',
     'wireless-tools',
     'wpasupplicant',
 ])


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

We were using "aptitude" in a few places, but it's not really necessary.
We can rely on apt-get for the functionality we need. In fact, it's more
predictable in terms of server state, especially using "dist-upgrade"
and also disabling automatic installation of "recommended" packages.


## Testing
1. Visual review.
2. Is the slight reduction in community/universe packages worthwhile? I'd say so.

 
## Deployment
The disabling-install-recommends functionality is applied to both Xenial & Focal hosts. The setting is mostly useful during initial install, when "recommended" packages will be pulled in. 

The goal of this change is to ensure predictable end state on new Focal installs, with a minimum of unnecessary packages.


