### PR TITLE
No longer offer v2/v3 choice on installs without v2 configs

### DIFF
--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -51,74 +51,6 @@ v2_onion_services: false
 v3_onion_services: true
 '''
 
-WHEN_BOTH_TRUE = '''app_hostname: app
-app_ip: 10.20.2.2
-daily_reboot_time: 5
-dns_server:
-- 8.8.8.8
-- 8.8.4.4
-enable_ssh_over_tor: true
-journalist_alert_email: ''
-journalist_alert_gpg_public_key: ''
-journalist_gpg_fpr: ''
-monitor_hostname: mon
-monitor_ip: 10.20.3.2
-ossec_alert_email: test@gmail.com
-ossec_alert_gpg_public_key: sd_admin_test.pub
-ossec_gpg_fpr: 1F544B31C845D698EB31F2FF364F1162D32E7E58
-sasl_domain: gmail.com
-sasl_password: testpassword
-sasl_username: testuser
-securedrop_app_gpg_fingerprint: 1F544B31C845D698EB31F2FF364F1162D32E7E58
-securedrop_app_gpg_public_key: sd_admin_test.pub
-securedrop_app_https_certificate_cert_src: ''
-securedrop_app_https_certificate_chain_src: ''
-securedrop_app_https_certificate_key_src: ''
-securedrop_app_https_on_source_interface: false
-securedrop_supported_locales:
-- de_DE
-- es_ES
-smtp_relay: smtp.gmail.com
-smtp_relay_port: 587
-ssh_users: sd
-v2_onion_services: true
-v3_onion_services: true
-'''
-
-WHEN_ONLY_V2 = '''app_hostname: app
-app_ip: 10.20.2.2
-daily_reboot_time: 5
-dns_server:
-- 8.8.8.8
-- 8.8.4.4
-enable_ssh_over_tor: true
-journalist_alert_email: ''
-journalist_alert_gpg_public_key: ''
-journalist_gpg_fpr: ''
-monitor_hostname: mon
-monitor_ip: 10.20.3.2
-ossec_alert_email: test@gmail.com
-ossec_alert_gpg_public_key: sd_admin_test.pub
-ossec_gpg_fpr: 1F544B31C845D698EB31F2FF364F1162D32E7E58
-sasl_domain: gmail.com
-sasl_password: testpassword
-sasl_username: testuser
-securedrop_app_gpg_fingerprint: 1F544B31C845D698EB31F2FF364F1162D32E7E58
-securedrop_app_gpg_public_key: sd_admin_test.pub
-securedrop_app_https_certificate_cert_src: ''
-securedrop_app_https_certificate_chain_src: ''
-securedrop_app_https_certificate_key_src: ''
-securedrop_app_https_on_source_interface: false
-securedrop_supported_locales:
-- de_DE
-- es_ES
-smtp_relay: smtp.gmail.com
-smtp_relay_port: 587
-ssh_users: sd
-v2_onion_services: true
-v3_onion_services: false
-'''
-
 JOURNALIST_ALERT_OUTPUT = '''app_hostname: app
 app_ip: 10.20.2.2
 daily_reboot_time: 5
@@ -339,21 +271,6 @@ def verify_locales_prompt(child):
     child.expect(rb'Space separated list of additional locales to support')  # noqa: E501
 
 
