### PR TITLE
fixes multiple Alembic heads

### DIFF
--- a/securedrop/alembic/versions/1ddb81fb88c2_unique_index_for_instanceconfig_valid_.py
+++ b/securedrop/alembic/versions/1ddb81fb88c2_unique_index_for_instanceconfig_valid_.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '1ddb81fb88c2'
-down_revision = '92fba0be98e9'
+down_revision = 'b060f38c0c31'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6050 by rebasing (if you will) Alembic revision `1ddb81fb88c2` (#5974) onto `b060f38c0c31` (#5954).

## Testing

1. [x] `alembic upgrade head` succeeds.
2. [x] All Alembic-based tests in `app-tests` and `staging-test-with-rebase` pass.

## Deployment

No special considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container