### PR TITLE
Adds /sources/<source_uuid>/conversation endpoint supporting DELETE

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -181,6 +181,16 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         db.session.commit()
         return jsonify({'message': 'Source flagged for reply'}), 200
 
+    @api.route('/sources/<source_uuid>/conversation', methods=['DELETE'])
+    @token_required
+    def source_conversation(source_uuid: str) -> Tuple[flask.Response, int]:
+        if request.method == 'DELETE':
+            source = get_or_404(Source, source_uuid, column=Source.uuid)
+            utils.delete_source_files(source.filesystem_id)
+            return jsonify({'message': 'Source data deleted'}), 200
+        else:
+            abort(405)
+
     @api.route('/sources/<source_uuid>/submissions', methods=['GET'])
     @token_required
     def all_source_submissions(source_uuid: str) -> Tuple[flask.Response, int]:

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -597,6 +597,16 @@ def test_authorized_user_can_delete_source_conversation(journalist_app,
         assert not Source.query.filter(uuid == uuid).all() == []
 
 
+def test_source_conversation_does_not_support_get(journalist_app, test_source,
+                                                  journalist_api_token):
+    with journalist_app.test_client() as app:
+        uuid = test_source['source'].uuid
+        response = app.get(url_for('api.source_conversation', source_uuid=uuid),
+                           headers=get_api_headers(journalist_api_token))
+
+        assert response.status_code == 405
+
+
 def test_authorized_user_can_delete_source_collection(journalist_app,
                                                       test_source,
                                                       journalist_api_token):

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -181,6 +181,7 @@ def test_user_without_token_cannot_del_protected_endpoints(journalist_app,
             url_for('api.single_submission', source_uuid=uuid,
                     submission_uuid=test_submissions['submissions'][0].uuid),
             url_for('api.remove_star', source_uuid=uuid),
+            url_for('api.source_conversation', source_uuid=uuid),
             ]
 
     with journalist_app.test_client() as app:
@@ -570,6 +571,30 @@ def test_authorized_user_can_delete_single_reply(journalist_app, test_files,
 
         # Reply should now be gone.
         assert Reply.query.filter(Reply.uuid == reply_uuid).all() == []
+
+
+def test_authorized_user_can_delete_source_conversation(journalist_app,
+                                                        test_files,
+                                                        journalist_api_token):
+    with journalist_app.test_client() as app:
+        uuid = test_files['source'].uuid
+        source_id = test_files['source'].id
+
+        # Submissions and Replies both exist
+        assert not Submission.query.filter(source_id == source_id).all() == []
+        assert not Reply.query.filter(source_id == source_id).all() == []
+
+        response = app.delete(url_for('api.source_conversation', source_uuid=uuid),
+                              headers=get_api_headers(journalist_api_token))
+
+        assert response.status_code == 200
+
+        # Submissions and Replies do not exist
+        assert Submission.query.filter(source_id == source_id).all() == []
+        assert Reply.query.filter(source_id == source_id).all() == []
+
+        # Source still exists
+        assert not Source.query.filter(uuid == uuid).all() == []
 
 
 def test_authorized_user_can_delete_source_collection(journalist_app,


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Adds an API endpoint `/sources/<source_uuid>/conversation`,  which, when called via the DELETE method, deletes all submissions and replies while preserving the source account. All other methods just return a `405`.

## Testing

Dev container:
- run `make dev` on this branch
- log into the JI via `http://localhost:8081` in a browser
- note the journalist designation of the  second source
- copy the test script in https://gist.github.com/zenmonkeykstop/2bd2ae05e486729743497d0914a6d28e to your local workstation, install its dependencies with `pip install pyotp requests`, and run it with `python3 wipe-convo.py`
  - [ ] The response for the GET request includes the text `method not allowed`, and the application log in `make dev` output shows a `405` status code for the request
  - [ ] After the GET request, the second listed source and its associated data is still present
- Hit `Enter` when prompted by the script to run the DELETE request
  - [ ] The response for the DELETE request includes the text `source data deleted`, and the application log in `make dev` output shows a `200` status code for the request
  - [ ] After the get request, the source is still present but associated conversation data is deleted
- [ ] Sources other than the second listed source are unaffected, with their conversations intact.

## Deployment
- This will be deployed with next server code update, no postint tasks or other fixup is required.
 
## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [x] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation
