### PR TITLE
Backport removal of old signing key from Ansible playbooks

### DIFF
--- a/install_files/ansible-base/group_vars/staging.yml
+++ b/install_files/ansible-base/group_vars/staging.yml
@@ -64,8 +64,8 @@ daily_reboot_time: 4 # An integer between 0 and 23
 # Apt-test repo is needed for testing new kernels in staging.
 apt_repo_url: "https://apt-test.freedom.press"
 
-# As of 0.7.0, we use separate repos for SecureDrop and Tor mirrors,
-# only one of which typically has a test/QA server configured.
+# As of v2.1.0, we ship only the 2021 version of the prod signing key.
+# For staging, we also include the apt-test.freedom.press repo key.
 apt_repo_pubkey_files:
   - apt-test-signing-key.pub
-  - fpf-signing-key.pub
+  - fpf-signing-key-2021.pub

--- a/install_files/ansible-base/roles/install-fpf-repo/defaults/main.yml
+++ b/install_files/ansible-base/roles/install-fpf-repo/defaults/main.yml
@@ -20,7 +20,6 @@ install_local_packages: False
 # May be overridden in staging to install from a test/QA server,
 # the Release file for which will *not* be signed with the prod key.
 apt_repo_pubkey_files:
-  - fpf-signing-key.pub
   - fpf-signing-key-2021.pub
 
 # As of v2.0.0, only Focal is supported.


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Backports #6138 

## Testing

- [ ] CI is passing
- [ ] base is `release/2.1.0`
- [ ] Contains only the changes committed in #6138
