### PR TITLE
  Make <time datetime= into valid HTML by using a custom jinja tag

### DIFF
--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -115,6 +115,8 @@ def create_app(config: 'SDConfig') -> Flask:
     app.jinja_env.filters['rel_datetime_format'] = \
         template_filters.rel_datetime_format
     app.jinja_env.filters['filesizeformat'] = template_filters.filesizeformat
+    app.jinja_env.filters['html_datetime_format'] = \
+        template_filters.html_datetime_format
 
     @app.before_first_request
     def expire_blacklisted_tokens() -> None:

--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -1,7 +1,7 @@
 {% set docs = source.documents_messages_count()['documents'] %}
 {% set msgs = source.documents_messages_count()['messages'] %}
 <li class="source {% if source.num_unread != 0 %}unread{% else %}read{% endif %}" data-source-designation="{{ source.journalist_designation|lower }}">
-  <time class="date" title="{{ source.last_updated|rel_datetime_format }}" datetime="{{ source.last_updated|rel_datetime_format(fmt="%Y-%m-%d %H:%M:%S%Z") }}">{{ source.last_updated|rel_datetime_format(relative=True) }}</time>
+  <time class="date" title="{{ source.last_updated|rel_datetime_format }}" datetime="{{ source.last_updated|html_datetime_format }}">{{ source.last_updated|rel_datetime_format(relative=True) }}</time>
   <div class="designation">
     {% if source.star.starred %}
       <button class="button-star starred" type="submit" formaction="{{ url_for('col.remove_star', filesystem_id=source.filesystem_id) }}" aria-label="{{ gettext('Un-star {designation}').format(designation=source.journalist_designation) }}">

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -98,6 +98,8 @@ def create_app(config: SDConfig) -> Flask:
         template_filters.rel_datetime_format
     app.jinja_env.filters['nl2br'] = evalcontextfilter(template_filters.nl2br)
     app.jinja_env.filters['filesizeformat'] = template_filters.filesizeformat
+    app.jinja_env.filters['html_datetime_format'] = \
+        template_filters.html_datetime_format
 
     for module in [main, info, api]:
         app.register_blueprint(module.make_blueprint(config))  # type: ignore

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -70,7 +70,7 @@
     {% for reply in replies %}
     <article class="reply">
       <h3 class="date"><time title="{{ reply.date|rel_datetime_format }}"
-          datetime="{{ reply.date }}">{{ reply.date|rel_datetime_format(relative=True) }}</time></h3>
+          datetime="{{ reply.date|html_datetime_format }}">{{ reply.date|rel_datetime_format(relative=True) }}</time></h3>
       <form id="delete" class="message" method="post" action="{{ url_for('main.delete') }}" autocomplete="off">
         <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         <input type="hidden" name="reply_filename" value="{{ reply.filename }}" autocomplete="off">

--- a/securedrop/template_filters.py
+++ b/securedrop/template_filters.py
@@ -49,3 +49,8 @@ def filesizeformat(value: int) -> str:
         prefix = prefixes[i]
         bytes = float(value) / base ** (i + 1)
         return units.format_unit(bytes, prefix, locale=locale, length="short")
+
+
+def html_datetime_format(dt: datetime) -> str:
+    """Return a datetime string that will pass HTML validation"""
+    return dates.format_datetime(dt, 'yyyy-MM-dd HH:mm:ss.SSS')


### PR DESCRIPTION
(Resubmitting @anorthall's changes from #6058, recovered after a broken rebase)

## Status

Ready for review 

## Description of Changes

Fixes #6057

Change the direct call to `__str__()` into a call to `strftime()` to meet the requirement of not having more than 3 decimal places for seconds on HTML. Now, no decimal places are displayed. I decided to implement this instead of the truncate filter as you cannot truncate the datetime object without first converting it to a string.

## Testing

Open the website and validate the HTML.

## Deployment

No special measures required.

## Checklist

- [X] These changes do not require documentation
