### PR TITLE
Updated image hash to builder image tagged 2022_02_17

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_02_14
-53fa3fcb2e28924aa4a7534939a1d2579806edd71080c78fa668a060bcef4dea
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_02_17
+546c61a0c67cf3ed0aef81f32cc5326d1c9ab196239281cc256597dc1c73e114


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Updates builder image to version tagged as `2022_02_17`, to include latest security updates

## Testing
- [ ] CI is passing (deb-tests in particular)
- [ ] `make build-debs` passes locally on this branch.
