### PR TITLE
Replace logo selection route with per-request global variable

### DIFF
--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
-
 from datetime import datetime
 from typing import Union
 
@@ -52,16 +50,6 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         session.pop('expires', None)
         session.pop('nonce', None)
         return redirect(url_for('main.index'))
-
-    @view.route('/org-logo')
-    def select_logo() -> werkzeug.Response:
-        if current_app.static_folder is None:
-            abort(500)
-        if os.path.exists(os.path.join(current_app.static_folder, 'i',
-                          'custom_logo.png')):
-            return redirect(url_for('static', filename='i/custom_logo.png'))
-        else:
-            return redirect(url_for('static', filename='i/logo.png'))
 
     @view.route("/")
     def index() -> str:

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -43,7 +43,7 @@
       <div class="container">
         {% block header %}
         <div id="header">
-          <a href="{{ url_for('main.index') }}" class="no-bottom-border"><img src="{{ url_for('main.select_logo') }}" class="logo small" alt="{{ g.organization_name }} | Home" width="250"></a>
+          <a href="{{ url_for('main.index') }}" class="no-bottom-border"><img src="{{ g.logo }}" class="logo small" alt="{{ g.organization_name }} | Home" width="250"></a>
           {% include 'locales.html' %}
         </div>
         {% endblock %}

--- a/securedrop/journalist_templates/config.html
+++ b/securedrop/journalist_templates/config.html
@@ -30,7 +30,7 @@
 <p>{{ gettext('Here you can update the image displayed on the SecureDrop web interfaces:') }}</p>
 
 <p>
-  <img src="{{ url_for('main.select_logo') }}" class="logo small" alt="{{ g.organization_name }}" width="250">
+  <img src="{{ g.logo }}" class="logo small" alt="{{ g.organization_name }}" width="250">
 </p>
 
 <form method="post" enctype="multipart/form-data">

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Optional
 
 import werkzeug
@@ -26,6 +27,22 @@ from source_app.decorators import ignore_static
 from source_app.utils import logged_in, was_in_generate_flow
 from store import Storage
 from server_os import is_os_past_eol
+
+
+def get_logo_url(app: Flask) -> str:
+    if not app.static_folder:
+        raise FileNotFoundError
+
+    custom_logo_filename = "i/custom_logo.png"
+    default_logo_filename = "i/logo.png"
+    custom_logo_path = Path(app.static_folder) / custom_logo_filename
+    default_logo_path = Path(app.static_folder) / default_logo_filename
+    if custom_logo_path.is_file():
+        return url_for("static", filename=custom_logo_filename)
+    elif default_logo_path.is_file():
+        return url_for("static", filename=default_logo_filename)
+
+    raise FileNotFoundError
 
 
 def create_app(config: SDConfig) -> Flask:
@@ -182,6 +199,11 @@ def create_app(config: SDConfig) -> Flask:
             g.organization_name = app.instance_config.organization_name
         else:
             g.organization_name = gettext('SecureDrop')
+
+        try:
+            g.logo = get_logo_url(app)
+        except FileNotFoundError:
+            app.logger.error("Site logo not found.")
 
         return None
 

