### PR TITLE
Disabled pylint undefined-variable check for tuple definition in test parametrization

### DIFF
--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1538,7 +1538,7 @@ def test_admin_add_user_too_short_username(config, journalist_app, test_admin, l
     (
         (locale, "a" * i)
         for locale in get_test_locales()
-        for i in get_plural_tests()[locale] if i != 0
+        for i in get_plural_tests()[locale] if i != 0  # pylint: disable=undefined-variable
     )
 )
 def test_admin_add_user_yubikey_odd_length(journalist_app, test_admin, locale, secret):


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Disables incorrect pylint `undefined-variable` check for a tuple definition in a test parametrization.

It looks like this error was introduced in pylint 2.6.0, probably as part of fixes in https://github.com/PyCQA/pylint/pull/3713 - it wasn't caught in the PR with the test changes as they were reviewed and approved against pylint 2.5.0.

## Testing

-  [ ] `make app-lint` passes locally
-  [ ] CI is green.

## Deployment

Test- and CI-only, no impact elsewhere
