### PR TITLE
[2.2.0] Backport builder image update

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_02_14
-53fa3fcb2e28924aa4a7534939a1d2579806edd71080c78fa668a060bcef4dea
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_02_17
+546c61a0c67cf3ed0aef81f32cc5326d1c9ab196239281cc256597dc1c73e114


### PR DESCRIPTION
## Status
 
Work in progress (until #6285 is merged)

## Description of Changes

Backports #6285 , updating image builder to version tagged with 2022_02_17

## Testing

- [ ] contains only commits from #6285 
- [ ] base is `release/2.2.0`
- [ ] CI is passing
