### PR TITLE
adds `aria-{invalid,describedby}` annotations for WTForms validation errors

### DIFF
--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -105,6 +105,7 @@ def create_app(config: 'SDConfig') -> Flask:
     app.jinja_env.filters['filesizeformat'] = template_filters.filesizeformat
     app.jinja_env.filters['html_datetime_format'] = \
         template_filters.html_datetime_format
+    app.jinja_env.add_extension('jinja2.ext.do')
 
     @app.before_first_request
     def expire_blacklisted_tokens() -> None:

--- a/securedrop/journalist_templates/admin_add_user.html
+++ b/securedrop/journalist_templates/admin_add_user.html
@@ -11,10 +11,16 @@
     <div class="container flex-end">
       <div>
         <label for="username">{{ gettext('Username') }}</label>
-        {{ form.username() }}
+        {% set aria_attributes = {} %}
+        {% if form.username.errors %}
+        {% set _dummy = aria_attributes.update({'aria-describedby': 'username-errors', 'aria-invalid': 'true'}) %}
+        {% endif %}
+        {{ form.username(**aria_attributes) }}
+        <span id="username-errors">
         {% for error in form.username.errors %}
         <span class="form-validation-error" role="alert">{{ error }}</span>
         {% endfor %}
+        </span>
       </div>
       <div>
         <ul id="username-notes" class="journalist-username__notes">
@@ -26,17 +32,29 @@
     <div class="container flex-end">
       <div>
         <label for="first_name">{{ gettext('First name') }}</label>
-        {{ form.first_name() }}
+        {% set aria_attributes = {} %}
+        {% if form.first_name.errors %}
+        {% set _dummy = aria_attributes.update({'aria-describedby': 'first-name-errors', 'aria-invalid': 'true'}) %}
+        {% endif %}
+        {{ form.first_name(**aria_attributes) }}
+        <span id="first-name-errors">
         {% for error in form.first_name.errors %}
         <span class="form-validation-error" role="alert">{{ error }}</span>
         {% endfor %}
+        </span>
       </div>
       <div>
         <label for="last_name">{{ gettext('Last name') }}</label>
-        {{ form.last_name() }}
+        {% set aria_attributes = {} %}
+        {% if form.last_name.errors %}
+        {% set _dummy = aria_attributes.update({'aria-describedby': 'last-name-errors', 'aria-invalid': 'true'}) %}
+        {% endif %}
+        {{ form.last_name(**aria_attributes) }}
+        <span id="last-name-errors">
         {% for error in form.last_name.errors %}
         <span class="form-validation-error" role="alert">{{ error }}</span>
         {% endfor %}
+        </span>
       </div>
       <div>
         <ul id="name-notes" class="journalist-username__notes">
@@ -46,20 +64,32 @@
     </div>
     <p>{{ gettext("The user's password will be:") }} <mark class="password" id="password">{{ password }}</mark></p>
     <div>
-      {{ form.is_admin(id="is-admin") }}
+      {% set aria_attributes = {} %}
+      {% if form.is_admin.errors %}
+      {% set _dummy = aria_attributes.update({'aria-describedby': 'is-admin-errors', 'aria-invalid': 'true'}) %}
+      {% endif %}
+      {{ form.is_admin(id="is-admin", **aria_attributes) }}
       <label for="is-admin">{{ gettext('Is Admin') }}</label>
+      <span id="is-admin-errors">
       {% for error in form.is_admin.errors %}
       <span class="form-validation-error" role="alert">{{ error }}</span>
       {% endfor %}
+      </span>
     </div>
     <div>
-      {{ form.is_hotp(id="is-hotp") }}
+      {% set aria_attributes = {} %}
+      {% if form.is_hotp.errors or form.otp_secret.errors %}
+      {% set _dummy = aria_attributes.update({'aria-describedby': 'otp-errors', 'aria-invalid': 'true'}) %}
+      {% endif %}
+      {{ form.is_hotp(id="is-hotp", **aria_attributes) }}
       <label for="is-hotp">{{ gettext("Is using a YubiKey [HOTP]") }} </label>
       <label for="otp_secret" class="visually-hidden">{{ gettext('HOTP Secret') }}</label>
-      {{ form.otp_secret(placeholder=gettext('HOTP Secret'), size="60") }}
+      {{ form.otp_secret(placeholder=gettext('HOTP Secret'), size="60", **aria_attributes) }}
+      <span id="otp-errors">
       {% for error in form.is_hotp.errors + form.otp_secret.errors %}
-      <span class="form-validation-error" role="alert">{{ error }}</span><br>
+      <span class="form-validation-error" role="alert">{{ error }}</span>
       {% endfor %}
+      </span>
     </div>
     <button type="submit" class="icon icon-plus" aria-label="{{ gettext('Add User') }}">
       {{ gettext('ADD USER') }}

