### PR TITLE
Use special "deleted" journalist for associations with deleted users

### DIFF
--- a/securedrop/alembic/versions/2e24fc7536e8_make_journalist_id_non_nullable.py
+++ b/securedrop/alembic/versions/2e24fc7536e8_make_journalist_id_non_nullable.py
@@ -1,0 +1,158 @@
+"""make journalist_id non-nullable
+
+Revision ID: 2e24fc7536e8
+Revises: de00920916bf
+Create Date: 2022-01-12 19:31:06.186285
+
+"""
+from passlib.hash import argon2
+import os
+import pyotp
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+# raise the errors if we're not in production
+raise_errors = os.environ.get("SECUREDROP_ENV", "prod") != "prod"
+
+try:
+    from models import ARGON2_PARAMS
+    from passphrases import PassphraseGenerator
+except:  # noqa
+    if raise_errors:
+        raise
+
+
+# revision identifiers, used by Alembic.
+revision = '2e24fc7536e8'
+down_revision = 'de00920916bf'
+branch_labels = None
+depends_on = None
+
+
+def generate_passphrase_hash() -> str:
+    passphrase = PassphraseGenerator.get_default().generate_passphrase()
+    return argon2.using(**ARGON2_PARAMS).hash(passphrase)
+
+
+def create_deleted() -> int:
+    """manually insert a "deleted" journalist user.
+
+    We need to do it this way since the model will reflect the current state of
+    the schema, not what it is at the current migration step
+
+    It should be basically identical to what Journalist.get_deleted() does
+    """
+    op.execute(sa.text(
+        """\
+        INSERT INTO journalists (uuid, username, session_nonce, passphrase_hash, otp_secret)
+        VALUES (:uuid, "deleted", 0, :passphrase_hash, :otp_secret);
+        """
+    ).bindparams(
+        uuid=str(uuid.uuid4()),
+        passphrase_hash=generate_passphrase_hash(),
+        otp_secret=pyotp.random_base32(),
+    ))
+    # Get the autoincrement ID back
+    conn = op.get_bind()
+    result = conn.execute('SELECT id FROM journalists WHERE username="deleted";').fetchall()
+    return result[0][0]
+
+
+def migrate_nulls():
+    """migrate existing journalist_id=NULL over to deleted or delete them"""
+    op.execute("DELETE FROM journalist_login_attempt WHERE journalist_id IS NULL;")
+    op.execute("DELETE FROM revoked_tokens WHERE journalist_id IS NULL;")
+    # Look to see if we have data to migrate
+    tables = ('replies', 'seen_files', 'seen_messages', 'seen_replies')
+    needs_migration = []
+    conn = op.get_bind()
+    for table in tables:
+        result = conn.execute(f'SELECT 1 FROM {table} WHERE journalist_id IS NULL;').first()  # nosec
+        if result is not None:
+            needs_migration.append(table)
+
+    if not needs_migration:
+        return
+
+    deleted_id = create_deleted()
+    for table in needs_migration:
+        # The seen_ tables have UNIQUE(fk_id, journalist_id), so the deleted journalist can only have
+        # seen each item once. It is possible multiple NULL journalist have seen the same thing so we
+        # do this update in two passes.
+        # First we update as many rows to point to the deleted journalist as possible, ignoring any
+        # unique key violations.
+        op.execute(sa.text(
+            f'UPDATE OR IGNORE {table} SET journalist_id=:journalist_id WHERE journalist_id IS NULL;'
+        ).bindparams(journalist_id=deleted_id))
+        # Then we delete any leftovers which had been ignored earlier.
+        op.execute(f'DELETE FROM {table} WHERE journalist_id IS NULL')  # nosec
+
+
+def upgrade():
+    migrate_nulls()
+
+    with op.batch_alter_table('journalist_login_attempt', schema=None) as batch_op:
+        batch_op.alter_column('journalist_id',
+                              existing_type=sa.INTEGER(),
+                              nullable=False)
+
+    with op.batch_alter_table('replies', schema=None) as batch_op:
+        batch_op.alter_column('journalist_id',
+                              existing_type=sa.INTEGER(),
+                              nullable=False)
+
+    with op.batch_alter_table('revoked_tokens', schema=None) as batch_op:
+        batch_op.alter_column('journalist_id',
+                              existing_type=sa.INTEGER(),
+                              nullable=False)
+
+    with op.batch_alter_table('seen_files', schema=None) as batch_op:
+        batch_op.alter_column('journalist_id',
+                              existing_type=sa.INTEGER(),
+                              nullable=False)
+
+    with op.batch_alter_table('seen_messages', schema=None) as batch_op:
+        batch_op.alter_column('journalist_id',
+                              existing_type=sa.INTEGER(),
+                              nullable=False)
+
+    with op.batch_alter_table('seen_replies', schema=None) as batch_op:
+        batch_op.alter_column('journalist_id',
+                              existing_type=sa.INTEGER(),
+                              nullable=False)
+
+
+def downgrade():
+    # We do not un-migrate the data back to journalist_id=NULL
+
+    with op.batch_alter_table('seen_replies', schema=None) as batch_op:
+        batch_op.alter_column('journalist_id',
+                              existing_type=sa.INTEGER(),
+                              nullable=True)
+
+    with op.batch_alter_table('seen_messages', schema=None) as batch_op:
+        batch_op.alter_column('journalist_id',
+                              existing_type=sa.INTEGER(),
+                              nullable=True)
+
+    with op.batch_alter_table('seen_files', schema=None) as batch_op:
+        batch_op.alter_column('journalist_id',
+                              existing_type=sa.INTEGER(),
+                              nullable=True)
+
+    with op.batch_alter_table('revoked_tokens', schema=None) as batch_op:
+        batch_op.alter_column('journalist_id',
+                              existing_type=sa.INTEGER(),
+                              nullable=True)
+
+    with op.batch_alter_table('replies', schema=None) as batch_op:
+        batch_op.alter_column('journalist_id',
+                              existing_type=sa.INTEGER(),
+                              nullable=True)
+
+    with op.batch_alter_table('journalist_login_attempt', schema=None) as batch_op:
+        batch_op.alter_column('journalist_id',
+                              existing_type=sa.INTEGER(),
+                              nullable=True)

