### PR TITLE
[2.0.0] Backport: disables haveged service in preinst, if unit file is present

### DIFF
--- a/install_files/securedrop-app-code/debian/preinst
+++ b/install_files/securedrop-app-code/debian/preinst
@@ -13,6 +13,17 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
+function service_exists() {
+    # Test for the existence of systemctl services. Added to check for and
+    # disable haveged if present
+
+    local x=$1
+    if systemctl list-unit-files --type service | grep -F "${x}.service"; then
+        return 0
+    else
+        return 1
+    fi
+}
 
 function permanently_disable_swap() {
     # Swap usage is prohibited in the context of SecureDrop, due to risk of
@@ -88,6 +99,12 @@ case "$1" in
         cp /var/www/securedrop/static/i/logo.png /tmp/securedrop_custom_logo.png
         # Remove the custom logo so we don't get an error from dpkg conffiles
         rm /var/www/securedrop/static/i/logo.png
+      fi
+
+      if service_exists 'haveged'; then
+        systemctl stop haveged
+        systemctl disable haveged
+        systemctl mask haveged
       fi
 
     ;;


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6005 

Disables haveged service in preinst, if unit file is present
(cherry picked from commit 04d62440e82340052ca29b7f031a11619551dfc9)

## Testing

- [ ] base is `release/2.0.0`
- [ ] PR contains only commits from #6008
- [ ] CI is green
