### PR TITLE
Use actual hostname in Postfix configuration

### DIFF
--- a/install_files/ansible-base/roles/postfix/defaults/main.yml
+++ b/install_files/ansible-base/roles/postfix/defaults/main.yml
@@ -1,8 +1,10 @@
 ---
 # Email address listed in the FROM line when sending OSSEc email alerts.
 # Some mail servers require that this match the account that authenticated
-# to send mail. Using the `ossec_from_address` for backwards-compatibility.
-postfix_from_address: "{{ ossec_from_address|default('') }}"
+# to send mail. Using the `ossec_from_address` for
+# backwards-compatibility.
+sasl_id: "{% if sasl_domain %}{{ sasl_username }}@{{ sasl_domain }}{% endif %}"
+postfix_from_address: "{{ ossec_from_address|default(sasl_id) }}"
 
 # Apt dependencies for the ossec server package
 postfix_dependencies:
@@ -11,7 +13,7 @@ postfix_dependencies:
   - mailutils
 
 # Configuration info for procmail and postfix
-postfix_hostname: ossec.server
+postfix_hostname: "{{ monitor_hostname }}"
 
 # Whether to enable Postfix for sending mail. Required in prod,
 # but unnecessary in staging contexts, where SASL authentication

--- a/install_files/ansible-base/roles/postfix/tasks/install_postfix.yml
+++ b/install_files/ansible-base/roles/postfix/tasks/install_postfix.yml
@@ -15,12 +15,23 @@
   tags:
     - postfix
 
-- name: Create mapping for outbound address.
+- name: Create outbound mapping for postfix_from_address in /etc/postfix/generic.
   copy:
-    content: "ossec@{{ postfix_hostname }} {{ postfix_from_address }}"
+    content: "ossec@{{ postfix_hostname }} {{ postfix_from_address }}\n"
     dest: /etc/postfix/generic
   notify: update generic_maps
   when: postfix_from_address != ""
+  tags:
+    - postfix
+
+- name: Remove /etc/postfix/generic database because postfix_from_address is empty.
+  file:
+    state: absent
+    dest: "{{ item }}"
+  with_items:
+    - /etc/postfix/generic
+    - /etc/postfix/generic.db
+  when: postfix_from_address == ""
   tags:
     - postfix
 

--- a/install_files/securedrop-ossec-server/DEBIAN/postinst
+++ b/install_files/securedrop-ossec-server/DEBIAN/postinst
@@ -16,10 +16,58 @@ set -x
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
+configure_postfix_myhostname() {
+    if [ -f /etc/postfix/main.cf ]
+    then
+        sed -i -E "s/^myhostname\\s*=\\s*ossec.server.*$/myhostname = $(hostname -f)/" /etc/postfix/main.cf
+    fi
+}
+
+configure_postfix_generics() {
+    if [ -f /etc/postfix/main.cf ]
+    then
+        python3 - <<EOF
+import pathlib
+import re
+import sys
+try:
+    sasl_id = open("/etc/postfix/sasl_passwd").readline().split()[1].split(":")[0]
+except:
+    print("Could not extract SASL ID from /etc/postfix/sasl_passwd")
+    sys.exit(0)
+
+try:
+    maincf = open("/etc/postfix/main.cf").read()
+    hostname = open("/etc/hostname").readline().strip()
+    rewrite_target = sasl_id
+    generic = pathlib.Path("/etc/postfix/generic")
+    if generic.is_file():
+        rewrite_target = generic.open().readline().split()[1]
+    if '@' in rewrite_target:
+        with generic.open("w") as g:
+            g.write("ossec@{} {}\n".format(hostname, rewrite_target))
+    else:
+        generic.unlink(missing_ok=True)
+        pathlib.Path("/etc/postfix/generic.db").unlink(missing_ok=True)
+except Exception as e:
+    print("Could not update /etc/postfix/generic:", e)
+    print('Please run "securedrop-admin install" from the admin workstation to correct.')
+    sys.exit(0)
+EOF
+        if [ -f /etc/postfix/generic ]
+        then
+            postmap /etc/postfix/generic
+        fi
+    fi
+}
+
 case "$1" in
     configure)
         GROUP="ossec"
         OSSEC_HOME="/var/ossec"
+
+        configure_postfix_myhostname
+        configure_postfix_generics
 
         # Ensure the correct file permissions and ownership are set for the
         # config files.
@@ -28,12 +76,12 @@ case "$1" in
 
         chown root:${GROUP} ${OSSEC_HOME}/rules/local_rules.xml
         chmod 440 ${OSSEC_HOME}/rules/local_rules.xml
-        
+
         # Ensure correct gnupg directory permissions and ownership
         chown -R ossec:${GROUP} ${OSSEC_HOME}/.gnupg
         find ${OSSEC_HOME}/.gnupg -type f -exec chmod 600 {} \;
         find ${OSSEC_HOME}/.gnupg -type d -exec chmod 700 {} \;
-      	
+
         # Replace localhost with 127.0.0.1 for smtp_server due to
         #  https://github.com/ossec/ossec-hids/issues/1145
         sed -i -e "s/<smtp_server>localhost<\/smtp_server>/<smtp_server>127.0.0.1<\/smtp_server>/g" /var/ossec/etc/ossec.conf

