### PR TITLE
adds "skip to main content" link to all pages that inherit from base templates

### DIFF
--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -20,6 +20,7 @@
 
   {% if g.user %}
   <nav aria-label="{{ gettext('Navigation') }}">
+    <a href="#main" class="visually-hidden until-focus">{{ gettext('Skip to main content') }}</a>
     {{ gettext('Logged on as') }}
     <a href="{{ url_for('account.edit') }}" id="link-edit-account">{{ g.user.username }}</a> |
     {% if g.user and g.user.is_admin %}
@@ -42,7 +43,7 @@
         <div class="flash-panel">
           {% include 'flashed.html' %}
         </div>
-        <main>
+        <main id="main" tabindex="-1">
 
           {% block body %}{% endblock %}
         </main>

--- a/securedrop/sass/modules/_visually-hidden.sass
+++ b/securedrop/sass/modules/_visually-hidden.sass
@@ -5,3 +5,6 @@
     left: -999rem
   &:dir(rtl)
     right: -999rem
+
+  &.until-focus:focus
+    position: revert

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -21,6 +21,7 @@
   <div class="content">
     <div class="container">
       <header>
+        <a href="#main" class="visually-hidden until-focus">{{ gettext('Skip to main content') }}</a>
         {% block header %}
         <a href="{% if is_user_logged_in %}{{ url_for('main.lookup') }}{% else %}{{ url_for('main.index') }}{% endif %}"
           class="no-bottom-border">
@@ -30,7 +31,7 @@
         {% endblock %}
       </header>
 
-      <main>
+      <main id="main" tabindex="-1">
         {% if g.show_offline_message %}
         <section>
           <h1>{{ gettext("We're sorry, our SecureDrop is currently offline.") }}</h1>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #5972, adds a "skip to main content link" to all pages that inherit from base templates.

## Testing

1. Log into the Source Interface.
2. Observe that there is no "Skip to main content link" visible.
3. Tab through the page, with or without a screen-reader running.
4. Observe that the "Skip to main content link" appears when it receives focus.
5. Click the link and continue tabbing through the `main` content.
6. Repeat steps (1)–(5) on the Journalist Interface.

## Deployment

No deployment considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container