### PR TITLE
Temporarily marked admin test_update() as xfailing, pending 2.0.1 tag

### DIFF
--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -586,6 +586,8 @@ def test_check_for_update_when_updates_not_needed(securedrop_git_repo):
     assert child.signalstatus is None
 
 
+# This test will fail until a tag with the 2021 signing key is pushed
+@pytest.mark.xfail
 @flaky(max_runs=3)
 def test_update(securedrop_git_repo):
     gpgdir = os.path.join(os.path.expanduser('~'), '.gnupg')


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Marks the `test_update()` test in `admin/tests/test_integration.py` as `xfail`, as it will fail until a 2.0.1 tag with the 2021 signing key is pushed.

## Testing

- [ ] CI is green.

## Deployment

n/a
