### PR TITLE
updated builder image to version tagged as 2021_11_16

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_10_19
-7d365b95c9d3e1b2e7d9902d7bd0673a323f7e525f7fa35a67f8b82ae07410ed
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_11_16
+e585182ba698c718034d60d7fb5d6eadbb9fe67c1c557818e5e66b1a6c9e4672


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #6158.

Updates build container to version tagged `2021_11_16`, including latest Rust.

## Testing

- [ ] CI is passing.
- [ ] `make build-debs` passes locally and new builder image is used

## Deployment
n/a
