### PR TITLE
Updated restore playbook to only compare tor configs  when configs are being updated.

### DIFF
--- a/install_files/ansible-base/roles/restore/defaults/main.yml
+++ b/install_files/ansible-base/roles/restore/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# By default, server restores overwrite the Tor config with the version in the
+# backup. add the `--preserve-tor-config` to preserve the server's existing config.
+
+restore_skip_tor: False

--- a/install_files/ansible-base/roles/restore/files/compare_torrc.py
+++ b/install_files/ansible-base/roles/restore/files/compare_torrc.py
@@ -46,11 +46,11 @@ if __name__ == "__main__":
     backup_versions = get_tor_versions(os.path.join(tempdir, "backup/etc/tor/torrc"))
 
     if server_versions == backup_versions:
-        print("The Tor configuration in the backup matches the server.")
+        print("Valid configuration: the Tor configuration in the backup matches the server.")
         sys.exit(0)
 
     if (3 in server_versions) and (3 in backup_versions):
-        print("V3 services detected in backup and server - proceeding with v3-only restore")
+        print("Valid configuration: V3 services only`")
         sys.exit(0)
 
     print(
@@ -65,9 +65,11 @@ if __name__ == "__main__":
         )
     )
 
-    print("\nRestoring a backup with a different Tor configuration than the server ")
-    print("is currently unsupported. If you require technical assistance, please ")
-    print("contact the SecureDrop team via the support portal or at ")
+    print("\nIncompatible configuration: Restoring a backup including a different ")
+    print("Tor configuration than the server Tor configuration is unsupported. ")
+    print("Optionally, use --preserve-tor-config to apply a data-only backup.")
+    print("If you require technical assistance, please contact the ")
+    print("SecureDrop team via the support portal or at ")
     print("securedrop@freedom.press.")
 
     sys.exit(1)

--- a/install_files/ansible-base/roles/restore/tasks/main.yml
+++ b/install_files/ansible-base/roles/restore/tasks/main.yml
@@ -82,7 +82,7 @@
     remote_src: yes
     src: "/tmp/{{ restore_file}}"
     exclude: "var/lib/tor,etc/tor/torrc"
-  when: not restore_skip_tor
+  when: restore_skip_tor
 
 - name: Reconfigure securedrop-app-code
   command: dpkg-reconfigure securedrop-app-code

--- a/install_files/ansible-base/roles/restore/tasks/main.yml
+++ b/install_files/ansible-base/roles/restore/tasks/main.yml
@@ -99,47 +99,47 @@
   copy:
     src: "{{ role_path }}/files/disable_v2.py"
     dest: /opt/disable_v2.py
-  when: (not restore_skip_tor) or
+  when: (not restore_skip_tor) and
         ("V3 services only" in compare_result.stdout)
 
 - name: Execute disable_v2 script
   command: python3 /opt/disable_v2.py /etc/tor/torrc /etc/tor/torrc
-  when: (not restore_skip_tor) or
+  when: (not restore_skip_tor) and
         ("V3 services only" in compare_result.stdout)
 
 - name: Remove v2 tor source directory
   file:
     state: absent
     path: /var/lib/tor/services/source
-  when: (not restore_skip_tor) or
+  when: (not restore_skip_tor) and
         ("V3 services only" in compare_result.stdout)
 
 - name: Remove v2 tor journalist directory
   file:
     state: absent
     path: /var/lib/tor/services/journalist
-  when: (not restore_skip_tor) or
+  when: (not restore_skip_tor) and
         ("V3 services only" in compare_result.stdout)
 
 - name: Remove v2 tor ssh directory
   file:
     state: absent
     path: /var/lib/tor/services/ssh
-  when: (not restore_skip_tor) or
+  when: (not restore_skip_tor) and
         ("V3 services only" in compare_result.stdout)
 
 - name: Remove v2 source_url application file
   file:
     state: absent
     path: /var/lib/securedrop/source_v2_url
