### PR TITLE
Use Rust 1.58.1 in builder

### DIFF
--- a/molecule/builder-focal/Dockerfile
+++ b/molecule/builder-focal/Dockerfile
@@ -41,7 +41,7 @@ COPY dh-virtualenv.pref /etc/apt/preferences.d/
 
 RUN apt-get update && apt-get install -y dh-virtualenv
 
-ENV RUST_VERSION 1.56.1
+ENV RUST_VERSION 1.58.1
 
 # Install Rust for building cryptography
 RUN TMPDIR=`mktemp -d` && cd ${TMPDIR} \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

From the official advisory[1] for CVE-2022-21658:

> The Rust Security Response WG was notified that the std::fs::remove_dir_all
> standard library function is vulnerable to a race condition enabling symlink
> following (CWE-363). An attacker could use this security issue to trick a
> privileged program into deleting files and directories the attacker
> couldn't otherwise access or delete.

We only use/need Rust to build the Python crytography package which does not
use this vulnerable function but upgrade anyways as a best practice.

[1] https://blog.rust-lang.org/2022/01/20/cve-2022-21658.html

## Testing

- [x] Verify cryptography package builds using Rust 1.58.1

## Deployment

No special considerations.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] These changes do not require documentation
