### PR TITLE
Updated focal builder image

### DIFF
--- a/install_files/securedrop-app-code/debian/rules
+++ b/install_files/securedrop-app-code/debian/rules
@@ -28,7 +28,8 @@ override_dh_virtualenv:
 	dh_virtualenv \
 		--python=/usr/bin/python3 \
 		--builtin-venv \
-		--preinstall setuptools-scm==5.0.2 \
+		--upgrade-pip-to "21.1.1" \
+		--preinstall setuptools-scm==6.0.1 \
 		--extra-pip-arg "--verbose" \
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-binary=:all:" \

--- a/install_files/securedrop-app-code/debian/rules
+++ b/install_files/securedrop-app-code/debian/rules
@@ -28,7 +28,6 @@ override_dh_virtualenv:
 	dh_virtualenv \
 		--python=/usr/bin/python3 \
 		--builtin-venv \
-		--upgrade-pip-to "21.1.1" \
 		--preinstall setuptools-scm==6.0.1 \
 		--extra-pip-arg "--verbose" \
 		--extra-pip-arg "--no-deps" \

--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_04_14
-46e06c9a83ec7f8f11d227aaaefb1da3b33d35c95f963d54087bcee965fae59e
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_05_13
+0bb7bfdad1336057b3d7a84528efba0f8ba14520b8de139f52df6f382c58e1a7

--- a/molecule/testinfra/app/test_appenv.py
+++ b/molecule/testinfra/app/test_appenv.py
@@ -1,4 +1,3 @@
-import os.path
 import pytest
 
 import testutils
@@ -9,9 +8,12 @@ testinfra_hosts = [sdvars.app_hostname]
 
 @pytest.mark.parametrize('exp_pip_pkg', sdvars.pip_deps)
 def test_app_pip_deps(host, exp_pip_pkg):
-    """ Ensure pip dependencies are installed """
-    pip = host.pip_package.get_packages(pip_path=os.path.join(sdvars.securedrop_venv_bin, "pip"))
-    assert pip[exp_pip_pkg['name']]['version'] == exp_pip_pkg['version']
+    """ Ensure expected package versions are installed """
+    cmd = "{}/bin/python3 -c \"from importlib.metadata import version; print(version('{}'))\"".format( # noqa
+        sdvars.securedrop_venv, exp_pip_pkg['name']
+    )
+    result = host.run(cmd)
+    assert result.stdout.strip() == exp_pip_pkg['version']
 
 
 @pytest.mark.skip_in_prod


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Towards #5929 .

- Updates Focal builder image.
- updates setuptools-scm versions used by dh_virtualenv:
  - setuptools-scm 5.0.2 -> 6.0.1
- updates testinfra tests using pip to check package versions to use importlib instead.

## Testing

- [ ] CI is passing (deb-tests in particular)

## Deployment

Dev-only
