### PR TITLE
Update translations for 2.0.0

### DIFF
--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -52,8 +52,8 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                 f.save(custom_logo_filepath)
                 flash(gettext("Image updated."), "logo-success")
             except Exception:
-                # Translators: This error is shown when an uploaded image cannot be used.
                 flash(
+                    # Translators: This error is shown when an uploaded image cannot be used.
                     gettext("Unable to process the image file. Please try another one."),
                     "logo-error"
                 )

--- a/securedrop/translations/ar/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ar/LC_MESSAGES/messages.po
@@ -66,7 +66,7 @@ msgid "Image updated."
 msgstr "تم تحديث الصورة بنجاح."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -122,8 +122,16 @@ msgstr "لم يتم اختيار شىء"
 msgid "You must select one or more items."
 msgstr "لا بد من اختيار عنصر أو أكثر."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "لم ينجح التحميل بسبب عدم امكانية العثور على ملف. الإداري يمكنه الحصول على المزيد من المعلومات عن هذا الأمر من خلال سجلات نظام التشغيل والمراقبة."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "لم ينجح التحميل بسبب عدم امكانية العثور على ملف. الإداري يمكنه الحصول على المزيد من المعلومات عن هذا الأمر من خلال سجلات نظام التشغيل والمراقبة."
+msgstr[1] "لم ينجح التحميل بسبب عدم امكانية العثور على ملف. الإداري يمكنه الحصول على المزيد من المعلومات عن هذا الأمر من خلال سجلات نظام التشغيل والمراقبة."
+msgstr[2] "لم ينجح التحميل بسبب عدم امكانية العثور على ملف. الإداري يمكنه الحصول على المزيد من المعلومات عن هذا الأمر من خلال سجلات نظام التشغيل والمراقبة."
+msgstr[3] "لم ينجح التحميل بسبب عدم امكانية العثور على ملف. الإداري يمكنه الحصول على المزيد من المعلومات عن هذا الأمر من خلال سجلات نظام التشغيل والمراقبة."
+msgstr[4] "لم ينجح التحميل بسبب عدم امكانية العثور على ملف. الإداري يمكنه الحصول على المزيد من المعلومات عن هذا الأمر من خلال سجلات نظام التشغيل والمراقبة."
+msgstr[5] "لم ينجح التحميل بسبب عدم امكانية العثور على ملف. الإداري يمكنه الحصول على المزيد من المعلومات عن هذا الأمر من خلال سجلات نظام التشغيل والمراقبة."
 
 msgid "Only admins can access this page."
 msgstr "الإداريون وحدهم بوسعهم النّفاذ إلى هذه الصفحة."
@@ -211,7 +219,10 @@ msgstr[5] "تم حذف {num} عنصر."
 msgid "No collections selected for deletion."
 msgstr "لَمْ تُختَر أيّ مجموعة لحذفها."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "لم يتم حذف أي حساب أو أي بيانات."
 msgstr[1] "تم حذف حساب وكل بيانات المصدر."
@@ -508,17 +519,11 @@ msgstr "لا يوجد ايداعات لعرضها."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "يمكن كتابة رد آمن إلى الشخص الذي أودع هذه الرسائل و/أو الملفات:"
 
-msgid "You've flagged this source for reply."
-msgstr "لقد أشّرت على هذا المصدر للرّدّ عليه."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "عند ولوج المصدر إلى النظام في المرّة التالية سيُولَّد له مفتاح تعمية، و&nbsp;سيمكنك بعد ذلك كتابة رسائل له هنا."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "انقر أدناه إذا أردت كتابة رد إلى المصدر."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "أشّر على المصدر للرَّدِّ عليه"
 
 msgid "Delete Source Account"
 msgstr "حذف حساب المصدر"
@@ -648,18 +653,6 @@ msgstr "تصفير الاستيثاق في خطوتين لمفاتيح المص�
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "إعادة ضبط وتصفير بيانات اعتماد مفاتيح المصادقة"
-
-msgid "info icon"
-msgstr "أيقونة المعلومة"
-
-msgid "Thanks!"
-msgstr "شكرا!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "سوف يولّد SecureDrop مفتاح تعمية للمصدر في المرة التالية التي يلج فيها إلى حسابه، و&nbsp;بعد توليد المفتاح سوف يظهر حقل للتراسل أسفل مجموعة مستندات المصدر. يمكن استخدام ذلك الحقل للتراسل السّري معه."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "واصل إلى قائمة مستندات {codename}..."
 
 msgid "Download Unread"
 msgstr "تنزيل المحتوى غير المقروء"
@@ -886,15 +879,6 @@ msgstr "أظهر"
 msgid "Hide"
 msgstr "اخفِ"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "معذرة لأننا لم نردّ حتّى الآن!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "تعرّضت منصتنا هذه مؤخّرا إلى طفرة في الزيارات، فلأجل الحيطة عطّلنا إنشاء قنوات التواصل ثنائي الاتجاه إلى حين زيارتك التالية."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "اطمئن إلى أنّنا اتمكنّا من تنزيل الوثائق التي أودعتها، و راجعنا لاحقًا لالتماس ردّ."
-
 msgid "Submit Files or Messages"
 msgstr "إيداع ملفات أو رسائل"
 
@@ -1018,6 +1002,36 @@ msgstr "<strong>هام:</strong> إذا كنت ترغب في البقاء مجه
 
 msgid "Back to submission page"
 msgstr "الرجوع إلى صفحة الإيداع"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "لقد أشّرت على هذا المصدر للرّدّ عليه."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "انقر أدناه إذا أردت كتابة رد إلى المصدر."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "أشّر على المصدر للرَّدِّ عليه"
+
+#~ msgid "info icon"
+#~ msgstr "أيقونة المعلومة"
+
+#~ msgid "Thanks!"
+#~ msgstr "شكرا!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "سوف يولّد SecureDrop مفتاح تعمية للمصدر في المرة التالية التي يلج فيها إلى حسابه، و&nbsp;بعد توليد المفتاح سوف يظهر حقل للتراسل أسفل مجموعة مستندات المصدر. يمكن استخدام ذلك الحقل للتراسل السّري معه."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "واصل إلى قائمة مستندات {codename}..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "معذرة لأننا لم نردّ حتّى الآن!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "تعرّضت منصتنا هذه مؤخّرا إلى طفرة في الزيارات، فلأجل الحيطة عطّلنا إنشاء قنوات التواصل ثنائي الاتجاه إلى حين زيارتك التالية."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "اطمئن إلى أنّنا اتمكنّا من تنزيل الوثائق التي أودعتها، و راجعنا لاحقًا لالتماس ردّ."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/ca/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ca/LC_MESSAGES/messages.po
@@ -61,7 +61,7 @@ msgid "Image updated."
 msgstr "S’ha actualitzat la imatge."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -117,8 +117,12 @@ msgstr "No hi ha res seleccionat"
 msgid "You must select one or more items."
 msgstr "Cal que seleccioneu un o més elements."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "La baixada ha fallat perquè no s'ha pogut trobar un fitxer. Un administrador pot obtenir més informació en els registres de sistema i seguiment."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "La baixada ha fallat perquè no s'ha pogut trobar un fitxer. Un administrador pot obtenir més informació en els registres de sistema i seguiment."
+msgstr[1] "La baixada ha fallat perquè no s'ha pogut trobar un fitxer. Un administrador pot obtenir més informació en els registres de sistema i seguiment."
 
 msgid "Only admins can access this page."
 msgstr "Només els administradors poden accedir a aquesta pàgina."
@@ -190,7 +194,10 @@ msgstr[1] "S'han suprimit {num} elements."
 msgid "No collections selected for deletion."
 msgstr "No s’ha seleccionat cap col·lecció per suprimir."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "S'ha suprimit el compte i totes les dades d'{n} font."
 msgstr[1] "S'ha suprimit el compte i totes les dades de {n} fonts."
@@ -471,17 +478,11 @@ msgstr "No hi ha cap enviament per mostrar."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Podeu escriure una resposta segura a la persona que ha enviat aquests missatges o fitxers:"
 
-msgid "You've flagged this source for reply."
-msgstr "Heu marcat aquesta font per a respondre-li."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Es generarà una clau per a la font la següent vegada que iniciï sessió, després d'això podreu respondre-hi aquí."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Feu clic a sota si voleu escriure una resposta a aquesta font."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "MARCA AQUESTA FONT PER A RESPONDRE-LI"
 
 msgid "Delete Source Account"
 msgstr "Suprimeix el compte font"
@@ -607,18 +608,6 @@ msgstr "Restableix l'autenticació de factor doble per a claus de seguretat, com
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "RESTABLEIX LES CREDENCIALS DE CLAUS DE SEGURETAT"
-
-msgid "info icon"
-msgstr "icona d'informació"
-
-msgid "Thanks!"
-msgstr "Gràcies!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "El SecureDrop generarà una clau de xifratge segura per a aquesta font la següent vegada que iniciï sessió. Una vegada s'hagi generat la clau, apareixerà una caixa de resposta sota la seva col·lecció de documents. Podeu usar aquesta caixa per escriure-hi respostes xifrades."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Continua cap a la llista de documents de {codename}..."
 
 msgid "Download Unread"
 msgstr "Baixa les pendents de llegir"
@@ -845,15 +834,6 @@ msgstr "Mostra"
 msgid "Hide"
 msgstr "Amaga"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Encara no hem respost!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "El nostre SecureDrop ha experimentat un increment d'activitat recentment. Per raons de seguretat, s'ha retardat la creació de canals de comunicació bidireccionals fins que torneu a connectar-vos."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Assegureu-vos que hem pogut baixar el vostre enviament i comproveu més endavant si hi ha cap resposta."
-
 msgid "Submit Files or Messages"
 msgstr "Envia fitxers o missatges"
 
@@ -977,6 +957,36 @@ msgstr "<strong>Important:</strong> si voleu romandre anònimament, <strong>no</
 
 msgid "Back to submission page"
 msgstr "Vés enrere a la pàgina d'enviaments"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Heu marcat aquesta font per a respondre-li."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Feu clic a sota si voleu escriure una resposta a aquesta font."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "MARCA AQUESTA FONT PER A RESPONDRE-LI"
+
+#~ msgid "info icon"
+#~ msgstr "icona d'informació"
+
+#~ msgid "Thanks!"
+#~ msgstr "Gràcies!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "El SecureDrop generarà una clau de xifratge segura per a aquesta font la següent vegada que iniciï sessió. Una vegada s'hagi generat la clau, apareixerà una caixa de resposta sota la seva col·lecció de documents. Podeu usar aquesta caixa per escriure-hi respostes xifrades."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Continua cap a la llista de documents de {codename}..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Encara no hem respost!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "El nostre SecureDrop ha experimentat un increment d'activitat recentment. Per raons de seguretat, s'ha retardat la creació de canals de comunicació bidireccionals fins que torneu a connectar-vos."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Assegureu-vos que hem pogut baixar el vostre enviament i comproveu més endavant si hi ha cap resposta."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/cs/LC_MESSAGES/messages.po
+++ b/securedrop/translations/cs/LC_MESSAGES/messages.po
@@ -62,7 +62,7 @@ msgid "Image updated."
 msgstr "Obrázek byl aktualizován."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -118,8 +118,13 @@ msgstr "Nic není vybráno"
 msgid "You must select one or more items."
 msgstr "Musíte vybrat jednu nebo více položek."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Stahování selhalo protože soubor nebyl nalezen. Administrátor může najít více informací v systémovém a monitorovacím logu."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Stahování selhalo protože soubor nebyl nalezen. Administrátor může najít více informací v systémovém a monitorovacím logu."
+msgstr[1] "Stahování selhalo protože soubor nebyl nalezen. Administrátor může najít více informací v systémovém a monitorovacím logu."
+msgstr[2] "Stahování selhalo protože soubor nebyl nalezen. Administrátor může najít více informací v systémovém a monitorovacím logu."
 
 msgid "Only admins can access this page."
 msgstr "Na tuto stránku mají přístup pouze administrátoři."
@@ -195,7 +200,10 @@ msgstr[2] "{num} položek bylo smazáno."
 msgid "No collections selected for deletion."
 msgstr "Nevybral/a jste žádnou sadu k smazání."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "Účet a všechna data pro {n} zdroj byla smazána."
 msgstr[1] "Účet a všechna data pro {n} zdroje byla smazána."
@@ -480,17 +488,11 @@ msgstr "Žádná podání k zobrazení."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Můžete napsat bezpečnou odpověď člověku, který poslal tyto zprávy a/nebo dokumenty:"
 
