### PR TITLE
switches `updater-gui-tests` to `cimg/python:3.7`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
 
   updater-gui-tests:
     docker:
-      - image: circleci/python:3.5
+      - image: cimg/python:3.7
     steps:
       - checkout
 

--- a/journalist_gui/Pipfile
+++ b/journalist_gui/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 url = "https://pypi.python.org/simple"
 
 [requires]
-python_version = "3.5"
+python_version = "3.7"
 
 [dev-packages]
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

1. Fixes #6068 by moving from the older `circleci/` image series, based on Debian Buster, to the newer `cimg/` series, based on Ubuntu Focal.
2. Closes #6025 by bumping from `python:3.5` to `python:3.7`.

Together, these changes bring `updater-gui-tests` in line with other CI jobs that use CircleCI's `python` images rather than the base `ubuntu` images.

## Testing

- [x] `updater-gui-tests` passes in CI.

## Deployment

Development-only; no deployment considerations.

## Checklist

### If you added or updated a code dependency:

Choose one of the following:

- ~~I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)~~
- [x] I would like someone else to do the diff review
    -  Since other SecureDrop projects already use both Python 3.7 in general and `cimg/python:3.7`, I do not believe a diff review is necessary.
