### PR TITLE
fix: torrc_additions file now created if it doesn't already exist

### DIFF
--- a/install_files/ansible-base/roles/tails-config/tasks/configure_torrc_additions.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/configure_torrc_additions.yml
@@ -28,4 +28,5 @@
     owner: root
     group: root
     mode: "0400"
+    create: yes
   when: find_v3_aths_info_result.matched >= 1


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #5997.

The `torrc_additions` file used to update Tails' base `torrc` was previously created by v2-related provisioning logic and then only updated by v3-related logic. It is now created during the v3 provisioning logic if it does not already exist.

## Testing

On an existing Tails Admin or Journalist workstation:

- check out `2.0.0-rc2`
- delete the file `~/Persistent/.securedrop/torrc_additions`
- run `cd  Persistent/securedrop && ./securedrop-admin tailsconfig`
  - [ ] verify that `tailsconfig` fails immediately complaining of a missing `torrc_additions` 
- check out this branch
- verify that the file `~/Persistent/.securedrop/torrc_additions` does not exist
- run `cd  Persistent/securedrop && ./securedrop-admin tailsconfig`
  - [ ] verify that `tailsconfig` completes successfully
  - [ ] verify that `torrc_additions` exists containing only the line `ClientOnionAuthDir /var/lib/tor/onion_auth`
- run `cd  Persistent/securedrop && ./securedrop-admin tailsconfig` again
  - [ ] verify that `tailsconfig` completes successfully
  - [ ] verify that `torrc_additions` still exists containing only one copy of the line `ClientOnionAuthDir /var/lib/tor/onion_auth`

## Deployment


## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
