### PR TITLE
Use a custom JSON encoder to format datetime objects consistently

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -20,7 +20,7 @@ from journalist_app import utils
 from models import (Journalist, Reply, SeenReply, Source, Submission,
                     LoginThrottledException, InvalidUsernameException,
                     BadTokenException, InvalidOTPSecretException,
-                    WrongPasswordException, API_DATETIME_FORMAT)
+                    WrongPasswordException)
 from sdconfig import SDConfig
 from store import NotEncrypted, Storage
 
@@ -120,7 +120,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
 
             response = jsonify({
                 'token': journalist.generate_api_token(expiration=TOKEN_EXPIRATION_MINS * 60),
-                'expiration': token_expiry.strftime(API_DATETIME_FORMAT),
+                'expiration': token_expiry,
                 'journalist_uuid': journalist.uuid,
                 'journalist_first_name': journalist.first_name,
                 'journalist_last_name': journalist.last_name,

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -48,9 +48,6 @@ HOTP_SECRET_LENGTH = 40  # 160 bits == 40 hex digits (== 32 ascii-encoded chars 
 # but existing Journalist users may still have 80-bit (16-char) secrets
 OTP_SECRET_MIN_ASCII_LENGTH = 16  # 80 bits == 40 hex digits (== 16 ascii-encoded chars in db)
 
-# Timezone-naive datetime format expected by SecureDrop Client
-API_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
-
 
 def get_one_or_else(query: Query,
                     logger: 'Logger',
@@ -141,9 +138,9 @@ class Source(db.Model):
         docs_msg_count = self.documents_messages_count()
 
         if self.last_updated:
-            last_updated = self.last_updated.strftime(API_DATETIME_FORMAT)
+            last_updated = self.last_updated
         else:
-            last_updated = datetime.datetime.utcnow().strftime(API_DATETIME_FORMAT)
+            last_updated = datetime.datetime.now(tz=datetime.timezone.utc)
 
         if self.star and self.star.starred:
             starred = True
@@ -780,7 +777,7 @@ class Journalist(db.Model):
         if all_info is True:
             json_user['is_admin'] = self.is_admin
             if self.last_access:
-                json_user['last_login'] = self.last_access.strftime(API_DATETIME_FORMAT)
+                json_user['last_login'] = self.last_access
             else:
                 json_user['last_login'] = None
 

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -21,9 +21,13 @@ from models import (
 
 from .utils.api_helper import get_api_headers
 
-API_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
-
 random.seed('◔ ⌣ ◔')
+
+
+def assert_valid_timestamp(timestamp: str) -> None:
+    """verify the timestamp is encoded in the format we want"""
+    dt_format = "%Y-%m-%dT%H:%M:%S.%fZ"
+    assert timestamp == datetime.strptime(timestamp, dt_format).strftime(dt_format)
 
 
 def test_unauthenticated_user_gets_all_endpoints(journalist_app):
@@ -56,14 +60,7 @@ def test_valid_user_can_get_an_api_token(journalist_app, test_journo):
         assert response.json['journalist_first_name'] == test_journo['first_name']
         assert response.json['journalist_last_name'] == test_journo['last_name']
 
-        def _valid_date(date_str, date_format):
-            try:
-                if date_str != datetime.strptime(date_str, date_format).strftime(date_format):
-                    raise ValueError
-                return True
-            except ValueError:
-                return False
-        assert _valid_date(response.json['expiration'], API_DATETIME_FORMAT)
+        assert_valid_timestamp(response.json['expiration'])
 
 
 def test_user_cannot_get_an_api_token_with_wrong_password(journalist_app,
@@ -151,6 +148,8 @@ def test_authorized_user_gets_all_sources(journalist_app, test_submissions,
         # We expect to see our test source in the response
         assert test_submissions['source'].journalist_designation == \
             response.json['sources'][0]['journalist_designation']
+        for source in response.json['sources']:
+            assert_valid_timestamp(source['last_updated'])
 
 
 def test_user_without_token_cannot_get_protected_endpoints(journalist_app,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We can set `app.json_encoder` to override the default Flask JSONEncoder
used by `jsonify()` when serializing custom types. This will make
changing the timestamp format in the future easier. It also makes it
easier on developers who can now just return a datetime object and
serializing it will just do the right thing.

While we're at it, simplify the test case that verifies the timestamp
format.

This follows up e4f385fb911d8040a7589d9a3a8c96c6ed45a330.

## Testing

- [ ] CI passes
- [ ] Hit an API endpoint that returns a timestamp, like /api/v1/sources (get_all_sources), observe that timestamp format is exactly the same.

## Deployment

None, this should functionally be a no-op

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] These changes do not require documentation

