### PR TITLE
Wordlist removals and translation updates for next SecureDrop release

### DIFF
--- a/securedrop/dictionaries/adjectives.txt
+++ b/securedrop/dictionaries/adjectives.txt
@@ -1110,7 +1110,6 @@ casebook
 cased
 cast-iron
 cast-off
-castrated
 casual
 catalytic
 catastrophic
@@ -3396,7 +3395,6 @@ histological
 historic
 historical
 histrionic
-hit-and-run
 hitless
 hoary
 holey

--- a/securedrop/dictionaries/nouns.txt
+++ b/securedrop/dictionaries/nouns.txt
@@ -11607,8 +11607,6 @@ pedal
 pedant
 pedantry
 peddler
-pederast
-pederasty
 pedestal
 pedestrian
 pediatrics

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -326,7 +326,7 @@ def col_delete(cols_selected: List[str]) -> werkzeug.Response:
         num = len(cols_selected)
 
         success_message = ngettext(
-            "The account and all data for {n} source have been deleted.",
+            "The account and all data for the source have been deleted.",
             "The accounts and all data for {n} sources have been deleted.",
             num).format(n=num)
 

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -169,7 +169,9 @@ class JournalistNavigationStepsMixin:
         def collection_deleted():
             if not self.accept_languages:
                 flash_msg = self.driver.find_element_by_css_selector(".flash")
-                assert "The account and all data for 1 source have been deleted." in flash_msg.text
+                assert (
+                    "The account and all data for the source have been deleted." in flash_msg.text
+                )
 
         self.wait_for(collection_deleted)
 


### PR DESCRIPTION
## Status

Ready for review. See previously: #5357, #1546; 366c657b5f79b3dae510404ea5d6fed6adb0f6ca.

## Description of Changes

- Removes potentially offensive words (alone or in combination) from the SecureDrop wordlists. Among other things, SecureDrop uses adjectives and nouns to generate journalist designations, and while we cannot avoid all potentially offensive combinations, we can exclude some words that are almost always inappropriate in journalist designations or passphrases.

- Addresses translation feedback by pappasadrian and KwadroNaut from https://weblate.securedrop.org/translate/securedrop/securedrop/en/?checksum=e3e9531df602610b