### PR TITLE
Update API to return datetimes without offset field.

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -20,10 +20,9 @@ from journalist_app import utils
 from models import (Journalist, Reply, SeenReply, Source, Submission,
                     LoginThrottledException, InvalidUsernameException,
                     BadTokenException, InvalidOTPSecretException,
-                    WrongPasswordException)
+                    WrongPasswordException, API_DATETIME_FORMAT)
 from sdconfig import SDConfig
 from store import NotEncrypted, Storage
-
 
 TOKEN_EXPIRATION_MINS = 60 * 8
 
@@ -121,7 +120,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
 
             response = jsonify({
                 'token': journalist.generate_api_token(expiration=TOKEN_EXPIRATION_MINS * 60),
-                'expiration': token_expiry.isoformat() + 'Z',
+                'expiration': token_expiry.strftime(API_DATETIME_FORMAT),
                 'journalist_uuid': journalist.uuid,
                 'journalist_first_name': journalist.first_name,
                 'journalist_last_name': journalist.last_name,

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -48,6 +48,9 @@ HOTP_SECRET_LENGTH = 40  # 160 bits == 40 hex digits (== 32 ascii-encoded chars 
 # but existing Journalist users may still have 80-bit (16-char) secrets
 OTP_SECRET_MIN_ASCII_LENGTH = 16  # 80 bits == 40 hex digits (== 16 ascii-encoded chars in db)
 
+# Timezone-naive datetime format expected by SecureDrop Client
+API_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
 
 def get_one_or_else(query: Query,
                     logger: 'Logger',
@@ -138,9 +141,9 @@ class Source(db.Model):
         docs_msg_count = self.documents_messages_count()
 
         if self.last_updated:
-            last_updated = self.last_updated.isoformat() + 'Z'
+            last_updated = self.last_updated.strftime(API_DATETIME_FORMAT)
         else:
-            last_updated = datetime.datetime.utcnow().isoformat() + 'Z'
+            last_updated = datetime.datetime.utcnow().strftime(API_DATETIME_FORMAT)
 
         if self.star and self.star.starred:
             starred = True
@@ -777,7 +780,7 @@ class Journalist(db.Model):
         if all_info is True:
             json_user['is_admin'] = self.is_admin
             if self.last_access:
-                json_user['last_login'] = self.last_access.isoformat() + 'Z'
+                json_user['last_login'] = self.last_access.strftime(API_DATETIME_FORMAT)
             else:
                 json_user['last_login'] = None
 

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -2,6 +2,7 @@
 import json
 import random
 
+from datetime import datetime
 from flask import url_for
 from itsdangerous import TimedJSONWebSignatureSerializer
 from pyotp import TOTP
@@ -19,6 +20,8 @@ from models import (
 )
 
 from .utils.api_helper import get_api_headers
+
+API_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 random.seed('◔ ⌣ ◔')
 
@@ -52,6 +55,15 @@ def test_valid_user_can_get_an_api_token(journalist_app, test_journo):
         assert response.status_code == 200
         assert response.json['journalist_first_name'] == test_journo['first_name']
         assert response.json['journalist_last_name'] == test_journo['last_name']
+
+        def _valid_date(date_str, date_format):
+            try:
+                if date_str != datetime.strptime(date_str, date_format).strftime(date_format):
+                    raise ValueError
+                return True
+            except ValueError:
+                return False
+        assert _valid_date(response.json['expiration'], API_DATETIME_FORMAT)
 
 
 def test_user_cannot_get_an_api_token_with_wrong_password(journalist_app,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6255 .

Sets datetime values returned by the API to the format `%Y-%m-%dT%H:%M:%S.%fZ`, excluding the timezone offset information being added after the Flask 2.0 update

## Testing

- Set up a staging or prod vm instance based off this branch, with source and journalist accounts, and configure a Securedrop Workstation install to use it:
  - [ ] Confirm that you can log in to the securedrop client
  - [ ] Confirm that you can view source conversations and reply to sources
- Add a new source
  - [ ] confirm that the new source is displayed correctly in the client's source list after a sync
- Upload new files as an existing source
  - [ ] Confirm that the source is displayed correctly in the client's source list after next sync.

## Deployment

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
