### PR TITLE
Update Focal vagrant box in CI

### DIFF
--- a/devops/gce-nested/gce-start.sh
+++ b/devops/gce-nested/gce-start.sh
@@ -25,7 +25,7 @@ function find_latest_ci_image() {
     #    --filter="family:fpf-securedrop AND name ~ ^ci-nested-virt" \
     #    --sort-by=~Name --limit=1 --format="value(Name)"
     # Return hardcoded image id to prevent newer builds from breaking CI
-    echo "ci-nested-virt-buster-1623169910"
+    echo "ci-nested-virt-buster-1633365108"
 }
 
 # Call out to GCE API and start a new instance, designating


### PR DESCRIPTION

## Status

Ready for review 
## Description of Changes

Built a new CI image for the staging tests. In this GCP image, the
Ubuntu Focal Vagrant VM has had its version bumped from
202105.25.0 -> 202107.28.0. The latest version, 202109.07.0, would not
install successfully via `vagrant box add`.


## Testing
Ideally we'd test it in CI first, but the new branch restrictions around the staging tests mean that's not a simple process anymore. I propose we merge optimistically and revert if problems show up. 

## Deployment

CI only.
