### PR TITLE
[1.8.0] Backport #5842 (Ensure the systemd-timesyncd service is not masked)

### DIFF
--- a/install_files/ansible-base/roles/common/tasks/post_ubuntu_install_checks.yml
+++ b/install_files/ansible-base/roles/common/tasks/post_ubuntu_install_checks.yml
@@ -71,6 +71,7 @@
   systemd:
     name: systemd-timesyncd
     enabled: yes
+    masked: no
     state: started
   when: ansible_distribution_release == "focal"
   become: yes


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #5842.

## Testing

- [ ] CI is green.
- [ ] PR contains the same commits as #5842.
- [ ] PR base branch is `release/1.8.0`