--- a/securedrop/loaddata.py
+++ b/securedrop/loaddata.py
@@ -382,7 +382,7 @@ def load(args: argparse.Namespace) -> None:
 
         # delete one journalist
         _, _, journalist_to_be_deleted = journalists
-        db.session.delete(journalist_to_be_deleted)
+        journalist_to_be_deleted.delete()
         db.session.commit()
 
 

--- a/securedrop/tests/migrations/migration_2e24fc7536e8.py
+++ b/securedrop/tests/migrations/migration_2e24fc7536e8.py
@@ -1,0 +1,113 @@
+import uuid
+
+from sqlalchemy import text
+
+from db import db
+from journalist_app import create_app
+from .helpers import random_datetime
+
+
+class UpgradeTester:
+    """Insert a Reply, SeenReply and JournalistLoginAttempt with journalist_id=NULL.
+    Verify that the first two are reassociated to the "Deleted" user, while the last
+    is deleted outright.
+    """
+
+    def __init__(self, config):
+        """This function MUST accept an argument named `config`.
+           You will likely want to save a reference to the config in your
+           class, so you can access the database later.
+        """
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        """This function loads data into the database and filesystem. It is
+           executed before the upgrade.
+        """
+        with self.app.app_context():
+            params = {
+                'uuid': str(uuid.uuid4()),
+                'journalist_id': None,
+                'source_id': 0,
+                'filename': 'dummy.txt',
+                'size': 1,
+                'checksum': '',
+                'deleted_by_source': False,
+            }
+            sql = """\
+                INSERT INTO replies (uuid, journalist_id, source_id, filename,
+                    size, checksum, deleted_by_source)
+                 VALUES (:uuid, :journalist_id, :source_id, :filename,
+                        :size, :checksum, :deleted_by_source);"""
+            db.engine.execute(text(sql), **params)
+            # Insert two SeenReplys corresponding to the just-inserted reply, which also
+            # verifies our handling of duplicate keys.
+            for _ in range(2):
+                db.engine.execute(text(
+                    """\
+                    INSERT INTO seen_replies (reply_id, journalist_id)
+                    VALUES (1, NULL);
+                    """
+                ))
+            # Insert a JournalistLoginAttempt
+            db.engine.execute(text(
+                """\
+                INSERT INTO journalist_login_attempt (timestamp, journalist_id)
+                VALUES (:timestamp, NULL)
+                """
+            ), timestamp=random_datetime(nullable=False))
+
+    def check_upgrade(self):
+        """This function is run after the upgrade and verifies the state
+           of the database or filesystem. It MUST raise an exception if the
+           check fails.
+        """
+        with self.app.app_context():
+            deleted = db.engine.execute(
+                'SELECT id, passphrase_hash, otp_secret FROM journalists WHERE username="deleted"'
+            ).first()
+            # A passphrase_hash is set
+            assert deleted[1].startswith('$argon2')
+            # And a TOTP secret is set
+            assert len(deleted[2]) == 32
+            deleted_id = deleted[0]
+            replies = db.engine.execute(
+                text('SELECT journalist_id FROM replies')).fetchall()
+            assert len(replies) == 1
+            # And the journalist_id matches our "deleted" one
+            assert replies[0][0] == deleted_id
+            seen_replies = db.engine.execute(
+                text('SELECT journalist_id FROM seen_replies')).fetchall()
+            assert len(seen_replies) == 1
+            # And the journalist_id matches our "deleted" one
+            assert seen_replies[0][0] == deleted_id
+            login_attempts = db.engine.execute(
+                text('SELECT * FROM journalist_login_attempt')).fetchall()
+            # The NULL login attempt was deleted outright
+            assert login_attempts == []
+
+
+class DowngradeTester:
+    """Downgrading only makes fields nullable again, which is a
+    non-destructive and safe operation"""
+
+    def __init__(self, config):
+        """This function MUST accept an argument named `config`.
+           You will likely want to save a reference to the config in your
+           class, so you can access the database later.
+        """
+        self.config = config
+
+    def load_data(self):
+        """This function loads data into the database and filesystem. It is
+           executed before the downgrade.
+        """
+        pass
+
+    def check_downgrade(self):
+        """This function is run after the downgrade and verifies the state
+           of the database or filesystem. It MUST raise an exception if the
+           check fails.
+        """
+        pass

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -488,9 +488,9 @@ def test_authorized_user_can_get_single_reply(journalist_app, test_files,
         assert response.json['journalist_uuid'] == \
             reply.journalist.uuid
         assert response.json['journalist_first_name'] == \
-            reply.journalist.first_name
+            (reply.journalist.first_name or '')
         assert response.json['journalist_last_name'] == \
-            reply.journalist.last_name
+            (reply.journalist.last_name or '')
         assert response.json['is_deleted_by_source'] is False
         assert response.json['filename'] == \
             test_files['source'].replies[0].filename
@@ -508,12 +508,12 @@ def test_reply_of_deleted_journalist(journalist_app,
                                    source_uuid=uuid,
                                    reply_uuid=reply_uuid),
                            headers=get_api_headers(journalist_api_token))
