### PR TITLE
default babel format switched to long in rel_datetime_format function

### DIFF
--- a/securedrop/template_filters.py
+++ b/securedrop/template_filters.py
@@ -9,7 +9,7 @@ from jinja2.nodes import EvalContext
 
 
 def rel_datetime_format(
-    dt: datetime, fmt: str = 'MMM dd, yyyy hh:mm a',
+    dt: datetime, fmt: str = 'long',
     relative: bool = False
 ) -> str:
     """Template filter for readable formatting of datetime.datetime"""

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -23,7 +23,7 @@ def verify_rel_datetime_format(app):
         assert session.get('locale') == "en_US"
         result = template_filters.rel_datetime_format(
             datetime(2016, 1, 1, 1, 1, 1))
-        assert "Jan 01, 2016 01:01 AM" == result
+        assert "January 1, 2016 at 1:01:01 AM UTC" == result
 
         result = template_filters.rel_datetime_format(
             datetime(2016, 1, 1, 1, 1, 1), fmt="yyyy")

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -38,7 +38,7 @@ def verify_rel_datetime_format(app):
         assert session.get('locale') == 'fr_FR'
         result = template_filters.rel_datetime_format(
             datetime(2016, 1, 1, 1, 1, 1))
-        assert "janv. 01, 2016 01:01 AM" == result
+        assert "1 janvier 2016 à 01:01:01 TU" == result
 
         result = template_filters.rel_datetime_format(
             datetime(2016, 1, 1, 1, 1, 1), fmt="yyyy")


### PR DESCRIPTION
## Status

Ready for review. `make test` and `make lint` are passing on my local dev instance.

## Description of Changes
This resolves the displayed ordered of date elements, based on locale (e.g. MM/DD/YYYY vs DD/MM/YYYY).
To be specific, `datetime` objects will now be displayed using the babel `long` formatting. For example:
`15. Oktober 2021 um 02:57:19 UTC` if the locale is `de_DE` or
`October 15, 2021 at 2:57:19 AM UTC` if the locale is `en_US`.

This is a fix for  #6073. Unfortunately, this solution does not distinguish between `en_UK` and `en_US` locales; the use of either  will display dates conforming to  the `en_US` style, e.g. `October 15, 2021`.
## Testing
The relevant tests in (`securedrop/tests/test_template_filters.py`), which checks the default date formatting returned by `rel_datetime_format()` has been updated to accept the new `long` date format.
## Deployment
Deployment strategy shouldn't be effected by this change. The method changed in this PR (`rel_datetime_format()`) is called by Jinja2 code in displayed html and in the test method `verify_rel_datetime_format()`. No other backend functionality (e.g. backups or other things that might require a date comparison) call this method.
## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
The test `verify_rel_datetime_format()` in `securedrop/tests/test_template_filters.py` was updated to reflect code changes and dev test suite is now passing.
### If you made changes to `securedrop-admin`:
**Not applicable.**
- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:
**Not applicable.**
- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:
**Not applicable.**
- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:
**Code changes are trivial, in my opinion.**
- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a production code dependency:
**Not applicable.**