### PR TITLE
Bump Firefox ESR and Geckodriver versions

### DIFF
--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -21,8 +21,8 @@ RUN gem install sass -v 3.4.23
 # Current versions of the test browser software. Tor Browser is based
 # on a specific version of Firefox, noted in Help > About Tor Browser.
 # Ideally we'll keep those in sync.
-ENV FF_VERSION 78.6.1esr
-ENV GECKODRIVER_VERSION v0.28.0
+ENV FF_VERSION 78.10.0esr
+ENV GECKODRIVER_VERSION v0.29.1
 
 # Import Tor release signing key
 ENV TOR_RELEASE_KEY_FINGERPRINT "EF6E286DDA85EA2A4BA7DE684E2C6E8793298290"

--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -21,8 +21,8 @@ RUN gem install sass -v 3.4.23
 # Current versions of the test browser software. Tor Browser is based
 # on a specific version of Firefox, noted in Help > About Tor Browser.
 # Ideally we'll keep those in sync.
-ENV FF_VERSION 78.6.1esr
-ENV GECKODRIVER_VERSION v0.28.0
+ENV FF_VERSION 78.10.0esr
+ENV GECKODRIVER_VERSION v0.29.1
 
 # Import Tor release signing key
 ENV TOR_RELEASE_KEY_FINGERPRINT "EF6E286DDA85EA2A4BA7DE684E2C6E8793298290"


### PR DESCRIPTION
## Status

Ready for review

## Description

My first guess on why app tests are failing was that there's a version discrepancy somewhere. We're running behind a bit, but the real reason for the test failures appears to be the post-April 30 Xenial EOL maintenance mode kicking in (#5920). 

Still, why not give FF and Geckodriver a bump while we're here? ESR version corresponds to the one the latest Tor Browser is based on (https://blog.torproject.org/new-release-tor-browser-10016), Geckodriver is simply latest (https://github.com/mozilla/geckodriver/releases).


## Testing

- app-tests should still be happy