### PR TITLE
Support using podman for the dev environment

### DIFF
--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -34,8 +34,8 @@ function run_x11vnc() {
 }
 
 function urandom() {
-    sudo rm /dev/random
-    sudo ln -s /dev/urandom /dev/random
+    sudo rm /dev/random ||:
+    sudo ln -s /dev/urandom /dev/random || echo "Unable to replace /dev/random"
 }
 
 function append_to_exit() {

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -11,6 +11,18 @@ export PATH="/opt/venvs/securedrop-app-code/bin:$PATH"
 TOPLEVEL=$(git rev-parse --show-toplevel)
 BASE_OS="${BASE_OS:-focal}"
 USE_TOR="${USE_TOR:-}"
+USE_PODMAN="${USE_PODMAN:-}"
+DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS:-}"
+
+# Allow opting into using podman with USE_PODMAN=1
+if  [[ -n "${USE_PODMAN}" ]]; then
+    DOCKER_BIN="podman"
+    # Make sure host UID/GID are mapped into container,
+    # see podman-run(1) manual.
+    DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} --userns=keep-id"
+else
+    DOCKER_BIN="docker"
+fi
 
 ## Get an integer offset for exposed ports, to support multiple containers
 get_port_offset() {
@@ -26,7 +38,7 @@ get_port_offset() {
 }
 
 function docker_image() {
-    docker build \
+    $DOCKER_BIN build \
            ${DOCKER_BUILD_ARGUMENTS:-} \
            --build-arg=USER_ID="$(id -u)" \
            --build-arg=USER_NAME="${USER:-root}" \
@@ -75,7 +87,7 @@ function docker_run() {
 
     # The --shm-size argument sets up dedicated shared memory for the
     # container. Our tests can fail with the default of 64m.
-    docker run $ci_env \
+    $DOCKER_BIN run $ci_env \
            --shm-size 2g \
            --rm \
            -p "127.0.0.1:${SD_HOSTPORT_VNC}:5909" \
@@ -94,7 +106,7 @@ function docker_run() {
            --volume "${TOPLEVEL}:${TOPLEVEL}" \
            --workdir "${TOPLEVEL}/securedrop" \
            --name "${SD_CONTAINER}" \
-           -ti ${DOCKER_RUN_ARGUMENTS:-} "securedrop-test-${1}-py3" "${@:2}"
+           -ti $DOCKER_RUN_ARGUMENTS "securedrop-test-${1}-py3" "${@:2}"
 }
 
 if [ "${DOCKER_BUILD_VERBOSE:-'false'}" = "true" ]


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

podman is mostly a drop-in replacement for Docker that's lighter and
better supports rootless execution. It tends to be more widely used
in the Fedora/Red Hat world, though was recently added to Debian. It
does not require running a background daemon as root, providing some
nice security benefits.

By setting a `USE_PODMAN=1` environment variable, the dev-shell and
related scripts will invoke `podman` instead of `docker.

We also need to pass `--userns=keep-id` to `podman run` so that the host
UID/GID are properly mapped in the container so files are writable.

podman doesn't allow deleting/overwriting `/dev/random` so that step is
optional now. I assume that's OK because this is just a dev environment.

This is mostly based on <https://github.com/wikimedia/fresh/commit/d1535438cfd8ccaf39d18fa2fd43350526e43401>,
which I had contributed to/reviewed.

In the future it would be nice to automatically detect if podman is
installed when docker can't be found, but that should probably wait
for more testing/usage under podman.

## Testing

On a Fedora/Debian system, install the `podman` system package. Then run `DOCKER_BUILD_VERBOSE=true USE_PODMAN=1 make dev` and see that it brings up a development environment under podman.

You can also try without the `USE_PODMAN=1` flag to verify nothing changed for normal Docker users.

## Checklist

- [x] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
  - I'll do this if this patch is acceptable, we can mention that podman is experimentally supported behind a `USE_PODMAN=1` flag in the dev docs as an alternative to using Docker.