### PR TITLE
[2.0.0] Backport: Updated builder image to tagged version 2021_06_22

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_06_01
-27f49d0b22c42864ad4cb4ef5702da0b3c7e1df1139944f868d8686ce5ee4651
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_06_22
+f8d12d7ebd9742374621a21ff16dcfa6cf9523a92a610f926e13ecf5679ff9bf


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backports #6012.

(cherry picked from commit b86b1e741f8d7e013b60e5cddea409763636590d)

## Testing

- [ ] base is release/2.0.0
- [ ] contains only commits from #6012
- [ ] CI green