-msgid "You've flagged this source for reply."
-msgstr "Označili jste tento zdroj na odpověď."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Až se zdroj příště přihlásí, bude mu vygenerován šifrovací klíč a poté mu budete moci odpovědět zde."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Pro odpověď tomuto zdroji klepněte níže."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "OZNAČIT TENTO ZDROJ NA ODPOVĚĎ"
 
 msgid "Delete Source Account"
 msgstr "Smazat účet zdroje"
@@ -617,18 +619,6 @@ msgstr "Obnovit dvojfaktorovou autentizaci pro bezpečnostní klíče (např. Yu
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "RESETOVAT PŘIHLAŠOVACÍ ÚDAJE BEZPEČNOSTNÍHO KLÍČE"
-
-msgid "info icon"
-msgstr "ikonka info"
-
-msgid "Thanks!"
-msgstr "Děkujeme!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop vygeneruje bezpečný šifrovací klíč pro tento zdroj při jeho příštím přihlášení. Jakmile se klíč vygeneruje, objeví se pod kolekcí zdroje textové pole pro odpověď. Přes toto pole můžete tomuto zdroji poslat zašifrovanou odpověď."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Pokračujte k seznamu dokumentů „{codename}“..."
 
 msgid "Download Unread"
 msgstr "Stáhnout nepřečtené"
@@ -855,15 +845,6 @@ msgstr "Zobrazit"
 msgid "Hide"
 msgstr "Skrýt"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Promiňte, že jsme ještě neodpověděli!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "Náš SecureDrop nedávno zaznamenal prudký nárůst aktivity. Z bezpečnostních důvodů jsme odložili vytvoření obousměrného komunikačního kanálu až do vašeho dalšího přihlášení."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Podařilo se nám stáhnout váš příspěvek, přihlaste se prosím později abyste si mohli přečíst naši odpověď."
-
 msgid "Submit Files or Messages"
 msgstr "Nahrání souborů nebo zpráv"
 
@@ -987,6 +968,36 @@ msgstr "<strong>Důležité:</strong> Chcete-li zůstat v anonymitě, <strong>ne
 
 msgid "Back to submission page"
 msgstr "Zpátky na stránku podání"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Označili jste tento zdroj na odpověď."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Pro odpověď tomuto zdroji klepněte níže."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "OZNAČIT TENTO ZDROJ NA ODPOVĚĎ"
+
+#~ msgid "info icon"
+#~ msgstr "ikonka info"
+
+#~ msgid "Thanks!"
+#~ msgstr "Děkujeme!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop vygeneruje bezpečný šifrovací klíč pro tento zdroj při jeho příštím přihlášení. Jakmile se klíč vygeneruje, objeví se pod kolekcí zdroje textové pole pro odpověď. Přes toto pole můžete tomuto zdroji poslat zašifrovanou odpověď."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Pokračujte k seznamu dokumentů „{codename}“..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Promiňte, že jsme ještě neodpověděli!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "Náš SecureDrop nedávno zaznamenal prudký nárůst aktivity. Z bezpečnostních důvodů jsme odložili vytvoření obousměrného komunikačního kanálu až do vašeho dalšího přihlášení."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Podařilo se nám stáhnout váš příspěvek, přihlaste se prosím později abyste si mohli přečíst naši odpověď."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/de_DE/LC_MESSAGES/messages.po
+++ b/securedrop/translations/de_DE/LC_MESSAGES/messages.po
@@ -57,7 +57,7 @@ msgid "Image updated."
 msgstr "Bild aktualisiert."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -113,8 +113,12 @@ msgstr "Nichts ausgewählt"
 msgid "You must select one or more items."
 msgstr "Sie müssen einen oder mehrere Einträge auswählen."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Ihr Download ist fehlgeschlagen, weil eine Datei nicht gefunden werden konnte. Ein Administrator kann weitere Informationen in den System- und Überwachungsprotokollen finden."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Ihr Download ist fehlgeschlagen, weil eine Datei nicht gefunden werden konnte. Ein Administrator kann weitere Informationen in den System- und Überwachungsprotokollen finden."
+msgstr[1] "Ihr Download ist fehlgeschlagen, weil eine Datei nicht gefunden werden konnte. Ein Administrator kann weitere Informationen in den System- und Überwachungsprotokollen finden."
 
 msgid "Only admins can access this page."
 msgstr "Nur Administratoren haben Zugriff auf diese Seite."
@@ -186,7 +190,10 @@ msgstr[1] "{num} Einträge wurden gelöscht."
 msgid "No collections selected for deletion."
 msgstr "Es sind keine Sammlungen zum Löschen ausgewählt."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "Das Konto und alle Daten von {n} Quelle wurden gelöscht."
 msgstr[1] "Die Konten und alle Daten von {n} Quellen wurden gelöscht."
@@ -467,17 +474,11 @@ msgstr "Keine anzuzeigenden Einreichungen."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Sie können der Person, die diese Nachrichten und/oder Dateien eingereicht hat, eine sichere Antwort schreiben:"
 
-msgid "You've flagged this source for reply."
-msgstr "Sie haben diese Quelle für eine Antwort markiert."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Beim nächsten Anmelden wird für die Quelle ein Verschlüsselungsschlüssel generiert, nach dem Sie auf die Quelle antworten können."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Klicken Sie hier, wenn Sie dieser Quelle eine Antwort schreiben möchten."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "DIESE QUELLE FÜR EINE ANTWORT MERKEN"
 
 msgid "Delete Source Account"
 msgstr "Quellkonto löschen"
@@ -603,18 +604,6 @@ msgstr "Zwei-Faktor-Authentifizierung für Sicherheitsschlüssel wie YubiKey zur
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "SICHERHEITSSCHLÜSSEL ZUGANGSDATEN ZURÜCKSETZEN"
-
-msgid "info icon"
-msgstr "Info-Symbol"
-
-msgid "Thanks!"
-msgstr "Danke!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop wird für diese Quelle einen sicheren Schlüssel für die Verschlüsselung generieren, wenn Sie sich das nächste Mal anmeldet. Nach der Generierung des Schlüssels erscheint ein Antwortfeld unter der Dokumentensammlung. Über dieses Feld können Sie der Quelle verschlüsselte Antworten schreiben."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Weiter zur Dokumentenliste von {codename}..."
 
 msgid "Download Unread"
 msgstr "Ungelesene herunterladen"
@@ -841,15 +830,6 @@ msgstr "Anzeigen"
 msgid "Hide"
 msgstr "Verstecken"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Es tut uns Leid, dass wir noch nicht geantwortet haben!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "Auf unserem SecureDrop wurde kürzlich eine hohe Aktivität beobachtet. Aus Sicherheitsgründen wird die Zwei-Wege-Kommunikation zurückgehalten, bis Sie sich erneut einloggen."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Bitte seien Sie versichert, dass wir Ihre übermittelten Daten erhalten haben. Schauen Sie zu einem späteren Zeitpunkt noch einmal nach einer Antwort."
-
 msgid "Submit Files or Messages"
 msgstr "Dateien oder Nachrichten versenden"
 
@@ -973,6 +953,36 @@ msgstr "<strong>Wichtig:</strong> Verwenden Sie <strong>nicht</strong> GPG, um d
 
 msgid "Back to submission page"
 msgstr "Zurück zur Einreichungsseite"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Sie haben diese Quelle für eine Antwort markiert."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Klicken Sie hier, wenn Sie dieser Quelle eine Antwort schreiben möchten."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "DIESE QUELLE FÜR EINE ANTWORT MERKEN"
+
+#~ msgid "info icon"
+#~ msgstr "Info-Symbol"
+
+#~ msgid "Thanks!"
+#~ msgstr "Danke!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop wird für diese Quelle einen sicheren Schlüssel für die Verschlüsselung generieren, wenn Sie sich das nächste Mal anmeldet. Nach der Generierung des Schlüssels erscheint ein Antwortfeld unter der Dokumentensammlung. Über dieses Feld können Sie der Quelle verschlüsselte Antworten schreiben."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Weiter zur Dokumentenliste von {codename}..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Es tut uns Leid, dass wir noch nicht geantwortet haben!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "Auf unserem SecureDrop wurde kürzlich eine hohe Aktivität beobachtet. Aus Sicherheitsgründen wird die Zwei-Wege-Kommunikation zurückgehalten, bis Sie sich erneut einloggen."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Bitte seien Sie versichert, dass wir Ihre übermittelten Daten erhalten haben. Schauen Sie zu einem späteren Zeitpunkt noch einmal nach einer Antwort."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/el/LC_MESSAGES/messages.po
+++ b/securedrop/translations/el/LC_MESSAGES/messages.po
@@ -61,7 +61,7 @@ msgid "Image updated."
 msgstr "Η φωτογραφία ενημερώθηκε."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -117,8 +117,12 @@ msgstr "Δεν έχει επιλεχθεί τίποτα"
 msgid "You must select one or more items."
 msgstr "Πρέπει να επιλέξετε ένα ή περισσότερα αντικείμενα."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Η λήψη σας απέτυχε επειδή ένα αρχείο δεν βρέθηκε. Κάποιος διαχειριστής μπορεί να βρει περισσότερες πληροφορίες στα αρχεία καταγραφής συμβάντων συστήματος."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Η λήψη σας απέτυχε επειδή ένα αρχείο δεν βρέθηκε. Κάποιος διαχειριστής μπορεί να βρει περισσότερες πληροφορίες στα αρχεία καταγραφής συμβάντων συστήματος."
+msgstr[1] "Η λήψη σας απέτυχε επειδή ένα αρχείο δεν βρέθηκε. Κάποιος διαχειριστής μπορεί να βρει περισσότερες πληροφορίες στα αρχεία καταγραφής συμβάντων συστήματος."
 
 msgid "Only admins can access this page."
 msgstr "Μόνο οι διαχειριστές έχουν πρόσβαση σε αυτήν την σελίδα."
@@ -190,7 +194,10 @@ msgstr[1] "{num} αντικείμενα διαγράφηκαν."
 msgid "No collections selected for deletion."
 msgstr "Δεν έχουν επιλεχθεί συλλογές για διαγραφή."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "Ο λογαριασμός και τα δεδομένα {n} πηγής έχουν διαγραφεί."
 msgstr[1] "Ο λογαριασμός και τα δεδομένα {n} πηγών έχουν διαγραφεί."
@@ -471,17 +478,11 @@ msgstr "Δεν υπάρχουν υποβολές προς προβολή."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Μπορείτε να γράψετε μια ασφαλή απάντηση στο άτομο που υπέβαλε αυτά τα μηνύματα ή/και αρχεία:"
 
-msgid "You've flagged this source for reply."
-msgstr "Σημειώσατε αυτή την πηγή για απάντηση."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Ένα κλειδί κρυπτογράφησης για την πηγή θα παραχθεί την επόμενη φορά που θα συνδεθεί, και μετά από αυτό θα μπορείτε να απαντήσετε στην πηγή εδώ."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Πατήστε παρακάτω αν θέλετε να γράψετε μια απάντηση στην πηγή."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "ΣΗΜΕΙΩΣΗ ΠΗΓΗΣ ΓΙΑ ΑΠΑΝΤΗΣΗ"
 
 msgid "Delete Source Account"
 msgstr "Διαγραφή λογαριασμού πηγής"
@@ -607,18 +608,6 @@ msgstr "Επαναφορά πιστοποίησης δύο παραγόντων 
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "ΕΠΑΝΑΦΟΡΑ ΣΤΟΙΧΕΙΩΝ ΠΙΣΤΟΠΟΙΗΣΗΣ ΚΛΕΙΔΙΟΥ ΑΣΦΑΛΕΙΑΣ"
-
-msgid "info icon"
-msgstr "εικονίδιο πληροφοριών"
-
-msgid "Thanks!"
-msgstr "Ευχαριστούμε!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "Το SecureDrop θα δημιουργήσει ένα ασφαλές κλειδί κρυπτογράφησης για αυτή την πηγή την επόμενη φορά που θα συνδεθεί. Μόλις δημιουργηθεί το κλειδί, θα εμφανιστεί ένα πεδίο απάντησης κάτω από την συλλογή εγγράφων του/της. Μπορείτε να χρησιμοποιήσετε αυτό το πεδίο για να του/της γράψετε κρυπτογραφημένες απαντήσεις."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Συνέχεια στην λίστα εγγράφων του/της {codename}..."
 
 msgid "Download Unread"
 msgstr "Κατέβασμα μη αναγνωσμένων"
