### PR TITLE
refactors status-indicator `img`s and related elements for ARIA labeling

### DIFF
--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -7,7 +7,7 @@
       <button class="button-star starred" type="submit" formaction="{{ url_for('col.remove_star', filesystem_id=source.filesystem_id) }}" aria-label="{{ gettext('Un-star {designation}').format(designation=source.journalist_designation) }}">
         <img src="{{ url_for('static', filename='icons/starred.png') }}" class="icon-drop icon-star-source" width="16" height="15" alt="{{ gettext('{designation} is starred').format(designation=source.journalist_designation) }}">
       </button>
-      <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}">
+      <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" aria-labelledby="starred-source-link-{{ loop_index }}">
       <a href="/col/{{ source.filesystem_id }}" id="starred-source-link-{{ loop_index }}" class="code-name {% if source.num_unread != 0 %}unread{% else %}read{% endif %}">
         {{ source.journalist_designation }}
       </a>
@@ -16,7 +16,7 @@
         <img src="{{ url_for('static', filename='icons/unstarred.png') }}" class="icon-drop icon-star-source off-hover" width="16" height="15" alt="{{ gettext('{designation} is not starred').format(designation=source.journalist_designation) }}">
         <img src="{{ url_for('static', filename='icons/starred.png') }}" class="icon-drop icon-star-source on-hover" width="16" height="15" alt="{{ gettext('{designation} is not starred').format(designation=source.journalist_designation) }}">
       </button>
-      <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}">
+      <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}" aria-labelledby="un-starred-source-link-{{ loop_index }}">
       <a href="/col/{{ source.filesystem_id }}" id="un-starred-source-link-{{ loop_index }}" class="code-name {% if source.num_unread != 0 %}unread{% else %}read{% endif %}">
         {{ source.journalist_designation }}
       </a>

--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -4,17 +4,17 @@
   <time class="date" title="{{ source.last_updated|rel_datetime_format }}" datetime="{{ source.last_updated|rel_datetime_format(fmt="%Y-%m-%d %H:%M:%S%Z") }}">{{ source.last_updated|rel_datetime_format(relative=True) }}</time>
   <div class="designation">
     {% if source.star.starred %}
-      <button class="button-star starred" type="submit" formaction="{{ url_for('col.remove_star', filesystem_id=source.filesystem_id) }}">
-        <img src="{{ url_for('static', filename='icons/starred.png') }}" class="icon-drop icon-star-source" width="16" height="15" alt="{{ gettext('Un-star {designation}').format(designation=source.journalist_designation) }}">
+      <button class="button-star starred" type="submit" formaction="{{ url_for('col.remove_star', filesystem_id=source.filesystem_id) }}" aria-label="{{ gettext('Un-star {designation}').format(designation=source.journalist_designation) }}">
+        <img src="{{ url_for('static', filename='icons/starred.png') }}" class="icon-drop icon-star-source" width="16" height="15" alt="{{ gettext('{designation} is starred').format(designation=source.journalist_designation) }}">
       </button>
       <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}">
       <a href="/col/{{ source.filesystem_id }}" id="starred-source-link-{{ loop_index }}" class="code-name {% if source.num_unread != 0 %}unread{% else %}read{% endif %}">
         {{ source.journalist_designation }}
       </a>
     {% else %}
-      <button class="button-star un-starred" type="submit" formaction="{{ url_for('col.add_star', filesystem_id=source.filesystem_id) }}">
-        <img src="{{ url_for('static', filename='icons/unstarred.png') }}" class="icon-drop icon-star-source off-hover" width="16" height="15" alt="{{ gettext('Star {designation}').format(designation=source.journalist_designation) }}">
-        <img src="{{ url_for('static', filename='icons/starred.png') }}" class="icon-drop icon-star-source on-hover" width="16" height="15" alt="{{ gettext('Star {designation}').format(designation=source.journalist_designation) }}">
+      <button class="button-star un-starred" type="submit" formaction="{{ url_for('col.add_star', filesystem_id=source.filesystem_id) }}" aria-label="{{ gettext('Star {designation}' ).format(designation=source.journalist_designation) }}">
+        <img src="{{ url_for('static', filename='icons/unstarred.png') }}" class="icon-drop icon-star-source off-hover" width="16" height="15" alt="{{ gettext('{designation} is not starred').format(designation=source.journalist_designation) }}">
+        <img src="{{ url_for('static', filename='icons/starred.png') }}" class="icon-drop icon-star-source on-hover" width="16" height="15" alt="{{ gettext('{designation} is not starred').format(designation=source.journalist_designation) }}">
       </button>
       <input type="checkbox" name="cols_selected" value="{{ source.filesystem_id }}">
       <a href="/col/{{ source.filesystem_id }}" id="un-starred-source-link-{{ loop_index }}" class="code-name {% if source.num_unread != 0 %}unread{% else %}read{% endif %}">

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -28,28 +28,28 @@
           <li class="submission {% if not doc.seen and not doc.filename.endswith('reply.gpg') %}unread{% endif %}">
             {% if doc.filename.endswith('reply.gpg') %}
               {% if not doc.deleted_by_source %}
