### PR TITLE
Translate Show/Hide strings in the remember codename widget

### DIFF
--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -40,7 +40,7 @@
       cursor: pointer
 
       &:after
-        content: "Show"
+        content: attr(data-show)
         display: block
         float: right
 
@@ -56,7 +56,7 @@
     &[open]
       summary
         &:after
-          content: "Hide"
+          content: attr(data-hide)
 
 @media only screen and (max-width: 880px)
   #codename-hint

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -3,7 +3,9 @@
 {% block body %}
 {% if new_user_codename %}
 <details class="code-reminder pull-left" id="codename-hint">
-  <summary>{{ gettext('Remember, your codename is:') }}</summary>
+  <summary data-show="{{ gettext('Show') }}" data-hide="{{ gettext('Hide') }}">
+   {{ gettext('Remember, your codename is:') }}
+  </summary>
   <mark class="codename">{{ new_user_codename }}</mark>
 </details>
 {% endif %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Add two new translated strings "Show" and "Hide" as data attributes in the codename widget and reference them from CSS.

Fixes #6287

## Testing

Because there's currently no translations for these strings, this is currently a kind of no-op, however a manual check can be done with the browser's Developer Tools by changing the contents of the `data-show` and `data-hide` attributes. 

## Checklist

- [x] These changes do not require documentation