### PR TITLE
Added codecov checksum validation, updated CircleCI machine to Focal.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ version: 2
 jobs:
   lint:
     machine:
+      image: ubuntu-2004:202010-01
       enabled: true
     environment:
       DOCKER_API_VERSION: 1.23
@@ -124,6 +125,7 @@ jobs:
 
   focal-app-tests:
     machine:
+      image: ubuntu-2004:202010-01
       enabled: true
     environment:
       DOCKER_API_VERSION: 1.23
@@ -157,6 +159,7 @@ jobs:
 
   app-tests:
     machine:
+      image: ubuntu-2004:202010-01
       enabled: true
     environment:
       DOCKER_API_VERSION: 1.23
@@ -190,7 +193,7 @@ jobs:
 
   translation-tests:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202010-01
       enabled: true
     environment:
       DOCKER_API_VERSION: 1.23
@@ -277,6 +280,7 @@ jobs:
 
   static-analysis-and-no-known-cves:
     machine:
+      image: ubuntu-2004:202010-01
       enabled: true
     environment:
       DOCKER_API_VERSION: 1.23
@@ -306,6 +310,7 @@ jobs:
 
   staging-test-with-rebase:
     machine:
+      image: ubuntu-2004:202010-01
       enabled: true
 
     working_directory: ~/sd
@@ -337,6 +342,7 @@ jobs:
 
   staging-test-with-rebase-focal:
     machine:
+      image: ubuntu-2004:202010-01
       enabled: true
 
     working_directory: ~/sd

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -62,13 +62,11 @@ function docker_run() {
     # If this is a CI run, pass CodeCov settings into the container.
     if [ -n "${CIRCLE_BRANCH:-}" ] ; then
         tmpdir=$(mktemp -d -t codecov-XXXX)
-        curl -s https://codecov.io/bash > "$tmpdir"/codecov; # env isn't in SHA256SUM yet!!
+        curl -s https://codecov.io/bash > "$tmpdir"/codecov;
         curl -s https://codecov.io/env > "$tmpdir"/env;
-        VERSION=$(curl --silent "https://api.github.com/repos/codecov/codecov-bash/releases/latest" | grep '"tag_name":' |sed -E 's/.*"([^"]+)".*/\1/')
+        VERSION="$(curl --silent "https://api.github.com/repos/codecov/codecov-bash/releases/latest" | grep '"tag_name":' |sed -E 's/.*"([^"]+)".*/\1/')"
         curl -s https://raw.githubusercontent.com/codecov/codecov-bash/"${VERSION}"/SHA256SUM > "$tmpdir"/codecov-hashes
-        pushd "$tmpdir" && shasum -a 256 -c --ignore-missing codecov-hashes && popd
-        chmod +x "$tmpdir"/env
-
+        pushd "$tmpdir" && shasum -a 256 -c codecov-hashes && popd
         ci_env=$(/bin/bash "$tmpdir"/env)
     else
         ci_env=""

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -61,7 +61,15 @@ function docker_run() {
 
     # If this is a CI run, pass CodeCov settings into the container.
     if [ -n "${CIRCLE_BRANCH:-}" ] ; then
-        ci_env=$(bash <(curl -s https://codecov.io/env))
+        tmpdir=$(mktemp -d -t codecov-XXXX)
+        curl -s https://codecov.io/bash > "$tmpdir"/codecov; # env isn't in SHA256SUM yet!!
+        curl -s https://codecov.io/env > "$tmpdir"/env;
+        VERSION=$(curl --silent "https://api.github.com/repos/codecov/codecov-bash/releases/latest" | grep '"tag_name":' |sed -E 's/.*"([^"]+)".*/\1/')
+        curl -s https://raw.githubusercontent.com/codecov/codecov-bash/"${VERSION}"/SHA256SUM > "$tmpdir"/codecov-hashes
+        pushd "$tmpdir" && shasum -a 256 -c --ignore-missing codecov-hashes && popd
+        chmod +x "$tmpdir"/env
+
+        ci_env=$(/bin/bash "$tmpdir"/env)
     else
         ci_env=""
     fi

--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -28,7 +28,7 @@ if [ -n "${CIRCLE_BRANCH:-}" ] ; then
         cp tests/log/firefox.log ../test-results
         tmpdir=$(mktemp -d -t codecov-XXXX)
         curl -s https://codecov.io/bash > "$tmpdir"/codecov;
-        VERSION=$(curl --silent "https://api.github.com/repos/codecov/codecov-bash/releases/latest" | grep '"tag_name":' |sed -E 's/.*"([^"]+)".*/\1/')
+        VERSION="$(curl --silent "https://api.github.com/repos/codecov/codecov-bash/releases/latest" | grep '"tag_name":' |sed -E 's/.*"([^"]+)".*/\1/')"
         curl -s https://raw.githubusercontent.com/codecov/codecov-bash/"${VERSION}"/SHA256SUM > "$tmpdir"/codecov-hashes
         pushd "$tmpdir" && shasum -a 256 -c --ignore-missing codecov-hashes && popd
         chmod +x "$tmpdir"/codecov

--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -26,7 +26,13 @@ if [ -n "${CIRCLE_BRANCH:-}" ] ; then
     touch tests/log/firefox.log
     function finish {
         cp tests/log/firefox.log ../test-results
-        bash <(curl -s https://codecov.io/bash -cF "$BASE_OS")
+        tmpdir=$(mktemp -d -t codecov-XXXX)
+        curl -s https://codecov.io/bash > "$tmpdir"/codecov;
+        VERSION=$(curl --silent "https://api.github.com/repos/codecov/codecov-bash/releases/latest" | grep '"tag_name":' |sed -E 's/.*"([^"]+)".*/\1/')
+        curl -s https://raw.githubusercontent.com/codecov/codecov-bash/"${VERSION}"/SHA256SUM > "$tmpdir"/codecov-hashes
+        pushd "$tmpdir" && shasum -a 256 -c --ignore-missing codecov-hashes && popd
+        chmod +x "$tmpdir"/codecov
+        /bin/bash "$tmpdir"/codecov
     }
     trap finish EXIT
 fi


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

- Updates invocations of codecov `bash` and `env` scripts in CI to validate checksums against their GitHub repo before running.
- Updates CircleCI machines to use Ubuntu 20.04 images (instead of Trusty).

## Testing

- [ ] CI is passing
- [ ] codecov scripts used in `securedrop/bin/{run-test,dev-shell} are not piped directly into bash 

## Deployment

CI only, no deployment issues

