### PR TITLE
adds diff-review decision tree to pull-request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,7 +48,17 @@ Choose one of the following:
 - [ ] I would appreciate help with the documentation
 - [ ] These changes do not require documentation
 
-### If you added or updated a code dependency:
+### If you added or updated a production code dependency:
+
+Production code dependencies are defined in:
+
+- `admin/requirements.in`
+- `admin/requirements-ansible.in`
+- `securedrop/requirements/python3/securedrop-app-code-requirements.in`
+
+If you changed another `requirements.in` file that applies only to development
+or testing environments, then no diff review is required, and you can skip
+(remove) this section.
 
 Choose one of the following:
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes my feeling that contributors should be given an explicit decision-tree for when dependency changes require diff reviews and when they do not.  :-)

## Testing

- [ ] List of `requirements.in` files that count as "production" is correct
- [ ] Instructions match project policy and maintainers' wishes