### PR TITLE
Disable caching of GPG passphrases in the GPG agent (CryptoUtil 1/3)

### DIFF
--- a/install_files/securedrop-app-code/debian/postinst
+++ b/install_files/securedrop-app-code/debian/postinst
@@ -132,10 +132,14 @@ case "$1" in
         if ! grep -qE '^allow-loopback-pinentry$' /var/lib/securedrop/keys/gpg-agent.conf; then
             echo allow-loopback-pinentry >> /var/lib/securedrop/keys/gpg-agent.conf
         fi
+        if ! grep -qE '^default-cache-ttl 0$' /var/lib/securedrop/keys/gpg-agent.conf; then
+            echo 'default-cache-ttl 0' >> /var/lib/securedrop/keys/gpg-agent.conf
+        fi
 
     else
         # gpg-agent.conf does not yet exist, create it.
         echo allow-loopback-pinentry > /var/lib/securedrop/keys/gpg-agent.conf
+        echo 'default-cache-ttl 0' >> /var/lib/securedrop/keys/gpg-agent.conf
     fi
 
     # Migrate private keyring to gpg2.1 if needed

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -94,6 +94,7 @@ function reset_demo() {
 
     # Create gpg-agent.conf
     echo allow-loopback-pinentry > /var/lib/securedrop/keys/gpg-agent.conf
+    echo 'default-cache-ttl 0' >> /var/lib/securedrop/keys/gpg-agent.conf
 
     # Kill gpg-agent(s) if they exist so it picks up the new config on restart.
     pkill -f gpg-agent || true

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -826,7 +826,7 @@ class JournalistNavigationStepsMixin:
         cks = cookie_string_from_selenium_cookies(self.driver.get_cookies())
         raw_content = self.return_downloaded_content(file_url, cks)
 
-        decrypted_submission = self.gpg.decrypt(raw_content)
+        decrypted_submission = self.journalist_app.crypto_util.gpg.decrypt(raw_content)
         submission = self._get_submission_content(file_url, decrypted_submission)
         if type(submission) == bytes:
             submission = submission.decode("utf-8")

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -1,36 +1,24 @@
 # -*- coding: utf-8 -*-
 """Testing utilities related to setup and teardown of test environment.
 """
-import io
 import os
 import shutil
 import threading
-from distutils.version import StrictVersion
 from os.path import abspath
 from os.path import dirname
 from os.path import isdir
 from os.path import join
 from os.path import realpath
 
-import pretty_bad_protocol as gnupg
 from db import db
-from sdconfig import config
 
 os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 
 
 TESTS_DIR = abspath(join(dirname(realpath(__file__)), '..'))
-FILES_DIR = join(TESTS_DIR, 'files')
-
-# The PID file for the redis worker is hard-coded below.  Ideally this
-# constant would be provided by a test harness.  It has been intentionally
-# omitted from `config.py.example` in order to isolate the test vars from prod
-# vars.  When refactoring the test suite, the test_worker_pidfile
-# test_worker_pidfile is also hard-coded in `manage.py`.
-TEST_WORKER_PIDFILE = "/tmp/securedrop_test_worker.pid"
 
 
-def create_directories():
+def create_directories(config):
     """Create directories for the file store and the GPG keyring.
     """
     for d in (config.SECUREDROP_DATA_ROOT, config.STORE_DIR,
@@ -39,39 +27,7 @@ def create_directories():
             os.mkdir(d)
 
 
-def init_gpg():
-    """Initialize the GPG keyring and import the journalist key for
-    testing.
-    """
-
-    # GPG 2.1+ requires gpg-agent, see #4013
-    gpg_agent_config = os.path.join(config.GPG_KEY_DIR, 'gpg-agent.conf')
-    with open(gpg_agent_config, 'w+') as f:
-        f.write('allow-loopback-pinentry')
-
-    gpg_binary = gnupg.GPG(binary='gpg2', homedir=config.GPG_KEY_DIR)
-    if StrictVersion(gpg_binary.binary_version) >= StrictVersion('2.1'):
-        gpg = gnupg.GPG(binary='gpg2',
-                        homedir=config.GPG_KEY_DIR,
-                        options=['--pinentry-mode loopback'])
-    else:
-        gpg = gpg_binary
-
-    # Faster to import a pre-generated key than to gen a new one every time.
-    for keyfile in (join(FILES_DIR, "test_journalist_key.pub"),
-                    join(FILES_DIR, "test_journalist_key.sec")):
-        gpg.import_keys(io.open(keyfile).read())
-    return gpg
-
-
-def setup():
-    """Set up the file system, GPG, and database."""
-    create_directories()
-    init_gpg()
-    db.create_all()
-
-
-def teardown():
+def teardown(config):
     # make sure threads launched by tests complete before
     # teardown, otherwise they may fail because resources
     # they need disappear


### PR DESCRIPTION
## Status

Ready.

## Description of Changes

This PR disables the caching of GPG passphrases by adding `default-cache-ttl 0` to the GPG agent's config.

* This fixes a security issue where any GPG passphrase could be supplied to the GPG decryption code, as long as the corresponding decryption key's GPG passphrase was already in the GPG cache. The decryption code (more specifically the GPG binary) transparently retrieves from the cache the GPG passphrase for the right key, and then uses the key to decrypt the data. This happens regardless of what GPG passphrase was supplied by the caller.
* AFAIK this issue is currently unexploitable. Exploiting it would require another another bug in the securedrop server code that would allow a malicious source to "ask" the server to decrypt another source's files/replies. In this scenario, the malicious source would not need to provide/guess the other source's GPG passphrase: the server would transparently retrieve it from its cache and decrypt the content; what this PR fixes.
* This is part 1 of a set of 3 PRs to refactor the GPG code. 
    * Part 2: https://github.com/freedomofpress/securedrop/pull/6184
    * Part 3: https://github.com/freedomofpress/securedrop/pull/6160 . That PR contains unit tests to ensure that the correct GPG passphrase must supplied to the decryption code.