-  when: (not restore_skip_tor) or
+  when: (not restore_skip_tor) and
         ("V3 services only" in compare_result.stdout)
 
 - name: Remove disable_v2.py script
   file:
     state: absent
     path: /opt/disable_v2.py
-  when: (not restore_skip_tor) or
+  when: (not restore_skip_tor) and
         ("V3 services only" in compare_result.stdout)
 
 - name: Reload Tor service

--- a/install_files/ansible-base/roles/restore/tasks/main.yml
+++ b/install_files/ansible-base/roles/restore/tasks/main.yml
@@ -32,6 +32,7 @@
   connection: local
   become: no
   command: "python {{ role_path }}/files/compare_torrc.py {{ torrc_check_dir.path }}"
+  ignore_errors: yes
   register: compare_result
 
 - name: Remove temporary directory for Tor configuration check
@@ -41,6 +42,16 @@
     path: "{{ torrc_check_dir.path }}"
     state: absent
   when: torrc_check_dir.path is defined
+
+- name: Verify that the backup Tor config is compatible with the server Tor config
+  assert:
+    that:
+      - "'Valid configuration' in compare_result.stdout"
+    fail_msg:
+      - "This backup's tor configuration cannot be applied on this server."
+      - "A data-only restore can be applied using the --preserve-tor-config argument"
+      - "More info: {{ compare_result.stdout }}"
+  when: not restore_skip_tor
 
 - name: Copy backup to application server
   synchronize:
@@ -53,8 +64,8 @@
     dest: /
     remote_src: yes
     src: "/tmp/{{ restore_file}}"
-  when: (restore_skip_tor is not defined) and
-        ("V3 services detected" not in compare_result.stdout)
+  when: (not restore_skip_tor) and
+        ("V3 services only" not in compare_result.stdout)
 
 - name: Extract backup, using v3 services only
   unarchive:
@@ -62,8 +73,8 @@
     remote_src: yes
     src: "/tmp/{{ restore_file}}"
     exclude: "var/lib/tor/services/source,var/lib/tor/services/journalist,var/lib/tor/services/ssh"
-  when: (restore_skip_tor is not defined) and
-        ("V3 services detected" in compare_result.stdout)
+  when: (not restore_skip_tor) and
+        ("V3 services only" in compare_result.stdout)
 
 - name: Extract backup, skipping tor service configuration
   unarchive:
@@ -71,7 +82,7 @@
     remote_src: yes
     src: "/tmp/{{ restore_file}}"
     exclude: "var/lib/tor,etc/tor/torrc"
-  when: restore_skip_tor is defined
+  when: not restore_skip_tor
 
 - name: Reconfigure securedrop-app-code
   command: dpkg-reconfigure securedrop-app-code
@@ -84,35 +95,52 @@
     name: apache2
     state: reloaded
 
-- name: Copy disable_v2.py script for Focal
+- name: Copy disable_v2.py script
   copy:
     src: "{{ role_path }}/files/disable_v2.py"
     dest: /opt/disable_v2.py
-  when: (ansible_distribution_release == 'focal') or
-        ("V3 services detected" in compare_result.stdout)
+  when: (not restore_skip_tor) or
+        ("V3 services only" in compare_result.stdout)
 
-- name: Execute disable_v2 script on Focal
+- name: Execute disable_v2 script
   command: python3 /opt/disable_v2.py /etc/tor/torrc /etc/tor/torrc
-  when: (ansible_distribution_release == 'focal') or
-        ("V3 services detected" in compare_result.stdout)
+  when: (not restore_skip_tor) or
+        ("V3 services only" in compare_result.stdout)
 
 - name: Remove v2 tor source directory
   file:
     state: absent
     path: /var/lib/tor/services/source
-  when: ansible_distribution_release == 'focal'
+  when: (not restore_skip_tor) or
+        ("V3 services only" in compare_result.stdout)
 
 - name: Remove v2 tor journalist directory
   file:
     state: absent
     path: /var/lib/tor/services/journalist