-def verify_v2_onion_for_first_time(child):
-    child.expect(rb'Do you want to enable v2 onion services\?\:', timeout=2)  # noqa: E501
-    assert ANSI_ESCAPE.sub('', child.buffer.decode("utf-8")).strip() == 'no'  # noqa: E501
-
-
-def verify_v3_onion_for_first_time(child):
-    child.expect(rb'Do you want to enable v3 onion services \(recommended\)\?\:', timeout=2)  # noqa: E501
-    assert ANSI_ESCAPE.sub('', child.buffer.decode("utf-8")).strip() == 'yes'  # noqa: E501
-
-
-def verify_v3_onion_when_v2_is_enabled(child):
-    child.expect(rb'Do you want to enable v3 onion services \(recommended\)\?\:', timeout=2)  # noqa: E501
-    assert ANSI_ESCAPE.sub('', child.buffer.decode("utf-8")).strip() == 'yes'  # noqa: E501
-
-
 def verify_install_has_valid_config():
     """
     Checks that securedrop-admin install validates the configuration.
@@ -424,10 +341,6 @@ def test_sdconfig_on_first_run():
     child.sendline('')
     verify_locales_prompt(child)
     child.sendline('de_DE es_ES')
-    verify_v2_onion_for_first_time(child)
-    child.sendline('\b' * 3 + 'no')
-    verify_v3_onion_for_first_time(child)
-    child.sendline('\b' * 4 + 'yes')
 
     child.expect(pexpect.EOF, timeout=10)  # Wait for validation to occur
     child.close()
@@ -437,134 +350,6 @@ def test_sdconfig_on_first_run():
     with open(os.path.join(SD_DIR, 'install_files/ansible-base/group_vars/all/site-specific')) as fobj:    # noqa: E501
         data = fobj.read()
     assert data == OUTPUT1
-
-    verify_install_has_valid_config()
-
-
-def test_sdconfig_both_v2_v3_true():
-    cmd = os.path.join(os.path.dirname(CURRENT_DIR),
-                       'securedrop_admin/__init__.py')
-    child = pexpect.spawn('python {0} --force --root {1} sdconfig'.format(cmd, SD_DIR))
-    verify_username_prompt(child)
-    child.sendline('')
-    verify_reboot_prompt(child)
-    child.sendline('\b5')  # backspace and put 5
-    verify_ipv4_appserver_prompt(child)
-    child.sendline('')
-    verify_ipv4_monserver_prompt(child)
-    child.sendline('')
-    verify_hostname_app_prompt(child)
-    child.sendline('')
-    verify_hostname_mon_prompt(child)
-    child.sendline('')
-    verify_dns_prompt(child)
-    child.sendline('')
-    verify_app_gpg_key_prompt(child)
-    child.sendline('\b' * 14 + 'sd_admin_test.pub')
-    verify_https_prompt(child)
-    # Default answer is no
-    child.sendline('')
-    verify_app_gpg_fingerprint_prompt(child)
-    child.sendline('1F544B31C845D698EB31F2FF364F1162D32E7E58')
-    verify_ossec_gpg_key_prompt(child)
-    child.sendline('\b' * 9 + 'sd_admin_test.pub')
-    verify_ossec_gpg_fingerprint_prompt(child)
-    child.sendline('1F544B31C845D698EB31F2FF364F1162D32E7E58')
-    verify_admin_email_prompt(child)
-    child.sendline('test@gmail.com')
-    verify_journalist_gpg_key_prompt(child)
-    child.sendline('')
-    verify_smtp_relay_prompt(child)
-    child.sendline('')
-    verify_smtp_port_prompt(child)
-    child.sendline('')
-    verify_sasl_domain_prompt(child)
-    child.sendline('')
-    verify_sasl_username_prompt(child)
-    child.sendline('testuser')
-    verify_sasl_password_prompt(child)
-    child.sendline('testpassword')
-    verify_ssh_over_lan_prompt(child)
-    child.sendline('')
-    verify_locales_prompt(child)
-    child.sendline('de_DE es_ES')
-    verify_v2_onion_for_first_time(child)
-    child.sendline('\b' * 3 + 'yes')
-    verify_v3_onion_when_v2_is_enabled(child)
-    child.sendline('\b' * 3 + 'yes')
-
-    child.expect(pexpect.EOF, timeout=10)  # Wait for validation to occur
-    child.close()
-    assert child.exitstatus == 0
-    assert child.signalstatus is None
-
-    with open(os.path.join(SD_DIR, 'install_files/ansible-base/group_vars/all/site-specific')) as fobj:    # noqa: E501
-        data = fobj.read()
-    assert data == WHEN_BOTH_TRUE
-
-    verify_install_has_valid_config()
-
-
-def test_sdconfig_only_v2_true():
-    cmd = os.path.join(os.path.dirname(CURRENT_DIR),
-                       'securedrop_admin/__init__.py')
-    child = pexpect.spawn('python {0} --force --root {1} sdconfig'.format(cmd, SD_DIR))
-    verify_username_prompt(child)
-    child.sendline('')
-    verify_reboot_prompt(child)
-    child.sendline('\b5')  # backspace and put 5
-    verify_ipv4_appserver_prompt(child)
-    child.sendline('')
-    verify_ipv4_monserver_prompt(child)
-    child.sendline('')
-    verify_hostname_app_prompt(child)
-    child.sendline('')
-    verify_hostname_mon_prompt(child)
-    child.sendline('')
-    verify_dns_prompt(child)
-    child.sendline('')
-    verify_app_gpg_key_prompt(child)
-    child.sendline('\b' * 14 + 'sd_admin_test.pub')
-    verify_https_prompt(child)
-    # Default answer is no
-    child.sendline('')
-    verify_app_gpg_fingerprint_prompt(child)
-    child.sendline('1F544B31C845D698EB31F2FF364F1162D32E7E58')
-    verify_ossec_gpg_key_prompt(child)
-    child.sendline('\b' * 9 + 'sd_admin_test.pub')
-    verify_ossec_gpg_fingerprint_prompt(child)
-    child.sendline('1F544B31C845D698EB31F2FF364F1162D32E7E58')
-    verify_admin_email_prompt(child)
-    child.sendline('test@gmail.com')
-    verify_journalist_gpg_key_prompt(child)
-    child.sendline('')
-    verify_smtp_relay_prompt(child)
-    child.sendline('')
-    verify_smtp_port_prompt(child)
-    child.sendline('')
-    verify_sasl_domain_prompt(child)
-    child.sendline('')
-    verify_sasl_username_prompt(child)
-    child.sendline('testuser')
-    verify_sasl_password_prompt(child)
-    child.sendline('testpassword')
-    verify_ssh_over_lan_prompt(child)
-    child.sendline('')
-    verify_locales_prompt(child)
-    child.sendline('de_DE es_ES')
-    verify_v2_onion_for_first_time(child)
-    child.sendline('\b' * 3 + 'yes')
-    verify_v3_onion_when_v2_is_enabled(child)
-    child.sendline('\b' * 3 + 'no')
-
-    child.expect(pexpect.EOF, timeout=10)  # Wait for validation to occur
-    child.close()
-    assert child.exitstatus == 0
-    assert child.signalstatus is None
-
-    with open(os.path.join(SD_DIR, 'install_files/ansible-base/group_vars/all/site-specific')) as fobj:    # noqa: E501
-        data = fobj.read()
-    assert data == WHEN_ONLY_V2
 
     verify_install_has_valid_config()
 
@@ -621,10 +406,6 @@ def test_sdconfig_enable_journalist_alerts():
     child.sendline('')
     verify_locales_prompt(child)
     child.sendline('de_DE es_ES')
-    verify_v2_onion_for_first_time(child)
-    child.sendline('\b' * 3 + 'no')
-    verify_v3_onion_for_first_time(child)
-    child.sendline('\b' * 4 + 'yes')
 
     child.expect(pexpect.EOF, timeout=10)  # Wait for validation to occur
     child.close()
@@ -697,10 +478,6 @@ def test_sdconfig_enable_https_on_source_interface():
     child.sendline('')
     verify_locales_prompt(child)
     child.sendline('de_DE es_ES')
-    verify_v2_onion_for_first_time(child)
-    child.sendline('\b' * 3 + 'no')
-    verify_v3_onion_for_first_time(child)
-    child.sendline('\b' * 4 + 'yes')
 
     child.expect(pexpect.EOF, timeout=10)  # Wait for validation to occur
     child.close()


### PR DESCRIPTION
## Status

Ready for initial review; integration test updates and detailed test plan pending.

## Description

Changes `securedrop-admin sdconfig` behavior with regard to v2/v3 configuration:

- Existing installs with v2 configurations should see the same prompts as before (with slightly tweaked deprecation language), and the prompts should behave the same.
- New installs or installs that never had v2 enabled should see no v2/v3 related prompts. Existing configuration values should be honored; if there are none, v3 should be enabled and v2 disabled.

The v2/v3 configuration values are still written to `site-specific` as before. In SecureDrop 2.0.0, when support for v2 is fully removed from the codebase, we can potentially avoid remove these configuration lines altogether.

## Description of Changes

Resolves #5687

Does not prevent an existing v2 configuration from being applied against a Focal server, which should be handled separately.

## Testing

Best tested on a configured Admin Workstation. Detailed test plan to come, but for now:

1) If `site-specific` is not present and no v2 onion service configuration exists, does `securedrop-admin` still write a valid configuration file with `v2_onion_services: false` and `v3_onion_services: true` present, without prompting the user about v2/v3?
2) If `site-specific` is present and v2 onion service configuration exists, does `securedrop-admin` show the v2/v3 prompts, honor the current configuration values, correctly prevent both from being disabled, and correctly write the configuration back to disk?
3) If `site-specific` contains invalid values for `v3_onion_services` or `v2_onion_services` (e.g., a nonsense string) does the install subcommand still refuse to run due to a validation error?

"v2 onion service configuration exists" in this case means that `app-source-ths` exists in `install_files/ansible-base` and contains a v2 address (which is the check performed by `check_for_v2_onion`) .

## Checklist
- [x] Linting and tests (`make -C admin test`) pass in the admin development container
- [ ] I have written a test plan and validated it for this PR (still to come)
- [ ] Docs updated (still to come)