### PR TITLE
Removes virtualbox support in VM scenarios

### DIFF
--- a/devops/scripts/create-staging-env
+++ b/devops/scripts/create-staging-env
@@ -2,7 +2,6 @@
 # Wrapper script to determine which VM driver is appropriate for the staging
 # environment, given the host OS and available tooling. Supports:
 #
-#   * VirtualBox (the default)
 #   * Libvirt/KVM
 #   * Qubes (via Admin API)
 #

--- a/devops/scripts/select-staging-env
+++ b/devops/scripts/select-staging-env
@@ -2,7 +2,6 @@
 # Wrapper script to determine which VM driver is appropriate for the staging
 # environment, given the host OS and available tooling. Supports:
 #
-#   * VirtualBox (the default)
 #   * Libvirt/KVM
 #   * Qubes (via Admin API)
 #
@@ -26,8 +25,9 @@ elif [[ "${OSTYPE:-}" == "linux-gnu" ]]; then
     # Default to Libvirt for Linux users, which works well with Tails VM virtualization.
     securedrop_vm_provider="libvirt"
 else
-    # Default to VirtualBox, since it's the safest bet.
-    securedrop_vm_provider="virtualbox"
+    # We previously maintained Virtualbox support, but don't any longer. Should we?
+    echo "WARNING: Unsupported platform. Libvirt staging environment may not work properly."
+    securedrop_vm_provider="libvirt"
 fi
 
 # Expect the scenario to reside in the molecule/ directory.

--- a/install_files/ansible-base/roles/common/tasks/post_ubuntu_install_checks.yml
+++ b/install_files/ansible-base/roles/common/tasks/post_ubuntu_install_checks.yml
@@ -31,6 +31,8 @@
   tags:
     - dns
 
+  # These services will be inside staging VMs via the Bento boxes,
+  # even if those boxes are running on libvirt.
 - name: Disable VirtualBox services to avoid conflict with systemd-timesyncd.
   systemd:
     name: "{{ item }}"

--- a/molecule/testinfra/common/test_grsecurity.py
+++ b/molecule/testinfra/common/test_grsecurity.py
@@ -140,17 +140,6 @@ def test_grsecurity_paxtest(host):
             host.run("apt-get remove -y paxtest")
 
 
-@pytest.mark.skip_in_prod
-def test_grub_pc_marked_manual(host):
-    """
-    Ensure the `grub-pc` packaged is marked as manually installed.
-    This is necessary for VirtualBox with Vagrant.
-    """
-    c = host.run('apt-mark showmanual grub-pc')
-    assert c.rc == 0
-    assert c.stdout.strip() == "grub-pc"
-
-
 def test_apt_autoremove(host):
     """
     Ensure old packages have been autoremoved.


### PR DESCRIPTION

## Status

Ready for review.

## Description of Changes

Towards #5904. In combination with https://github.com/freedomofpress/securedrop-docs/pull/216, closes #5904.

Changes proposed in this pull request:

The team isn't using virtualbox actively, and for e.g. macos we have a
much more convenient docker dev env for making app code changes.
Let's remove virtualbox support entirely, until we have a pressing
reason for it.

## Testing

These are mostly removals, building on changes in #5911. One important workflow to make sure we haven't broken is to provision prod VMs, and configure them via a virtualized Tails Admin Workstation. I've tested that myself, before opening this PR, and am satisfied with the behavior. Anyone else with a Debian Stable machine is welcome to try the same. 

## Deployment

Dev-only. 
