### PR TITLE
Updates builder image to version tagged 2021_10_19

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_10_03
-c7a7af66cb509f1096aa9123eb27f83dd504effce8b9fdf0269b9432ee84a707
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_10_19
+7d365b95c9d3e1b2e7d9902d7bd0673a323f7e525f7fa35a67f8b82ae07410ed


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Updates builder image to version tagged `2021_10_19`


## Testing

- [ ] CI passes - in particular, `deb-tests`
- [ ] only repo change is to `molecule/builder-focal/image_hash` 
