### PR TITLE
Re-enables paxtest in testinfra

### DIFF
--- a/molecule/testinfra/common/paxtest_results.j2
+++ b/molecule/testinfra/common/paxtest_results.j2
@@ -1,0 +1,18 @@
+Executable anonymous mapping             : Killed
+Executable bss                           : Killed
+Executable data                          : Killed
+Executable heap                          : Killed
+Executable stack                         : Killed
+Executable shared library bss            : Killed
+Executable shared library data           : Killed
+Executable anonymous mapping (mprotect)  : Killed
+Executable bss (mprotect)                : Killed
+Executable data (mprotect)               : Killed
+Executable heap (mprotect)               : Killed
+Executable stack (mprotect)              : Killed
+Executable shared library bss (mprotect) : Killed
+Executable shared library data (mprotect): Killed
+Return to function (strcpy)              : paxtest: return address contains a NULL byte.
+Return to function (memcpy)              : {{ memcpy_result }}
+Return to function (strcpy, PIE)         : paxtest: return address contains a NULL byte.
+Return to function (memcpy, PIE)         : {{ memcpy_result }}


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Fixes #1039 

These tests were skipped because we weren't installing paxtest by
default. Let's just install it as part of the test run. Removes
the skip-in-prod marker, so that these checks can be used as part of QA
on hardware. Updates the logic to be distro-specific.

## Testing

CI should be passing on both platforms.
Try to run against hardware, or at least prodVMs, via the `./securedrop-admin verify` workflow.
Are we OK with installing `paxtest` automatically via tests? I'd think so, given that we do it manually as part of QA anyway.

## Deployment
Mostly QA, so developer-focused. Technically if an Admin runs `./securedrop-admin verify`, the remote state will change because `paxtest` will be installed now. That's acceptable, IMO, since otherwise the paxtest checks would have been skipped. 

## Checklist