### PR TITLE
uses valid BCP47/RFC5646 `RequestLocaleInfo.language_tag`s in locale selectors

### DIFF
--- a/securedrop/journalist_templates/locales.html
+++ b/securedrop/journalist_templates/locales.html
@@ -6,7 +6,7 @@
       <img class="menu__trigger-icon" src="/static/i/languages_globe.png" alt="" width="18" height="18">
     </div>
     <div class="menu-text-container">
-      <span class="menu__trigger-text">{{ g.locales[g.localeinfo.id] }}</span>
+      <span class="menu__trigger-text">{{ g.locales[g.localeinfo.id].display_name }}</span>
     </div>
     <div class="menu-trigger-container">
       <img class="menu__trigger-icon" src="/static/i/languages_arrow.png" alt="" width="12" height="18">
@@ -26,7 +26,7 @@
           {% set url = '' %}
         {% endif %}
         <a href="{{ url }}" rel="nofollow" class="no-bottom-border">
-          <span>{{ g.locales[locale] }}</span>
+          <span>{{ g.locales[locale].display_name }}</span>
         </a>
       </li>
     {% endfor %}

--- a/securedrop/source_templates/locales.html
+++ b/securedrop/source_templates/locales.html
@@ -1,10 +1,10 @@
 {% if g.locales|length > 1 %}
 <section class="menu" aria-labelledby="locale-menu-heading">
   <h2 id="locale-menu-heading" hidden>
-    {{ gettext('Selected language')}}: {{ g.locales[g.localeinfo.id] }}
+    {{ gettext('Selected language')}}: {{ g.locales[g.localeinfo.id].display_name }}
   </h2>
   <label id="locale-menu-trigger" for="menu-1-checkbox" class="menu__trigger" aria-hidden="true">
-    {{ g.locales[g.localeinfo.id] }}
+    {{ g.locales[g.localeinfo.id].display_name }}
   </label>
   <input id="menu-1-checkbox" class="menu__checkbox visually-hidden" type="checkbox" role="button"
     aria-label="{{ gettext('Choose language') }}" aria-haspopup="menu" aria-controls="locales-menu" aria-pressed="true">
@@ -23,9 +23,9 @@
       {% set url = '' %}
       {% set checked = 'true' %}
       {% endif %}
-      <a href="{{ url }}" rel="nofollow" class="no-bottom-border" lang="{{ locale }}" hreflang="{{ locale }}"
+      <a href="{{ url }}" rel="nofollow" class="no-bottom-border" lang="{{ g.locales[locale].language_tag }}" hreflang="{{ g.locales[locale].language_tag }}"
         role="menuitemradio" aria-checked="{{ checked }}">
-        {{ g.locales[locale] }}
+        {{ g.locales[locale].display_name }}
       </a>
     </li>
     {% endfor %}

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -158,6 +158,16 @@ def verify_i18n(app):
         locales = render_template('locales.html')
         assert '?l=fr_FR' in locales
         assert '?l=en_US' not in locales
+
+        # Test that A[lang,hreflang] attributes (if present) will validate as
+        # BCP47/RFC5646 language tags from `i18n.RequestLocaleInfo.language_tag`.
+        if 'lang="' in locales:
+            assert 'lang="en-US"' in locales
+            assert 'lang="fr-FR"' in locales
+        if 'hreflang="' in locales:
+            assert 'hreflang="en-US"' in locales
+            assert 'hreflang="fr-FR"' in locales
+
         c.get('/?l=ar')
         base = render_template('base.html')
         assert 'dir="rtl"' in base


### PR DESCRIPTION
## Status

**Ready for review,** but this branch depends on and includes commits pending merge in:
- #6041

## Description of Changes

Closes #6056 by:

1. **refactoring `i18n.map_locale_display_names()`** so that the values of the global `LOCALES` dictionary are `i18n.RequestLocaleInfo` instances rather than strings; and
2. **updating `securedrop/{journalist,source}_templates/locales.html` accordingly** to use the `RequestLocaleInfo.display_name` property in user-facing text and the `RequestLocaleInfo.language_tag` property as required for the `a[lang,hreflang]` attributes to validate.

## Testing

Follow #6056's steps to reproduce:

1. [ ] **on `develop`** (or, pending #6041, on its branch`5986-semantic-source-interface`)
    1. [ ] The locale selectors fail HTML validation on their `a[lang,hreflang]` attributes.
2. [ ] **on this branch `6056-language-tag`**
    - [ ] The locale selectors pass HTML validation on their `a[lang,hreflang]` attributes.
    - [ ] The locale selectors are otherwise unchanged.

## Deployment

No deployment considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container