### PR TITLE
Updated ansible from 2.9.21 to 2.9.26 to address CVE-2021-3583

### DIFF
--- a/admin/requirements-ansible.in
+++ b/admin/requirements-ansible.in
@@ -1,4 +1,4 @@
 Jinja2>=2.11.3
-ansible>=2.9.13,<2.10.0
+ansible>=2.9.23,<2.10.0
 cryptography>=3.2
 netaddr

--- a/admin/requirements-testinfra.txt
+++ b/admin/requirements-testinfra.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements-testinfra.txt requirements-ansible.in requirements-testinfra.in requirements.in
 #
-ansible==2.9.21 \
-    --hash=sha256:4098246b67aa143e1e3af79d99346419e0545d5405d1cdf6e7fd389beab6de5a
+ansible==2.9.26 \
+    --hash=sha256:3ae02aad2bbedcfb419ce75ebd2a648e9deb73e9e2d8de86c82d6047b1bdeb63
     # via -r requirements-ansible.in
 apipkg==1.5 \
     --hash=sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6 \

--- a/admin/requirements.txt
+++ b/admin/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements-ansible.in requirements.in
 #
-ansible==2.9.21 \
-    --hash=sha256:4098246b67aa143e1e3af79d99346419e0545d5405d1cdf6e7fd389beab6de5a
+ansible==2.9.26 \
+    --hash=sha256:3ae02aad2bbedcfb419ce75ebd2a648e9deb73e9e2d8de86c82d6047b1bdeb63
     # via -r requirements-ansible.in
 cffi==1.14.5 \
     --hash=sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813 \

--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -1,6 +1,6 @@
 Jinja2>=2.11.3
 ansible-lint>=4.2.0
-ansible>=2.9.13,<2.10.0
+ansible>=2.9.23,<2.10.0
 argon2_cffi>=20.1.0
 bandit
 # yes, we need both boto and boto3

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -8,8 +8,8 @@ ansible-lint==4.2.0 \
     --hash=sha256:b9fc9a6564f5d60a4284497f966f38ef78f0e2505edbe2bd1225f1ade31c2d8a \
     --hash=sha256:eb925d8682d70563ccb80e2aca7b3edf84fb0b768cea3edc6846aac7abdc414a
     # via -r requirements/python3/develop-requirements.in
-ansible==2.9.21 \
-    --hash=sha256:4098246b67aa143e1e3af79d99346419e0545d5405d1cdf6e7fd389beab6de5a
+ansible==2.9.26 \
+    --hash=sha256:3ae02aad2bbedcfb419ce75ebd2a648e9deb73e9e2d8de86c82d6047b1bdeb63
     # via
     #   -r ../admin/requirements-ansible.in
     #   -r requirements/python3/develop-requirements.in


### PR DESCRIPTION
## Status

Ready for review

Resolves #6108 

## Description of Changes


Updates Ansible dependencies from version 2.9.21 to 2.9.26

## Testing

- [ ] CI is passing
- [ ] only updated dependencies are for ansible 2.9.26
- [ ] `pip install --require-hashes --no-deps securedrop/requirements/python3/develop-requirements.txt` succeeds locally on this branch
- [ ] `make build-debs` and `make staging` succeed locally on this branch.



## Checklist

### If you added or updated a production code dependency:

Choose one of the following:

- [x] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