@@ -845,15 +834,6 @@ msgstr "Εμφάνιση"
 msgid "Hide"
 msgstr "Απόκρυψη"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Συγγνώμη που δεν έχουμε απαντήσει ακόμα!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "Το SecureDrop μας είχε μια ξαφνική αύξηση δραστηριότητας πρόσφατα. Για λόγους ασφαλείας, η δημιουργία διαύλου επικοινωνίας καθυστερήθηκε μέχρι να ξανασυνδεθείτε."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Επιβεβαιώνουμε ότι μπορέσαμε να κατεβάσουμε την καταχώρησή σας. Ελέγξτε ξανά αργότερα για κάποια απάντηση."
-
 msgid "Submit Files or Messages"
 msgstr "Υποβολή αρχείων ή μηνυμάτων"
 
@@ -977,6 +957,36 @@ msgstr "<strong>Σημαντικό:</strong> Αν επιθυμείτε να δι
 
 msgid "Back to submission page"
 msgstr "Πίσω στη σελίδα υποβολών"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Σημειώσατε αυτή την πηγή για απάντηση."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Πατήστε παρακάτω αν θέλετε να γράψετε μια απάντηση στην πηγή."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "ΣΗΜΕΙΩΣΗ ΠΗΓΗΣ ΓΙΑ ΑΠΑΝΤΗΣΗ"
+
+#~ msgid "info icon"
+#~ msgstr "εικονίδιο πληροφοριών"
+
+#~ msgid "Thanks!"
+#~ msgstr "Ευχαριστούμε!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "Το SecureDrop θα δημιουργήσει ένα ασφαλές κλειδί κρυπτογράφησης για αυτή την πηγή την επόμενη φορά που θα συνδεθεί. Μόλις δημιουργηθεί το κλειδί, θα εμφανιστεί ένα πεδίο απάντησης κάτω από την συλλογή εγγράφων του/της. Μπορείτε να χρησιμοποιήσετε αυτό το πεδίο για να του/της γράψετε κρυπτογραφημένες απαντήσεις."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Συνέχεια στην λίστα εγγράφων του/της {codename}..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Συγγνώμη που δεν έχουμε απαντήσει ακόμα!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "Το SecureDrop μας είχε μια ξαφνική αύξηση δραστηριότητας πρόσφατα. Για λόγους ασφαλείας, η δημιουργία διαύλου επικοινωνίας καθυστερήθηκε μέχρι να ξανασυνδεθείτε."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Επιβεβαιώνουμε ότι μπορέσαμε να κατεβάσουμε την καταχώρησή σας. Ελέγξτε ξανά αργότερα για κάποια απάντηση."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/es_ES/LC_MESSAGES/messages.po
+++ b/securedrop/translations/es_ES/LC_MESSAGES/messages.po
@@ -62,7 +62,7 @@ msgid "Image updated."
 msgstr "Imagen actualizada."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -118,8 +118,12 @@ msgstr "Nada Seleccionado"
 msgid "You must select one or more items."
 msgstr "Debes seleccionar uno o más ítems."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Tu descarga falló porque un archivo no pudo ser encontrado. Un administrador puede encontrar más información en los registros de sistema y monitoreo."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Tu descarga falló porque un archivo no pudo ser encontrado. Un administrador puede encontrar más información en los registros de sistema y monitoreo."
+msgstr[1] "Tu descarga falló porque un archivo no pudo ser encontrado. Un administrador puede encontrar más información en los registros de sistema y monitoreo."
 
 msgid "Only admins can access this page."
 msgstr "Solo administradores pueden acceder a esta página."
@@ -191,7 +195,10 @@ msgstr[1] "{num} ítems han sido borrados."
 msgid "No collections selected for deletion."
 msgstr "No hay colecciones seleccionadas para eliminar."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "La cuenta y todos los datos de {n} fuente han sido eliminados."
 msgstr[1] "Las cuentas y todos los datos de {n} fuentes han sido eliminados."
@@ -472,17 +479,11 @@ msgstr "No hay envíos que mostrar."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Puedes escribir una respuesta segura a la persona que envió estos mensajes y/o archivos:"
 
-msgid "You've flagged this source for reply."
-msgstr "Has marcado esta fuente para responder."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Una llave de cifrado se generará para la fuente la próxima vez que ésta se conecte, después de lo cual podrás responderle desde aquí."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Haz clic abajo si deseas escribir una respuesta a esta fuente."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "MARCAR ESTA FUENTE PARA RESPONDER"
 
 msgid "Delete Source Account"
 msgstr "Eliminar Cuenta de Fuente"
@@ -608,18 +609,6 @@ msgstr "Restablecer autenticación de dos factores para llaves de seguridad como
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "RESTABLECER CREDENCIALES DE CLAVE DE SEGURIDAD"
-
-msgid "info icon"
-msgstr "ícono de Información"
-
-msgid "Thanks!"
-msgstr "¡Gracias!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop generará una llave de cifrado segura para esta fuente la próxima vez que inicie sesión. Una vez que la llave sea generada, un cuadro de respuesta aparecerá debajo de la colección de sus documentos. Puedes utilizar este cuadro para escribirle respuestas cifradas."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Continuar a la lista de documentos para {codename}..."
 
 msgid "Download Unread"
 msgstr "Descargar No Leídos"
@@ -846,15 +835,6 @@ msgstr "Mostrar"
 msgid "Hide"
 msgstr "Esconder"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "¡Sentimos no haber respondido todavía!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "Nuestro SecureDrop experimentó recientemente un pico de actividad. Por razones de seguridad, la creación de un canal de comunicación de doble vía fue demorada hasta que hayas iniciado sesión nuevamente."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Por favor quédate tranquilo que hemos podido descargar tu envío, y vuelve a comprobar más tarde por una respuesta."
-
 msgid "Submit Files or Messages"
 msgstr "Enviar Archivos o Mensajes"
 
@@ -978,6 +958,36 @@ msgstr "<strong>Importante:</strong> Si deseas permanecer anónimo, <strong>no</
 
 msgid "Back to submission page"
 msgstr "Regresar a la página de envío"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Has marcado esta fuente para responder."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Haz clic abajo si deseas escribir una respuesta a esta fuente."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "MARCAR ESTA FUENTE PARA RESPONDER"
+
+#~ msgid "info icon"
+#~ msgstr "ícono de Información"
+
+#~ msgid "Thanks!"
+#~ msgstr "¡Gracias!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop generará una llave de cifrado segura para esta fuente la próxima vez que inicie sesión. Una vez que la llave sea generada, un cuadro de respuesta aparecerá debajo de la colección de sus documentos. Puedes utilizar este cuadro para escribirle respuestas cifradas."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Continuar a la lista de documentos para {codename}..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "¡Sentimos no haber respondido todavía!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "Nuestro SecureDrop experimentó recientemente un pico de actividad. Por razones de seguridad, la creación de un canal de comunicación de doble vía fue demorada hasta que hayas iniciado sesión nuevamente."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Por favor quédate tranquilo que hemos podido descargar tu envío, y vuelve a comprobar más tarde por una respuesta."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/securedrop/translations/fr_FR/LC_MESSAGES/messages.po
@@ -62,7 +62,7 @@ msgid "Image updated."
 msgstr "L’image a été mise à jour."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -118,8 +118,12 @@ msgstr "Rien n’a été sélectionné"
 msgid "You must select one or more items."
 msgstr "Vous devez sélectionner un ou plusieurs éléments."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Votre téléchargement a échoué, car un fichier est introuvable. Un administrateur peut trouver de plus amples renseignements dans les journaux du système et dans les journaux de suivi."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Votre téléchargement a échoué, car un fichier est introuvable. Un administrateur peut trouver de plus amples renseignements dans les journaux du système et dans les journaux de suivi."
+msgstr[1] "Votre téléchargement a échoué, car un fichier est introuvable. Un administrateur peut trouver de plus amples renseignements dans les journaux du système et dans les journaux de suivi."
 
 msgid "Only admins can access this page."
 msgstr "Seuls les administrateurs peuvent accéder à cette page."
@@ -191,7 +195,10 @@ msgstr[1] "{num} éléments ont été supprimés."
 msgid "No collections selected for deletion."
 msgstr "Aucune collection n’a été sélectionnée pour être supprimée."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "Le compte et toutes les données de {n} source ont été supprimés."
 msgstr[1] "Le compte et toutes les données de {n} sources ont été supprimés."
@@ -472,17 +479,11 @@ msgstr "Il n’y a aucun envoi à afficher."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Vous pouvez écrire une réponse sécurisée à la personne qui a envoyé ces messages ou fichiers :"
 
-msgid "You've flagged this source for reply."
-msgstr "Vous avez balisé cette source pour y répondre."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Une clé de chiffrement sera générée pour la source la prochaine fois qu’elle se connectera, après quoi vous serez en mesure de lui répondre ici."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Cliquez ci-dessous si vous souhaitez rédiger une réponse pour cette source."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "BALISER CETTE SOURCE POUR LUI RÉPONDRE"
 
 msgid "Delete Source Account"
 msgstr "Supprimer le compte source"
@@ -608,18 +609,6 @@ msgstr "Réinitialiser l’A2F pour les clés de sécurité telles que la YubiKe
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "RÉINITIALISER LES AUTHENTIFIANTS DE LA CLÉ DE SÉCURITÉ"
-
-msgid "info icon"
-msgstr "icône Renseignements"
-
-msgid "Thanks!"
-msgstr "Merci !"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop générera une clé de chiffrement sécurisée pour cette source la prochaine fois qu’elle se connectera. Lorsque la clé aura été générée, une boîte de réponse apparaîtra sous la collection de documents de la source. Vous pourrez utiliser cette boîte de dialogue pour lui écrire des messages chiffrés."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Continuer vers la liste de documents de {codename}…"
 
 msgid "Download Unread"
 msgstr "Télécharger les non lus"
@@ -846,15 +835,6 @@ msgstr "Afficher"
 msgid "Hide"
 msgstr "Cacher"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Nous sommes désolés de ne pas avoir encore répondu."
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "Notre SecureDrop a récemment connu une poussée d’activité. Pour des raisons de sécurité, la création d’une voie de communication bidirectionnelle a été retardée jusqu’à ce que vous vous reconnectiez."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Soyez assuré que nous avons pu télécharger votre envoi. Veuillez vérifier la présence d’une réponse ultérieurement."
-
 msgid "Submit Files or Messages"
 msgstr "Envoyer des fichiers ou des messages"
 
@@ -978,6 +958,36 @@ msgstr "<strong>Important :</strong> Si vous souhaitez rester anonyme, <strong>
 
 msgid "Back to submission page"
 msgstr "Revenir à la page d'envoi"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Vous avez balisé cette source pour y répondre."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Cliquez ci-dessous si vous souhaitez rédiger une réponse pour cette source."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "BALISER CETTE SOURCE POUR LUI RÉPONDRE"
+
+#~ msgid "info icon"
+#~ msgstr "icône Renseignements"
+
+#~ msgid "Thanks!"
+#~ msgstr "Merci !"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop générera une clé de chiffrement sécurisée pour cette source la prochaine fois qu’elle se connectera. Lorsque la clé aura été générée, une boîte de réponse apparaîtra sous la collection de documents de la source. Vous pourrez utiliser cette boîte de dialogue pour lui écrire des messages chiffrés."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Continuer vers la liste de documents de {codename}…"
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Nous sommes désolés de ne pas avoir encore répondu."
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "Notre SecureDrop a récemment connu une poussée d’activité. Pour des raisons de sécurité, la création d’une voie de communication bidirectionnelle a été retardée jusqu’à ce que vous vous reconnectiez."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Soyez assuré que nous avons pu télécharger votre envoi. Veuillez vérifier la présence d’une réponse ultérieurement."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/hi/LC_MESSAGES/messages.po
+++ b/securedrop/translations/hi/LC_MESSAGES/messages.po
@@ -61,7 +61,7 @@ msgid "Image updated."
 msgstr "छवि अपडेट की गई है।"
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -117,8 +117,12 @@ msgstr "कुछ भी चयनित नहीं"
 msgid "You must select one or more items."
 msgstr "आपको एक या अधिक आइटम का चयन करना होगा।"
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "फ़ाइल डाउनलोड नहीं हो पाने के कारण आपका डाउनलोड विफल रहा। एक व्यवस्थापक सिस्टम और निगरानी लॉग में अधिक जानकारी पा सकता है।"
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "फ़ाइल डाउनलोड नहीं हो पाने के कारण आपका डाउनलोड विफल रहा। एक व्यवस्थापक सिस्टम और निगरानी लॉग में अधिक जानकारी पा सकता है।"
+msgstr[1] "फ़ाइल डाउनलोड नहीं हो पाने के कारण आपका डाउनलोड विफल रहा। एक व्यवस्थापक सिस्टम और निगरानी लॉग में अधिक जानकारी पा सकता है।"
 
 msgid "Only admins can access this page."
 msgstr "केवल व्यवस्थापक ही इस पृष्ठ को एक्सेस कर सकते हैं।"
