### PR TITLE
Use latest Buster CI image

### DIFF
--- a/devops/gce-nested/gce-start.sh
+++ b/devops/gce-nested/gce-start.sh
@@ -25,7 +25,7 @@ function find_latest_ci_image() {
     #    --filter="family:fpf-securedrop AND name ~ ^ci-nested-virt" \
     #    --sort-by=~Name --limit=1 --format="value(Name)"
     # Return hardcoded image id to prevent newer builds from breaking CI
-    echo "ci-nested-virt-buster-1606755081"
+    echo "ci-nested-virt-buster-1623169910"
 }
 
 # Call out to GCE API and start a new instance, designating

--- a/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
+++ b/install_files/ansible-base/roles/app/tasks/install_and_harden_apache.yml
@@ -1,9 +1,11 @@
 ---
+- name: Update apt cache.
+  shell: apt-get update -q
+
 - name: Install apache packages.
   apt:
     pkg: "{{ apache_packages }}"
     state: present
-    update_cache: yes
     cache_valid_time: 3600
   tags:
     - apt


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Works towards #5928.

Changes proposed in this pull request: rebuild the Buster-based CI image.

## Testing

I think this should just require `make ci-go`.

## Deployment

Any special considerations for deployment? No.

## Checklist

- [x] These changes do not require documentation
