### PR TITLE
Update mypy configuration for Python 3.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,6 @@ shellcheckclean:  ## Clean up temporary container associated with shellcheck tar
 typelint:  ## Run mypy type linting.
 	@echo "███ Running mypy type checking..."
 	@mypy ./securedrop ./admin
-	@mypy --disallow-incomplete-defs --disallow-untyped-defs ./securedrop/rm.py
 	@echo
 
 .PHONY: yamllint

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,8 @@
 ignore_missing_imports = True
 no_implicit_optional = True
 disallow_untyped_defs = True
-python_version = 3.5
+disallow_incomplete_defs = True
+python_version = 3.8
 
 [mypy-tests.*]
 disallow_untyped_defs = False

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -207,7 +207,7 @@ def new_codename(client, session):
     return codename
 
 
-def bulk_setup_for_seen_only(journo) -> List[Dict]:
+def bulk_setup_for_seen_only(journo: Journalist) -> List[Dict]:
     """
     Create some sources with some seen submissions that are not marked as 'downloaded' in the
     database and some seen replies from journo.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updates our mypy configuration to expect Python 3.8. We have dependencies using variable annotation syntax, causing `Variable annotation syntax is only supported in Python 3.6 and greater` errors from `make typelint`.

Also remove special-case linting of `securedrop/rm.py`.

## Testing

- `make typelint` should report no issues found.

## Deployment

Dev only.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