-                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
+                <input aria-labelledby="doc-link-{{ loop.index }}" type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
                 <span title="{{ gettext('Reply') }}" class="icon">
                   <img src="{{ url_for('static', filename='icons/reply.png') }}" class="icon" width="16" height="16" alt="{{ gettext('Reply') }}">
                 </span>
               {% else %}
-                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
+                <input aria-labelledby="doc-link-{{ loop.index }}" type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
                 <span title="{{ gettext('Read') }}" class="icon">
                   <img src="{{ url_for('static', filename='icons/check.png') }}" class="icon" width="16" height="12" alt="{{ gettext('Reply read') }}">
                 </span>
               {% endif %}
             {% elif not doc.seen %}
-              <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
+              <input aria-labelledby="doc-link-{{ loop.index }}" type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
               <span title="{{ gettext('Unread') }}" class="icon">
                 <img src="{{ url_for('static', filename='icons/envelope-closed.png') }}" class="icon" width="16" height="15" alt="{{ gettext('Unread') }}">
               </span>
             {% else %}
-              <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
+              <input aria-labelledby="doc-link-{{ loop.index }}" type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
               <span title="{{ gettext('Read') }}" class="icon">
                 <img src="{{ url_for('static', filename='icons/envelope-open.png') }}" class="icon" width="16" height="15" alt="{{ gettext('Read') }}">
               </span>
             {% endif %}
-            <a class="file {% if not doc.seen and not doc.filename.endswith('reply.gpg') %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_file', filesystem_id=filesystem_id, fn=doc.filename) }}">
+            <a id="doc-link-{{ loop.index }}" class="file {% if not doc.seen and not doc.filename.endswith('reply.gpg') %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_file', filesystem_id=filesystem_id, fn=doc.filename) }}">
               <span class="filename">{{ doc.filename }}</span>
             </a>
             <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat() }}</span></span>

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -25,29 +25,21 @@
 
       <ul id="submissions" class="plain submissions">
         {% for doc in source.collection %}
-          <li class="submission {% if not doc.seen and not doc.filename.endswith('reply.gpg') %}unread{% endif %}">
+          <li class="submission {% if not doc.seen and not doc.filename.endswith('reply.gpg') %}unread{% endif %}" aria-labelledby="doc-link-{{ loop.index }} status-icon-{{ loop.index }} type-icon-{{ loop.index }}">
             {% if doc.filename.endswith('reply.gpg') %}
               {% if not doc.deleted_by_source %}
-                <input aria-labelledby="doc-link-{{ loop.index }}" type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
-                <span title="{{ gettext('Reply') }}" class="icon">
-                  <img src="{{ url_for('static', filename='icons/reply.png') }}" class="icon" width="16" height="16" alt="{{ gettext('Reply') }}">
-                </span>
+                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check" aria-labelledby="doc-link-{{ loop.index }}">
+                <img id="status-icon-{{ loop.index }}" src="{{ url_for('static', filename='icons/reply.png') }}" class="icon" width="16" height="16" alt="{{ gettext('Unread') }}" title="{{ gettext('Unread') }}">
               {% else %}
-                <input aria-labelledby="doc-link-{{ loop.index }}" type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
-                <span title="{{ gettext('Read') }}" class="icon">
-                  <img src="{{ url_for('static', filename='icons/check.png') }}" class="icon" width="16" height="12" alt="{{ gettext('Reply read') }}">
-                </span>
+                <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check" aria-labelledby="doc-link-{{ loop.index }}">
+                <img id="status-icon-{{ loop.index }}" src="{{ url_for('static', filename='icons/check.png') }}" class="icon" width="16" height="12" alt="{{ gettext('Read') }}" title="{{ gettext('Read') }}">
               {% endif %}
             {% elif not doc.seen %}
