### PR TITLE
[Focal] Fix reboot-flag cron syntax

### DIFF
--- a/install_files/securedrop-config-focal/opt/securedrop/reboot-flag
+++ b/install_files/securedrop-config-focal/opt/securedrop/reboot-flag
@@ -1,4 +1,4 @@
 # The purpose of this cron is to drop the reboot-required flag every 12 hours
 # to ensure the system is rebooted nightly, regardless of updates being installed
 # or not.
-* */12 * * * touch /var/run/reboot-required
+0 */12 * * * root touch /var/run/reboot-required

--- a/molecule/testinfra/common/test_automatic_updates.py
+++ b/molecule/testinfra/common/test_automatic_updates.py
@@ -291,7 +291,7 @@ def test_reboot_required_cron(host):
         assert f.user == "root"
         assert f.mode == 0o644
 
-        line = '^{}$'.format(re.escape("* */12 * * * touch /var/run/reboot-required"))
+        line = '^{}$'.format(re.escape("0 */12 * * * root touch /var/run/reboot-required"))
         assert f.contains(line)
 
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #5812 

Updates the cron syntax.

Since this is the only we managed, did not think it was worth adding `chkcrontab` against this file for every CI run

## Testing
- CI is passing
- `chkcrontab install_files/securedrop-config-focal/opt/securedrop/reboot-flag` returns 0 [1]
## Deployment
- New and existing installs will be updated via the securedrop-config package (but these changes are focal-only so not yet in production)


### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR


[1] https://pypi.org/project/chkcrontab/