### PR TITLE
Updated urllib3 and requests dependencies

### DIFF
--- a/admin/requirements-dev.in
+++ b/admin/requirements-dev.in
@@ -7,11 +7,11 @@ pbr
 pip>=21.1
 pip-tools>=6.1.0
 py>=1.10.0
-pylint>=2.7.0; python_version > '3.6'
+pylint>=2.7.0
 pytest==3.2.0
-requests>=2.22.0
+requests>=2.26.0
 tox
 pexpect
-urllib3>=1.25.9
+urllib3>=1.26.5
 pytest-catchlog
 setuptools==56.0.0

--- a/admin/requirements-dev.txt
+++ b/admin/requirements-dev.txt
@@ -12,9 +12,9 @@ certifi==2018.4.16 \
     --hash=sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7 \
     --hash=sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0
     # via requests
-chardet==3.0.4 \
-    --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
-    --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
+charset-normalizer==2.0.3 \
+    --hash=sha256:88fce3fa5b1a84fdcb3f603d889f723d1dd89b26059d0123ca435570e848d5e1 \
+    --hash=sha256:c46c3ace2d744cfbdebceaa3c19ae691f53ae621b39fd7570f59d14fb7f2fd12
     # via requests
 click==7.1.2 \
     --hash=sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a \
@@ -153,7 +153,7 @@ pyflakes==1.6.0 \
     --hash=sha256:08bd6a50edf8cffa9fa09a463063c425ecaaf10d1eb0335a7e8b1401aef89e6f \
     --hash=sha256:8d616a382f243dbf19b54743f280b80198be0bca3a5396f1d2e1fca6223e8805
     # via flake8
-pylint==2.7.4 ; python_version > "3.6" \
+pylint==2.7.4 \
     --hash=sha256:209d712ec870a0182df034ae19f347e725c1e615b2269519ab58a35b3fcbbe7a \
     --hash=sha256:bd38914c7731cdc518634a8d3c5585951302b6e2b6de60fbb3f7a0220e21eeee
     # via -r requirements-dev.in
@@ -167,9 +167,9 @@ pytest==3.2.0 \
     # via
     #   -r requirements-dev.in
     #   pytest-catchlog
-requests==2.22.0 \
-    --hash=sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4 \
-    --hash=sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31
+requests==2.26.0 \
+    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
+    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
     # via -r requirements-dev.in
 six==1.15.0 \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
@@ -215,9 +215,9 @@ typing-extensions==3.10.0.0 \
     --hash=sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342 \
     --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
     # via importlib-metadata
-urllib3==1.25.10 \
-    --hash=sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a \
-    --hash=sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461
+urllib3==1.26.6 \
+    --hash=sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4 \
+    --hash=sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f
     # via
     #   -r requirements-dev.in
     #   requests

--- a/admin/requirements-testinfra.txt
+++ b/admin/requirements-testinfra.txt
@@ -224,7 +224,7 @@ pytest==6.1.1 \
     #   pytest-forked
     #   pytest-xdist
     #   testinfra
-pyyaml==5.4.1 ; python_version > "3.6" \
+pyyaml==5.4.1 \
     --hash=sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf \
     --hash=sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696 \
     --hash=sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393 \

--- a/admin/requirements.in
+++ b/admin/requirements.in
@@ -1,5 +1,5 @@
 markupsafe>=1.1
 prompt_toolkit==2.0.9
-pyyaml>=5.4.1; python_version > '3.6'
+pyyaml>=5.4.1
 setuptools>=56.0.0
 six==1.15.0

--- a/admin/requirements.txt
+++ b/admin/requirements.txt
@@ -129,7 +129,7 @@ prompt_toolkit==2.0.9 \
 pycparser==2.18 \
     --hash=sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226
     # via cffi
-pyyaml==5.4.1 ; python_version > "3.6" \
+pyyaml==5.4.1 \
     --hash=sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf \
     --hash=sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696 \
     --hash=sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393 \

--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -21,22 +21,22 @@ mypy>=0.761
 # http://docs.ansible.com/ansible/latest/playbooks_filters_ipaddr.html
 netaddr
 # Now also pin pip due to https://github.com/jazzband/pip-tools/issues/853
-pathlib2==2.3.5; python_version < '3.6'
 pip>=21.1
 pip-tools>=6.1.0
 psutil>=5.6.6
 pyenchant
-pylint>=2.7.0; python_version > '3.6'
+pylint>=2.7.0
 pynacl>=1.4.0
 py>=1.10.0
 pytest>=6.1.1
 pytest-xdist>=2.1.0
 python-vagrant
-pyyaml>=5.4.1; python_version > '3.6'
+pyyaml>=5.4.1
+requests>=2.26.0
 ruamel.yaml>=0.16.10
 safety>=1.8.7
 setuptools>=56.0.0
 testinfra>=5.3.1
-urllib3>=1.25.9
+urllib3>=1.26.5
 yamllint
 sqlalchemy-stubs==0.3

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -183,9 +183,11 @@ cfgv==2.0.1 \
 chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
