### PR TITLE
Adds optional onion service support to the dev Docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,11 @@ dev:  ## Run the development server in a Docker container.
 	@OFFSET_PORTS='false' DOCKER_BUILD_VERBOSE='true' $(DEVSHELL) $(SDBIN)/run
 	@echo
 
+.PHONY: dev-tor
+dev-tor:  ## Run the development server with onion services in a Docker container.
+	@echo "███ Starting development server..."
+	@OFFSET_PORTS='false' DOCKER_BUILD_VERBOSE='true' USE_TOR='true' $(DEVSHELL) $(SDBIN)/run
+	@echo
 
 .PHONY: staging
 staging:  ## Create a local staging environment in virtual machines (Focal)

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -55,6 +55,36 @@ function run_sass() {
     sass --stop-on-error sass:static/css --style compressed "$@"
 }
 
+function maybe_use_tor() {
+    if  [[ -n "${USE_TOR}" ]]; then
+        echo "Setting up Tor..."
+        # append torrc lines for SI and JI
+        sudo -u debian-tor mkdir -p /var/lib/tor/services
+        echo "HiddenServiceDir /var/lib/tor/services/source/" | sudo tee -a /etc/tor/torrc
+        echo "HiddenServicePort 80 127.0.0.1:8080" | sudo tee -a /etc/tor/torrc
+        echo "HiddenServiceDir /var/lib/tor/services/journalist/" | sudo tee -a /etc/tor/torrc
+        echo "HiddenServicePort 80 127.0.0.1:8081" | sudo tee -a /etc/tor/torrc
+        # start Tor to create service directories
+        sudo service tor start
+        # create x25519 keypair and journalist client auth file
+        openssl genpkey -algorithm x25519 -out /tmp/k1.prv.pem
+        grep -v " PRIVATE KEY" < /tmp/k1.prv.pem | base64pem -d | tail --bytes=32 | base32 | sed 's/=//g' > /tmp/k1.prv.key
+        openssl pkey -in /tmp/k1.prv.pem -pubout | grep -v " PUBLIC KEY" | base64pem -d | tail --bytes=32 | base32 | sed 's/=//g' > /tmp/k1.pub.key
+        echo "descriptor:x25519:$(cat /tmp/k1.pub.key)" | sudo -u debian-tor tee /var/lib/tor/services/journalist/authorized_clients/client.auth
+        # kill and restart Tor to pick up authorized_clients change
+        # (restart a little flaky hence the kill)
+        sudo kill "$(cat /run/tor/tor.pid)"; sudo service tor restart
+        # print out the addresses and the JI client auth key
+        echo
+        echo  ##############################################################################
+        echo "Tor configuration complete! details as follows:"
+        echo "Source Interface:     http://$(sudo -u debian-tor cat /var/lib/tor/services/source/hostname)"
+        echo "Journalist Interface: http://$(sudo -u debian-tor cat /var/lib/tor/services/journalist/hostname)"
+        echo "Journalist Auth Key:  $(sudo -u debian-tor cat /tmp/k1.prv.key)"
+        echo  ##############################################################################
+    fi
+}
+
 function reset_demo() {
     # Set up GPG keys directory structure.
     sudo mkdir -p /var/lib/securedrop/{store,keys,tmp}

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -10,6 +10,7 @@ export PATH="/opt/venvs/securedrop-app-code/bin:$PATH"
 
 TOPLEVEL=$(git rev-parse --show-toplevel)
 BASE_OS="${BASE_OS:-focal}"
+USE_TOR="${USE_TOR:-}"
 
 ## Get an integer offset for exposed ports, to support multiple containers
 get_port_offset() {
@@ -80,6 +81,7 @@ function docker_run() {
            -p "127.0.0.1:${SD_HOSTPORT_VNC}:5909" \
            -p "127.0.0.1:${SD_HOSTPORT_SI}:8080" \
            -p "127.0.0.1:${SD_HOSTPORT_JI}:8081" \
+           -e USE_TOR=$USE_TOR \
            -e NUM_JOURNALISTS \
            -e NUM_SOURCES \
            -e LOADDATA_ARGS \

--- a/securedrop/bin/run
+++ b/securedrop/bin/run
@@ -13,6 +13,7 @@ urandom
 run_sass --watch &
 maybe_create_config_py
 reset_demo
+maybe_use_tor
 
 # run the batch processing services normally managed by systemd
 /opt/venvs/securedrop-app-code/bin/rqworker &

--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y paxctl && \
                        # cached along with everything else too.
                        default-jdk \
                        libasound2 libdbus-glib-1-2 libgtk2.0-0 libfontconfig1 libxrender1 \
-                       libcairo-gobject2 libgtk-3-0 libstartup-notification0 tor
+                       libcairo-gobject2 libgtk-3-0 libstartup-notification0 tor basez
 
 RUN gem install sass -v 3.4.23
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6152 .

Adds a makefile target `make dev-tor`, that sets up the SI with a public v3 onion service address, and the JI with an authenticated onion service.

## Testing
- check out this branch
- run `make dev-tor`:
  - [ ] confirm that Tor services were set up and their information was displayed in the Docker output (just before the web applications are started)
  - [ ] confirm that the SI is accessible via its onion service address
  - [ ] confirm that the JI is *not* accessible via its onion service address without the use of the auth key
  - [ ] confirm that the JI is accessible when the auth key is used (either directly via the Tor Browser dialog if available (ie. if using the TBB bundle), or by setting up the onion-auth config in the Tor daemon being used by the browser (if using Whonix or Tails))
- kill the docker container and run `make dev`
  - [ ] confirm that the dev container is set up without the Tor services being configured and that the SI and JI are available via `localhost:8080` and `localhost:8081` as normal.

## Deployment

Dev-only, no deployment issues.

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
