### PR TITLE
Remove resolvconf dependency on Focal

### DIFF
--- a/install_files/ansible-base/roles/common/vars/Ubuntu_focal.yml
+++ b/install_files/ansible-base/roles/common/vars/Ubuntu_focal.yml
@@ -12,5 +12,4 @@ securedrop_common_packages:
   - unattended-upgrades
   - ntp
   - ntpdate
-  - resolvconf
   - tmux


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Stops installing `resolvconf` on Focal. Keeps `systemd-resolved` disabled. Name resolution keeps working: `man resolv.conf`. 

## Testing

- `git checkout -b remove-resolvconf origin/remove-resolvconf`
- `make build-debs-focal`
- `make staging-focal`

Servers should not have `resolvconf` installed, nor `systemd-resolved` running. DNS lookups should still succeed.

## Deployment

Changes resolver configuration. 

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