@@ -190,7 +194,10 @@ msgstr[1] "{num} आइटम हटा दिए गए हैं।"
 msgid "No collections selected for deletion."
 msgstr "हटाए जाने के लिए कोई संग्रह नहीं चुना गया।"
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "खाता और {n} स्रोत के सभी डेटा हटा दिए गए हैं।"
 msgstr[1] "{n} स्रोतों के खाते और सभी डेटा हटा दिए गए हैं।"
@@ -471,17 +478,11 @@ msgstr "प्रदर्शित करने के लिए कोई स�
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "आप इन दस्तावेजों को सबमिट करने वाले व्यक्ति को एक सुरक्षित उत्तर लिख सकते हैं:"
 
-msgid "You've flagged this source for reply."
-msgstr "आपने उत्तर के लिए इस स्रोत को चिह्नित किया है |"
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "अगली बार जब वे लॉग इन करते हैं, तो स्रोत के लिए एक एन्क्रिप्शन कुंजी उत्पन्न होगी, जिसके बाद आप यहां स्रोत को जवाब दे पाएंगे।"
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "यदि आप इस स्रोत को उत्तर लिखना चाहते हैं तो नीचे क्लिक करें।"
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "उत्तर के लिए इस स्रोत को फ़्लैग करें"
 
 msgid "Delete Source Account"
 msgstr "स्रोत खाता हटाएं"
@@ -607,18 +608,6 @@ msgstr "सुरक्षा कुंजी जैसे YubiKey के द्
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "सुरक्षा कुंजी क्रेडेंशियल्स रीसेट"
-
-msgid "info icon"
-msgstr ""
-
-msgid "Thanks!"
-msgstr "धन्यवाद!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "सेक्योरड्राप इस स्रोत के लिए एक सुरक्षित एन्क्रिप्शन कुंजी उत्पन्न करेगा, अगली बार जब वे लॉग इन करेंगे। एक बार कुंजी उत्पन्न हो जाने के बाद, एक दस्तावेज के संग्रह के तहत एक उत्तर बॉक्स दिखाई देगा। आप इस बॉक्स को उनसे एन्क्रिप्शन कए गए उत्तर लिखने के लिए उपयोग कर सकते हैं।"
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "{codename} के लिए दस्तावेज़ों की सूची पर जारी रखें..."
 
 msgid "Download Unread"
 msgstr "न पढ़े मसाज डाउनलोड करें"
@@ -845,15 +834,6 @@ msgstr "दिखाएं"
 msgid "Hide"
 msgstr "छुपाएं"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "क्षमा करें, हमने अभी तक कोई प्रतिक्रिया नहीं दी है!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "हमारे SecureDrop ने हाल ही में गतिविधि में वृद्धि का अनुभव किया। सुरक्षा कारणों से, जब तक आप फिर से जाँच नहीं करते, तब तक दो-तरफ़ा संचार चैनल के निर्माण में देरी हो रही थी।"
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "कृपया निश्चिंत रहें कि हम आपका सबमिशन डाउनलोड करने में सक्षम थे, और उत्तर के लिए बाद में फिर से जाँच करेंगे।"
-
 msgid "Submit Files or Messages"
 msgstr "फ़ाइलें या संदेश जमा करें"
 
@@ -977,6 +957,33 @@ msgstr "<strong>महत्वपूर्ण:</strong> यदि आप गु
 
 msgid "Back to submission page"
 msgstr "सबमिशन पृष्ठ पर वापस जाएं"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "आपने उत्तर के लिए इस स्रोत को चिह्नित किया है |"
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "यदि आप इस स्रोत को उत्तर लिखना चाहते हैं तो नीचे क्लिक करें।"
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "उत्तर के लिए इस स्रोत को फ़्लैग करें"
+
+#~ msgid "Thanks!"
+#~ msgstr "धन्यवाद!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "सेक्योरड्राप इस स्रोत के लिए एक सुरक्षित एन्क्रिप्शन कुंजी उत्पन्न करेगा, अगली बार जब वे लॉग इन करेंगे। एक बार कुंजी उत्पन्न हो जाने के बाद, एक दस्तावेज के संग्रह के तहत एक उत्तर बॉक्स दिखाई देगा। आप इस बॉक्स को उनसे एन्क्रिप्शन कए गए उत्तर लिखने के लिए उपयोग कर सकते हैं।"
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "{codename} के लिए दस्तावेज़ों की सूची पर जारी रखें..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "क्षमा करें, हमने अभी तक कोई प्रतिक्रिया नहीं दी है!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "हमारे SecureDrop ने हाल ही में गतिविधि में वृद्धि का अनुभव किया। सुरक्षा कारणों से, जब तक आप फिर से जाँच नहीं करते, तब तक दो-तरफ़ा संचार चैनल के निर्माण में देरी हो रही थी।"
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "कृपया निश्चिंत रहें कि हम आपका सबमिशन डाउनलोड करने में सक्षम थे, और उत्तर के लिए बाद में फिर से जाँच करेंगे।"
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/is/LC_MESSAGES/messages.po
+++ b/securedrop/translations/is/LC_MESSAGES/messages.po
@@ -61,7 +61,7 @@ msgid "Image updated."
 msgstr "Mynd var uppfærð."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -117,8 +117,12 @@ msgstr "Ekkert valið"
 msgid "You must select one or more items."
 msgstr "Þú verður að velja eitt eða fleiri atriði."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Niðurhalið þitt mistókst vegna þess að skrá fannst ekki. Stjórnandi getur fundið ítarlegri upplýsingar í kerfinu og vöktunarskrám."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Niðurhalið þitt mistókst vegna þess að skrá fannst ekki. Stjórnandi getur fundið ítarlegri upplýsingar í kerfinu og vöktunarskrám."
+msgstr[1] "Niðurhalið þitt mistókst vegna þess að skrá fannst ekki. Stjórnandi getur fundið ítarlegri upplýsingar í kerfinu og vöktunarskrám."
 
 msgid "Only admins can access this page."
 msgstr "Einungis stjórnendur fá aðgang að þessari síðu."
@@ -190,7 +194,10 @@ msgstr[1] "{num} atriðum hefur verið eytt."
 msgid "No collections selected for deletion."
 msgstr "Engin söfn valin til eyðingar."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "Notandaaðgangur og öllum gögnum {n} heimildarmanns hefur verið eytt."
 msgstr[1] "Notandaaðgangur og öllum gögnum {n} heimildarmanna hefur verið eytt."
@@ -471,17 +478,11 @@ msgstr "Engar innsendingar til að birta."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Þú getur skrifað öruggt svar til aðilans sem sendi inn þessi skilaboð og/eða skjöl:"
 
-msgid "You've flagged this source for reply."
-msgstr "Þú hefur merkt við að þú ætlir að svara þessum heimildarmanni."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Dulritunarlykill verður útbúinn fyrir heimildarmanninn næst þegar hán skráir sig inn; eftir það muntu geta svarað heimildarmanninum hér."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Smelltu hér fyrir neðan ef þú vilt skrifa svar til þessa heimildarmanns."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "MERKJA ÞENNAN HEIMILDARMANN TIL AÐ SVARA"
 
 msgid "Delete Source Account"
 msgstr "Eyða notandaaðgangi heimildarmanns"
@@ -607,18 +608,6 @@ msgstr "Endurstilla tvíþátta auðkenningu fyrir öryggislykla, eins og t.d. Y
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "ENDURSTILLA AUÐKENNI ÖRYGGISLYKILS"
-
-msgid "info icon"
-msgstr "tákn fyrir upplýsingar"
-
-msgid "Thanks!"
-msgstr "Takk!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop mun útbúa öruggan dulritunarlykil fyrir þennan heimildarmann næst þegar hán skráir sig inn. Eftir að dulritunarlykillinn hefur verið útbúinn, mun birtast svarreitur undir skjalasafninu háns. Þú getur notað þennan reit til að skrifa dulrituð svör til háns."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Halda áfram í lista yfir skjöl fyrir {codename}..."
 
 msgid "Download Unread"
 msgstr "Niðurhal ólesið"
@@ -845,15 +834,6 @@ msgstr "Sýna"
 msgid "Hide"
 msgstr "Fela"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Biðjumst velvirðingar á að hafa ekki svarað!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "SecureDrop-netþjónar okkar urðu nýlega varir við mikla aukningu á virkni. Af öryggisástæðum var beðið með að koma á gagnkvæmum samskiptum þar til þú myndir skrá þig inn aftur."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Ekki hafa neinar áhyggjur, við náðum að sækja innsendinguna þína og þú ættir því að skrá þig aftur inn síðar til að athuga með svar frá okkur."
-
 msgid "Submit Files or Messages"
 msgstr "Senda inn skrár eða skilaboð"
 
@@ -977,6 +957,36 @@ msgstr "<strong>Mikilvægt:</strong> Ef þú óskar áframhaldandi nafnleyndar, 
 
 msgid "Back to submission page"
 msgstr "Til baka á innsendingasíðuna"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Þú hefur merkt við að þú ætlir að svara þessum heimildarmanni."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Smelltu hér fyrir neðan ef þú vilt skrifa svar til þessa heimildarmanns."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "MERKJA ÞENNAN HEIMILDARMANN TIL AÐ SVARA"
+
+#~ msgid "info icon"
+#~ msgstr "tákn fyrir upplýsingar"
+
+#~ msgid "Thanks!"
+#~ msgstr "Takk!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop mun útbúa öruggan dulritunarlykil fyrir þennan heimildarmann næst þegar hán skráir sig inn. Eftir að dulritunarlykillinn hefur verið útbúinn, mun birtast svarreitur undir skjalasafninu háns. Þú getur notað þennan reit til að skrifa dulrituð svör til háns."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Halda áfram í lista yfir skjöl fyrir {codename}..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Biðjumst velvirðingar á að hafa ekki svarað!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "SecureDrop-netþjónar okkar urðu nýlega varir við mikla aukningu á virkni. Af öryggisástæðum var beðið með að koma á gagnkvæmum samskiptum þar til þú myndir skrá þig inn aftur."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Ekki hafa neinar áhyggjur, við náðum að sækja innsendinguna þína og þú ættir því að skrá þig aftur inn síðar til að athuga með svar frá okkur."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/it_IT/LC_MESSAGES/messages.po
+++ b/securedrop/translations/it_IT/LC_MESSAGES/messages.po
@@ -65,7 +65,7 @@ msgid "Image updated."
 msgstr "Immagine aggiornata."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -121,8 +121,12 @@ msgstr "Nessun oggetto selezionato"
 msgid "You must select one or more items."
 msgstr "È necessario selezionare uno o più oggetti."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Lo scaricamento non è riuscito perché un file non è stato trovato. Un amministratore può avere maggiori informazioni sul sistema e monitorare i log."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Lo scaricamento non è riuscito perché un file non è stato trovato. Un amministratore può avere maggiori informazioni sul sistema e monitorare i log."
+msgstr[1] "Lo scaricamento non è riuscito perché un file non è stato trovato. Un amministratore può avere maggiori informazioni sul sistema e monitorare i log."
 
 msgid "Only admins can access this page."
 msgstr "Solo gli amministratori possono accedere a questa pagina."
@@ -194,7 +198,10 @@ msgstr[1] "{num} oggetti sono stati eliminati."
 msgid "No collections selected for deletion."
 msgstr "Nessun archivio è stato selezionato per essere eliminato."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "L'account è tutti i dati di {n} fonte sono stati eliminati."
 msgstr[1] "Gli account è tutti i dati di {n} fonti sono stati eliminati."
@@ -475,17 +482,11 @@ msgstr "Non ci sono invii da visualizzare."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Puoi scrivere una risposta sicura alla persona che ha inviato questi messaggi e/o file:"
 
-msgid "You've flagged this source for reply."
-msgstr "Hai contrassegnato questa fonte per fornire una risposta."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Una chiave di cifratura sarà generata per la fonte la prossima volta che eseguirà l'accesso, dopodiché potrai rispondere qui."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Fare clic qui sotto per scrivere una risposta a questa fonte."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "CONTRASSEGNA QUESTA FONTE PER UNA RISPOSTA"
 
 msgid "Delete Source Account"
 msgstr "Elimina l'account della fonte"
