### PR TITLE
limits codenames in session to maximum cookie size

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -19,7 +19,8 @@ from models import Source, Submission, Reply, get_one_or_else
 from sdconfig import SDConfig
 from source_app.decorators import login_required
 from source_app.utils import (logged_in, generate_unique_codename,
-                              normalize_timestamps, valid_codename)
+                              normalize_timestamps, valid_codename,
+                              fit_codenames_into_cookie)
 from source_app.forms import LoginForm, SubmissionForm
 
 
@@ -48,7 +49,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         tab_id = urlsafe_b64encode(os.urandom(64)).decode()
         codenames = session.get('codenames', {})
         codenames[tab_id] = codename
-        session['codenames'] = codenames
+        session['codenames'] = fit_codenames_into_cookie(codenames)
 
         session['new_user'] = True
         return render_template('generate.html', codename=codename, tab_id=tab_id)

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 
 from flask import session, current_app, abort, g
@@ -91,3 +92,20 @@ def check_url_file(path: str, regexp: str) -> 'Optional[str]':
 def get_sourcev3_url() -> 'Optional[str]':
     return check_url_file("/var/lib/securedrop/source_v3_url",
                           r"^[a-z0-9]{56}\.onion$")
+
+
+def fit_codenames_into_cookie(codenames: dict) -> dict:
+    """
+    If `codenames` will approach `werkzeug.Response.max_cookie_size` once
+    serialized, incrementally pop off the oldest codename until the remaining
+    (newer) ones will fit.
+    """
+
+    serialized = json.dumps(codenames).encode()
+    if len(codenames) > 1 and len(serialized) > 4000:  # werkzeug.Response.max_cookie_size = 4093
+        current_app.logger.warn(f"Popping oldest of {len(codenames)} codenames ({len(serialized)} bytes) to fit within maximum cookie size")
+        del codenames[list(codenames)[0]]  # FIFO
+
+        return fit_codenames_into_cookie(codenames)
+
+    return codenames

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -103,7 +103,10 @@ def fit_codenames_into_cookie(codenames: dict) -> dict:
 
     serialized = json.dumps(codenames).encode()
     if len(codenames) > 1 and len(serialized) > 4000:  # werkzeug.Response.max_cookie_size = 4093
-        current_app.logger.warn(f"Popping oldest of {len(codenames)} codenames ({len(serialized)} bytes) to fit within maximum cookie size")
+        if current_app:
+            current_app.logger.warn(f"Popping oldest of {len(codenames)} "
+                                    f"codenames ({len(serialized)} bytes) to "
+                                    f"fit within maximum cookie size")
         del codenames[list(codenames)[0]]  # FIFO
 
         return fit_codenames_into_cookie(codenames)

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -1,3 +1,6 @@
+import werkzeug
+
+from ..test_journalist import VALID_PASSWORD
 from . import source_navigation_steps, journalist_navigation_steps
 from . import functional_test
 from sdconfig import config
@@ -157,3 +160,15 @@ class TestDuplicateSourceInterface(
         codename_lookup_b = self.get_codename_lookup()
         assert codename_lookup_b == codename_a2
         self._source_submits_a_message()
+
+    def test_codenames_exceed_max_cookie_size(self):
+        # Test generation of enough codenames (from multiple tabs and/or serial
+        # refreshes) that the resulting cookie exceeds the recommended
+        # `werkzeug.Response.max_cookie_size` = 4093 bytes.  (#6043)
+
+        too_many = 2*(werkzeug.Response.max_cookie_size // len(VALID_PASSWORD))
+        for i in range(too_many):
+            self._source_visits_source_homepage()
+            self._source_chooses_to_submit_documents()
+
+        self._source_continues_to_submit_page()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6043 by truncating the `codenames` dictionary FIFO if its serialized length will exceed the recommended `werkzeug.Response.maximum_cookie_size` = 4093 bytes.

The general solution to this behavior (i.e., the Flask/Werkzeug warning that a "cookie is too large") is to use server-side sessions instead, via (e.g.) [Flask-Session](https://flask-session.readthedocs.io/en/latest/) or [Flask-KVSession](https://pythonhosted.org/Flask-KVSession/).  In the current `tab_id`-based codename-generation scheme, however, server-side state for the `/generate` flow would introduce a vector for resource-exhaustion attacks without some kind of rate- and/or resource-limiting, which this fix also effectively provides.

See also:

* #204

## Testing

### Test case to reproduce #6043

```sh-session
$ git checkout ad4964f7c56881d810c7a95b15c2b36b7fa6dfff
$ securedrop/bin/dev-shell bin/run-test -v tests/functional/test_source.py::TestDuplicateSourceInterface tests/test_source_utils.py
```

- [ ] `test_codenames_exceed_max_cookie_size` fails

Or reproduce this behavior manually by hitting `/generate` ~30 times (in multiple tabs and/or serial refreshes) and then clicking **Submit Documents**.

### Resolution of #6043 

```sh-session
$ git checkout 6043-limit-codenames-to-cookie-size
$ securedrop/bin/dev-shell bin/run-test -v tests/functional/test_source.py::TestDuplicateSourceInterface tests/test_source_utils.py
```

- [ ] `test_codenames_exceed_max_cookie_size` passes

Or confirm this resolution manually by hitting `/generate` ~30 times (in multiple tabs and/or serial refreshes) and then clicking **Submit Documents**.

## Deployment

No special considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container