### PR TITLE
updates Tor package version to 0.4.5.9

### DIFF
--- a/molecule/fetch-tor-packages/playbook.yml
+++ b/molecule/fetch-tor-packages/playbook.yml
@@ -12,7 +12,7 @@
     tor_repo_pubkey: "{{ sd_repo_root + '/install_files/ansible-base/roles/tor-hidden-services/files/tor-signing-key.pub' }}"
     tor_repo_url: "deb https://deb.torproject.org/torproject.org {{ ansible_distribution_release }} main"
     # Used to fetch a precise version; must also be updated in the test vars
-    tor_version: "0.4.5.8-1~{{ ansible_distribution_release }}+1"
+    tor_version: "0.4.5.9-1~{{ ansible_distribution_release }}+1"
 
   tasks:
     - name: Add Tor apt repo pubkey

--- a/molecule/fetch-tor-packages/tests/test_tor_packages.py
+++ b/molecule/fetch-tor-packages/tests/test_tor_packages.py
@@ -11,7 +11,7 @@ TOR_PACKAGES = [
     {"name": "tor-geoipdb", "arch": "all"},
 ]
 # The '{}' will be replaced with platform, e.g. Focal
-TOR_VERSION_TEMPLATE = "0.4.5.8-1~{}+1"
+TOR_VERSION_TEMPLATE = "0.4.5.9-1~{}+1"
 
 
 def test_tor_apt_repo(host):


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Updates Tor package version downloaded from Tor Project repos from 0.4.5.8 to 0.4.5.9.

## Testing

- [x] Has version been incremented?
- [x] are corresponding focal packages available on https://deb.torproject.org/torproject.org/pool/main/t/tor/ ?
- [x] does `make fetch-tor-packages` pass locally?
- [x] does CI pass?



