### PR TITLE
Adds SI and JI header updates

### DIFF
--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
@@ -24,15 +24,18 @@ Header onsuccess unset X-Frame-Options
 Header always set X-Frame-Options "DENY"
 Header onsuccess unset Referrer-Policy
 Header always set Referrer-Policy "no-referrer"
+Header onsuccess unset Cross-Origin-Opener-Policy
+Header always set Cross-Origin-Opener-Policy "same-origin"
+Header onsuccess unset Cross-Origin-Embedder-Policy
+Header always set Cross-Origin-Embedder-Policy "same-origin"
+Header onsuccess unset Cross-Origin-Resource-Policy
+Header always set Cross-Origin-Resource-Policy "same-site"
 
 Header onsuccess unset X-Content-Type-Options
 Header always set X-Content-Type-Options "nosniff"
-Header onsuccess unset X-Download-Options
+
 Header onsuccess unset Content-Security-Policy
-Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
-Header set Cross-Origin-Opener-Policy "same-origin"
-Header set Cross-Origin-Embedder-Policy "same-origin"
-Header set Cross-Origin-Resource-Policy "same-site"
+Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
 
 # Limit the max submitted size of requests.
 LimitRequestBody 524288000

--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
@@ -29,7 +29,10 @@ Header onsuccess unset X-Content-Type-Options
 Header always set X-Content-Type-Options "nosniff"
 Header onsuccess unset X-Download-Options
 Header onsuccess unset Content-Security-Policy
-Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
+Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+Header set Cross-Origin-Opener-Policy "same-origin"
+Header set Cross-Origin-Embedder-Policy "same-origin"
+Header set Cross-Origin-Resource-Policy "same-site"
 
 # Limit the max submitted size of requests.
 LimitRequestBody 524288000

--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
@@ -32,8 +32,7 @@ Header always set X-Content-Type-Options "nosniff"
 Header onsuccess unset X-Download-Options
 Header always set X-Download-Options "noopen"
 Header onsuccess unset Content-Security-Policy
-Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
-Header set Cross-Origin-Opener-Policy "same-origin"
+Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
 
 # Limit the max submitted size of requests.
 LimitRequestBody 524288000

--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
@@ -33,6 +33,7 @@ Header onsuccess unset X-Download-Options
 Header always set X-Download-Options "noopen"
 Header onsuccess unset Content-Security-Policy
 Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+Header set Cross-Origin-Opener-Policy "same-origin"
 
 # Limit the max submitted size of requests.
 LimitRequestBody 524288000

--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
@@ -30,7 +30,6 @@ Header always set X-XSS-Protection "1; mode=block"
 Header onsuccess unset X-Content-Type-Options
 Header always set X-Content-Type-Options "nosniff"
 Header onsuccess unset X-Download-Options
-Header always set X-Download-Options "noopen"
 Header onsuccess unset Content-Security-Policy
 Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
 

--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
@@ -24,8 +24,6 @@ Header onsuccess unset X-Frame-Options
 Header always set X-Frame-Options "DENY"
 Header onsuccess unset Referrer-Policy
 Header always set Referrer-Policy "no-referrer"
-Header onsuccess unset X-XSS-Protection
-Header always set X-XSS-Protection "1; mode=block"
 
 Header onsuccess unset X-Content-Type-Options
 Header always set X-Content-Type-Options "nosniff"

--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
@@ -52,6 +52,8 @@ Header onsuccess unset X-Download-Options
 Header onsuccess unset X-Content-Type-Options
 Header always set X-Content-Type-Options "nosniff"
 Header set Cross-Origin-Opener-Policy "same-origin"
+Header set Cross-Origin-Embedder-Policy "same-origin"
+Header set Cross-Origin-Resource-Policy "same-site"
 
 Header unset Etag
 

--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
@@ -43,17 +43,20 @@ Header onsuccess unset X-Frame-Options
 Header always set X-Frame-Options "DENY"
 Header onsuccess unset Referrer-Policy
 Header always set Referrer-Policy "same-origin"
+Header onsuccess unset Cross-Origin-Opener-Policy
+Header always set Cross-Origin-Opener-Policy "same-origin"
+Header onsuccess unset Cross-Origin-Embedder-Policy
+Header always set Cross-Origin-Embedder-Policy "same-origin"
+Header onsuccess unset Cross-Origin-Resource-Policy
+Header always set Cross-Origin-Resource-Policy "same-site"
 
 # Set a strict CSP; "default-src 'self'" prevents 3rd party subresources from
 # loading and prevents inline script from executing.
 Header onsuccess unset Content-Security-Policy
 Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors: 'none';"