--- a/molecule/testinfra/mon/test_postfix.py
+++ b/molecule/testinfra/mon/test_postfix.py
@@ -29,14 +29,18 @@ def test_postfix_headers(host, header):
 
 def test_postfix_generic_maps(host):
     """
-    Regression test to check that generic Postfix maps are not configured
-    by default. As of #1565 Admins can opt-in to overriding the FROM address
-    used for sending OSSEC alerts, but by default we're preserving the old
-    `ossec@ossec.server` behavior, to avoid breaking email for previously
-    existing instances.
+    Check configuration of Postfix generic map when sasl_domain is set
+    and ossec_from_address is not specified.
     """
-    assert not host.file("/etc/postfix/generic").exists
-    assert not host.file("/etc/postfix/main.cf").contains("^smtp_generic_maps")
+    assert host.file("/etc/postfix/generic").exists
+    assert host.file("/etc/postfix/generic").contains(
+        "^ossec@{} {}@{}".format(
+            securedrop_test_vars.monitor_hostname,
+            securedrop_test_vars.sasl_username,
+            securedrop_test_vars.sasl_domain,
+        )
+    )
+    assert host.file("/etc/postfix/main.cf").contains("^smtp_generic_maps")
     assert host.file("/etc/postfix/main.cf").contains(
                      "^smtpd_recipient_restrictions = reject_unauth_destination")
 

--- a/molecule/testinfra/vars/mon-staging.yml
+++ b/molecule/testinfra/vars/mon-staging.yml
@@ -13,8 +13,13 @@ tor_services:
     authenticated: yes # value will automatically be coerced to boolean
     client: admin
 
-# Disable Postfix in staging, since we don't have valid credentials.
+# Postfix is disabled in staging.
 postfix_enabled: False
+
+# But it does get configured.
+sasl_username: "test"
+sasl_domain: "ossec.test"
+sasl_password: "password123"
 
 # Log events for OSSEC alerts we suppress
 log_events_without_ossec_alerts:

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -74,8 +74,13 @@ allowed_apache_logfiles:
   - /var/log/apache2/other_vhosts_access.log
   - /var/log/apache2/source-error.log
 
-# Disable Postfix in staging, since we don't have valid credentials.
+# Postfix is disabled in staging.
 postfix_enabled: False
+
+# But it does get configured.
+sasl_username: "test"
+sasl_domain: "ossec.test"
+sasl_password: "password123"
 
 # Log events for OSSEC alerts we suppress
 log_events_without_ossec_alerts:

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -74,8 +74,13 @@ allowed_apache_logfiles:
   - /var/log/apache2/other_vhosts_access.log
   - /var/log/apache2/source-error.log
 
-# Disable Postfix in staging, since we don't have valid credentials.
+# Postfix is disabled in staging.
 postfix_enabled: False
+
+# But it does get configured.
+sasl_username: "test"
+sasl_domain: "ossec.test"
+sasl_password: "password123"
 
 # Log events for OSSEC alerts we suppress
 log_events_without_ossec_alerts:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5916.

The legacy "ossec.server" value of the Postfix `myhostname` setting does not match our current recommended mon server hostname ("mon"), so prevents correct rewriting of the from address when sending to the SMTP relay.

This changes the `postfix_hostname` Ansible variable to use the value of `monitor_hostname`. The `postfix_from_address` still uses `ossec_from_address` if configured, but now defaults to "sasl_username@sasl_domain" if `sasl_domain` is supplied, enabling another chance for a valid rewrite of "ossec@mon". If neither `ossec_from_address` nor `sasl_domain` is specified, `postfix_from_address` will be empty, and in that case the playbook will now remove an existing `/etc/postfix/generic` database.

## Testing

### Playbook on hardware or prod VMs

- Check out this branch: `git checkout -b fix-postfix-hostname origin/fix-postfix-hostname`

- Follow #5916 STR. The `generic` database should contain the proper rewrite.

- Remove `ossec_from_address` from `site-specific`, ensure that it contains a valid `sasl_domain`, and rerun `securedrop-admin install`, or to save time, activate the admin virtualenv, `cd install_files/ansible-base` and run `ansible-playbook securedrop-prod.yml -t postfix`. The `generic` database should contain a valid rewrite from `ossec@mon` to `sasl_username@sasl_domain`, and if your SMTP relay configuration is valid, mail should flow.
- Edit `site-specific` to set `sasl_domain: ''`, then apply the configuration as above. The `generic` database should be removed.

### `postinst`

- `git checkout develop && make build-debs && make staging`
- on mon server: `grep myhostname /etc/postfix/main.cf` should return `myhostname = ossec.server`
- `/etc/postfix/generic` should not exist
- back in dev env: `mv build/focal build/focal-develop`
- `git checkout fix-postfix-hostname`
- `make build-debs`
- scp the `securedrop-ossec-server` deb to the mon server
- on mon server: `sudo apt install --reinstall /path/to/securedrop-ossec-server-3.6.0+1.9.0~rc1+focal-amd64.deb`
- `grep myhostname /etc/postfix/main.cf` should now return `myhostname = mon-staging`
- `/etc/postfix/generic` should contain `ossec@mon-staging test@ossec.test`

## Deployment

This should ensure valid from addresses in outbound OSSEC alerts. 

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation