### PR TITLE
fix: updated validate role to skip journalist auth check on fresh installs

### DIFF
--- a/install_files/ansible-base/roles/validate/tasks/validate_tails_environment.yml
+++ b/install_files/ansible-base/roles/validate/tasks/validate_tails_environment.yml
@@ -50,6 +50,11 @@
     path: "/home/amnesia/Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private"
   register: v3_journalist_auth_file
 
+- name: Check for Source THS file
+  stat:
+    path: "/home/amnesia/Persistent/securedrop/install_files/ansible-base/app-sourcev3-ths"
+  register: v3_source_file
+
 - name: Check for Tor v3 key file
   stat:
     path: "/home/amnesia/Persistent/securedrop/install_files/ansible-base/tor_v3_keys.json"
@@ -63,7 +68,6 @@
       One of the SSH `.auth_private` files is missing. Please add the missing
       file under `~/Persistent/securedrop/install_files/ansible-base/ and
       retry the install command.
-  when:
 
 - name: Confirm that the Journalist auth file is present
   assert:
@@ -73,6 +77,8 @@
       The `app-journalist.auth_private` file is missing. Please add the missing
       file under `~/Persistent/securedrop/install_files/ansible-base/ and
       retry the install command.
+  when:
+   - v3_source_file.stat.exists
 
 - name: Confirm that the Tor keys file is present
   assert:


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #5989 .

Modifies Tails validation check to only check for journalist auth file if there's also a source THS file, to allow for the case of fresh installs.

## Testing

- Perform a prod fresh install and confirm that it does not fail early in the `validate` role
