### PR TITLE
Ask search engines not to index Source Interface

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -8,7 +8,7 @@ from typing import Union
 
 import werkzeug
 from flask import (Blueprint, render_template, flash, redirect, url_for,
-                   session, current_app, request, Markup, abort, g)
+                   session, current_app, request, Markup, abort, g, make_response)
 from flask_babel import gettext
 
 import store
@@ -321,5 +321,12 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             return render_template('logout.html')
         else:
             return redirect(url_for('.index'))
+
+    @view.route('/robots.txt')
+    def robots_txt() -> werkzeug.Response:
+        """Tell robots we don't want them"""
+        resp = make_response("User-agent: *\nDisallow: /")
+        resp.headers["content-type"] = "text/plain"
+        return resp
 
     return view

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
   {% if g.organization_name == "SecureDrop" %}
   <title>{{ g.organization_name }} | {{ gettext('Protecting Journalists and Sources') }}</title>
   {% else %}

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -12,6 +12,7 @@
   <link rel="icon" type="image/png" href="/static/i/favicon.png">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
 
   {% assets filters="jsmin", output="gen/source.js", "js/source.js" %}
   <script src="{{ ASSET_URL }}"></script>

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -869,3 +869,13 @@ def test_source_can_only_delete_own_replies(source_app, app_storage):
 
     reply = Reply.query.filter_by(filename=filename).one()
     assert reply.deleted_by_source
+
+
+def test_robots_txt(source_app):
+    """Test that robots.txt works"""
+    with source_app.test_client() as app:
+        # Not using url_for here because we care about the actual URL path
+        resp = app.get('/robots.txt')
+        assert resp.status_code == 200
+        text = resp.data.decode('utf-8')
+        assert 'Disallow: /' in text


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We don't want the SI ending up in traditional clearnet search engines via
tor2web proxies. So add a restrictive robots.txt to disallow all crawlers
that respect it, plus a `<meta name="robots" content="noindex,nofollow">`
tag which tells any search engine that ignores the robots.txt to not index
the page, nor follow any links on the page.

Fixes #6292.

## Testing

- [ ] Load `/robots.txt` in SI, verify it disallows everybody on all paths
- [ ] Load index and a few other pages on SI, verify it contains the above `<meta>` tag.

## Deployment

Any special considerations for deployment? No.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] These changes do not require documentation
