### PR TITLE
Fixes #6005 removed haveged from control file

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/templates/control.j2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/templates/control.j2
@@ -8,8 +8,8 @@ Standards-Version: 3.9.8
 
 Package: securedrop-app-code
 Architecture: amd64
-Conflicts: haveged, libapache2-mod-wsgi, supervisor
-Replaces: haveged, libapache2-mod-wsgi, supervisor
+Conflicts: libapache2-mod-wsgi, supervisor
+Replaces: libapache2-mod-wsgi, supervisor
 {% if securedrop_target_distribution == "focal" %}
 Depends: ${dist:Depends}, ${misc:Depends}, ${python3:Depends}, apache2, apparmor-utils, coreutils, gnupg2, libapache2-mod-xsendfile, libpython3.8, paxctld, python3, python3-distutils, redis-server, securedrop-config, securedrop-keyring, sqlite3
 {% else %}


### PR DESCRIPTION
We can remove haveged from the system later by an ansible run.

## Status

Ready for review

## Description of Changes

Fixes #6005

Changes proposed in this pull request:

## Testing

0. Make sure you're using libvirt-based VMs (upgrade scenario does not support Qubes env)
1. `molecule create -s libvirt-prod-focal`
2. Boot up admin workstation and install against those prod VMs with `./securedrop-admin install`
3. `make build-debs` on this branch on host (ok to run this in parallel with step 2 to save time)
4. `make upgrade-start` on host, to set up local apt repo
5. Back in admin workstation, run the playbook `securedrop-apt-local.yml` in the ansible-base directory (make sure to source the admin venv first, see docs), `ansible-playbook --diff -vv ./securedrop-apt-local.yml`
6. `ssh app`  and then `sudo unattended-upgrade -d`

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
