### PR TITLE
[1.8.2] Backport 5937

### DIFF
--- a/install_files/securedrop-ossec-server/DEBIAN/postinst
+++ b/install_files/securedrop-ossec-server/DEBIAN/postinst
@@ -57,7 +57,10 @@ EOF
         if [ -f /etc/postfix/generic ]
         then
             postmap /etc/postfix/generic
-            postconf -e smtp_generic_maps=hash:/etc/postfix/generic
+            if [ -f /etc/postfix/generic.db ]
+            then
+               postconf -e smtp_generic_maps=hash:/etc/postfix/generic
+            fi
         fi
     fi
 }

--- a/install_files/securedrop-ossec-server/DEBIAN/postinst
+++ b/install_files/securedrop-ossec-server/DEBIAN/postinst
@@ -57,6 +57,7 @@ EOF
         if [ -f /etc/postfix/generic ]
         then
             postmap /etc/postfix/generic
+            postconf -e smtp_generic_maps=hash:/etc/postfix/generic
         fi
     fi
 }


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Backports #5937.

## Testing

- [ ] Contains only commits from #5937 
- [ ] CI is passing (with expected xenial-only and pillow-dependency fails)
- [ ] base is `release/1.8.2`
