### PR TITLE
Fix errors in Tails validation logic; bump Tails version req

### DIFF
--- a/install_files/ansible-base/roles/validate/tasks/validate_tails_environment.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_tails_environment.yml
@@ -9,9 +9,9 @@
   assert:
     that:
       - ansible_lsb.id == "Tails" or tails_os_string.matched
-      - ansible_lsb.major_release|int >= 9
+      - ansible_lsb.major_release|int >= 10
     msg: >-
-      SecureDrop requires Tails 3 or greater for workstation environments.
+      SecureDrop requires Tails 4 or greater for workstation environments.
 
 - name: Check for persistence volume.
   stat:
@@ -73,18 +73,16 @@
       The `app-journalist.auth_private` file is missing. Please add the missing
       file under `~/Persistent/securedrop/install_files/ansible-base/ and
       retry the install command.
-  when:
-    - enable_ssh_over_tor
-    - v3_ssh_auth_file_count == "2"
 
 - name: Confirm that the Tor keys file is present
   assert:
     that:
       - v3_tor_key.stat.exists
     msg: >-
-      Authentication files for v3 onion services were found, but the
+      Authentication files for v3 SSH onion services were found, but the
       corresponding `tor_v3_keys.json` file is missing. To enable updates
       to an existing SecureDrop instance, please add this file under
       `~/Persistent/securedrop/install_files/ansible-base`.
   when:
-    - v3_journalist_auth_file.stat.exists
+    - enable_ssh_over_tor
+    - v3_ssh_auth_file_count == "2"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5942

- The journalist auth file should always be present when `./securedrop-admin tailsconfig` is run and is not logically tied to the SSH-over-Tor setting or the presence of SSH onion service secrets.

- The `tor_v3_keys.json` file is _only_ required if SSH secrets are present and SSH-over-Tor is enabled

- We can no longer support the Tails 3 series, so it's appropriate to error out at this point when users attempt to use it

## Testing

Estimated testing time: 30-60 minutes

On a physical or virtualized Admin Workstation with SSH-over-Tor enabled
1. Move `app-journalist.auth_private`, `tor_v3_keys.json`, `app-ssh.auth_private` and `mon-ssh.auth_private` from  `~/Persistent/securedrop/install_files/ansible-base` into a temporary location like `~/Persistent`
2. On this branch, run `./securedrop-admin --force tailsconfig` in `/Persistent/securedrop`
3. - [ ] Observe that it fails with an error noting that `app-journalist.auth_private` is missing.  [Explanation: This file must always be present to access the web-based Journalist/Admin Interface.]
4. Copy `app-journalist.auth_private` into place
5. Repeat step 2
6. - [ ] Observe that the command completes successfully.
7. Copy `app-ssh.auth_private` and `mon-ssh.auth_private` into place
8. Repeat step 2
9. - [ ] Observe that it fails with an error noting that `tor_v3_keys.json` is missing [Explanation: This file contains the private key needed to authenticate against the SSH onion services.]
10. Edit `~/Persistent/securedrop/install_files/ansible-base/group_vars/all/site-specific` and set `enable_ssh_over_tor` to `false`
11. Repeat step 2
12. - [ ] Observe that the command completes successfully. [Explanation: When SSH-over-Tor is disabled, we do not need to strictly confirm existence of the file.]
13. Undo your modification in step 10
14. Copy `tor_v3_keys.json` into place
15. - [ ] Observe that the command completes successfully


## Deployment

Although folks _really_ should not be using Tails 3 anymore, it likely will warrant a call-out in our release notes.

## Checklist
- [x] These changes do not require documentation
