### PR TITLE
Update dev container to use Firefox 91.5.0esr for tests and screenshots

### DIFF
--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -25,7 +25,7 @@ RUN gem install sass -v 3.4.23
 # Current versions of the test browser software. Tor Browser is based
 # on a specific version of Firefox, noted in Help > About Tor Browser.
 # Ideally we'll keep those in sync.
-ENV FF_VERSION 78.10.0esr
+ENV FF_VERSION 91.5.0esr
 ENV GECKODRIVER_VERSION v0.29.1
 
 # Import Tor release signing key


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This matches Tor Browser 11.0.4, which is the current latest version.

Notably the refactored (in 5daebb694a581c) deletion confirmation dialog
does not work properly in Firefox 78/Tor Browser 10.5.

Fixes #6248.

This should probably be cherry-picked to 2.2.0 for completeness.

## Testing

* Run `LOCALES=en_US make translation-test`, observe deletion-related screenshots are not garbled
* Observe that all other tests pass in CI.

## Deployment

All journalists need to be using Tor Browser 11.x.

## Checklist

Not sure about if this needs docs:
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

