### PR TITLE
Updated codecov version check to pull it from the downloaded script instead of the github API

### DIFF
--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -65,7 +65,7 @@ function docker_run() {
         tmpdir=$(mktemp -d -t codecov-XXXX)
         curl -s https://codecov.io/bash > "$tmpdir"/codecov;
         curl -s https://codecov.io/env > "$tmpdir"/env;
-        VERSION="$(curl --silent "https://api.github.com/repos/codecov/codecov-bash/releases/latest" | grep '"tag_name":' |sed -E 's/.*"([^"]+)".*/\1/')"
+        VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' "$tmpdir"/codecov | cut -d'"' -f2);
         curl -s https://raw.githubusercontent.com/codecov/codecov-bash/"${VERSION}"/SHA256SUM > "$tmpdir"/codecov-hashes
         pushd "$tmpdir" && shasum -a 256 -c codecov-hashes && popd
         ci_env=$(/bin/bash "$tmpdir"/env)

--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -36,7 +36,7 @@ if [ -n "${CIRCLE_BRANCH:-}" ] ; then
         cp tests/log/firefox.log "$TEST_RESULTS"
         tmpdir=$(mktemp -d -t codecov-XXXX)
         curl -s https://codecov.io/bash > "$tmpdir"/codecov;
-        VERSION="$(curl --silent "https://api.github.com/repos/codecov/codecov-bash/releases/latest" | grep '"tag_name":' |sed -E 's/.*"([^"]+)".*/\1/')"
+        VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' "$tmpdir"/codecov | cut -d'"' -f2);
         curl -s https://raw.githubusercontent.com/codecov/codecov-bash/"${VERSION}"/SHA256SUM > "$tmpdir"/codecov-hashes
         pushd "$tmpdir" && shasum -a 256 -c --ignore-missing codecov-hashes && popd
         chmod +x "$tmpdir"/codecov


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Codecov is used to track coverage metrics - results are uploaded to codecov.io using a bash script in the test container. The bash script's integrity is verified by comparing its sha256 hash against a Codecov-published hash. To determine which version to compare, the script's latest release tag is pulled via the Github API

This logic is currently broken, as the latest version of the codecov script does not have a corresponding release object. This PR extracts the version from the downloaded bash script instead.

## Testing
 - [ ] CI is passing
 - [ ] the **Build Docker Image** step does *not* contain errors like:
 ```
  codecov: FAILED
  env: FAILED
  shasum: WARNING: 2 computed checksums did NOT match
  ```



