### PR TITLE
Use paxctl for Xenial, paxctld for Focal

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -44,4 +44,4 @@ securedrop_pkg_grsec_xenial:
 
 securedrop_pkg_grsec_focal:
   ver: "5.4.97"
-  depends: "linux-image-5.4.97-grsec-securedrop,linux-image-4.14.188-grsec-securedrop,intel-microcode"
+  depends: "linux-image-5.4.97-grsec-securedrop,intel-microcode"

--- a/install_files/ansible-base/roles/grsecurity/tasks/main.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/main.yml
@@ -4,6 +4,7 @@
 - include: check_installation.yml
 
 - include: paxctl.yml
+  when: ansible_distribution_release == "xenial"
   tags:
     - paxctl
     - kernel

--- a/install_files/securedrop-grsec-focal/opt/securedrop/paxctld.conf
+++ b/install_files/securedrop-grsec-focal/opt/securedrop/paxctld.conf
@@ -115,3 +115,6 @@
 # /usr/lib/libreoffice/program/soffice.bin	m
 
 /usr/bin/totem			m
+
+# Disable memprotect for Apache, see 4110 for context.
+/usr/sbin/apache2	m


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #3916. 

Continues to use paxctld under Xenial, same as always, but removes any
use of it under Focal, where paxctld is already preferred.

Updated the tests accordingly. Removes an unused (xfail) paxctl test,
since it wasn't running anyway. Preserved the "paxctld" dependency for
securedrop-app-code, since the postinst logic still uses it. We can
remove that after OS migration.

Removes mention of the 4.14.x kernel series for Focal, as well, since we
don't plan to support that series post-Xenial.


## Testing
- Visual review of test changes
- CI passing is sufficient 

## Deployment

Changes are Focal-specific, Xenial behavior has been preserved.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
