### PR TITLE
fix: added match for new key in updater

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -946,7 +946,9 @@ def update(args: argparse.Namespace) -> int:
         good_sig_text = ['Good signature from "SecureDrop Release Signing ' +
                          'Key"',
                          'Good signature from "SecureDrop Release Signing ' +
-                         'Key <securedrop-release-key@freedom.press>"']
+                         'Key <securedrop-release-key@freedom.press>"',
+                         'Good signature from "SecureDrop Release Signing ' +
+                         'Key <securedrop-release-key-2021@freedom.press>"']
         bad_sig_text = 'BAD signature'
         gpg_lines = sig_result.split('\n')
 

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -277,6 +277,25 @@ class TestSecureDropAdmin(object):
                               b'gpg: Signature made Thu 20 Jul '
                               b'2017 08:12:25 PM EDT\n'
                               b'gpg:                using RSA key '
+                              b'2359E6538C0613E652955E6C188EDD3B7B22E6A3\n'
+                              b'gpg: Good signature from "SecureDrop Release '
+                              b'Signing Key '
+                              b'<securedrop-release-key-2021@freedom.press>"\n',
+
+                              b'gpg: Signature made Thu 20 Jul '
+                              b'2017 08:12:25 PM EDT\n'
+                              b'gpg:                using RSA key '
+                              b'2359E6538C0613E652955E6C188EDD3B7B22E6A3\n'
+                              b'gpg: Good signature from "SecureDrop Release '
+                              b'Signing Key" [unknown]\n'
+                              b'gpg:                 aka "SecureDrop Release '
+                              b'Signing Key '
+                              b'<securedrop-release-key-2021@freedom.press>" '
+                              b'[unknown]\n',
+
+                              b'gpg: Signature made Thu 20 Jul '
+                              b'2017 08:12:25 PM EDT\n'
+                              b'gpg:                using RSA key '
                               b'22245C81E3BAEB4138B36061310F561200F4AD77\n'
                               b'gpg: Good signature from "SecureDrop Release '
                               b'Signing Key" [unknown]\n'


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5994 .

Adds signature verification match for 2021 release key, allowing GUI updater to validate tags signed with new key.

## Testing

### Updates with existing tags signed with old key:

On an admin or journalist workstation:
- check out this branch
- bounce the network connection:
  - [ ] verify that the GUI updater appears
  - [ ] verify that the update completes successfully when triggered

### Updates with new tag signed with new key:

- TBD

## Deployment

- Change to be deployed with last release with tag signed with old key. 
- Once the new updater code is in place, tags can be signed with new key

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [x] I would appreciate help with the documentation
- [ ] These changes do not require documentation
