### PR TITLE
[2.0.0] Backport: Prevent creation of a duplicate source keypair

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -226,11 +226,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             db.session.add(submission)
             new_submissions.append(submission)
 
-        # If necessary, generate a keypair to encrypt replies from the journalist
-        if g.source.pending or not current_app.crypto_util.get_fingerprint(g.filesystem_id):
-            current_app.crypto_util.genkeypair(g.filesystem_id, g.codename)
-            g.source.pending = False
-
+        g.source.pending = False
         g.source.last_updated = datetime.utcnow()
         db.session.commit()
 


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Backports #6011 .

Prevent creation of a duplicate source keypair

(cherry picked from commit 919744607f4b7229df3c208bdf6249b599d751a7)

## Testing
 - [ ] base is release/2.0.0
 - [ ] contains only commits from #6011 
 - [ ] CI green
