### PR TITLE
Move CryptoUtil.display_id() out of CryptoUtil to fix type-checking 

### DIFF
--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -80,8 +80,6 @@ def create_app(config: 'SDConfig') -> Flask:
     # breaks code analysis tools) for code that uses current_app.storage; it should be refactored
     app.crypto_util = CryptoUtil(
         securedrop_root=config.SECUREDROP_ROOT,
-        nouns_file=config.NOUNS,
-        adjectives_file=config.ADJECTIVES,
         gpg_key_dir=config.GPG_KEY_DIR,
     )
 

--- a/securedrop/loaddata.py
+++ b/securedrop/loaddata.py
@@ -116,7 +116,7 @@ def set_source_count(s: str) -> int:
 
 
 def add_journalist(
-    username: str = "",
+    username: str,
     is_admin: bool = False,
     first_name: str = "",
     last_name: str = "",
@@ -127,9 +127,6 @@ def add_journalist(
     """
     test_password = "correct horse battery staple profanity oil chewy"
     test_otp_secret = "JHCOGO7VCER3EJ4L"
-
-    if not username:
-        username = current_app.crypto_util.display_id()
 
     journalist = Journalist(
         username=username,
@@ -258,7 +255,6 @@ def add_source() -> Tuple[Source, str]:
     source_user = create_source_user(
         db_session=db.session,
         source_passphrase=codename,
-        source_app_crypto_util=current_app.crypto_util,
         source_app_storage=current_app.storage,
     )
     source = source_user.get_db_record()
@@ -319,7 +315,7 @@ def create_default_journalists() -> Tuple[Journalist, ...]:
 def add_journalists(args: argparse.Namespace) -> None:
     total = args.journalist_count
     for i in range(1, total + 1):
-        add_journalist(progress=(i, total))
+        add_journalist(username=f"journalist{str(i)}", progress=(i, total))
 
 
 def add_sources(args: argparse.Namespace, journalists: Tuple[Journalist, ...]) -> None:

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -76,8 +76,6 @@ def create_app(config: SDConfig) -> Flask:
     # breaks code analysis tools) for code that uses current_app.storage; it should be refactored
     app.crypto_util = CryptoUtil(
         securedrop_root=config.SECUREDROP_ROOT,
-        nouns_file=config.NOUNS,
-        adjectives_file=config.ADJECTIVES,
         gpg_key_dir=config.GPG_KEY_DIR,
     )
 

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -81,7 +81,6 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                 create_source_user(
                     db_session=db.session,
                     source_passphrase=codename,
-                    source_app_crypto_util=current_app.crypto_util,
                     source_app_storage=current_app.storage,
                 )
             except (SourcePassphraseCollisionError, SourceDesignationCollisionError) as e:

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -239,7 +239,6 @@ def test_source(journalist_app: Flask) -> Dict[str, Any]:
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=passphrase,
-            source_app_crypto_util=journalist_app.crypto_util,
             source_app_storage=journalist_app.storage,
         )
         journalist_app.crypto_util.genkeypair(source_user)

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -1,5 +1,6 @@
 import werkzeug
 
+import source_user
 from ..test_journalist import VALID_PASSWORD
 from . import source_navigation_steps, journalist_navigation_steps
 from . import functional_test
@@ -11,14 +12,17 @@ class TestSourceInterfaceDesignationCollision(
         source_navigation_steps.SourceNavigationStepsMixin):
 
     def start_source_server(self, source_port):
-        self.source_app.crypto_util.adjectives = \
-            self.source_app.crypto_util.adjectives[:1]
-        self.source_app.crypto_util.nouns = self.source_app.crypto_util.nouns[:1]
+        # Generator that always returns the same journalist designation
+        source_user._default_designation_generator = source_user._DesignationGenerator(
+            nouns=["accent"],
+            adjectives=["tonic"],
+        )
+
         config.SESSION_EXPIRATION_MINUTES = self.session_expiration / 60.0
 
         self.source_app.run(port=source_port, debug=True, use_reloader=False, threaded=True)
 
-    def test_display_id_designation_collisions(self):
+    def test_journalist_designation_collisions(self):
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()
         self._source_continues_to_submit_page()

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -227,7 +227,6 @@ def test_were_there_submissions_today(source_app, config):
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
-            source_app_crypto_util=source_app.crypto_util,
             source_app_storage=source_app.storage,
         )
         source = source_user.get_db_record()

--- a/securedrop/tests/test_session_manager.py
+++ b/securedrop/tests/test_session_manager.py
@@ -21,7 +21,6 @@ class TestSessionManager:
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=passphrase,
-            source_app_crypto_util=source_app.crypto_util,
             source_app_storage=source_app.storage,
         )
 
@@ -40,7 +39,6 @@ class TestSessionManager:
         create_source_user(
             db_session=db.session,
             source_passphrase=passphrase,
-            source_app_crypto_util=source_app.crypto_util,
             source_app_storage=source_app.storage,
         )
 
@@ -62,7 +60,6 @@ class TestSessionManager:
         create_source_user(
             db_session=db.session,
             source_passphrase=passphrase,
-            source_app_crypto_util=source_app.crypto_util,
             source_app_storage=source_app.storage,
         )
 
@@ -86,7 +83,6 @@ class TestSessionManager:
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=passphrase,
-            source_app_crypto_util=source_app.crypto_util,
             source_app_storage=source_app.storage,
         )
 

--- a/securedrop/tests/test_store.py
+++ b/securedrop/tests/test_store.py
@@ -223,7 +223,6 @@ def test_add_checksum_for_file(config, db_model):
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
-            source_app_crypto_util=app.crypto_util,
             source_app_storage=app.storage,
         )
         source = source_user.get_db_record()
@@ -271,7 +270,6 @@ def test_async_add_checksum_for_file(config, db_model):
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
-            source_app_crypto_util=app.crypto_util,
             source_app_storage=app.storage,
         )
         source = source_user.get_db_record()

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -133,7 +133,6 @@ def init_source():
     source_user = create_source_user(
         db_session=db.session,
         source_passphrase=passphrase,
-        source_app_crypto_util=current_app.crypto_util,
         source_app_storage=current_app.storage,
     )
     current_app.crypto_util.genkeypair(source_user)


### PR DESCRIPTION
## Status

Ready.

## Description of Changes

This small PR refactors `CryptoUtil.display_id()` and moves it out of `CryptoUtil` in order to:

* Enable/fix type-checking  for `display_id()` for #5599 .
* Rename display_id to journalist_designation to clarify what it is.
* Simplify the code for creating a new source.
* Make it easier to add support for journalist designations in other languages (in the future).

I tested this in the dev environment and checked that journalist designations are properly generated.
