### PR TITLE
Install dh-virtualenv from Ubuntu 21.10 (Impish)

### DIFF
--- a/molecule/builder-focal/Dockerfile
+++ b/molecule/builder-focal/Dockerfile
@@ -34,10 +34,10 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         unzip
 
 
-# TEMPORARY: install dh-virtualenv from debian unstable, pending focal package:
+# TEMPORARY: install dh-virtualenv from unstable Ubuntu release, pending focal package:
 # https://github.com/spotify/dh-virtualenv/issues/298
-RUN echo "deb http://archive.ubuntu.com/ubuntu/ groovy universe" > /etc/apt/sources.list.d/ubuntu-groovy.list
-COPY aptpreferences.conf /etc/apt/preferences.d/ubuntu-groovy
+RUN echo "deb http://archive.ubuntu.com/ubuntu/ impish universe main" > /etc/apt/sources.list.d/ubuntu-impish.list
+COPY dh-virtualenv.pref /etc/apt/preferences.d/
 
 RUN apt-get update && apt-get install -y dh-virtualenv
 

--- a/molecule/builder-focal/aptpreferences.conf
+++ b/molecule/builder-focal/aptpreferences.conf
@@ -1,7 +1,0 @@
-Package: *
-Pin: release a=focal
-Pin-Priority: 700
-
-Package: *
-Pin: release a=groovy
-Pin-Priority: 1

--- a/molecule/builder-focal/dh-virtualenv.pref
+++ b/molecule/builder-focal/dh-virtualenv.pref
@@ -1,0 +1,11 @@
+Package: *
+Pin: release a=focal
+Pin-Priority: 500
+
+Package: dh-virtualenv libjs-sphinxdoc sphinx-rtd-theme-common
+Pin: release a=impish
+Pin-Priority: 700
+
+Package: *
+Pin: release a=impish
+Pin-Priority: 1

--- a/molecule/builder-focal/tests/test_build_dependencies.py
+++ b/molecule/builder-focal/tests/test_build_dependencies.py
@@ -4,6 +4,7 @@ import os
 
 SECUREDROP_TARGET_DISTRIBUTION = os.environ.get("SECUREDROP_TARGET_DISTRIBUTION")
 SECUREDROP_PYTHON_VERSION = os.environ.get("SECUREDROP_PYTHON_VERSION", "3.5")
+DH_VIRTUALENV_VERSION = "1.2.2"
 
 testinfra_hosts = [
         "docker://{}-sd-app".format(SECUREDROP_TARGET_DISTRIBUTION)
@@ -48,7 +49,7 @@ def test_dh_virtualenv(host):
     """
     Confirm the expected version of dh-virtualenv is found.
     """
-    expected_version = "1.2.1"
+    expected_version = DH_VIRTUALENV_VERSION
     version_string = "dh_virtualenv {}".format(expected_version)
     c = host.run("dh_virtualenv --version")
     assert c.stdout.startswith(version_string)


### PR DESCRIPTION
Groovy is no longer available, and there are still no official Focal packages.

## Status

Ready for review

## Description of Changes
Fixes #6205 

## Testing
- Follow the instructions in https://docs.securedrop.org/en/stable/development/dockerbuildmaint.html to test the updated build container.
- Carefully examine the pinning rules and the installation log to ensure that no unwanted packages are pulled in from Impish.

## Checklist

(None applicable)