### PR TITLE
Use pyjwt for API tokens instead of itsdangerous's deprecated code

### DIFF
--- a/securedrop/requirements/python3/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.in
@@ -18,6 +18,7 @@ mod_wsgi
 passlib
 pretty-bad-protocol>=3.1.1
 psutil>=5.6.6
+pyjwt>=2.3.0
 pyotp>=2.6.0
 qrcode
 redis>=3.3.6

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.txt
@@ -251,6 +251,10 @@ psutil==5.7.0 \
 pycparser==2.18 \
     --hash=sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226
     # via cffi
+pyjwt==2.3.0 \
+    --hash=sha256:b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41 \
+    --hash=sha256:e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f
+    # via -r requirements/python3/securedrop-app-code-requirements.in
 pyotp==2.6.0 \
     --hash=sha256:9d144de0f8a601d6869abe1409f4a3f75f097c37b50a36a3bf165810a6e23f28 \
     --hash=sha256:d28ddfd40e0c1b6a6b9da961c7d47a10261fb58f378cb00f05ce88b26df9c432


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

itsdangerous deprecated TimedJSONWebSignatureSerializer in 2.0 and has
entirely removed it in 2.1, so we need to switch to something else. They
recommended authlib, except that's a pretty large general-purpose
authentication library.

pyjwt is a smallish (1k LOC) library that just provides JWT/JWS
functionality. For the HS512 algorithm, it uses the same implementation
from hashlib in the Python standard library as itsdangerous did.

Tests are provided to verify successful operation as well as different
failure modes, such as invalid tokens, incorrect secret key, wrong
algorithm, and lack of an expiry.

Tokens generated by itsdangerous are not decodable by pyjwt because
itsdangerous passed the expiry as a header while pyjwt includes the
expiry in the body/payload itself. This shouldn't be a significant issue
since these tokens already expire after 8 hours.

Fixes #6224.

## Testing

- [ ] Get a valid token: `curl -X POST -d '{"username":"journalist", "passphrase":"correct horse battery staple profanity oil chewy","one_time_code":"XXXXXX"}' -H "Content-Type: application/json" http://127.0.0.1:8081/api/v1/token`. Then try it against an API endpoint: `curl -H 'Authorization: Token {token}' http://127.0.0.1:8081/api/v1/users` and get a proper response back.
- [ ] Log in with SD Client, perform various interactions (uses API token for authentication)
- [ ] Log out of SD client, select the previously used token out of the `revoked_tokens` database table and try to use it against the API, e.g. `curl -H 'Authorization: Token {token}' http://127.0.0.1:8081/api/v1/users`. You should get an error message saying the token is invalid or expired.
- [ ] Edit line 122 of journalist_app/api.py so that the expiration is `10` (seconds). Get a valid token using the first curl command, then wait 10 seconds. Try making an API request using that token, and get a response back saying the token is invalid or expired.

## Deployment

Any special considerations for deployment? Yes-ish.

Existing API tokens will no longer be valid and need to be reissued. This shouldn't be a big deal since they only live for 8 hours anyways.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation

### If you added or updated a production code dependency:

- [x] I would like someone else to do the diff review
  - I already reviewed the code myself, it would be good for someone else to do a review as well.