### PR TITLE
Updates for flask and jinja deprecations

### DIFF
--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -241,7 +241,7 @@ def download(
     return send_file(
         zf.name,
         mimetype="application/zip",
-        attachment_filename=attachment_filename,
+        download_name=attachment_filename,
         as_attachment=True,
     )
 
@@ -504,7 +504,7 @@ def serve_file_with_etag(db_obj: Union[Reply, Submission]) -> flask.Response:
     response = send_file(file_path,
                          mimetype="application/pgp-encrypted",
                          as_attachment=True,
-                         add_etags=False)  # Disable Flask default ETag
+                         etag=False)  # Disable Flask default ETag
 
     if not db_obj.checksum:
         add_checksum_for_file(db.session, db_obj, file_path)

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives.kdf import scrypt
 from flask import current_app, url_for
 from flask_babel import gettext, ngettext
 from itsdangerous import TimedJSONWebSignatureSerializer, BadData
-from jinja2 import Markup
+from markupsafe import Markup
 from passlib.hash import argon2
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import relationship, backref, Query, RelationshipProperty

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -7,7 +7,6 @@ from flask import (Flask, render_template, escape, flash, Markup, request, g, se
 from flask_babel import gettext
 from flask_assets import Environment
 from flask_wtf.csrf import CSRFProtect, CSRFError
-from jinja2 import evalcontextfilter
 from os import path
 from typing import Tuple
 
@@ -80,7 +79,7 @@ def create_app(config: SDConfig) -> Flask:
     app.jinja_env.globals['submission_key_fpr'] = config.JOURNALIST_KEY
     app.jinja_env.filters['rel_datetime_format'] = \
         template_filters.rel_datetime_format
-    app.jinja_env.filters['nl2br'] = evalcontextfilter(template_filters.nl2br)
+    app.jinja_env.filters['nl2br'] = template_filters.nl2br
     app.jinja_env.filters['filesizeformat'] = template_filters.filesizeformat
     app.jinja_env.filters['html_datetime_format'] = \
         template_filters.html_datetime_format

--- a/securedrop/template_filters.py
+++ b/securedrop/template_filters.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
+from jinja2 import pass_eval_context
 from flask_babel import gettext, get_locale
 from babel import units, dates
 from datetime import datetime
-from jinja2 import Markup, escape
+from markupsafe import Markup, escape
 import math
 
 from jinja2.nodes import EvalContext
@@ -21,6 +22,7 @@ def rel_datetime_format(
         return dates.format_datetime(dt, fmt, locale=get_locale())
 
 
+@pass_eval_context
 def nl2br(context: EvalContext, value: str) -> str:
     formatted = '<br>\n'.join(escape(value).split('\n'))
     if context.autoescape:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Update deprecated/renamed parameters in `flask.send_file()`  
   * `attachment_filename` is now `download_name`
   * `add_etags` is now `etag`
   * See <https://flask.palletsprojects.com/en/2.0.x/api/#flask.send_file>.
* Update for jinja deprecations
   * `Markup` and `escape` must be imported from markupsafe directly, they
      were already internally imported from there by jinja.
   * `evalcontextfilter` was renamed to `pass_eval_context`. Apply it
      directly on the filter itself as a decorator for ease of use and
      to match the style in the jinja documentation (<https://jinja.palletsprojects.com/en/3.0.x/api/#custom-filters>).


## Testing

These changes are pretty trivial, it's easy to trace in the jinja/flask code that these are simple renames and shouldn't affect functionality.

* From the journalist UI, send a message to a source with newlines and HTML tags. View the message in the source UI and see that the newlines are converted into `<br>` and the HTML is escaped properly.
* Download multiple files from the journalist UI so it gets turned into a zip file and verify the filename on the zip is as expected, like `{source_name}--{timestamp}.zip`.

## Deployment

Not really.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] These changes do not require documentation
