### PR TITLE
Shellcheck filter update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,14 +72,10 @@ jobs:
       - *installenchant
 
       - run:
-          name: Run all linters but shellcheck
+          name: Run all linters
           command: |
             fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
-            DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" securedrop/bin/dev-shell bash -c "/opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/develop-requirements.txt && make -C .. ansible-config-lint app-lint flake8 html-lint typelint yamllint"
-
-      - run:
-          name: Run shellcheck
-          command: make shellcheck
+            DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" securedrop/bin/dev-shell bash -c "sudo apt install shellcheck && /opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/develop-requirements.txt && make -C .. lint"
 
   app-tests:
     machine:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Skips a lot more irrelevant filesystem content when running shellcheck. Installs shellcheck in the dev container so that we can run `make lint` instead of enumerating everything but shellcheck, making it less likely that this CI job will need adjustment if we add or remove linters.

Adding a line printing the files actually passed to shellcheck showed that with this extra filtering, the only differences in the set of files checked were some third-party scripts under `admin/.tox`.

## Testing

CI is green.

## Deployment

Dev-only.

## Checklist

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation