### PR TITLE
`app-page-layout-tests`: follows consistent `$DOCKER_BUILD_ARGUMENTS`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,10 @@ jobs:
       # "informational" status---in other words, fail if validation fails!
       - run:
           name: Validate HTML (informational)
-          command: make validate-test-html || true
+          command: |
+            fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
+            DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" \
+              make validate-test-html || true
 
       - store_test_results:
           path: ~/project/test-results


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6104 by letting the `Validate HTML (informational)` step of the `app-page-layout-tests` job reuse Docker's image-layer cache as expected.  (This was my omission in #6072.)

As a nice side benefit, reduces the clock time of `make validate-test-html` by 99%, from ~5.5 minutes to ~7 seconds.

## Testing

- [ ] CI passes.

## Deployment

CI-only; no deployment considerations.