### PR TITLE
Added nomodeset to kernel options

### DIFF
--- a/install_files/securedrop-grsec-focal/DEBIAN/postinst.j2
+++ b/install_files/securedrop-grsec-focal/DEBIAN/postinst.j2
@@ -28,7 +28,8 @@ set_grub_default() {
     # When using CONFIG_PAX_KERNEXEC, the grsecurity team recommends the kernel
     # is booted with "noefi" on the kernel command line if "CONFIG_EFI" is
     # enabled, as EFI runtime services are necessarily mapped as RWX.
-    sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT=/s/=.*/=\"noefi ipv6\.disable=1 quiet\"/' /etc/default/grub
+    # 'nomodeset' is added to work around issues with Mac Mini graphics support
+    sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT=/s/=.*/=\"noefi nomodeset ipv6\.disable=1 quiet\"/' /etc/default/grub
     update-grub
 }
 


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #6271 .

Adds the `nomodeset` kernel option, to work around a kernel panic with the 5.15 series kernels when applied to 2014 Mac Minis.

## Testing

### Staging
- `make build-debs && make staging` on this branch
- [ ] verify that staging servers boot successfully
- [ ] verify that the `GRUB_CMDLINE_LINUX_DEFAULT` variable includes the `nomodeset` option in `/etc/default/grub`

### Prod hardware (Mac Minis preferred)
- set up a production instance using the current release (2.1.0)
- `make build-debs` on this branch and manually transfer the `securedrop-grsec` package to the  instance
- manually install the `securedrop-grsec` package
- [ ] verify that the package installed successfully
- reboot
- [ ] verify that the system boots successfully using the 5.15.18 grsec kernel
- [ ] verify that the `GRUB_CMDLINE_LINUX_DEFAULT` variable includes the `nomodeset` option in `/etc/default/grub`

## Deployment

As it involves a change to kernel boot options, this change should be tested on supported hardware before deployment.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