--- a/securedrop/source_app/decorators.py
+++ b/securedrop/source_app/decorators.py
@@ -22,7 +22,7 @@ def ignore_static(f: Callable) -> Callable:
     a static resource."""
     @wraps(f)
     def decorated_function(*args: Any, **kwargs: Any) -> Any:
-        if request.path.startswith("/static") or request.path == "/org-logo":
+        if request.path.startswith("/static"):
             return  # don't execute the decorated function
         return f(*args, **kwargs)
     return decorated_function

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -54,16 +54,6 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         session['new_user'] = True
         return render_template('generate.html', codename=codename, tab_id=tab_id)
 
-    @view.route('/org-logo')
-    def select_logo() -> werkzeug.Response:
-        if current_app.static_folder is None:
-            abort(500)
-        if os.path.exists(os.path.join(current_app.static_folder, 'i',
-                          'custom_logo.png')):
-            return redirect(url_for('static', filename='i/custom_logo.png'))
-        else:
-            return redirect(url_for('static', filename='i/logo.png'))
-
     @view.route('/create', methods=['POST'])
     def create() -> werkzeug.Response:
         if session.get('logged_in', False):

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -21,7 +21,7 @@
         {% block header %}
         <div id="header">
           <a href="{% if 'logged_in' in session %}{{ url_for('main.lookup') }}{% else %}{{ url_for('main.index') }}{% endif %}" class="no-bottom-border">
-            <img src="{{ url_for('main.select_logo') }}" class="logo small" alt="{{ g.organization_name }} | {{ gettext('SecureDrop Home') }}" width="250">
+            <img src="{{ g.logo }}" class="logo small" alt="{{ g.organization_name }} | {{ gettext('SecureDrop Home') }}" width="250">
           </a>
           {% include 'locales.html' %}
         </div>

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -30,7 +30,7 @@
            See _source_index.sass for a more full understanding. #}
         <div class="index-wrap">
           <div class="header">
-            <img src="{{ url_for('main.select_logo') }}" alt="{{ g.organization_name }} | {{ gettext('Logo Image') }}" class="logo-image">
+            <img src="{{ g.logo }}" alt="{{ g.organization_name }} | {{ gettext('Logo Image') }}" class="logo-image">
             <div id="index-locales">
               {% include 'locales.html' %}
             </div>

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -24,6 +24,7 @@ from journalist_app.utils import delete_collection
 from models import InstanceConfig, Source, Reply
 from source_app import main as source_app_main
 from source_app import api as source_app_api
+from source_app import get_logo_url
 from .utils.db_helper import new_codename, submit
 from .utils.instrument import InstrumentedApp
 from sdconfig import config
@@ -110,12 +111,10 @@ def test_logo_default_available(source_app):
         os.remove(custom_image_location)
 
     with source_app.test_client() as app:
-        response = app.get(url_for('main.select_logo'), follow_redirects=False)
-
-        assert response.status_code == 302
-        observed_headers = response.headers
-        assert 'Location' in list(observed_headers.keys())
-        assert url_for('static', filename='i/logo.png') in observed_headers['Location']
+        logo_url = get_logo_url(source_app)
+        assert logo_url.endswith('i/logo.png')
+        response = app.get(logo_url, follow_redirects=False)
+        assert response.status_code == 200
 
 
 def test_logo_custom_available(source_app):
@@ -126,12 +125,10 @@ def test_logo_custom_available(source_app):
         shutil.copyfile(default_image, custom_image)
 
     with source_app.test_client() as app:
-        response = app.get(url_for('main.select_logo'), follow_redirects=False)
-
-        assert response.status_code == 302
-        observed_headers = response.headers
-        assert 'Location' in list(observed_headers.keys())
-        assert url_for('static', filename='i/custom_logo.png') in observed_headers['Location']
+        logo_url = get_logo_url(source_app)
+        assert logo_url.endswith('i/custom_logo.png')
+        response = app.get(logo_url, follow_redirects=False)
+        assert response.status_code == 200
 
 
 def test_page_not_found(source_app):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Getting the logo URL via the `/org-logo` route's redirect meant that the logo had to be retrieved with every page load, which of course over Tor can take several seconds. Selecting the logo at the start of each request and storing its URL in the Flask globals allows the static URL to be used in the templates, with the default caching of static assets, eliminating the extra requests.

## Testing

- `git checkout -b static-logo origin/static-logo`
- If you have a custom logo in your working copy at `securedrop/static/i/custom_logo.png`, remove it.
- `make dev`
- Verify that the default logo is shown on both source and journalist interfaces, served from its static URL, not from `/org-logo`.
- Note that the logo is cached like other static assets, and not retrieved on subsequent normal page loads.
- Visit the instance configuration page in the journalist interface, upload a custom logo, and check that it's used in both source and journalist interfaces.
- Make the same checks in an environment using Apache, like staging.

## Deployment

This does introduce the possibility of OSSEC alerts from the errors logged if no site logo is available, or if the static directory is missing.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