--- a/securedrop/journalist_templates/admin_add_user.html
+++ b/securedrop/journalist_templates/admin_add_user.html
@@ -13,7 +13,7 @@
         <label for="username">{{ gettext('Username') }}</label>
         {% set aria_attributes = {} %}
         {% if form.username.errors %}
-        {% set _dummy = aria_attributes.update({'aria-describedby': 'username-errors', 'aria-invalid': 'true'}) %}
+        {% do aria_attributes.update({'aria-describedby': 'username-errors', 'aria-invalid': 'true'}) %}
         {% endif %}
         {{ form.username(**aria_attributes) }}
         <span id="username-errors">
@@ -34,7 +34,7 @@
         <label for="first_name">{{ gettext('First name') }}</label>
         {% set aria_attributes = {} %}
         {% if form.first_name.errors %}
-        {% set _dummy = aria_attributes.update({'aria-describedby': 'first-name-errors', 'aria-invalid': 'true'}) %}
+        {% do aria_attributes.update({'aria-describedby': 'first-name-errors', 'aria-invalid': 'true'}) %}
         {% endif %}
         {{ form.first_name(**aria_attributes) }}
         <span id="first-name-errors">
@@ -47,7 +47,7 @@
         <label for="last_name">{{ gettext('Last name') }}</label>
         {% set aria_attributes = {} %}
         {% if form.last_name.errors %}
-        {% set _dummy = aria_attributes.update({'aria-describedby': 'last-name-errors', 'aria-invalid': 'true'}) %}
+        {% do aria_attributes.update({'aria-describedby': 'last-name-errors', 'aria-invalid': 'true'}) %}
         {% endif %}
         {{ form.last_name(**aria_attributes) }}
         <span id="last-name-errors">
@@ -66,7 +66,7 @@
     <div>
       {% set aria_attributes = {} %}
       {% if form.is_admin.errors %}
-      {% set _dummy = aria_attributes.update({'aria-describedby': 'is-admin-errors', 'aria-invalid': 'true'}) %}
+      {% do aria_attributes.update({'aria-describedby': 'is-admin-errors', 'aria-invalid': 'true'}) %}
       {% endif %}
       {{ form.is_admin(id="is-admin", **aria_attributes) }}
       <label for="is-admin">{{ gettext('Is Admin') }}</label>
@@ -79,7 +79,7 @@
     <div>
       {% set aria_attributes = {} %}
       {% if form.is_hotp.errors or form.otp_secret.errors %}
-      {% set _dummy = aria_attributes.update({'aria-describedby': 'otp-errors', 'aria-invalid': 'true'}) %}
+      {% do aria_attributes.update({'aria-describedby': 'otp-errors', 'aria-invalid': 'true'}) %}
       {% endif %}
       {{ form.is_hotp(id="is-hotp", **aria_attributes) }}
       <label for="is-hotp">{{ gettext("Is using a YubiKey [HOTP]") }} </label>

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -85,6 +85,7 @@ def create_app(config: SDConfig) -> Flask:
     app.jinja_env.filters['filesizeformat'] = template_filters.filesizeformat
     app.jinja_env.filters['html_datetime_format'] = \
         template_filters.html_datetime_format
+    app.jinja_env.add_extension('jinja2.ext.do')
 
     for module in [main, info, api]:
         app.register_blueprint(module.make_blueprint(config))  # type: ignore

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -11,7 +11,7 @@
   <div class="center">
     {% set aria_attributes = {'aria-label': gettext('Enter your codename'), 'aria-required': 'true'} %}
     {% if form.codename.errors %}
-    {% set _dummy = aria_attributes.update({'aria-describedby': 'flashed login-with-existing-code-name-errors', 'aria-invalid': 'true'}) %}
+    {% do aria_attributes.update({'aria-describedby': 'flashed login-with-existing-code-name-errors', 'aria-invalid': 'true'}) %}
     {% endif %}
     {{ form.codename(id='login-with-existing-codename', class='codename-box', autocomplete='off', placeholder=gettext('Enter your codename'), autofocus=True, **aria_attributes) }}
     {% if form.codename.errors %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #6238 (towards #5972) by adding `aria-invalid` and `aria-describedby` annotations where possible for validated WTForms-based forms.  This is admittedly a pretty minor improvement; see #6238 for details on all the places where even this improvement is either not applicable or not possible in the current interfaces of the Source and Journalist Interfaces.

## Testing

1. Log in to the Journalist Interface as an administrator.
2. Begin adding a user and enter invalid values for each field.
3. Click **Add User**.
4. When the form comes back with validation errors, view source and observe that each invalid field is marked `aria-invalid` and has an `aria-describedby` annotation pointing to its validation errors.  (These annotations will also be used by assistive tech.)

## Deployment

No deployment considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container