### PR TITLE
Updated expected grsec kernel version to 5.15.18

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -39,8 +39,8 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder-focal/tests/vars.yml
 securedrop_pkg_grsec_focal:
-  ver: "5.4.136"
-  depends: "linux-image-5.4.136-grsec-securedrop,intel-microcode"
+  ver: "5.15.18"
+  depends: "linux-image-5.15.18-grsec-securedrop,intel-microcode"
 
 # Mostly useful for local package installation
 grsec_version: "{{ securedrop_pkg_grsec_focal.ver }}"

--- a/molecule/builder-focal/tests/vars.yml
+++ b/molecule/builder-focal/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "2.2.0~rc1"
 ossec_version: "3.6.0"
 keyring_version: "0.1.5"
 config_version: "0.1.4"
-grsec_version_focal: "5.4.136"
+grsec_version_focal: "5.15.18"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -179,6 +179,6 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt.freedom.press"
-grsec_version_focal: "5.4.136"
+grsec_version_focal: "5.15.18"
 
 daily_reboot_time: "4"

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -178,4 +178,4 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt.freedom.press"
-grsec_version_focal: "5.4.136"
+grsec_version_focal: "5.15.18"

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -186,6 +186,6 @@ log_events_with_ossec_alerts:
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
 
-grsec_version_focal: "5.4.136"
+grsec_version_focal: "5.15.18"
 
 daily_reboot_time: "4"

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -215,6 +215,6 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
-grsec_version_focal: "5.4.136"
+grsec_version_focal: "5.15.18"
 
 daily_reboot_time: "4"


### PR DESCRIPTION
## Status

Ready for review (requires merge of https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/130 before release)

## Description of Changes

Fixes #6170 .

Adds 5.15.18 grsec kernel, with the `igc` module enabled to support 11th-gen NUCs

## Testing
 
### installing via dpkg 
- provision a prod instance (hardware preferred, VMs fine)
- grab the `linux-headers-5.15.18-grsec-securedrop_5.15.18-grsec-securedrop-1_amd64.deb` and `linux-image-5.15.18-grsec-securedrop_5.15.18-grsec-securedrop-1_amd64.deb` debs  from apt-test.freedom.press.
- transfer the kernels to app and mon
- install via `sudo dpkg -i linux-headers-5.15.18-grsec-securedrop_5.15.18-grsec-securedrop-1_amd64.deb && sudo dpkg -i linux-image-5.15.18-grsec-securedrop_5.15.18-grsec-securedrop-1_amd64.deb`
- reboot the servers

### testing via metapackage
- provision a prod VM install on latest release (2.1.0)
- check out this branch and `make build-debs`
- grab the `linux-headers-5.15.18-grsec-securedrop_5.15.18-grsec-securedrop-1_amd64.deb` and `linux-image-5.15.18-grsec-securedrop_5.15.18-grsec-securedrop-1_amd64.deb` debs  from apt-test.freedom.press.
- copy the header and image debs to `securedrop/build/focal`
- use the [upgrade scenario docs](https://docs.securedrop.org/en/stable/development/upgrade_testing.html) to upgrade the VM install using the locally-built packages.
- reboot servers after the upgrade

### validating the kernel
- [ ] confirm that the system boots, and that `uname -r` returns the expected kernel
- [ ] install paxtest and run `sudo paxtest blackhat`, confirm that values are comparable to previous kernels
- [ ] grab the meltdown check script from https://meltdown.ovh and verify that the kernel is not vulnerable to known exploits. 

## Deployment
As this is a non-patch-level kernel change, it should be validated on all supported hardware and on as much deprecated or unofficially-supported hardware as possible. Release docs should flag the kernel change and include instructions on how to downgrade to the previous version if needed.

## Checklist

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
