### PR TITLE
Updates kernel version to 5.4.136

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -39,8 +39,8 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder-focal/tests/vars.yml
 securedrop_pkg_grsec_focal:
-  ver: "5.4.97"
-  depends: "linux-image-5.4.97-grsec-securedrop,intel-microcode"
+  ver: "5.4.136"
+  depends: "linux-image-5.4.136-grsec-securedrop,intel-microcode"
 
 # Mostly useful for local package installation
 grsec_version: "{{ securedrop_pkg_grsec_focal.ver }}"

--- a/molecule/builder-focal/tests/vars.yml
+++ b/molecule/builder-focal/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "2.1.0~rc1"
 ossec_version: "3.6.0"
 keyring_version: "0.1.5"
 config_version: "0.1.4"
-grsec_version_focal: "5.4.97"
+grsec_version_focal: "5.4.136"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -178,6 +178,6 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt.freedom.press"
-grsec_version_focal: "5.4.97"
+grsec_version_focal: "5.4.136"
 
 daily_reboot_time: "4"

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -177,4 +177,4 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt.freedom.press"
-grsec_version_focal: "5.4.97"
+grsec_version_focal: "5.4.136"

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -185,6 +185,6 @@ log_events_with_ossec_alerts:
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
 
-grsec_version_focal: "5.4.97"
+grsec_version_focal: "5.4.136"
 
 daily_reboot_time: "4"

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -198,6 +198,6 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
-grsec_version_focal: "5.4.97"
+grsec_version_focal: "5.4.136"
 
 daily_reboot_time: "4"


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Towards a prospective 2.0.2 release  (issue #6055)

Updates the kernel metapackage version to 5.4.136 for Focal installs. 

freedomofpress/securedrop-dev-packages-lfs#118

## Testing

[ ] Focal metapackage pulls in 5.4.136 kernel image
[ ] CI passes.
