### PR TITLE
Update Focal and Xenial builders

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_03_11
-bc1509c77301fc16662ad43b8be56e6f6c13c4366c2cab648e15dc0e3d46ab66
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_04_14
+46e06c9a83ec7f8f11d227aaaefb1da3b33d35c95f963d54087bcee965fae59e

--- a/molecule/builder-xenial/image_hash
+++ b/molecule/builder-xenial/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2021_03_11
-191501f0653623a0eb8859cd9b37bddab0061a7a02158bdeb9d7318844b47cf4
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-xenial:2021_04_14
+3fefc5cb2382fbcdb650606a62c88e58003d858c6722a72b51a8982dec37a052


### PR DESCRIPTION
## Status

Ready for Review
## Description of Changes

Towards https://github.com/freedomofpress/securedrop/issues/5891

Updates Xenial and Focal builder images

## Testing
- [ ] CI (including deb-tests target is passing)

## Deployment

Dev-only
