### PR TITLE
Remove upload-screenshots.py from package

### DIFF
--- a/securedrop/.rsync-filter
+++ b/securedrop/.rsync-filter
@@ -1,4 +1,5 @@
 exclude config.py
+exclude upload-screenshots.py
 include alembic.ini
 include alembic/
 include alembic/env.py


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #5832

Uses `.rsync-filter` as suggested by @conorsch on https://github.com/freedomofpress/securedrop/issues/5832#issuecomment-788164580. We could also move the script somewhere else, but none of the existing directories (e.g., `devops`) felt like a great fit.

## Testing

1. `make build-debs-notest` on this branch
2. Make a coffee, read a book, ponder the mysteries of the universe
3. Inspect `securedrop-app-code` package in `build/focal` 
4. - [ ] Observe that `upload-screenshots.py` is no longer present.