### PR TITLE
Bump 2FA secret bit length from 80 to 160 bits as recommended by RFC4226

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -35,8 +35,8 @@ if os.environ.get('SECUREDROP_ENV') == 'test':
 ARGON2_PARAMS = dict(memory_cost=2**16, rounds=4, parallelism=2)
 
 
-def generate_otp_secret() -> bytes:
-    return base64.b32encode(os.urandom(20))
+def generate_otp_secret() -> str:
+    return base64.b32encode(os.urandom(20)).decode()
 
 
 def get_one_or_else(query: Query,

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -407,7 +407,7 @@ class Journalist(db.Model):
     is_admin = Column(Boolean)  # type: Column[Optional[bool]]
     session_nonce = Column(Integer, nullable=False, default=0)
 
-    otp_secret = Column(String(16), default=generate_otp_secret)
+    otp_secret = Column(String(32), default=generate_otp_secret)
     is_totp = Column(Boolean, default=True)  # type: Column[Optional[bool]]
     hotp_counter = Column(Integer, default=0)  # type: Column[Optional[int]]
     last_token = Column(String(6))

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -35,7 +35,7 @@ if os.environ.get('SECUREDROP_ENV') == 'test':
 ARGON2_PARAMS = dict(memory_cost=2**16, rounds=4, parallelism=2)
 
 
-def generate_otp_secret():
+def generate_otp_secret() -> bytes:
     return base64.b32encode(os.urandom(20))
 
 

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -35,6 +35,10 @@ if os.environ.get('SECUREDROP_ENV') == 'test':
 ARGON2_PARAMS = dict(memory_cost=2**16, rounds=4, parallelism=2)
 
 
+def generate_otp_secret():
+    return base64.b32encode(os.urandom(20))
+
+
 def get_one_or_else(query: Query,
                     logger: 'Logger',
                     failure_method: 'Callable[[int], None]') -> db.Model:
@@ -403,7 +407,7 @@ class Journalist(db.Model):
     is_admin = Column(Boolean)  # type: Column[Optional[bool]]
     session_nonce = Column(Integer, nullable=False, default=0)
 
-    otp_secret = Column(String(16), default=pyotp.random_base32)
+    otp_secret = Column(String(16), default=generate_otp_secret)
     is_totp = Column(Boolean, default=True)  # type: Column[Optional[bool]]
     hotp_counter = Column(Integer, default=0)  # type: Column[Optional[int]]
     last_token = Column(String(6))
@@ -566,7 +570,7 @@ class Journalist(db.Model):
         return is_valid
 
     def regenerate_totp_shared_secret(self) -> None:
-        self.otp_secret = pyotp.random_base32()
+        self.otp_secret = generate_otp_secret()
 
     def set_hotp_secret(self, otp_secret: str) -> None:
         self.otp_secret = base64.b32encode(


### PR DESCRIPTION
Implement fix for ticket https://github.com/freedomofpress/securedrop/issues/5933