### PR TITLE
Properly register "pagelayout" marker with pytest

### DIFF
--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -65,4 +65,5 @@ pytest \
     --cov-report "xml:${TEST_RESULTS}/cov.xml" \
     --cov-report "annotate:${TEST_RESULTS}/cov_annotate" \
     --cov=. \
+    --strict-markers \
     "$@"

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -66,6 +66,10 @@ def pytest_addoption(parser):
                      default=False, help="run page layout tests")
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "pagelayout: Tests which verify page layout")
+
+
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--page-layout"):
         return

--- a/securedrop/tests/pageslayout/test_source_layout_torbrowser.py
+++ b/securedrop/tests/pageslayout/test_source_layout_torbrowser.py
@@ -15,12 +15,15 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import pytest
+
 from tests.functional import journalist_navigation_steps
 from tests.functional import source_navigation_steps
 from tests.functional.functional_test import TORBROWSER
 from . import functional_test
 
 
+@pytest.mark.pagelayout
 class TestSourceLayoutTorbrowser(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationStepsMixin,

--- a/securedrop/tests/pytest.ini
+++ b/securedrop/tests/pytest.ini
@@ -2,4 +2,4 @@
 log_format = %(created)f %(asctime)s %(lineno)4d:%(filename)-25s %(levelname)s %(message)s
 testpaths = . functional
 usefixtures = setUpTearDown
-addopts = --cov=../securedrop/
+addopts = --cov=../securedrop/ --strict-markers


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This gets rid of warnings like:

```
tests/pageslayout/test_journalist.py:25
.../securedrop/securedrop/tests/pageslayout/test_journalist.py:25:
PytestUnknownMarkWarning: Unknown pytest.mark.pagelayout - is this a
typo?  You can register custom marks to avoid this warning - for
details, see https://docs.pytest.org/en/stable/mark.html
    @pytest.mark.pagelayout
```

Our `--page-layout` parameter setup now matches the example from
<https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option>.

While we're at it, run pytest with the `--strict-markers` flag so if a new
marker is added without properly registering it, it'll fail right away.

## Testing

- [ ] Run tests and see that the PytestUnknownMarkWarnings are gone
- [ ] Run `./securedrop/bin/dev-shell bin/run-test --markers` and see "@pytest.mark.pagelayout: ..." in the output
- [ ] Run `./securedrop/bin/dev-shell bin/run-test -m pagelayout` and see it only runs tests marked as pagelayout
- [ ] Comment out the newly added pytest_configure function and observe that pytest fails when collecting tests because we use `--strict-markers` and didn't register it

## Deployment

No special considerations for deployment.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
