### PR TITLE
factors out page-layout tests to parallelize explicitly alongside `app-tests`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,41 @@ jobs:
           command: |
             BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|update-builder)")
             if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
-            export TESTFILES=$(cd securedrop; circleci tests glob 'tests/test*py' 'tests/**/test*py' |circleci tests split --split-by=timings |xargs echo)
+            export TESTFILES=$(cd securedrop; circleci tests glob 'tests/test*py' 'tests/{files,functional}/test*py' |circleci tests split --split-by=timings |xargs echo)
+            fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
+            DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" make test
+          no_output_timeout: 15m
+
+      - store_test_results:
+          path: ~/project/test-results
+
+      - store_artifacts:
+          path: ~/project/test-results
+
+  app-page-layout-tests:
+    machine:
+      image: ubuntu-2004:202010-01
+      enabled: true
+    environment:
+      DOCKER_API_VERSION: 1.23
+      BASE_OS: focal
+    parallelism: 3
+    steps:
+      - checkout
+      - *rebaseontarget
+      - *createcachedir
+      - *restorecache
+      - *loadimagelayers
+      - *dockerimagebuild
+      - *saveimagelayers
+      - *savecache
+
+      - run:
+          name: Run tests
+          command: |
+            BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|update-builder)")
+            if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
+            export TESTFILES=$(cd securedrop; circleci tests glob 'tests/pageslayout/test*py' |circleci tests split --split-by=timings |xargs echo)
             fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" make test
           no_output_timeout: 15m
@@ -289,6 +323,14 @@ workflows:
     jobs:
       - lint
       - app-tests:
+          filters:
+            branches:
+              ignore:
+                - /i18n-.*/
+                - /update-builder-.*/
+          requires:
+            - lint
+      - app-page-layout-tests:
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,11 @@ jobs:
           command: |
             BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|update-builder)")
             if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
-            export TESTFILES=$(cd securedrop; circleci tests glob 'tests/test*py' 'tests/{files,functional}/test*py' |circleci tests split --split-by=timings |xargs echo)
+            JOB_TESTFILES=$(cd securedrop; circleci tests glob 'tests/test*py' 'tests/{files,functional}/test*py')
+            echo "JOB_TESTFILES: ${JOB_TESTFILES}"
+            RUN_TESTFILES=$(echo "$JOB_TESTFILES" |circleci tests split --split-by=timings)
+            echo "RUN_TESTFILES: ${RUN_TESTFILES}"
+            export TESTFILES=$RUN_TESTFILES
             fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" make test
           no_output_timeout: 15m
@@ -134,7 +138,11 @@ jobs:
           command: |
             BRANCH_MATCH=$(devops/scripts/match-ci-branch.sh "^(i18n|update-builder)")
             if [[ $BRANCH_MATCH =~ ^found ]]; then echo "Skipping: ${BRANCH_MATCH}"; exit 0; fi
-            export TESTFILES=$(cd securedrop; circleci tests glob 'tests/pageslayout/test*py' |circleci tests split --split-by=timings |xargs echo)
+            JOB_TESTFILES=$(cd securedrop; circleci tests glob 'tests/pageslayout/test*py')
+            echo "JOB_TESTFILES: ${JOB_TESTFILES}"
+            RUN_TESTFILES=$(echo "$JOB_TESTFILES" |circleci tests split --split-by=timings)
+            echo "RUN_TESTFILES: ${RUN_TESTFILES}"
+            export TESTFILES=$RUN_TESTFILES
             fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" make test
           no_output_timeout: 15m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
     environment:
       DOCKER_API_VERSION: 1.23
       BASE_OS: focal
-    parallelism: 3
+    parallelism: 2
     steps:
       - checkout
       - *rebaseontarget

--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -13,7 +13,9 @@ RUN apt-get update && apt-get install -y paxctl && \
                        python3-pip python3-all python3-venv virtualenv libpython3.8-dev libssl-dev \
                        gnupg2 ruby redis-server git xvfb curl wget \
                        gettext paxctl x11vnc enchant libffi-dev sqlite3 gettext sudo \
-                       # for html5validator
+                       # For html5validator.  Used only in "app-page-layout-tests", but we can live
+                       # with its being installed along with everything else since it will be
+                       # cached along with everything else too.
                        default-jdk \
                        libasound2 libdbus-glib-1-2 libgtk2.0-0 libfontconfig1 libxrender1 \
                        libcairo-gobject2 libgtk-3-0 libstartup-notification0 tor


### PR DESCRIPTION
## Status

Ready for review; see discussion in https://github.com/freedomofpress/securedrop/issues/6026#issuecomment-905758983
* Squash-merge recommended

## Description of Changes

Towards #6026, optimizes CI runtime [as much as currently possible](https://github.com/freedomofpress/securedrop/issues/6026#issuecomment-905758983) by factoring out page-layout tests into their own job `app-page-layout-tests` with `parallelism: 2`.  The resulting workflow looks like this:

1. `app-page-layout-tests` parallelized into runs:
    1. `tests/pageslayout/test_journalist.py`
    2. `tests/pageslayout/test_source.py`
2. `app-tests` parallelized into runs:
    1. everything else split by CircleCI according to pytest timings
    2. everything else split by CircleCI according to pytest timings
    3. everything else split by CircleCI according to pytest timings

In addition:

- 6491b63d54778a48593819ff65f7686daabec7ea logs *how* CircleCI has split `$JOB_TESTFILES` into the `$RUN_TESTFILES` that it passes to pytest within each run.  This can be rebased out if undesirable.

## Testing

[For branch `6026-parallelism-split-pageslayout` in CircleCI:](https://app.circleci.com/pipelines/github/freedomofpress/securedrop?branch=6026-parallelism-split-pageslayout)

1. [x] `app-tests` passes ca. 20 min
2. [x] `app-page-layout-tests` passes ca. 30 min
3. [x] CI output is satisfactory

## Deployment

CI-only; no deployment implications.