### PR TITLE
Fix Ansible deprecation warning when building deb packages

### DIFF
--- a/install_files/ansible-base/roles/build-ossec-deb-pkg/tasks/main.yml
+++ b/install_files/ansible-base/roles/build-ossec-deb-pkg/tasks/main.yml
@@ -55,11 +55,10 @@
 
 - name: Install apt dependencies for building OSSEC packages.
   apt:
-    name: "{{ item }}"
+    name: "{{ build_ossec_deb_pkg_dependencies }}"
     state: present
     update_cache: yes
     cache_valid_time: 3600
-  with_items: "{{ build_ossec_deb_pkg_dependencies }}"
 
 - name: Extract OSSEC source tarball.
   unarchive:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Applies the recommendation to fix a deprecation warning that was printed (18 times) when `make build-debs-focal`.

```txt
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: "{{ item }}"`, please use `name: '{{
build_ossec_deb_pkg_dependencies }}'` and remove the loop. This feature will be
 removed in version 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```

Other tasks in the same file already use that syntax.
I thought I'd compare the output of the command with and without the change, but the Ansible tasks weren't executed in the same order, so the diff is large. I can go through it if deemed useful, though, I kept for log files, just let me know.

Loosely related to https://github.com/freedomofpress/securedrop/issues/5914 (once more, 2.11 won't be a semver minor update!)

## Testing

1. Run `make build-debs-focal`
2. Verify whatever you'd normally expect after running it. (Sorry, that's not super helpful!)

## Deployment

Because [other][1] [tasks][2] already use this syntax, and it is suggested by the deprecation warning, I don't have any reason to think that this change would change the resulting **deb** packages. Maybe that's worth a thought anyway before deploying.

  [1]: https://github.com/freedomofpress/securedrop/blob/develop/install_files/ansible-base/roles/common/tasks/install_packages.yml#L3-L4
  [2]: https://github.com/freedomofpress/securedrop/blob/develop/install_files/ansible-base/roles/common/tasks/remove_unused_packages.yml#L3-L4

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass :warning: _I am in the process of building staging. I can only tell that the first step, `make build-debs-focal` exits successfully._

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