-
+        deleted_uuid = Journalist.get_deleted().uuid
         assert response.status_code == 200
 
         assert response.json['uuid'] == reply_uuid
         assert response.json['journalist_username'] == "deleted"
-        assert response.json['journalist_uuid'] == "deleted"
+        assert response.json['journalist_uuid'] == deleted_uuid
         assert response.json['journalist_first_name'] == ""
         assert response.json['journalist_last_name'] == ""
         assert response.json['is_deleted_by_source'] is False

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -51,7 +51,7 @@ def delete_journalist(journalist):
 
     :returns: None
     """
-    db.session.delete(journalist)
+    journalist.delete()
     db.session.commit()
 
 


### PR DESCRIPTION
## Status

Ready for review. Note that this depends on #6223 to work properly.

## Description of Changes

Currently when a journalist is deleted, most referential tables are
updated with `journalist_id=NULL`, forcing all clients to accomodate
that case. Instead, we are now going to either re-associate those rows
with a special "deleted" journalist account, or delete them outright.
All journalist_id columns are now NOT NULL to enforce this.

Tables with rows migrated to "deleted":
* replies
* seen_files
* seen_messages
* seen_replies

Tables with rows that are deleted outright:
* journalist_login_attempt
* revoked_tokens

The "deleted" journalist account is a real account that exists in the
database, but cannot be logged into and has no passphase set. It is not
possible to delete it nor is it shown in the admin listing of
journalists. It is lazily created on demand using a special
DeletedJournalist subclass that bypasses username and passphrase
validation.

Because we now have a real user to reference, the api.single_reply
endpoint will return a real UUID instead of the "deleted" placeholder.

Journalist objects must now be deleted by calling the new delete()
function on them. Trying to directly `db.session.delete(journalist)`
will most likely fail with an Exception because of rows that weren't
migrated first.

The migration step looks for any existing rows in those tables with
journalist_id=NULL and either migrates them to "deleted" or deletes
them. Then all the columns are changed to be NOT NULL.

Fixes #6192.

## Testing

* Start the dev environment, which calls loaddata.py. Doing so creates a journalist ("clarkkent"), adds some replies, and then immediately deletes it
* Using the same dev environment, visit the admin page and notice that no "deleted" journalist is shown.
* Create a journalist, login as them, have them reply, then delete them (so journalist_id=NULL exists in the DB). Then apply this patch, run the upgrader and observe in the DB that a "deleted" user is created and all the replies, seen_* rows have been updated to point to it
*  Hit the API single_reply endpoint and see that you still get "deleted" for username but a real UUID

## Deployment

This has a schema change and data migration for existing installs.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation (correct me if I'm wrong please)