@@ -611,18 +612,6 @@ msgstr "Ripristina l'autenticazione a due fattori per le chiavi di sicurezza, co
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "RIPRISTINA CREDENZIALI CHIAVI DI SICUREZZA"
-
-msgid "info icon"
-msgstr "icona info"
-
-msgid "Thanks!"
-msgstr "Grazie!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop genererà una chiave di cifratura sicura per la fonte la prossima volta che eseguirà l'accesso. Una volta che la chiave è stata generata, apparirà una casella di risposta sotto l'archivio di documenti. È possibile usare questa casella per scrivere le risposte cifrate."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Continua all'elenco dei documenti di {codename}..."
 
 msgid "Download Unread"
 msgstr "Scarica non letti"
@@ -849,15 +838,6 @@ msgstr "Mostra"
 msgid "Hide"
 msgstr "Nascondi"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Non c'è ancora alcuna risposta!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "SecureDrop ha recentemente registrato un sovraccarico di attività. Per motivi di sicurezza, la creazione di un canale di comunicazione bidirezionale è stata posticipata fino a quando non verrà eseguito un nuovo accesso."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Assicuriamo che quanto inviato è stato scaricato. Verificare nuovamente in un secondo momento la presenza di una risposta."
-
 msgid "Submit Files or Messages"
 msgstr "Invia file o messaggi"
 
@@ -981,6 +961,36 @@ msgstr "<strong>Importante:</strong> per rimanere anonimi <strong>non usare</str
 
 msgid "Back to submission page"
 msgstr "Torna alla pagina di invio documenti e messaggi"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Hai contrassegnato questa fonte per fornire una risposta."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Fare clic qui sotto per scrivere una risposta a questa fonte."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "CONTRASSEGNA QUESTA FONTE PER UNA RISPOSTA"
+
+#~ msgid "info icon"
+#~ msgstr "icona info"
+
+#~ msgid "Thanks!"
+#~ msgstr "Grazie!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop genererà una chiave di cifratura sicura per la fonte la prossima volta che eseguirà l'accesso. Una volta che la chiave è stata generata, apparirà una casella di risposta sotto l'archivio di documenti. È possibile usare questa casella per scrivere le risposte cifrate."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Continua all'elenco dei documenti di {codename}..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Non c'è ancora alcuna risposta!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "SecureDrop ha recentemente registrato un sovraccarico di attività. Per motivi di sicurezza, la creazione di un canale di comunicazione bidirezionale è stata posticipata fino a quando non verrà eseguito un nuovo accesso."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Assicuriamo che quanto inviato è stato scaricato. Verificare nuovamente in un secondo momento la presenza di una risposta."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -14,7 +14,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.5.1\n"
+"Generated-By: Babel 2.9.1\n"
 
 msgid "Name too long"
 msgstr ""
@@ -55,7 +55,7 @@ msgid "Image updated."
 msgstr ""
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -107,8 +107,10 @@ msgstr ""
 msgid "You must select one or more items."
 msgstr ""
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr ""
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Only admins can access this page."
 msgstr ""
@@ -178,7 +180,7 @@ msgstr[1] ""
 msgid "No collections selected for deletion."
 msgstr ""
 
-msgid "The account and all data for {n} source have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] ""
 msgstr[1] ""
@@ -459,16 +461,10 @@ msgstr ""
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr ""
 
-msgid "You've flagged this source for reply."
+msgid "This source has no encryption key."
 msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
-msgstr ""
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr ""
-
-msgid "FLAG THIS SOURCE FOR REPLY"
 msgstr ""
 
 msgid "Delete Source Account"
@@ -594,18 +590,6 @@ msgid "Reset two-factor authentication for security keys, like a YubiKey"
 msgstr ""
 
 msgid "RESET SECURITY KEY CREDENTIALS"
-msgstr ""
-
-msgid "info icon"
-msgstr ""
-
-msgid "Thanks!"
-msgstr ""
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr ""
-
-msgid "Continue to the list of documents for {codename}..."
 msgstr ""
 
 msgid "Download Unread"
@@ -828,15 +812,6 @@ msgid "Show"
 msgstr ""
 
 msgid "Hide"
-msgstr ""
-
-msgid "Sorry we haven't responded yet!"
-msgstr ""
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr ""
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
 msgstr ""
 
 msgid "Submit Files or Messages"

--- a/securedrop/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/securedrop/translations/nb_NO/LC_MESSAGES/messages.po
@@ -62,7 +62,7 @@ msgid "Image updated."
 msgstr "Bilde oppdatert."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -118,8 +118,12 @@ msgstr "Ingenting valgt"
 msgid "You must select one or more items."
 msgstr "Du må velge ett eller flere elementer."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Nedlastingen mislyktes fordi en fil ikke ble funnet. En administrator kan finne detaljer om feilen i system- og driftsloggene."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Nedlastingen mislyktes fordi en fil ikke ble funnet. En administrator kan finne detaljer om feilen i system- og driftsloggene."
+msgstr[1] "Nedlastingen mislyktes fordi en fil ikke ble funnet. En administrator kan finne detaljer om feilen i system- og driftsloggene."
 
 msgid "Only admins can access this page."
 msgstr "Kun administratorer har tilgang til denne siden."
@@ -191,7 +195,10 @@ msgstr[1] "{num} elementer har blitt slettet."
 msgid "No collections selected for deletion."
 msgstr "Ingen kildeoppføringer valgt for sletting."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "Kontoen og dataene knyttet til {n} kilde har blitt slettet."
 msgstr[1] "Kontoene og dataene knyttet til {n} kilder har blitt slettet."
@@ -472,17 +479,11 @@ msgstr "Ingen bidragene å vise."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Du kan skrive et sikkert svar til personen som sendte inn disse meldingene og/eller filene:"
 
-msgid "You've flagged this source for reply."
-msgstr "Du har markert denne kilden for å kunne sende et svar til personen."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Neste gang kilden logger seg inn med kodeordet sitt vil det bli laget en krypteringsnøkkel. Dette vil gjøre at du deretter kan skrive et svar til kilden her."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Klikk her, om du ønsker skrive et svar til kilden."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "MARKER DENNE KILDEN FOR Å SVARE"
 
 msgid "Delete Source Account"
 msgstr "Slett kilde-konto"
@@ -608,18 +609,6 @@ msgstr "Tilbakestill tofaktoroppsett for sikkerhetsnøkler, som YubiKey"
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "Tilbakestill identitetsdetaljer fra sikkerhetsnøkkel"
-
-msgid "info icon"
-msgstr "info-ikon"
-
-msgid "Thanks!"
-msgstr "Takk."
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop vil generere en sikker krypteringsnøkkel for denne kilden neste gang de logger inn. Når nøkkelen har blitt opprettet, vil en svarboks bli synlig i kildeoppføringene av innsendelsene deres. Du kan da bruke denne boksen for å sende krypterte tilbakemeldinger til dem."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Fortsett til listen over innsendelser fra {codename}…"
 
 msgid "Download Unread"
 msgstr "Last ned uleste"
@@ -846,15 +835,6 @@ msgstr "Vis"
 msgid "Hide"
 msgstr "Skjul"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Beklager at vi ikke har svart enda!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "Vår SecureDrop har nylig hatt en kraftig økning i aktivitet. Av hensyn til sikkerheten, ble muligheten for toveis-kommunikasjon utsatt til neste gang du logger inn."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Du skal likevel vite at vi har kunnet laste ned det du sendte. Kom innom senere for å se etter nye svar."
-
 msgid "Submit Files or Messages"
 msgstr "Send inn filer eller meldinger"
 
@@ -978,6 +958,36 @@ msgstr "<strong>Viktig:</strong> Om du ønsker å være helt anonym, <strong>ikk
 
 msgid "Back to submission page"
 msgstr "Tilbake til innsendelsesside"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Du har markert denne kilden for å kunne sende et svar til personen."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Klikk her, om du ønsker skrive et svar til kilden."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "MARKER DENNE KILDEN FOR Å SVARE"
+
+#~ msgid "info icon"
+#~ msgstr "info-ikon"
+
+#~ msgid "Thanks!"
+#~ msgstr "Takk."
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop vil generere en sikker krypteringsnøkkel for denne kilden neste gang de logger inn. Når nøkkelen har blitt opprettet, vil en svarboks bli synlig i kildeoppføringene av innsendelsene deres. Du kan da bruke denne boksen for å sende krypterte tilbakemeldinger til dem."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Fortsett til listen over innsendelser fra {codename}…"
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Beklager at vi ikke har svart enda!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "Vår SecureDrop har nylig hatt en kraftig økning i aktivitet. Av hensyn til sikkerheten, ble muligheten for toveis-kommunikasjon utsatt til neste gang du logger inn."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Du skal likevel vite at vi har kunnet laste ned det du sendte. Kom innom senere for å se etter nye svar."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/nl/LC_MESSAGES/messages.po
+++ b/securedrop/translations/nl/LC_MESSAGES/messages.po
@@ -62,7 +62,7 @@ msgid "Image updated."
 msgstr "Afbeelding bijgewerkt."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -118,8 +118,12 @@ msgstr "Niets geselecteerd"
 msgid "You must select one or more items."
 msgstr "U moet één of meerdere elementen selecteren."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Uw download is mislukt omdat een bestand niet kon worden gevonden. Een administrator kan meer informatie vinden in de systeem en monitoring logs."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Uw download is mislukt omdat een bestand niet kon worden gevonden. Een administrator kan meer informatie vinden in de systeem en monitoring logs."
+msgstr[1] "Uw download is mislukt omdat een bestand niet kon worden gevonden. Een administrator kan meer informatie vinden in de systeem en monitoring logs."
 
 msgid "Only admins can access this page."
 msgstr "Alleen beheerders hebben toegang tot deze pagina."
@@ -191,7 +195,10 @@ msgstr[1] "Alle {num} items zijn verwijderd."
 msgid "No collections selected for deletion."
 msgstr "Geen collecties geselecteerd om te verwijderen."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "Het account en alle data van {n} bron zijn verwijderd."
 msgstr[1] "De accounts en alle data van de {n} bronnen zijn verwijderd."
@@ -472,17 +479,11 @@ msgstr "Geen inzendingen om te tonen."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "U kunt beveiligd reageren naar de persoon die deze berichten en/of bestanden gestuurd heeft:"
 
-msgid "You've flagged this source for reply."
-msgstr "U heeft deze bron gemarkeerd om te reageren."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Er wordt een encryptiesleutel gegenereerd voor de bron en wanneer deze de volgende keer inlogt, kunt u daarna hier reageren naar de bron."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Klik hieronder indien u wilt reageren naar deze bron."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "MARKEER DEZE BRON OM TE REAGEREN"
 
 msgid "Delete Source Account"
 msgstr "Verwijder bronaccount"
@@ -608,18 +609,6 @@ msgstr "Reset tweefactorauthenticatie voor beveiligingssleutels, zoals YubiKeys"
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "HERSTEL INSTELLINGEN VOOR BEVEILIGINGSSLEUTEL"
-
-msgid "info icon"
-msgstr "info icoon"
-
-msgid "Thanks!"
-msgstr "Bedankt!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop zal de volgende keer dat de bron inlogt een veilige encryptiesleutel genereren. Zodra de sleutel is gegenereerd zal er een antwoordvakje verschijnen onder hun collectie documenten. U kunt dit vakje gebruiken om versleutelde antwoorden naar hun te versturen."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Ga door naar documentenlijst van {codename}…"
 
 msgid "Download Unread"
 msgstr "Ongelezen downloaden"
@@ -846,15 +835,6 @@ msgstr "Tonen"
 msgid "Hide"
 msgstr "Verbergen"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Sorry dat we nog niet hebben gereageerd!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "Onze SecureDrop heeft onlangs heel wat activiteit gezien. Vanwege veiligheidsredenen is de creatie van een tweezijdig communicatiekanaal uitgesteld totdat u weer ingelogd heeft."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Vrees niet, we hebben uw inzending gedownload. Kom terug op een later moment om te kijken of we een antwoord gestuurd hebben."
-
 msgid "Submit Files or Messages"
 msgstr "Verstuur bestanden of berichten"
 
@@ -978,6 +958,36 @@ msgstr "<strong>Belangrijk:</strong> Als u anoniem wilt blijven, gebruik dan <st
 
 msgid "Back to submission page"
 msgstr "Terug naar inzendingenpagina"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "U heeft deze bron gemarkeerd om te reageren."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Klik hieronder indien u wilt reageren naar deze bron."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "MARKEER DEZE BRON OM TE REAGEREN"
