### PR TITLE
Prevent creation of a duplicate source keypair

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -226,11 +226,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             db.session.add(submission)
             new_submissions.append(submission)
 
-        # If necessary, generate a keypair to encrypt replies from the journalist
-        if g.source.pending or not current_app.crypto_util.get_fingerprint(g.filesystem_id):
-            current_app.crypto_util.genkeypair(g.filesystem_id, g.codename)
-            g.source.pending = False
-
+        g.source.pending = False
         g.source.last_updated = datetime.utcnow()
         db.session.commit()
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

#5954 introduced a bug causing two keypairs to be generated for new sources: once when they arrived at the lookup page, and the next the first time they submitted something (because all sources have `pending=True` by default, passing this [faulty check](https://github.com/freedomofpress/securedrop/blob/6c9fd2fd43728b6836b33b6343dbbfb17e6682fb/securedrop/source_app/main.py#L230)). This eliminates the key generation in the source /submit handler. A keypair should never actually need to be generated when submitting, as it happens on the previous /lookup page. Even if a source without a keypair were somehow sitting at /lookup during the upgrade, when they pushed submit, a keypair would be generated when they were redirected back to /lookup.

## Testing

- `git checkout develop`
- `make dev`
- `docker exec -it securedrop-dev-0 bash` and in that shell:
  - `gpg --homedir /var/lib/securedrop/keys --list-keys` -- only the three default sources should be listed.
- Visit the source interface and create a new source.
- List the GPG keys again. The new source should have one key.
- Submit a message, then list keys again -- the source will have a second key.
- Back in your dev environment, `git checkout prevent-dup-source-keys` -- the dev server should pick up the changes.
- In the source interface, log out and create another source. Once at the /lookup page, list keys and confirm the new source has one.
- Submit a message, list keys, and confirm that no additional key was created for this source.
 

## Deployment

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
