### PR TITLE
Use GitHub group for code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,1 @@
-# application code
-/securedrop/ @redshiftzero @kushaldas
-
-# updater GUI
-/journalist_gui/ @redshiftzero @kushaldas
-
-# admin CLI
-/admin/ @redshiftzero @kushaldas @emkll
-
-# docs
-/docs/ @zenmonkeykstop @redshiftzero @kushaldas @emkll
-
-# ansible / deployment
-/devops/        @conorsch @kushaldas @emkll
-/install_files/ @conorsch @kushaldas @emkll
-/molecule/      @conorsch @kushaldas @emkll
-/testinfra/     @conorsch @kushaldas @emkll
-/tails_files/   @conorsch @kushaldas @emkll
+*       @freedomofpress/securedrop-maintainers


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Resolves #5865 (unless we want to immediately apply this logic across all SD repos)

## Checklist / testing

Pure GitHub-level config change: 
- Contents should be identical to https://github.com/freedomofpress/securedrop-client/blob/main/.github/CODEOWNERS
- Post-merge, we can verify that the maintainers group is tagged for review on new PRs