### PR TITLE
Bumped Tor version to 0.4.5.7

### DIFF
--- a/molecule/fetch-tor-packages/playbook.yml
+++ b/molecule/fetch-tor-packages/playbook.yml
@@ -12,7 +12,7 @@
     tor_repo_pubkey: "{{ sd_repo_root + '/install_files/ansible-base/roles/tor-hidden-services/files/tor-signing-key.pub' }}"
     tor_repo_url: "deb https://deb.torproject.org/torproject.org {{ ansible_distribution_release }} main"
     # Used to fetch a precise version; must also be updated in the test vars
-    tor_version: "0.4.5.6-1~{{ ansible_distribution_release }}+1"
+    tor_version: "0.4.5.7-1~{{ ansible_distribution_release }}+1"
 
   tasks:
     - name: Add Tor apt repo pubkey

--- a/molecule/fetch-tor-packages/tests/test_tor_packages.py
+++ b/molecule/fetch-tor-packages/tests/test_tor_packages.py
@@ -12,7 +12,7 @@ TOR_PACKAGES = [
     {"name": "tor-geoipdb", "arch": "all"},
 ]
 # The '{}' will be replaced with platform, e.g. Focal
-TOR_VERSION_TEMPLATE = "0.4.5.6-1~{}+1"
+TOR_VERSION_TEMPLATE = "0.4.5.7-1~{}+1"
 
 
 def test_tor_apt_repo(host):


### PR DESCRIPTION
## Status

WIP

## Description of Changes

Fixes #5873 .

Updates Tor package version downloaded from Tor Project repos from 0.4.5.6 to 0.4.5.7.

This update includes fixes for two DoS attacks, one directly against directory authorities, which does not affect SecureDrop , and one using compromised authorities to launch attacks against any Tor instances, including SecureDrop. Severity for the latter is rated High - it is being tracked as [TROVE-2021- 001](https://gitlab.torproject.org/tpo/core/team/-/wikis/NetworkTeam/TROVE) in Tor's vulnerability listings and CVE-2021-28089 (pending) in general. There are no recorded cases of it affecting SecureDrop instances so far.

## Testing

- [ ] Has version been incremented?
- [ ] are corresponding xenial and focal packages available on https://deb.torproject.org/torproject.org/pool/main/t/tor/ ?
- [ ] does CI pass?

## Deployment

Will be deployed independently to apt.freedom.press and picked up on next nightly update. Users wishing to apply it earlier can do so via `cron-apt` on Xenial and `unattended-upgrades` on Focal.
