### PR TITLE
[2.0.0] Backport: Fixes #6005 removed haveged from control file

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/templates/control.j2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/templates/control.j2
@@ -8,8 +8,8 @@ Standards-Version: 3.9.8
 
 Package: securedrop-app-code
 Architecture: amd64
-Conflicts: haveged, libapache2-mod-wsgi, supervisor
-Replaces: haveged, libapache2-mod-wsgi, supervisor
+Conflicts: libapache2-mod-wsgi, supervisor
+Replaces: libapache2-mod-wsgi, supervisor
 {% if securedrop_target_distribution == "focal" %}
 Depends: ${dist:Depends}, ${misc:Depends}, ${python3:Depends}, apache2, apparmor-utils, coreutils, gnupg2, libapache2-mod-xsendfile, libpython3.8, paxctld, python3, python3-distutils, redis-server, securedrop-config, securedrop-keyring, sqlite3
 {% else %}


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Backports #6006.

Fixes 6005 removed haveged from control file
We can remove haveged from the system later by an ansible run.

(cherry picked from commit 48131354903f441e568c343e61c947067eb0bcac)

## Testing

- [ ] Contains same commits as #6006 
- [ ] base is release/2.0.0

