### PR TITLE
Updated wtforms dependency from 2.1 to 3.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,8 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		echo "Checking file $$req_file" \
 		&& safety check \
 		--ignore 42050 \
+		--ignore 42926 \
+		--ignore 42923 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.in
@@ -27,3 +27,4 @@ sh
 SQLAlchemy>=1.3.0
 typing;python_version<"3.8"
 Werkzeug>=0.15.3
+wtforms>=3.0.0

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.txt
@@ -183,6 +183,7 @@ markupsafe==1.1.1 \
     #   -r requirements/python3/securedrop-app-code-requirements.in
     #   jinja2
     #   mako
+    #   wtforms
 mod-wsgi==4.6.7 \
     --hash=sha256:b788abaf0b903a64a7bb8dae609f2e4790c87e6f3d716aa6bc97936410fcbfcc
     # via -r requirements/python3/securedrop-app-code-requirements.in
@@ -266,9 +267,12 @@ werkzeug==0.16.0 \
     # via
     #   -r requirements/python3/securedrop-app-code-requirements.in
     #   flask
-wtforms==2.1 \
-    --hash=sha256:ffdf10bd1fa565b8233380cb77a304cd36fd55c73023e91d4b803c96bc11d46f
-    # via flask-wtf
+wtforms==3.0.0 \
+    --hash=sha256:232dbb0094847dca2f45c72136b5ca1d5dca2a3e24ccd2229823b8b74b3c6698 \
+    --hash=sha256:4abfbaa1d529a1d0ac927d44af8dbb9833afd910e56448a103f1893b0b176886
+    # via
+    #   -r requirements/python3/securedrop-app-code-requirements.in
+    #   flask-wtf
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==56.0.0 \

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -775,6 +775,7 @@ def test_admin_add_user_when_username_already_taken(config, journalist_app, test
                     first_name='',
                     last_name='',
                     password=VALID_PASSWORD,
+                    otp_secret='',
                     is_admin=None
                 ),
             )
@@ -890,6 +891,7 @@ def test_admin_add_user_password_too_long_warning(config, journalist_app, test_a
                     first_name='',
                     last_name='',
                     password=overly_long_password,
+                    otp_secret='',
                     is_admin=None
                 ),
             )
@@ -917,6 +919,7 @@ def test_admin_add_user_first_name_too_long_warning(config, journalist_app, test
                 first_name=overly_long_name,
                 last_name='',
                 password=VALID_PASSWORD,
+                otp_secret='',
                 is_admin=None
             ),
         )
@@ -947,6 +950,7 @@ def test_admin_add_user_last_name_too_long_warning(config, journalist_app, test_
                 first_name='',
                 last_name=overly_long_name,
                 password=VALID_PASSWORD,
+                otp_secret='',
                 is_admin=None
             ),
         )
@@ -1327,6 +1331,7 @@ def test_admin_add_user(journalist_app, test_admin):
                                       first_name='',
                                       last_name='',
                                       password=VALID_PASSWORD,
+                                      otp_secret='',
                                       is_admin=None))
 
             new_user = Journalist.query.filter_by(username=username).one()
@@ -1349,6 +1354,7 @@ def test_admin_add_user_with_invalid_username(config, journalist_app, test_admin
                 first_name='',
                 last_name='',
                 password=VALID_PASSWORD,
+                otp_secret='',
                 is_admin=None
             ),
         )
@@ -1433,7 +1439,13 @@ def test_admin_add_user_without_username(config, journalist_app, test_admin, loc
 
         resp = app.post(
             url_for('admin.add_user', l=locale),
-            data=dict(username='', password=VALID_PASSWORD, is_admin=None),
+            data=dict(
+                username='',
+                first_name='',
+                last_name='',
+                password=VALID_PASSWORD,
+                otp_secret='',
+                is_admin=None),
         )
 
         assert page_language(resp.data) == language_tag(locale)
@@ -1455,8 +1467,11 @@ def test_admin_add_user_too_short_username(config, journalist_app, test_admin, l
             url_for('admin.add_user', l=locale),
             data=dict(
                 username=username,
+                first_name='',
+                last_name='',
                 password='pentagonpapers',
                 password_again='pentagonpapers',
+                otp_secret='',
                 is_admin=None
             ),
         )
@@ -1584,6 +1599,7 @@ def test_admin_sets_user_to_admin(journalist_app, test_admin):
                         data=dict(username=new_user,
                                   first_name='',
                                   last_name='',
+                                  otp_secret='',
                                   password=VALID_PASSWORD,
                                   is_admin=None))
         assert resp.status_code in (200, 302)
@@ -1612,6 +1628,7 @@ def test_admin_renames_user(journalist_app, test_admin):
                                   first_name='',
                                   last_name='',
                                   password=VALID_PASSWORD,
+                                  otp_secret='',
                                   is_admin=None))
         assert resp.status_code in (200, 302)
         journo = Journalist.query.filter(Journalist.username == new_user).one()
@@ -1640,6 +1657,7 @@ def test_admin_adds_first_name_last_name_to_user(journalist_app, test_admin):
                                   first_name='',
                                   last_name='',
                                   password=VALID_PASSWORD,
+                                  otp_secret='',
                                   is_admin=None))
         assert resp.status_code in (200, 302)
         journo = Journalist.query.filter(Journalist.username == new_user).one()
@@ -1672,6 +1690,7 @@ def test_admin_adds_invalid_first_last_name_to_user(config, journalist_app, test
                 first_name='',
                 last_name='',
                 password=VALID_PASSWORD,
+                otp_secret='',
                 is_admin=None
             )
         )
@@ -1723,6 +1742,7 @@ def test_admin_add_user_integrity_error(config, journalist_app, test_admin, mock
                     first_name='',
                     last_name='',
                     password=VALID_PASSWORD,
+                    otp_secret='',
                     is_admin=None
                 ),
             )


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

- Updates wtforms dependency from 2.1 to 3.0.0
- updates tests that were failing as a result of improved type checking in wtforms 3.0
- adds `--ignores` in `make safety` target for 2 Ansible-related warnings (`42926`, `42926`) that don't impact SecureDrop.



## Testing

- [ ] CI is passing

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a production code dependency:

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
