### PR TITLE
Make logo file error nicer

### DIFF
--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -53,7 +53,10 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                 flash(gettext("Image updated."), "logo-success")
             except Exception:
                 # Translators: This error is shown when an uploaded image cannot be used.
-                flash(gettext("Unable to process the image file. Try another one."), "logo-error")
+                flash(
+                    gettext("Unable to process the image file. Please try another one."),
+                    "logo-error"
+                )
             finally:
                 return redirect(url_for("admin.manage_config") + "#config-logoimage")
         else:

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -2025,7 +2025,7 @@ def test_logo_upload_save_fails(config, journalist_app, test_admin, locale):
                     )
 
                     assert page_language(resp.data) == language_tag(locale)
-                    msgids = ["Unable to process the image file. Try another one."]
+                    msgids = ["Unable to process the image file. Please try another one."]
                     with xfail_untranslated_messages(config, locale, msgids):
                         ins.assert_message_flashed(gettext(msgids[0]), "logo-error")
     finally:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5931.

Adds a "please" to the logo file error message.

## Testing

Prevent custom logo uploads: `chmod 555 securedrop/static/i`.

Check out `develop` and run the dev server with `make dev`.

Log in as a journalist, and upload a PNG logo. Consider the error message and how it makes you feel.

Check out this branch with `git checkout -b nicer-logo-error origin/nicer-logo-error`. Upload the logo again, and see if the new error message stings a bit less.

## Deployment

Any special considerations for deployment? Nope.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
