### PR TITLE
Upgrade Flask dependency to 2.0.2 and refactor applications to improve static type checks

### DIFF
--- a/molecule/testinfra/vars/app-qubes-staging.yml
+++ b/molecule/testinfra/vars/app-qubes-staging.yml
@@ -30,7 +30,7 @@ app_ip: 10.137.0.50
 
 pip_deps:
   - name: 'Flask'
-    version: '1.0.2'
+    version: '2.0.2'
 
 apparmor_complain: []
 

--- a/molecule/testinfra/vars/app-staging.yml
+++ b/molecule/testinfra/vars/app-staging.yml
@@ -29,7 +29,7 @@ app_ip: 10.0.1.2
 
 pip_deps:
   - name: 'Flask'
-    version: '1.0.2'
+    version: '2.0.2'
 
 apparmor_complain: []
 

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -29,7 +29,7 @@ app_ip: 10.20.2.2
 
 pip_deps:
   - name: 'Flask'
-    version: '1.0.2'
+    version: '2.0.2'
 
 apparmor_complain: []
 

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -28,7 +28,7 @@ app_ip: 10.0.1.4
 
 pip_deps:
   - name: 'Flask'
-    version: '1.0.2'
+    version: '2.0.2'
 
 apparmor_complain: []
 

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -30,7 +30,7 @@ app_ip: 10.137.0.50
 
 pip_deps:
   - name: 'Flask'
-    version: '1.0.2'
+    version: '2.0.2'
 
 apparmor_complain: []
 

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -30,7 +30,7 @@ app_ip: 10.0.1.2
 
 pip_deps:
   - name: 'Flask'
-    version: '1.0.2'
+    version: '2.0.2'
 
 apparmor_complain: []
 

--- a/securedrop/alembic/versions/3da3fcab826a_delete_orphaned_submissions.py
+++ b/securedrop/alembic/versions/3da3fcab826a_delete_orphaned_submissions.py
@@ -17,7 +17,7 @@ raise_errors = os.environ.get("SECUREDROP_ENV", "prod") != "prod"
 try:
     from journalist_app import create_app
     from sdconfig import config
-    from store import NoFileFoundException, TooManyFilesException
+    from store import NoFileFoundException, TooManyFilesException, Storage
 except ImportError:
     # This is a fresh install, and config.py has not been created yet.
     if raise_errors:
@@ -61,8 +61,8 @@ def upgrade():
                     """).bindparams(id=submission.id)
                     )
 
-                    path = app.storage.path_without_filesystem_id(submission.filename)
-                    app.storage.move_to_shredder(path)
+                    path = Storage.get_default().path_without_filesystem_id(submission.filename)
+                    Storage.get_default().move_to_shredder(path)
                 except NoFileFoundException:
                     # The file must have been deleted by the admin, remove the row
                     conn.execute(
@@ -83,8 +83,8 @@ def upgrade():
                         """).bindparams(id=reply.id)
                     )
 
-                    path = app.storage.path_without_filesystem_id(reply.filename)
-                    app.storage.move_to_shredder(path)
+                    path = Storage.get_default().path_without_filesystem_id(reply.filename)
+                    Storage.get_default().move_to_shredder(path)
                 except NoFileFoundException:
                     # The file must have been deleted by the admin, remove the row
                     conn.execute(

--- a/securedrop/alembic/versions/b58139cfdc8c_add_checksum_columns_revoke_table.py
+++ b/securedrop/alembic/versions/b58139cfdc8c_add_checksum_columns_revoke_table.py
@@ -14,7 +14,7 @@ try:
     from journalist_app import create_app
     from models import Submission, Reply
     from sdconfig import config
-    from store import queued_add_checksum_for_file
+    from store import queued_add_checksum_for_file, Storage
     from worker import create_queue
 except:  # noqa
     if raise_errors:
@@ -58,7 +58,7 @@ def upgrade():
                             """
             )
             for (sub_id, filesystem_id, filename) in conn.execute(query):
-                full_path = app.storage.path(filesystem_id, filename)
+                full_path = Storage.get_default().path(filesystem_id, filename)
                 create_queue().enqueue(
                     queued_add_checksum_for_file,
                     Submission,
@@ -75,7 +75,7 @@ def upgrade():
                             """
             )
             for (rep_id, filesystem_id, filename) in conn.execute(query):
-                full_path = app.storage.path(filesystem_id, filename)
+                full_path = Storage.get_default().path(filesystem_id, filename)
                 create_queue().enqueue(
                     queued_add_checksum_for_file,
                     Reply,

--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -65,8 +65,8 @@ RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_
 COPY requirements requirements
 RUN python3 -m venv /opt/venvs/securedrop-app-code && \
     /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/docker-requirements.txt && \
-    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/securedrop-app-code-requirements.txt && \
-    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/test-requirements.txt
+    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/test-requirements.txt && \
+    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/securedrop-app-code-requirements.txt 
 
 RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi && \
     cp -r /root/.local /tmp/ && chmod +x /tmp/.local/tbb/tor-browser_en-US/Browser/firefox && chmod -R 777 /tmp/.local && \

--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -245,6 +245,6 @@ def set_locale(config: SDConfig) -> None:
     Update locale info in request and session.
     """
     locale = get_locale(config)
-    g.localeinfo = RequestLocaleInfo(locale)
+    g.localeinfo = RequestLocaleInfo(locale)  # pylint: disable=assigning-non-slot
     session["locale"] = locale
-    g.locales = LOCALES
+    g.locales = LOCALES  # pylint: disable=assigning-non-slot

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -21,7 +21,6 @@ from journalist_app.utils import (get_source, logged_in,
                                   JournalistInterfaceSessionInterface,
                                   cleanup_expired_revoked_tokens)
 from models import InstanceConfig, Journalist
-from store import Storage
 
 import typing
 # https://www.python.org/dev/peps/pep-0484/#runtime-or-type-checking
@@ -68,10 +67,6 @@ def create_app(config: 'SDConfig') -> Flask:
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['SQLALCHEMY_DATABASE_URI'] = config.DATABASE_URI
     db.init_app(app)
-
-    # TODO: Attaching a Storage dynamically like this disables all type checking (and
-    # breaks code analysis tools) for code that uses current_app.storage; it should be refactored
-    app.storage = Storage(config.STORE_DIR, config.TEMP_DIR)
 
     @app.errorhandler(CSRFError)
     def handle_csrf_error(e: CSRFError) -> 'Response':

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -138,17 +138,18 @@ def create_app(config: 'SDConfig') -> Flask:
 
         uid = session.get('uid', None)
         if uid:
-            g.user = Journalist.query.get(uid)
+            g.user = Journalist.query.get(uid)  # pylint: disable=assigning-non-slot
 
         i18n.set_locale(config)
 
         if app.instance_config.organization_name:
-            g.organization_name = app.instance_config.organization_name
+            g.organization_name = \
+                app.instance_config.organization_name  # pylint: disable=assigning-non-slot
         else:
-            g.organization_name = gettext('SecureDrop')
+            g.organization_name = gettext('SecureDrop')  # pylint: disable=assigning-non-slot
 
         try:
-            g.logo = get_logo_url(app)
+            g.logo = get_logo_url(app)  # pylint: disable=assigning-non-slot
         except FileNotFoundError:
             app.logger.error("Site logo not found.")
 
@@ -161,8 +162,8 @@ def create_app(config: 'SDConfig') -> Flask:
         if request.method == 'POST':
             filesystem_id = request.form.get('filesystem_id')
             if filesystem_id:
-                g.filesystem_id = filesystem_id
-                g.source = get_source(filesystem_id)
+                g.filesystem_id = filesystem_id  # pylint: disable=assigning-non-slot
+                g.source = get_source(filesystem_id)  # pylint: disable=assigning-non-slot
 
         return None
 

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -111,10 +111,6 @@ def create_app(config: 'SDConfig') -> Flask:
         cleanup_expired_revoked_tokens()
 
     @app.before_request
-    def load_instance_config() -> None:
-        app.instance_config = InstanceConfig.get_current()
-
-    @app.before_request
     def setup_g() -> 'Optional[Response]':
         """Store commonly used values in Flask's special g object"""
         if 'expires' in session and datetime.now(timezone.utc) >= session['expires']:
@@ -142,9 +138,9 @@ def create_app(config: 'SDConfig') -> Flask:
 
         i18n.set_locale(config)
 
-        if app.instance_config.organization_name:
+        if InstanceConfig.get_default().organization_name:
             g.organization_name = \
-                app.instance_config.organization_name  # pylint: disable=assigning-non-slot
+                InstanceConfig.get_default().organization_name  # pylint: disable=assigning-non-slot
         else:
             g.organization_name = gettext('SecureDrop')  # pylint: disable=assigning-non-slot
 

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -111,6 +111,10 @@ def create_app(config: 'SDConfig') -> Flask:
         cleanup_expired_revoked_tokens()
 
     @app.before_request
+    def update_instance_config() -> None:
+        InstanceConfig.get_default(refresh=True)
+
+    @app.before_request
     def setup_g() -> 'Optional[Response]':
         """Store commonly used values in Flask's special g object"""
         if 'expires' in session and datetime.now(timezone.utc) >= session['expires']:

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from flask import (Flask, session, redirect, url_for, flash, g, request,
@@ -117,7 +117,7 @@ def create_app(config: 'SDConfig') -> Flask:
     @app.before_request
     def setup_g() -> 'Optional[Response]':
         """Store commonly used values in Flask's special g object"""
-        if 'expires' in session and datetime.utcnow() >= session['expires']:
+        if 'expires' in session and datetime.now(timezone.utc) >= session['expires']:
             session.clear()
             flash(gettext('You have been logged out due to inactivity.'),
                   'error')
@@ -131,7 +131,7 @@ def create_app(config: 'SDConfig') -> Flask:
                 flash(gettext('You have been logged out due to password change'),
                       'error')
 
-        session['expires'] = datetime.utcnow() + \
+        session['expires'] = datetime.now(timezone.utc) + \
             timedelta(minutes=getattr(config,
                                       'SESSION_EXPIRATION_MINUTES',
                                       120))

--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -38,9 +38,9 @@ def make_blueprint(config: SDConfig) -> Blueprint:
     def manage_config() -> Union[str, werkzeug.Response]:
         # The UI prompt ("prevent") is the opposite of the setting ("allow"):
         submission_preferences_form = SubmissionPreferencesForm(
-            prevent_document_uploads=not current_app.instance_config.allow_document_uploads)
+            prevent_document_uploads=not InstanceConfig.get_default().allow_document_uploads)
         organization_name_form = OrgNameForm(
-            organization_name=current_app.instance_config.organization_name)
+            organization_name=InstanceConfig.get_default().organization_name)
         logo_form = LogoForm()
         if logo_form.validate_on_submit():
             f = logo_form.logo.data

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -265,7 +265,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             # issue #3918
             filename = path.basename(filename)
 
-            reply = Reply(user, source, filename)
+            reply = Reply(user, source, filename, Storage.get_default())
 
             reply_uuid = data.get('uuid', None)
             if reply_uuid is not None:

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -1,7 +1,7 @@
 import collections.abc
 import json
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Tuple, Callable, Any, Set, Union
 
 import flask
@@ -116,7 +116,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
 
         try:
             journalist = Journalist.login(username, passphrase, one_time_code)
