### PR TITLE
[2.2.0] Backport pagelayout marker registration fix

### DIFF
--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -65,4 +65,5 @@ pytest \
     --cov-report "xml:${TEST_RESULTS}/cov.xml" \
     --cov-report "annotate:${TEST_RESULTS}/cov_annotate" \
     --cov=. \
+    --strict-markers \
     "$@"

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -66,6 +66,10 @@ def pytest_addoption(parser):
                      default=False, help="run page layout tests")
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "pagelayout: Tests which verify page layout")
+
+
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--page-layout"):
         return

--- a/securedrop/tests/pageslayout/test_source_layout_torbrowser.py
+++ b/securedrop/tests/pageslayout/test_source_layout_torbrowser.py
@@ -15,12 +15,15 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import pytest
+
 from tests.functional import journalist_navigation_steps
 from tests.functional import source_navigation_steps
 from tests.functional.functional_test import TORBROWSER
 from . import functional_test
 
 
+@pytest.mark.pagelayout
 class TestSourceLayoutTorbrowser(
         functional_test.FunctionalTest,
         source_navigation_steps.SourceNavigationStepsMixin,

--- a/securedrop/tests/pytest.ini
+++ b/securedrop/tests/pytest.ini
@@ -2,4 +2,4 @@
 log_format = %(created)f %(asctime)s %(lineno)4d:%(filename)-25s %(levelname)s %(message)s
 testpaths = . functional
 usefixtures = setUpTearDown
-addopts = --cov=../securedrop/
+addopts = --cov=../securedrop/ --strict-markers


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backports #6244  .

## Testing

- [ ] Changes are identical to those in https://github.com/freedomofpress/securedrop/pull/6244
- [ ] Target branch is release/2.2.0
- [ ] CI is passing
