### PR TITLE
Remove remnants of v2 configuration code

### DIFF
--- a/devops/clean
+++ b/devops/clean
@@ -29,10 +29,11 @@ function remove_unwanted_files() {
     fi
 
     # Remove any Onion URL info from previous instances.
-    rm -vf install_files/ansible-base/app-source-ths \
-        install_files/ansible-base/app-ssh-aths \
-        install_files/ansible-base/app-journalist-aths \
-        install_files/ansible-base/mon-ssh-aths \
+    rm -vf install_files/ansible-base/app-journalist.auth_private \
+        install_files/ansible-base/app-sourcev3-ths \
+        install_files/ansible-base/app-ssh.auth_private \
+        install_files/ansible-base/mon-ssh.auth_private \
+        install_files/ansible-base/tor_v3_keys.json \
         build/*.deb
 
     # Remove extraneous copies of the git repos, pulled in

--- a/install_files/ansible-base/group_vars/securedrop_application_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_application_server.yml
@@ -14,13 +14,6 @@ local_deb_packages:
   - "ossec-agent-3.6.0+{{ securedrop_target_distribution }}-amd64.deb"
 
 # Configuring the tor onion services
-tor_instances:
-  - "{{ {'service': 'ssh', 'filename': 'app-ssh-aths'} if enable_ssh_over_tor else [] }}"
-  - service: source
-    filename: app-source-ths
-  - service: journalist
-    filename: app-journalist-aths
-
 tor_instances_v3:
   - "{{ {'service': 'sshv3', 'filename': 'app-ssh.auth_private'} if enable_ssh_over_tor else [] }}"
   - service: sourcev3

--- a/install_files/ansible-base/group_vars/securedrop_monitor_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_monitor_server.yml
@@ -14,7 +14,6 @@ local_deb_packages:
 
 # Configure the tor onion services. The Monitor server has only one,
 # for SSH, since no web interfaces.
-tor_instances: "{{ [{ 'service': 'ssh', 'filename': 'mon-ssh-aths'}] if enable_ssh_over_tor else [] }}"
 tor_instances_v3: "{{ [{ 'service': 'sshv3', 'filename': 'mon-ssh.auth_private'}] if enable_ssh_over_tor else [] }}"
 
 tor_auth_instances_v3:

--- a/install_files/ansible-base/roles/restrict-direct-access/templates/ths_config.j2
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/ths_config.j2
@@ -1,1 +1,0 @@
-{% if item.item.filename.endswith('-aths') %}HidServAuth {% endif %}{{ item.stdout }}


### PR DESCRIPTION
- devops clean script should remove v3, not v2, configuration files
- v2 tor_instances task is unused

## Status

Ready for review. I've tested:

- manually running the `rm` command in a checkout that was used to previously provision a staging env
- a fresh install via `securedrop-admin install` playbook run against prod VM with these changes in place
   - all expected onion services were created correctly
   - install completed without errors