-Header onsuccess unset X-Download-Options
+
 Header onsuccess unset X-Content-Type-Options
 Header always set X-Content-Type-Options "nosniff"
-Header set Cross-Origin-Opener-Policy "same-origin"
-Header set Cross-Origin-Embedder-Policy "same-origin"
-Header set Cross-Origin-Resource-Policy "same-site"
 
 Header unset Etag
 

--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
@@ -51,7 +51,6 @@ Header always set X-XSS-Protection "1; mode=block"
 Header onsuccess unset Content-Security-Policy
 Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors: 'none';"
 Header onsuccess unset X-Download-Options
-Header always set X-Download-Options "noopen"
 Header onsuccess unset X-Content-Type-Options
 Header always set X-Content-Type-Options "nosniff"
 Header set Cross-Origin-Opener-Policy "same-origin"

--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
@@ -54,6 +54,7 @@ Header onsuccess unset X-Download-Options
 Header always set X-Download-Options "noopen"
 Header onsuccess unset X-Content-Type-Options
 Header always set X-Content-Type-Options "nosniff"
+Header set Cross-Origin-Opener-Policy "same-origin"
 
 Header unset Etag
 

--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
@@ -43,8 +43,6 @@ Header onsuccess unset X-Frame-Options
 Header always set X-Frame-Options "DENY"
 Header onsuccess unset Referrer-Policy
 Header always set Referrer-Policy "same-origin"
-Header onsuccess unset X-XSS-Protection
-Header always set X-XSS-Protection "1; mode=block"
 
 # Set a strict CSP; "default-src 'self'" prevents 3rd party subresources from
 # loading and prevents inline script from executing.

--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
@@ -49,7 +49,7 @@ Header always set X-XSS-Protection "1; mode=block"
 # Set a strict CSP; "default-src 'self'" prevents 3rd party subresources from
 # loading and prevents inline script from executing.
 Header onsuccess unset Content-Security-Policy
-Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors: 'none';"
 Header onsuccess unset X-Download-Options
 Header always set X-Download-Options "noopen"
 Header onsuccess unset X-Content-Type-Options

