### PR TITLE
[backport] #5998 fix: added match for new key in updater

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -948,7 +948,9 @@ def update(args: argparse.Namespace) -> int:
         good_sig_text = ['Good signature from "SecureDrop Release Signing ' +
                          'Key"',
                          'Good signature from "SecureDrop Release Signing ' +
-                         'Key <securedrop-release-key@freedom.press>"']
+                         'Key <securedrop-release-key@freedom.press>"',
+                         'Good signature from "SecureDrop Release Signing ' +
+                         'Key <securedrop-release-key-2021@freedom.press>"']
         bad_sig_text = 'BAD signature'
         gpg_lines = sig_result.split('\n')
 

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -277,6 +277,25 @@ class TestSecureDropAdmin(object):
                               b'gpg: Signature made Thu 20 Jul '
                               b'2017 08:12:25 PM EDT\n'
                               b'gpg:                using RSA key '
+                              b'2359E6538C0613E652955E6C188EDD3B7B22E6A3\n'
+                              b'gpg: Good signature from "SecureDrop Release '
+                              b'Signing Key '
+                              b'<securedrop-release-key-2021@freedom.press>"\n',
+
+                              b'gpg: Signature made Thu 20 Jul '
+                              b'2017 08:12:25 PM EDT\n'
+                              b'gpg:                using RSA key '
+                              b'2359E6538C0613E652955E6C188EDD3B7B22E6A3\n'
+                              b'gpg: Good signature from "SecureDrop Release '
+                              b'Signing Key" [unknown]\n'
+                              b'gpg:                 aka "SecureDrop Release '
+                              b'Signing Key '
+                              b'<securedrop-release-key-2021@freedom.press>" '
+                              b'[unknown]\n',
+
+                              b'gpg: Signature made Thu 20 Jul '
+                              b'2017 08:12:25 PM EDT\n'
+                              b'gpg:                using RSA key '
                               b'22245C81E3BAEB4138B36061310F561200F4AD77\n'
                               b'gpg: Good signature from "SecureDrop Release '
                               b'Signing Key" [unknown]\n'


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #5998

## Testing

- [ ] CI is green
- [ ] The commit is same from #5998 

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
