### PR TITLE
Update builder image to version tagged 2022_02_14

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2021_12_28
-0ab59f3d7cdd1aa086f25bbfbe3f164196ba3035cdee5f1c3704cfcf7d5503e8
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_02_14
+53fa3fcb2e28924aa4a7534939a1d2579806edd71080c78fa668a060bcef4dea


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updates builder image with rustup-init verification changes in #6266 

## Testing

- [ ] CI is passing, in particular the deb-tests job
- [ ] make build-debs passes locally