### PR TITLE
Update flake8 configuration to exclude admin/ subfolders

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,8 @@
 max-line-length = 100
 exclude =
     config.py,
-    admin/.venv,
+    admin/.venv*,
+    admin/.eggs,
     .venv*/,
     journalist_gui/journalist_gui/updaterUI.py,
     journalist_gui/journalist_gui/resources_rc.py,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6129.

Changes proposed in this pull request:

Exclude admin virtual environment (`.venv3`) and `.eggs` subfolders from flake8 analysis.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

1. Run `admin/bootstrap.py` as per as per [Docs » Development of Securedrop-Admin in the Admin Directory](https://docs.securedrop.org/en/latest/development/admin_development.html).
2. Run `flake8` from the root of the repository (or commit changes to run pre-commit hook).
    - [ ] Verify that flake8 passes in a couple of seconds.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/securedrop-app-code-requirements.in`

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
