### PR TITLE
Correct backup location of custom logo

### DIFF
--- a/install_files/ansible-base/roles/backup/files/backup.py
+++ b/install_files/ansible-base/roles/backup/files/backup.py
@@ -1,8 +1,11 @@
 #!/opt/venvs/securedrop-app-code/bin/python
 """
-This script is copied to the App server and run by the Ansible playbook. When
-run (as root), it collects all of the necessary information to backup the 0.3
-system and stores it in /tmp/sd-backup-0.3-TIME_STAMP.tar.gz.
+This script is copied to the App server (to /tmp) and run by the Ansible playbook,
+typically via `securedrop-admin`.
+
+The backup file in the format sd-backup-$TIMESTAMP.tar.gz is then copied to the
+Admin Workstation by the playbook, and removed on the server. For further
+information and limitations, see https://docs.securedrop.org/en/stable/backup_and_restore.html
 """
 
 from datetime import datetime
@@ -19,14 +22,17 @@ def main():
 
     sd_code = '/var/www/securedrop'
     sd_config = os.path.join(sd_code, "config.py")
-    sd_custom_logo = os.path.join(sd_code, "static/i/logo.png")
+    sd_custom_logo = os.path.join(sd_code, "static/i/custom_logo.png")
 
     tor_hidden_services = "/var/lib/tor/services"
     torrc = "/etc/tor/torrc"
 
     with tarfile.open(backup_filename, 'w:gz') as backup:
         backup.add(sd_config)
-        backup.add(sd_custom_logo)
+
+        # If no custom logo has been configured, the file will not exist
+        if os.path.exists(sd_custom_logo):
+            backup.add(sd_custom_logo)
         backup.add(sd_data)
         backup.add(tor_hidden_services)
         backup.add(torrc)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

- Corrects location of custom logo
- Updates docstring in backup script
- Fixes #5868 

## Testing

1. Check out this branch on a real or virtualized (but preferably non-imaginary) Admin Workstation
2. Configure a custom logo on your server
3. Run `./securedrop-admin --force backup` from `~/Persistent/securedrop`
4. - [ ] Observe no errors in output and that resultant tarball contains `custom_logo.png ` (under `/var/www`)
5. Remove/rename custom logo (`/var/www/securedrop/static/i/custom_logo.png` on app)
6. Repeat step 3
7. - [ ] Observe no errors in output and that resultant tarball does not contain a logo file

## Deployment

No special considerations; instructions added via https://github.com/freedomofpress/securedrop-docs/pull/181 can be removed once this is included in a release.

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] Docs update ready to go: https://github.com/freedomofpress/securedrop-docs/pull/188