### PR TITLE
Pre-install setuptools-scm <6 in venv

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/translations.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/translations.yml
@@ -1,8 +1,10 @@
 ---
 
 - name: Install SecureDrop Python requirements in virtualenv for translation work
-  shell: |
-    python3 -m venv /tmp/securedrop-app-code-i18n-ve
+  shell: >
+    set -e &&
+    python3 -m venv /tmp/securedrop-app-code-i18n-ve &&
+    /tmp/securedrop-app-code-i18n-ve/bin/pip3 install "setuptools-scm==5.0.2" &&
     /tmp/securedrop-app-code-i18n-ve/bin/pip3 install --no-deps --no-binary :all: --require-hashes -r {{ securedrop_app_code_prep_dir }}/requirements.txt
   tags:
     - pip

--- a/install_files/securedrop-app-code/debian/rules
+++ b/install_files/securedrop-app-code/debian/rules
@@ -28,6 +28,7 @@ override_dh_virtualenv:
 	dh_virtualenv \
 		--python=/usr/bin/python3 \
 		--builtin-venv \
+		--preinstall setuptools-scm==5.0.2 \
 		--extra-pip-arg "--verbose" \
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-binary=:all:" \


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Fixes #5876

Required in order to maintain support for Python 3.5, under Xenial.
The python-dateutil package pulls in whatever the latest setuptools-scm
version is, and as of setuptools_scm>=6, Python 3.5 is no longer
supported.

## Testing
CI must be passing. 


## Deployment
Unbreaks Xenial deb builds, so critical for deployment. 