+
+#~ msgid "info icon"
+#~ msgstr "info icoon"
+
+#~ msgid "Thanks!"
+#~ msgstr "Bedankt!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop zal de volgende keer dat de bron inlogt een veilige encryptiesleutel genereren. Zodra de sleutel is gegenereerd zal er een antwoordvakje verschijnen onder hun collectie documenten. U kunt dit vakje gebruiken om versleutelde antwoorden naar hun te versturen."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Ga door naar documentenlijst van {codename}…"
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Sorry dat we nog niet hebben gereageerd!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "Onze SecureDrop heeft onlangs heel wat activiteit gezien. Vanwege veiligheidsredenen is de creatie van een tweezijdig communicatiekanaal uitgesteld totdat u weer ingelogd heeft."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Vrees niet, we hebben uw inzending gedownload. Kom terug op een later moment om te kijken of we een antwoord gestuurd hebben."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/securedrop/translations/pt_BR/LC_MESSAGES/messages.po
@@ -61,7 +61,7 @@ msgid "Image updated."
 msgstr "Imagem atualizada."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -117,8 +117,12 @@ msgstr "Nada foi selecionado"
 msgid "You must select one or more items."
 msgstr "Você deve selecionar um ou mais itens."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "O seu download falhou, porque o arquivo não foi encontrado. Um(a) admin poderá encontrar mais informações no sistema e nos logs de monitoramento."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "O seu download falhou, porque o arquivo não foi encontrado. Um(a) admin poderá encontrar mais informações no sistema e nos logs de monitoramento."
+msgstr[1] "O seu download falhou, porque o arquivo não foi encontrado. Um(a) admin poderá encontrar mais informações no sistema e nos logs de monitoramento."
 
 msgid "Only admins can access this page."
 msgstr "Apenas administradores podem acessar esta página."
@@ -190,7 +194,10 @@ msgstr[1] "{num} itens foram apagados."
 msgid "No collections selected for deletion."
 msgstr "Nenhuma coleção selecionada para ser apagada."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "A conta e todos os dados de {n} fonte foram apagados."
 msgstr[1] "A conta e todos os dados de {n} fontes foram apagados."
@@ -471,17 +478,11 @@ msgstr "Nenhum envio a exibir."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Você pode escrever uma resposta criptografadas à pessoa que enviou essas mensagens e/ou documentos:"
 
-msgid "You've flagged this source for reply."
-msgstr "Você marcou esta fonte para responder."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Uma chave criptográfica será gerada para esta fonte na próxima vez que ela se conectar. Em seguida, você poderá responder a ela aqui."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Clique abaixo para responder a esta fonte."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "MARCAR ESTA FONTE PARA RESPONDER"
 
 msgid "Delete Source Account"
 msgstr "Apagar a conta da fonte"
@@ -607,18 +608,6 @@ msgstr "Redefinir autenticação de dois fatores (2FA) para chaves de segurança
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "REDEFINIR CREDENCIAIS DE CHAVE DE SEGURANÇA"
-
-msgid "info icon"
-msgstr "ícone Info"
-
-msgid "Thanks!"
-msgstr "Agradecemos!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "O SecureDrop gerará uma chave criptográfica segura para esta fonte na próxima vez que ela se conectar. Quando a chave tiver sido criada, um campo de respostas aparecerá abaixo da sua coleção de documentos. Esse campo de respostas poderá ser usado para redigir mensagens criptografadas para esta fonte."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Acessar a lista de documentos de {codename}..."
 
 msgid "Download Unread"
 msgstr "Baixar Não Lidas"
@@ -844,15 +833,6 @@ msgstr "Mostrar"
 msgid "Hide"
 msgstr "Ocultar"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Desculpas por ainda não termos respondido!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "O nosso SecureDrop passou por um excesso de atividades. Por razões de segurança, a criação de um canal de comunicação entre nós foi adiada até o seu próximo acesso."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Nós confirmamos que fizemos o download do seu envio. Por favor, acesse a sua conta posteriormente para ver a resposta."
-
 msgid "Submit Files or Messages"
 msgstr "Enviar documentos ou mensagens"
 
@@ -976,6 +956,36 @@ msgstr "<strong>Importante:</strong> Para manter o seu anonimato, <strong>não</
 
 msgid "Back to submission page"
 msgstr "Voltar à página de envio"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Você marcou esta fonte para responder."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Clique abaixo para responder a esta fonte."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "MARCAR ESTA FONTE PARA RESPONDER"
+
+#~ msgid "info icon"
+#~ msgstr "ícone Info"
+
+#~ msgid "Thanks!"
+#~ msgstr "Agradecemos!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "O SecureDrop gerará uma chave criptográfica segura para esta fonte na próxima vez que ela se conectar. Quando a chave tiver sido criada, um campo de respostas aparecerá abaixo da sua coleção de documentos. Esse campo de respostas poderá ser usado para redigir mensagens criptografadas para esta fonte."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Acessar a lista de documentos de {codename}..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Desculpas por ainda não termos respondido!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "O nosso SecureDrop passou por um excesso de atividades. Por razões de segurança, a criação de um canal de comunicação entre nós foi adiada até o seu próximo acesso."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Nós confirmamos que fizemos o download do seu envio. Por favor, acesse a sua conta posteriormente para ver a resposta."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/ro/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ro/LC_MESSAGES/messages.po
@@ -62,7 +62,7 @@ msgid "Image updated."
 msgstr "Imaginea a fost actualizată."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -118,8 +118,13 @@ msgstr "Nimic selectat"
 msgid "You must select one or more items."
 msgstr "Trebuie să selectezi unul sau mai multe elemente."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Descărcarea a eșuat deoarece nu a fost găsit un fișier. Un administrator poate găsi mai multe informații în sistem și în jurnalele de monitorizare."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Descărcarea a eșuat deoarece nu a fost găsit un fișier. Un administrator poate găsi mai multe informații în sistem și în jurnalele de monitorizare."
+msgstr[1] "Descărcarea a eșuat deoarece nu a fost găsit un fișier. Un administrator poate găsi mai multe informații în sistem și în jurnalele de monitorizare."
+msgstr[2] "Descărcarea a eșuat deoarece nu a fost găsit un fișier. Un administrator poate găsi mai multe informații în sistem și în jurnalele de monitorizare."
 
 msgid "Only admins can access this page."
 msgstr "Doar administratorii pot accesa această pagină."
@@ -195,7 +200,10 @@ msgstr[2] "Au fost șterse {num} de elemente."
 msgid "No collections selected for deletion."
 msgstr "Nu a fost selectată nicio colecție pentru ștergere."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "Contul și toate datele pentru {n} sursă au fost șterse."
 msgstr[1] "Conturile și toate datele pentru {n} surse au fost șterse."
@@ -480,17 +488,11 @@ msgstr "Nicio trimitere de afișat."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Poți scrie un răspuns securizat persoanei care a trimis aceste mesaje și/sau fișiere:"
 
-msgid "You've flagged this source for reply."
-msgstr "Ai marcat această sursă pentru răspuns."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Sursa va primi o cheie de criptare generată data următoare când se autentifică, după care îi vei putea răspunde aici."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Dă clic mai jos dacă vrei să-i răspunzi acestei surse."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "MARCHEAZĂ ACEASTĂ SURSĂ PENTRU RĂSPUNS"
 
 msgid "Delete Source Account"
 msgstr "Șterge contul de sursă"
@@ -617,18 +619,6 @@ msgstr "Resetează 2FA (autentificarea cu doi factori) pentru chei de securitate
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "RESETEAZĂ DATELE DE AUTENTIFICARE PENTRU CHEIA DE SECURITATE"
-
-msgid "info icon"
-msgstr "pictogramă de informații"
-
-msgid "Thanks!"
-msgstr "Îți mulțumim!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop va genera o cheie de criptare securizată pentru această sursă data viitoare când se va autentifica. După ce a fost generată cheia, sub colecția de documente a sursei va apărea o casetă de răspuns. Poți folosi această casetă pentru a-i scrie răspunsuri criptate."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Deschide lista de documente pentru {codename}..."
 
 msgid "Download Unread"
 msgstr "Descarcă necitite"
@@ -855,15 +845,6 @@ msgstr "Arată"
 msgid "Hide"
 msgstr "Ascunde"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Ne cerem scuze că nu am răspuns încă!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "Am întâmpinat recent un vârf de activitate pe SecureDrop. Din motive de securitate, crearea canalelor de comunicații bidirecționale a fost întârziată până la următoarea ta autentificare."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Te asigurăm că am reușit să descărcăm ce ai trimis. Revino mai târziu pentru un răspuns."
-
 msgid "Submit Files or Messages"
 msgstr "Trimite fișiere sau mesaje"
 
@@ -987,6 +968,36 @@ msgstr "<strong>Important:</strong> Dacă vrei să rămâi anonim(ă), <strong>n
 
 msgid "Back to submission page"
 msgstr "Înapoi la pagina de trimitere"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Ai marcat această sursă pentru răspuns."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Dă clic mai jos dacă vrei să-i răspunzi acestei surse."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "MARCHEAZĂ ACEASTĂ SURSĂ PENTRU RĂSPUNS"
+
+#~ msgid "info icon"
+#~ msgstr "pictogramă de informații"
+
+#~ msgid "Thanks!"
+#~ msgstr "Îți mulțumim!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop va genera o cheie de criptare securizată pentru această sursă data viitoare când se va autentifica. După ce a fost generată cheia, sub colecția de documente a sursei va apărea o casetă de răspuns. Poți folosi această casetă pentru a-i scrie răspunsuri criptate."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Deschide lista de documente pentru {codename}..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Ne cerem scuze că nu am răspuns încă!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "Am întâmpinat recent un vârf de activitate pe SecureDrop. Din motive de securitate, crearea canalelor de comunicații bidirecționale a fost întârziată până la următoarea ta autentificare."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Te asigurăm că am reușit să descărcăm ce ai trimis. Revino mai târziu pentru un răspuns."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/ru/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ru/LC_MESSAGES/messages.po
@@ -62,7 +62,7 @@ msgid "Image updated."
 msgstr "Изображение обновлено."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -118,8 +118,13 @@ msgstr "Ничего не выбрано"
 msgid "You must select one or more items."
 msgstr "Нужно выбрать минимум один элемент."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Загрузка не удалась, поскольку файл не был найден. Администратор может получить более подробную информацию в журналах системы и мониторинга."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Загрузка не удалась, поскольку файл не был найден. Администратор может получить более подробную информацию в журналах системы и мониторинга."
+msgstr[1] "Загрузка не удалась, поскольку файл не был найден. Администратор может получить более подробную информацию в журналах системы и мониторинга."
+msgstr[2] "Загрузка не удалась, поскольку файл не был найден. Администратор может получить более подробную информацию в журналах системы и мониторинга."
 
 msgid "Only admins can access this page."
 msgstr "Только администраторы имеют доступ к этой странице."
@@ -195,7 +200,10 @@ msgstr[2] "{num} элементов были удалены."
 msgid "No collections selected for deletion."
 msgstr "Не выбраны коллекции для удаления."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "Учетная запись и данные для {n} источника были удалены."
 msgstr[1] "Учетные записи и данные для {n} источников были удалены."
@@ -480,17 +488,11 @@ msgstr "Нет отправлений для отображения."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Вы можете написать безопасный ответ пользователю, предоставившему эти сообщения/файлы:"
 
-msgid "You've flagged this source for reply."
-msgstr "Вы отметили этот источник для ответа."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Ключ шифрования будет сгенерирован для источника при следующем входе в систему, после чего вы сможете ответить здесь."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Нажмите ниже, если вы хотите написать ответ этому источнику."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "ОТМЕТИТЬ ЭТОТ ИСТОЧНИК ДЛЯ ОТВЕТА"
 
 msgid "Delete Source Account"
 msgstr "Удалить учетную запись источника"
@@ -617,18 +619,6 @@ msgstr "Сбросить двухэтапную аутентификацию д�
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "СБРОСИТЬ ДОСТУП ЭЛЕКТРОННОГО КЛЮЧА"
-
-msgid "info icon"
-msgstr "значок информации"
-
-msgid "Thanks!"
-msgstr "Спасибо!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop сгенерирует безопасный ключ шифрования для этого источника при следующем входе в систему. После генерации ключа в коллекции документов пользователя появится окно ответа. Вы можете использовать его для написания зашифрованных ответов пользователям."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Перейдите к списку документов для {codename}..."
 
 msgid "Download Unread"
 msgstr "Загрузить непрочитанное"
@@ -855,15 +845,6 @@ msgstr "Показать"
 msgid "Hide"
 msgstr "Скрыть"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Извините, мы еще не ответили!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "На нашем SecureDrop недавно наблюдалась высокая активность. По соображениям безопасности двусторонняя связь приостановлена до повторного входа в систему."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Мы подтверждаем, что нам удалось получить ваши данные. Зайдите позже, чтобы увидеть наш ответ."
