### PR TITLE
Do not create local copy of backup file before extracting Tor config

### DIFF
--- a/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
+++ b/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
@@ -23,8 +23,10 @@
   connection: local
   become: no
   unarchive:
+    # Avoid creating an unnecessary local copy
+    remote_src: yes
     dest: "{{ torrc_check_dir.path }}/backup/"
-    src: "{{ restore_file }}"
+    src: "{{playbook_dir}}/{{ restore_file }}"
     extra_opts:
       - "etc/tor/torrc"
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5918

## Testing
Estimated testing time: ~30-60 minutes (depending on any errors encountered)

Using a VM or production server environment, from your Admin Workstation:
1. [ ] Observe that you can reproduce #5918 on 1.8.1 by following the steps to reproduce
2. [ ] Observe that you can no longer reproduce #5918 with the changes in this branch in place (you will have to specify `--force` to run `securedrop-admin` commands directly from this branch)

(I suggest cancelling the large file transfer to the server, assuming it successfully proceeds to that stage.)

## Checklist
- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container