### PR TITLE
fixes failing `test_apache_source_interface()`

### DIFF
--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
@@ -53,7 +53,7 @@ Header always set Cross-Origin-Resource-Policy "same-site"
 # Set a strict CSP; "default-src 'self'" prevents 3rd party subresources from
 # loading and prevents inline script from executing.
 Header onsuccess unset Content-Security-Policy
-Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors: 'none';"
+Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
 
 Header onsuccess unset X-Content-Type-Options
 Header always set X-Content-Type-Options "nosniff"


### PR DESCRIPTION
## Status

Ready for review iff `staging-test-with-rebase` passes
* https://app.circleci.com/pipelines/github/freedomofpress/securedrop/3338/workflows/32fa80ce-7549-4ce7-afda-f6dcf0bcf172

## Description of Changes

Fixes 0ebd564's failing `testinfra.app.apache.test_apache_source_interface()`, which is parameterized correctly (without a stray colon) in `molecule/testinfra/vars/*.yml`.

## Testing

- [ ] CI is green.

## Deployment

No deployment considerations beyond #6187.

## Checklist

- [ ] Take this opportunity to reevaluate #6063.  :-)

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass