### PR TITLE
restricts `staging-test-with-rebase` to release branches and nightlies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,7 @@ workflows:
               only:
                 - develop
     jobs:
+      - staging-test-with-rebase
       - static-analysis-and-no-known-cves
 
   weekly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,8 +312,8 @@ workflows:
       - staging-test-with-rebase:
           filters:
             branches:
-              ignore:
-                - /i18n-.*/
+              only:
+                - /release\/.*/
           requires:
             - lint
       - translation-tests:


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Towards #5336, restrict `staging-test-with-rebase` to run only:

1. on pushes to `release/*` branches; and
2. as part of the `nightly` workflow.

## Testing

To test the restriction to `release/*` branches:

1. [ ] Confirm that `staging-test-with-rebase` has not run on this branch.
2. [ ] [Test](https://regexr.com/) `staging-test-with-rebase`'s `filters.branches.only` regex against a known `release/` branch.

I'm not aware of a way to test the inclusion of `staging-test-with-rebase` as a job in the `nightly` workflow until this PR is merged into `develop`, but this change is trivial.

## Deployment

Development-only; no deployment considerations.

## Checklist

### If you made non-trivial code changes:

- ~I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later~
- [x] I would appreciate help with the documentation
- ~These changes do not require documentation~

Per #5336, these CI changes imply process changes that will need to be determined and documented.