### PR TITLE
 Skip translation tests earlier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
     environment:
       DOCKER_API_VERSION: 1.23
       BASE_OS: focal
-    parallelism: 20
+    parallelism: 21
     steps:
       - checkout
       - *rebaseontarget
@@ -323,6 +323,9 @@ workflows:
       - translation-tests:
           requires:
             - lint
+          filters:
+            branches:
+              only: /i18n-.*/
       - deb-tests:
           filters:
             branches:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds CircleCI branch filtering to translation tests, skipping them altogether if the branch doesn't start with `i18n-`.

Increases `translation-tests` job parallelism to 21, matching the number of locales to test. We can't get away with just bumping it up to some higher number, because locales are then tested repeatedly; the test splitting input is apparently cycled.

This change eliminates 100+ minutes of useless CI time on every PR that isn't on an `i18n-` branch, and reduces the time of those that are, because with 20 jobs, one was left to run after the first 20 had completed.

## Testing

CI is green, and only `lint`, `static-analysis-and-no-known-cves`, and `translation-tests` jobs are run on this branch.

Observe that on a branch not prefixed with `i18n-`, [translation tests were skipped entirely](https://app.circleci.com/pipelines/github/freedomofpress/securedrop/2640/workflows/e2e194de-60a4-4c9b-ad03-bae3bae32107).

## Deployment

CI-only.

## Checklist

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
