### PR TITLE
[1.8.0] Backport builder updates for release

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_01_26
-60436817a1e7a2b1f2abe19ef456b73e0b6e6d4064f2edb27e1ae0da3fcccef3
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_03_11
+bc1509c77301fc16662ad43b8be56e6f6c13c4366c2cab648e15dc0e3d46ab66

--- a/molecule/builder-xenial/image_hash
+++ b/molecule/builder-xenial/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2021_01_26
-f17105ea2618621d2de42ee6ef4d2cff507845fbf4d26581581bcf7c99d47217
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2021_03_11
+191501f0653623a0eb8859cd9b37bddab0061a7a02158bdeb9d7318844b47cf4


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Backports changes from #5858 to the 1.8.0 release branch

## Testing
- [x] Commits same as #5858 
- [x] Target is `release/1.8.0`
- [x] CI (including deb-tests and deb-tests-focal) is passing