-  when: ansible_distribution_release == 'focal'
+  when: (not restore_skip_tor) or
+        ("V3 services only" in compare_result.stdout)
 
-- name: Remove disable_v2.py script on Focal
+- name: Remove v2 tor ssh directory
+  file:
+    state: absent
+    path: /var/lib/tor/services/ssh
+  when: (not restore_skip_tor) or
+        ("V3 services only" in compare_result.stdout)
+
+- name: Remove v2 source_url application file
+  file:
+    state: absent
+    path: /var/lib/securedrop/source_v2_url
+  when: (not restore_skip_tor) or
+        ("V3 services only" in compare_result.stdout)
+
+- name: Remove disable_v2.py script
   file:
     state: absent
     path: /opt/disable_v2.py
-  when: ansible_distribution_release == 'focal'
+  when: (not restore_skip_tor) or
+        ("V3 services only" in compare_result.stdout)
 
 - name: Reload Tor service
   service:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5829 .

Updates the restore playbook tor config comparison logic such that:

- if `--preserve-tor-config` is set, the results of the comparison are ignored and a data-only restore is performed
- if the backup and server have the same tor service types defined, a full restore is performed
- if the backup is 'v2+v3' and the server is v3, a restore is performed of v3 services and data only.
- the restore is not performed in any other cases.

## Testing

On a production v2+v3 install (vms or h/w):

- take a backup with `./securedrop-admin backup`
- restore the v2+v3 backup with `./securedrop-admin --force restore your/backupfile/path/here` 
  - [ ] Verify that the "Verify that the backup Tor config is compatible with the server Tor config" task runs and passes.
  - [ ] Verify that the `Extract backup` task runs, but the `Extract backup, skipping tor service configurations` task does *not* 
  - [ ] verify that the restore completes and that the JI/SI and SSH configs are unchanged.
- restore the backup again with  `./securedrop-admin --force restore --preserve-tor-config your/backupfile/path/here`
  - [ ] Verify that the "Verify that the backup Tor config is compatible with the server Tor config" task is not executed.
  - [ ] Verify that the `Extract backup, skipping tor service configurations` task runs, but the `Extract backup` task does *not* 
  - [ ] verify that the restore completes and that the JI/SI and SSH configs are unchanged.
- if a v2 backup is available from any test server, attempt to apply it with `./securedrop-admin --force restore your/v2backupfile/path/here`
  - [ ] Verify that the "Verify that the backup Tor config is compatible with the server Tor config" task runs and fails.
  - [ ]  Verify that the restore finishes immediately without applying data or config changes

- flip the install to v3-only using the `sdconfig` and `install` admin subcommands, then:
  - restore the  v2+v3 backup with `./securedrop-admin --force restore your/backupfile/path/here` 
    - [ ] Verify that the "Verify that the backup Tor config is compatible with the server Tor config" task runs and passes.
    - [ ] Verify that the `Extract backup using v3-only` task runs, but the other `Extract` tasks do *not* 
    - [ ] verify that the restore completes and that only the v3 JI/SI and SSH configs are present.
  - restore the backup again with  `./securedrop-admin --force restore --preserve-tor-config your/backupfile/path/here`
    - [ ] Verify that the "Verify that the backup Tor config is compatible with the server Tor config" task is not executed.
    - [ ] Verify that the `Extract backup, skipping tor service configurations` task runs, but the other `Extract` task do *not* 
    - [ ] verify that the restore completes and that the v3 JI/SI and SSH configs are unchanged and the v2 ssh configs have not been restored
  - if a v2 backup is available from any test server, attempt to apply it with `./securedrop-admin --force restore your/v2backupfile/path/here`
    - [ ] Verify that the "Verify that the backup Tor config is compatible with the server Tor config" task runs and fails.
    - [ ]  Verify that the restore finishes immediately without applying data or config changes

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [x] I would appreciate help with the documentation
- [ ] These changes do not require documentation
