### PR TITLE
fix: Recreate store directory if not there for existing source

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -188,6 +188,11 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         journalist_filename = g.source.journalist_filename
         first_submission = g.source.interaction_count == 0
 
+        if not os.path.exists(current_app.storage.path(g.filesystem_id)):
+            current_app.logger.debug("Store directory not found for source '{}', creating one."
+                                     .format(g.source.journalist_designation))
+            os.mkdir(current_app.storage.path(g.filesystem_id))
+
         if msg:
             g.source.interaction_count += 1
             fnames.append(


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes
If an admin accidentally or intentionally wipes out the store directory of a particular source (i.e., the `store/{filesystem_id}`), the source gets a `FileNotFoundError` when trying to submitting the documents again.

Fixes #5787 

Changes proposed in this pull request:
A simple check which creates the `store/{filesystem_id}` dir for a source if it not already exists. 

## Testing

How should the reviewer test this PR?
Mentioned in the description of issue #5787 

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