-
 msgid "Submit Files or Messages"
 msgstr "Отправить файлы или сообщения"
 
@@ -987,6 +968,36 @@ msgstr "<strong>Внимание:</strong> Если вы хотите сохра
 
 msgid "Back to submission page"
 msgstr "Вернуться на страницу отправки"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Вы отметили этот источник для ответа."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Нажмите ниже, если вы хотите написать ответ этому источнику."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "ОТМЕТИТЬ ЭТОТ ИСТОЧНИК ДЛЯ ОТВЕТА"
+
+#~ msgid "info icon"
+#~ msgstr "значок информации"
+
+#~ msgid "Thanks!"
+#~ msgstr "Спасибо!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop сгенерирует безопасный ключ шифрования для этого источника при следующем входе в систему. После генерации ключа в коллекции документов пользователя появится окно ответа. Вы можете использовать его для написания зашифрованных ответов пользователям."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Перейдите к списку документов для {codename}..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Извините, мы еще не ответили!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "На нашем SecureDrop недавно наблюдалась высокая активность. По соображениям безопасности двусторонняя связь приостановлена до повторного входа в систему."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Мы подтверждаем, что нам удалось получить ваши данные. Зайдите позже, чтобы увидеть наш ответ."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/sk/LC_MESSAGES/messages.po
+++ b/securedrop/translations/sk/LC_MESSAGES/messages.po
@@ -62,7 +62,7 @@ msgid "Image updated."
 msgstr "Obrázok bol aktualizovaný."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -118,8 +118,13 @@ msgstr "Nič nebolo vybrané"
 msgid "You must select one or more items."
 msgstr "Musíte vybrať jednu či viac položiek."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Sťahovanie zlyhalo, pretože súbor sa nenašiel. Administrátor môže nájsť viac informácií v logoch."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Sťahovanie zlyhalo, pretože súbor sa nenašiel. Administrátor môže nájsť viac informácií v logoch."
+msgstr[1] "Sťahovanie zlyhalo, pretože súbor sa nenašiel. Administrátor môže nájsť viac informácií v logoch."
+msgstr[2] "Sťahovanie zlyhalo, pretože súbor sa nenašiel. Administrátor môže nájsť viac informácií v logoch."
 
 msgid "Only admins can access this page."
 msgstr "Táto stránka je prístupná iba pre administrátorov."
@@ -195,7 +200,10 @@ msgstr[2] "{num} položiek bolo zmazaných."
 msgid "No collections selected for deletion."
 msgstr "Žiadne sady neboli vybrané na zmazanie."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "Účet a všetky dáta pre {n} zdroj boli zmazané."
 msgstr[1] "Účet a všetky dáta pre {n} zdroje boli zmazané."
@@ -480,17 +488,11 @@ msgstr "Žiadne podania na zobrazenie."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Môžete napísať bezpečnú odpoveď osobe, ktorá poslala dané správy a/alebo dokumenty:"
 
-msgid "You've flagged this source for reply."
-msgstr "Označili ste tento zdroj na odpoveď."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Keď sa zdroj nabudúce prihlási, bude mu vygenerovaný šifrovací kľúč. Následnete tu budete mať môžnosť zdroju odpovedať."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Pre odpoveď tomuto zdroju kliknite nižšie."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "OZNAČIŤ TENTO ZDROJ NA ODPOVEĎ"
 
 msgid "Delete Source Account"
 msgstr "Zmazať účet zdroja"
@@ -617,18 +619,6 @@ msgstr "Resetovať dvojfaktorovú autentifikáciu pre bezpečnostné kľúče, a
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "RESETOVAŤ PRIHLASOVACIE ÚDAJE BEZPEČNOSTNÉHO KĽÚČA"
-
-msgid "info icon"
-msgstr "ikona info"
-
-msgid "Thanks!"
-msgstr "Vďaka!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "Keď sa tento zdroj nabudúce prihlási, SecureDrop mu vygeneruje zabezpečený šifrovací kľúč. Keď bude kľúč vygenerovaný, pole pre odpoveď sa objaví pod ich sadou dokumentov. Toto pole môžete používať pre písanie zašifrovaných odpovedí."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Pokračujte na zoznam dokumentov pre {codename}..."
 
 msgid "Download Unread"
 msgstr "Stiahnuť neprečítané"
@@ -855,15 +845,6 @@ msgstr "Zobraziť"
 msgid "Hide"
 msgstr "Skryť"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Ospravedlňujeme sa, ešte sme neodpovedali!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "Náš SecureDrop zaznamenal zvýšenú aktivitu. Z bezpečnostných dôvodov bolo vytvorenie obojsmerného komunikačného kanála odložené až do vašeho ďalšieho prihlásenia."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Vaše podanie sa nám podarilo stiahnuť, prosím skontrolujte si našu odpoveď neskôr."
-
 msgid "Submit Files or Messages"
 msgstr "Odovzdať súbory alebo správy"
 
@@ -987,6 +968,36 @@ msgstr "<strong>Dôležité:</strong> Ak chcete zostať v anonymite, <strong>nep
 
 msgid "Back to submission page"
 msgstr "Späť na stránku podania"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Označili ste tento zdroj na odpoveď."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Pre odpoveď tomuto zdroju kliknite nižšie."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "OZNAČIŤ TENTO ZDROJ NA ODPOVEĎ"
+
+#~ msgid "info icon"
+#~ msgstr "ikona info"
+
+#~ msgid "Thanks!"
+#~ msgstr "Vďaka!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "Keď sa tento zdroj nabudúce prihlási, SecureDrop mu vygeneruje zabezpečený šifrovací kľúč. Keď bude kľúč vygenerovaný, pole pre odpoveď sa objaví pod ich sadou dokumentov. Toto pole môžete používať pre písanie zašifrovaných odpovedí."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Pokračujte na zoznam dokumentov pre {codename}..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Ospravedlňujeme sa, ešte sme neodpovedali!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "Náš SecureDrop zaznamenal zvýšenú aktivitu. Z bezpečnostných dôvodov bolo vytvorenie obojsmerného komunikačného kanála odložené až do vašeho ďalšieho prihlásenia."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Vaše podanie sa nám podarilo stiahnuť, prosím skontrolujte si našu odpoveď neskôr."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/sv/LC_MESSAGES/messages.po
+++ b/securedrop/translations/sv/LC_MESSAGES/messages.po
@@ -61,7 +61,7 @@ msgid "Image updated."
 msgstr "Bild uppdaterad."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -117,8 +117,12 @@ msgstr "Inget markerat"
 msgid "You must select one or more items."
 msgstr "Du måste välja ett eller flera meddelanden."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "Din nedladdning misslyckades eftersom filen inte hittades. En administratör kan hitta mer i systemloggarna."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "Din nedladdning misslyckades eftersom filen inte hittades. En administratör kan hitta mer i systemloggarna."
+msgstr[1] "Din nedladdning misslyckades eftersom filen inte hittades. En administratör kan hitta mer i systemloggarna."
 
 msgid "Only admins can access this page."
 msgstr "Endast administratörer har tillgång till denna sida."
@@ -190,7 +194,10 @@ msgstr[1] "{num} meddelanden har raderats."
 msgid "No collections selected for deletion."
 msgstr "Inga samlingar har markerats för radering."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "Kontot och all data för {n} källa har raderats."
 msgstr[1] "Konton och data för {n} källor har raderats."
@@ -471,17 +478,11 @@ msgstr "Inga inlämningar att visa."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Du kan skriva ett säkert svar till personen som lämnade dessa meddelanden och/eller filer:"
 
-msgid "You've flagged this source for reply."
-msgstr "Du har flaggat den här källan för svar."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "En krypteringsnyckel kommer att genereras till denna källa nästa gång den loggar in, därefter kommer du att kunna svara till källan här."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Klicka nedan ifall du vill skriva ett svar till denna källa."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "FLAGGA DEN HÄR KÄLLAN FÖR SVAR"
 
 msgid "Delete Source Account"
 msgstr "Radera en källa"
@@ -607,18 +608,6 @@ msgstr "Nollställ tvåfaktorsautentisering för säkerhetsnyckler som t.ex Yubi
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "ÅTERSTÄLL SÄKERHETSNYCKELSUPPGIFTER"
-
-msgid "info icon"
-msgstr "Info"
-
-msgid "Thanks!"
-msgstr "Tack!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop kommer att generera en säker krypteringsnyckel för den här källan nästa gång den loggar in. När nyckeln har genererats kommer en svarsruta att dyka upp under dokumentsamlingen. Du kan använda rutan till att skriva krypterade svar."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "Fortsätt till listan med dokument för {codename}..."
 
 msgid "Download Unread"
 msgstr "Ladda ned olästa"
@@ -845,15 +834,6 @@ msgstr "Visa"
 msgid "Hide"
 msgstr "Göm"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Tyvärr har vi inte svarat ännu."
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "Vår SecureDrop såg nyligen ökad aktivitet. Av säkerhetsskäl kan du inte upprätta en tvåvägskommunikation innan du checkar in igen."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Du kan vara säker på att vi kan läsa ditt meddelande, logga in igen lite senare för att se vårt svar."
-
 msgid "Submit Files or Messages"
 msgstr "Skicka filer eller meddelanden"
 
@@ -977,6 +957,36 @@ msgstr "<strong> Viktigt:</strong> Ifall du önskar att förbli anonym, <strong>
 
 msgid "Back to submission page"
 msgstr "Tillbaka till inlämningssidan"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Du har flaggat den här källan för svar."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Klicka nedan ifall du vill skriva ett svar till denna källa."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "FLAGGA DEN HÄR KÄLLAN FÖR SVAR"
+
+#~ msgid "info icon"
+#~ msgstr "Info"
+
+#~ msgid "Thanks!"
+#~ msgstr "Tack!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop kommer att generera en säker krypteringsnyckel för den här källan nästa gång den loggar in. När nyckeln har genererats kommer en svarsruta att dyka upp under dokumentsamlingen. Du kan använda rutan till att skriva krypterade svar."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "Fortsätt till listan med dokument för {codename}..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Tyvärr har vi inte svarat ännu."
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "Vår SecureDrop såg nyligen ökad aktivitet. Av säkerhetsskäl kan du inte upprätta en tvåvägskommunikation innan du checkar in igen."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Du kan vara säker på att vi kan läsa ditt meddelande, logga in igen lite senare för att se vårt svar."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/tr/LC_MESSAGES/messages.po
+++ b/securedrop/translations/tr/LC_MESSAGES/messages.po
@@ -61,7 +61,7 @@ msgid "Image updated."
 msgstr "Görüntü güncellendi."
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -117,8 +117,12 @@ msgstr "Herhangi Bir Şey Seçilmemiş"
 msgid "You must select one or more items."
 msgstr "Bir ya da daha fazla öge seçmelisiniz."
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "İndirme işleminiz bir dosya bulunamadığı için başarısız oldu. Bir yönetici sistem ve izleme günlüklerinde sorunla ilgili daha fazla bilgiye ulaşabilir."
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "İndirme işleminiz bir dosya bulunamadığı için başarısız oldu. Bir yönetici sistem ve izleme günlüklerinde sorunla ilgili daha fazla bilgiye ulaşabilir."
+msgstr[1] "İndirme işleminiz bir dosya bulunamadığı için başarısız oldu. Bir yönetici sistem ve izleme günlüklerinde sorunla ilgili daha fazla bilgiye ulaşabilir."
 
 msgid "Only admins can access this page."
 msgstr "Bu sayfaya yalnızca yöneticiler erişebilir."
@@ -190,7 +194,10 @@ msgstr[1] "{num} öge silindi."
 msgid "No collections selected for deletion."
 msgstr "Silinecek bir derleme seçilmemiş."
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "{n} kaynağın hesap bilgileri ve verileri silinecek."
 msgstr[1] "{n} kaynağın hesap bilgileri ve verileri silinecek."
@@ -471,17 +478,11 @@ msgstr "Görüntülenecek bir gönderi yok."
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "Bu ileti ve/veya dosyaları gönderen kişiye güvenli bir yanıt yazabilirsiniz:"
 
-msgid "You've flagged this source for reply."
-msgstr "Bu kaynağı yanıtlamak amacıyla işaretlediniz."
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "Bu kaynağın bir sonraki oturum açışında bir şifreleme anahtarı üretilecek. Ardından kaynağa buradan yanıt yazabilirsiniz."
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "Bu kaynağa bir yanıt yazmak istiyorsanız aşağıya tıklayın."
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "BU KAYNAĞI YANITLAMAK İÇİN İŞARETLEYİN"
 
 msgid "Delete Source Account"
 msgstr "Kaynak Hesabını Sil"
