### PR TITLE
Ensure securedrop-ossec-server postinst configures smtp_generic_maps

### DIFF
--- a/install_files/securedrop-ossec-server/DEBIAN/postinst
+++ b/install_files/securedrop-ossec-server/DEBIAN/postinst
@@ -57,7 +57,10 @@ EOF
         if [ -f /etc/postfix/generic ]
         then
             postmap /etc/postfix/generic
-            postconf -e smtp_generic_maps=hash:/etc/postfix/generic
+            if [ -f /etc/postfix/generic.db ]
+            then
+               postconf -e smtp_generic_maps=hash:/etc/postfix/generic
+            fi
         fi
     fi
 }

--- a/install_files/securedrop-ossec-server/DEBIAN/postinst
+++ b/install_files/securedrop-ossec-server/DEBIAN/postinst
@@ -57,6 +57,7 @@ EOF
         if [ -f /etc/postfix/generic ]
         then
             postmap /etc/postfix/generic
+            postconf -e smtp_generic_maps=hash:/etc/postfix/generic
         fi
     fi
 }


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

If the generic maps need to be created, make sure they're also added to `smtp_generic_maps`.

## Testing

- Perform clean install of 1.8.1. Confirm Postfix configuration:
  - `smtp_generic_maps` is blank
  - `/etc/postfix/generic*` do not exist

- Run `make build-debs` on this branch, copy the `securedrop-ossec-server` deb to mon server and install. Now:
  - `smtp_generic_maps` is `hash:/etc/postfix/generic`
  - `/etc/postfix/generic` maps `ossec@mon` to the SASL username @ SASL domain.

## Deployment

This change ensures that the `securedrop-ossec-server` `postinst` script configures `smtp_generic_maps` to ensure that mail doesn't go out as `ossec@mon`.

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

