### PR TITLE
Added -u flag to tmux invocations, to force the use of UTF-8 for CLI QR codes

### DIFF
--- a/install_files/securedrop-config-focal/etc/profile.d/securedrop_additions.sh
+++ b/install_files/securedrop-config-focal/etc/profile.d/securedrop_additions.sh
@@ -11,12 +11,12 @@ tmux_attach_via_proc() {
     pid=$(pgrep --newest tmux)
     if test -n "$pid"
     then
-        /proc/$pid/exe attach
+        /proc/$pid/exe -u attach
     fi
     return 1
 }
 
 if test -z "$TMUX"
 then
-    (tmux attach || tmux_attach_via_proc || tmux new-session)
+    (tmux -u attach || tmux_attach_via_proc || tmux -u new-session)
 fi


### PR DESCRIPTION

## Status

Ready for review 

## Description of Changes

Fixes #5841 

Adds the `-u` flag to tmux invocations in `/etc/profile.d/securedrop_additions.sh` -  this is required for qr codes to render properly from `manage.py`.

## Testing

on a production (1.8.0-rc1 currently) Focal system:
- log into the application server via `ssh app` in an Admin Workstation
- [x] as the `www-data` user, in `/var/www/securedrop`, run `./manage.py add-admin` and confirm that the qr code is rendered as a black square.
- log out from the application server. check out this branch, and copy the file `~/Persistent/securedrop/install_files/securedrop-config-focal/etc/profile.d/securedrop_additions.sh` to the application server
- log back into the application server, and overwrite `/etc/profile.d/securedrop_additions.sh` with the file you just copied, preserving the originals permissions and ownership
- log out of the application server and log back in again with `ssh app`
- [x] as the `www-data` user, in `/var/www/securedrop`, run `./manage.py add-admin` and confirm that the qr code is rendered correctly.

## Deployment
This is deployed in the securedrop-config package, and should be focal-only.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
