### PR TITLE
Focal: force confold and force confdef in apt options for unattended-upgrades

### DIFF
--- a/install_files/securedrop-config-focal/opt/securedrop/50unattended-upgrades
+++ b/install_files/securedrop-config-focal/opt/securedrop/50unattended-upgrades
@@ -58,3 +58,9 @@ Unattended-Upgrade::Automatic-Reboot-WithUsers "true";
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";
+
+// Here we set the dpkg options to force the old conffile if it's already present
+// or force the default config if no config is present
+// see https://github.com/freedomofpress/securedrop/pull/911
+Dpkg::Options "force-confdef";
+Dpkg::Options "force-confold";

--- a/molecule/testinfra/common/test_automatic_updates.py
+++ b/molecule/testinfra/common/test_automatic_updates.py
@@ -199,6 +199,8 @@ def test_unattended_upgrades_config(host):
         assert f.user == "root"
         assert f.mode == 0o644
         assert f.contains("origin=SecureDrop,codename=${distro_codename}")
+        assert f.contains('Dpkg::Options "force-confold";')
+        assert f.contains('Dpkg::Options "force-confdef";')
 
 
 def test_unattended_securedrop_specific(host):


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #5849 

This ensures the old (existing) configuration is preserved. Otherwise,
requires interactive prompt by the package manager, and unattended
upgrades will prevent the package from being upgraded.

Keeping the existing configuration is the recommended default apt
behavior as indicated by the prompt.

## Testing

On this branch:
- make build-debs-focal
- molecule converge -s libvirt-staging-focal
- molecule login -s libvirt-staging-focal --host app-staging
- sudo apt-mark unhold securedrop-app-code
- sudo unattended-upgrades -d
- [ ] securedrop-app-code package is upgraded after running the unattended-upgrades command

## Deployment

Configuration is shipped via apt package of securedrop-config-focal

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
