### PR TITLE
unbreaks testinfra tests against a production instance with non-default hostnames

### DIFF
--- a/install_files/ansible-base/roles/tails-config/tasks/create_ssh_aliases.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/create_ssh_aliases.yml
@@ -36,6 +36,16 @@
     mode: "0600"
     owner: amnesia
     group: amnesia
+  vars:
+    # Make the configured hostnames easily available to the Jinja template.
+    # An explicit dictionary is necessary only because the unabbreviated key
+    # "monitor_hostname" prevents us from doing (e.g.) the following over the
+    # items in "ssh_v3_onion_lookup":
+    #
+    #     hostvars[inventory_hostname][svc.item+'_hostname']
+    hostnames:
+      app: "{{ app_hostname }}"
+      mon: "{{ monitor_hostname }}"
   with_items:
     - "{{ tails_config_securedrop_dotfiles }}/ssh_config"
     - "{{ tails_config_amnesia_home }}/.ssh/config"

--- a/install_files/ansible-base/roles/tails-config/templates/ssh_config.j2
+++ b/install_files/ansible-base/roles/tails-config/templates/ssh_config.j2
@@ -1,7 +1,9 @@
 {% set svc_awk = "awk -F ':' '{print $1 \".onion\"}' svc-ssh.auth_private" %}
 
 {% for svc in ssh_v3_onion_lookup.results %}
-Host {{ svc.item }}
+{% set alias = svc.item %}
+{% set hostname = hostnames.get(alias) %}
+Host {{ [alias,hostname]|unique|join(' ') }}
   {% set svc_awk = "awk -F ':' '{print $1 \".onion\"}' "+svc.item+"-ssh.auth_private" -%}
   {% set direct_ip = hostvars[inventory_hostname][svc.item+'_ip'] -%}
   User {{ ssh_users }}

--- a/molecule/testinfra/conftest.py
+++ b/molecule/testinfra/conftest.py
@@ -47,7 +47,9 @@ def securedrop_import_testinfra_vars(hostname, with_header=False):
                 hostvars[vars_key] = prodvars[prod_key]
 
         _prod_override('app_ip', 'app_ip')
+        _prod_override('app_hostname', 'app_hostname')
         _prod_override('mon_ip', 'monitor_ip')
+        _prod_override('monitor_hostname', 'monitor_hostname')
         _prod_override('sasl_domain', 'sasl_domain')
         _prod_override('sasl_username', 'sasl_username')
         _prod_override('sasl_password', 'sasl_password')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6145 by:

1. including `{app,monitor}_hostname` among the variables overridden from the `site-specific` configuration when testinfra tests are run against a production instance; and
2. including the configured hostnames, in addition to the `app` and `mon` aliases, in the `Host` directives configured in `~/.ssh/config` so that testinfra can use them to connect to the servers.

## Testing

This pull request has a high ratio of testing burden to benefit until the next QA period, so feel free to defer review until then.

1. `securedrop-admin {sdconfig,install}` an instance with non-default hostnames, which could be as simple as those configured by `molecule create -s libvirt-prod-focal`:

    ```yaml
    app_hostname: app-prod
    monitor_hostname: mon-prod
    ```
2. `securedrop-admin tailsconfig`
3. [ ] Confirm that your `~/.ssh/config` contains `Host` directives that include the configured hostnames, e.g.:

    ```
    # [...]
    Host app app-prod
    # [...]
    Host mon mon-prod
    # [...]
    ```
4. [ ] `securedrop-admin verify` and confirm that all tests pass, especially those flagged in #6145:
    * `app/test_ossec_agent.py::test_hosts_files`
    * `mon/test_ossec_server.py::test_ossec_connectivity`
    * `mon/test_ossec_server.py::test_hosts_files`
    * `mon/test_postfix.py::test_postfix_generic_maps`
5. `securedrop-admin sdconfig` back to the default values (no need to `securedrop-admin install`):

    ```yaml
    app_hostname: app
    monitor_hostname: mon
    ```
6. `securedrop-admin tailsconfig`
7. [ ] Confirm that your `~/.ssh/config` contains non-duplicative `Host` directives, e.g.:

    ```
    # [...]
    Host app
    # [...]
    Host mon
    # [...]
    ```

## Deployment

Existing `ssh app` and `ssh mon` aliases will remain unchanged for production instances regardless of their configured hostnames.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass