### PR TITLE
updated builder image hash for image tagged as 2021_12_28

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_11_16
-e585182ba698c718034d60d7fb5d6eadbb9fe67c1c557818e5e66b1a6c9e4672
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_12_28
+0ab59f3d7cdd1aa086f25bbfbe3f164196ba3035cdee5f1c3704cfcf7d5503e8


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6205

Changes proposed in this pull request:

Updates builder image to version built with changes in #6206

## Testing

- [ ] CI is passing, in particular the `deb-tests` job
- [ ] `make build-debs` passes locally
