### PR TITLE
Fix retrieval of Tor Browser version number

### DIFF
--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -33,7 +33,7 @@ ENV TOR_RELEASE_KEY_FINGERPRINT "EF6E286DDA85EA2A4BA7DE684E2C6E8793298290"
 RUN curl -s https://openpgpkey.torproject.org/.well-known/openpgpkey/torproject.org/hu/kounek7zrdx745qydx6p59t9mqjpuhdf | gpg2 --import -
 
 # Fetch latest TBB version (obtained from https://github.com/micahflee/torbrowser-launcher/blob/develop/torbrowser_launcher/common.py#L198) and install Tor Browser
-RUN TBB_VERSION=$(curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US | grep -oP '\d+\.\d+\.\d+' | head -1) && \
+RUN TBB_VERSION=$(curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US | grep -oP 'appVersion="\d+\.\d+\.*\d*"' | grep -oP '\d+\.\d+\.*\d*') && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \
     gpg2 --verify tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc 2>&1 | grep "Primary key fingerprint:" | sed -e 's/Primary key fingerprint: //' -e 's/ //g' | tail -1 | grep -qE "${TOR_RELEASE_KEY_FINGERPRINT}" && \

--- a/securedrop/dockerfiles/xenial/python3/Dockerfile
+++ b/securedrop/dockerfiles/xenial/python3/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -s https://openpgpkey.torproject.org/.well-known/openpgpkey/torproject.
 
 # Install Tor Browser
 # Fetch latest TBB version (obtained from https://github.com/micahflee/torbrowser-launcher/blob/develop/torbrowser_launcher/common.py#L198) and install Tor Browser
-RUN TBB_VERSION=$(curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US | grep -oP '\d+\.\d+\.\d+' | head -1) && \
+RUN TBB_VERSION=$(curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US | grep -oP 'appVersion="\d+\.\d+\.*\d*"' | grep -oP '\d+\.\d+\.*\d*') && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \
     gpg2 --verify tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc 2>&1 | grep "Primary key fingerprint:" | sed -e 's/Primary key fingerprint: //' -e 's/ //g' | tail -1 | grep -qE "${TOR_RELEASE_KEY_FINGERPRINT}" && \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes https://github.com/freedomofpress/securedrop/issues/6163

Changes proposed in this pull request:

- Ensure the Tor Browser version is stored into `TBB_BROWSER`
- Take steps to prevent similar issues when the reference document format is extended.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

1. Make sure you can reproduce #6163 
2. Verify that the error doesn't happen anymore.

Alternatively, run the failing and fixed command progressively to understand what was happening:

```sh
## Not currently returning the Tor Browser version:
# Get Tor Browser information
curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US
# Select all strings that look like a version number with three components
curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US | grep -oP '\d+\.\d+\.\d+'
# Pick the first one
curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US | grep -oP '\d+\.\d+\.\d+' | head -1

## Fixed - returns the Tor Browser version reliably:
# Get Tor Browser information
curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US
# Select the specific string that describes the application version number:
curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US | grep -oP 'appVersion="\d+\.\d+\.*\d*"'
# Extract the version number from that string (which may have two or three components):
curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US | grep -oP 'appVersion="\d+\.\d+\.*\d*"' | grep -oP '\d+\.\d+\.*\d*'
```

## Deployment

No special considerations for deployment come to mind. This affected the development environment. (And mostly _new_ development environments, see description of #6163.)

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/securedrop-app-code-requirements.in`

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
