### PR TITLE
backport #6141 to `release/2.1.0`

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/translations.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/translations.yml
@@ -1,4 +1,19 @@
 ---
+# We create the virtualenv separately from the "pip install" commands below,
+# to make error-reporing a bit more obvious. We also update beforehand,
+# beyond what the system version provides, see #6317.
+- name: Create virtualenv for translation work
+  shell: >
+    set -e &&
+    python3 -m venv /tmp/securedrop-app-code-i18n-ve &&
+    /tmp/securedrop-app-code-i18n-ve/bin/pip3 install -r
+    <(echo "pip==21.3
+    --hash=sha256:4a1de8f97884ecfc10b48fe61c234f7e7dcf4490a37217011ad9369d899ad5a6
+    --hash=sha256:741a61baab1dbce2d8ca415effa48a2b6a964564f81a9f4f1fce4c433346c034")
+  args:
+    executable: /bin/bash
+  tags:
+    - pip
 
 - name: Install SecureDrop Python requirements in virtualenv for translation work
   shell: >

--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/translations.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/translations.yml
@@ -1,6 +1,6 @@
 ---
 # We create the virtualenv separately from the "pip install" commands below,
-# to make error-reporing a bit more obvious. We also update beforehand,
+# to make error-reporting a bit more obvious. We also update beforehand,
 # beyond what the system version provides, see #6317.
 - name: Create virtualenv for translation work
   shell: >

--- a/install_files/securedrop-app-code/debian/rules
+++ b/install_files/securedrop-app-code/debian/rules
@@ -29,6 +29,7 @@ override_dh_virtualenv:
 		--python=/usr/bin/python3 \
 		--builtin-venv \
 		--preinstall setuptools-scm==6.0.1 \
+		--preinstall pip==21.3 \
 		--extra-pip-arg "--verbose" \
 		--extra-pip-arg "--no-deps" \
 		--extra-pip-arg "--no-binary=:all:" \

--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -21,7 +21,7 @@ mypy>=0.761
 # http://docs.ansible.com/ansible/latest/playbooks_filters_ipaddr.html
 netaddr
 # Now also pin pip due to https://github.com/jazzband/pip-tools/issues/853
-pip>=21.1
+pip>=21.3
 pip-tools>=6.1.0
 psutil>=5.6.6
 pyenchant

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -836,9 +836,9 @@ zipp==0.6.0 \
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.1.1 \
-    --hash=sha256:11d095ed5c15265fc5c15cc40a45188675c239fb0f9913b673a33e54ff7d45f0 \
-    --hash=sha256:51ad01ddcd8de923533b01a870e7b987c2eb4d83b50b89e1bf102723ff9fed8b
+pip==21.3 \
+    --hash=sha256:4a1de8f97884ecfc10b48fe61c234f7e7dcf4490a37217011ad9369d899ad5a6 \
+    --hash=sha256:741a61baab1dbce2d8ca415effa48a2b6a964564f81a9f4f1fce4c433346c034
     # via
     #   -r requirements/python3/develop-requirements.in
     #   pip-tools

--- a/securedrop/requirements/python3/docker-requirements.in
+++ b/securedrop/requirements/python3/docker-requirements.in
@@ -1,3 +1,3 @@
-pip>=21.1
+pip>=21.3
 setuptools>=56.0.0
 wheel

--- a/securedrop/requirements/python3/docker-requirements.txt
+++ b/securedrop/requirements/python3/docker-requirements.txt
@@ -10,9 +10,9 @@ wheel==0.33.6 \
     # via -r requirements/python3/docker-requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.1.1 \
-    --hash=sha256:11d095ed5c15265fc5c15cc40a45188675c239fb0f9913b673a33e54ff7d45f0 \
-    --hash=sha256:51ad01ddcd8de923533b01a870e7b987c2eb4d83b50b89e1bf102723ff9fed8b
+pip==21.3 \
+    --hash=sha256:4a1de8f97884ecfc10b48fe61c234f7e7dcf4490a37217011ad9369d899ad5a6 \
+    --hash=sha256:741a61baab1dbce2d8ca415effa48a2b6a964564f81a9f4f1fce4c433346c034
     # via -r requirements/python3/docker-requirements.in
 setuptools==56.0.0 \
     --hash=sha256:08a1c0f99455307c48690f00d5c2ac2c1ccfab04df00454fef854ec145b81302 \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backports #6141 to v2.1.0 release branch.

## Testing

- [ ] Commits are identical to those merged from `stg-6137-get-thee-to-an-upgradery-pip-now-with-hashes` in #6141, e.g.:
    ```sh-session
    $ git checkout -b check-backport-6141 release/2.1.0
    $ git cherry-pick -n 89063e4b3f2b8473f36c501a4bc539e42c9a2c1d^..stg-6137-get-thee-to-an-upgradery-pip-now-with-hashes
    $ git diff backport-6141 | wc -l  # expect 0
    ```
- [ ] `release/2.1.0` is the base and target of this pull request.