### PR TITLE
Don't register trigger on Python for securedrop-app-code package

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/defaults/main.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/defaults/main.yml
@@ -46,7 +46,3 @@ securedrop_venv: "/opt/venvs/securedrop-app-code"
 securedrop_venv_bin: "{{ securedrop_venv }}/bin"
 securedrop_python_version: "{{ '3.8' if securedrop_target_distribution == 'focal' else '3.5' }}"
 securedrop_venv_site_packages: "{{ securedrop_venv }}/lib/python{{ securedrop_python_version }}/site-packages"
-
-securedrop_app_focal_files:
-  - src: securedrop-app-code.triggers-focal
-    dest: "{{ securedrop_app_code_prep_dir }}/debian/securedrop-app-code.triggers"

--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/securedrop-app-code.triggers-focal
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/securedrop-app-code.triggers-focal
@@ -1,7 +1,0 @@
-# Register interest in Python interpreter changes; and
-# don't make the Python package dependent on the virtualenv package
-# processing (noawait)
-interest-noawait /usr/bin/python3.8
-
-# Also provide a symbolic trigger for all dh-virtualenv packages
-interest dh-virtualenv-interpreter-update

--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/main.yml
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/tasks/main.yml
@@ -60,13 +60,6 @@
     src: "changelog-{{ securedrop_target_distribution }}"
     dest: "{{ securedrop_app_code_prep_dir }}/debian/changelog"
 
-- name: Replace the files required for focal package
-  copy:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-  with_items: "{{ securedrop_app_focal_files }}"
-  when: securedrop_target_distribution == "focal"
-
 - name: Create the control file based on distribution
   template:
     src: "control.j2"

--- a/install_files/securedrop-app-code/debian/postinst
+++ b/install_files/securedrop-app-code/debian/postinst
@@ -243,7 +243,7 @@ case "$1" in
 
     ;;
 
-    abort-upgrade|abort-remove|abort-deconfigure)
+    abort-upgrade|abort-remove|abort-deconfigure|triggered)
     ;;
 
     *)

--- a/install_files/securedrop-app-code/debian/securedrop-app-code.triggers
+++ b/install_files/securedrop-app-code/debian/securedrop-app-code.triggers
@@ -1,7 +1,0 @@
-# Register interest in Python interpreter changes; and
-# don't make the Python package dependent on the virtualenv package
-# processing (noawait)
-interest-noawait /usr/bin/python3.5
-
-# Also provide a symbolic trigger for all dh-virtualenv packages
-interest dh-virtualenv-interpreter-update


### PR DESCRIPTION
## Status

Ready for review, but untested

## Description of Changes

Don't register trigger on Python for securedrop-app-code package
    
We currently register a trigger with the Python
interpreter so dh_virtualenv can fix up the interpreter's symlinks
in case something changes as recommended in their docs[1].
    
However, our packages are designed for a single Ubuntu release, which
keeps the same version of Python for its entire lifetime, so the
interpreter in the venv will always be a symlink to `/usr/bin/python3`
and the dh_virtualenv postinst code will always be a no-op because it
skips all symlinks.
    
This was noticed because our custom postinst was not handling the
"triggered" state, which is valid per deb-postinst(5). Add that in for
future proofing even though we don't expect it to be called

[1] https://dh-virtualenv.readthedocs.io/en/latest/tutorial.html?highlight=trigger#step-2-set-up-packaging-for-your-project

Fixes #6230.

Changes proposed in this pull request:

## Testing

* Install an older version of Python 3 (grab an old Ubuntu container maybe?)
* Install old or currently released securedrop-app-code package
* Build new securedrop-app-code package with this patch
* Install new securedrop-app-code package
* Upgrade Python 3 package
* Observe no error message related to triggers being unrecognized.
* Observe no triggers run (no "Processing triggers for securedrop-app-code...")

Alternatively I think you can directly run the trigger with something like `dpkg-trigger --by-package python3.8 /usr/bin/python3.8`

## Deployment

This will remove the trigger behavior entirely, which should be a no-op because it was broken until now.

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
- [ ] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
