### PR TITLE
Adds option to restore from backup file already on server.

### DIFF
--- a/install_files/ansible-base/roles/restore/defaults/main.yml
+++ b/install_files/ansible-base/roles/restore/defaults/main.yml
@@ -3,3 +3,4 @@
 # backup. add the `--preserve-tor-config` to preserve the server's existing config.
 
 restore_skip_tor: False
+restore_manual_transfer: False

--- a/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
+++ b/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
@@ -53,11 +53,40 @@
       - "More info: {{ compare_result.stdout }}"
   when: not restore_skip_tor
 
+- name: Calculate local backup file checksum
+  connection: local
+  become: no
+  stat:
+    path: "{{ restore_file }}"
+    checksum_algorithm: sha256
+  register: local_backup_file
+  when: restore_manual_transfer
+
+- name: Calculate remote backup file checksum
+  stat:
+    path: "/tmp/{{ restore_file }}"
+    checksum_algorithm: sha256
+  register: remote_backup_file
+  when: restore_manual_transfer
+
+- name: Verify that local and remote backup file checksums match
+  assert:
+    that:
+      - "remote_backup_file.stat.checksum == local_backup_file.stat.checksum"
+    fail_msg:
+      - "Checksum comparison for the local and remote copies of the backup file failed."
+      - "When using the --no-transfer flag. the same file must be present both locally"
+      - "in `install_files/ansible-base and on the Application Server in `/tmp`, to allow"
+      - "for config verification. Please copy the backup file into place on the"
+      - "Application Server before proceeding, or restore without the --no-transfer flag."
+  when: restore_manual_transfer
+
 - name: Copy backup to application server
   synchronize:
     src: "{{ restore_file }}"
     dest: /tmp/{{ restore_file }}
     partial: yes
+  when: not restore_manual_transfer
 
 - name: Extract backup
   unarchive:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5906 .

when the `--no-transfer` argument is used with `./securedrop-admin restore`,
instead of transferring the backup tarball to the Application Server, the
local copy of the tarball will be compared with an expected remote file of the
same name in `/tmp` on the server. If checksums match, the remote copy will be
used to perform the backup.

This is intended to address cases where backups are too large to reliably
transmit over Tor via the Ansible synchronize module. Instead, backups can be
copied to the server using rsync, or via an encrypted transfer USB.

## Testing
- Acquire some backup files (one v2-only (`v2-only.tar.gz`), one v2+v3(`v2nv3.tar.gz`))
- Set up a prod Focal instance
- switch to this branch on the admin workstation
- copy the backup files to the ad admin home directory on the app server
- on the app server: `sudo cp v2nv3.tar.gz /tmp/v2-only.tar.gz`
- on the admin workstation: `./securedrop-admin --force restore --preserve-tor-config --no-transfer install_files/ansible-base/v2-only.tar.gz`
  - [ ] confirm that the restore process quits with a message about a checksum mismatch without performing any server-side steps.
- on the app server: `sudo cp v2-only.tar.gz /tmp/`
- on the admin workstation: `./securedrop-admin --force restore --preserve-tor-config --no-transfer install_files/ansible-base/v2-only.tar.gz`
  - [ ] confirm that the restore process completes sucessfully, and that the task to transfer the tarball does *not* run.
- on the app server: `sudo rm /tmp/v2-only.tar.gz `
- on the admin workstation: `./securedrop-admin --force restore --preserve-tor-config install_files/ansible-base/v2-only.tar.gz` 
  - [ ] confirm that the restore process completes sucessfully, and that the task to transfer the tarball *does* run. 

- on the app server: `sudo cp v2-only.tar.gz /tmp/v2nv3.tar.gz`
- on the admin workstation: `./securedrop-admin --force restore --no-transfer install_files/ansible-base/v2nv3.tar.gz`
  - [ ] confirm that the restore process quits with a message about a checksum mismatch without performing any server-side steps.
- on the app server: `sudo cp v2nv3.tar.gz /tmp/`
- on the admin workstation: `./securedrop-admin --force restore --no-transfer install_files/ansible-base/v2nv3.tar.gz`
  - [ ] confirm that the restore process completes sucessfully, and that the task to transfer the tarball does *not* run.
- on the app server: `sudo rm /tmp/v2nv3.tar.gz `
- on the admin workstation: `./securedrop-admin --force restore --no-transfer install_files/ansible-base/v2nv3.tar.gz`
  - [ ] confirm that the restore process completes sucessfully, and that the task to transfer the tarball *does* run. 

- [ ] for extra points, try playing around with other backup files - take chances, make mistakes, get messy!
 
## Deployment

Deployed with admin workstaiton update

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [x] I would appreciate help with the documentation
- [ ] These changes do not require documentation
