### PR TITLE
Fixes #5796 updates apparmor rule set for apache2

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -124,6 +124,7 @@
   /var/lib/securedrop/keys/*.app-staging.* w,
   /var/lib/securedrop/keys/gpg-agent.conf r,
   /var/lib/securedrop/keys/openpgp-revocs.d/* rw,
+  /var/lib/securedrop/keys/private-keys-v1.d/ rw,
   /var/lib/securedrop/keys/private-keys-v1.d/* rw,
   /var/lib/securedrop/keys/pubring.gpg r,
   /var/lib/securedrop/keys/pubring.gpg rw,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5796

Adds correct path `apparmor` for `apache2` process

## Testing

- [x] `make build-debs-focal && make staging-focal`
- [x] No denial message from `apparmor` for `apache2` process after a source submits a message

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
