### PR TITLE
Normalize translator comments to correct them in Weblate

### DIFF
--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -66,8 +66,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         flash(
             Markup(
                 "<b>{}</b> {}".format(
-                    # Translators: Here, "Success!" appears before a message
-                    # confirming the success of an operation.
+                    # Translators: Precedes a message confirming the success of an operation.
                     escape(gettext("Success!")),
                     escape(gettext(
                         "The account and data for the source {} has been deleted.").format(
@@ -86,8 +85,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         if 'cols_selected' not in request.form:
             flash(
                 Markup("<b>{}</b> {}".format(
-                    # Translators: Here, "Nothing Selected" appears before a message
-                    # asking the user to select one or more items.
+                    # Translators: Error shown when a user has not selected items to act on.
                     escape(gettext('Nothing Selected')),
                     escape(gettext('You must select one or more items.'))
                     )

--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -142,8 +142,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             flash(
                 Markup(
                     "<b>{}</b> {}".format(
-                        # Translators: Here, "Success!" appears before a message
-                        # confirming the success of an operation.
+                        # Translators: Precedes a message confirming the success of an operation.
                         escape(gettext("Success!")),
                         escape(gettext("Your reply has been stored."))
                     )
@@ -170,8 +169,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                 flash(
                     Markup(
                         "<b>{}</b> {}".format(
-                            # Translators: Here, "Nothing Selected" appears before a message
-                            # asking the users to select one or more items
+                            # Translators: Error shown when a user has not selected items to act on.
                             escape(gettext("Nothing Selected")),
                             escape(gettext("You must select one or more items for download"))
                         )
@@ -180,8 +178,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                 flash(
                     Markup(
                         "<b>{}</b> {}".format(
-                            # Translators: Here, "Nothing Selected" appears before a message
-                            # asking the users to select one or more items
+                            # Translators: Error shown when a user has not selected items to act on.
                             escape(gettext("Nothing Selected")),
                             escape(gettext("You must select one or more items for deletion"))
                         )

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -260,8 +260,7 @@ def bulk_delete(
     flash(
         Markup(
            "<b>{}</b> {}".format(
-               # Translators: Here, "Success!" appears before a message
-               # indicating a successful deletion
+               # Translators: Precedes a message confirming the success of an operation.
                escape(gettext("Success!")), escape(success_message))), 'success')
 
     if deletion_errors > 0:
@@ -331,8 +330,7 @@ def col_delete(cols_selected: List[str]) -> werkzeug.Response:
         flash(
             Markup(
                "<b>{}</b> {}".format(
-                   # Translators: Here, "Success!" appears before a message
-                   # indicating a successful deletion
+                   # Translators: Precedes a message confirming the success of an operation.
                    escape(gettext("Success!")), escape(success_message))), 'success')
 
     return redirect(url_for('main.index'))
@@ -356,8 +354,7 @@ def col_delete_data(cols_selected: List[str]) -> werkzeug.Response:
         flash(
             Markup(
                 "<b>{}</b> {}".format(
-                    # Translators: Here, "Nothing Selected" appears before a message
-                    # asking the user to select one or more items
+                    # Translators: Error shown when a user has not selected items to act on.
                     escape(gettext("Nothing Selected")),
                     escape(gettext("You must select one or more items for deletion.")))
                 ), 'error')
@@ -369,8 +366,7 @@ def col_delete_data(cols_selected: List[str]) -> werkzeug.Response:
         flash(
             Markup(
                 "<b>{}</b> {}".format(
-                    # Translators: Here, "Success" appears before a message
-                    # indicating a successful deletion
+                    # Translators: Precedes a message confirming the success of an operation.
                     escape(gettext("Success!")),
                     escape(gettext("The files and messages have been deleted.")))
                 ), 'success')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Babel sometimes mangles translator comments extracted from source code, so Weblate ends up presenting nonsense to translators. I think it's because Babel eliminates duplicate lines in comments (https://github.com/python-babel/babel/issues/417 may be relevant?), so if multi-line comments for the same string in different locations differ only slightly, pieces of them will be eliminated, and the comment displayed in Weblate will end up being a jumble of the total set of distinct lines. 

For now, eliminating those slight differences in the few comments we have will get sensible hints to translators.

It would be good to correct this before the 1.8.0 translation period begins.

## Testing

Just verify this change reduces the set of `Translator:` comments down to two:

- `Translators: Precedes a message confirming the success of an operation.`
- `Translators: Error shown when a user has not selected items to act on.`

## Deployment

No. This only affects translator comments.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
