### PR TITLE
Tweak "Reply has been stored" message

### DIFF
--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -163,7 +163,8 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                     "<b>{}</b> {}".format(
                         # Translators: Precedes a message confirming the success of an operation.
                         escape(gettext("Success!")),
-                        escape(gettext("Your reply has been stored."))
+                        escape(gettext("The source will receive your reply "
+                                       "next time they log in."))
                     )
                 ), 'success')
         finally:

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -857,7 +857,7 @@ class JournalistNavigationStepsMixin:
 
         def reply_stored():
             if not self.accept_languages:
-                assert "Your reply has been stored." in self.driver.page_source
+                assert "The source will receive your reply" in self.driver.page_source
 
         self.wait_for(reply_stored)
 

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -284,7 +284,7 @@ def _helper_test_reply(journalist_app, source_app, config, test_journo,
             pass
         else:
             text = resp.data.decode('utf-8')
-            assert "Your reply has been stored." in text
+            assert "The source will receive your reply" in text
 
         resp = app.get(col_url)
         text = resp.data.decode('utf-8')


### PR DESCRIPTION
"Stored" is a very technical term, let's speak instead to the journalist<->source interaction. In context:

![Screenshot from 2021-09-21 12-59-51](https://user-images.githubusercontent.com/213636/134239442-c96530c3-7814-450a-b3ed-dfe0c3dfa6f7.png)

Resolves #5828

## Status

Ready for review