### PR TITLE
splits up `app-page-layout-tests` for more-efficient parallelization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
     environment:
       DOCKER_API_VERSION: 1.23
       BASE_OS: focal
-    parallelism: 2
+    parallelism: 5
     steps:
       - checkout
       - *rebaseontarget

--- a/securedrop/tests/pageslayout/test_journalist.py
+++ b/securedrop/tests/pageslayout/test_journalist.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-import time
-
 import pytest
 
 from tests.functional import journalist_navigation_steps
@@ -30,147 +28,10 @@ class TestJournalistLayout(
         source_navigation_steps.SourceNavigationStepsMixin,
         journalist_navigation_steps.JournalistNavigationStepsMixin):
 
-    def test_account_edit_hotp_secret(self):
-        self._journalist_logs_in()
-        self._visit_edit_account()
-        self._visit_edit_hotp_secret()
-        self._screenshot('journalist-account_edit_hotp_secret.png')
-        self._save_html('journalist-account_edit_hotp_secret.html')
-
-    def test_account_new_two_factor_hotp(self):
-        self._journalist_logs_in()
-        self._visit_edit_account()
-        self._visit_edit_hotp_secret()
-        self._set_hotp_secret()
-        self._screenshot('journalist-account_new_two_factor_hotp.png')
-        self._save_html('journalist-account_new_two_factor_hotp.html')
-
-    def test_account_new_two_factor_totp(self):
-        self._journalist_logs_in()
-        self._visit_edit_account()
-        self._visit_edit_totp_secret()
-        self._screenshot('journalist-account_new_two_factor_totp.png')
-        self._save_html('journalist-account_new_two_factor_totp.html')
-
-    def test_admin_add_user_hotp(self):
-        self._admin_logs_in()
-        self._admin_visits_admin_interface()
-        self._admin_visits_add_user()
-        self._admin_enters_journalist_account_details_hotp(
-            'journalist2',
-            'c4 26 43 52 69 13 02 49 9f 6a a5 33 96 46 d9 05 42 a3 4f ae'
-        )
-        self._screenshot('journalist-admin_add_user_hotp.png')
-        self._save_html('journalist-admin_add_user_hotp.html')
-
-    def test_admin_add_user_totp(self):
-        self._admin_logs_in()
-        self._admin_visits_admin_interface()
-        self._admin_visits_add_user()
-        self._screenshot('journalist-admin_add_user_totp.png')
-        self._save_html('journalist-admin_add_user_totp.html')
-
-    def test_admin_edit_hotp_secret(self):
-        self._admin_logs_in()
-        self._admin_visits_admin_interface()
-        self._admin_adds_a_user()
-        self._admin_visits_edit_user()
-        self._admin_visits_reset_2fa_hotp()
-        self._screenshot('journalist-admin_edit_hotp_secret.png')
-        self._save_html('journalist-admin_edit_hotp_secret.html')
-
-    def test_admin_edit_totp_secret(self):
-        self._admin_logs_in()
-        self._admin_visits_admin_interface()
-        self._admin_adds_a_user()
-        self._admin_visits_edit_user()
-        self._admin_visits_reset_2fa_totp()
-        self._screenshot('journalist-admin_edit_totp_secret.png')
-        self._save_html('journalist-admin_edit_totp_secret.html')
-
     def test_login(self):
         self.driver.get(self.journalist_location + "/login")
         self._screenshot('journalist-login.png')
         self._save_html('journalist-login.html')
