### PR TITLE
Do not declare logo as conffile

### DIFF
--- a/install_files/securedrop-app-code/debian/conffiles
+++ b/install_files/securedrop-app-code/debian/conffiles
@@ -1,1 +1,0 @@
-/var/www/securedrop/static/i/logo.png

--- a/install_files/securedrop-app-code/debian/postinst
+++ b/install_files/securedrop-app-code/debian/postinst
@@ -192,15 +192,6 @@ case "$1" in
 
     # Version migrations
 
-    if [ -n "$2" ] && [ "$2" = "0.3" ] ; then
-      # Restore custom logo
-      cp /tmp/securedrop_custom_logo.png /var/www/securedrop/static/i/logo.png
-      rm /tmp/securedrop_custom_logo.png
-    fi
-
-    # in versions prior to 0.5.1 a custom logo was installed with u-w
-    chmod u+w /var/www/securedrop/static/i/logo.png
-
     database_migration
 
     ;;

--- a/install_files/securedrop-app-code/debian/preinst
+++ b/install_files/securedrop-app-code/debian/preinst
@@ -94,13 +94,6 @@ case "$1" in
       permanently_disable_swap
       convert_document_to_journalist_interface
 
-      if [ -n "$2" ] && [ "$2" = "0.3" ] ; then
-        # Copy the custom logo (workaround due to #911)
-        cp /var/www/securedrop/static/i/logo.png /tmp/securedrop_custom_logo.png
-        # Remove the custom logo so we don't get an error from dpkg conffiles
-        rm /var/www/securedrop/static/i/logo.png
-      fi
-
       if service_exists 'haveged'; then
         systemctl stop haveged
         systemctl disable haveged

--- a/install_files/securedrop-app-code/debian/preinst
+++ b/install_files/securedrop-app-code/debian/preinst
@@ -58,6 +58,18 @@ function permanently_disable_swap() {
 }
 
 
+function migrate_custom_logo() {
+  # Previously, logo customization was done by overwriting the logo file
+  # that ships as part of the package. This is no longer supported. For older
+  # installations, if no custom logo exists, we instantiate it here.
+
+  if [[ -f "/var/www/securedrop/static/i/logo.png" &&
+        ! -e "/var/www/securedrop/static/i/custom_logo.png" ]]; then
+          cp /var/www/securedrop/static/i/logo.png /var/www/securedrop/static/i/custom_logo.png
+  fi
+}
+
+
 function convert_document_to_journalist_interface() {
     # Helper function to migrate the old "Document Interface" config files
     # to the new "Journalist Interface" naming scheme. Affects tor and apache.
@@ -93,6 +105,7 @@ case "$1" in
 
       permanently_disable_swap
       convert_document_to_journalist_interface
+      migrate_custom_logo
 
       if service_exists 'haveged'; then
         systemctl stop haveged

--- a/molecule/builder-focal/tests/test_securedrop_deb_package.py
+++ b/molecule/builder-focal/tests/test_securedrop_deb_package.py
@@ -303,7 +303,7 @@ def test_deb_package_contains_no_generated_assets(securedrop_app_code_contents: 
 @pytest.mark.parametrize("deb", deb_paths.values())
 def test_deb_package_contains_expected_conffiles(host: Host, deb: Path):
     """
-    Ensures the `securedrop-app-code` package declares only whitelisted
+    Ensures the `securedrop-app-code` package declares only allow-listed
     `conffiles`. Several files in `/etc/` would automatically be marked
     conffiles, which would break unattended updates to critical package
     functionality such as AppArmor profiles. This test validates overrides
@@ -319,10 +319,11 @@ def test_deb_package_contains_expected_conffiles(host: Host, deb: Path):
         f = host.file(conffiles_path)
 
         assert f.is_file
-        # Ensure that the entirety of the file lists only the logo as conffile;
-        # effectively ensures e.g. AppArmor profiles are not conffiles.
+
         conffiles = f.content_string.rstrip()
-        assert conffiles == "/var/www/securedrop/static/i/logo.png"
+
+        # No files are currently allow-listed to be conffiles
+        assert conffiles == ""
 
     # For the securedrop-config package, we want to ensure there are no
     # conffiles so securedrop_additions.sh is squashed every time


### PR DESCRIPTION
Resolves #5850

## Status

Ready for review.

(`conffiles` needs to be preserved as a zero-byte file to squash the autogenerated one.)

## Testing

1. Set up a staging environment without this change
2. Upload a custom logo
3. `make build-debs` from this branch
4. Install updated packages
5. - [ ] Observe that packages are updated successfully and that logo image is not clobbered

## Deployment considerations

This change will clobber custom logos on very long-running installations that were upgraded during a specific time window; see https://github.com/freedomofpress/securedrop/issues/5850#issuecomment-923482373 . Only a very small number of installations are likely to be impacted, which we can resolve with direct notices.