### PR TITLE
Updates testinfra tests to run cleanly in production from an Admin Workstation

### DIFF
--- a/devops/scripts/run_prod_testinfra
+++ b/devops/scripts/run_prod_testinfra
@@ -29,4 +29,4 @@ cd ~/Persistent/securedrop
 source admin/.venv3/bin/activate
 
 cd molecule/testinfra
-CI_SD_ENV=${TEST_ENV:-prod} SECUREDROP_TESTINFRA_TARGET_HOST=${TEST_ENV:-prod} py.test -v -n 2 --disable-warnings -m "not skip_in_prod" 
+CI_SD_ENV=${TEST_ENV:-prod} SECUREDROP_TESTINFRA_TARGET_HOST=${TEST_ENV:-prod} py.test -v -n 2 --disable-warnings -m "not skip_in_prod"

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -179,3 +179,5 @@ log_events_with_ossec_alerts:
 
 fpf_apt_repo_url: "https://apt.freedom.press"
 grsec_version_focal: "5.4.97"
+
+daily_reboot_time: "4"

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -186,3 +186,5 @@ log_events_with_ossec_alerts:
 fpf_apt_repo_url: "https://apt-test.freedom.press"
 
 grsec_version_focal: "5.4.97"
+
+daily_reboot_time: "4"

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -199,3 +199,5 @@ log_events_with_ossec_alerts:
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
 grsec_version_focal: "5.4.97"
+
+daily_reboot_time: "4"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6022.

- Overrides default variables with values from production site-specific file
- Generalizes nightly update/upgrade/reboot checks
- Sets expected repo URL based on workstation ansible defaults

## Testing

### prod

- Provision a production system based on the latest tag (2.0.0) (VMs or HW). Set a non-standard value for the reboot time. If practical, use non-standard IPs (ie other than 10.20.2.2 and 10.20.3.2) for the app and mon servers.
- install the testinfra dependencies with `./securedrop-admin setup -t`
- run the testinfra suite with `./securedrop-admin verify
- [ ] verify that multiple test errors are seen relating to OSSEC, IP addresses, and update scheduling
- check out this branch on the Admin Workstation
- run testinfra again with `./securedrop-admin --force verify`
- [ ] verify that all tests pass.

### staging

- [ ] provision a staging environment, run `make testinfra`, and verify that tests pass.

## Deployment

(No deployment issues)

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
