### PR TITLE
Stop using app.babel_instance

### DIFF
--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -101,7 +101,7 @@ class RequestLocaleInfo:
         return get_locale_identifier(parse_locale(str(self.locale)), sep="-")
 
 
-def configure_babel(config: SDConfig, app: Flask) -> None:
+def configure_babel(config: SDConfig, app: Flask) -> Babel:
     """
     Set up Flask-Babel according to the SecureDrop configuration.
     """
@@ -123,9 +123,10 @@ def configure_babel(config: SDConfig, app: Flask) -> None:
 
     # register the function used to determine the locale of a request
     babel.localeselector(lambda: get_locale(config))
+    return babel
 
 
-def validate_locale_configuration(config: SDConfig, app: Flask) -> None:
+def validate_locale_configuration(config: SDConfig, babel: Babel) -> None:
     """
     Ensure that the configured locales are valid and translated.
     """
@@ -136,7 +137,7 @@ def validate_locale_configuration(config: SDConfig, app: Flask) -> None:
             )
         )
 
-    translations = app.babel_instance.list_translations()
+    translations = babel.list_translations()
     for locale in config.SUPPORTED_LOCALES:
         if locale == "en_US":
             continue
@@ -179,8 +180,8 @@ def map_locale_display_names(config: SDConfig) -> None:
 
 
 def configure(config: SDConfig, app: Flask) -> None:
-    configure_babel(config, app)
-    validate_locale_configuration(config, app)
+    babel = configure_babel(config, app)
+    validate_locale_configuration(config, babel)
     map_locale_display_names(config)
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Using dynamically created properties on `app` hurts our ability to
statically type check these code paths, so we want to move away from
them.

Instead, we can pass the Babel instance we just created to the one place
we've been using `app.babel_instance` for basically the same effect.

This is related to the other changes @zenmonkeykstop has been working on as part of the Flask 2.0 upgrade.

## Testing

* Verify that other locales can be switched to without any regression
* Verify that setting the default to a locale there are no translations for continues to throw an exception
 
## Deployment

I do not think there are any special considerations for deployment.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

Choose one of the following:

- [x] These changes do not require documentation
