### PR TITLE
Use rust v1.56.1 in app-code build process

### DIFF
--- a/molecule/builder-focal/Dockerfile
+++ b/molecule/builder-focal/Dockerfile
@@ -41,7 +41,7 @@ COPY aptpreferences.conf /etc/apt/preferences.d/ubuntu-groovy
 
 RUN apt-get update && apt-get install -y dh-virtualenv
 
-ENV RUST_VERSION 1.52.1
+ENV RUST_VERSION 1.56.1
 
 # Install Rust for building cryptography
 RUN TMPDIR=`mktemp -d` && cd ${TMPDIR} \


### PR DESCRIPTION
Towards #6158.

## Status

Ready for review, although still needs builder changes. 

## Description of Changes

Fixes #6158 

## Testing
Ideally, we'd test both building the debs and using them in a staging environment. I haven't done that yet, but I'm comfortable merging as-is and inspecting CI output from the nightly staging jobs to make sure there are no surprises. 

## Deployment
Logic is specifically to the build process for app code. Strictly speaking this change could have side-effects, but highly unlikely given it's a stable release.