-              <input aria-labelledby="doc-link-{{ loop.index }}" type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb">
-              <span title="{{ gettext('Unread') }}" class="icon">
-                <img src="{{ url_for('static', filename='icons/envelope-closed.png') }}" class="icon" width="16" height="15" alt="{{ gettext('Unread') }}">
-              </span>
+              <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check unread-cb" aria-labelledby="doc-link-{{ loop.index }}">
+              <img id="status-icon-{{ loop.index }}" src="{{ url_for('static', filename='icons/envelope-closed.png') }}" class="icon" width="16" height="15" alt="{{ gettext('Unread') }}" title="{{ gettext('Unread') }}">
             {% else %}
-              <input aria-labelledby="doc-link-{{ loop.index }}" type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check">
-              <span title="{{ gettext('Read') }}" class="icon">
-                <img src="{{ url_for('static', filename='icons/envelope-open.png') }}" class="icon" width="16" height="15" alt="{{ gettext('Read') }}">
-              </span>
+              <input type="checkbox" name="doc_names_selected" value="{{ doc.filename }}" class="doc-check" aria-labelledby="doc-link-{{ loop.index }}">
+              <img id="status-icon-{{ loop.index }}" src="{{ url_for('static', filename='icons/envelope-open.png') }}" class="icon" width="16" height="15" alt="{{ gettext('Read') }}" title="{{ gettext('Read') }}">
             {% endif %}
             <a id="doc-link-{{ loop.index }}" class="file {% if not doc.seen and not doc.filename.endswith('reply.gpg') %}unread{% else %}read{% endif %}" href="{{ url_for('col.download_single_file', filesystem_id=filesystem_id, fn=doc.filename) }}">
               <span class="filename">{{ doc.filename }}</span>
@@ -55,17 +47,11 @@
             <span class="info"><span title="{{ doc.size }} bytes">{{ doc.size|filesizeformat() }}</span></span>
 
             {% if doc.filename.endswith('-doc.gz.gpg') %}
-              <i title="{{ gettext('Uploaded Document') }}" class="pull-right">
-                <img src="{{ url_for('static', filename='icons/files.png') }}" width="14" height="16" alt="{{ gettext('Uploaded Document') }}">
-              </i>
+              <img id="type-icon-{{ loop.index }}" src="{{ url_for('static', filename='icons/files.png') }}" class="pull-right" width="14" height="16" alt="{{ gettext('Uploaded Document') }}" title="{{ gettext('Uploaded Document') }}">
             {% elif doc.filename.endswith('-reply.gpg') %}
-              <i title="{{ gettext('Reply') }}" class="pull-right">
-                <img src="{{ url_for('static', filename='icons/reply.png') }}" width="16" height="16" alt="{{ gettext('Reply') }}">
-              </i>
+              <img id="type-icon-{{ loop.index }}" src="{{ url_for('static', filename='icons/reply.png') }}" class="pull-right" width="16" height="16" alt="{{ gettext('Reply') }}" title="{{ gettext('Reply') }}">
             {% else %}
-              <i title="{{ gettext('Message') }}" class="pull-right">
-                <img src="{{ url_for('static', filename='icons/messages.png') }}" width="15" height="13" alt="{{ gettext('Message') }}">
-              </i>
+              <img id="type-icon-{{ loop.index }}" src="{{ url_for('static', filename='icons/messages.png') }}" class="pull-right" width="15" height="13" alt="{{ gettext('Message') }}" title="{{ gettext('Message') }}">
             {% endif %}
           </li>
         {% endfor %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Resolves #5985.

This PR builds on #5996 to make more-meaningful use of both `alt` attributes (on `img` elements) and `aria-*` annotations (on `img` and other elements) in those cases where an image indicates the status of another UI element.  These images are not strictly decorative, but nor is their UI role communicated (and narrated by screen-readers) from functional markup such as `button` elements.  Instead, this more-nuanced refactoring (a) simplifies the existing markup (and narration) and (b) establishes narratable relationships between elements.

This PR (especially cbff6b9) can be thought of as the prototype for the top-down semantic refactoring proposed in #5986 and #5987.

## Testing

With a screen-reader running:

1. **Journalist Interface → log in as a journalist:**  Observe that a source's "star" button, un/starred status, selection checkbox, and link are announced separately and logically, before the other information in the row.
2. **Journalist Interface → log in as a journalist → select a source:**  Observe that a document's name, un/read status, and type are announced together; followed by its selection checkbox; followed by the other information in the row.

## Deployment

No special considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container