--- a/install_files/securedrop-app-code/debian/postinst
+++ b/install_files/securedrop-app-code/debian/postinst
@@ -119,6 +119,12 @@ update_to_tls13(){
 #
 # Q4-2021 Apache2 header updates:
 update_apache2_headers(){
+
+    if [ ! -e "$1" ]; then
+        echo "Apache vhost '$1' does not exist, skipping header changes..." >&2
+        return
+    fi
+
     # update CSP header, adding frame-ancestors (see #6178)
     if grep -qP "^Header always set Content-Security-Policy \"default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';\"" "$1"; then
         sed -i "/^Header always set Content-Security-Policy \"default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';\"/c\Header always set Content-Security-Policy \"default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';\"" "$1"

--- a/install_files/securedrop-app-code/debian/postinst
+++ b/install_files/securedrop-app-code/debian/postinst
@@ -116,6 +116,39 @@ update_to_tls13(){
     fi
 }
 
+#
+# Q4-2021 Apache2 header updates:
+update_apache2_headers(){
+    # update CSP header, adding frame-ancestors (see #6178)
+    if grep -qP "^Header always set Content-Security-Policy \"default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';\"" "$1"; then
+        sed -i "/^Header always set Content-Security-Policy \"default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';\"/c\Header always set Content-Security-Policy \"default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';\"" "$1"
+    fi
+
+    # remove X-XSS-Protection block if it exists (see #6182)
+    if grep -qP "^Header onsuccess unset X-XSS-Protection" "$1"; then
+        sed -i '/^Header onsuccess unset X-XSS-Protection/d' "$1"
+        sed -i '/^Header always set X-XSS-Protection "1; mode=block"/d' "$1"
+    fi
+
+    # remove X-Download-Only block if it exists (see #6180)
+    if grep -qP "^Header onsuccess unset X-Download-Options" "$1"; then
+        sed -i '/^Header onsuccess unset X-Download-Options/d' "$1"
+        sed -i '/^Header always set X-Download-Options "noopen"/d' "$1"
+    fi
+
+    # Add Cross-Origin headers if not present (see #6176)
+        if ! grep -qP '^Header onsuccess unset Cross-Origin-Opener-Policy' "$1"; then
+            sed -i '/^Header always set Referrer-Policy .*/a Header onsuccess unset Cross-Origin-Opener-Policy\nHeader always set Cross-Origin-Opener-Policy "same-origin"' "$1"
+        fi
+        if ! grep -qP '^Header onsuccess unset Cross-Origin-Embedder-Policy' "$1"; then
+            sed -i '/^Header always set Cross-Origin-Opener-Policy .*/a Header onsuccess unset Cross-Origin-Embedder-Policy\nHeader always set Cross-Origin-Embedder-Policy "same-origin"' "$1"
+        fi
+        if ! grep -qP '^Header onsuccess unset Cross-Origin-Resource-Policy' "$1"; then
+            sed -i '/^Header always set Cross-Origin-Embedder-Policy .*/a Header onsuccess unset Cross-Origin-Resource-Policy\nHeader always set Cross-Origin-Resource-Policy "same-site"' "$1"
+        fi
+}
+
+
 case "$1" in
     configure)
 
@@ -187,6 +220,10 @@ case "$1" in
 
     # Add TLS1.3 configruation to the source configruation if required
     update_to_tls13
+
+    # Apply Q4-2021 header updates
+    update_apache2_headers /etc/apache2/sites-available/source.conf
+    update_apache2_headers /etc/apache2/sites-available/journalist.conf
 
     # Restart apache so it loads with the apparmor profiles in enforce mode.
     service apache2 restart

--- a/molecule/testinfra/vars/app-qubes-staging.yml
+++ b/molecule/testinfra/vars/app-qubes-staging.yml
@@ -3,6 +3,10 @@
 wanted_apache_headers:
   X-Content-Type-Options: nosniff
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Cross-Origin-Opener-Policy: "same-origin"
+  Cross-Origin-Embedder-Policy: "same-origin"
+  Cross-Origin-Resource-Policy: "same-site"
+
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "{{ securedrop_venv }}/bin"

--- a/molecule/testinfra/vars/app-qubes-staging.yml
+++ b/molecule/testinfra/vars/app-qubes-staging.yml
@@ -5,6 +5,8 @@ wanted_apache_headers:
   X-Content-Type-Options: nosniff
   X-Download-Options: noopen
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Cross-Origin-Opener-Policy: "same-origin"
+
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "{{ securedrop_venv }}/bin"

--- a/molecule/testinfra/vars/app-qubes-staging.yml
+++ b/molecule/testinfra/vars/app-qubes-staging.yml
@@ -3,8 +3,7 @@
 wanted_apache_headers:
   X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
-  X-Download-Options: noopen
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "{{ securedrop_venv }}/bin"

--- a/molecule/testinfra/vars/app-qubes-staging.yml
+++ b/molecule/testinfra/vars/app-qubes-staging.yml
@@ -4,9 +4,7 @@ wanted_apache_headers:
   X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
   X-Download-Options: noopen
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
-  Cross-Origin-Opener-Policy: "same-origin"
-
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "{{ securedrop_venv }}/bin"

--- a/molecule/testinfra/vars/app-qubes-staging.yml
+++ b/molecule/testinfra/vars/app-qubes-staging.yml
@@ -2,7 +2,7 @@
 # Testinfra vars file for app-staigng.
 wanted_apache_headers:
   X-Content-Type-Options: nosniff
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
   Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Embedder-Policy: "same-origin"
   Cross-Origin-Resource-Policy: "same-site"

--- a/molecule/testinfra/vars/app-qubes-staging.yml
+++ b/molecule/testinfra/vars/app-qubes-staging.yml
@@ -1,7 +1,6 @@
 ---
 # Testinfra vars file for app-staigng.
 wanted_apache_headers:
-  X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 

--- a/molecule/testinfra/vars/app-staging.yml
+++ b/molecule/testinfra/vars/app-staging.yml
@@ -5,6 +5,7 @@ wanted_apache_headers:
   X-Content-Type-Options: nosniff
   X-Download-Options: noopen
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Cross-Origin-Opener-Policy: "same-origin"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: /opt/venvs/securedrop-app-code/bin

--- a/molecule/testinfra/vars/app-staging.yml
+++ b/molecule/testinfra/vars/app-staging.yml
@@ -3,6 +3,9 @@
 wanted_apache_headers:
   X-Content-Type-Options: nosniff
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Cross-Origin-Opener-Policy: "same-origin"
+  Cross-Origin-Embedder-Policy: "same-origin"
+  Cross-Origin-Resource-Policy: "same-site"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: /opt/venvs/securedrop-app-code/bin

--- a/molecule/testinfra/vars/app-staging.yml
+++ b/molecule/testinfra/vars/app-staging.yml
@@ -3,8 +3,7 @@
 wanted_apache_headers:
   X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
-  X-Download-Options: noopen
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: /opt/venvs/securedrop-app-code/bin

--- a/molecule/testinfra/vars/app-staging.yml
+++ b/molecule/testinfra/vars/app-staging.yml
@@ -2,7 +2,7 @@
 # Testinfra vars file for app-staigng.
 wanted_apache_headers:
   X-Content-Type-Options: nosniff
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
   Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Embedder-Policy: "same-origin"
   Cross-Origin-Resource-Policy: "same-site"

--- a/molecule/testinfra/vars/app-staging.yml
+++ b/molecule/testinfra/vars/app-staging.yml
@@ -1,7 +1,6 @@
 ---
 # Testinfra vars file for app-staigng.
 wanted_apache_headers:
-  X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 

--- a/molecule/testinfra/vars/app-staging.yml
+++ b/molecule/testinfra/vars/app-staging.yml
@@ -4,8 +4,7 @@ wanted_apache_headers:
   X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
   X-Download-Options: noopen
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
-  Cross-Origin-Opener-Policy: "same-origin"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: /opt/venvs/securedrop-app-code/bin

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -4,6 +4,8 @@ wanted_apache_headers:
   X-Content-Type-Options: nosniff
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
   Cross-Origin-Opener-Policy: "same-origin"
+  Cross-Origin-Embedder-Policy: "same-origin"
+  Cross-Origin-Resource-Policy: "same-site"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -3,7 +3,6 @@
 wanted_apache_headers:
   X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
-  X-Download-Options: noopen
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
   Cross-Origin-Opener-Policy: "same-origin"
 

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -2,7 +2,7 @@
 # Testinfra vars file for app-staigng.
 wanted_apache_headers:
   X-Content-Type-Options: nosniff
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
   Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Embedder-Policy: "same-origin"
   Cross-Origin-Resource-Policy: "same-site"

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -1,7 +1,6 @@
 ---
 # Testinfra vars file for app-staigng.
 wanted_apache_headers:
-  X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
   Cross-Origin-Opener-Policy: "same-origin"

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -5,6 +5,7 @@ wanted_apache_headers:
   X-Content-Type-Options: nosniff
   X-Download-Options: noopen
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Cross-Origin-Opener-Policy: "same-origin"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -4,8 +4,7 @@ wanted_apache_headers:
   X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
   X-Download-Options: noopen
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
-  Cross-Origin-Opener-Policy: "same-origin"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -3,8 +3,7 @@
 wanted_apache_headers:
   X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
-  X-Download-Options: noopen
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -3,6 +3,9 @@
 wanted_apache_headers:
   X-Content-Type-Options: nosniff
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Cross-Origin-Opener-Policy: "same-origin"
+  Cross-Origin-Embedder-Policy: "same-origin"
+  Cross-Origin-Resource-Policy: "same-site"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -2,7 +2,7 @@
 # Testinfra vars file for app-staigng.
 wanted_apache_headers:
   X-Content-Type-Options: nosniff
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
   Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Embedder-Policy: "same-origin"
   Cross-Origin-Resource-Policy: "same-site"

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -1,7 +1,6 @@
 ---
 # Testinfra vars file for app-staigng.
 wanted_apache_headers:
-  X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -5,6 +5,7 @@ wanted_apache_headers:
   X-Content-Type-Options: nosniff
   X-Download-Options: noopen
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Cross-Origin-Opener-Policy: "same-origin"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -4,8 +4,7 @@ wanted_apache_headers:
   X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
   X-Download-Options: noopen
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
-  Cross-Origin-Opener-Policy: "same-origin"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -3,8 +3,7 @@
 wanted_apache_headers:
   X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
-  X-Download-Options: noopen
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -3,6 +3,9 @@
 wanted_apache_headers:
   X-Content-Type-Options: nosniff
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Cross-Origin-Opener-Policy: "same-origin"
+  Cross-Origin-Embedder-Policy: "same-origin"
+  Cross-Origin-Resource-Policy: "same-site"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -2,7 +2,7 @@
 # Testinfra vars file for app-staigng.
 wanted_apache_headers:
   X-Content-Type-Options: nosniff
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
   Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Embedder-Policy: "same-origin"
   Cross-Origin-Resource-Policy: "same-site"

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -1,7 +1,6 @@
 ---
 # Testinfra vars file for app-staigng.
 wanted_apache_headers:
-  X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -5,6 +5,7 @@ wanted_apache_headers:
   X-Content-Type-Options: nosniff
   X-Download-Options: noopen
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Cross-Origin-Opener-Policy: "same-origin"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -5,6 +5,7 @@ wanted_apache_headers:
   X-Content-Type-Options: nosniff
   X-Download-Options: noopen
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Cross-Origin-Opener-Policy: "same-origin"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: /opt/venvs/securedrop-app-code/bin

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -3,6 +3,9 @@
 wanted_apache_headers:
   X-Content-Type-Options: nosniff
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Cross-Origin-Opener-Policy: "same-origin"
+  Cross-Origin-Embedder-Policy: "same-origin"
+  Cross-Origin-Resource-Policy: "same-site"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: /opt/venvs/securedrop-app-code/bin

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -3,8 +3,7 @@
 wanted_apache_headers:
   X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
-  X-Download-Options: noopen
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: /opt/venvs/securedrop-app-code/bin

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -2,7 +2,7 @@
 # Testinfra vars file for app-staigng.
 wanted_apache_headers:
   X-Content-Type-Options: nosniff
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
   Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Embedder-Policy: "same-origin"
   Cross-Origin-Resource-Policy: "same-site"

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -1,7 +1,6 @@
 ---
 # Testinfra vars file for app-staigng.
 wanted_apache_headers:
-  X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
 

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -4,8 +4,7 @@ wanted_apache_headers:
   X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: nosniff
   X-Download-Options: noopen
-  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
-  Cross-Origin-Opener-Policy: "same-origin"
+  Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: /opt/venvs/securedrop-app-code/bin


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6186.
Multiple updates to Apache2 security headers in the SI and JI:

- Adds Cross-Origin-\ * headers - see #6176
- Adds `frame-ancestors` attribute in CSP header - see #6178
- Removes X-Download-Options header - see #6180
- Removes X-XSS-Protections header - see #6182 

## Testing

### fresh install (staging):
- check out this branch
- run `make build-debs && make staging`
- on the app server, in both `/etc/apache2/sites-enabled/source.conf` and `/etc/apache2/sites-enabled/journalist.conf`:
  - [ ] Verify that config lines for both X-Download-Options and X-XSS-Protection have been removed
  - [ ] Verify that `frame-ancestors:  'none'` has been added to the Content-Security-Policy header
  - [ ] Verify that Cross-Origin-Opener-Policy is set to "same-origin"
  - [ ] Verify that Cross-Origin-Embedder-Policy  is set to "same-origin"
  - [ ] Verify that Cross-Origin-Resource-Policy is set to "same-site"
  - [ ] Verify that the header changes above are reflected in Apache's response headers for both web interfaces

### upgrade scenario (prod VMs): @cfm
- Using this branch, follow the [upgrade testing procedure](https://docs.securedrop.org/en/stable/development/upgrade_testing.html) to update a productions system with packages built against the branch.
- on the app server, in both `/etc/apache2/sites-enabled/source.conf` and `/etc/apache2/sites-enabled/journalist.conf`:
  - [ ] Verify that config lines for both X-Download-Options and X-XSS-Protection have been removed
  - [ ] Verify that `frame-ancestors:  'none'` has been added to the Content-Security-Policy header
  - [ ] Verify that Cross-Origin-Opener-Policy is set to "same-origin"
  - [ ] Verify that Cross-Origin-Embedder-Policy  is set to "same-origin"
  - [ ] Verify that Cross-Origin-Resource-Policy is set to "same-site"
  - [ ] Verify that the header changes above are reflected in Apache's response headers for both web interfaces
- on the app server, make backup copies of `/etc/apache2/sites-enabled/{source,journalist}.conf` and then run `sudo dpkg-reconfigure securedroop-app-code`
  - [ ] Verify that the backup conf files and the versions in place after `dpkg-reconfigure` are identical.


## Deployment

- New installs will receive these changes via Ansible (with the postint script function that also applies them effectively being a noop).
- Existing installs will be updated via postint.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [x] I would appreciate help with the documentation (these changes themselves don't need docs, but we should consider refreshing the landing page recommendations)
- [ ] These changes do not require documentation
