### PR TITLE
Adds check to prevent v2 installs on Focal instances

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -89,7 +89,23 @@ _T = TypeVar('_T', bound=Union[int, str, bool])
 # https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
 _FuncT = TypeVar('_FuncT', bound=Callable[..., Any])
 
-# (var, default, type, prompt, validator, transform, condition)
+# Configuration description tuples drive the CLI user experience and the
+# validation logic of the  securedrop-admin tool. A tuple is in the following
+# format.
+#
+# (var, default, type, prompt, validator, transform, condition):
+#
+# var         configuration variable name (will be stored in `site-specific`)
+# default     default value (can be a callable)
+# type        configuration variable type
+# prompt      text prompt presented to the user
+# validator   input validator based on `prompt_toolkit`'s Validator class
+# transform   transformation function to run on input
+# condition   condition under which this prompt is shown, receives the
+#             in-progress configuration object as input. Used for "if this
+#             then that" branching of prompts.
+#
+# The mypy type description of the format follows.
 _DescEntryType = Tuple[str, _T, Type[_T], str, Optional[Validator], Optional[Callable], Callable]
 
 
@@ -442,9 +458,8 @@ class SiteConfig:
              str.split,
              lambda config: True),
             ('v2_onion_services', self.check_for_v2_onion(), bool,
-             'WARNING: For security reasons, support for v2 onion services ' +
-             'will be removed in March 2021. ' +
-             'Do you want to enable v2 onion services?',
+             'WARNING: v2 onion services cannot be installed on servers ' +
+             'running Ubuntu 20.04. Do you want to enable v2 onion services?',
              SiteConfig.ValidateYesNo(),
              lambda x: x.lower() == 'yes',
              lambda config: True),

--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -28,6 +28,15 @@
   max_fail_percentage: 0
   any_errors_fatal: yes
   pre_tasks:
+    - name: Verify that v2 onion services are not enabled on a Focal install
+      assert:
+        that:
+          - "v2_onion_services|bool != true"
+        fail_msg: >-
+          V2 services were enabled via ./securedrop-admin sdconfig, but are not
+          available on Focal. Please run sdconfig again, disabling v2 services.
+      when: ansible_distribution_release == 'focal'
+
     - name: Check if install has been done before
       stat:
         path: /var/www/securedrop


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5818.
Fixes #5687.

Adds a check in the install playbook to bug out early if v2 is enabled for a Focal install.

## Testing

- prod (vms or h/w) with Xenial:
  - [x] when v2 is enabled in sdconfig, install playbook runs normally, *without* `V2 services were enabled via ./securedrop-admin sdconfig, but are not available on Focal.` message being triggered
  - [x] when v2 is not enabled in sdconfig, install playbook runs normally.
- prod (vms or h/w) with Focal
  - [x] when v2 is enabled in sdconfig, install playbook stops early, *with* `V2 services were enabled via ./securedrop-admin sdconfig, but are not available on Focal.` message being triggered
  - [x] when v2 is not enabled in sdconfig, install playbook runs normally.

## Deployment
Deployed with workstation code update.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
