### PR TITLE
Get rid of the need to explicitly flush the database session

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -278,8 +278,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
 
             try:
                 db.session.add(reply)
-                db.session.flush()
-                seen_reply = SeenReply(reply_id=reply.id, journalist_id=user.id)
+                seen_reply = SeenReply(reply=reply, journalist=user)
                 db.session.add(seen_reply)
                 db.session.add(source)
                 db.session.commit()

--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -141,8 +141,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         try:
             reply = Reply(g.user, g.source, filename)
             db.session.add(reply)
-            db.session.flush()
-            seen_reply = SeenReply(reply_id=reply.id, journalist_id=g.user.id)
+            seen_reply = SeenReply(reply=reply, journalist=g.user)
             db.session.add(seen_reply)
             db.session.commit()
             store.async_add_checksum_for_file(reply)

--- a/securedrop/loaddata.py
+++ b/securedrop/loaddata.py
@@ -188,12 +188,10 @@ def submit_message(source: Source, journalist_who_saw: Optional[Journalist]) -> 
     )
     submission = Submission(source, fpath)
     db.session.add(submission)
-    db.session.flush()
 
     if journalist_who_saw:
-        seen_message = SeenMessage(message_id=submission.id, journalist_id=journalist_who_saw.id)
+        seen_message = SeenMessage(message=submission, journalist=journalist_who_saw)
         db.session.add(seen_message)
-        db.session.flush()
 
 
 def submit_file(source: Source, journalist_who_saw: Optional[Journalist]) -> None:
@@ -210,12 +208,10 @@ def submit_file(source: Source, journalist_who_saw: Optional[Journalist]) -> Non
     )
     submission = Submission(source, fpath)
     db.session.add(submission)
-    db.session.flush()
 
     if journalist_who_saw:
-        seen_file = SeenFile(file_id=submission.id, journalist_id=journalist_who_saw.id)
+        seen_file = SeenFile(file=submission, journalist=journalist_who_saw)
         db.session.add(seen_file)
-        db.session.flush()
 
 
 def add_reply(
@@ -233,14 +229,13 @@ def add_reply(
     )
     reply = Reply(journalist, source, fname)
     db.session.add(reply)
-    db.session.flush()
 
     # Journalist who replied has seen the reply
-    author_seen_reply = SeenReply(reply_id=reply.id, journalist_id=journalist.id)
+    author_seen_reply = SeenReply(reply=reply, journalist=journalist)
     db.session.add(author_seen_reply)
 
     if journalist_who_saw:
-        other_seen_reply = SeenReply(reply_id=reply.id, journalist_id=journalist_who_saw.id)
+        other_seen_reply = SeenReply(reply=reply, journalist=journalist_who_saw)
         db.session.add(other_seen_reply)
 
     db.session.commit()

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -283,7 +283,7 @@ class Reply(db.Model):
                  journalist: 'Journalist',
                  source: Source,
                  filename: str) -> None:
-        self.journalist_id = journalist.id
+        self.journalist = journalist
         self.source_id = source.id
         self.uuid = str(uuid.uuid4())
         self.filename = filename
@@ -841,7 +841,7 @@ class JournalistLoginAttempt(db.Model):
     journalist_id = Column(Integer, ForeignKey('journalists.id'))
 
     def __init__(self, journalist: Journalist) -> None:
-        self.journalist_id = journalist.id
+        self.journalist = journalist
 
 
 class RevokedToken(db.Model):

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -84,8 +84,7 @@ def reply(journalist, source, num_replies):
         reply = Reply(journalist, source, fname)
         replies.append(reply)
         db.session.add(reply)
-        db.session.flush()
-        seen_reply = SeenReply(reply_id=reply.id, journalist_id=journalist.id)
+        seen_reply = SeenReply(reply=reply, journalist=journalist)
         db.session.add(seen_reply)
 
     db.session.commit()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

From what I can tell, nearly all the calls to db.session.flush() have
been introduced so that a newly created object's autoincrement ID can be
referenced in a second object to be created, most often this is creating
a Reply, and then a corresponding SeenReply.

However, if we just pass the Reply object into SeenReply, rather than
the id (which is None if it hasn't been flushed), SQLAlchemy takes care
of it all for us, properly assigning the correct autoincrement ID using
the specified relationship.

The motivation for doing this is that JournalistLoginAttempt in loaddata
was not properly flushing and was being assigned to a
journalist_id=NULL, which will soon be an error as part of #6192. Rather
than stick another flush in to fix that case, we can just get rid of
nearly all of them.

There is still one explicit flush() left in loaddata.py's
record_source_interaction(), but that's a different pattern than these
so I've left it alone for now.

I am splitting this out of my deleted-journalist work because it ends up touching a pretty different area of code (saving replies) compared to the rest of the branch.

## Testing

* Run loaddata.py, check in the database that there are no journalist_id=NULL being inserted, nor reply_id=NULL.
  * In my deleted-journalist branch there will soon be a migration to make all those fields nullable=False, which is how I tested this, that no exceptions were thrown .
* Leave a reply, observe that it correctly is marked as seen.

## Deployment

No special considerations for deployment.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
