### PR TITLE
Remove old apt key from Ansible logic

### DIFF
--- a/install_files/ansible-base/group_vars/staging.yml
+++ b/install_files/ansible-base/group_vars/staging.yml
@@ -64,8 +64,8 @@ daily_reboot_time: 4 # An integer between 0 and 23
 # Apt-test repo is needed for testing new kernels in staging.
 apt_repo_url: "https://apt-test.freedom.press"
 
-# As of 0.7.0, we use separate repos for SecureDrop and Tor mirrors,
-# only one of which typically has a test/QA server configured.
+# As of v2.1.0, we ship only the 2021 version of the prod signing key.
+# For staging, we also include the apt-test.freedom.press repo key.
 apt_repo_pubkey_files:
   - apt-test-signing-key.pub
-  - fpf-signing-key.pub
+  - fpf-signing-key-2021.pub

--- a/install_files/ansible-base/roles/install-fpf-repo/defaults/main.yml
+++ b/install_files/ansible-base/roles/install-fpf-repo/defaults/main.yml
@@ -20,7 +20,6 @@ install_local_packages: False
 # May be overridden in staging to install from a test/QA server,
 # the Release file for which will *not* be signed with the prod key.
 apt_repo_pubkey_files:
-  - fpf-signing-key.pub
   - fpf-signing-key-2021.pub
 
 # As of v2.0.0, only Focal is supported.


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes

Fixes #6133 

Follow-up to #5979. Removes the old, i.e. 22245C81E3BAEB4138B36061310F561200F4AD77, apt key from the Ansible install-time logic. The key has been expired since 2021-06-30. Also updates the staging vars to use only the new key, never the old key, alongside the apt-test key. 


## Testing
Here's what I did while working on the change:

1. Clean install in prod VMs, observe that 2224 key is unexpectedly present (as reported in #6133)
2. Manually remove 2224 key via `sudo apt-key del '22245C81E3BAEB4138B36061310F561200F4AD77'`
3. Re-run `./securedrop-admin install` and observe after that 2224 was re-added.
4. Manually remove 2224 key again
5. Check out this branch, rerun `./securedrop-admin install`
6. Observe 2224 key was _not_ re-added

Because we're about to publish rc2, I think running through all those steps as part of PR review is overkill, and I encourage visual review. cc @zenmonkeykstop for thoughts on that. 

I'm also submitting this PR from a `stg-*` branch to ensure that the staging changes don't break anything. 

## Deployment
No special considerations. The old key is expired, and can't be used anymore, and we want it gone everywhere. 
