### PR TITLE
Add csrf-token to OSSEC test alert and log error

### DIFF
--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -91,6 +91,7 @@ def create_app(config: 'SDConfig') -> Flask:
 
     @app.errorhandler(CSRFError)
     def handle_csrf_error(e: CSRFError) -> 'Response':
+        app.logger.error("The CSRF token is invalid.")
         session.clear()
         msg = gettext('You have been logged out due to inactivity.')
         flash(msg, 'error')

--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -305,7 +305,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             db.session.commit()
         return redirect(url_for('admin.edit_user', user_id=user_id))
 
-    @view.route('/ossec-test')
+    @view.route('/ossec-test', methods=('POST',))
     @admin_required
     def ossec_test() -> werkzeug.Response:
         current_app.logger.error('This is a test OSSEC alert')

--- a/securedrop/journalist_templates/config.html
+++ b/securedrop/journalist_templates/config.html
@@ -74,13 +74,16 @@
 
 <p>{{ gettext('Send an encrypted email to verify if OSSEC alerts work correctly:') }}</p>
 
-<p>
-  <a class="btn" href="{{ url_for('admin.ossec_test') }}" id="test-ossec-alert">
-    <img src="{{ url_for('static', filename='icons/bell.png') }}" class="icon" width="13" height="15" alt="">
-    {{ gettext('SEND TEST OSSEC ALERT') }}
-  </a>
-  {% set prefs_filter = ["testalert-success","testalert-error","testalert-notification"] %}
-  {% include 'preferences_saved_flash.html' %}
-</p>
+<form method="post" action="{{ url_for('admin.ossec_test') }}">
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+  <p>
+    <button type="submit" id="test-ossec-alert">
+      <img src="{{ url_for('static', filename='icons/bell.png') }}" class="icon" width="13" height="15" alt="">
+      {{ gettext('SEND TEST OSSEC ALERT') }}
+    </button>
+    {% set prefs_filter = ["testalert-success","testalert-error","testalert-notification"] %}
+    {% include 'preferences_saved_flash.html' %}
+  </p>
+</form>
 
 {% endblock %}

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -2039,7 +2039,7 @@ def test_creation_of_ossec_test_log_event(journalist_app, test_admin, mocker):
     with journalist_app.test_client() as app:
         _login_user(app, test_admin['username'], test_admin['password'],
                     test_admin['otp_secret'])
-        app.get(url_for('admin.ossec_test'))
+        app.post(url_for('admin.ossec_test'))
 
     mocked_error_logger.assert_called_once_with(
         "This is a test OSSEC alert"


### PR DESCRIPTION
## Status

Ready for review

Closes https://github.com/freedomofpress/securedrop/issues/5956

## Description of Changes

Add CSRF token when making an OSSEC test alert and log if an error occurs.

## Testing

- [x] Verify user is logged out when there is an error during the OSSEC test alert operation
- [x] Verify there is a log when such an error occurs