### PR TITLE
Fixed an insufficiently-specific SSL config check

### DIFF
--- a/install_files/securedrop-app-code/debian/postinst
+++ b/install_files/securedrop-app-code/debian/postinst
@@ -108,7 +108,7 @@ remove_bytecode() {
 # Modify existing instance to use only TLS1.3 for the source.
 update_to_tls13(){
     source_conf="/etc/apache2/sites-available/source.conf"
-    if grep -qP '^SSLProtocol all' "$source_conf"; then
+    if grep -qP '^SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1$' "$source_conf"; then
         sed -i '/^SSLProtocol all/c\SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1 -TLSv1.2' "$source_conf"
         sed -i '/^SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384/d' "$source_conf"
         sed -i '/^SSLHonorCipherOrder on/c\SSLHonorCipherOrder off' "$source_conf"


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6263.

Updates the TLS1.3 update function in the postint to only update the SI Apache config if TLS 1.2 or lower is enabled, instead of all the time.

## Testing
on this branch:
- `make build-debs`
- set up a staging instance with HTTPS enabled 
- [ ] verify that TLS  1.3 is enabled and other SSL/TLS protocols are not.
- [ ] verify that there is a single copy of the `SSLSessionTickets off` directive
- log in to the app server and run `sudo dpkg-reconfigure securedrop-app-code
- [x] verify that the SSL configuration is unchanged
- manually edit /etc/apache2/source.conf, replacing the block
  ```
  SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1 -TLSv1.2
  SSLHonorCipherOrder off                 
  SSLSessionTickets off
  SSLCompression off
  ```
  with: 
  ```
  SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
  SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384
  SSLHonorCipherOrder on
  SSLCompression off
  ```
- run `sudo dpkg-reconfigure securedrop-app-code` again
- [x] verify that the TLS1.3 directives have been updated.

## Deployment

- fixes a postint deployment issue

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

