### PR TITLE
silences OSSEC alerts from `fwupd` running without `udisks2`

### DIFF
--- a/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
+++ b/install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml
@@ -90,6 +90,18 @@
     <description>fwupd error for auto updates</description>
     <options>no_email_alert</options>
   </rule>
+  <rule id="100113" level="0">
+    <decoded_as>fwupd</decoded_as>
+    <match>The name org.freedesktop.UDisks2 was not provided by any .service files</match>
+    <description>fwupd error missing UDisks2</description>
+    <options>no_email_alert</options>
+  </rule>
+  <rule id="100114" level="0">
+    <decoded_as>fwupd</decoded_as>
+    <match>failed to get chassis type: no structure with type 03</match>
+    <description>fwupd error missing structure</description>
+    <options>no_email_alert</options>
+  </rule>
 </group>
 
 <!--

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -128,6 +128,22 @@ log_events_without_ossec_alerts:
     level: "0"
     rule_id: "100112"
 
+  - name: test_ossec_fwupd_udisks2_does_not_produce_alert
+    alert: >
+      Aug 10 14:30:51 mon fwupd[134620]: 14:30:51:0528 FuPluginLinuxSwap    could
+      not parse /proc/swaps: failed to call
+      org.freedesktop.UDisks2.Manager.GetBlockDevices(): The name
+      org.freedesktop.UDisks2 was not provided by any .service files
+    level: "0"
+    rule_id: "100113"
+
+  - name: test_ossec_fwupd_chassis_type_does_not_produce_alert
+    alert: >
+      Sep 18 13:32:22 mon fwupd[134454]: 13:32:22:0632 FuEngine             failed
+      to get chassis type: no structure with type 03
+    level: "0"
+    rule_id: "100114"
+
 # Log events we expect an OSSEC alert to occur for
 log_events_with_ossec_alerts:
   # Check that a denied RWX mmaping would produce an OSSEC alert


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6097 by adding OSSEC rules to ignore (classify as level 0) errors logged by `fwupd` in the absence of `udisks2`.

## Testing

1. [x] **Staging environment:**  Confirm `Level: 0` returned for both log messages cited in #6097:
```sh-session
$ molecule login -s libvirt-staging-focal -h mon-staging
vagrant@mon-staging:~$ echo "Aug 10 14:30:51 mon fwupd[134620]: 14:30:51:0528 FuPluginLinuxSwap    could not parse /proc/swaps: failed to call org.freedesktop.UDisks2.Manager.GetBlockDevices(): The name org.freedesktop.UDisks2 was not provided by any .service files" | sudo /var/ossec/bin/ossec-logtest
2021/09/23 23:33:33 ossec-testrule: INFO: Reading local decoder file.
2021/09/23 23:33:33 ossec-testrule: INFO: Started (pid: 132681).
ossec-testrule: Type one log per line.



**Phase 1: Completed pre-decoding.
       full event: 'Aug 10 14:30:51 mon fwupd[134620]: 14:30:51:0528 FuPluginLinuxSwap    could not parse /proc/swaps: failed to call org.freedesktop.UDisks2.Manager.GetBlockDevices(): The name org.freedesktop.UDisks2 was not provided by any .service files'
       hostname: 'mon'
       program_name: 'fwupd'
       log: '14:30:51:0528 FuPluginLinuxSwap    could not parse /proc/swaps: failed to call org.freedesktop.UDisks2.Manager.GetBlockDevices(): The name org.freedesktop.UDisks2 was not provided by any .service files'

**Phase 2: Completed decoding.
       decoder: 'fwupd'

**Phase 3: Completed filtering (rules).
       Rule id: '100113'
       Level: '0'
       Description: 'fwupd error missing UDisks2'
vagrant@mon-staging:~$ echo "Sep 18 13:32:22 mon fwupd[134454]: 13:32:22:0632 FuEngine             failed to get chassis type: no structure with type 03" | sudo /var/ossec/bin/ossec-logtest
2021/09/23 23:34:17 ossec-testrule: INFO: Reading local decoder file.
2021/09/23 23:34:17 ossec-testrule: INFO: Started (pid: 132684).
ossec-testrule: Type one log per line.



**Phase 1: Completed pre-decoding.
       full event: 'Sep 18 13:32:22 mon fwupd[134454]: 13:32:22:0632 FuEngine             failed to get chassis type: no structure with type 03'
       hostname: 'mon'
       program_name: 'fwupd'
       log: '13:32:22:0632 FuEngine             failed to get chassis type: no structure with type 03'

**Phase 2: Completed decoding.
       decoder: 'fwupd'

**Phase 3: Completed filtering (rules).
       Rule id: '100114'
       Level: '0'
       Description: 'fwupd error missing structure'
```

2. [ ] **Production environment:**  I do not currently have access to a *hardware* production environment I can test against (as suggested by #5882) but hope to have this capability next week.

## Deployment

No deployment considerations.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass