### PR TITLE
resolves visual discrepancies on Source Interface

### DIFF
--- a/securedrop/sass/modules/_panel.sass
+++ b/securedrop/sass/modules/_panel.sass
@@ -11,3 +11,7 @@
       section, article, .section-spacing
         display: flow-root
         margin-top: 10px + 2*8px  // cf. hr.no-line
+
+  li
+    section, article, .section-spacing
+      margin-top: 0 !important

--- a/securedrop/sass/modules/_panel.sass
+++ b/securedrop/sass/modules/_panel.sass
@@ -1,6 +1,6 @@
 =panel
   body:not(#source-index)
-    main
+    main, div.panel
       max-width: 800px
       width: 100%
       margin: 0 auto

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -124,7 +124,8 @@ p#codename
 
   .danger
     display: inline-block
-    width: 30%
+    min-width: 30%
+    max-width: 50%
 
   .cancel
     display: inline-block

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -263,6 +263,7 @@ p#max-file-size
   border: 3px solid #666
   padding: 10px 25px
   display: none
+  z-index: 99999
 
   .close
     cursor: pointer

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -64,7 +64,7 @@
 
   <div id="replies">
     {% if replies %}
-    <p>
+    <p class="aside">
       {{ gettext("You have received a reply. To protect your identity in the unlikely event someone learns your codename, please delete all replies when you're done with them. This also lets us know that you are aware of our reply. You can respond by submitting new files and messages above.") }}
     </p>
     {% for reply in replies %}


### PR DESCRIPTION
## Status

**Work in progress**—pending discovery, resolution, and testing of any further discrepancies prior to the 2.1.0 freeze!

## Description of Changes

Fixes #6080; individual bugs (introduced in #6041) are tracked and referred to in commits.

## Testing

For each bug tracked in #6080:

1. Run this branch `6080-cfm-rendering-discrepancies` locally.
2. For each flow documented in the bug:
    1. Reproduce it on `demo-{journalist,source}.securedrop.org`.
    2. Reproduce it locally.
3. Compare the two screens visually (side-by-side will be easiest) and confirm that the discrepancy has been resolved.

## Deployment

No deployment considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container