### PR TITLE
[1.8.0] Backport fixes for safety warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,12 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 	@echo "███ Running safety..."
 	@for req_file in `find . -type f -name '*requirements.txt'`; do \
 		echo "Checking file $$req_file" \
-		&& safety check --ignore 39252 --full-report -r $$req_file \
+		&& safety check \
+		--ignore 39252 \
+		--ignore 39606 \
+		--ignore 39611 \
+		--ignore 39621 \
+		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \
 	done

--- a/admin/requirements-ansible.in
+++ b/admin/requirements-ansible.in
@@ -1,3 +1,4 @@
+Jinja2>=2.11.3
 ansible==2.9.7
 cryptography>=3.2
 netaddr

--- a/admin/requirements-testinfra.txt
+++ b/admin/requirements-testinfra.txt
@@ -98,10 +98,10 @@ iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32 \
     # via pytest
-jinja2==2.11.2 \
-    --hash=sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0 \
-    --hash=sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035 \
-    # via ansible
+jinja2==2.11.3 \
+    --hash=sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419 \
+    --hash=sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6 \
+    # via -r requirements-ansible.in, ansible
 markupsafe==1.1.1 \
     --hash=sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473 \
     --hash=sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161 \

--- a/admin/requirements.txt
+++ b/admin/requirements.txt
@@ -60,10 +60,10 @@ cryptography==3.2.1 \
     --hash=sha256:d3d5e10be0cf2a12214ddee45c6bd203dab435e3d83b4560c03066eda600bfe3 \
     --hash=sha256:efe15aca4f64f3a7ea0c09c87826490e50ed166ce67368a68f315ea0807a20df \
     # via -r requirements-ansible.in, ansible
-jinja2==2.10.1 \
-    --hash=sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013 \
-    --hash=sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b \
-    # via ansible
+jinja2==2.11.3 \
+    --hash=sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419 \
+    --hash=sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6 \
+    # via -r requirements-ansible.in, ansible
 markupsafe==1.1.1 \
     --hash=sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473 \
     --hash=sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161 \

--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -1,3 +1,4 @@
+Jinja2>=2.11.3
 ansible-lint>=4.2.0
 ansible>=2.9.7,<2.10.0
 argon2_cffi>=20.1.0

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -281,10 +281,10 @@ jinja2-time==0.2.0 \
     --hash=sha256:d14eaa4d315e7688daa4969f616f226614350c48730bfa1692d2caebd8c90d40 \
     --hash=sha256:d3eab6605e3ec8b7a0863df09cc1d23714908fa61aa6986a845c20ba488b4efa \
     # via cookiecutter
-jinja2==2.10.1 \
-    --hash=sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013 \
-    --hash=sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b \
-    # via ansible, click-completion, cookiecutter, jinja2-time, molecule
+jinja2==2.11.3 \
+    --hash=sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419 \
+    --hash=sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6 \
+    # via -r ../admin/requirements-ansible.in, -r requirements/python3/develop-requirements.in, ansible, click-completion, cookiecutter, jinja2-time, molecule
 jmespath==0.9.3 \
     --hash=sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64 \
     --hash=sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63 \

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.in
@@ -15,7 +15,7 @@ Flask-Babel
 Flask-SQLAlchemy
 Flask-WTF
 Flask>0.12.2
-Jinja2>=2.10.1
+Jinja2>=2.11.3
 jsmin
 markupsafe>=1.1
 mod_wsgi

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.txt
@@ -109,9 +109,9 @@ flask==1.0.2 \
 itsdangerous==0.24 \
     --hash=sha256:cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519 \
     # via flask
-jinja2==2.10.1 \
-    --hash=sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013 \
-    --hash=sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b \
+jinja2==2.11.3 \
+    --hash=sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419 \
+    --hash=sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6 \
     # via -r requirements/python3/securedrop-app-code-requirements.in, flask, flask-babel
 jsmin==2.2.2 \
     --hash=sha256:b6df99b2cd1c75d9d342e4335b535789b8da9107ec748212706ef7bbe5c2553b \

--- a/securedrop/requirements/python3/test-requirements.in
+++ b/securedrop/requirements/python3/test-requirements.in
@@ -1,3 +1,4 @@
+Jinja2>=2.11.3
 beautifulsoup4
 blinker
 coverage>=4.5.2

--- a/securedrop/requirements/python3/test-requirements.txt
+++ b/securedrop/requirements/python3/test-requirements.txt
@@ -106,10 +106,10 @@ iniconfig==1.0.1 \
 itsdangerous==0.24 \
     --hash=sha256:cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519 \
     # via flask
-jinja2==2.10.1 \
-    --hash=sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013 \
-    --hash=sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b \
-    # via flask
+jinja2==2.11.3 \
+    --hash=sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419 \
+    --hash=sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6 \
+    # via -r requirements/python3/test-requirements.in, flask
 markupsafe==1.1.1 \
     --hash=sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473 \
     --hash=sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161 \


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Backports #5837 .

- Updates jinja dependency
- adds ignores for unresolveable-on-Xenial dev-only warnings.

## Testing

- [ ] CI is green
- [x] PR contains only the commits from #5837 
- [x] PR base is `release/1.8.0`
