### PR TITLE
Ensure the systemd-timesyncd service is not masked

### DIFF
--- a/install_files/ansible-base/roles/common/tasks/post_ubuntu_install_checks.yml
+++ b/install_files/ansible-base/roles/common/tasks/post_ubuntu_install_checks.yml
@@ -71,6 +71,7 @@
   systemd:
     name: systemd-timesyncd
     enabled: yes
+    masked: no
     state: started
   when: ansible_distribution_release == "focal"
   become: yes


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Explicitly unmasks the `systemd-timesyncd` service.

Fixes #5840.

## Testing

- Build a Focal staging environment, or install on hardware. 
- On both servers:
  - Ensure that `systemctl list-unit-files --state=masked | grep time` reports nothing.
  - `systemctl list-unit-files systemd-timesyncd.service` should report that the service is enabled.
  - `systemctl status systemd-timesyncd` should report that it is enabled and loaded.

## Deployment

No new concerns.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
