### PR TITLE
Removed version check for 'securedrop-admin verify' command

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -776,7 +776,6 @@ def install_securedrop(args: argparse.Namespace) -> int:
     )
 
 
-@update_check_required("verify")
 def verify_install(args: argparse.Namespace) -> int:
     """Run configuration tests against SecureDrop servers"""
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6128



## Testing

on a Tails admin workstation:
- check out this branch
- run `./securedrop-admin setup -t && ./securdrop-admin verify
- [ ] Observe that the admin tool does not first check the securedrop version before running `verify`
 
## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [x] I would appreciate help with the documentation
- [ ] These changes do not require documentation
