### PR TITLE
Disables OSSEC email for fwupd

### DIFF
--- a/install_files/securedrop-ossec-server/var/ossec/etc/local_decoder.xml
+++ b/install_files/securedrop-ossec-server/var/ossec/etc/local_decoder.xml
@@ -47,3 +47,10 @@
 <decoder name="dhclient">
   <program_name>dhclient</program_name>
 </decoder>
+
+<!--
+  The default fwupd tries to auto-update and generates error.
+-->
+<decoder name="fwupd">
+  <program_name>fwupd</program_name>
+</decoder>

--- a/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
+++ b/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
@@ -74,6 +74,25 @@
 </group>
 
 <!--
+  fwupd auto-updates realted rules.
+-->
+
+<group name="fwupd">
+  <rule id="100111" level="0">
+    <decoded_as>fwupd</decoded_as>
+    <match>Error opening directory</match>
+    <description>fwupd error</description>
+    <options>no_email_alert</options>
+  </rule>
+  <rule id="100112" level="0">
+    <decoded_as>fwupd</decoded_as>
+    <match>Failed to load SMBIOS</match>
+    <description>fwupd error for auto updates</description>
+    <options>no_email_alert</options>
+  </rule>
+</group>
+
+<!--
   Do not alert on stagging VM dhcp client errors. These events should not occur
   in production environments
 -->

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -133,6 +133,20 @@ log_events_without_ossec_alerts:
       jp&B1qSJM431TmEg,YJ][ge;6-dJI69?-TB?!BI4?Uza63V3vMY3ake6a
       hj-%A-m_5lgab!OVR,!pR+;L]eLgilU
 
+  # Override and suppress fwupd-specific errors under Ubuntu Focal
+  - name: test_ossec_fwupd_fuplugin_uefi_does_not_produce_alert
+    alert: >
+      Mar  1 13:22:53 app fwupd[133921]: 13:22:53:0883 FuPluginUefi
+      Error opening directory â€œ/sys/firmware/efi/esrt/entriesâ€�: No such file or directory
+    level: "0"
+    rule_id: "100111"
+
+  - name: test_ossec_fwupd_fuengine_does_not_produce_alert
+    alert: >
+      Mar  1 13:22:53 mon fwupd[133921]: 13:22:53:0576 FuEngine
+      Failed to load SMBIOS: invalid DMI data size, got 2527 bytes, expected 2745
+    level: "0"
+    rule_id: "100112"
 
 # Log events we expect an OSSEC alert to occur for
 log_events_with_ossec_alerts:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5835 

Adds a new rules group and also the related decoder.

Changes proposed in this pull request:

## Testing


- [x] Do install from this branch to hardware
- [x] Make sure you don't receive the ossec alerts mentioned in #5835  


## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
