### PR TITLE
makes pytest timings available to CircleCI

### DIFF
--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -51,6 +51,7 @@ pytest \
     --page-layout \
     --durations 10 \
     --junitxml=../test-results/junit.xml \
+    --override-ini junit_family=xunit1 \
     --cov-report term-missing \
     --cov-report html:../test-results/cov_html \
     --cov-report xml:../test-results/cov.xml \

--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -11,6 +11,9 @@ cd "${REPOROOT}/securedrop"
 PYTHONPATH=".:${PYTHONPATH:-}"
 export PYTHONPATH
 
+TEST_RESULTS=../test-results
+JUNIT_XML=${TEST_RESULTS}/junit.xml
+
 source "${BASH_SOURCE%/*}/dev-deps"
 
 run_xvfb
@@ -25,7 +28,12 @@ maybe_create_config_py
 if [ -n "${CIRCLE_BRANCH:-}" ] ; then
     touch tests/log/firefox.log
     function finish {
-        cp tests/log/firefox.log ../test-results
+        # Rewrite the TESTCASE[file] attribute in $JUNIT_XML relative to our
+        # working directory so that CircleCI can match timings to files on the
+        # next job.
+        sed -i 's/file="/file="tests\//g' "$JUNIT_XML"
+
+        cp tests/log/firefox.log "$TEST_RESULTS"
         tmpdir=$(mktemp -d -t codecov-XXXX)
         curl -s https://codecov.io/bash > "$tmpdir"/codecov;
         VERSION="$(curl --silent "https://api.github.com/repos/codecov/codecov-bash/releases/latest" | grep '"tag_name":' |sed -E 's/.*"([^"]+)".*/\1/')"
@@ -37,7 +45,7 @@ if [ -n "${CIRCLE_BRANCH:-}" ] ; then
     trap finish EXIT
 fi
 
-mkdir -p "../test-results"
+mkdir -p "$TEST_RESULTS"
 
 : "${TEST_LOCALES:="ar en_US"}"
 export TEST_LOCALES
@@ -50,11 +58,11 @@ pytest \
     --no-success-flaky-report \
     --page-layout \
     --durations 10 \
-    --junitxml=../test-results/junit.xml \
+    --junitxml "$JUNIT_XML" \
     --override-ini junit_family=xunit1 \
     --cov-report term-missing \
-    --cov-report html:../test-results/cov_html \
-    --cov-report xml:../test-results/cov.xml \
-    --cov-report annotate:../test-results/cov_annotate \
+    --cov-report "html:${TEST_RESULTS}/cov_html" \
+    --cov-report "xml:${TEST_RESULTS}/cov.xml" \
+    --cov-report "annotate:${TEST_RESULTS}/cov_annotate" \
     --cov=. \
     "$@"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #6026:

1. **Switch pytest to xUnit v1 output (in `junit.xml`),** which includes the `testcase[file]` attribute CircleCI requires to be able to match timings reported from job `n` to the files under test in job `n+1`.
2. **Rewrite the paths reported in `junit.xml`** to be relative to the repository/working directory, as CircleCI expects.
    * I looked into enforcing an absolute `$TEST_RESULTS` path at the job level, but the relative `../test-results` path is more portable across developer and nested-virtualization CI environments.

## Testing

Compare the `app-tests` jobs of the following workflow runs, both against 045c10b:

### [Job 56035](https://app.circleci.com/pipelines/github/freedomofpress/securedrop/2824/workflows/7ee18ff3-e236-4f53-a524-09d1dae3d245/jobs/56035#step-109-17)

First run with these changes:

```
Error autodetecting timing type, falling back to weighting by name. Autodetect no matching filename or classname.  If file names are used, double check paths for absolute vs relative.
Example input file: "tests/functional/test_admin_interface.py"
Example file from timings: "functional/test_source_metadata.py"
███ Running SecureDrop application tests...
```

### [Job 56041](https://app.circleci.com/pipelines/github/freedomofpress/securedrop/2824/workflows/753b6be3-6bd1-465e-9400-b6049542a696/jobs/56041/parallel-runs/1#step-109-17)

Second run with these changes:

```
Autodetected filename timings.
███ Running SecureDrop application tests...
```

Now, 56041's parallelism was _not_ more balanced than 56035's in practice:

| Job | 1 | 2 | 3 |
| --- | --- | --- | --- |
| [56035](https://app.circleci.com/pipelines/github/freedomofpress/securedrop/2824/workflows/7ee18ff3-e236-4f53-a524-09d1dae3d245/jobs/56035/steps) | 28:09 | 42:54 | 27:01 |
| [56041](https://app.circleci.com/pipelines/github/freedomofpress/securedrop/2824/workflows/753b6be3-6bd1-465e-9400-b6049542a696/jobs/56041/parallel-runs/1?filterBy=ALL) | 28:51 | 41:46 | 29:26 |

However, I suggest merging this PR, to start by fixing this glitch between pytest and CircleCI.  Then we can see whether CircleCI's test-splitting improves over time on `develop`, whether we should tinker with a higher `parallelism` value, &c.

## Deployment

Development-only; no deployment considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
    - In job no. 56041, `test_worker_for_job` flaked.