### PR TITLE
Adds Rust to the builder image

### DIFF
--- a/molecule/builder-focal/Dockerfile
+++ b/molecule/builder-focal/Dockerfile
@@ -42,6 +42,10 @@ COPY aptpreferences.conf /etc/apt/preferences.d/ubuntu-groovy
 
 RUN apt-get update && apt-get install -y dh-virtualenv
 
+# Install Rust for building cryptography
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.52.1 -y
+RUN echo "source $HOME/.cargo/env" >> $HOME/.bashrc
+
 RUN paxctl -cm /usr/bin/python3.8 && mkdir -p /tmp/build
 RUN apt-get clean \
         && rm -rf /var/lib/apt/lists/*

--- a/molecule/builder-focal/Dockerfile
+++ b/molecule/builder-focal/Dockerfile
@@ -42,8 +42,19 @@ COPY aptpreferences.conf /etc/apt/preferences.d/ubuntu-groovy
 
 RUN apt-get update && apt-get install -y dh-virtualenv
 
+ENV RUST_VERSION 1.52.1
+
 # Install Rust for building cryptography
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.52.1 -y
+RUN TMPDIR=`mktemp -d` && cd ${TMPDIR} \
+        && curl --proto '=https' --tlsv1.2 -OO -sSf https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init{,.sha256} \
+        && mkdir -p target/x86_64-unknown-linux-gnu/release/ \
+        && mv rustup-init target/x86_64-unknown-linux-gnu/release/ \
+        && sha256sum --check rustup-init.sha256 \
+        && cd target/x86_64-unknown-linux-gnu/release/ \
+        && chmod +x rustup-init \
+        && ./rustup-init --default-toolchain=${RUST_VERSION} -y \
+        && cd && rm -rf ${TMPDIR}
+
 RUN echo "source $HOME/.cargo/env" >> $HOME/.bashrc
 
 RUN paxctl -cm /usr/bin/python3.8 && mkdir -p /tmp/build


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes

Version 1.52.1 of Rust.
After this is merged, we will have to push a new image. And then update https://github.com/freedomofpress/securedrop/pull/5964

## Testing

- [ ] CI should be green
- [ ] @zenmonkeykstop can push a new builder image based on this

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
