### PR TITLE
[backport] fix: torrc_additions file now created if it doesn't already exist

### DIFF
--- a/install_files/ansible-base/roles/tails-config/tasks/configure_torrc_additions.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/configure_torrc_additions.yml
@@ -28,4 +28,5 @@
     owner: root
     group: root
     mode: "0400"
+    create: yes
   when: find_v3_aths_info_result.matched >= 1


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Backport of #5999

## Testing

- [ ] CI is green
- [ ] same commit from #5999

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
