### PR TITLE
Remove "automatic decompression" fix

### DIFF
--- a/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
+++ b/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
@@ -94,13 +94,6 @@ try:
 except subprocess.CalledProcessError:
     sys.exit('Error restarting Tor')
 
-# Turn off "automatic-decompression" in Nautilus to ensure the original
-# submission filename is restored (see
-# https://github.com/freedomofpress/securedrop/issues/1862#issuecomment-311519750).
-subprocess.call(['/usr/bin/dconf', 'write',
-                 '/org/gnome/nautilus/preferences/automatic-decompression',
-                 'false'])
-
 # Set journalist.desktop and source.desktop links as trusted with Nautilus (see
 # https://github.com/freedomofpress/securedrop/issues/2586)
 # set euid and env variables to amnesia user


### PR DESCRIPTION
As of Tails 4, this is no longer needed (see #4947)

## Status

Ready for review

## Description of Changes

In Tails <4, it was necessary to manually set a configuration flag to ensure filenames of extracted files are preserved. This is no longer needed in Tails >=4, and accordingly, we can remove this from the automatic logic in `securedrop_init` as well.

## Test plan

- [ ] On an Admin Workstation with this change, run network hook manually or by bouncing connection to ensure that correct network hook behavior is preserved (icons and connections are configured)
- [ ] Boot a Tails stick without unlocking the persistent volume. Decompress a file using the "Extract here" (right click) method and observe that filenames are preserved.