@@ -607,18 +608,6 @@ msgstr "YubiKey gibi fiziksel güvenlik anahtarları için iki aşamalı kimlik 
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "FİZİKSEL GÜVENLİK ANAHTARI KİMLİK BİLGİLERİNİ SIFIRLA"
-
-msgid "info icon"
-msgstr "bilgi simgesi"
-
-msgid "Thanks!"
-msgstr "Teşekkürler!"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop bu kaynak için bir sonraki oturum açmasında kullanacağı güvenli bir şifreleme anahtarı üretecek. Anahtar üretildikten sonra, kaynağın belgelerinin derlemesi altında bir yanıt kutusu görüntülenir. Bu kutuyu kullanarak kaynağa şifrelenmiş yanıtlar gönderebilirsiniz."
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "{codename} belgelerini listelemeye devam edin..."
 
 msgid "Download Unread"
 msgstr "Okunmamışları İndir"
@@ -845,15 +834,6 @@ msgstr "Göster"
 msgid "Hide"
 msgstr "Gizle"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "Üzgünüz, henüz yanıt vermedik!"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "Son zamanlarda SecureDrop'umuz üzerinde yoğun etkinlik görüldü. Güvenlik nedenleriyle, iki yönlü iletişim kanalının oluşturulması tekrar girişinize kadar ertelendi."
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "Gönderinizi indirebildiğimizden emin olabilirsiniz. Bir yanıt olup olmadığını denetlemek için daha sonra tekrar kontrol edin."
-
 msgid "Submit Files or Messages"
 msgstr "Dosya veya İleti Gönderin"
 
@@ -977,6 +957,36 @@ msgstr "<strong>Önemli:</strong> Anonim kalmak istiyorsanız, dosyanın GPG tar
 
 msgid "Back to submission page"
 msgstr "Gönderi sayfasına geri dön"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "Bu kaynağı yanıtlamak amacıyla işaretlediniz."
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "Bu kaynağa bir yanıt yazmak istiyorsanız aşağıya tıklayın."
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "BU KAYNAĞI YANITLAMAK İÇİN İŞARETLEYİN"
+
+#~ msgid "info icon"
+#~ msgstr "bilgi simgesi"
+
+#~ msgid "Thanks!"
+#~ msgstr "Teşekkürler!"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop bu kaynak için bir sonraki oturum açmasında kullanacağı güvenli bir şifreleme anahtarı üretecek. Anahtar üretildikten sonra, kaynağın belgelerinin derlemesi altında bir yanıt kutusu görüntülenir. Bu kutuyu kullanarak kaynağa şifrelenmiş yanıtlar gönderebilirsiniz."
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "{codename} belgelerini listelemeye devam edin..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "Üzgünüz, henüz yanıt vermedik!"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "Son zamanlarda SecureDrop'umuz üzerinde yoğun etkinlik görüldü. Güvenlik nedenleriyle, iki yönlü iletişim kanalının oluşturulması tekrar girişinize kadar ertelendi."
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "Gönderinizi indirebildiğimizden emin olabilirsiniz. Bir yanıt olup olmadığını denetlemek için daha sonra tekrar kontrol edin."
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/securedrop/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -60,7 +60,7 @@ msgid "Image updated."
 msgstr "图片已更新。"
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -116,8 +116,11 @@ msgstr "请选择项目"
 msgid "You must select one or more items."
 msgstr "您必须选择之前一个项目。"
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "找不到文件，下载失败。管理员可以在系统日志中查看更多信息。"
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "找不到文件，下载失败。管理员可以在系统日志中查看更多信息。"
 
 msgid "Only admins can access this page."
 msgstr "此页面仅供管理员访问。"
@@ -185,7 +188,10 @@ msgstr[0] "已删除{num}个项目。"
 msgid "No collections selected for deletion."
 msgstr "未选择要删除的集合。"
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "{n}位线人的帐号与数据已删除。"
 
@@ -462,17 +468,11 @@ msgstr "无接受文件可显示。"
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "您可以撰写一个私密的回复给消息或文件的提供者："
 
-msgid "You've flagged this source for reply."
-msgstr "您已经把这名线人标记为待回复。"
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "系统会在下次线人登陆时生成新的加密密钥，之后你可以在这里回复线人。"
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "如果要回复此名线人，请点击下方。"
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "标记此线人为待回复"
 
 msgid "Delete Source Account"
 msgstr "删除线人账户"
@@ -597,18 +597,6 @@ msgstr "重置安全密钥，如 YubiKey"
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "重置安全密钥凭证"
-
-msgid "info icon"
-msgstr "信息图标"
-
-msgid "Thanks!"
-msgstr "万分感谢！"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop 将在此线人下次登录时为其生成安全加密密钥。生成后，其文档库下将会显示回复框。您可使用此回复框来撰写并向其发送加密信息。"
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "继续至 {codename} 的文档列表···"
 
 msgid "Download Unread"
 msgstr "下载未读项"
@@ -835,15 +823,6 @@ msgstr "显示"
 msgid "Hide"
 msgstr "隐藏"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "抱歉，我们还尚未作答！"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "我们的 SecureDrop 近期正收到大量请求。为了保障安全，我们在您再次登记前延缓了双边交流频道的创建。"
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "请放心我们可以下载您所提交的文件，稍等我们的回复。"
-
 msgid "Submit Files or Messages"
 msgstr "提交文件或信息"
 
@@ -967,6 +946,36 @@ msgstr "<strong>重要提示：</strong>若您想保持匿名身份，<strong>�
 
 msgid "Back to submission page"
 msgstr "返回提交页面"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "您已经把这名线人标记为待回复。"
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "如果要回复此名线人，请点击下方。"
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "标记此线人为待回复"
+
+#~ msgid "info icon"
+#~ msgstr "信息图标"
+
+#~ msgid "Thanks!"
+#~ msgstr "万分感谢！"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop 将在此线人下次登录时为其生成安全加密密钥。生成后，其文档库下将会显示回复框。您可使用此回复框来撰写并向其发送加密信息。"
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "继续至 {codename} 的文档列表···"
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "抱歉，我们还尚未作答！"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "我们的 SecureDrop 近期正收到大量请求。为了保障安全，我们在您再次登记前延缓了双边交流频道的创建。"
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "请放心我们可以下载您所提交的文件，稍等我们的回复。"
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."

--- a/securedrop/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/securedrop/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -61,7 +61,7 @@ msgid "Image updated."
 msgstr "圖片已更新。"
 
 #. This error is shown when an uploaded image cannot be used.
-msgid "Unable to process the image file. Try another one."
+msgid "Unable to process the image file. Please try another one."
 msgstr ""
 
 msgid "Preferences saved."
@@ -117,8 +117,11 @@ msgstr "無選取"
 msgid "You must select one or more items."
 msgstr "須至少選取一個項目。"
 
-msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
-msgstr "因為找不到檔案，下載失敗。系統管理員能在系統及監控記錄中查詢更多資訊。"
+#, fuzzy
+#| msgid "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgid "Your download failed because the file could not be found. An admin can find more information in the system and monitoring logs."
+msgid_plural "Your download failed because a file could not be found. An admin can find more information in the system and monitoring logs."
+msgstr[0] "因為找不到檔案，下載失敗。系統管理員能在系統及監控記錄中查詢更多資訊。"
 
 msgid "Only admins can access this page."
 msgstr "本頁面僅限管理員訪問。"
@@ -186,7 +189,10 @@ msgstr[0] "{num}隻件已被删除。"
 msgid "No collections selected for deletion."
 msgstr "未選擇要刪除的集件。"
 
-msgid "The account and all data for {n} source have been deleted."
+#, fuzzy
+#| msgid "The account and all data for {n} source have been deleted."
+#| msgid_plural "The accounts and all data for {n} sources have been deleted."
+msgid "The account and all data for the source have been deleted."
 msgid_plural "The accounts and all data for {n} sources have been deleted."
 msgstr[0] "這些帳號與{n}位線人的資料皆已刪除。"
 
@@ -463,17 +469,11 @@ msgstr "無提收文件顯示。"
 msgid "You can write a secure reply to the person who submitted these messages and/or files:"
 msgstr "您可以撰寫安全的回覆訊息給提交者："
 
-msgid "You've flagged this source for reply."
-msgstr "您已把這名線人標記為待回覆。"
+msgid "This source has no encryption key."
+msgstr ""
 
 msgid "An encryption key will be generated for the source the next time they log in, after which you will be able to reply to the source here."
 msgstr "系統會在線人下次登入時產生新的加密密鑰，之後您可以在這裡回覆線人。"
-
-msgid "Click below if you would like to write a reply to this source."
-msgstr "如要回覆此名線人，請點擊下方。"
-
-msgid "FLAG THIS SOURCE FOR REPLY"
-msgstr "請對此位線人加註旗誌，以進行回覆"
 
 msgid "Delete Source Account"
 msgstr "刪除線人帳號"
@@ -598,18 +598,6 @@ msgstr "重設安全密鑰例如 YubiKey 的雙重驗證"
 
 msgid "RESET SECURITY KEY CREDENTIALS"
 msgstr "重置安全密鑰憑證"
-
-msgid "info icon"
-msgstr "資訊圖示"
-
-msgid "Thanks!"
-msgstr "感謝您！"
-
-msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
-msgstr "SecureDrop 會在這個線人下次登入時產生新的加密金鑰。加密金鑰產生後，文件列表下會出現回覆欄。您可以在回覆欄撰寫訊息給線人。"
-
-msgid "Continue to the list of documents for {codename}..."
-msgstr "繼續 {codename} 文件列表..."
 
 msgid "Download Unread"
 msgstr "下載未讀文件"
@@ -836,15 +824,6 @@ msgstr "顯示"
 msgid "Hide"
 msgstr "隱藏"
 
-msgid "Sorry we haven't responded yet!"
-msgstr "抱歉，我們尚無回應！"
-
-msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
-msgstr "SecureDrop 近期遭逢一陣亂流，因安全考量，雙向的交流頻道暫且停止直到用戶再重新登入。"
-
-msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
-msgstr "請放心，我們能夠下載您的提交內容。請稍後回來檢查回覆。"
-
 msgid "Submit Files or Messages"
 msgstr "提交檔案和訊息"
 
@@ -968,6 +947,36 @@ msgstr "<strong>重要：</strong>如果您希望保持匿名，<strong>請勿</
 
 msgid "Back to submission page"
 msgstr "返回提交文件頁面"
+
+#~ msgid "You've flagged this source for reply."
+#~ msgstr "您已把這名線人標記為待回覆。"
+
+#~ msgid "Click below if you would like to write a reply to this source."
+#~ msgstr "如要回覆此名線人，請點擊下方。"
+
+#~ msgid "FLAG THIS SOURCE FOR REPLY"
+#~ msgstr "請對此位線人加註旗誌，以進行回覆"
+
+#~ msgid "info icon"
+#~ msgstr "資訊圖示"
+
+#~ msgid "Thanks!"
+#~ msgstr "感謝您！"
+
+#~ msgid "SecureDrop will generate a secure encryption key for this source the next time that they log in. Once the key has been generated, a reply box will appear under their collection of documents. You can use this box to write encrypted replies to them."
+#~ msgstr "SecureDrop 會在這個線人下次登入時產生新的加密金鑰。加密金鑰產生後，文件列表下會出現回覆欄。您可以在回覆欄撰寫訊息給線人。"
+
+#~ msgid "Continue to the list of documents for {codename}..."
+#~ msgstr "繼續 {codename} 文件列表..."
+
+#~ msgid "Sorry we haven't responded yet!"
+#~ msgstr "抱歉，我們尚無回應！"
+
+#~ msgid "Our SecureDrop recently experienced a surge of activity. For security reasons, the creation of a two-way communication channel was delayed until you checked in again."
+#~ msgstr "SecureDrop 近期遭逢一陣亂流，因安全考量，雙向的交流頻道暫且停止直到用戶再重新登入。"
+
+#~ msgid "Please rest assured that we were able to download your submission, and check back again later for a reply."
+#~ msgstr "請放心，我們能夠下載您的提交內容。請稍後回來檢查回覆。"
 
 #, fuzzy
 #~| msgid "Must be at least {num} character long."


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updates the message catalogs with string changes in 2.0.0. 

One translator comment in [journalist_app/admin.py](https://github.com/freedomofpress/securedrop/blob/1a80ef5f885647d7368447afd2a9b9386bb4d309/securedrop/journalist_app/admin.py#L55) had to be moved down a line for Babel to pick it up.

## Testing

Check the changes in `securedrop/translations/messages.pot` and the `messages.po` changes for one language of your choice.