-
-    def test_admin(self):
-        self._admin_logs_in()
-        self._admin_visits_admin_interface()
-        self._admin_adds_a_user()
-        self._screenshot('journalist-admin.png')
-        self._save_html('journalist-admin.html')
-
-    def test_admin_new_user_two_factor_hotp(self):
-        self._admin_logs_in()
-        self._admin_visits_admin_interface()
-        valid_hotp = '1234567890123456789012345678901234567890'
-        self._admin_creates_a_user(hotp=valid_hotp)
-        self._screenshot('journalist-admin_new_user_two_factor_hotp.png')
-        self._save_html('journalist-admin_new_user_two_factor_hotp.html')
-
-    def test_admin_new_user_two_factor_totp(self):
-        self._admin_logs_in()
-        self._admin_visits_admin_interface()
-        self._admin_creates_a_user(hotp=None)
-        self._screenshot('journalist-admin_new_user_two_factor_totp.png')
-        self._save_html('journalist-admin_new_user_two_factor_totp.html')
-
-    def test_admin_changes_logo(self):
-        self._admin_logs_in()
-        self._admin_visits_admin_interface()
-        self._admin_visits_system_config_page()
-        self._screenshot('journalist-admin_system_config_page.png')
-        self._save_html('journalist-admin_system_config_page.html')
-        self._admin_updates_logo_image()
-        self._screenshot('journalist-admin_changes_logo_image.png')
-        self._save_html('journalist-admin_changes_logo_image.html')
-
-    def test_col_no_documents(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_delete_all()
-        self._journalist_confirm_delete_selected()
-        self._screenshot('journalist-col_no_document.png')
-        self._save_html('journalist-col_no_document.html')
-
-    def test_col_has_no_key(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._source_delete_key()
-        self._journalist_visits_col()
-        self._screenshot('journalist-col_has_no_key.png')
-        self._save_html('journalist-col_has_no_key.html')
-
-    def test_col(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._screenshot('journalist-col.png')
-        self._save_html('journalist-col.html')
-
-    def test_col_javascript(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._screenshot('journalist-col_javascript.png')
-        self._save_html('journalist-col_javascript.html')
 
     def test_journalist_composes_reply(self):
         self._source_visits_source_homepage()
@@ -185,109 +46,16 @@ class TestJournalistLayout(
         self._screenshot('journalist-composes_reply.png')
         self._save_html('journalist-composes_reply.html')
 
-    def test_admin_uses_ossec_alert_button(self):
-        self._admin_logs_in()
-        self._admin_visits_admin_interface()
-        self._admin_visits_system_config_page()
-        self._admin_can_send_test_alert()
-        self._screenshot('journalist-admin_ossec_alert_button.png')
-        self._save_html('journalist-admin_ossec_alert_button.html')
-
-    def test_delete_none(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_submits_a_message()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_clicks_delete_selected_link()
-        self._journalist_confirm_delete_selected()
-        self._screenshot('journalist-delete_none.png')
-        self._save_html('journalist-delete_none.html')
-
-    def test_delete_one_confirmation(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_submits_a_message()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_selects_first_doc()
-        self._journalist_clicks_delete_selected_link()
-        time.sleep(1)
-        self._screenshot('journalist-delete_one_confirmation.png')
-        self._save_html('journalist-delete_one_confirmation.html')
-
-    def test_delete_all_confirmation(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_submits_a_message()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_delete_all_confirmation()
-        time.sleep(1)
-        self._screenshot('journalist-delete_all_confirmation.png')
-        self._save_html('journalist-delete_all_confirmation.html')
-
-    def test_delete_one(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_submits_a_message()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_delete_one()
-        self._journalist_confirm_delete_selected()
-        self._screenshot('journalist-delete_one.png')
-        self._save_html('journalist-delete_one.html')
-
-    def test_delete_all(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_submits_a_message()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_delete_all()
-        self._journalist_confirm_delete_selected()
-        self._screenshot('journalist-delete_all.png')
-        self._save_html('journalist-delete_all.html')
-
     def test_edit_account_user(self):
         self._journalist_logs_in()
         self._visit_edit_account()
         self._screenshot('journalist-edit_account_user.png')
         self._save_html('journalist-edit_account_user.html')
 
-    def test_edit_account_admin(self):
-        self._admin_logs_in()
-        self._admin_visits_admin_interface()
-        self._admin_adds_a_user()
-        self._admin_visits_edit_user()
-        self._screenshot('journalist-edit_account_admin.png')
-        self._save_html('journalist-edit_account_admin.html')
-
     def test_index_no_documents_admin(self):
         self._admin_logs_in()
         self._screenshot('journalist-admin_index_no_documents.png')
         self._save_html('journalist-admin_index_no_documents.html')
-
-    def test_admin_interface_index(self):
-        self._admin_logs_in()
-        self._admin_visits_admin_interface()
-        self._screenshot('journalist-admin_interface_index.png')
-        self._save_html('journalist-admin_interface_index.html')
 
     def test_index_no_documents(self):
         self._journalist_logs_in()

--- a/securedrop/tests/pageslayout/test_journalist_account.py
+++ b/securedrop/tests/pageslayout/test_journalist_account.py
@@ -1,0 +1,51 @@
+#
+# SecureDrop whistleblower submission system
+# Copyright (C) 2017 Loic Dachary <loic@dachary.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import pytest
+
+from tests.functional import journalist_navigation_steps
+from tests.functional import source_navigation_steps
+import tests.pageslayout.functional_test as pft
+
+
+@pytest.mark.pagelayout
+class TestJournalistLayoutAccount(
+        pft.FunctionalTest,
+        source_navigation_steps.SourceNavigationStepsMixin,
+        journalist_navigation_steps.JournalistNavigationStepsMixin):
+
+    def test_account_edit_hotp_secret(self):
+        self._journalist_logs_in()
+        self._visit_edit_account()
+        self._visit_edit_hotp_secret()
+        self._screenshot('journalist-account_edit_hotp_secret.png')
+        self._save_html('journalist-account_edit_hotp_secret.html')
+
+    def test_account_new_two_factor_hotp(self):
+        self._journalist_logs_in()
+        self._visit_edit_account()
+        self._visit_edit_hotp_secret()
+        self._set_hotp_secret()
+        self._screenshot('journalist-account_new_two_factor_hotp.png')
+        self._save_html('journalist-account_new_two_factor_hotp.html')
+
+    def test_account_new_two_factor_totp(self):
+        self._journalist_logs_in()
+        self._visit_edit_account()
+        self._visit_edit_totp_secret()
+        self._screenshot('journalist-account_new_two_factor_totp.png')
+        self._save_html('journalist-account_new_two_factor_totp.html')

--- a/securedrop/tests/pageslayout/test_journalist_admin.py
+++ b/securedrop/tests/pageslayout/test_journalist_admin.py
@@ -1,0 +1,119 @@
+#
+# SecureDrop whistleblower submission system
+# Copyright (C) 2017 Loic Dachary <loic@dachary.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import pytest
+
+from tests.functional import journalist_navigation_steps
+from tests.functional import source_navigation_steps
+import tests.pageslayout.functional_test as pft
+
+
+@pytest.mark.pagelayout
+class TestJournalistLayoutAdmin(
+        pft.FunctionalTest,
+        source_navigation_steps.SourceNavigationStepsMixin,
+        journalist_navigation_steps.JournalistNavigationStepsMixin):
+
+    def test_admin_add_user_hotp(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_visits_add_user()
+        self._admin_enters_journalist_account_details_hotp(
+            'journalist2',
+            'c4 26 43 52 69 13 02 49 9f 6a a5 33 96 46 d9 05 42 a3 4f ae'
+        )
+        self._screenshot('journalist-admin_add_user_hotp.png')
+        self._save_html('journalist-admin_add_user_hotp.html')
+
+    def test_admin_add_user_totp(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_visits_add_user()
+        self._screenshot('journalist-admin_add_user_totp.png')
+        self._save_html('journalist-admin_add_user_totp.html')
+
+    def test_admin_edit_hotp_secret(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_adds_a_user()
+        self._admin_visits_edit_user()
+        self._admin_visits_reset_2fa_hotp()
+        self._screenshot('journalist-admin_edit_hotp_secret.png')
+        self._save_html('journalist-admin_edit_hotp_secret.html')
+
+    def test_admin_edit_totp_secret(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_adds_a_user()
+        self._admin_visits_edit_user()
+        self._admin_visits_reset_2fa_totp()
+        self._screenshot('journalist-admin_edit_totp_secret.png')
+        self._save_html('journalist-admin_edit_totp_secret.html')
+
+    def test_edit_account_admin(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_adds_a_user()
+        self._admin_visits_edit_user()
+        self._screenshot('journalist-edit_account_admin.png')
+        self._save_html('journalist-edit_account_admin.html')
+
+    def test_admin(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_adds_a_user()
+        self._screenshot('journalist-admin.png')
+        self._save_html('journalist-admin.html')
+
+    def test_admin_new_user_two_factor_hotp(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        valid_hotp = '1234567890123456789012345678901234567890'
+        self._admin_creates_a_user(hotp=valid_hotp)
+        self._screenshot('journalist-admin_new_user_two_factor_hotp.png')
+        self._save_html('journalist-admin_new_user_two_factor_hotp.html')
+
+    def test_admin_new_user_two_factor_totp(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_creates_a_user(hotp=None)
+        self._screenshot('journalist-admin_new_user_two_factor_totp.png')
+        self._save_html('journalist-admin_new_user_two_factor_totp.html')
+
+    def test_admin_changes_logo(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_visits_system_config_page()
+        self._screenshot('journalist-admin_system_config_page.png')
+        self._save_html('journalist-admin_system_config_page.html')
+        self._admin_updates_logo_image()
+        self._screenshot('journalist-admin_changes_logo_image.png')
+        self._save_html('journalist-admin_changes_logo_image.html')
+
+    def test_admin_uses_ossec_alert_button(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._admin_visits_system_config_page()
+        self._admin_can_send_test_alert()
+        self._screenshot('journalist-admin_ossec_alert_button.png')
+        self._save_html('journalist-admin_ossec_alert_button.html')
+
+    def test_admin_interface_index(self):
+        self._admin_logs_in()
+        self._admin_visits_admin_interface()
+        self._screenshot('journalist-admin_interface_index.png')
+        self._save_html('journalist-admin_interface_index.html')

--- a/securedrop/tests/pageslayout/test_journalist_col.py
+++ b/securedrop/tests/pageslayout/test_journalist_col.py
@@ -1,0 +1,76 @@
+#
+# SecureDrop whistleblower submission system
+# Copyright (C) 2017 Loic Dachary <loic@dachary.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import pytest
+
+from tests.functional import journalist_navigation_steps
+from tests.functional import source_navigation_steps
+import tests.pageslayout.functional_test as pft
+
+
+@pytest.mark.pagelayout
+class TestJournalistLayoutCol(
+        pft.FunctionalTest,
+        source_navigation_steps.SourceNavigationStepsMixin,
+        journalist_navigation_steps.JournalistNavigationStepsMixin):
+
+    def test_col_no_documents(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_logs_out()
+        self._journalist_logs_in()
+        self._journalist_visits_col()
+        self._journalist_delete_all()
+        self._journalist_confirm_delete_selected()
+        self._screenshot('journalist-col_no_document.png')
+        self._save_html('journalist-col_no_document.html')
+
+    def test_col_has_no_key(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_logs_out()
+        self._journalist_logs_in()
+        self._source_delete_key()
+        self._journalist_visits_col()
+        self._screenshot('journalist-col_has_no_key.png')
+        self._save_html('journalist-col_has_no_key.html')
+
+    def test_col(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_logs_out()
+        self._journalist_logs_in()
+        self._journalist_visits_col()
+        self._screenshot('journalist-col.png')
+        self._save_html('journalist-col.html')
+
+    def test_col_javascript(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_logs_out()
+        self._journalist_logs_in()
+        self._journalist_visits_col()
+        self._screenshot('journalist-col_javascript.png')
+        self._save_html('journalist-col_javascript.html')

--- a/securedrop/tests/pageslayout/test_journalist_delete.py
+++ b/securedrop/tests/pageslayout/test_journalist_delete.py
@@ -1,0 +1,102 @@
+#
+# SecureDrop whistleblower submission system
+# Copyright (C) 2017 Loic Dachary <loic@dachary.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import time
+
+import pytest
+
+from tests.functional import journalist_navigation_steps
+from tests.functional import source_navigation_steps
+import tests.pageslayout.functional_test as pft
+
+
+@pytest.mark.pagelayout
+class TestJournalistLayoutDelete(
+        pft.FunctionalTest,
+        source_navigation_steps.SourceNavigationStepsMixin,
+        journalist_navigation_steps.JournalistNavigationStepsMixin):
+
+    def test_delete_none(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_submits_a_message()
+        self._source_logs_out()
+        self._journalist_logs_in()
+        self._journalist_visits_col()
+        self._journalist_clicks_delete_selected_link()
+        self._journalist_confirm_delete_selected()
+        self._screenshot('journalist-delete_none.png')
+        self._save_html('journalist-delete_none.html')
+
+    def test_delete_one_confirmation(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_submits_a_message()
+        self._source_logs_out()
+        self._journalist_logs_in()
+        self._journalist_visits_col()
+        self._journalist_selects_first_doc()
+        self._journalist_clicks_delete_selected_link()
+        time.sleep(1)
+        self._screenshot('journalist-delete_one_confirmation.png')
+        self._save_html('journalist-delete_one_confirmation.html')
+
+    def test_delete_all_confirmation(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_submits_a_message()
+        self._source_logs_out()
+        self._journalist_logs_in()
+        self._journalist_visits_col()
+        self._journalist_delete_all_confirmation()
+        time.sleep(1)
+        self._screenshot('journalist-delete_all_confirmation.png')
+        self._save_html('journalist-delete_all_confirmation.html')
+
+    def test_delete_one(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_submits_a_message()
+        self._source_logs_out()
+        self._journalist_logs_in()
+        self._journalist_visits_col()
+        self._journalist_delete_one()
+        self._journalist_confirm_delete_selected()
+        self._screenshot('journalist-delete_one.png')
+        self._save_html('journalist-delete_one.html')
+
+    def test_delete_all(self):
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_submits_a_message()
+        self._source_logs_out()
+        self._journalist_logs_in()
+        self._journalist_visits_col()
+        self._journalist_delete_all()
+        self._journalist_confirm_delete_selected()
+        self._screenshot('journalist-delete_all.png')
+        self._save_html('journalist-delete_all.html')

--- a/securedrop/tests/pageslayout/test_source.py
+++ b/securedrop/tests/pageslayout/test_source.py
@@ -17,7 +17,6 @@
 #
 from tests.functional import journalist_navigation_steps
 from tests.functional import source_navigation_steps
-from tests.functional.functional_test import TORBROWSER
 from . import functional_test
 import pytest
 
@@ -118,47 +117,3 @@ class TestSourceLayout(
         self._source_why_journalist_key()
         self._screenshot('source-why_journalist_key.png')
         self._save_html('source-why_journalist_key.html')
-
-
-@pytest.mark.pagelayout
-class TestSourceSessionLayout(
-        functional_test.FunctionalTest,
-        source_navigation_steps.SourceNavigationStepsMixin,
-        journalist_navigation_steps.JournalistNavigationStepsMixin):
-    default_driver_name = TORBROWSER
-
-    session_expiration = 5
-
-    def test_source_session_timeout(self):
-        self.disable_js_torbrowser_driver()
-        self._source_visits_source_homepage()
-        self._source_clicks_submit_documents_on_homepage()
-        self._source_continues_to_submit_page()
-        self._source_waits_for_session_to_timeout()
-        self._source_enters_text_in_message_field()
-        self._source_visits_source_homepage()
-        self._screenshot('source-session_timeout.png')
-        self._save_html('source-session_timeout.html')
-
-
-class TestSourceLayoutTorbrowser(
-        functional_test.FunctionalTest,
-        source_navigation_steps.SourceNavigationStepsMixin,
-        journalist_navigation_steps.JournalistNavigationStepsMixin):
-    default_driver_name = TORBROWSER
-
-    def test_index(self):
-        self.disable_js_torbrowser_driver()
-        self._source_visits_source_homepage()
-        self._screenshot('source-index.png')
-        self._save_html('source-index.html')
-
-    def test_logout(self):
-        self.disable_js_torbrowser_driver()
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_logs_out()
-        self._screenshot('source-logout_page.png')
-        self._save_html('source-logout_page.html')

--- a/securedrop/tests/pageslayout/test_source_layout_torbrowser.py
+++ b/securedrop/tests/pageslayout/test_source_layout_torbrowser.py
@@ -1,0 +1,44 @@
+#
+# SecureDrop whistleblower submission system
+# Copyright (C) 2017 Loic Dachary <loic@dachary.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from tests.functional import journalist_navigation_steps
+from tests.functional import source_navigation_steps
+from tests.functional.functional_test import TORBROWSER
+from . import functional_test
+
+
+class TestSourceLayoutTorbrowser(
+        functional_test.FunctionalTest,
+        source_navigation_steps.SourceNavigationStepsMixin,
+        journalist_navigation_steps.JournalistNavigationStepsMixin):
+    default_driver_name = TORBROWSER
+
+    def test_index(self):
+        self.disable_js_torbrowser_driver()
+        self._source_visits_source_homepage()
+        self._screenshot('source-index.png')
+        self._save_html('source-index.html')
+
+    def test_logout(self):
+        self.disable_js_torbrowser_driver()
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_file()
+        self._source_logs_out()
+        self._screenshot('source-logout_page.png')
+        self._save_html('source-logout_page.html')

--- a/securedrop/tests/pageslayout/test_source_session_layout.py
+++ b/securedrop/tests/pageslayout/test_source_session_layout.py
@@ -1,0 +1,43 @@
+#
+# SecureDrop whistleblower submission system
+# Copyright (C) 2017 Loic Dachary <loic@dachary.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from tests.functional import journalist_navigation_steps
+from tests.functional import source_navigation_steps
+from tests.functional.functional_test import TORBROWSER
+from . import functional_test
+import pytest
+
+
+@pytest.mark.pagelayout
+class TestSourceSessionLayout(
+        functional_test.FunctionalTest,
+        source_navigation_steps.SourceNavigationStepsMixin,
+        journalist_navigation_steps.JournalistNavigationStepsMixin):
+    default_driver_name = TORBROWSER
+
+    session_expiration = 5
+
+    def test_source_session_timeout(self):
+        self.disable_js_torbrowser_driver()
+        self._source_visits_source_homepage()
+        self._source_clicks_submit_documents_on_homepage()
+        self._source_continues_to_submit_page()
+        self._source_waits_for_session_to_timeout()
+        self._source_enters_text_in_message_field()
+        self._source_visits_source_homepage()
+        self._screenshot('source-session_timeout.png')
+        self._save_html('source-session_timeout.html')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #6090 by:

1. factoring out `securedrop/tests/pageslayout/test_{journalist,source}.py` into topical classes, with one class per file, so that `circleci` and `pytest` can more-granularly parallelize tests across jobs; and
2. raising `app-page-layout-tests` from 2 to 5 parallel jobs.

Together, these changes bring `app-page-layout-tests` closer to `app-tests` in the neighborhood of 20 minutes' runtime, for total `securedrop_ci` runtime ca. 30 minutes.

## Testing

1. [ ] Sanity check:  No tests have gone missing!
    ```sh-session
    $ git checkout develop
    $ grep -R "def test_" securedrop/tests | wc -l
     465
    $ git checkout 6090-split-up-page-layout-tests
    $ grep -R "def test_" securedrop/tests | wc -l
     465
    ```
1. [ ] All page-layout tests run and pass.
2. [ ] The `app-[page-layout-]tests` jobs take approximately 20 minutes.
3. [ ] The `securedrop_ci` workflow takes approximately 30 minutes.

## Deployment

CI-only; no deployment considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container