### PR TITLE
Fix "securedrop-admin verify" kernel checks

### DIFF
--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -197,4 +197,5 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt.freedom.press"
-grsec_version: "4.14.188"
+grsec_version_xenial: "4.14.188"
+grsec_version_focal: "5.4.97"

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -196,4 +196,5 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt.freedom.press"
-grsec_version: "4.14.175"
+grsec_version_xenial: "4.14.188"
+grsec_version_focal: "5.4.97"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds the new kernel version variables to `molecule/testinfra/vars/prod*.yml`.

## Testing

Run `securedrop-admin verify` against a production Focal installation, on hardware or in VMs. There should be no `AttributeError: 'Myvalues' object has no attribute 'grsec_version_focal'` errors.

## Deployment

Test only. Kinda. It will fix the configuration tests for production instances.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
