### PR TITLE
removes 'source_v2_url' field from SI metadata endpoint

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -148,7 +148,6 @@
   /var/lib/securedrop/shredder/*/ w,
   /var/lib/securedrop/store/** rw,
   /var/lib/securedrop/store/*/ w,
-  /var/lib/securedrop/source_v2_url r,
   /var/lib/securedrop/source_v3_url r,
   /var/lib/securedrop/tmp/** rw,
   /var/lib/ssl/* r,

--- a/securedrop/source_app/api.py
+++ b/securedrop/source_app/api.py
@@ -4,7 +4,7 @@ import flask
 from flask import Blueprint, current_app, make_response
 
 from sdconfig import SDConfig
-from source_app.utils import get_sourcev2_url, get_sourcev3_url
+from source_app.utils import get_sourcev3_url
 
 import server_os
 import version
@@ -22,7 +22,6 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             'sd_version': version.__version__,
             'server_os': server_os.get_os_release(),
             'supported_languages': config.SUPPORTED_LOCALES,
-            'v2_source_url': get_sourcev2_url(),
             'v3_source_url': get_sourcev3_url()
         }
         resp = make_response(json.dumps(meta))

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -118,7 +118,7 @@ def check_url_file(path: str, regexp: str) -> 'Optional[str]':
     """
     Check that a file exists at the path given and contains a single line
     matching the regexp. Used for checking the source interface address
-    files at /var/lib/securedrop/source_{v2,v3}_url.
+    files in /var/lib/securedrop (as the Apache user can't read Tor config)
     """
     try:
         f = open(path, "r")
@@ -130,11 +130,6 @@ def check_url_file(path: str, regexp: str) -> 'Optional[str]':
             return None
     except IOError:
         return None
-
-
-def get_sourcev2_url() -> 'Optional[str]':
-    return check_url_file("/var/lib/securedrop/source_v2_url",
-                          r"^[a-z0-9]{16}\.onion$")
 
 
 def get_sourcev3_url() -> 'Optional[str]':

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -32,7 +32,7 @@ class SourceNavigationStepsMixin:
     def _source_checks_instance_metadata(self):
         self.driver.get(self.source_location + "/metadata")
         j = json.loads(self.driver.find_element_by_tag_name("body").text)
-        assert j["server_os"] in ["16.04", "20.04"]
+        assert j["server_os"] == "20.04"
         assert j["sd_version"] == self.source_app.jinja_env.globals["version"]
         assert j["gpg_fpr"] != ""
 

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -619,7 +619,7 @@ def test_why_journalist_key(source_app):
 
 
 def test_metadata_route(config, source_app):
-    with patch("server_os.get_os_release", return_value="16.04"):
+    with patch("server_os.get_os_release", return_value="20.04"):
         with source_app.test_client() as app:
             resp = app.get(url_for('api.metadata'))
             assert resp.status_code == 200
@@ -627,22 +627,9 @@ def test_metadata_route(config, source_app):
             assert resp.json.get('allow_document_uploads') ==\
                 InstanceConfig.get_current().allow_document_uploads
             assert resp.json.get('sd_version') == version.__version__
-            assert resp.json.get('server_os') == '16.04'
+            assert resp.json.get('server_os') == '20.04'
             assert resp.json.get('supported_languages') ==\
                 config.SUPPORTED_LOCALES
-            assert resp.json.get('v2_source_url') is None
-            assert resp.json.get('v3_source_url') is None
-
-
-def test_metadata_v2_url(config, source_app):
-    onion_test_url = "abcdabcdabcdabcd.onion"
-    with patch.object(source_app_api, "get_sourcev2_url") as mocked_v2_url:
-        mocked_v2_url.return_value = (onion_test_url)
-        with source_app.test_client() as app:
-            resp = app.get(url_for('api.metadata'))
-            assert resp.status_code == 200
-            assert resp.headers.get('Content-Type') == 'application/json'
-            assert resp.json.get('v2_source_url') == onion_test_url
             assert resp.json.get('v3_source_url') is None
 
 
@@ -654,7 +641,6 @@ def test_metadata_v3_url(config, source_app):
             resp = app.get(url_for('api.metadata'))
             assert resp.status_code == 200
             assert resp.headers.get('Content-Type') == 'application/json'
-            assert resp.json.get('v2_source_url') is None
             assert resp.json.get('v3_source_url') == onion_test_url
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Super-closes #5731

Removes the v2 source URL from the Source Interface `/metadata` endpoint.

## Testing

### Dev
- run `make dev` and visit http://localhost:8080/metadata
  - [ ] verify that the `v2_source_url` field is not present
  - [ ] verify that the `v3_source_url` field is present with a null value
 - log into the docker container with `docker exec -it securedrop-dev-0 bash`
 - create a file `/var/lib/securedrop/source_v3_url` containing a valid v3 address (56-char.onion, no protocol)
 - create a file `/var/lib/securedrop/source_v2_url` containing a valid v2 address (16-char.onion no protocol)
 - visit http://localhost:8080/metadata
   - [ ] verify that the `v2_source_url` field is not present
   - [ ] verify that the `v3_source_url` field is present with the value from the `source_v3_url` file.

## Deployment

Deployed with app-code .deb install/upgrade.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you added or removed a file deployed with the application:

- [x] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

