### PR TITLE
Remove workaround for CSRF token set under Python 2

### DIFF
--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -9,7 +9,6 @@ from flask_assets import Environment
 from flask_babel import gettext
 from flask_wtf.csrf import CSRFProtect, CSRFError
 from os import path
-import sys
 from werkzeug.exceptions import default_exceptions
 
 import i18n
@@ -149,17 +148,6 @@ def create_app(config: 'SDConfig') -> Flask:
             timedelta(minutes=getattr(config,
                                       'SESSION_EXPIRATION_MINUTES',
                                       120))
-
-        # Work around https://github.com/lepture/flask-wtf/issues/275
-        # -- after upgrading from Python 2 to Python 3, any existing
-        # session's csrf_token value will be retrieved as bytes,
-        # causing a TypeError. This simple fix, deleting the existing
-        # token, was suggested in the issue comments. This code will
-        # be safe to remove after Python 2 reaches EOL in 2020, and no
-        # supported SecureDrop installations can still have this
-        # problem.
-        if sys.version_info.major > 2 and type(session.get('csrf_token')) is bytes:
-            del session['csrf_token']
 
         uid = session.get('uid', None)
         if uid:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In the transition to Python 3, we needed special handling of the `csrf_token` session attribute if set under Python 2. That's no longer necessary.

## Testing

CI is green.

## Deployment

No production site has been running Python 2 for a long time; this should have no impact.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
