### PR TITLE
Use the existing GPG fixture in the functional tests (CryptoUtil 2/3)

### DIFF
--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -21,20 +21,23 @@ from passphrases import PassphraseGenerator
 
 sys.path.insert(0, "/var/www/securedrop")  # noqa: E402
 
-import qrcode
-from sqlalchemy.orm.exc import NoResultFound
+import qrcode  # noqa: E402
+from sqlalchemy.orm.exc import NoResultFound  # noqa: E402
 
-os.environ['SECUREDROP_ENV'] = 'dev'  # noqa
 
-from db import db
-from models import (
+if not os.environ.get("SECUREDROP_ENV"):
+    os.environ['SECUREDROP_ENV'] = 'dev'  # noqa
+
+
+from db import db  # noqa: E402
+from models import (  # noqa: E402
     FirstOrLastNameError,
     InvalidUsernameException,
     Journalist,
 )
-from management import app_context, config
-from management.run import run
-from management.submissions import (
+from management import app_context, config  # noqa: E402
+from management.run import run  # noqa: E402
+from management.submissions import (  # noqa: E402
     add_check_db_disconnect_parser,
     add_check_fs_disconnect_parser,
     add_delete_db_disconnect_parser,

--- a/securedrop/tests/__init__.py
+++ b/securedrop/tests/__init__.py
@@ -2,6 +2,11 @@
 from os.path import abspath, dirname, join, realpath
 import pytest
 import sys
+import os
+
+# WARNING: This variable must be set before any import of the securedrop code/app
+# or most tests will fail
+os.environ["SECUREDROP_ENV"] = "test"
 
 # The tests directory should be adjacent to the securedrop directory. By adding
 # the securedrop directory to sys.path here, all test modules are able to

--- a/securedrop/tests/test_2fa.py
+++ b/securedrop/tests/test_2fa.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
 import pytest
 import time
 
@@ -8,7 +7,6 @@ from datetime import datetime, timedelta
 from flask import url_for
 from pyotp import TOTP
 
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 from models import Journalist, BadTokenException
 from .utils import login_user
 from .utils.instrument import InstrumentedApp

--- a/securedrop/tests/test_crypto_util.py
+++ b/securedrop/tests/test_crypto_util.py
@@ -10,9 +10,6 @@ from passphrases import PassphraseGenerator
 
 from source_user import create_source_user
 
-
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-
 from crypto_util import CryptoUtil, CryptoException
 from db import db
 

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -38,8 +38,6 @@ from sh import sed
 from .utils.env import TESTS_DIR
 from werkzeug.datastructures import Headers
 
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-
 
 def verify_i18n(app):
     not_translated = 'code hello i18n'

--- a/securedrop/tests/test_i18n_tool.py
+++ b/securedrop/tests/test_i18n_tool.py
@@ -3,7 +3,6 @@
 import io
 import os
 from os.path import abspath, dirname, exists, getmtime, join, realpath
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 import i18n_tool
 from mock import patch
 import pytest

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -20,8 +20,6 @@ from source_app.session_manager import SessionManager
 from . import utils
 from .utils.instrument import InstrumentedApp
 
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-
 
 # Seed the RNG for deterministic testing
 random.seed('ಠ_ಠ')

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import json
-import os
 import random
 
 from flask import url_for
@@ -18,8 +17,6 @@ from models import (
     RevokedToken,
 )
 
-
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 from .utils.api_helper import get_api_headers
 
 random.seed('◔ ⌣ ◔')

--- a/securedrop/tests/test_journalist_utils.py
+++ b/securedrop/tests/test_journalist_utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from flask import url_for
-import os
 import pytest
 import random
 
@@ -9,7 +8,6 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from journalist_app.utils import cleanup_expired_revoked_tokens
 
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 from .utils.api_helper import get_api_headers
 
 random.seed('◔ ⌣ ◔')

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -15,8 +15,6 @@ from passphrases import PassphraseGenerator
 from source_user import create_source_user
 
 
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-
 YUBIKEY_HOTP = ['cb a0 5f ad 41 a2 ff 4e eb 53 56 3a 1b f7 23 2e ce fc dc',
                 'cb a0 5f ad 41 a2 ff 4e eb 53 56 3a 1b f7 23 2e ce fc dc d7']
 

--- a/securedrop/tests/test_secure_tempfile.py
+++ b/securedrop/tests/test_secure_tempfile.py
@@ -5,7 +5,6 @@ import pytest
 
 from pretty_bad_protocol._util import _is_stream
 
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 from secure_tempfile import SecureTemporaryFile
 
 MESSAGE = '410,757,864,530'

--- a/securedrop/tests/test_store.py
+++ b/securedrop/tests/test_store.py
@@ -10,7 +10,6 @@ import zipfile
 from passphrases import PassphraseGenerator
 from source_user import create_source_user
 
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
 from . import utils
 
 from db import db

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -14,8 +14,6 @@ from flask import session
 from sh import pybabel
 from .utils.env import TESTS_DIR
 
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-
 
 def verify_rel_datetime_format(app):
     with app.test_client() as c:

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -19,8 +19,6 @@ from passphrases import PassphraseGenerator
 from sdconfig import config
 from source_user import create_source_user
 
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-
 
 def init_journalist(first_name=None, last_name=None, is_admin=False):
     """Initialize a journalist into the database. Return their

--- a/securedrop/tests/utils/env.py
+++ b/securedrop/tests/utils/env.py
@@ -4,6 +4,7 @@
 import os
 import shutil
 import threading
+from pathlib import Path
 from os.path import abspath
 from os.path import dirname
 from os.path import isdir
@@ -12,17 +13,16 @@ from os.path import realpath
 
 from db import db
 
-os.environ['SECUREDROP_ENV'] = 'test'  # noqa
-
 
 TESTS_DIR = abspath(join(dirname(realpath(__file__)), '..'))
 
 
 def create_directories(config):
-    """Create directories for the file store and the GPG keyring.
+    """Create directories for the file store.
     """
-    for d in (config.SECUREDROP_DATA_ROOT, config.STORE_DIR,
-              config.GPG_KEY_DIR, config.TEMP_DIR):
+    # config.SECUREDROP_DATA_ROOT and config.GPG_KEY_DIR already get created by the
+    # setup_journalist_key_and_gpg_folder fixture
+    for d in [config.STORE_DIR, config.TEMP_DIR]:
         if not isdir(d):
             os.mkdir(d)
 
@@ -34,16 +34,15 @@ def teardown(config):
     for t in threading.enumerate():
         if t.is_alive() and not isinstance(t, threading._MainThread):
             t.join()
+
+    # Delete the DB file
     db.session.remove()
-    try:
-        shutil.rmtree(config.TEMP_DIR)
-    except OSError:
-        # Then check the directory was already deleted
-        assert not os.path.exists(config.TEMP_DIR)
-    try:
-        shutil.rmtree(config.SECUREDROP_DATA_ROOT)
-        # safeguard for #844
-        assert not os.path.exists(config.SECUREDROP_DATA_ROOT)
-    except OSError as exc:
-        if 'No such file or directory' != exc.strerror:
-            raise
+    Path(config.DATABASE_FILE).unlink()
+
+    # Delete other directories
+    for config_dir in [config.TEMP_DIR, config.STORE_DIR]:
+        try:
+            shutil.rmtree(config_dir)
+        except OSError:
+            # Then check the directory was already deleted
+            assert not os.path.exists(config_dir)


### PR DESCRIPTION
## Status

Ready. 

## Description of Changes

This PR updates the functional tests to use the same fixture for GPG as the other tests. It also updates the config fixture.

* This is a prerequisite for the refactoring of the GPG code in https://github.com/freedomofpress/securedrop/pull/6160 which uses the updated config fixture.
* This is a small step forward for https://github.com/freedomofpress/securedrop/issues/3836. More work is needed to refactor the functional tests and their fixtures.
* Because the GPG fixture that is now being used is session-scoped, it is only called once during the whole test suite, and only one GPG home directory is used for all the tests. This helps a little bit with https://github.com/freedomofpress/securedrop/issues/4332 (only 1 GPG process should get created instead of ~80).
* There is more work to be done with the config fixture itself, and I might take a look at it eventually. The biggest problem is that tests might either use the config from the `config()` fixture, or the config from the config.py file generated by `make test` right before the tests run.
    * This creates really tricky interactions and bugs when working on the test suite, because it's unclear which config is being used. It's also sometime unclear what config is needed for a specific test to succeed, and some tests also tend to mutate the config object (for example changing the time it takes for a session to expire).
    * This PR makes small changes to slightly improve this situation.