### PR TITLE
Removes stale --ignores from "make safety", adds one for Werkzeug 0.16.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,11 +132,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 	@for req_file in `find . -type f -name '*requirements.txt'`; do \
 		echo "Checking file $$req_file" \
 		&& safety check \
-		--ignore 39252 \
-		--ignore 39606 \
-		--ignore 39611 \
-		--ignore 39621 \
-		--ignore 41002 \
+		--ignore 42050 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

The `make safety` Makefile target is set to ignore some safety errors, most of which will not longer be triggered anyway thanks to recent dependency updates. This PR removes the irrelevant `--ignore` flags. It also adds a new one for Werkzeug (42050), which is inapplicable to the production environment but will be triggered until the refactor and update to Flask 2.* is complete.

## Testing

- [ ] CI is passing, including the safety check and `staging-test-with-rebase`.

## Deployment
