### PR TITLE
Support Debian 11 for dev env

### DIFF
--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -24,7 +24,7 @@ netaddr
 pip>=21.1
 pip-tools>=6.1.0
 psutil>=5.6.6
-pyenchant
+pyenchant>=3.2.1
 pylint>=2.7.0
 pynacl>=1.4.0
 py>=1.10.0

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -540,10 +540,11 @@ pycodestyle==2.5.0 \
 pycparser==2.18 \
     --hash=sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226
     # via cffi
-pyenchant==2.0.0 \
-    --hash=sha256:b9526fc2c5f1ba0637e50200b645a7c20fb6644dbc6f6322027e7d2fbf1084a5 \
-    --hash=sha256:e8000144e61551fcab9cd1b6fdccdded20e577e8d6d0985533f0b2b9c38fd952 \
-    --hash=sha256:fc31cda72ace001da8fe5d42f11c26e514a91fa8c70468739216ddd8de64e2a0
+pyenchant==3.2.1 \
+    --hash=sha256:37c79e1dab492092fe8135222b2ba404c1b79595b459af9edaeddb77a2cb89a5 \
+    --hash=sha256:49e0b255bef9356f57eeeee1d983ffa8599c0a46727d55cddbc71ec26226ca80 \
+    --hash=sha256:5e206a1d6596904a922496f6c9f7d0b964b243905f401f5f2f40ea4d1f74e2cf \
+    --hash=sha256:e8546c28b630f6d9f76642166656e337df2a1849cbef2b8ee198e7f64266f4ee
     # via -r requirements/python3/develop-requirements.in
 pyflakes==2.1.1 \
     --hash=sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0 \


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Towards https://github.com/freedomofpress/securedrop-dev-docs/issues/9 , adding support for Debian 11 

While testing the dev env on Debian 11 Bullseye, was not able to install
the development requirements due to an error on pyenchant. Bumping the
req to a recent version resolved for me.

Marking as a draft because I haven't tested on Buster, and there may be more changes that should be appended here (as well as changes to the docs). 

## Testing
You must use a Debian 11 machine to test! Following the docs in https://docs.securedrop.org/en/latest/development/setup_development.html#install-python-requirements , make sure you see no errors (or report ones you do encounter!).

## Deployment
So far, dev-env only. 

## Checklist

I haven't performed a diff review, but this is explicitly a dev req. 