-            token_expiry = datetime.utcnow() + timedelta(
+            token_expiry = datetime.now(timezone.utc) + timedelta(
                 seconds=TOKEN_EXPIRATION_MINS * 60)
 
             response = jsonify({
@@ -128,7 +128,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             })
 
             # Update access metadata
-            journalist.last_access = datetime.utcnow()
+            journalist.last_access = datetime.now(timezone.utc)
             db.session.add(journalist)
             db.session.commit()
 

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -6,7 +6,7 @@ from typing import Tuple, Callable, Any, Set, Union
 
 import flask
 import werkzeug
-from flask import abort, Blueprint, current_app, jsonify, request
+from flask import abort, Blueprint, jsonify, request
 from functools import wraps
 
 from sqlalchemy import Column
@@ -22,7 +22,7 @@ from models import (Journalist, Reply, SeenReply, Source, Submission,
                     BadTokenException, InvalidOTPSecretException,
                     WrongPasswordException)
 from sdconfig import SDConfig
-from store import NotEncrypted
+from store import NotEncrypted, Storage
 
 
 TOKEN_EXPIRATION_MINS = 60 * 8
@@ -253,7 +253,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
 
             source.interaction_count += 1
             try:
-                filename = current_app.storage.save_pre_encrypted_reply(
+                filename = Storage.get_default().save_pre_encrypted_reply(
                     source.filesystem_id,
                     source.interaction_count,
                     source.journalist_filename,

--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -138,8 +138,8 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                 reply = Reply.query.filter(Reply.filename == fn).one()
                 mark_seen([reply], journalist)
             elif fn.endswith("-doc.gz.gpg") or fn.endswith("doc.zip.gpg"):
-                the_file = Submission.query.filter(Submission.filename == fn).one()
-                mark_seen([the_file], journalist)
+                submitted_file = Submission.query.filter(Submission.filename == fn).one()
+                mark_seen([submitted_file], journalist)
             else:
                 message = Submission.query.filter(Submission.filename == fn).one()
                 mark_seen([message], journalist)

--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -29,6 +29,7 @@ from journalist_app.utils import (make_star_true, make_star_false, get_source,
                                   col_download_all, col_star, col_un_star,
                                   col_delete, col_delete_data, mark_seen)
 from sdconfig import SDConfig
+from store import Storage
 
 
 def make_blueprint(config: SDConfig) -> Blueprint:
@@ -118,7 +119,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         if '..' in fn or fn.startswith('/'):
             abort(404)
 
-        file = current_app.storage.path(filesystem_id, fn)
+        file = Storage.get_default().path(filesystem_id, fn)
         if not Path(file).is_file():
             flash(
                 gettext(
@@ -145,7 +146,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         except NoResultFound as e:
             current_app.logger.error("Could not mark {} as seen: {}".format(fn, e))
 
-        return send_file(current_app.storage.path(filesystem_id, fn),
+        return send_file(Storage.get_default().path(filesystem_id, fn),
                          mimetype="application/pgp-encrypted")
 
     return view

--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -138,8 +138,8 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                 reply = Reply.query.filter(Reply.filename == fn).one()
                 mark_seen([reply], journalist)
             elif fn.endswith("-doc.gz.gpg") or fn.endswith("doc.zip.gpg"):
-                file = Submission.query.filter(Submission.filename == fn).one()
-                mark_seen([file], journalist)
+                the_file = Submission.query.filter(Submission.filename == fn).one()
+                mark_seen([the_file], journalist)
             else:
                 message = Submission.query.filter(Submission.filename == fn).one()
                 mark_seen([message], journalist)

--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Union
 
@@ -36,7 +36,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                                                 request.form['token']))
 
                 # Update access metadata
-                user.last_access = datetime.utcnow()
+                user.last_access = datetime.now(timezone.utc)
                 db.session.add(user)
                 db.session.commit()
 

--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -140,12 +140,12 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         )
 
         try:
-            reply = Reply(g.user, g.source, filename)
+            reply = Reply(g.user, g.source, filename, Storage.get_default())
             db.session.add(reply)
             seen_reply = SeenReply(reply=reply, journalist=g.user)
             db.session.add(seen_reply)
             db.session.commit()
-            store.async_add_checksum_for_file(reply)
+            store.async_add_checksum_for_file(reply, Storage.get_default())
         except Exception as exc:
             flash(gettext(
                 "An unexpected error occurred! Please "

--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -19,6 +19,7 @@ from journalist_app.forms import ReplyForm
 from journalist_app.utils import (validate_user, bulk_delete, download,
                                   confirm_bulk_delete, get_source)
 from sdconfig import SDConfig
+from store import Storage
 
 
 def make_blueprint(config: SDConfig) -> Blueprint:
@@ -135,7 +136,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         EncryptionManager.get_default().encrypt_journalist_reply(
             for_source_with_filesystem_id=g.filesystem_id,
             reply_in=form.message.data,
-            encrypted_reply_path_out=Path(current_app.storage.path(g.filesystem_id, filename)),
+            encrypted_reply_path_out=Path(Storage.get_default().path(g.filesystem_id, filename)),
         )
 
         try:

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -518,7 +518,7 @@ class JournalistInterfaceSessionInterface(
         sessions.SecureCookieSessionInterface):
     """A custom session interface that skips storing sessions for api requests but
     otherwise just uses the default behaviour."""
-    def save_session(self, app: flask.Flask, session: Any, response: werkzeug.Response) -> None:
+    def save_session(self, app: flask.Flask, session: Any, response: flask.Response) -> None:
         # If this is an api request do not save the session
         if request.path.split("/")[1] == "api":
             return

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import binascii
-import datetime
+from datetime import datetime, timezone
 import os
 from typing import Optional, List, Union, Any
 
@@ -233,7 +233,7 @@ def download(
         return redirect(on_error_redirect)
 
     attachment_filename = "{}--{}.zip".format(
-        zip_basename, datetime.datetime.utcnow().strftime("%Y-%m-%d--%H-%M-%S")
+        zip_basename, datetime.now(timezone.utc).strftime("%Y-%m-%d--%H-%M-%S")
     )
 
     mark_seen(submissions, g.user)
@@ -332,7 +332,7 @@ def col_delete(cols_selected: List[str]) -> werkzeug.Response:
     if len(cols_selected) < 1:
         flash(gettext("No collections selected for deletion."), "error")
     else:
-        now = datetime.datetime.utcnow()
+        now = datetime.now(timezone.utc)
         sources = Source.query.filter(Source.filesystem_id.in_(cols_selected))
         sources.update({Source.deleted_at: now}, synchronize_session="fetch")
         db.session.commit()

--- a/securedrop/loaddata.py
+++ b/securedrop/loaddata.py
@@ -17,7 +17,6 @@ import string
 from itertools import cycle
 from typing import Optional, Tuple
 
-from flask import current_app
 from sqlalchemy.exc import IntegrityError
 
 import journalist_app
@@ -38,6 +37,7 @@ from passphrases import PassphraseGenerator
 from sdconfig import config
 from source_user import create_source_user
 from specialstrings import strings
+from store import Storage
 
 messages = cycle(strings)
 replies = cycle(strings)
@@ -180,7 +180,7 @@ def submit_message(source: Source, journalist_who_saw: Optional[Journalist]) -> 
     Adds a single message submitted by a source.
     """
     record_source_interaction(source)
-    fpath = current_app.storage.save_message_submission(
+    fpath = Storage.get_default().save_message_submission(
         source.filesystem_id,
         source.interaction_count,
         source.journalist_filename,
@@ -199,7 +199,7 @@ def submit_file(source: Source, journalist_who_saw: Optional[Journalist]) -> Non
     Adds a single file submitted by a source.
     """
     record_source_interaction(source)
-    fpath = current_app.storage.save_file_submission(
+    fpath = Storage.get_default().save_file_submission(
         source.filesystem_id,
         source.interaction_count,
         source.journalist_filename,
@@ -225,7 +225,7 @@ def add_reply(
     EncryptionManager.get_default().encrypt_journalist_reply(
         for_source_with_filesystem_id=source.filesystem_id,
         reply_in=next(replies),
-        encrypted_reply_path_out=Path(current_app.storage.path(source.filesystem_id, fname)),
+        encrypted_reply_path_out=Path(Storage.get_default().path(source.filesystem_id, fname)),
     )
     reply = Reply(journalist, source, fname)
     db.session.add(reply)
@@ -249,7 +249,7 @@ def add_source() -> Tuple[Source, str]:
     source_user = create_source_user(
         db_session=db.session,
         source_passphrase=codename,
-        source_app_storage=current_app.storage,
+        source_app_storage=Storage.get_default(),
     )
     source = source_user.get_db_record()
     source.pending = False

--- a/securedrop/loaddata.py
+++ b/securedrop/loaddata.py
@@ -186,7 +186,7 @@ def submit_message(source: Source, journalist_who_saw: Optional[Journalist]) -> 
         source.journalist_filename,
         next(messages),
     )
-    submission = Submission(source, fpath)
+    submission = Submission(source, fpath, Storage.get_default())
     db.session.add(submission)
 
     if journalist_who_saw:
@@ -206,7 +206,7 @@ def submit_file(source: Source, journalist_who_saw: Optional[Journalist]) -> Non
         "memo.txt",
         io.BytesIO(b"This is an example of a plain text file upload."),
     )
-    submission = Submission(source, fpath)
+    submission = Submission(source, fpath, Storage.get_default())
     db.session.add(submission)
 
     if journalist_who_saw:
@@ -227,7 +227,7 @@ def add_reply(
         reply_in=next(replies),
         encrypted_reply_path_out=Path(Storage.get_default().path(source.filesystem_id, fname)),
     )
-    reply = Reply(journalist, source, fname)
+    reply = Reply(journalist, source, fname, Storage.get_default())
     db.session.add(reply)
 
     # Journalist who replied has seen the reply

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -895,9 +895,10 @@ class InstanceConfig(db.Model):
         return new
 
     @classmethod
-    def get_default(cls) -> "InstanceConfig":
+    def get_default(cls, refresh: Optional[bool] = False) -> "InstanceConfig":
         global _default_instance_config
-        _default_instance_config = InstanceConfig.get_current()
+        if (_default_instance_config is None) or (refresh is not None and refresh is True):
+            _default_instance_config = InstanceConfig.get_current()
         return _default_instance_config
 
     @classmethod

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -194,12 +194,11 @@ class Submission(db.Model):
     '''
     checksum = Column(String(255))
 
-    def __init__(self, source: Source, filename: str) -> None:
+    def __init__(self, source: Source, filename: str, storage: Storage) -> None:
         self.source_id = source.id
         self.filename = filename
         self.uuid = str(uuid.uuid4())
-        self.size = os.stat(Storage.get_default().path(source.filesystem_id,
-                                                       filename)).st_size
+        self.size = os.stat(storage.path(source.filesystem_id, filename)).st_size
 
     def __repr__(self) -> str:
         return '<Submission %r>' % (self.filename)
@@ -285,13 +284,13 @@ class Reply(db.Model):
     def __init__(self,
                  journalist: 'Journalist',
                  source: Source,
-                 filename: str) -> None:
+                 filename: str,
+                 storage: Storage) -> None:
         self.journalist = journalist
         self.source_id = source.id
         self.uuid = str(uuid.uuid4())
         self.filename = filename
-        self.size = os.stat(Storage.get_default().path(source.filesystem_id,
-                                                       filename)).st_size
+        self.size = os.stat(storage.path(source.filesystem_id, filename)).st_size
 
     def __repr__(self) -> str:
         return '<Reply %r>' % (self.filename)

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -133,7 +133,7 @@ class Source(db.Model):
         except GpgKeyNotFoundError:
             return None
 
-    def to_json(self) -> 'Dict[str, Union[str, bool, int, str]]':
+    def to_json(self) -> 'Dict[str, object]':
         docs_msg_count = self.documents_messages_count()
 
         if self.last_updated:

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -31,6 +31,8 @@ from pyotp import TOTP, HOTP
 
 from encryption import EncryptionManager, GpgKeyNotFoundError
 
+_default_instance_config: Optional["InstanceConfig"] = None
+
 LOGIN_HARDENING = True
 if os.environ.get('SECUREDROP_ENV') == 'test':
     LOGIN_HARDENING = False
@@ -891,6 +893,12 @@ class InstanceConfig(db.Model):
             setattr(new, col.name, getattr(self, col.name))
 
         return new
+
+    @classmethod
+    def get_default(cls) -> "InstanceConfig":
+        global _default_instance_config
+        _default_instance_config = InstanceConfig.get_current()
+        return _default_instance_config
 
     @classmethod
     def get_current(cls) -> "InstanceConfig":

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -30,6 +30,7 @@ from logging import Logger
 from pyotp import TOTP, HOTP
 
 from encryption import EncryptionManager, GpgKeyNotFoundError
+from store import Storage
 
 _default_instance_config: Optional["InstanceConfig"] = None
 
@@ -197,8 +198,8 @@ class Submission(db.Model):
         self.source_id = source.id
         self.filename = filename
         self.uuid = str(uuid.uuid4())
-        self.size = os.stat(current_app.storage.path(source.filesystem_id,
-                                                     filename)).st_size
+        self.size = os.stat(Storage.get_default().path(source.filesystem_id,
+                                                       filename)).st_size
 
     def __repr__(self) -> str:
         return '<Submission %r>' % (self.filename)
@@ -289,8 +290,8 @@ class Reply(db.Model):
         self.source_id = source.id
         self.uuid = str(uuid.uuid4())
         self.filename = filename
-        self.size = os.stat(current_app.storage.path(source.filesystem_id,
-                                                     filename)).st_size
+        self.size = os.stat(Storage.get_default().path(source.filesystem_id,
+                                                       filename)).st_size
 
     def __repr__(self) -> str:
         return '<Reply %r>' % (self.filename)

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -895,9 +895,9 @@ class InstanceConfig(db.Model):
         return new
 
     @classmethod
-    def get_default(cls, refresh: Optional[bool] = False) -> "InstanceConfig":
+    def get_default(cls, refresh: bool = False) -> "InstanceConfig":
         global _default_instance_config
-        if (_default_instance_config is None) or (refresh is not None and refresh is True):
+        if (_default_instance_config is None) or (refresh is True):
             _default_instance_config = InstanceConfig.get_current()
         return _default_instance_config
 

--- a/securedrop/request_that_secures_file_uploads.py
+++ b/securedrop/request_that_secures_file_uploads.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import Optional, BinaryIO
+from typing import Optional, IO
 
 from flask import wrappers
 from werkzeug.formparser import FormDataParser
@@ -11,11 +11,11 @@ class RequestThatSecuresFileUploads(wrappers.Request):
 
     def _secure_file_stream(
         self,
-        total_content_length: int,
+        total_content_length: Optional[int],
         content_type: Optional[str],
         filename: Optional[str] = None,
         content_length: Optional[int] = None,
-    ) -> BinaryIO:
+    ) -> IO[bytes]:
         """Storage class for data streamed in from requests.
 
         If the data is relatively small (512KB), just store it in
@@ -24,7 +24,7 @@ class RequestThatSecuresFileUploads(wrappers.Request):
         forensic recovery of the plaintext.
 
         """
-        if total_content_length > 1024 * 512:
+        if total_content_length is None or total_content_length > 1024 * 512:
             # We don't use `config.TEMP_DIR` here because that
             # directory is exposed via X-Send-File and there is no
             # reason for these files to be publicly accessible. See

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.in
@@ -7,11 +7,11 @@ cffi>=1.14.2
 cryptography>=3.4.7
 
 Flask-Assets
-Flask-Babel
+Flask-Babel>=1.0.0
 Flask-SQLAlchemy
-Flask-WTF
-Flask>0.12.2
-Jinja2>=2.11.3
+Flask-WTF>=1.0.0
+Flask>=2.0.2
+Jinja2>=3.0.0
 jsmin
 markupsafe>=1.1
 mod_wsgi
@@ -21,10 +21,10 @@ psutil>=5.6.6
 pyotp>=2.6.0
 qrcode
 redis>=3.3.6
-rq>=1.1.0
+rq>=1.8.1
 setuptools>=56.0.0
 sh
 SQLAlchemy>=1.3.0
 typing;python_version<"3.8"
-Werkzeug>=0.15.3
+Werkzeug>=2.0.2
 wtforms>=3.0.0

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.txt
@@ -85,9 +85,9 @@ cffi==1.14.5 \
     #   -r requirements/python3/securedrop-app-code-requirements.in
     #   argon2-cffi
     #   cryptography
-click==6.7 \
-    --hash=sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d \
-    --hash=sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b
+click==8.0.3 \
+    --hash=sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3 \
+    --hash=sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b
     # via
     #   flask
     #   rq
@@ -108,33 +108,36 @@ cryptography==3.4.7 \
 flask-assets==0.12 \
     --hash=sha256:6031527b89fb3509d1581d932affa5a79dd348cfffb58d0aef99a43461d47847
     # via -r requirements/python3/securedrop-app-code-requirements.in
-flask-babel==0.11.2 \
-    --hash=sha256:462a3c599b0ccf426ca1757cc612f1db383844efd346d14170da04c8c76dd521 \
-    --hash=sha256:c0d75710bd4b0fe866f9f2347de6e19208712f9cec006436b4c1c15d4cb0c939
+flask-babel==2.0.0 \
+    --hash=sha256:e6820a052a8d344e178cdd36dd4bb8aea09b4bda3d5f9fa9f008df2c7f2f5468 \
+    --hash=sha256:f9faf45cdb2e1a32ea2ec14403587d4295108f35017a7821a2b1acb8cfd9257d
     # via -r requirements/python3/securedrop-app-code-requirements.in
 flask-sqlalchemy==2.4.0 \
     --hash=sha256:0c9609b0d72871c540a7945ea559c8fdf5455192d2db67219509aed680a3d45a \
     --hash=sha256:8631bbea987bc3eb0f72b1f691d47bd37ceb795e73b59ab48586d76d75a7c605
     # via -r requirements/python3/securedrop-app-code-requirements.in
-flask-wtf==0.14.2 \
-    --hash=sha256:5d14d55cfd35f613d99ee7cba0fc3fbbe63ba02f544d349158c14ca15561cc36 \
-    --hash=sha256:d9a9e366b32dcbb98ef17228e76be15702cd2600675668bca23f63a7947fd5ac
+flask-wtf==1.0.0 \
+    --hash=sha256:01feccfc395405cea48a3f36c23f0d766e2cc6fd2a5a065ad50ad3e5827ec797 \
+    --hash=sha256:872fbb17b5888bfc734edbdcf45bc08fb365ca39f69d25dc752465a455517b28
     # via -r requirements/python3/securedrop-app-code-requirements.in
-flask==1.0.2 \
-    --hash=sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48 \
-    --hash=sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05
+flask==2.0.2 \
+    --hash=sha256:7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2 \
+    --hash=sha256:cb90f62f1d8e4dc4621f52106613488b5ba826b2e1e10a33eac92f723093ab6a
     # via
     #   -r requirements/python3/securedrop-app-code-requirements.in
     #   flask-assets
     #   flask-babel
     #   flask-sqlalchemy
     #   flask-wtf
-itsdangerous==0.24 \
-    --hash=sha256:cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519
-    # via flask
-jinja2==2.11.3 \
-    --hash=sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419 \
-    --hash=sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6
+itsdangerous==2.0.1 \
+    --hash=sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c \
+    --hash=sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0
+    # via
+    #   flask
+    #   flask-wtf
+jinja2==3.0.2 \
+    --hash=sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45 \
+    --hash=sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c
     # via
     #   -r requirements/python3/securedrop-app-code-requirements.in
     #   flask
@@ -145,40 +148,76 @@ jsmin==2.2.2 \
 mako==1.0.7 \
     --hash=sha256:4e02fde57bd4abb5ec400181e4c314f56ac3e49ba4fb8b0d50bba18cb27d25ae
     # via alembic
-markupsafe==1.1.1 \
-    --hash=sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473 \
-    --hash=sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161 \
-    --hash=sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235 \
-    --hash=sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5 \
-    --hash=sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42 \
-    --hash=sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff \
-    --hash=sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b \
-    --hash=sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1 \
-    --hash=sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e \
-    --hash=sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183 \
-    --hash=sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66 \
-    --hash=sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b \
-    --hash=sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1 \
-    --hash=sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15 \
-    --hash=sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1 \
-    --hash=sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e \
-    --hash=sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b \
-    --hash=sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905 \
-    --hash=sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735 \
-    --hash=sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d \
-    --hash=sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e \
-    --hash=sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d \
-    --hash=sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c \
-    --hash=sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21 \
-    --hash=sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2 \
-    --hash=sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5 \
-    --hash=sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b \
-    --hash=sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6 \
-    --hash=sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f \
-    --hash=sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f \
-    --hash=sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2 \
-    --hash=sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7 \
-    --hash=sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be
+markupsafe==2.0.1 \
+    --hash=sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298 \
+    --hash=sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64 \
+    --hash=sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b \
+    --hash=sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194 \
+    --hash=sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567 \
+    --hash=sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff \
+    --hash=sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724 \
+    --hash=sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74 \
+    --hash=sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646 \
+    --hash=sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35 \
+    --hash=sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6 \
+    --hash=sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a \
+    --hash=sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6 \
+    --hash=sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad \
+    --hash=sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26 \
+    --hash=sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38 \
+    --hash=sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac \
+    --hash=sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7 \
+    --hash=sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6 \
+    --hash=sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047 \
+    --hash=sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75 \
+    --hash=sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f \
+    --hash=sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b \
+    --hash=sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135 \
+    --hash=sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8 \
+    --hash=sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a \
+    --hash=sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a \
+    --hash=sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1 \
+    --hash=sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9 \
+    --hash=sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864 \
+    --hash=sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914 \
+    --hash=sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee \
+    --hash=sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f \
+    --hash=sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18 \
+    --hash=sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8 \
+    --hash=sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2 \
+    --hash=sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d \
+    --hash=sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b \
+    --hash=sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b \
+    --hash=sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86 \
+    --hash=sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6 \
+    --hash=sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f \
+    --hash=sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb \
+    --hash=sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833 \
+    --hash=sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28 \
+    --hash=sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e \
+    --hash=sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415 \
+    --hash=sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902 \
+    --hash=sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f \
+    --hash=sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d \
+    --hash=sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9 \
+    --hash=sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d \
+    --hash=sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145 \
+    --hash=sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066 \
+    --hash=sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c \
+    --hash=sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1 \
+    --hash=sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a \
+    --hash=sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207 \
+    --hash=sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f \
+    --hash=sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53 \
+    --hash=sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd \
+    --hash=sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134 \
+    --hash=sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85 \
+    --hash=sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9 \
+    --hash=sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5 \
+    --hash=sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94 \
+    --hash=sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509 \
+    --hash=sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51 \
+    --hash=sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872
     # via
     #   -r requirements/python3/securedrop-app-code-requirements.in
     #   jinja2
@@ -226,20 +265,22 @@ python-editor==1.0.3 \
 pytz==2017.3 \
     --hash=sha256:c41c62827ce9cafacd6f2f7018e4f83a6f1986e87bfd000b8cfbd4ab5da95f1a \
     --hash=sha256:fae4cffc040921b8a2d60c6cf0b5d662c1190fe54d718271db4eb17d44a185b7
-    # via babel
+    # via
+    #   babel
+    #   flask-babel
 qrcode==5.3 \
     --hash=sha256:4115ccee832620df16b659d4653568331015c718a754855caf5930805d76924e \
     --hash=sha256:60222a612b83231ed99e6cb36e55311227c395d0d0f62e41bb51ebbb84a9a22b
     # via -r requirements/python3/securedrop-app-code-requirements.in
-redis==3.3.6 \
-    --hash=sha256:45682ecf226c7611efe731974c4fa3390170ba045b9cdb26f0051114a5c2a68b \
-    --hash=sha256:f2609a85e5f37f489ba3b5652e1175dc3711c4d7a7818c4f657615810afd23df
+redis==3.5.3 \
+    --hash=sha256:0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2 \
+    --hash=sha256:432b788c4530cfe16d8d943a09d40ca6c16149727e4afe8c2c9d5580c59d9f24
     # via
     #   -r requirements/python3/securedrop-app-code-requirements.in
     #   rq
-rq==1.1.0 \
-    --hash=sha256:2798d26a7b850e759f23f69695a389d676a9c08f2c14f96f0d34d9648c9d5616 \
-    --hash=sha256:4f27c6a690d1bd02b9157e615d8819555b9b359c0c4ec8ff0013d160c31b40bb
+rq==1.10.0 \
+    --hash=sha256:92950a3e60863de48dd1800882939bbaf089a37497ebf9f2ecf7c9fd0a4c4a95 \
+    --hash=sha256:be09ec43fae9a75a4d26ea3cd520e5fa3ea2ea8cf481be33e6ec9416f0369cac
     # via -r requirements/python3/securedrop-app-code-requirements.in
 sh==1.12.14 \
     --hash=sha256:ae3258c5249493cebe73cb4e18253a41ed69262484bad36fdb3efcb8ad8870bb \
@@ -261,9 +302,9 @@ sqlalchemy==1.3.3 \
 webassets==0.12.1 \
     --hash=sha256:e7d9c8887343123fd5b32309b33167428cb1318cdda97ece12d0907fd69d38db
     # via flask-assets
-werkzeug==0.16.0 \
-    --hash=sha256:7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7 \
-    --hash=sha256:e5f4a1f98b52b18a93da705a7458e55afb26f32bff83ff5d19189f92462d65c4
+werkzeug==2.0.2 \
+    --hash=sha256:63d3dc1cf60e7b7e35e97fa9861f7397283b75d765afcaefd993d6046899de8f \
+    --hash=sha256:aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a
     # via
     #   -r requirements/python3/securedrop-app-code-requirements.in
     #   flask

--- a/securedrop/scripts/shredder
+++ b/securedrop/scripts/shredder
@@ -17,6 +17,7 @@ sys.path.insert(0, "/var/www/securedrop")  # noqa: E402
 
 import journalist_app
 from sdconfig import config
+from store import Storage
 
 
 def parse_args():
@@ -33,7 +34,7 @@ def parse_args():
 
 def clear_shredder():
     try:
-        app.storage.clear_shredder()
+        Storage.get_default().clear_shredder()
     except Exception as e:
         logging.info("Error clearing shredder: {}".format(e))
 

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -64,7 +64,9 @@ def create_app(config: SDConfig) -> Flask:
     app.config['SQLALCHEMY_DATABASE_URI'] = config.DATABASE_URI
     db.init_app(app)
 
-    @app.errorhandler(CSRFError)
+    # TODO: enable typechecking once upstream Flask fix is available. See:
+    # https://github.com/pallets/flask/issues/4295
+    @app.errorhandler(CSRFError)  # type: ignore
     def handle_csrf_error(e: CSRFError) -> werkzeug.Response:
         return clear_session_and_redirect_to_logged_out_page(flask_session=session)
 

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -122,12 +122,13 @@ def create_app(config: SDConfig) -> Flask:
     @ignore_static
     def setup_g() -> Optional[werkzeug.Response]:
         if app.instance_config.organization_name:
-            g.organization_name = app.instance_config.organization_name
+            g.organization_name = \
+                app.instance_config.organization_name  # pylint: disable=assigning-non-slot
         else:
-            g.organization_name = gettext('SecureDrop')
+            g.organization_name = gettext('SecureDrop')  # pylint: disable=assigning-non-slot
 
         try:
-            g.logo = get_logo_url(app)
+            g.logo = get_logo_url(app)  # pylint: disable=assigning-non-slot
         except FileNotFoundError:
             app.logger.error("Site logo not found.")
 

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -113,7 +113,7 @@ def create_app(config: SDConfig) -> Flask:
     @app.before_request
     @ignore_static
     def setup_g() -> Optional[werkzeug.Response]:
-        if InstanceConfig.get_default().organization_name:
+        if InstanceConfig.get_default(refresh=True).organization_name:
             g.organization_name = \
                 InstanceConfig.get_default().organization_name  # pylint: disable=assigning-non-slot
         else:

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -115,15 +115,10 @@ def create_app(config: SDConfig) -> Flask:
 
     @app.before_request
     @ignore_static
-    def load_instance_config() -> None:
-        app.instance_config = InstanceConfig.get_current()
-
-    @app.before_request
-    @ignore_static
     def setup_g() -> Optional[werkzeug.Response]:
-        if app.instance_config.organization_name:
+        if InstanceConfig.get_default().organization_name:
             g.organization_name = \
-                app.instance_config.organization_name  # pylint: disable=assigning-non-slot
+                InstanceConfig.get_default().organization_name  # pylint: disable=assigning-non-slot
         else:
             g.organization_name = gettext('SecureDrop')  # pylint: disable=assigning-non-slot
 

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -22,7 +22,6 @@ from sdconfig import SDConfig
 from source_app import main, info, api
 from source_app.decorators import ignore_static
 from source_app.utils import clear_session_and_redirect_to_logged_out_page
-from store import Storage
 
 
 def get_logo_url(app: Flask) -> str:
@@ -64,10 +63,6 @@ def create_app(config: SDConfig) -> Flask:
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['SQLALCHEMY_DATABASE_URI'] = config.DATABASE_URI
     db.init_app(app)
-
-    # TODO: Attaching a Storage dynamically like this disables all type checking (and
-    # breaks code analysis tools) for code that uses current_app.storage; it should be refactored
-    app.storage = Storage(config.STORE_DIR, config.TEMP_DIR)
 
     @app.errorhandler(CSRFError)
     def handle_csrf_error(e: CSRFError) -> werkzeug.Response:

--- a/securedrop/source_app/api.py
+++ b/securedrop/source_app/api.py
@@ -1,9 +1,10 @@
 import json
 
 import flask
-from flask import Blueprint, current_app, make_response
+from flask import Blueprint, make_response
 
 from sdconfig import SDConfig
+from models import InstanceConfig
 from source_app.utils import get_sourcev3_url
 
 import server_os
@@ -16,8 +17,8 @@ def make_blueprint(config: SDConfig) -> Blueprint:
     @view.route('/metadata')
     def metadata() -> flask.Response:
         meta = {
-            'organization_name': current_app.instance_config.organization_name,
-            'allow_document_uploads': current_app.instance_config.allow_document_uploads,
+            'organization_name': InstanceConfig.get_default().organization_name,
+            'allow_document_uploads': InstanceConfig.get_default().allow_document_uploads,
             'gpg_fpr': config.JOURNALIST_KEY,
             'sd_version': version.__version__,
             'server_os': server_os.get_os_release(),

--- a/securedrop/source_app/forms.py
+++ b/securedrop/source_app/forms.py
@@ -1,11 +1,10 @@
 import wtforms
-from flask import current_app
 from flask_babel import lazy_gettext as gettext
 from flask_wtf import FlaskForm
 from wtforms import FileField, PasswordField, TextAreaField
 from wtforms.validators import InputRequired, Regexp, Length, ValidationError
 
-from models import Submission
+from models import Submission, InstanceConfig
 from passphrases import PassphraseGenerator
 
 
@@ -31,7 +30,7 @@ class SubmissionForm(FlaskForm):
     def validate_msg(self, field: wtforms.Field) -> None:
         if len(field.data) > Submission.MAX_MESSAGE_LEN:
             message = gettext("Message text too long.")
-            if current_app.instance_config.allow_document_uploads:
+            if InstanceConfig.get_default().allow_document_uploads:
                 message = "{} {}".format(
                     message,
                     gettext(

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -233,7 +233,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
 
         new_submissions = []
         for fname in fnames:
-            submission = Submission(logged_in_source_in_db, fname)
+            submission = Submission(logged_in_source_in_db, fname, Storage.get_default())
             db.session.add(submission)
             new_submissions.append(submission)
 
@@ -242,7 +242,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         db.session.commit()
 
         for sub in new_submissions:
-            store.async_add_checksum_for_file(sub)
+            store.async_add_checksum_for_file(sub, Storage.get_default())
 
         normalize_timestamps(logged_in_source)
 

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -19,7 +19,7 @@ from db import db
 from encryption import EncryptionManager, GpgKeyNotFoundError
 
 from models import Submission, Reply, get_one_or_else, InstanceConfig
-from passphrases import PassphraseGenerator
+from passphrases import PassphraseGenerator, DicewarePassphrase
 from sdconfig import SDConfig
 from source_app.decorators import login_required
 from source_app.session_manager import SessionManager
@@ -99,7 +99,8 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             # All done - source user was successfully created
             current_app.logger.info("New source user created")
             session['new_user_codename'] = codename
-            SessionManager.log_user_in(db_session=db.session, supplied_passphrase=codename)
+            SessionManager.log_user_in(db_session=db.session,
+                                       supplied_passphrase=DicewarePassphrase(codename))
 
         return redirect(url_for('.lookup'))
 
@@ -291,7 +292,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             try:
                 SessionManager.log_user_in(
                     db_session=db.session,
-                    supplied_passphrase=request.form['codename'].strip()
+                    supplied_passphrase=DicewarePassphrase(request.form['codename'].strip())
                 )
             except InvalidPassphraseError:
                 current_app.logger.info("Login failed for invalid codename")

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -16,7 +16,7 @@ import store
 from db import db
 from encryption import EncryptionManager, GpgKeyNotFoundError
 
-from models import Submission, Reply, get_one_or_else
+from models import Submission, Reply, get_one_or_else, InstanceConfig
 from passphrases import PassphraseGenerator
 from sdconfig import SDConfig
 from source_app.decorators import login_required
@@ -147,7 +147,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         return render_template(
             'lookup.html',
             is_user_logged_in=True,
-            allow_document_uploads=current_app.instance_config.allow_document_uploads,
+            allow_document_uploads=InstanceConfig.get_default().allow_document_uploads,
             replies=replies,
             new_user_codename=session.get('new_user_codename', None),
             form=SubmissionForm(),
@@ -156,7 +156,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
     @view.route('/submit', methods=('POST',))
     @login_required
     def submit(logged_in_source: SourceUser) -> werkzeug.Response:
-        allow_document_uploads = current_app.instance_config.allow_document_uploads
+        allow_document_uploads = InstanceConfig.get_default().allow_document_uploads
         form = SubmissionForm()
         if not form.validate():
             for field, errors in form.errors.items():

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -3,7 +3,7 @@ import os
 import io
 
 from base64 import urlsafe_b64encode
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Union
 
 import werkzeug
@@ -56,7 +56,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         codenames = session.get('codenames', {})
         codenames[tab_id] = codename
         session['codenames'] = fit_codenames_into_cookie(codenames)
-        session["codenames_expire"] = datetime.utcnow() + timedelta(
+        session["codenames_expire"] = datetime.now(timezone.utc) + timedelta(
             minutes=config.SESSION_EXPIRATION_MINUTES
         )
         return render_template('generate.html', codename=codename, tab_id=tab_id)
@@ -70,7 +70,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         else:
             # Ensure the codenames have not expired
             date_codenames_expire = session.get("codenames_expire")
-            if not date_codenames_expire or datetime.utcnow() >= date_codenames_expire:
+            if not date_codenames_expire or datetime.now(timezone.utc) >= date_codenames_expire:
                 return clear_session_and_redirect_to_logged_out_page(flask_session=session)
 
             tab_id = request.form['tab_id']
@@ -235,7 +235,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             new_submissions.append(submission)
 
         logged_in_source_in_db.pending = False
-        logged_in_source_in_db.last_updated = datetime.utcnow()
+        logged_in_source_in_db.last_updated = datetime.now(timezone.utc)
         db.session.commit()
 
         for sub in new_submissions:

--- a/securedrop/source_app/session_manager.py
+++ b/securedrop/source_app/session_manager.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 import sqlalchemy
@@ -50,7 +50,8 @@ class SessionManager:
 
         # Save the session expiration date in the user's session cookie
         session_duration = timedelta(minutes=config.SESSION_EXPIRATION_MINUTES)
-        session[cls._SESSION_COOKIE_KEY_FOR_EXPIRATION_DATE] = datetime.utcnow() + session_duration
+        session[cls._SESSION_COOKIE_KEY_FOR_EXPIRATION_DATE] = datetime.now(
+            timezone.utc) + session_duration
 
         return source_user
 
@@ -77,7 +78,7 @@ class SessionManager:
             cls.log_user_out()
             raise UserNotLoggedIn()
 
-        if datetime.utcnow() >= date_session_expires:
+        if datetime.now(timezone.utc) >= date_session_expires:
             cls.log_user_out()
             raise UserSessionExpired()
 

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -7,6 +7,7 @@ from flask import redirect
 from flask import render_template
 from flask import current_app
 from flask import url_for
+from flask.sessions import SessionMixin
 from markupsafe import Markup
 from store import Storage
 
@@ -20,7 +21,7 @@ if typing.TYPE_CHECKING:
     from typing import Optional
 
 
-def clear_session_and_redirect_to_logged_out_page(flask_session: typing.Dict) -> werkzeug.Response:
+def clear_session_and_redirect_to_logged_out_page(flask_session: SessionMixin) -> werkzeug.Response:
     msg = render_template('session_timeout.html')
 
     # Clear the session after we render the message so it's localized

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -8,6 +8,7 @@ from flask import render_template
 from flask import current_app
 from flask import url_for
 from markupsafe import Markup
+from store import Storage
 
 import typing
 
@@ -36,7 +37,7 @@ def normalize_timestamps(logged_in_source: SourceUser) -> None:
     #301.
     """
     source_in_db = logged_in_source.get_db_record()
-    sub_paths = [current_app.storage.path(logged_in_source.filesystem_id, submission.filename)
+    sub_paths = [Storage.get_default().path(logged_in_source.filesystem_id, submission.filename)
                  for submission in source_in_db.submissions]
     if len(sub_paths) > 1:
         args = ["touch", "--no-create"]

--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -402,12 +402,12 @@ class Storage:
         return filename
 
 
-def async_add_checksum_for_file(db_obj: 'Union[Submission, Reply]') -> str:
+def async_add_checksum_for_file(db_obj: 'Union[Submission, Reply]', storage: Storage) -> str:
     return create_queue().enqueue(
         queued_add_checksum_for_file,
         type(db_obj),
         db_obj.id,
-        Storage.get_default().path(db_obj.source.filesystem_id, db_obj.filename),
+        storage.path(db_obj.source.filesystem_id, db_obj.filename),
         current_app.config['SQLALCHEMY_DATABASE_URI'],
     )
 

--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -28,9 +28,8 @@ if typing.TYPE_CHECKING:
     # That is why all type annotation relative import
     # statements has to be marked as noqa.
     # http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401
-    from typing import List, Type, Union  # noqa: F401
+    from typing import List, Type, Union, Optional, IO  # noqa: F401
     from tempfile import _TemporaryFileWrapper  # type: ignore # noqa: F401
-    from io import BufferedIOBase  # noqa: F401
     from sqlalchemy.orm import Session  # noqa: F401
     from models import Reply, Submission  # noqa: F401
 
@@ -330,9 +329,12 @@ class Storage:
                              filesystem_id: str,
                              count: int,
                              journalist_filename: str,
-                             filename: str,
-                             stream: 'BufferedIOBase') -> str:
-        sanitized_filename = secure_filename(filename)
+                             filename: typing.Optional[str],
+                             stream: 'IO[bytes]') -> str:
+
+        sanitized_filename = secure_filename("unknown.file")
+        if filename is not None:
+            sanitized_filename = secure_filename(filename)
 
         # We store file submissions in a .gz file for two reasons:
         #

--- a/securedrop/store.py
+++ b/securedrop/store.py
@@ -332,9 +332,10 @@ class Storage:
                              filename: typing.Optional[str],
                              stream: 'IO[bytes]') -> str:
 
-        sanitized_filename = secure_filename("unknown.file")
         if filename is not None:
             sanitized_filename = secure_filename(filename)
+        else:
+            sanitized_filename = secure_filename("unknown.file")
 
         # We store file submissions in a .gz file for two reasons:
         #

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -23,6 +23,7 @@ from source_user import _SourceScryptManager
 from . import functional_test as ft
 from . import journalist_navigation_steps
 from . import source_navigation_steps
+from store import Storage
 
 from tbselenium.utils import SECURITY_LOW
 
@@ -120,7 +121,7 @@ class TestJournalistMissingFile(
         filesystem_id = _SourceScryptManager.get_default().derive_source_filesystem_id(
             self.source_name
         )
-        storage_path = Path(self.journalist_app.storage.storage_path) / filesystem_id
+        storage_path = Path(Storage.get_default().storage_path) / filesystem_id
         msg_files = [p for p in storage_path.glob("*-msg.gpg")]
         assert len(msg_files) == 1
         msg_files[0].unlink()

--- a/securedrop/tests/test_db.py
+++ b/securedrop/tests/test_db.py
@@ -74,18 +74,19 @@ def test_throttle_login(journalist_app, test_journo):
             Journalist.throttle_login(journalist)
 
 
-def test_submission_string_representation(journalist_app, test_source):
+def test_submission_string_representation(journalist_app, test_source, app_storage):
     with journalist_app.app_context():
-        db_helper.submit(test_source['source'], 2)
+        db_helper.submit(app_storage, test_source['source'], 2)
         test_submission = Submission.query.first()
         test_submission.__repr__()
 
 
 def test_reply_string_representation(journalist_app,
                                      test_journo,
-                                     test_source):
+                                     test_source,
+                                     app_storage):
     with journalist_app.app_context():
-        db_helper.reply(test_journo['journalist'],
+        db_helper.reply(app_storage, test_journo['journalist'],
                         test_source['source'],
                         2)
         test_reply = Reply.query.first()

--- a/securedrop/tests/test_encryption.py
+++ b/securedrop/tests/test_encryption.py
@@ -17,13 +17,14 @@ class TestEncryptionManager:
         assert encryption_mgr
         assert encryption_mgr.get_journalist_public_key()
 
-    def test_generate_source_key_pair(self, setup_journalist_key_and_gpg_folder, source_app):
+    def test_generate_source_key_pair(self, setup_journalist_key_and_gpg_folder,
+                                      source_app, app_storage):
         # Given a source user
         with source_app.app_context():
             source_user = create_source_user(
                 db_session=db.session,
                 source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
-                source_app_storage=source_app.storage,
+                source_app_storage=app_storage,
             )
 
         # And an encryption manager
@@ -225,7 +226,8 @@ class TestEncryptionManager:
         # For GPG 2.1+, a non-null passphrase _must_ be passed to decrypt()
         assert not encryption_mgr._gpg.decrypt(encrypted_file, passphrase="test 123").ok
 
-    def test_encrypt_and_decrypt_journalist_reply(self, source_app, test_source, tmp_path):
+    def test_encrypt_and_decrypt_journalist_reply(self, source_app, test_source,
+                                                  tmp_path, app_storage):
         # Given a source user with a key pair in the default encryption manager
         source_user1 = test_source["source_user"]
         encryption_mgr = EncryptionManager.get_default()
@@ -235,7 +237,7 @@ class TestEncryptionManager:
             source_user2 = create_source_user(
                 db_session=db.session,
                 source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
-                source_app_storage=source_app.storage,
+                source_app_storage=app_storage,
             )
         encryption_mgr.generate_source_key_pair(source_user2)
 

--- a/securedrop/tests/test_encryption.py
+++ b/securedrop/tests/test_encryption.py
@@ -60,7 +60,7 @@ class TestEncryptionManager:
         # And the user's key does not expire
         assert source_key_details["expires"] == ""
 
-    def test_get_source_public_key(self, source_app, test_source):
+    def test_get_source_public_key(self, test_source):
         # Given a source user with a key pair in the default encryption manager
         source_user = test_source["source_user"]
         encryption_mgr = EncryptionManager.get_default()

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -11,12 +11,13 @@ from io import BytesIO
 import mock
 
 from bs4 import BeautifulSoup
-from flask import current_app, escape, g, session
+from flask import escape, g, session
 from pyotp import HOTP, TOTP
 
 import journalist_app as journalist_app_module
 from db import db
 from encryption import EncryptionManager
+from store import Storage
 from source_app.session_manager import SessionManager
 from . import utils
 from .test_encryption import import_journalist_private_key
@@ -37,7 +38,7 @@ def _login_user(app, user_dict):
     assert hasattr(g, 'user')  # ensure logged in
 
 
-def test_submit_message(journalist_app, source_app, test_journo):
+def test_submit_message(journalist_app, source_app, test_journo, app_storage):
     """When a source creates an account, test that a new entry appears
     in the journalist interface"""
     test_msg = "This is a test message."
@@ -134,12 +135,12 @@ def test_submit_message(journalist_app, source_app, test_journo):
         # needs to wait for the worker to get the job and execute it
         def assertion():
             assert not (
-                os.path.exists(current_app.storage.path(filesystem_id,
-                                                        doc_name)))
+                os.path.exists(app_storage.path(filesystem_id,
+                                                doc_name)))
         utils.asynchronous.wait_for_assertion(assertion)
 
 
-def test_submit_file(journalist_app, source_app, test_journo):
+def test_submit_file(journalist_app, source_app, test_journo, app_storage):
     """When a source creates an account, test that a new entry appears
     in the journalist interface"""
     test_file_contents = b"This is a test file."
@@ -243,8 +244,7 @@ def test_submit_file(journalist_app, source_app, test_journo):
         # needs to wait for the worker to get the job and execute it
         def assertion():
             assert not (
-                os.path.exists(current_app.storage.path(filesystem_id,
-                                                        doc_name)))
+                os.path.exists(app_storage.path(filesystem_id, doc_name)))
         utils.asynchronous.wait_for_assertion(assertion)
 
 
@@ -380,8 +380,8 @@ def _helper_filenames_delete(journalist_app, soup, i):
 
     # Make sure the files were deleted from the filesystem
     def assertion():
-        assert not any([os.path.exists(current_app.storage.path(filesystem_id,
-                                                                doc_name))
+        assert not any([os.path.exists(Storage.get_default().path(filesystem_id,
+                                                                  doc_name))
                         for doc_name in checkbox_values])
     utils.asynchronous.wait_for_assertion(assertion)
 
@@ -481,7 +481,7 @@ def test_delete_collection(mocker, source_app, journalist_app, test_journo):
 
         # Make sure the collection is deleted from the filesystem
         def assertion():
-            assert not os.path.exists(current_app.storage.path(filesystem_id))
+            assert not os.path.exists(Storage.get_default().path(filesystem_id))
 
         utils.asynchronous.wait_for_assertion(assertion)
 
@@ -525,7 +525,7 @@ def test_delete_collections(mocker, journalist_app, source_app, test_journo):
         # Make sure the collections are deleted from the filesystem
         def assertion():
             assert not (
-                any([os.path.exists(current_app.storage.path(filesystem_id))
+                any([os.path.exists(Storage.get_default().path(filesystem_id))
                     for filesystem_id in checkbox_values]))
 
         utils.asynchronous.wait_for_assertion(assertion)

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -718,7 +718,7 @@ def test_unencrypted_replies_get_rejected(journalist_app, journalist_api_token,
 
 
 def test_authorized_user_can_add_reply(journalist_app, journalist_api_token,
-                                       test_source, test_journo):
+                                       test_source, test_journo, app_storage):
     with journalist_app.test_client() as app:
         source_id = test_source['source'].id
         uuid = test_source['source'].uuid
@@ -760,8 +760,7 @@ def test_authorized_user_can_add_reply(journalist_app, journalist_api_token,
         expected_filename = '{}-{}-reply.gpg'.format(
             source.interaction_count, source.journalist_filename)
 
-        expected_filepath = journalist_app.storage.path(
-            source.filesystem_id, expected_filename)
+        expected_filepath = app_storage.path(source.filesystem_id, expected_filename)
 
         with open(expected_filepath, 'rb') as fh:
             saved_content = fh.read()

--- a/securedrop/tests/test_manage.py
+++ b/securedrop/tests/test_manage.py
@@ -215,7 +215,7 @@ def test_clean_tmp_removed(config, caplog):
     assert 'FILE removed' in caplog.text
 
 
-def test_were_there_submissions_today(source_app, config):
+def test_were_there_submissions_today(source_app, config, app_storage):
     with source_app.app_context() as context:
         # We need to override the config to point at the per-test DB
         data_root = config.SECUREDROP_DATA_ROOT
@@ -225,7 +225,7 @@ def test_were_there_submissions_today(source_app, config):
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
-            source_app_storage=source_app.storage,
+            source_app_storage=app_storage,
         )
         source = source_user.get_db_record()
         source.last_updated = (datetime.datetime.utcnow() - datetime.timedelta(hours=24*2))

--- a/securedrop/tests/test_session_manager.py
+++ b/securedrop/tests/test_session_manager.py
@@ -15,13 +15,13 @@ from source_user import create_source_user
 
 
 class TestSessionManager:
-    def test_log_user_in(self, source_app):
+    def test_log_user_in(self, source_app, app_storage):
         # Given a source user
         passphrase = PassphraseGenerator.get_default().generate_passphrase()
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=passphrase,
-            source_app_storage=source_app.storage,
+            source_app_storage=app_storage,
         )
 
         with source_app.test_request_context():
@@ -33,13 +33,13 @@ class TestSessionManager:
             logged_in_user = SessionManager.get_logged_in_user(db_session=db.session)
             assert logged_in_user.db_record_id == source_user.db_record_id
 
-    def test_log_user_out(self, source_app):
+    def test_log_user_out(self, source_app, app_storage):
         # Given a source user
         passphrase = PassphraseGenerator.get_default().generate_passphrase()
         create_source_user(
             db_session=db.session,
             source_passphrase=passphrase,
-            source_app_storage=source_app.storage,
+            source_app_storage=app_storage,
         )
 
         with source_app.test_request_context():
@@ -54,13 +54,13 @@ class TestSessionManager:
             with pytest.raises(UserNotLoggedIn):
                 SessionManager.get_logged_in_user(db_session=db.session)
 
-    def test_get_logged_in_user_but_session_expired(self, source_app):
+    def test_get_logged_in_user_but_session_expired(self, source_app, app_storage):
         # Given a source user
         passphrase = PassphraseGenerator.get_default().generate_passphrase()
         create_source_user(
             db_session=db.session,
             source_passphrase=passphrase,
-            source_app_storage=source_app.storage,
+            source_app_storage=app_storage,
         )
 
         with source_app.test_request_context():
@@ -77,13 +77,13 @@ class TestSessionManager:
                 with pytest.raises(UserSessionExpired):
                     SessionManager.get_logged_in_user(db_session=db.session)
 
-    def test_get_logged_in_user_but_user_deleted(self, source_app):
+    def test_get_logged_in_user_but_user_deleted(self, source_app, app_storage):
         # Given a source user
         passphrase = PassphraseGenerator.get_default().generate_passphrase()
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=passphrase,
-            source_app_storage=source_app.storage,
+            source_app_storage=app_storage,
         )
 
         with source_app.test_request_context():

--- a/securedrop/tests/test_session_manager.py
+++ b/securedrop/tests/test_session_manager.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import pytest
@@ -69,8 +69,8 @@ class TestSessionManager:
 
             # But we're now 6 hours later hence their session expired
             with mock.patch("source_app.session_manager.datetime") as mock_datetime:
-                six_hours_later = datetime.utcnow() + timedelta(hours=6)
-                mock_datetime.utcnow.return_value = six_hours_later
+                six_hours_later = datetime.now(timezone.utc) + timedelta(hours=6)
+                mock_datetime.now.return_value = six_hours_later
 
                 # When querying the current user from the SessionManager
                 # it fails with the right error

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -6,7 +6,7 @@ import subprocess
 import time
 import os
 import shutil
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import BytesIO, StringIO
 from pathlib import Path
 from unittest import mock
@@ -766,8 +766,8 @@ def test_source_session_expiration(source_app):
 
         # But we're now 6 hours later hence their session expired
         with mock.patch("source_app.session_manager.datetime") as mock_datetime:
-            six_hours_later = datetime.utcnow() + timedelta(hours=6)
-            mock_datetime.utcnow.return_value = six_hours_later
+            six_hours_later = datetime.now(timezone.utc) + timedelta(hours=6)
+            mock_datetime.now.return_value = six_hours_later
 
             # When they browse to an authenticated page
             resp = app.get(url_for('main.lookup'), follow_redirects=True)
@@ -785,8 +785,8 @@ def test_source_session_expiration_create(source_app):
 
         # But we're now 6 hours later hence they did not finish the account creation flow in time
         with mock.patch("source_app.main.datetime") as mock_datetime:
-            six_hours_later = datetime.utcnow() + timedelta(hours=6)
-            mock_datetime.utcnow.return_value = six_hours_later
+            six_hours_later = datetime.now(timezone.utc) + timedelta(hours=6)
+            mock_datetime.now.return_value = six_hours_later
 
             # When the user tries to complete the create flow
             resp = app.post(url_for('main.create'), follow_redirects=True)
@@ -805,7 +805,7 @@ def test_source_no_session_expiration_message_when_not_logged_in(source_app):
         # And their session expired
         with mock.patch("source_app.session_manager.datetime") as mock_datetime:
             six_hours_later = datetime.utcnow() + timedelta(hours=6)
-            mock_datetime.utcnow.return_value = six_hours_later
+            mock_datetime.now.return_value = six_hours_later
 
         # When they browse again the index page
         refreshed_resp = app.get(url_for('main.index'), follow_redirects=True)

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -319,17 +319,17 @@ def test_login_with_whitespace(source_app):
             login_test(app, codename_)
 
 
-def test_login_with_missing_reply_files(source_app):
+def test_login_with_missing_reply_files(source_app, app_storage):
     """
     Test that source can log in when replies are present in database but missing
     from storage.
     """
-    source, codename = utils.db_helper.init_source()
+    source, codename = utils.db_helper.init_source(app_storage)
     journalist, _ = utils.db_helper.init_journalist()
-    replies = utils.db_helper.reply(journalist, source, 1)
+    replies = utils.db_helper.reply(app_storage, journalist, source, 1)
     assert len(replies) > 0
     # Delete the reply file
-    reply_file_path = Path(source_app.storage.path(source.filesystem_id, replies[0].filename))
+    reply_file_path = Path(app_storage.path(source.filesystem_id, replies[0].filename))
     reply_file_path.unlink()
     assert not reply_file_path.exists()
 
@@ -445,12 +445,12 @@ def test_submit_both(source_app):
         assert "Thanks! We received your message and document" in text
 
 
-def test_delete_all_successfully_deletes_replies(source_app):
+def test_delete_all_successfully_deletes_replies(source_app, app_storage):
     with source_app.app_context():
         journalist, _ = utils.db_helper.init_journalist()
-        source, codename = utils.db_helper.init_source()
+        source, codename = utils.db_helper.init_source(app_storage)
         source_id = source.id
-        utils.db_helper.reply(journalist, source, 1)
+        utils.db_helper.reply(app_storage, journalist, source, 1)
 
     with source_app.test_client() as app:
         resp = app.post(url_for('main.login'),
@@ -469,13 +469,13 @@ def test_delete_all_successfully_deletes_replies(source_app):
             assert reply.deleted_by_source is True
 
 
-def test_delete_all_replies_deleted_by_source_but_not_journalist(source_app):
+def test_delete_all_replies_deleted_by_source_but_not_journalist(source_app, app_storage):
     """Replies can be deleted by a source, but not by journalists. As such,
     replies may still exist in the replies table, but no longer be visible."""
     with source_app.app_context():
         journalist, _ = utils.db_helper.init_journalist()
-        source, codename = utils.db_helper.init_source()
-        utils.db_helper.reply(journalist, source, 1)
+        source, codename = utils.db_helper.init_source(app_storage)
+        utils.db_helper.reply(app_storage, journalist, source, 1)
         replies = Reply.query.filter(Reply.source_id == source.id).all()
         for reply in replies:
             reply.deleted_by_source = True
@@ -496,10 +496,10 @@ def test_delete_all_replies_deleted_by_source_but_not_journalist(source_app):
             )
 
 
-def test_delete_all_replies_already_deleted_by_journalists(source_app):
+def test_delete_all_replies_already_deleted_by_journalists(source_app, app_storage):
     with source_app.app_context():
         journalist, _ = utils.db_helper.init_journalist()
-        source, codename = utils.db_helper.init_source()
+        source, codename = utils.db_helper.init_source(app_storage)
         # Note that we are creating the source and no replies
 
     with source_app.test_client() as app:
@@ -627,7 +627,7 @@ def test_login_with_overly_long_codename(source_app):
                 .format(PassphraseGenerator.MAX_PASSPHRASE_LENGTH)) in text
 
 
-def test_normalize_timestamps(source_app):
+def test_normalize_timestamps(source_app, app_storage):
     """
     Check function of source_app.utils.normalize_timestamps.
 
@@ -637,14 +637,14 @@ def test_normalize_timestamps(source_app):
     """
     with source_app.test_client() as app:
         # create a source
-        source, codename = utils.db_helper.init_source()
+        source, codename = utils.db_helper.init_source(app_storage)
 
         # create one submission
-        first_submission = submit(source, 1)[0]
+        first_submission = submit(app_storage, source, 1)[0]
 
         # delete the submission's file from the store
         first_submission_path = Path(
-            source_app.storage.path(source.filesystem_id, first_submission.filename)
+            app_storage.path(source.filesystem_id, first_submission.filename)
         )
         first_submission_path.unlink()
         assert not first_submission_path.exists()
@@ -676,7 +676,7 @@ def test_normalize_timestamps(source_app):
         # only two of the source's three submissions should have files in the store
         assert 3 == len(source.submissions)
         submission_paths = [
-            Path(source_app.storage.path(source.filesystem_id, s.filename))
+            Path(app_storage.path(source.filesystem_id, s.filename))
             for s in source.submissions
         ]
         extant_paths = [p for p in submission_paths if p.exists()]
@@ -827,14 +827,14 @@ def test_csrf_error_page(source_app):
         assert 'You were logged out due to inactivity' in text
 
 
-def test_source_can_only_delete_own_replies(source_app):
+def test_source_can_only_delete_own_replies(source_app, app_storage):
     '''This test checks for a bug an authenticated source A could delete
        replies send to source B by "guessing" the filename.
     '''
-    source0, codename0 = utils.db_helper.init_source()
-    source1, codename1 = utils.db_helper.init_source()
+    source0, codename0 = utils.db_helper.init_source(app_storage)
+    source1, codename1 = utils.db_helper.init_source(app_storage)
     journalist, _ = utils.db_helper.init_journalist()
-    replies = utils.db_helper.reply(journalist, source0, 1)
+    replies = utils.db_helper.reply(app_storage, journalist, source0, 1)
     filename = replies[0].filename
     confirmation_msg = 'Reply deleted'
 

--- a/securedrop/tests/test_source_user.py
+++ b/securedrop/tests/test_source_user.py
@@ -19,7 +19,7 @@ TEST_SALT_FOR_FILESYSTEM_ID = "mEFXIwvxoBqjyxc/JypLdvgMRNRjApoaM0OBNrxJM2E="
 
 
 class TestSourceUser:
-    def test_create_source_user(self, source_app):
+    def test_create_source_user(self, source_app, app_storage):
         # Given a passphrase
         passphrase = PassphraseGenerator.get_default().generate_passphrase()
 
@@ -27,18 +27,18 @@ class TestSourceUser:
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=passphrase,
-            source_app_storage=source_app.storage,
+            source_app_storage=app_storage,
         )
         assert source_user
         assert source_user.get_db_record()
 
-    def test_create_source_user_passphrase_collision(self, source_app):
+    def test_create_source_user_passphrase_collision(self, source_app, app_storage):
         # Given a source in the DB
         passphrase = PassphraseGenerator.get_default().generate_passphrase()
         create_source_user(
             db_session=db.session,
             source_passphrase=passphrase,
-            source_app_storage=source_app.storage,
+            source_app_storage=app_storage,
         )
 
         # When trying to create another with the same passphrase, it fails
@@ -46,15 +46,15 @@ class TestSourceUser:
             create_source_user(
                 db_session=db.session,
                 source_passphrase=passphrase,
-                source_app_storage=source_app.storage,
+                source_app_storage=app_storage,
             )
 
-    def test_create_source_user_designation_collision(self, source_app):
+    def test_create_source_user_designation_collision(self, source_app, app_storage):
         # Given a source in the DB
         existing_source = create_source_user(
             db_session=db.session,
             source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
-            source_app_storage=source_app.storage,
+            source_app_storage=app_storage,
         )
         existing_designation = existing_source.get_db_record().journalist_designation
 
@@ -69,16 +69,16 @@ class TestSourceUser:
                 create_source_user(
                     db_session=db.session,
                     source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
-                    source_app_storage=source_app.storage,
+                    source_app_storage=app_storage,
                 )
 
-    def test_authenticate_source_user(self, source_app):
+    def test_authenticate_source_user(self, source_app, app_storage):
         # Given a source in the DB
         passphrase = PassphraseGenerator.get_default().generate_passphrase()
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=passphrase,
-            source_app_storage=source_app.storage,
+            source_app_storage=app_storage,
         )
 
         # When they try to authenticate using their passphrase
@@ -90,12 +90,12 @@ class TestSourceUser:
         assert authenticated_user
         assert authenticated_user.db_record_id == source_user.db_record_id
 
-    def test_authenticate_source_user_wrong_passphrase(self, source_app):
+    def test_authenticate_source_user_wrong_passphrase(self, source_app, app_storage):
         # Given a source in the DB
         create_source_user(
             db_session=db.session,
             source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
-            source_app_storage=source_app.storage,
+            source_app_storage=app_storage,
         )
 
         # When a user tries to authenticate using a wrong passphrase, it fails

--- a/securedrop/tests/test_store.py
+++ b/securedrop/tests/test_store.py
@@ -32,30 +32,29 @@ def create_file_in_source_dir(config, filesystem_id, filename):
     return source_directory, file_path
 
 
-def test_path_returns_filename_of_folder(journalist_app, config):
+def test_path_returns_filename_of_folder(journalist_app, app_storage, config):
     """`Storage.path` is called in this way in
         journalist.delete_collection
     """
     filesystem_id = 'example'
-    generated_absolute_path = journalist_app.storage.path(filesystem_id)
+    generated_absolute_path = app_storage.path(filesystem_id)
 
     expected_absolute_path = os.path.join(config.STORE_DIR, filesystem_id)
     assert generated_absolute_path == expected_absolute_path
 
 
-def test_path_returns_filename_of_items_within_folder(journalist_app, config):
+def test_path_returns_filename_of_items_within_folder(journalist_app, app_storage, config):
     """`Storage.path` is called in this way in journalist.bulk_delete"""
     filesystem_id = 'example'
     item_filename = '1-quintuple_cant-msg.gpg'
-    generated_absolute_path = journalist_app.storage.path(filesystem_id,
-                                                          item_filename)
+    generated_absolute_path = app_storage.path(filesystem_id, item_filename)
 
     expected_absolute_path = os.path.join(config.STORE_DIR,
                                           filesystem_id, item_filename)
     assert generated_absolute_path == expected_absolute_path
 
 
-def test_path_without_filesystem_id(journalist_app, config):
+def test_path_without_filesystem_id(journalist_app, app_storage, config):
     filesystem_id = 'example'
     item_filename = '1-quintuple_cant-msg.gpg'
 
@@ -67,14 +66,14 @@ def test_path_without_filesystem_id(journalist_app, config):
         os.utime(path_to_file, None)
 
     generated_absolute_path = \
-        journalist_app.storage.path_without_filesystem_id(item_filename)
+        app_storage.path_without_filesystem_id(item_filename)
 
     expected_absolute_path = os.path.join(config.STORE_DIR,
                                           filesystem_id, item_filename)
     assert generated_absolute_path == expected_absolute_path
 
 
-def test_path_without_filesystem_id_duplicate_files(journalist_app, config):
+def test_path_without_filesystem_id_duplicate_files(journalist_app, app_storage, config):
     filesystem_id = 'example'
     filesystem_id_duplicate = 'example2'
     item_filename = '1-quintuple_cant-msg.gpg'
@@ -89,43 +88,43 @@ def test_path_without_filesystem_id_duplicate_files(journalist_app, config):
             os.utime(path_to_file, None)
 
     with pytest.raises(store.TooManyFilesException):
-        journalist_app.storage.path_without_filesystem_id(item_filename)
+        app_storage.path_without_filesystem_id(item_filename)
 
 
-def test_path_without_filesystem_id_no_file(journalist_app, config):
+def test_path_without_filesystem_id_no_file(journalist_app, app_storage, config):
     item_filename = 'not there'
     with pytest.raises(store.NoFileFoundException):
-        journalist_app.storage.path_without_filesystem_id(item_filename)
+        app_storage.path_without_filesystem_id(item_filename)
 
 
-def test_verify_path_not_absolute(journalist_app, config):
+def test_verify_path_not_absolute(journalist_app, app_storage, config):
     with pytest.raises(store.PathException):
-        journalist_app.storage.verify(
+        app_storage.verify(
             os.path.join(config.STORE_DIR, '..', 'etc', 'passwd'))
 
 
-def test_verify_in_store_dir(journalist_app, config):
+def test_verify_in_store_dir(journalist_app, app_storage, config):
     with pytest.raises(store.PathException) as e:
         path = config.STORE_DIR + "_backup"
-        journalist_app.storage.verify(path)
+        app_storage.verify(path)
         assert e.message == "Path not valid in store: {}".format(path)
 
 
-def test_verify_store_path_not_absolute(journalist_app):
+def test_verify_store_path_not_absolute(journalist_app, app_storage):
     with pytest.raises(store.PathException) as e:
-        journalist_app.storage.verify('..')
+        app_storage.verify('..')
         assert e.message == "Path not valid in store: .."
 
 
-def test_verify_rejects_symlinks(journalist_app):
+def test_verify_rejects_symlinks(journalist_app, app_storage):
     """
     Test that verify rejects paths involving links outside the store.
     """
     try:
-        link = os.path.join(journalist_app.storage.storage_path, "foo")
+        link = os.path.join(app_storage.storage_path, "foo")
         os.symlink("/foo", link)
         with pytest.raises(store.PathException) as e:
-            journalist_app.storage.verify(link)
+            app_storage.verify(link)
             assert e.message == "Path not valid in store: {}".format(link)
     finally:
         os.unlink(link)
@@ -147,7 +146,7 @@ def test_verify_store_temp_dir_not_absolute():
     assert re.compile('temp_dir.*is not absolute').match(msg)
 
 
-def test_verify_regular_submission_in_sourcedir_returns_true(journalist_app, config):
+def test_verify_regular_submission_in_sourcedir_returns_true(journalist_app, config, app_storage):
     """
     Tests that verify is happy with a regular submission file.
 
@@ -158,45 +157,45 @@ def test_verify_regular_submission_in_sourcedir_returns_true(journalist_app, con
         config, 'example-filesystem-id', '1-regular-doc.gz.gpg'
     )
 
-    assert journalist_app.storage.verify(file_path)
+    assert app_storage.verify(file_path)
 
 
 def test_verify_invalid_file_extension_in_sourcedir_raises_exception(
-        journalist_app, config):
+        journalist_app, app_storage, config):
 
     source_directory, file_path = create_file_in_source_dir(
         config, 'example-filesystem-id', 'not_valid.txt'
     )
 
     with pytest.raises(store.PathException) as e:
-        journalist_app.storage.verify(file_path)
+        app_storage.verify(file_path)
 
     assert 'Path not valid in store: {}'.format(file_path) in str(e)
 
 
 def test_verify_invalid_filename_in_sourcedir_raises_exception(
-        journalist_app, config):
+        journalist_app, app_storage, config):
 
     source_directory, file_path = create_file_in_source_dir(
         config, 'example-filesystem-id', 'NOTVALID.gpg'
     )
 
     with pytest.raises(store.PathException) as e:
-        journalist_app.storage.verify(file_path)
+        app_storage.verify(file_path)
         assert e.message == 'Path not valid in store: {}'.format(file_path)
 
 
-def test_get_zip(journalist_app, test_source, config):
+def test_get_zip(journalist_app, test_source, app_storage, config):
     with journalist_app.app_context():
         submissions = utils.db_helper.submit(
-            test_source['source'], 2)
+            app_storage, test_source['source'], 2)
         filenames = [os.path.join(config.STORE_DIR,
                                   test_source['filesystem_id'],
                                   submission.filename)
                      for submission in submissions]
 
         archive = zipfile.ZipFile(
-            journalist_app.storage.get_bulk_archive(submissions))
+            app_storage.get_bulk_archive(submissions))
         archivefile_contents = archive.namelist()
 
     for archived_file, actual_file in zip(archivefile_contents, filenames):
@@ -207,7 +206,7 @@ def test_get_zip(journalist_app, test_source, config):
 
 
 @pytest.mark.parametrize('db_model', [Submission, Reply])
-def test_add_checksum_for_file(config, db_model):
+def test_add_checksum_for_file(config, app_storage, db_model):
     '''
     Check that when we execute the `add_checksum_for_file` function, the database object is
     correctly updated with the actual hash of the file.
@@ -217,15 +216,17 @@ def test_add_checksum_for_file(config, db_model):
     '''
     app = create_app(config)
 
+    test_storage = app_storage
+
     with app.app_context():
         db.create_all()
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
-            source_app_storage=app.storage,
+            source_app_storage=test_storage,
         )
         source = source_user.get_db_record()
-        target_file_path = app.storage.path(source.filesystem_id, '1-foo-msg.gpg')
+        target_file_path = test_storage.path(source.filesystem_id, '1-foo-msg.gpg')
         test_message = b'hash me!'
         expected_hash = 'f1df4a6d8659471333f7f6470d593e0911b4d487856d88c83d2d187afa195927'
 
@@ -233,10 +234,10 @@ def test_add_checksum_for_file(config, db_model):
             f.write(test_message)
 
         if db_model == Submission:
-            db_obj = Submission(source, target_file_path)
+            db_obj = Submission(source, target_file_path, app_storage)
         else:
             journalist, _ = utils.db_helper.init_journalist()
-            db_obj = Reply(journalist, source, target_file_path)
+            db_obj = Reply(journalist, source, target_file_path, app_storage)
 
         db.session.add(db_obj)
         db.session.commit()
@@ -254,7 +255,7 @@ def test_add_checksum_for_file(config, db_model):
 
 
 @pytest.mark.parametrize('db_model', [Submission, Reply])
-def test_async_add_checksum_for_file(config, db_model):
+def test_async_add_checksum_for_file(config, app_storage, db_model):
     '''
     Check that when we execute the `add_checksum_for_file` function, the database object is
     correctly updated with the actual hash of the file.
@@ -269,10 +270,10 @@ def test_async_add_checksum_for_file(config, db_model):
         source_user = create_source_user(
             db_session=db.session,
             source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
-            source_app_storage=app.storage,
+            source_app_storage=app_storage,
         )
         source = source_user.get_db_record()
-        target_file_path = app.storage.path(source.filesystem_id, '1-foo-msg.gpg')
+        target_file_path = app_storage.path(source.filesystem_id, '1-foo-msg.gpg')
         test_message = b'hash me!'
         expected_hash = 'f1df4a6d8659471333f7f6470d593e0911b4d487856d88c83d2d187afa195927'
 
@@ -280,16 +281,16 @@ def test_async_add_checksum_for_file(config, db_model):
             f.write(test_message)
 
         if db_model == Submission:
-            db_obj = Submission(source, target_file_path)
+            db_obj = Submission(source, target_file_path, app_storage)
         else:
             journalist, _ = utils.db_helper.init_journalist()
-            db_obj = Reply(journalist, source, target_file_path)
+            db_obj = Reply(journalist, source, target_file_path, app_storage)
 
         db.session.add(db_obj)
         db.session.commit()
         db_obj_id = db_obj.id
 
-        job = async_add_checksum_for_file(db_obj)
+        job = async_add_checksum_for_file(db_obj, app_storage)
 
     utils.asynchronous.wait_for_redis_worker(job, timeout=5)
 
@@ -299,7 +300,7 @@ def test_async_add_checksum_for_file(config, db_model):
         assert db_obj.checksum == 'sha256:' + expected_hash
 
 
-def test_path_configuration_is_immutable(journalist_app):
+def test_path_configuration_is_immutable(journalist_app, app_storage):
     """
     Check that the store's paths cannot be changed.
 
@@ -309,62 +310,62 @@ def test_path_configuration_is_immutable(journalist_app):
     are prevented.
     """
     with pytest.raises(AttributeError):
-        journalist_app.storage.storage_path = "/foo"
+        app_storage.storage_path = "/foo"
 
-    original_storage_path = journalist_app.storage.storage_path[:]
-    journalist_app.storage.__storage_path = "/foo"
-    assert journalist_app.storage.storage_path == original_storage_path
+    original_storage_path = app_storage.storage_path[:]
+    app_storage.__storage_path = "/foo"
+    assert app_storage.storage_path == original_storage_path
 
     with pytest.raises(AttributeError):
-        journalist_app.storage.shredder_path = "/foo"
+        app_storage.shredder_path = "/foo"
 
-    original_shredder_path = journalist_app.storage.shredder_path[:]
-    journalist_app.storage.__shredder_path = "/foo"
-    assert journalist_app.storage.shredder_path == original_shredder_path
+    original_shredder_path = app_storage.shredder_path[:]
+    app_storage.__shredder_path = "/foo"
+    assert app_storage.shredder_path == original_shredder_path
 
 
-def test_shredder_configuration(journalist_app):
+def test_shredder_configuration(journalist_app, app_storage):
     """
     Ensure we're creating the shredder directory correctly.
 
     We want to ensure that it's a sibling of the store directory, with
     mode 0700.
     """
-    store_path = journalist_app.storage.storage_path
-    shredder_path = journalist_app.storage.shredder_path
+    store_path = app_storage.storage_path
+    shredder_path = app_storage.shredder_path
     assert os.path.dirname(shredder_path) == os.path.dirname(store_path)
     s = os.stat(shredder_path)
     assert stat.S_ISDIR(s.st_mode) is True
     assert stat.S_IMODE(s.st_mode) == 0o700
 
 
-def test_shredder_deletes_symlinks(journalist_app, caplog):
+def test_shredder_deletes_symlinks(journalist_app, app_storage, caplog):
     """
     Confirm that `store.clear_shredder` removes any symlinks in the shredder.
     """
     caplog.set_level(logging.DEBUG)
 
     link_target = "/foo"
-    link = os.path.abspath(os.path.join(journalist_app.storage.shredder_path, "foo"))
+    link = os.path.abspath(os.path.join(app_storage.shredder_path, "foo"))
     os.symlink(link_target, link)
-    journalist_app.storage.clear_shredder()
+    app_storage.clear_shredder()
     assert "Deleting link {} to {}".format(link, link_target) in caplog.text
     assert not os.path.exists(link)
 
 
-def test_shredder_shreds(journalist_app, caplog):
+def test_shredder_shreds(journalist_app, app_storage, caplog):
     """
     Confirm that `store.clear_shredder` removes files.
     """
     caplog.set_level(logging.DEBUG)
 
-    testdir = os.path.abspath(os.path.join(journalist_app.storage.shredder_path, "testdir"))
+    testdir = os.path.abspath(os.path.join(app_storage.shredder_path, "testdir"))
     os.makedirs(testdir)
     testfile = os.path.join(testdir, "testfile")
     with open(testfile, "w") as f:
         f.write("testdata\n")
 
-    journalist_app.storage.clear_shredder()
+    app_storage.clear_shredder()
     assert "Securely deleted file 1/1: {}".format(testfile) in caplog.text
     assert not os.path.isfile(testfile)
     assert not os.path.isdir(testdir)

--- a/securedrop/tests/test_submission_cleanup.py
+++ b/securedrop/tests/test_submission_cleanup.py
@@ -8,16 +8,16 @@ from models import Submission
 from tests import utils
 
 
-def test_delete_disconnected_db_submissions(journalist_app, config):
+def test_delete_disconnected_db_submissions(journalist_app, app_storage, config):
     """
     Test that Submission records without corresponding files are deleted.
     """
     with journalist_app.app_context():
-        source, _ = utils.db_helper.init_source()
+        source, _ = utils.db_helper.init_source(app_storage)
         source_id = source.id
 
         # make two submissions
-        utils.db_helper.submit(source, 2)
+        utils.db_helper.submit(app_storage, source, 2)
         submission_id = source.submissions[0].id
 
         # remove one submission's file
@@ -39,14 +39,14 @@ def test_delete_disconnected_db_submissions(journalist_app, config):
         assert db.session.query(Submission).filter(Submission.source_id == source_id).count() == 1
 
 
-def test_delete_disconnected_fs_submissions(journalist_app, config):
+def test_delete_disconnected_fs_submissions(journalist_app, app_storage, config):
     """
     Test that files in the store without corresponding Submission records are deleted.
     """
-    source, _ = utils.db_helper.init_source()
+    source, _ = utils.db_helper.init_source(app_storage)
 
     # make two submissions
-    utils.db_helper.submit(source, 2)
+    utils.db_helper.submit(app_storage, source, 2)
     source_filesystem_id = source.filesystem_id
     submission_filename = source.submissions[0].filename
     disconnect_path = os.path.join(config.STORE_DIR, source_filesystem_id, submission_filename)
@@ -54,7 +54,7 @@ def test_delete_disconnected_fs_submissions(journalist_app, config):
     # make two replies, to make sure that their files are not seen
     # as disconnects
     journalist, _ = utils.db_helper.init_journalist("Mary", "Lane")
-    utils.db_helper.reply(journalist, source, 2)
+    utils.db_helper.reply(app_storage, journalist, source, 2)
 
     # delete the first Submission record
     db.session.delete(source.submissions[0])


### PR DESCRIPTION
## Status

Ready for review (but test plan TK)

## Description of Changes

Fixes #6154.

This PR updates the application Flask version to 2.0.2 and updates associated dependencies. It also refactors out the app.storage and app.instance_config dynamic attributes and corrects several typing errors, in order to allow for successul static typechecking via mypy.

- Dependency updates:
  - click from 6.7 to 8.0.3
  - flask-babel from 011.2 to 2.0.0
  - flask-wtf from 0.14.2 to 1.0.0
  - Flask from 1.0.2 to 2.0.2
  - itsdangerous from 0.24 to 2.0.1
  - jinja2 from 2.11.3 to 3.0.2
  - markupsafe from 1.1.1 to 2.0.1
  - redis from 3.3.6 to 3.5.3
  - rq from 1.1.0 to 1.10.0
  - werkzeug from 0.16.0 to 2.0.2

### Application refactor:
- Flask app.storage attribute has been removed in favour of a global Storage object, accessed via a `.get_default()` class method that creates the global object if it doesn't already exist, and then returns it.
- Flask app.instance_config attribute has been removed in favour of a global InstanceConfig object, accessed similarly to Storage.
- Numerous typing fixes have been made.
- datetime variables have been updated to be timezone-aware as required by Flask 2.0.2

### Test updates:
Tests have been updated to account for the refactor above. An app_storage fixture was added, returning a function-scoped Storage object. For tests which access storage directly, that fixture was added to their args and references like `current_app.storage.whatever()` were changed to `app_storage.whatever()`. For tests that access storage indirectly (for example, via a test journalist or source application),  the `Storage.get_default()` method must be mocked to return the `app_storage fixture`. This patch has been added in the `source_app` and `journalist_app` fixtures, so it will be applied automatically in tests that use them.

### General notes:
- There a few TODOs not addressed by this PR for various reasons
  - ~The `babel_instance` Flask app dynamic attribute has not been refactored out - it's added by `flask-babel` and an upstream change is probably required~ Fixed in #6220  
  - type checking is disabled for the CSRFError error handlers due to an issue similar to: https://github.com/pallets/flask/issues/4295
  - type checking is [disabled in the generic error handler ](https://github.com/freedomofpress/securedrop/pull/6217/commits/bae4effa98a9f9133fbb215ddbc0f003e97233c5#diff-24b8e3317d6c0ff33dfe29a1c3edfbb95a6ebfac51562e105f9214c55d1e955cR91) - error handling should be updated to remove the use of Flask's internal `app.error_handler_spec` structure
  - during initial testing, it was found that test requirements would override app requirements in the test Docker environment, meaning that updates to app requirements weren't always being applied. As a quick fix, the order in which requirements were installed was switched, so that app requirements would always be applied last. A better fix would be to clean up those requirements files to either keep them in sync or to remove application dependencies from the test requirements files altogether.

## Testing

### Storage-specific tests     
                                  
#### Secure temporary files    
                                                    
- check out this branch and run  `make dev-tor` (some latency will help when observing the tempfile behaviour)                          
- in another teminal, connect to the dev env  with `docker exec -t securedrop-dev-0 bash`                           
- in the dev env, monitor /tmp with `watch -n 1 ls -l /tmp`                                       
- connect to the Source Interface(SI) (you'll find the address listed in docker output just before the applications start) and upload a file greater than 512k.                                
  - [x] confirm that 2 files with a `.aes` extension are written and then deleted as the upload completes (the first is the gzipped initial submission, second is decompressed version)
- (optional) for bonus points, retain both files by adding a `delete=False` argument to the super().__init() in the SecureTemporaryFile class and submitting another file larger than 512k
  - [x] verify that both files contents "look" random. 
  - [x] verify that the size of the first file matches the gzipped size of the submission and the size of the second matches that of the original file.
                                                                                
#### Submissions and replies                                                       
- are files being saved to the right location?                                 
  - check out this branch and run  `make dev`                       
  - in another teminal, connect to the dev env  with `docker exec -t securedrop-dev-0 bash`       
  - in  the SI, start at least 2 source sessions, upload distinct files to both    
  - [x] verify that they were stored to the correct `/var/lib/securedrop/store/<UUID>/` paths for the respective sources
- are they being attributed to the correct source in the JI?                  
  - [x] in the Journalist Interface(JI), verify that the submissions are listed under the correct source page
- are replies only visible to the intended recipient in the SI?               
  - in the JI, reply to both sources                                                     
  - [x] in SI, confirm for each source that they can see their own reply only     
- are they encrypted?                
    - [x] in the JI, download the submissions and confirm that they can be decrypted with the submission key
- are they being deleted correctly (individually, en masse, or as part of a source wipe)
  - [x] delete one source's submissions and replies via the "files and messages" only option, confirm they are no longer present
  - [x] delete an individual submission from another source, confirm that the file was removed from the store
  - [x] delete the source in its entirety, confirm that the source store directory was deleted
- are source store directories being recreated correctly?   
  - in the SI, create another source and submit some docs/messages.                  
  - delete all files and messages from a source while preserving the source itself
  - in the dev env shell, manually delete the source's store directory                    
  - [x] attempt to submit a new doc as that source and confirm that the directory is recreated and the source submission is present
                                                                                
                                                                                
### Instance config tests                            
- check out this branch and run  `make dev`, then log in to the JI                                                 
 - on the **Admin > Instance Config** page, update the instance name.
   - [x] verify that the name is saved successfully and that the JI titles change to reflect it.
   - [x] load the SI and verify that the new name is used there as well.
 - on the **Admin > Instance Config** page, disable file uploads.
   - [x] load the SI and verify that sources only have the option to submit messages, not files.
                                                                                
### End-to-end tests                                                            
-  Perform as much of the [Acceptance Tests section ](https://github.com/freedomofpress/securedrop/wiki/2.1.0-Test-Plan#application-acceptance-testing)of the `2.1.0` test plan as you have time and patience for.
    - [x] verify that acceptance tests pass.
                                                                                
### Upgrade scenario         
- Follow the [upgrade scenario docs](https://docs.securedrop.org/en/stable/development/upgrade_testing.html#upgrade-testing-using-locally-built-packages)  to verify an upgrade from 2.1.0 to locally-built packages.      
  - [ ] verify that the upgrade scenario completes successfully       
  - [ ] verify that basic functionality is available after the upgrade.                                
  
## Deployment

These application changes will be deployed with the next release containing them. There are no schema changes or data migrations, but 2 of the alembic migration scripts were modified to reference the new global Storage object - as such, attention should be paid during testing to QA scenarios involving upgrades to verify that they work as expected.


## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR **TK**

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/securedrop-app-code-requirements.in`

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [x] I would like someone else to do the diff review - given the scope, looking for volunteers. So far we have:
  - [x] click from 6.7 to 8.0.3 - @conorsch
  - [x] flask-babel from 011.2 to 2.0.0 - @cfm
  - [x] flask-wtf from 0.14.2 to 1.0.0 - @zenmonkeykstop
  - [x] Flask from 1.0.2 to 2.0.2 - @zenmonkeykstop
  - [x] itsdangerous from 0.24 to 2.0.1 - @conorsch
  - [x] jinja2 from 2.11.3 to 3.0.2 - @legoktm
  - [x] redis from 3.3.6 to 3.5.3 - @legoktm
  - [x] rq from 1.1.0 to 1.10.0 - @eaon

 
