### PR TITLE
fix: Application Server submissions checker runs 60 times a day

### DIFF
--- a/install_files/ansible-base/roles/app/tasks/setup_cron.yml
+++ b/install_files/ansible-base/roles/app/tasks/setup_cron.yml
@@ -20,6 +20,7 @@
   cron:
     name: Update the number of submissions in the past 24h
     job: "{{ securedrop_code }}/manage.py were-there-submissions-today"
+    minute: "0"
     # 0 -> 23, 1 -> 0, 2 -> 1, ... 23 -> 22
     hour: "{{ (daily_reboot_time + 23) % 24 }}"
   tags:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes
Application Server submissions checker runs 60 times a day because the crontab entry has `*` in minutes position. So the submission checker runs from 3, every minute till 4 which is `daily_reboot_time`.  

Fixes #5847 

Changes proposed in this pull request:
Add minutes value in crontab to be 0.

## Testing

How should the reviewer test this PR?
Reference documentation is [here](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/cron_module.html).

## Checklist

### If you made changes to the server application code:

- [X] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to the system configuration:

- [X] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
