### PR TITLE
Pin and verify rustup-init sha256 in builder image

### DIFF
--- a/molecule/builder-focal/Dockerfile
+++ b/molecule/builder-focal/Dockerfile
@@ -42,14 +42,13 @@ COPY dh-virtualenv.pref /etc/apt/preferences.d/
 RUN apt-get update && apt-get install -y dh-virtualenv
 
 ENV RUST_VERSION 1.58.1
+ENV RUSTUP_VERSION 1.24.3
+ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
 
 # Install Rust for building cryptography
 RUN TMPDIR=`mktemp -d` && cd ${TMPDIR} \
-        && curl --proto '=https' --tlsv1.2 -OO -sSf https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init{,.sha256} \
-        && mkdir -p target/x86_64-unknown-linux-gnu/release/ \
-        && mv rustup-init target/x86_64-unknown-linux-gnu/release/ \
-        && sha256sum --check rustup-init.sha256 \
-        && cd target/x86_64-unknown-linux-gnu/release/ \
+        && curl --proto '=https' --tlsv1.2 -OO -sSf https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init \
+        && echo "${RUSTUP_INIT_SHA256} *rustup-init" | sha256sum -c - \
         && chmod +x rustup-init \
         && ./rustup-init --default-toolchain=${RUST_VERSION} -y \
         && cd && rm -rf ${TMPDIR}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

As an extra defense, pin the rustup version used and verify the
hash of the downloaded rustup-init binary. Previously we were downloading
the hash from the same place we were downloading the binary, so it didn't
really offer any extra protection besides making sure the download wasn't
corrupted (which HTTPS does for us).

This does not completely protect us, as rustup-init downloads rustup
without verifying signatures, but that will hopefully be fixed
soon: <https://github.com/rust-lang/rustup/issues/2028>.

This shouldn't add a significant amount of maintenance overhead, as old
rustup versions can still be used to download newer Rust versions.

Fixes https://github.com/freedomofpress/securedrop-security/issues/70.

## Testing

- [ ] Build image, see "rustup-init: OK" in output
- [ ] Modify sha256sum in the Dockerfile, try to build, see that it fails

## Deployment

Any special considerations for deployment? No

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
