### PR TITLE
Added mokutil check to detect SecureBoot status before installing

### DIFF
--- a/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
+++ b/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
@@ -21,6 +21,21 @@
       SecureDrop cannot be installed. For details, see
       https://github.com/freedomofpress/securedrop/issues/4058
 
+- name: Check SecureBoot status
+  raw: 'mokutil --sb-state'
+  ignore_errors: yes
+  register: _mokutil_results
+
+- name: Verify that SecureBoot is not enabled
+  assert:
+    that:
+      - "'SecureBoot enabled' not in _mokutil_results.stdout"
+      - "'SecureBoot enabled' not in _mokutil_results.stderr"
+    fail_msg: >-
+      SecureBoot is enabled. SecureDrop cannot be installed, as it uses a
+      custom kernel that is not signed. Please disable SecureBoot on the
+      target servers and try again.
+
 - name: Install python and packages required by installer
   raw: apt install -y python3 apt-transport-https dnsutils ubuntu-release-upgrader-core
   register: _apt_install_prereqs_results

--- a/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
+++ b/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
@@ -21,9 +21,15 @@
       SecureDrop cannot be installed. For details, see
       https://github.com/freedomofpress/securedrop/issues/4058
 
+- name: Install python and packages required by installer
+  raw: apt install -y python3 apt-transport-https dnsutils ubuntu-release-upgrader-core mokutil
+  register: _apt_install_prereqs_results
+  changed_when: "'0 upgraded, 0 newly installed, 0 to remove' not in _apt_install_prereqs_results.stdout"
+
 - name: Check SecureBoot status
-  raw: 'mokutil --sb-state'
-  ignore_errors: yes
+  command: mokutil --sb-state
+  changed_when: false
+  failed_when: false # results inspected below
   register: _mokutil_results
 
 - name: Verify that SecureBoot is not enabled
@@ -35,11 +41,6 @@
       SecureBoot is enabled. SecureDrop cannot be installed, as it uses a
       custom kernel that is not signed. Please disable SecureBoot on the
       target servers and try again.
-
-- name: Install python and packages required by installer
-  raw: apt install -y python3 apt-transport-https dnsutils ubuntu-release-upgrader-core
-  register: _apt_install_prereqs_results
-  changed_when: "'0 upgraded, 0 newly installed, 0 to remove' not in _apt_install_prereqs_results.stdout"
 
 - name: Remove cloud-init
   apt:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5871.

Adds a raw command check in the `prepare_servers` ansible role, to see if SecureBoot is enabled. If it is, the install exits early with an informative error. The check runs `mokutil --sb-state`, and fails iff the output includes `SecureBoot enabled`:
- `mokutil` will error out if `noefi` is set in kernel boot args (as it is for the current grsec kernel) - this is ignored and the check passes
- if mokutil isn't present (it is present for UEFI installs on 16.04.6 and 20.04) the check passes (because this is probably a Legacy boot setup)
- if the response is `SecureBoot disabled`, it obviously passes :)


## Testing

On prod hardware,
 - before installing, enable SecureBoot in the app server BIOS and disable it for the mon server
 - complete the OS install and initial setup/sdconfig using this branch
 - run `./securedrop-admin --force install` entering the server password when prompted
   -  [ ] verify that the secureboot check fails for the app server and passes for the mon server, and that the install playbook exits immediately after.
 - disable SecureBoot for the app server and rerun the `install` command
   - [ ] verify that the secureboot check passes for both servers and that the installation completes without issues.
 - after installation and `tailsconfig`, run `ssh mon sudo apt remove mokutil` to remove the utility from the mon server.
 - run `./securedrop-admin --force install` again
   - [ ] verify that the app server check fails with an `EFI variables are not supported` message
   - [ ] verify that the mon server check fails with `mokutil: not found`
   - [ ] verify that the failures are ignored and the installation completes without issues.
  

## Deployment

Deployed when workstation is updated. No implications for older systems IMO

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
