### PR TITLE
Use definite article for single file error case; improve functional test output

### DIFF
--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -116,7 +116,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         if not Path(file).is_file():
             flash(
                 gettext(
-                    "Your download failed because a file could not be found. An admin can find "
+                    "Your download failed because the file could not be found. An admin can find "
                     + "more information in the system and monitoring logs."
                 ),
                 "error"

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -205,9 +205,12 @@ def download(
         zf = current_app.storage.get_bulk_archive(submissions, zip_directory=zip_basename)
     except FileNotFoundError:
         flash(
-            gettext(
+            ngettext(
+                "Your download failed because the file could not be found. An admin can find "
+                + "more information in the system and monitoring logs.",
                 "Your download failed because a file could not be found. An admin can find "
-                + "more information in the system and monitoring logs."
+                + "more information in the system and monitoring logs.",
+                len(submissions)
             ),
             "error"
         )

--- a/securedrop/tests/__init__.py
+++ b/securedrop/tests/__init__.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 from os.path import abspath, dirname, join, realpath
+import pytest
 import sys
 
 # The tests directory should be adjacent to the securedrop directory. By adding
 # the securedrop directory to sys.path here, all test modules are able to
 # directly import modules in the securedrop directory.
 sys.path.append(abspath(join(dirname(realpath(__file__)), '..', 'securedrop')))
+
+# This ensures we get pytest's more detailed assertion output in helper functions
+pytest.register_assert_rewrite('tests.functional.journalist_navigation_steps')
+pytest.register_assert_rewrite('tests.functional.source_navigation_steps')

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -1181,15 +1181,24 @@ class JournalistNavigationStepsMixin:
             classes = checkbox.get_attribute("class")
             assert "unread-cb" in classes
 
-    def _journalist_sees_missing_file_error_message(self):
+    def _journalist_sees_missing_file_error_message(self, single_file=False):
         notification = self.driver.find_element_by_css_selector(".error")
 
-        if self.accept_languages is None:
-            expected_text = (
+        # We use a definite article ("the" instead of "a") if a single file
+        # is downloaded directly.
+        if single_file:
+            error_msg = (
+                "Your download failed because the file could not be found. An admin can find "
+                + "more information in the system and monitoring logs."
+            )
+        else:
+            error_msg = (
                 "Your download failed because a file could not be found. An admin can find "
                 + "more information in the system and monitoring logs."
             )
-            assert expected_text == notification.text
+
+        if self.accept_languages is None:
+            assert notification.text == error_msg
 
     def _journalist_is_on_collection_page(self):
         return self.wait_for(

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -133,7 +133,7 @@ class TestJournalistMissingFile(
         journalist home page."""
         self._journalist_logs_in()
         self._journalist_clicks_source_unread()
-        self._journalist_sees_missing_file_error_message()
+        self._journalist_sees_missing_file_error_message(single_file=True)
         self._is_on_journalist_homepage()
 
     def test_select_source_and_download_all(self, missing_msg_file):
@@ -141,7 +141,7 @@ class TestJournalistMissingFile(
         from the journalist home page."""
         self._journalist_logs_in()
         self._journalist_selects_first_source_then_download_all()
-        self._journalist_sees_missing_file_error_message()
+        self._journalist_sees_missing_file_error_message(single_file=True)
         self._is_on_journalist_homepage()
 
     def test_select_source_and_download_unread(self, missing_msg_file):
@@ -149,7 +149,7 @@ class TestJournalistMissingFile(
         button from the journalist home page."""
         self._journalist_logs_in()
         self._journalist_selects_first_source_then_download_unread()
-        self._journalist_sees_missing_file_error_message()
+        self._journalist_sees_missing_file_error_message(single_file=True)
         self._is_on_journalist_homepage()
 
     def test_download_message(self, missing_msg_file):
@@ -158,7 +158,7 @@ class TestJournalistMissingFile(
         self._journalist_logs_in()
         self._journalist_checks_messages()
         self._journalist_downloads_message_missing_file()
-        self._journalist_sees_missing_file_error_message()
+        self._journalist_sees_missing_file_error_message(single_file=True)
         self._journalist_is_on_collection_page()
 
     def test_select_message_and_download_selected(self, missing_msg_file):
@@ -167,5 +167,5 @@ class TestJournalistMissingFile(
         self._journalist_logs_in()
         self._journalist_selects_the_first_source()
         self._journalist_selects_message_then_download_selected()
-        self._journalist_sees_missing_file_error_message()
+        self._journalist_sees_missing_file_error_message(single_file=True)
         self._journalist_is_on_collection_page()


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

- Distinguishes single/multiple file error case. See @deeplow's comment in https://weblate.securedrop.org/translate/securedrop/securedrop/en/?checksum=aec87110942e8803#comments
- Registers `pytest` assertion rewriting for our helper functions so test failures show helpful string comparison when an assertion fails.

## Testing
### Error message behavior
On this PR's branch:
1. Spin up Docker env
2. Remove all files from disk in the container's `/var/lib/securedrop/store` directory
3. Attempt to download single file by clicking its filename directly in the Journalist Interface
4. - [ ] Observe that single file error message is displayed
5. Attempt to download single file via the checkbox interface
6. - [ ] Observe that single file error message is displayed
7. Attempt to download multiple files
8. - [ ] Observe that multiple file error message is displayed
### Improved assertion output
1. Break one of the tests like so:
```patch
diff --git a/securedrop/tests/functional/journalist_navigation_steps.py b/securedrop/tests/functional/journalist_navigation_steps.py
index 3f3813a7d..da8e6d825 100644
--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -1189,7 +1189,7 @@ class JournalistNavigationStepsMixin:
         if single_file:
             error_msg = (
                 "Your download failed because the file could not be found. An admin can find "
-                + "more information in the system and monitoring logs."
+                + "more information in the system and monitoring logs. XYZZY"
             )
         else:
             error_msg = (
```

2. Run it via `securedrop/bin/dev-shell bin/run-test -s -v tests/functional/test_journalist.py -k test_download_source_unread^`
3. - [ ] Observe that the assertion output includes a diff, unlike the output in [previous test failures](https://app.circleci.com/pipelines/github/freedomofpress/securedrop/2338/workflows/da8ee35e-3cd1-4c3e-8fbb-ca9c0a481e6e/jobs/53730)