### PR TITLE
Adjust timing of daily apt tasks

### DIFF
--- a/install_files/securedrop-config-focal/etc/systemd/system/apt-daily-upgrade.timer.d/override.conf
+++ b/install_files/securedrop-config-focal/etc/systemd/system/apt-daily-upgrade.timer.d/override.conf
@@ -1,0 +1,4 @@
+[Timer]
+OnCalendar=
+OnCalendar=04:00
+RandomizedDelaySec=1h

--- a/install_files/securedrop-config-focal/etc/systemd/system/apt-daily.timer.d/override.conf
+++ b/install_files/securedrop-config-focal/etc/systemd/system/apt-daily.timer.d/override.conf
@@ -1,0 +1,5 @@
+[Timer]
+OnCalendar=
+OnCalendar=*-*-* 00/3:00
+RandomizedDelaySec=1h
+Persistent=true

--- a/molecule/testinfra/common/test_automatic_updates.py
+++ b/molecule/testinfra/common/test_automatic_updates.py
@@ -273,6 +273,20 @@ def test_apt_daily_services_and_timers_enabled(host, service):
             assert s.is_enabled
 
 
+def test_apt_daily_timer_schedule(host):
+    if host.system_info.codename != "xenial":
+        c = host.run("systemctl show apt-daily.timer")
+        assert "TimersCalendar={ OnCalendar=*-*-* 00/3:00:00 ;" in c.stdout
+        assert "RandomizedDelayUSec=1h" in c.stdout
+
+
+def test_apt_daily_upgrade_timer_schedule(host):
+    if host.system_info.codename != "xenial":
+        c = host.run("systemctl show apt-daily-upgrade.timer")
+        assert "TimersCalendar={ OnCalendar=*-*-* 04:00:00 ;" in c.stdout
+        assert "RandomizedDelayUSec=1h" in c.stdout
+
+
 def test_reboot_required_cron(host):
     """
     Unatteded-upgrades does not reboot the system if the updates don't require it.


### PR DESCRIPTION
## Status

Work in progress (timing needs to honor `sdconfig` options)

## Description of Changes

Fixes #5851.

Adjusts the timing of the `apt-daily` `systemd` timer so that updates are downloaded about every three hours.

Adjusts the timing of the `apt-daily-upgrade` timer so that the updates are applied at a random time between 0400 and 0500.

## Testing

- `make build-debs-focal && make staging-focal`
- On each server, check that:
  - An `override.conf` file is present in both of:
    - `/etc/systemd/system/apt-daily.timer.d`
    - `/etc/systemd/system/apt-daily-upgrade.timer.d`
  - The `CalendarOn` and `RandomizedDelaySec` entries in those files match what's reported by:
    - `systemctl show apt-daily.timer`
    - `systemctl show apt-daily-upgrade.timer`

## Deployment

This should ensure that updates are more reliably noticed and applied every day. 

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

