### PR TITLE
Remove ntp and ntpdate dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
-build/*.deb
+build/**
 develop-eggs/
 dist/
 downloads/

--- a/install_files/ansible-base/roles/common/tasks/install_packages.yml
+++ b/install_files/ansible-base/roles/common/tasks/install_packages.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install base apt depedencies
+- name: Install base apt dependencies
   apt:
     name: "{{ securedrop_common_packages }}"
     state: present

--- a/install_files/ansible-base/roles/common/tasks/post_ubuntu_install_checks.yml
+++ b/install_files/ansible-base/roles/common/tasks/post_ubuntu_install_checks.yml
@@ -40,12 +40,73 @@
   changed_when: "'offset' in ntpdate_result.stdout"
   ignore_errors: yes
   become: yes
+  when: ansible_distribution_release == "xenial"
   tags:
     - ntp
 
 - name: See if ntpd is already running.
   fail:
     msg: "{{ ntpdate_result.stderr }}"
-  when: "ntpdate_result.rc != 0 and 'NTP socket is in use' not in ntpdate_result.stderr"
+  when:
+    - ansible_distribution_release == "xenial"
+    - "ntpdate_result.rc != 0 and 'NTP socket is in use' not in ntpdate_result.stderr"
+  tags:
+    - ntp
+
+- name: Disable VirtualBox service vboxadd to avoid conflict with systemd-timesyncd.
+  systemd:
+    name: vboxadd
+    enabled: no
+    state: stopped
+  when: ansible_distribution_release == "focal"
+  become: yes
+  tags:
+    - ntp
+
+- name: Disable VirtualBox service vboxadd-service to avoid conflict with systemd-timesyncd.
+  systemd:
+    name: vboxadd-service
+    enabled: no
+    state: stopped
+  when: ansible_distribution_release == "focal"
+  become: yes
+  tags:
+    - ntp
+
+- name: Ensure systemd-timesyncd service is enabled.
+  systemd:
+    name: systemd-timesyncd
+    enabled: yes
+    state: started
+  when: ansible_distribution_release == "focal"
+  become: yes
+  tags:
+    - ntp
+
+- name: Ensure NTP is enabled.
+  command: "timedatectl set-ntp 1"
+  when: ansible_distribution_release == "focal"
+  become: yes
+  tags:
+    - ntp
+
+- name: Verify time service configuration.
+  command: "timedatectl show"
+  register: timedatectl_show_result
+  when: ansible_distribution_release == "focal"
+  become: yes
+  changed_when:
+    - "'\nNTP=yes' in timedatectl_show_result.stdout"
+    - "'\nNTPSynchronized=yes' in timedatectl_show_result.stdout"
+  tags:
+    - ntp
+
+- name: Ensure the system clock is set accurately.
+  command: "timedatectl show-timesync"
+  register: timedatectl_show_timesync_result
+  when: ansible_distribution_release == "focal"
+  become: yes
+  changed_when:
+    - "'\nNTPMessage=' in timedatectl_show_timesync_result.stdout"
   tags:
     - ntp

--- a/install_files/ansible-base/roles/common/vars/Ubuntu_focal.yml
+++ b/install_files/ansible-base/roles/common/vars/Ubuntu_focal.yml
@@ -10,6 +10,4 @@ securedrop_common_packages:
   - apt-transport-https
   - iptables-persistent
   - unattended-upgrades
-  - ntp
-  - ntpdate
   - tmux

--- a/install_files/ansible-base/roles/restrict-direct-access/defaults/main.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/defaults/main.yml
@@ -40,3 +40,5 @@ tor_v3_service_map:
   app-journalist.auth_private: "app_journalist_private_key"
   app-ssh.auth_private: "app_ssh_private_key"
   mon-ssh.auth_private: "mon_ssh_private_key"
+
+time_service_user: '{{ "root" if ansible_distribution_release == "xenial" else "systemd-timesync" }}'

--- a/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/rules_v4
@@ -60,8 +60,8 @@
 {% endfor -%}
 
 # NTP rules
--A OUTPUT -p udp --sport 123 --dport 123 -m owner --uid-owner root -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "ntp"
--A INPUT -p udp --sport 123 --dport 123 -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "ntp"
+-A OUTPUT -p udp --dport 123 -m owner --uid-owner {{ time_service_user }} -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "ntp"
+-A INPUT -p udp --sport 123 -m state --state ESTABLISHED,RELATED -j ACCEPT -m comment --comment "ntp"
 
 # apt rules can't be restricted by destination address because iptables will only resolve FQDNs once at startup
 -A OUTPUT -p tcp --match multiport --dports 80,8080,443 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT -m comment --comment "apt updates"

--- a/molecule/builder-focal/Dockerfile
+++ b/molecule/builder-focal/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         libffi-dev \
         libssl-dev \
         make \
-        ntp \
         paxctl \
         python3-all \
         python3-pip \

--- a/molecule/libvirt-staging-focal/molecule.yml
+++ b/molecule/libvirt-staging-focal/molecule.yml
@@ -72,3 +72,5 @@ verifier:
     n: auto
     v: 2
     junit-xml: ../../junit/testinfra-results.xml
+  env:
+    SECUREDROP_TARGET_DISTRIBUTION: focal

--- a/molecule/libvirt-staging-xenial/molecule.yml
+++ b/molecule/libvirt-staging-xenial/molecule.yml
@@ -72,3 +72,5 @@ verifier:
     n: auto
     v: 2
     junit-xml: ../../junit/testinfra-results.xml
+  env:
+    SECUREDROP_TARGET_DISTRIBUTION: xenial

--- a/molecule/qubes-staging-focal/molecule.yml
+++ b/molecule/qubes-staging-focal/molecule.yml
@@ -56,4 +56,5 @@ verifier:
     n: auto
     v: 2
   env:
+    SECUREDROP_TARGET_DISTRIBUTION: focal
     SECUREDROP_TESTINFRA_TARGET_HOST: qubes-staging

--- a/molecule/qubes-staging-xenial/molecule.yml
+++ b/molecule/qubes-staging-xenial/molecule.yml
@@ -56,4 +56,5 @@ verifier:
     n: auto
     v: 2
   env:
+    SECUREDROP_TARGET_DISTRIBUTION: xenial
     SECUREDROP_TESTINFRA_TARGET_HOST: qubes-staging

--- a/molecule/testinfra/app/iptables-app-prod.j2
+++ b/molecule/testinfra/app/iptables-app-prod.j2
@@ -11,7 +11,7 @@
 -A INPUT -s {{ address }}/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A INPUT -s {{ address }}/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A INPUT -p udp -m udp --sport 123 --dport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A INPUT -p udp -m udp --sport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A INPUT -p tcp -m multiport --sports 80,8080,443 -m state --state RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A INPUT -s {{ mon_ip }}/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
 -A INPUT -s {{ mon_ip }}/32 -p tcp -m tcp --dport 22 -m comment --comment "Block explicitly SSH from the adjacent SD component" -j DROP
@@ -31,7 +31,7 @@
 -A OUTPUT -d {{ address }}/32 -p tcp -m tcp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -d {{ address }}/32 -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A OUTPUT -p udp -m udp --dport 123 -m owner --uid-owner {{ time_service_user }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A OUTPUT -d {{ mon_ip }}/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
 -A OUTPUT -o eth0 -p tcp -m owner --uid-owner 0 -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT

--- a/molecule/testinfra/app/iptables-app-prodVM.j2
+++ b/molecule/testinfra/app/iptables-app-prodVM.j2
@@ -11,7 +11,7 @@
 -A INPUT -s {{ address }}/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A INPUT -s {{ address }}/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A INPUT -p udp -m udp --sport 123 --dport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A INPUT -p udp -m udp --sport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A INPUT -p tcp -m multiport --sports 80,8080,443 -m state --state RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A INPUT -s {{ mon_ip }}/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
 -A INPUT -s {{ mon_ip }}/32 -p tcp -m tcp --dport 22 -m comment --comment "Block explicitly SSH from the adjacent SD component" -j DROP
@@ -31,7 +31,7 @@
 -A OUTPUT -d {{ address }}/32 -p tcp -m tcp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -d {{ address }}/32 -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A OUTPUT -p udp -m udp --dport 123 -m owner --uid-owner {{ time_service_user }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A OUTPUT -d {{ mon_ip }}/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
 -A OUTPUT -o eth1 -p tcp -m owner --uid-owner 0 -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT

--- a/molecule/testinfra/app/iptables-app-qubes-staging.j2
+++ b/molecule/testinfra/app/iptables-app-qubes-staging.j2
@@ -11,7 +11,7 @@
 -A INPUT -s {{ address }}/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A INPUT -s {{ address }}/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A INPUT -p udp -m udp --sport 123 --dport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A INPUT -p udp -m udp --sport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A INPUT -p tcp -m multiport --sports 80,8080,443 -m state --state RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A INPUT -s {{ mon_ip }}/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
 -A INPUT -s {{ mon_ip }}/32 -p tcp -m tcp --dport 22 -m comment --comment "Block explicitly SSH from the adjacent SD component" -j DROP
@@ -31,7 +31,7 @@
 -A OUTPUT -d {{ address }}/32 -p tcp -m tcp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -d {{ address }}/32 -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A OUTPUT -p udp -m udp --dport 123 -m owner --uid-owner {{ time_service_user }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A OUTPUT -d {{ mon_ip }}/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
 -A OUTPUT -o eth0 -p tcp -m owner --uid-owner 0 -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT

--- a/molecule/testinfra/app/iptables-app-staging.j2
+++ b/molecule/testinfra/app/iptables-app-staging.j2
@@ -11,7 +11,7 @@
 -A INPUT -s {{ address }}/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A INPUT -s {{ address }}/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A INPUT -p udp -m udp --sport 123 --dport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A INPUT -p udp -m udp --sport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A INPUT -p tcp -m multiport --sports 80,8080,443 -m state --state RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A INPUT -s {{ mon_ip }}/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
 -A INPUT -s {{ mon_ip }}/32 -p tcp -m tcp --dport 22 -m comment --comment "Block explicitly SSH from the adjacent SD component" -j DROP
@@ -31,7 +31,7 @@
 -A OUTPUT -d {{ address }}/32 -p tcp -m tcp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -d {{ address }}/32 -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A OUTPUT -p udp -m udp --dport 123 -m owner --uid-owner {{ time_service_user }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A OUTPUT -d {{ mon_ip }}/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
 -A OUTPUT -o eth0 -p tcp -m owner --uid-owner 0 -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT

--- a/molecule/testinfra/app/test_app_network.py
+++ b/molecule/testinfra/app/test_app_network.py
@@ -16,12 +16,19 @@ def test_app_iptables_rules(host):
 
     local = host.get_host("local://")
 
+    time_service_user = (
+        host.check_output("id -u systemd-timesync")
+        if securedrop_test_vars.securedrop_target_distribution == "focal"
+        else 0
+    )
+
     # Build a dict of variables to pass to jinja for iptables comparison
     kwargs = dict(
         mon_ip=os.environ.get('MON_IP', securedrop_test_vars.mon_ip),
         default_interface=host.check_output("ip r | head -n 1 | "
                                             "awk '{ print $5 }'"),
         tor_user_id=host.check_output("id -u debian-tor"),
+        time_service_user=time_service_user,
         securedrop_user_id=host.check_output("id -u www-data"),
         ssh_group_gid=host.check_output("getent group ssh | cut -d: -f3"),
         dns_server=securedrop_test_vars.dns_server)

--- a/molecule/testinfra/common/test_automatic_updates.py
+++ b/molecule/testinfra/common/test_automatic_updates.py
@@ -19,7 +19,7 @@ def test_automatic_updates_dependencies(host):
     """
     apt_dependencies = {
         'xenial': ['cron-apt', 'ntp'],
-        'focal': ['unattended-upgrades', 'ntp']
+        'focal': ['unattended-upgrades']
     }
 
     for package in apt_dependencies[host.system_info.codename]:

--- a/molecule/testinfra/common/test_basic_configuration.py
+++ b/molecule/testinfra/common/test_basic_configuration.py
@@ -5,11 +5,23 @@ testinfra_hosts = [test_vars.app_hostname, test_vars.monitor_hostname]
 
 
 def test_system_time(host):
-    if test_vars.securedrop_target_distribution == "xenial":
+    if host.system_info.codename == "xenial":
         c = host.run("timedatectl status")
         assert "Network time on: yes" in c.stdout
         assert "NTP synchronized: yes" in c.stdout
     else:
+        assert not host.package("ntp").is_installed
+        assert not host.package("ntpdate").is_installed
+
+        s = host.service("systemd-timesyncd")
+        assert s.is_running
+        assert s.is_enabled
+        assert not s.is_masked
+
+        # File will be touched on every successful synchronization,
+        # see 'man systemd-timesyncd'`
+        assert host.file("/run/systemd/timesync/synchronized").exists
+
         c = host.run("timedatectl show")
         assert "NTP=yes" in c.stdout
         assert "NTPSynchronized=yes" in c.stdout

--- a/molecule/testinfra/common/test_basic_configuration.py
+++ b/molecule/testinfra/common/test_basic_configuration.py
@@ -1,14 +1,26 @@
+from testinfra.host import Host
+
 import testutils
+
 
 test_vars = testutils.securedrop_test_vars
 testinfra_hosts = [test_vars.app_hostname, test_vars.monitor_hostname]
 
 
-def test_system_time(host):
+def test_system_time(host: Host) -> None:
     if host.system_info.codename == "xenial":
-        c = host.run("timedatectl status")
-        assert "Network time on: yes" in c.stdout
-        assert "NTP synchronized: yes" in c.stdout
+        assert host.package("ntp").is_installed
+        assert host.package("ntpdate").is_installed
+
+        # TODO: The staging setup timing is too erratic for the
+        # following check. If we do want to reinstate it before
+        # dropping Xenial support, it should be done in a loop to give
+        # ntpd time to sync after the machines are created.
+
+        # c = host.run("ntpq -c rv")
+        # assert "leap_none" in c.stdout
+        # assert "sync_ntp" in c.stdout
+        # assert "refid" in c.stdout
     else:
         assert not host.package("ntp").is_installed
         assert not host.package("ntpdate").is_installed

--- a/molecule/testinfra/common/test_basic_configuration.py
+++ b/molecule/testinfra/common/test_basic_configuration.py
@@ -1,0 +1,15 @@
+import testutils
+
+test_vars = testutils.securedrop_test_vars
+testinfra_hosts = [test_vars.app_hostname, test_vars.monitor_hostname]
+
+
+def test_system_time(host):
+    if test_vars.securedrop_target_distribution == "xenial":
+        c = host.run("timedatectl status")
+        assert "Network time on: yes" in c.stdout
+        assert "NTP synchronized: yes" in c.stdout
+    else:
+        c = host.run("timedatectl show")
+        assert "NTP=yes" in c.stdout
+        assert "NTPSynchronized=yes" in c.stdout

--- a/molecule/testinfra/mon/iptables-mon-prod.j2
+++ b/molecule/testinfra/mon/iptables-mon-prod.j2
@@ -8,7 +8,7 @@
 -A INPUT -s {{ address }}/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A INPUT -s {{ address }}/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A INPUT -p udp -m udp --sport 123 --dport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A INPUT -p udp -m udp --sport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A INPUT -p tcp -m multiport --sports 80,8080,443 -m state --state RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A INPUT -s {{ app_ip }}/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow OSSEC agent to monitor" -j ACCEPT
 {% for address in dns_server -%}
@@ -29,7 +29,7 @@
 -A OUTPUT -d {{ address }}/32 -p tcp -m tcp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -d {{ address }}/32 -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A OUTPUT -p udp -m udp --dport 123 -m owner --uid-owner {{ time_service_user }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A OUTPUT -d {{ app_ip }}/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "Allow OSSEC agent to monitor" -j ACCEPT
 {% for address in dns_server -%}

--- a/molecule/testinfra/mon/iptables-mon-prodVM.j2
+++ b/molecule/testinfra/mon/iptables-mon-prodVM.j2
@@ -8,7 +8,7 @@
 -A INPUT -s {{ address }}/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A INPUT -s {{ address }}/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A INPUT -p udp -m udp --sport 123 --dport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A INPUT -p udp -m udp --sport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A INPUT -p tcp -m multiport --sports 80,8080,443 -m state --state RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A INPUT -s {{ app_ip }}/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow OSSEC agent to monitor" -j ACCEPT
 {% for address in dns_server -%}
@@ -29,7 +29,7 @@
 -A OUTPUT -d {{ address }}/32 -p tcp -m tcp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -d {{ address }}/32 -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A OUTPUT -p udp -m udp --dport 123 -m owner --uid-owner {{ time_service_user }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A OUTPUT -d {{ app_ip }}/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "Allow OSSEC agent to monitor" -j ACCEPT
 {% for address in dns_server -%}

--- a/molecule/testinfra/mon/iptables-mon-qubes-staging.j2
+++ b/molecule/testinfra/mon/iptables-mon-qubes-staging.j2
@@ -8,7 +8,7 @@
 -A INPUT -s {{ address }}/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A INPUT -s {{ address }}/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A INPUT -p udp -m udp --sport 123 --dport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A INPUT -p udp -m udp --sport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A INPUT -p tcp -m multiport --sports 80,8080,443 -m state --state RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A INPUT -s {{ app_ip }}/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow OSSEC agent to monitor" -j ACCEPT
 {% for address in dns_server -%}
@@ -29,7 +29,7 @@
 -A OUTPUT -d {{ address }}/32 -p tcp -m tcp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -d {{ address }}/32 -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A OUTPUT -p udp -m udp --dport 123 -m owner --uid-owner {{ time_service_user }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A OUTPUT -d {{ app_ip }}/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "Allow OSSEC agent to monitor" -j ACCEPT
 {% for address in dns_server -%}

--- a/molecule/testinfra/mon/iptables-mon-staging.j2
+++ b/molecule/testinfra/mon/iptables-mon-staging.j2
@@ -8,7 +8,7 @@
 -A INPUT -s {{ address }}/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A INPUT -s {{ address }}/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A INPUT -p udp -m udp --sport 123 --dport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A INPUT -p udp -m udp --sport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A INPUT -p tcp -m multiport --sports 80,8080,443 -m state --state RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A INPUT -s {{ app_ip }}/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow OSSEC agent to monitor" -j ACCEPT
 {% for address in dns_server -%}
@@ -29,7 +29,7 @@
 -A OUTPUT -d {{ address }}/32 -p tcp -m tcp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 -A OUTPUT -d {{ address }}/32 -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
 {% endfor -%}
--A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
+-A OUTPUT -p udp -m udp --dport 123 -m owner --uid-owner {{ time_service_user }} -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
 -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
 -A OUTPUT -d {{ app_ip }}/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "Allow OSSEC agent to monitor" -j ACCEPT
 {% for address in dns_server -%}

--- a/molecule/testinfra/mon/test_mon_network.py
+++ b/molecule/testinfra/mon/test_mon_network.py
@@ -15,12 +15,19 @@ def test_mon_iptables_rules(host):
 
     local = host.get_host("local://")
 
+    time_service_user = (
+        host.check_output("id -u systemd-timesync")
+        if securedrop_test_vars.securedrop_target_distribution == "focal"
+        else 0
+    )
+
     # Build a dict of variables to pass to jinja for iptables comparison
     kwargs = dict(
         app_ip=os.environ.get('APP_IP', securedrop_test_vars.app_ip),
         default_interface=host.check_output(
             "ip r | head -n 1 | awk '{ print $5 }'"),
         tor_user_id=host.check_output("id -u debian-tor"),
+        time_service_user=time_service_user,
         ssh_group_gid=host.check_output("getent group ssh | cut -d: -f3"),
         postfix_user_id=host.check_output("id -u postfix"),
         dns_server=securedrop_test_vars.dns_server)

--- a/molecule/testinfra/vars/app-prod.yml
+++ b/molecule/testinfra/vars/app-prod.yml
@@ -20,16 +20,27 @@ app_directories:
   - /var/lib/securedrop/tmp
 
 apparmor_enforce:
-  - "sbin/dhclient"
-  - "/usr/lib/NetworkManager/nm-dhcp-client.action"
-  - "/usr/lib/connman/scripts/dhclient-script"
-  - "/usr/sbin/ntpd"
-  - "/usr/sbin/tcpdump"
-  - "system_tor"
-  - "/usr/sbin/apache2"
-  - "/usr/sbin/apache2//DEFAULT_URI"
-  - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
-  - "/usr/sbin/tor"
+  focal:
+    - "sbin/dhclient"
+    - "/usr/lib/NetworkManager/nm-dhcp-client.action"
+    - "/usr/lib/connman/scripts/dhclient-script"
+    - "/usr/sbin/tcpdump"
+    - "system_tor"
+    - "/usr/sbin/apache2"
+    - "/usr/sbin/apache2//DEFAULT_URI"
+    - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
+    - "/usr/sbin/tor"
+  xenial:
+    - "sbin/dhclient"
+    - "/usr/lib/NetworkManager/nm-dhcp-client.action"
+    - "/usr/lib/connman/scripts/dhclient-script"
+    - "/usr/sbin/ntpd"
+    - "/usr/sbin/tcpdump"
+    - "system_tor"
+    - "/usr/sbin/apache2"
+    - "/usr/sbin/apache2//DEFAULT_URI"
+    - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
+    - "/usr/sbin/tor"
 
 apparmor_complain: []
 
@@ -40,44 +51,5 @@ allowed_apache_logfiles:
   - /var/log/apache2/journalist-access.log
   - /var/log/apache2/journalist-error.log
   - /var/log/apache2/other_vhosts_access.log
-
-iptables_complete_ruleset: |-
-  -P INPUT DROP
-  -P FORWARD DROP
-  -P OUTPUT DROP
-  -N LOGNDROP
-  -A INPUT -p tcp -m state --state RELATED,ESTABLISHED -m comment --comment "Allow traffic back for tor" -j ACCEPT
-  -A INPUT -i lo -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor connection from local loopback to connect to source int" -j ACCEPT
-  -A INPUT -i lo -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor connection from local loopback to connect to journalist int" -j ACCEPT
-  -A INPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -i lo -p tcp -m state --state RELATED,ESTABLISHED -m comment --comment "for redis worker all application user local loopback user" -j ACCEPT
-  -A INPUT -s 8.8.8.8/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -s 8.8.8.8/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -p udp -m udp --sport 123 --dport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
-  -A INPUT -p tcp -m multiport --sports 80,8080,443 -m state --state RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
-  -A INPUT -s 10.0.1.5/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
-  -A INPUT -i lo -m comment --comment "Allow lo to lo traffic all protocols" -j ACCEPT
-  -A INPUT -p tcp -m state --state INVALID -m comment --comment "drop but do not log inbound invalid state packets" -j DROP
-  -A INPUT -m comment --comment "Drop and log all other incoming traffic" -j LOGNDROP
-  -A OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 107 -m state --state NEW -m limit --limit 3/min --limit-burst 3 -m comment --comment "Rate limit traffic from tor to the ssh dameon" -j ACCEPT
-  -A OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 107 -m state --state NEW -m comment --comment "Drop all other new connections from tor to the ssh dameon" -j LOGNDROP
-  -A OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 107 -m state --state RELATED,ESTABLISHED -m comment --comment "Allow the established traffic from tor to the ssh dameon" -j ACCEPT
-  -A OUTPUT -p tcp -m owner --uid-owner 107 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tor instance that provides ssh access" -j ACCEPT
-  -A OUTPUT -m owner --uid-owner 107 -m comment --comment "Drop all other traffic for the tor instance used for ssh" -j LOGNDROP
-  -A OUTPUT -o lo -p tcp -m tcp --sport 80 -m owner --uid-owner 33 -m state --state RELATED,ESTABLISHED -m comment --comment "Restrict the apache user outbound connections" -j ACCEPT
-  -A OUTPUT -o lo -p tcp -m tcp --sport 8080 -m owner --uid-owner 33 -m state --state RELATED,ESTABLISHED -m comment --comment "Restrict the apache user outbound connections" -j ACCEPT
-  -A OUTPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -o lo -p tcp -m owner --uid-owner 33 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "for redis worker all application user local loopback user" -j ACCEPT
-  -A OUTPUT -m owner --uid-owner 33 -m comment --comment "Drop all other traffic by the securedrop user" -j LOGNDROP
-  -A OUTPUT -m owner --gid-owner 108 -m comment --comment "Drop all other outbound traffic for ssh user" -j LOGNDROP
-  -A OUTPUT -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A OUTPUT -d 8.8.8.8/32 -p udp -m udp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
-  -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
-  -A OUTPUT -d 10.0.1.5/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
-  -A OUTPUT -o lo -m comment --comment "Allow lo to lo traffic all protocols" -j ACCEPT
-  -A OUTPUT -m comment --comment "Drop all other outgoing traffic" -j DROP
-  -A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-tcp-options --log-ip-options --log-uid
-  -A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-ip-options --log-uid
-  -A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-ip-options --log-uid
-  -A LOGNDROP -j DROP
 
 fpf_apt_repo_url: "https://apt.freedom.press"

--- a/molecule/testinfra/vars/app-staging.yml
+++ b/molecule/testinfra/vars/app-staging.yml
@@ -38,16 +38,27 @@ pip_deps:
 apparmor_complain: []
 
 apparmor_enforce:
-  - "sbin/dhclient"
-  - "/usr/lib/NetworkManager/nm-dhcp-client.action"
-  - "/usr/lib/connman/scripts/dhclient-script"
-  - "/usr/sbin/ntpd"
-  - "/usr/sbin/tcpdump"
-  - "system_tor"
-  - "/usr/sbin/apache2"
-  - "/usr/sbin/apache2//DEFAULT_URI"
-  - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
-  - "/usr/sbin/tor"
+  focal:
+    - "sbin/dhclient"
+    - "/usr/lib/NetworkManager/nm-dhcp-client.action"
+    - "/usr/lib/connman/scripts/dhclient-script"
+    - "/usr/sbin/tcpdump"
+    - "system_tor"
+    - "/usr/sbin/apache2"
+    - "/usr/sbin/apache2//DEFAULT_URI"
+    - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
+    - "/usr/sbin/tor"
+  xenial:
+    - "sbin/dhclient"
+    - "/usr/lib/NetworkManager/nm-dhcp-client.action"
+    - "/usr/lib/connman/scripts/dhclient-script"
+    - "/usr/sbin/ntpd"
+    - "/usr/sbin/tcpdump"
+    - "system_tor"
+    - "/usr/sbin/apache2"
+    - "/usr/sbin/apache2//DEFAULT_URI"
+    - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
+    - "/usr/sbin/tor"
 
 app_directories:
   - /var/www/securedrop
@@ -91,57 +102,5 @@ allowed_apache_logfiles:
   - /var/log/apache2/journalist-error.log
   - /var/log/apache2/other_vhosts_access.log
   - /var/log/apache2/source-error.log
-
-# Hardcoded values, only appropriate for local testing via Vagrant.
-iptables_complete_ruleset: |-
-  -P INPUT DROP
-  -P FORWARD DROP
-  -P OUTPUT DROP
-  -N LOGNDROP
-  -A INPUT -p tcp -m state --state RELATED,ESTABLISHED -m comment --comment "Allow traffic back for tor" -j ACCEPT
-  -A INPUT -i lo -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor connection from local loopback to connect to source int" -j ACCEPT
-  -A INPUT -i lo -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow tor connection from local loopback to connect to journalist int" -j ACCEPT
-  -A INPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -i lo -p tcp -m state --state RELATED,ESTABLISHED -m comment --comment "for redis worker all application user local loopback user" -j ACCEPT
-  -A INPUT -s 8.8.8.8/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -s 8.8.8.8/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -s 8.8.4.4/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -s 8.8.4.4/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -p udp -m udp --sport 123 --dport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
-  -A INPUT -p tcp -m multiport --sports 80,8080,443 -m state --state RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
-  -A INPUT -s 10.0.1.3/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
-  -A INPUT -i eth0 -p tcp -m tcp --dport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
-  -A INPUT -p udp -m udp --sport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
-  -A INPUT -i eth0 -p tcp -m tcp --dport 80 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
-  -A INPUT -i eth0 -p tcp -m tcp --dport 8080 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
-  -A INPUT -i lo -m comment --comment "Allow lo to lo traffic all protocols" -j ACCEPT
-  -A INPUT -p tcp -m state --state INVALID -m comment --comment "drop but do not log inbound invalid state packets" -j DROP
-  -A INPUT -m comment --comment "Drop and log all other incoming traffic" -j LOGNDROP
-  -A OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 107 -m state --state NEW -m limit --limit 3/min --limit-burst 3 -m comment --comment "Rate limit traffic from tor to the ssh dameon" -j ACCEPT
-  -A OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 107 -m state --state NEW -m comment --comment "Drop all other new connections from tor to the ssh dameon" -j LOGNDROP
-  -A OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 107 -m state --state RELATED,ESTABLISHED -m comment --comment "Allow the established traffic from tor to the ssh dameon" -j ACCEPT
-  -A OUTPUT -p tcp -m owner --uid-owner 107 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tor instance that provides ssh access" -j ACCEPT
-  -A OUTPUT -m owner --uid-owner 107 -m comment --comment "Drop all other traffic for the tor instance used for ssh" -j LOGNDROP
-  -A OUTPUT -o lo -p tcp -m tcp --sport 80 -m owner --uid-owner 33 -m state --state RELATED,ESTABLISHED -m comment --comment "Restrict the apache user outbound connections" -j ACCEPT
-  -A OUTPUT -o lo -p tcp -m tcp --sport 8080 -m owner --uid-owner 33 -m state --state RELATED,ESTABLISHED -m comment --comment "Restrict the apache user outbound connections" -j ACCEPT
-  -A OUTPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -o lo -p tcp -m owner --uid-owner 33 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "for redis worker all application user local loopback user" -j ACCEPT
-  -A OUTPUT -m owner --uid-owner 33 -m comment --comment "Drop all other traffic by the securedrop user" -j LOGNDROP
-  -A OUTPUT -m owner --gid-owner 108 -m comment --comment "Drop all other outbound traffic for ssh user" -j LOGNDROP
-  -A OUTPUT -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A OUTPUT -d 8.8.8.8/32 -p udp -m udp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A OUTPUT -d 8.8.4.4/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A OUTPUT -d 8.8.4.4/32 -p udp -m udp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
-  -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
-  -A OUTPUT -d 10.0.1.3/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "OSSEC server agent" -j ACCEPT
-  -A OUTPUT -o eth0 -p tcp -m owner --uid-owner 0 -m tcp --sport 22 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
-  -A OUTPUT -p udp -m udp --dport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
-  -A OUTPUT -o eth0 -p tcp -m tcp --sport 80 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
-  -A OUTPUT -o eth0 -p tcp -m tcp --sport 8080 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
-  -A OUTPUT -o lo -m comment --comment "Allow lo to lo traffic all protocols" -j ACCEPT
-  -A OUTPUT -m comment --comment "Drop all other outgoing traffic" -j DROP
-  -A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-tcp-options --log-ip-options --log-uid
-  -A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-ip-options --log-uid
-  -A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-ip-options --log-uid
-  -A LOGNDROP -j DROP
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"

--- a/molecule/testinfra/vars/mon-prod.yml
+++ b/molecule/testinfra/vars/mon-prod.yml
@@ -13,52 +13,6 @@ tor_stealth_services:
   - service: "HiddenServicePort 22 127.0.0.1:22"
     stealth: admin
 
-iptables_complete_ruleset: |-
-  -P INPUT DROP
-  -P FORWARD DROP
-  -P OUTPUT DROP
-  -N LOGNDROP
-  -A INPUT -p tcp -m state --state RELATED,ESTABLISHED -m comment --comment "Allow traffic back for tor" -j ACCEPT
-  -A INPUT -s 8.8.8.8/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -s 8.8.8.8/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -s 8.8.4.4/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -s 8.8.4.4/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -p udp -m udp --sport 123 --dport 123 -m state --state RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
-  -A INPUT -p tcp -m multiport --sports 80,8080,443 -m state --state RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
-  -A INPUT -s 10.0.1.4/32 -p udp -m udp --dport 1514 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow OSSEC agent to monitor" -j ACCEPT
-  -A INPUT -s 8.8.8.8/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -s 8.8.8.8/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -s 8.8.4.4/32 -p tcp -m tcp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -s 8.8.4.4/32 -p udp -m udp --sport 53 -m state --state RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A INPUT -p tcp -m tcp --sport 587 -m state --state RELATED,ESTABLISHED -m comment --comment "Allow ossec email alerts out" -j ACCEPT
-  -A INPUT -i lo -m comment --comment "Allow lo to lo traffic all protocols" -j ACCEPT
-  -A INPUT -p tcp -m state --state INVALID -m comment --comment "drop but do not log inbound invalid state packets" -j DROP
-  -A INPUT -m comment --comment "Drop and log all other incoming traffic" -j LOGNDROP
-  -A OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 107 -m state --state NEW -m limit --limit 3/min --limit-burst 3 -m comment --comment "Rate limit traffic from tor to the ssh dameon" -j ACCEPT
-  -A OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 107 -m state --state NEW -m comment --comment "Drop all other new connections from tor to the ssh dameon" -j LOGNDROP
-  -A OUTPUT -o lo -p tcp -m tcp --dport 22 -m owner --uid-owner 107 -m state --state RELATED,ESTABLISHED -m comment --comment "Allow the established traffic from tor to the ssh dameon" -j ACCEPT
-  -A OUTPUT -p tcp -m owner --uid-owner 107 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tor instance that provides ssh access" -j ACCEPT
-  -A OUTPUT -m owner --uid-owner 107 -m comment --comment "Drop all other traffic for the tor instance used for ssh" -j LOGNDROP
-  -A OUTPUT -m owner --gid-owner 108 -m comment --comment "Drop all other outbound traffic for ssh user" -j LOGNDROP
-  -A OUTPUT -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A OUTPUT -d 8.8.8.8/32 -p udp -m udp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A OUTPUT -d 8.8.4.4/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A OUTPUT -d 8.8.4.4/32 -p udp -m udp --dport 53 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "tcp/udp dns" -j ACCEPT
-  -A OUTPUT -p udp -m udp --sport 123 --dport 123 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment ntp -j ACCEPT
-  -A OUTPUT -p tcp -m multiport --dports 80,8080,443 -m owner --uid-owner 0 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "apt updates" -j ACCEPT
-  -A OUTPUT -d 10.0.1.4/32 -p udp -m udp --sport 1514 -m state --state RELATED,ESTABLISHED -m comment --comment "Allow OSSEC agent to monitor" -j ACCEPT
-  -A OUTPUT -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 108 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "postfix dns rule" -j ACCEPT
-  -A OUTPUT -d 8.8.8.8/32 -p udp -m udp --dport 53 -m owner --uid-owner 108 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "postfix dns rule" -j ACCEPT
-  -A OUTPUT -d 8.8.4.4/32 -p tcp -m tcp --dport 53 -m owner --uid-owner 108 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "postfix dns rule" -j ACCEPT
-  -A OUTPUT -d 8.8.4.4/32 -p udp -m udp --dport 53 -m owner --uid-owner 108 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "postfix dns rule" -j ACCEPT
-  -A OUTPUT -p tcp -m tcp --dport 587 -m owner --uid-owner 108 -m state --state NEW,RELATED,ESTABLISHED -m comment --comment "Allow ossec email alerts out" -j ACCEPT
-  -A OUTPUT -o lo -m comment --comment "Allow lo to lo traffic all protocols" -j ACCEPT
-  -A OUTPUT -m comment --comment "Drop all other outgoing traffic" -j DROP
-  -A LOGNDROP -p tcp -m limit --limit 5/min -j LOG --log-tcp-options --log-ip-options --log-uid
-  -A LOGNDROP -p udp -m limit --limit 5/min -j LOG --log-ip-options --log-uid
-  -A LOGNDROP -p icmp -m limit --limit 5/min -j LOG --log-ip-options --log-uid
-  -A LOGNDROP -j DROP
-
 # Postfix should indeed be running on prod hosts, otherwise
 # OSSEC alerts cannot be delivered. It's disabled in staging.
 postfix_enabled: True

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -38,16 +38,27 @@ pip_deps:
 apparmor_complain: []
 
 apparmor_enforce:
-  - "/sbin/dhclient"
-  - "/usr/lib/NetworkManager/nm-dhcp-client.action"
-  - "/usr/lib/connman/scripts/dhclient-script"
-  - "/usr/sbin/ntpd"
-  - "/usr/sbin/haveged"
-  - "system_tor"
-  - "/usr/sbin/apache2"
-  - "/usr/sbin/apache2//DEFAULT_URI"
-  - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
-  - "/usr/sbin/tor"
+  focal:
+    - "sbin/dhclient"
+    - "/usr/lib/NetworkManager/nm-dhcp-client.action"
+    - "/usr/lib/connman/scripts/dhclient-script"
+    - "/usr/sbin/tcpdump"
+    - "system_tor"
+    - "/usr/sbin/apache2"
+    - "/usr/sbin/apache2//DEFAULT_URI"
+    - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
+    - "/usr/sbin/tor"
+  xenial:
+    - "sbin/dhclient"
+    - "/usr/lib/NetworkManager/nm-dhcp-client.action"
+    - "/usr/lib/connman/scripts/dhclient-script"
+    - "/usr/sbin/ntpd"
+    - "/usr/sbin/tcpdump"
+    - "system_tor"
+    - "/usr/sbin/apache2"
+    - "/usr/sbin/apache2//DEFAULT_URI"
+    - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
+    - "/usr/sbin/tor"
 
 app_directories:
   - /var/www/securedrop

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -37,16 +37,27 @@ pip_deps:
 apparmor_complain: []
 
 apparmor_enforce:
-  - "/sbin/dhclient"
-  - "/usr/lib/NetworkManager/nm-dhcp-client.action"
-  - "/usr/lib/connman/scripts/dhclient-script"
-  - "/usr/sbin/ntpd"
-  - "/usr/sbin/tcpdump"
-  - "system_tor"
-  - "/usr/sbin/apache2"
-  - "/usr/sbin/apache2//DEFAULT_URI"
-  - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
-  - "/usr/sbin/tor"
+  focal:
+    - "sbin/dhclient"
+    - "/usr/lib/NetworkManager/nm-dhcp-client.action"
+    - "/usr/lib/connman/scripts/dhclient-script"
+    - "/usr/sbin/tcpdump"
+    - "system_tor"
+    - "/usr/sbin/apache2"
+    - "/usr/sbin/apache2//DEFAULT_URI"
+    - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
+    - "/usr/sbin/tor"
+  xenial:
+    - "sbin/dhclient"
+    - "/usr/lib/NetworkManager/nm-dhcp-client.action"
+    - "/usr/lib/connman/scripts/dhclient-script"
+    - "/usr/sbin/ntpd"
+    - "/usr/sbin/tcpdump"
+    - "system_tor"
+    - "/usr/sbin/apache2"
+    - "/usr/sbin/apache2//DEFAULT_URI"
+    - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
+    - "/usr/sbin/tor"
 
 app_directories:
   - /var/www/securedrop

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -39,15 +39,27 @@ pip_deps:
 apparmor_complain: []
 
 apparmor_enforce:
-  - "/sbin/dhclient"
-  - "/usr/lib/NetworkManager/nm-dhcp-client.action"
-  - "/usr/lib/connman/scripts/dhclient-script"
-  - "/usr/sbin/ntpd"
-  - "system_tor"
-  - "/usr/sbin/apache2"
-  - "/usr/sbin/apache2//DEFAULT_URI"
-  - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
-  - "/usr/sbin/tor"
+  focal:
+    - "sbin/dhclient"
+    - "/usr/lib/NetworkManager/nm-dhcp-client.action"
+    - "/usr/lib/connman/scripts/dhclient-script"
+    - "/usr/sbin/tcpdump"
+    - "system_tor"
+    - "/usr/sbin/apache2"
+    - "/usr/sbin/apache2//DEFAULT_URI"
+    - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
+    - "/usr/sbin/tor"
+  xenial:
+    - "sbin/dhclient"
+    - "/usr/lib/NetworkManager/nm-dhcp-client.action"
+    - "/usr/lib/connman/scripts/dhclient-script"
+    - "/usr/sbin/ntpd"
+    - "/usr/sbin/tcpdump"
+    - "system_tor"
+    - "/usr/sbin/apache2"
+    - "/usr/sbin/apache2//DEFAULT_URI"
+    - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
+    - "/usr/sbin/tor"
 
 app_directories:
   - /var/www/securedrop
@@ -200,4 +212,3 @@ fpf_apt_repo_url: "https://apt-test.freedom.press"
 
 grsec_version_xenial: "4.14.188"
 grsec_version_focal: "5.4.97"
-

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -39,16 +39,27 @@ pip_deps:
 apparmor_complain: []
 
 apparmor_enforce:
-  - "sbin/dhclient"
-  - "/usr/lib/NetworkManager/nm-dhcp-client.action"
-  - "/usr/lib/connman/scripts/dhclient-script"
-  - "/usr/sbin/ntpd"
-  - "/usr/sbin/tcpdump"
-  - "system_tor"
-  - "/usr/sbin/apache2"
-  - "/usr/sbin/apache2//DEFAULT_URI"
-  - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
-  - "/usr/sbin/tor"
+  focal:
+    - "sbin/dhclient"
+    - "/usr/lib/NetworkManager/nm-dhcp-client.action"
+    - "/usr/lib/connman/scripts/dhclient-script"
+    - "/usr/sbin/tcpdump"
+    - "system_tor"
+    - "/usr/sbin/apache2"
+    - "/usr/sbin/apache2//DEFAULT_URI"
+    - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
+    - "/usr/sbin/tor"
+  xenial:
+    - "sbin/dhclient"
+    - "/usr/lib/NetworkManager/nm-dhcp-client.action"
+    - "/usr/lib/connman/scripts/dhclient-script"
+    - "/usr/sbin/ntpd"
+    - "/usr/sbin/tcpdump"
+    - "system_tor"
+    - "/usr/sbin/apache2"
+    - "/usr/sbin/apache2//DEFAULT_URI"
+    - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
+    - "/usr/sbin/tor"
 
 app_directories:
   - /var/www/securedrop

--- a/molecule/virtualbox-staging-xenial/molecule.yml
+++ b/molecule/virtualbox-staging-xenial/molecule.yml
@@ -65,3 +65,5 @@ verifier:
   options:
     n: auto
     v: 2
+  env:
+    SECUREDROP_TARGET_DISTRIBUTION: xenial


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

On Focal, stop installing the `ntp` and `ntpdate` packages, and update the system time with `systemd-timesyncd`.

Fixes #5730.
Fixes #5795.

I also updated `molecule/testinfra/conftest` to make the class that provides attribute access to test variables aware of distribution-specific variables, such that you can ask for `apparmor_enforce`, and if that's a dictionary containing your target distribution, e.g. `focal`, it will return that item from the dictionary.

Finally, there were some complete iptables rulesets in the testinfra vars that didn't seem to be used anywhere, so I removed those.

## Testing

- `make build-debs-focal && make staging-focal`
- confirm that the `ntp` and `ntpdate` packages are not installed on either server
- confirm that time has been synchronized to NTP servers on both machines:
  - `timedatectl show` should contain `NTPSynchronized=yes`
  - `timedatectl show-timesync` should contain `ServerName=ntp.ubuntu.com`, with an `NTPMessage` indicating that the server has been reached

## Deployment

For Focal systems, this replaces the `universe` packages `ntp` and `ntpdate` with the `admin` package `systemd-timesyncd`.

The iptables rules for NTP required changes:
- `systemd-timesyncd` does not control its source port
- it also runs as the `systemd-timesync user`

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [x] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation
