### PR TITLE
In test_alembic.py, test upgrade/downgrade more efficiently

### DIFF
--- a/securedrop/tests/test_alembic.py
+++ b/securedrop/tests/test_alembic.py
@@ -121,23 +121,9 @@ def test_alembic_head_matches_db_models(journalist_app,
 
 
 @pytest.mark.parametrize('migration', ALL_MIGRATIONS)
-def test_alembic_migration_upgrade(alembic_config, config, migration):
-    # run migrations in sequence from base -> head
-    for mig in list_migrations(alembic_config, migration):
-        upgrade(alembic_config, mig)
-
-
-@pytest.mark.parametrize('migration', ALL_MIGRATIONS)
-def test_alembic_migration_downgrade(alembic_config, config, migration):
-    # upgrade to the parameterized test case ("head")
+def test_alembic_migration_up_and_down(alembic_config, config, migration):
     upgrade(alembic_config, migration)
-
-    # run migrations in sequence from "head" -> base
-    migrations = list_migrations(alembic_config, migration)
-    migrations.reverse()
-
-    for mig in migrations:
-        downgrade(alembic_config, mig)
+    downgrade(alembic_config, "base")
 
 
 @pytest.mark.parametrize('migration', ALL_MIGRATIONS)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Walking the change path ourselves and calling `alembic` for each revision is slow, and doesn't match how migrations are applied in production. Simply calling `alembic` once with the target revision is more accurate and much faster since it doesn't incur the overhead of the extra invocations.

Also, since `test_alembic_migration_downgrade` upgrades to the target migration before downgrading to base, `test_alembic_migration_upgrade` is superfluous. I've renamed `test_alembic_migration_downgrade` to reflect what it does.

## Testing

- `git checkout develop && make test TESTFILES="tests/test_alembic.py"`
- `git checkout -b faster-alembic-tests origin/faster-alembic-tests && make test TESTFILES="tests/test_alembic.py"`

The tests should take about half as long on `faster-alembic-tests`.


## Deployment

This only affects tests.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
