### PR TITLE
Display "Forgot you codename?" codename-hint link only on initial login

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -201,7 +201,10 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                     fh.stream))
 
         if first_submission:
-            flash_message = render_template('first_submission_flashed_message.html')
+            flash_message = render_template(
+                'first_submission_flashed_message.html',
+                new_user_codename=session.get('new_user_codename', None),
+            )
             flash(Markup(flash_message), "success")
 
         else:

--- a/securedrop/source_templates/first_submission_flashed_message.html
+++ b/securedrop/source_templates/first_submission_flashed_message.html
@@ -1,8 +1,10 @@
 <section class="message">
   <h2>{{ gettext('Success!') }}</h2>
   <p>{{ gettext('Thank you for sending this information to us. Please check back later for replies.') }}
+    {% if new_user_codename %}
     <a href="#codename-hint">
       {{ gettext('Forgot your codename?') }}
     </a>
+    {% endif %}
   </p>
 </section>

--- a/securedrop/source_templates/first_submission_flashed_message.html
+++ b/securedrop/source_templates/first_submission_flashed_message.html
@@ -1,10 +1,7 @@
 <section class="message">
   <h2>{{ gettext('Success!') }}</h2>
-  <p>{{ gettext('Thank you for sending this information to us. Please check back later for replies.') }}
-    {% if new_user_codename %}
-    <a href="#codename-hint">
-      {{ gettext('Forgot your codename?') }}
-    </a>
-    {% endif %}
-  </p>
+  <p>{{ gettext('Thank you for sending this information to us. Please check back later for replies.') }}</p>
+  {% if new_user_codename %}
+    <p><a href="#codename-hint">{{ gettext('Forgot your codename?') }}</a></p>
+  {% endif %}
 </section>

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -163,7 +163,9 @@ class SourceNavigationStepsMixin:
             # allow time for reply key to be generated
             time.sleep(self.timeout)
 
-    def _source_submits_a_message(self):
+    def _source_submits_a_message(
+        self, verify_notification=False, first_submission=False, first_login=False
+    ):
         self._source_enters_text_in_message_field()
         self._source_clicks_submit_button_on_submission_page()
 
@@ -171,6 +173,22 @@ class SourceNavigationStepsMixin:
             if not self.accept_languages:
                 notification = self.driver.find_element_by_css_selector(".success")
                 assert "Thank" in notification.text
+
+                if verify_notification:
+                    first_submission_text = (
+                        "Please check back later for replies." in notification.text
+                    )
+                    first_login_text = "Forgot your codename?" in notification.text
+
+                    if first_submission:
+                        assert first_submission_text
+
+                        if first_login:
+                            assert first_login_text
+                        else:
+                            assert not first_login_text
+                    else:
+                        assert not first_submission_text
 
         self.wait_for(message_submitted)
 

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -44,6 +44,33 @@ class TestSourceInterface(
         self._source_proceeds_to_login()
         self._source_sees_no_codename()
 
+    def test_lookup_submit_notification_first_login(self):
+        """Test that on a first login, the submission notification includes the 'Please check back
+        later' and 'Forgot your codename?' messages. Also verify that those messages are not
+        present on a subsequent submission."""
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_submits_a_message(
+            verify_notification=True, first_submission=True, first_login=True
+        )
+        self._source_submits_a_message(verify_notification=True)
+
+    def test_lookup_submit_notification_2nd_login(self):
+        """Test that on a second login, the first submission notification includes the 'Please
+        check back later' message but not the 'Forgot your codename?' message since the codename
+        hint section is not present on a second login (Ref. issue #5101). Also verify that none of
+        those messages are present on a subsequent submission."""
+        self._source_visits_source_homepage()
+        self._source_chooses_to_submit_documents()
+        self._source_continues_to_submit_page()
+        self._source_logs_out()
+        self._source_visits_source_homepage()
+        self._source_chooses_to_login()
+        self._source_proceeds_to_login()
+        self._source_submits_a_message(verify_notification=True, first_submission=True)
+        self._source_submits_a_message(verify_notification=True)
+
 
 class TestDownloadKey(
         functional_test.FunctionalTest,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5101.

Changes proposed in this pull request:

Display the "Forgot you codename?" link to the `codename-hint` section in the `/submit` flashed message only on the source's initial login (i.e. do not display the link after the source logged in using their codename).

Add functional test to verify the above behavior. Also include verification of the first submission specific message.

## Testing

**Verify link does not show on second login - from `/logout`**
1. Access the Source Interface and click "GET STARTED".
1. Take note of the codename on `/generate` and click "SUBMIT DOCUMENTS".
1. On `/lookup`, click "LOGOUT".
1. On `/logout` click "LOG IN".
1. Enter the codename noted in 2 and click "CONTINUE".
1. On `/lookup` enter a message and click "SUBMIT".
    - [ ] Verify that the flashed message **does not include** the "Forgot you codename?" link
    ![image](https://user-images.githubusercontent.com/22901938/137431363-f9ad6734-aa0a-421f-bc09-5f1bae71d5ab.png)


**Verify link does not show on second login - from `/`**
1. Access the Source Interface and click "GET STARTED".
1. Take note of the codename on `/generate` and click "SUBMIT DOCUMENTS".
1. On `/lookup`, click "LOGOUT".
1. Click on the SecureDrop logo to return to `/`.
1. On `/` click "LOG IN".
1. Enter the codename noted in 2 and click "CONTINUE".
1. On `/lookup` enter a message and click "SUBMIT".
    - [ ] Verify that the flashed message **does not include** the "Forgot you codename?" link.
    ![image](https://user-images.githubusercontent.com/22901938/137431363-f9ad6734-aa0a-421f-bc09-5f1bae71d5ab.png)

**Verify link shows on first login**
1. Access the Source Interface and click "GET STARTED".
1. Take note of the codename on `/generate` and click "SUBMIT DOCUMENTS".
1. On `/lookup` enter a message and click "SUBMIT".
    - [ ] Verify that the flashed message **includes** the "Forgot you codename?" link.
    ![image](https://user-images.githubusercontent.com/22901938/137431554-e7d352e6-5c17-4ba7-8707-6892144d60f2.png)

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

N/A.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/securedrop-app-code-requirements.in`

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
