### PR TITLE
Repair auto-updates on Tails < 4.19 workstations 

### DIFF
--- a/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
+++ b/install_files/ansible-base/roles/tails-config/files/securedrop_init.py
@@ -7,7 +7,8 @@ import pwd
 import sys
 import subprocess
 
-from shutil import copyfile
+import tempfile
+from shutil import copyfile, copyfileobj
 
 
 # check for root
@@ -148,3 +149,70 @@ flag_location = "/home/amnesia/Persistent/.securedrop/securedrop_update.flag"
 if b'Update needed' in output or os.path.exists(flag_location):
     # Start the SecureDrop updater GUI.
     subprocess.Popen(['python3', path_gui_updater], env=env)
+
+# Check for Tails < 4.19 and apply a fix to the auto-updater.
+# See https://tails.boum.org/news/version_4.18/
+# (Suggested removal: 2022/01)
+tails_4_min_version = 19
+needs_update = False
+tails_current_version = None
+
+with open('/etc/os-release') as file:
+    for line in file:
+        try:
+            k, v = line.strip().split("=")
+            if k == "TAILS_VERSION_ID":
+                tails_current_version = v.strip("\"").split(".")
+        except ValueError:
+            continue
+
+if tails_current_version:
+    try:
+        needs_update = (len(tails_current_version) >= 2 and
+                        int(tails_current_version[1]) < tails_4_min_version)
+
+    except (TypeError, ValueError):
+        sys.exit(0)  # Don't break tailsconfig trying to fix this
+
+    if needs_update:
+        cert_name = 'isrg-root-x1-cross-signed.pem'
+        pem_file = tempfile.NamedTemporaryFile(delete=True)
+
+        try:
+            subprocess.call(['torsocks', 'curl', '--silent',
+                             'https://tails.boum.org/' + cert_name],
+                            stdout=pem_file, env=env)
+
+            # Verify against /etc/ssl/certs/DST_Root_CA_X3.pem, which cross-signs
+            # the new LetsEncrypt cert but is expiring
+            verify_proc = subprocess.check_output(['openssl', 'verify',
+                                                   '-no_check_time', '-no-CApath',
+                                                   '-CAfile',
+                                                   '/etc/ssl/certs/DST_Root_CA_X3.pem',
+                                                   pem_file.name],
+                                                  universal_newlines=True, env=env)
+
+            if 'OK' in verify_proc:
+
+                # Updating the cert chain requires sudo privileges
+                os.setresgid(0, 0, -1)
+                os.setresuid(0, 0, -1)
+
+                with open('/usr/local/etc/ssl/certs/tails.boum.org-CA.pem', 'a') as chain:
+                    pem_file.seek(0)
+                    copyfileobj(pem_file, chain)
+
+                # As amnesia user, start updater GUI
+                os.setresgid(amnesia_gid, amnesia_gid, -1)
+                os.setresuid(amnesia_uid, amnesia_uid, -1)
+                restart_proc = subprocess.call(['systemctl', '--user', 'restart',
+                                                'tails-upgrade-frontend'], env=env)
+
+        except subprocess.CalledProcessError:
+            sys.exit(0)   # Don't break tailsconfig trying to fix this
+
+        except IOError:
+            sys.exit(0)
+
+        finally:
+            pem_file.close()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6098

Changes proposed in this pull request: Include check for pre-4.19 Tails versions in network hook. Attempt to repair auto-updates on Tails < 4.19 by applying the fix at https://tails.boum.org/news/version_4.18/, with the additional step of verifying the new CA file against existing files on the user's machine prior to installation.  

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

**On an Admin or Journo Workstation running Tails < 4.19**
- Ensure network connectivity
- `cd ~/Persistent/securedrop` and check out this branch
- Run `./securedrop-admin --force tailsconfig` 
- [ ] `tailsconfig` completes successfully
- [ ] After about 30 seconds, the Tails updater GUI appears and prompts you to download the latest version of Tails  

**On Admin/Journo Workstation running Tails 4.19 or greater** (no op)
- Ensure network connectivity
- Check out this branch
- Run `./securedrop-admin --force tailsconfig` 
- [ ] `tailsconfig completes successfully`

(note: If you don't have an old Tails workstation and are QAing, these steps aren't recommended but are acceptable)
- Edit `/etc/os-release` to change the `TAILS_VERSION_ID` to a pre-4.19 version
- `touch /usr/local/etc/ssl/certs/tails.boum.org-CA.pem`
- Check out this branch, then run `./securedrop-admin --force tailsconfig`
- [ ] `tailsconfig` completes successfully
- [ ] `cat /usr/local/etc/ssl/certs/tails.boum.org-CA.pem` and verify that the isrg-root-x1-cross-signed cert was added to the file (https://tails.boum.org/isrg-root-x1-cross-signed.pem)  

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

