### PR TITLE
Disables haveged service in preinst, if unit file is present

### DIFF
--- a/install_files/securedrop-app-code/debian/preinst
+++ b/install_files/securedrop-app-code/debian/preinst
@@ -13,6 +13,17 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
+function service_exists() {
+    # Test for the existence of systemctl services. Added to check for and
+    # disable haveged if present
+
+    local x=$1
+    if systemctl list-unit-files --type service | grep -F "${x}.service"; then
+        return 0
+    else
+        return 1
+    fi
+}
 
 function permanently_disable_swap() {
     # Swap usage is prohibited in the context of SecureDrop, due to risk of
@@ -88,6 +99,12 @@ case "$1" in
         cp /var/www/securedrop/static/i/logo.png /tmp/securedrop_custom_logo.png
         # Remove the custom logo so we don't get an error from dpkg conffiles
         rm /var/www/securedrop/static/i/logo.png
+      fi
+
+      if service_exists 'haveged'; then
+        systemctl stop haveged
+        systemctl disable haveged
+        systemctl mask haveged
       fi
 
     ;;


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Adds to fix for #6005 .

If haveged is present, stop/disable/mask the service - this is a compromise vs removing the package altogether.

## Testing

- Make sure you're using libvirt-based VMs (upgrade scenario does not support Qubes env)
- `molecule create -s libvirt-prod-focal`
- Boot up admin workstation and install against those prod VMs with ./securedrop-admin install
- make build-debs on this branch on host (ok to run this in parallel with step 2 to save time)
- `make upgrade-start` on host, to set up local apt repo
- Back in admin workstation, run the playbook securedrop-apt-local.yml in the ansible-base directory (make sure to source the admin venv first, see docs), `ansible-playbook --diff -vv ./securedrop-apt-local.yml`
- `ssh app` and then `sudo apt-get update && sudo unattended-upgrade -d`
  - [ ] the unattended upgrade command completes successfully
  - [ ] `apt-cache policy securedrop-app-code` shows package is upgraded
  - [ ] `systemctl status haveged` shows haveged is stopped, disabled, and masked.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrades: script change has been tested as above - in cases where haveged is present it should just be disabled
2. New installs: since havaged will not be installed on fresh SD installs from 2.0.0 on, the script won't do anything.

## Checklist

### If you made changes to the server application code:

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
