### PR TITLE
Excludes source_v*_url files from backup restores

### DIFF
--- a/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
+++ b/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
@@ -78,7 +78,8 @@
     exclude:
       - "var/lib/tor/services/source,var/lib/tor/services/journalist"
       - "var/lib/tor/services/ssh"
-      -  "var/lib/tor/services/sshv3"
+      - "var/lib/tor/services/sshv3"
+      - "var/lib/securedrop/source_v2_url"
   when: (not restore_skip_tor) and
         ("V3 services only" in compare_result.stdout)
 
@@ -87,7 +88,10 @@
     dest: /
     remote_src: yes
     src: "/tmp/{{ restore_file}}"
-    exclude: "var/lib/tor,etc/tor/torrc"
+    exclude:
+      - "var/lib/tor,etc/tor/torrc"
+      - "var/lib/securedrop/source_v2_url"
+      - "var/lib/securedrop/source_v3_url"
   when: restore_skip_tor
 
 - name: Reconfigure securedrop-app-code

--- a/molecule/testinfra/app/test_tor_hidden_services.py
+++ b/molecule/testinfra/app/test_tor_hidden_services.py
@@ -87,3 +87,21 @@ def test_tor_services_config(host, tor_service):
     # Check for block in file, to ensure declaration order
     service_regex = "\n".join([dir_regex, port_regex])
     assert service_regex in f.content_string
+
+
+def test_tor_apache_url_files(host):
+    """
+    Ensure that the Tor Source Interface address matches those present
+    in files used by the Source Interface /metadata endpoint.
+    """
+
+    v3_url_file = host.file("/var/lib/securedrop/source_v3_url")
+    v3_source_hostname = host.file("/var/lib/tor/services/sourcev3/hostname")
+
+    with host.sudo():
+        # v2 source file should no longer be present
+        assert not host.file("/var/lib/securedrop/source_v2_url").exists
+
+        assert v3_source_hostname.exists
+        assert v3_url_file.exists
+        assert v3_url_file.content_string == v3_source_hostname.content_string


### PR DESCRIPTION
## Status
Ready for review

## Description of Changes

Fixes #5912 .

- Updates playbook such that when a data-only restore is performed, the source_v*_url files used by the SI metadata endpoint should not be overridden
- Updates playbook such that when a v3-only restore is performed, the source_v2_url files should not be included
- Adds a testinfra test to verify that the v2 file is not present and that the v3 file matches the tor configuration


## Testing

- set up a prod Focal instance
- do a data-only restore from a v2 backup
  - [ ] verify that the SI `/metadata` endpoint does not list a v2 source address
  - [ ] verify that the same endpoint  does list the correct v3 source address
- do a restore from a v2+v3 backup (from an instance with a different v3 source address)
  - [ ] verify that the SI `/metadata` endpoint does not list a v2 source address
  - [ ] verify that the same endpoint  does list the correct v3 source address
- run the prod testinfra tests
  - [ ] verify that `test_tor_apache_files` passes 

## Deployment

Deployed with admin workstation setup/update.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

