### PR TITLE
 [1.8.0]  Added -u flag to tmux invocations, to force the use of UTF-8 for CLI QR codes

### DIFF
--- a/install_files/securedrop-config-focal/etc/profile.d/securedrop_additions.sh
+++ b/install_files/securedrop-config-focal/etc/profile.d/securedrop_additions.sh
@@ -11,12 +11,12 @@ tmux_attach_via_proc() {
     pid=$(pgrep --newest tmux)
     if test -n "$pid"
     then
-        /proc/$pid/exe attach
+        /proc/$pid/exe -u attach
     fi
     return 1
 }
 
 if test -z "$TMUX"
 then
-    (tmux attach || tmux_attach_via_proc || tmux new-session)
+    (tmux -u attach || tmux_attach_via_proc || tmux -u new-session)
 fi


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backports #5844 to the 1.8.0 release branch

## Testing

- [ ] #5844 is merged to develop
- [ ] changes/commits identical to #5844 
- [ ] base branch is 1.8.0
