### PR TITLE
Fix focal testinfra test failures

### DIFF
--- a/molecule/testinfra/app/test_apparmor.py
+++ b/molecule/testinfra/app/test_apparmor.py
@@ -88,7 +88,7 @@ def test_app_apparmor_complain_count(host):
         assert c == str(len(sdvars.apparmor_complain))
 
 
-@pytest.mark.parametrize('aa_enforced', sdvars.apparmor_enforce)
+@pytest.mark.parametrize('aa_enforced', sdvars.apparmor_enforce_actual)
 def test_apparmor_enforced(host, aa_enforced):
     awk = ("awk '/[0-9]+ profiles.*enforce./"
            "{flag=1;next}/^[0-9]+.*/{flag=0}flag'")

--- a/molecule/testinfra/common/test_automatic_updates.py
+++ b/molecule/testinfra/common/test_automatic_updates.py
@@ -192,9 +192,7 @@ def test_unattended_upgrades_config(host):
     Ensures the 50unattended-upgrades config is correct only under Ubuntu Focal
     """
     f = host.file('/etc/apt/apt.conf.d/50unattended-upgrades')
-    if host.system_info.codename == "xenial":
-        assert not f.exists
-    else:
+    if host.system_info.codename != "xenial":
         assert f.is_file
         assert f.user == "root"
         assert f.mode == 0o644

--- a/molecule/testinfra/common/test_grsecurity.py
+++ b/molecule/testinfra/common/test_grsecurity.py
@@ -173,7 +173,10 @@ def test_paxctld_xenial(host):
     """
     if host.system_info.codename != "xenial":
         return True
-    hostname = host.ansible.get_variables()["inventory_hostname"]
+
+    hostname = host.check_output('hostname -s')
+    assert (("app" in hostname) or ("mon" in hostname))
+
     # Under Xenial, apache2 pax flags managed by securedrop-app-code.
     if "app" not in hostname:
         return True
@@ -209,7 +212,9 @@ def test_paxctld_focal(host):
     # out of /opt/ to ensure the file is always clobbered on changes.
     assert host.file("/opt/securedrop/paxctld.conf").is_file
 
-    hostname = host.ansible.get_variables()["inventory_hostname"]
+    hostname = host.check_output('hostname -s')
+    assert (("app" in hostname) or ("mon" in hostname))
+
     # Under Focal, apache2 pax flags managed by securedrop-grsec metapackage.
     # Both hosts, app & mon, should have the same exemptions. Check precedence
     # between install-local-packages & apt-test repo for securedrop-grsec.

--- a/molecule/testinfra/conftest.py
+++ b/molecule/testinfra/conftest.py
@@ -43,9 +43,11 @@ def securedrop_import_testinfra_vars(hostname, with_header=False):
     if testing_focal:
         hostvars['securedrop_venv_site_packages'] = hostvars["securedrop_venv_site_packages"].format("3.8")  # noqa: E501
         hostvars['python_version'] = "3.8"
+        hostvars['apparmor_enforce_actual'] = hostvars['apparmor_enforce']['focal']
     else:
         hostvars['securedrop_venv_site_packages'] = hostvars["securedrop_venv_site_packages"].format("3.5")  # noqa: E501
         hostvars['python_version'] = "3.5"
+        hostvars['apparmor_enforce_actual'] = hostvars['apparmor_enforce']['xenial']
 
     if with_header:
         hostvars = dict(securedrop_test_vars=hostvars)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5825 .

- loads per-OS apparmor profile details
- uses `host.check_output('hostname -s')` instead of ansible backend to get hostname, as ansible backend not used in prod verify.

## Testing
- set up a prod Focal system on latest 1.8.0 RC (or 1.8.0 if released).
- On the Admin Workstation, switch to this branch.
- In a  terminal, run `USE_FOCAL=True ./securedrop-admin verify`
  - [ ] verify that tests pass (with the exception of `test_fpf_apt_repo` if the apt-test repo was used for the install)

- on a dev workstation, set up a staging environment and run tests with `make build-debs-notest && make staging && make testinfra`
  - [ ] verify that tests pass.
- on a dev workstation, set up a *focal* staging environment and run tests with `make build-debs-focal-notest && make staging-focal && USE_FOCAL=True make testinfra`
  - [ ] verify that tests pass.
 
 
## Deployment
test-only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