-    # via
-    #   binaryornot
-    #   requests
+    # via binaryornot
+charset-normalizer==2.0.3 \
+    --hash=sha256:88fce3fa5b1a84fdcb3f603d889f723d1dd89b26059d0123ca435570e848d5e1 \
+    --hash=sha256:c46c3ace2d744cfbdebceaa3c19ae691f53ae621b39fd7570f59d14fb7f2fd12
+    # via requests
 click-completion==0.5.2 \
     --hash=sha256:5bf816b81367e638a190b6e91b50779007d14301b3f9f3145d68e3cade7bce86
     # via molecule
@@ -547,7 +549,7 @@ pyflakes==2.1.1 \
     --hash=sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0 \
     --hash=sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2
     # via flake8
-pylint==2.7.4 ; python_version > "3.6" \
+pylint==2.7.4 \
     --hash=sha256:209d712ec870a0182df034ae19f347e725c1e615b2269519ab58a35b3fcbbe7a \
     --hash=sha256:bd38914c7731cdc518634a8d3c5585951302b6e2b6de60fbb3f7a0220e21eeee
     # via -r requirements/python3/develop-requirements.in
@@ -609,7 +611,7 @@ python-vagrant==0.5.15 \
     # via
     #   -r requirements/python3/develop-requirements.in
     #   molecule-vagrant
-pyyaml==5.4.1 ; python_version > "3.6" \
+pyyaml==5.4.1 \
     --hash=sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf \
     --hash=sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696 \
     --hash=sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393 \
@@ -652,10 +654,11 @@ pyyaml==5.4.1 ; python_version > "3.6" \
     #   pre-commit
     #   python-gilt
     #   yamllint
-requests==2.22.0 \
-    --hash=sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4 \
-    --hash=sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31
+requests==2.26.0 \
+    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
+    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
     # via
+    #   -r requirements/python3/develop-requirements.in
     #   cookiecutter
     #   docker
     #   safety
@@ -796,9 +799,9 @@ typing-extensions==3.7.4.1 \
     # via
     #   mypy
     #   sqlalchemy-stubs
-urllib3==1.25.10 \
-    --hash=sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a \
-    --hash=sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461
+urllib3==1.26.6 \
+    --hash=sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4 \
+    --hash=sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f
     # via
     #   -r requirements/python3/develop-requirements.in
     #   requests

--- a/securedrop/requirements/python3/test-requirements.in
+++ b/securedrop/requirements/python3/test-requirements.in
@@ -16,9 +16,9 @@ pluggy>=0.13.1
 pytest-cov
 pytest-mock
 hypothesis
-requests[socks]>2.21.0
+requests[socks]>=2.26.0
 setuptools>=56.0.0
 selenium>=3.141.0
 tbselenium>=0.5.2
 pyvirtualdisplay
-urllib3>=1.25.9
+urllib3>=1.26.5

--- a/securedrop/requirements/python3/test-requirements.txt
+++ b/securedrop/requirements/python3/test-requirements.txt
@@ -26,9 +26,9 @@ certifi==2018.11.29 \
     --hash=sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7 \
     --hash=sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033
     # via requests
-chardet==3.0.4 \
-    --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
-    --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
+charset-normalizer==2.0.3 \
+    --hash=sha256:88fce3fa5b1a84fdcb3f603d889f723d1dd89b26059d0123ca435570e848d5e1 \
+    --hash=sha256:c46c3ace2d744cfbdebceaa3c19ae691f53ae621b39fd7570f59d14fb7f2fd12
     # via requests
 click==7.1.2 \
     --hash=sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a \
@@ -264,9 +264,9 @@ pytest==6.1.1 \
 pyvirtualdisplay==0.2.1 \
     --hash=sha256:012883851a992f9c53f0dc6a512765a95cf241bdb734af79e6bdfef95c6e9982
     # via -r requirements/python3/test-requirements.in
-requests[socks]==2.22.0 \
-    --hash=sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4 \
-    --hash=sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31
+requests[socks]==2.26.0 \
+    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
+    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
     # via -r requirements/python3/test-requirements.in
 selenium==3.141.0 \
     --hash=sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c \
@@ -290,9 +290,9 @@ toml==0.10.1 \
     # via
     #   pep517
     #   pytest
-urllib3==1.25.10 \
-    --hash=sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a \
-    --hash=sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461
+urllib3==1.26.6 \
+    --hash=sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4 \
+    --hash=sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f
     # via
     #   -r requirements/python3/test-requirements.in
     #   requests


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

-Updates 
  - requests from 2.22.0 to 2.26.0; 
  - urllib3 from 1.25.10 to 1.26.6. 
 
- Removes python 3.6 clauses from `*.in` files

## Testing

- [ ] CI is passing
- [ ] securedrop-app-code-requirements.txt is unchanged
- [ ] all references to `requests` and `urllib3` in requirements files are updated.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a code dependency:

Choose one of the following:

- [x] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
