### PR TITLE
add apt upgrade to all packages prior to changes to sources lists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ workflows:
             branches:
               # Ignore needs to be here explicitely as only clause introduced in PR #6086 might be removed afterwards.
               ignore: /i18n-.*/
-              only: /release\/.*/
+              only: /(stg-|release\/).*/
           requires:
             - lint
       - translation-tests:

--- a/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
+++ b/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
@@ -50,10 +50,10 @@
   tags:
     - apt
 
-- name: Upgrade all packages
+- name: Ensure dist-upgrade before SecureDrop install
   apt:
-    name: "*"
-    state: latest
+    upgrade: dist
     update_cache: yes
   tags:
     - apt
+    - apt-upgrade

--- a/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
+++ b/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
@@ -49,3 +49,11 @@
     purge: yes
   tags:
     - apt
+
+- name: Upgrade all packages
+  apt:
+    name: "*"
+    state: latest
+    update_cache: yes
+  tags:
+    - apt


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6119

- adds an explicit update to all base packages in the `prepare-server` role before proceeding with the SD install. This will ensure that the staging env is up-to-date, and should effectively be a no-op in production unless updated packages are made available in the time between the OS install and the securedrop install playbook run.
- modifies the branch filtering logic to run `staging-test-with-rebase` if the branch is prefixed with `release/` or `stg-`

## Testing

- [ ] CI completes successfully
- [ ] `staging-test-with-rebase` is run against this branch.

