### PR TITLE
Updated tor2web check to return a 403 status on success

### DIFF
--- a/securedrop/source_app/info.py
+++ b/securedrop/source_app/info.py
@@ -16,7 +16,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
 
     @view.route('/tor2web-warning')
     def tor2web_warning() -> flask.Response:
-        flash(gettext("Tor2Web proxies do not protect your anonymity!"), "error")
+        flash(gettext("Your connection is not anonymous right now!"), "error")
         return flask.Response(
             render_template("tor2web-warning.html", source_url=get_sourcev3_url()),
             403)

--- a/securedrop/source_app/info.py
+++ b/securedrop/source_app/info.py
@@ -15,9 +15,11 @@ def make_blueprint(config: SDConfig) -> Blueprint:
     view = Blueprint('info', __name__)
 
     @view.route('/tor2web-warning')
-    def tor2web_warning() -> str:
+    def tor2web_warning() -> flask.Response:
         flash(gettext("Tor2Web proxies do not protect your anonymity!"), "error")
-        return render_template("tor2web-warning.html", source_url=get_sourcev3_url())
+        return flask.Response(
+            render_template("tor2web-warning.html", source_url=get_sourcev3_url()),
+            403)
 
     @view.route('/use-tor')
     def recommend_tor_browser() -> str:

--- a/securedrop/source_app/info.py
+++ b/securedrop/source_app/info.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 import flask
-from flask import Blueprint, render_template, send_file, redirect, url_for
+from flask import Blueprint, render_template, send_file, redirect, url_for, flash
+from flask_babel import gettext
 import werkzeug
 
 from io import BytesIO  # noqa
 
 from encryption import EncryptionManager
 from sdconfig import SDConfig
+from source_app.utils import get_sourcev3_url
 
 
 def make_blueprint(config: SDConfig) -> Blueprint:
@@ -14,7 +16,8 @@ def make_blueprint(config: SDConfig) -> Blueprint:
 
     @view.route('/tor2web-warning')
     def tor2web_warning() -> str:
-        return render_template("tor2web-warning.html")
+        flash(gettext("Tor2Web proxies do not protect your anonymity!"), "error")
+        return render_template("tor2web-warning.html", source_url=get_sourcev3_url())
 
     @view.route('/use-tor')
     def recommend_tor_browser() -> str:

--- a/securedrop/source_templates/tor2web-warning.html
+++ b/securedrop/source_templates/tor2web-warning.html
@@ -4,12 +4,12 @@
 <div class="center">
   {% include 'flashed.html' %}
 </div>
-<p>{{ gettext(' If you use a Tor2Web proxy to connect to SecureDrop, anyone monitoring your Internet traffic &mdash; such as your government, your Internet provider, or the proxy operator &mdash; may be able to identify you.') }}
+<p>{{ gettext(' If you use a remote proxy like Tor2Web to connect to SecureDrop, anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you.') }}
 </p>
-<p>{{ gettext('Use the <a href="www.torproject.org/projects/torbrowser.html">Tor Browser</a>, and access this service directly instead. The correct onion service address is:') }}
+<p>{{ gettext('Use the <a href="www.torproject.org/projects/torbrowser.html">Tor Browser</a>, and access this site directly instead. The correct address is:') }}
 <pre>{{ source_url }}</pre>
 </p>
-<p> {{ gettext ('If you are using Tor Browser and have been brought to this page, generate a new identity before connecting to this service directly.') }} {{ gettext('Click the <img src={icon} alt="" width="16" height="16">&nbsp;<b>New Identity</b> button in your Tor Browser\'s toolbar. This will clear your Tor Browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom-black.png'))  }}
+<p> {{ gettext ('If you are using Tor Browser and have been brought to this page, generate a new identity before connecting to this site directly.') }} {{ gettext('Click the <img src={icon} alt="" width="16" height="16">&nbsp;<b>New Identity</b> button in your Tor Browser\'s toolbar. This will clear your Tor Browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom-black.png'))  }}
 </p>
 <p>{{ gettext('If there is a reasonable risk of your Internet traffic being monitored, you should also consider connecting from a different location or network.') }}
 </p>

--- a/securedrop/source_templates/tor2web-warning.html
+++ b/securedrop/source_templates/tor2web-warning.html
@@ -1,16 +1,18 @@
 {% extends "base.html" %}
 {% block body %}
-<h1>{{ gettext('Tor2Web Detected') }}</h1>
+<h1>{{ gettext('Proxy Service Detected') }}</h1>
 <div class="center">
   {% include 'flashed.html' %}
 </div>
-<p>{{ gettext(' If you use a remote proxy like Tor2Web to connect to SecureDrop, anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you.') }}
+<p>{{ gettext('You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity.') }}
 </p>
-<p>{{ gettext('Use the <a href="www.torproject.org/projects/torbrowser.html">Tor Browser</a>, and access this site directly instead. The correct address is:') }}
+<p>{{ gettext('Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you.') }}
+</p>
+<p>{{ gettext('Always use <a href="www.torproject.org/projects/torbrowser.html">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:') }}
 <pre>{{ source_url }}</pre>
 </p>
-<p> {{ gettext ('If you are using Tor Browser and have been brought to this page, generate a new identity before connecting to this site directly.') }} {{ gettext('Click the <img src={icon} alt="" width="16" height="16">&nbsp;<b>New Identity</b> button in your Tor Browser\'s toolbar. This will clear your Tor Browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom-black.png'))  }}
+<p> {{ gettext ('If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop.') }} {{ gettext('Click the <img src={icon} alt="" width="16" height="16">&nbsp;<b>New Identity</b> button in your Tor Browser\'s toolbar. This will clear your Tor Browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom-black.png'))  }}
 </p>
-<p>{{ gettext('If there is a reasonable risk of your Internet traffic being monitored, you should also consider connecting from a different location or network.') }}
+<p>{{ gettext('If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network.') }}
 </p>
 {% endblock %}

--- a/securedrop/source_templates/tor2web-warning.html
+++ b/securedrop/source_templates/tor2web-warning.html
@@ -1,9 +1,16 @@
 {% extends "base.html" %}
 {% block body %}
-<h1>{{ gettext('Why is there a warning about Tor2Web?') }}</h1>
-<p>{{ gettext('Using Tor2Web to connect to SecureDrop will not protect your anonymity.') }}</p>
-<p>{{ gettext('It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you.') }}
+<h1>{{ gettext('Tor2Web Detected') }}</h1>
+<div class="center">
+  {% include 'flashed.html' %}
+</div>
+<p>{{ gettext(' If you use a Tor2Web proxy to connect to SecureDrop, anyone monitoring your Internet traffic &mdash; such as your government, your Internet provider, or the proxy operator &mdash; may be able to identify you.') }}
 </p>
-<p>{{ gettext('We <strong>strongly advise</strong> you to use the <a href="www.torproject.org/projects/torbrowser.html">Tor Browser</a> instead.') }}
+<p>{{ gettext('Use the <a href="www.torproject.org/projects/torbrowser.html">Tor Browser</a>, and access this service directly instead. The correct onion service address is:') }}
+<pre>{{ source_url }}</pre>
+</p>
+<p> {{ gettext ('If you are using Tor Browser and have been brought to this page, generate a new identity before connecting to this service directly.') }} {{ gettext('Click the <img src={icon} alt="" width="16" height="16">&nbsp;<b>New Identity</b> button in your Tor Browser\'s toolbar. This will clear your Tor Browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom-black.png'))  }}
+</p>
+<p>{{ gettext('If there is a reasonable risk of your Internet traffic being monitored, you should also consider connecting from a different location or network.') }}
 </p>
 {% endblock %}

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -538,16 +538,20 @@ def test_submit_sanitizes_filename(source_app):
 
 
 @pytest.mark.parametrize("test_url", ['main.index', 'main.create', 'main.submit'])
-def test_tor2web_warning_as_403(config, source_app, test_url):
+def test_redirect_when_tor2web(config, source_app, test_url):
     with source_app.test_client() as app:
-        resp = app.get(url_for(test_url), headers=[('X-tor2web', 'encrypted')])
+        resp = app.get(
+            url_for(test_url),
+            headers=[('X-tor2web', 'encrypted')],
+            follow_redirects=True)
         text = resp.data.decode('utf-8')
+        assert resp.status_code == 403
         assert "Tor2Web Detected" in text
 
 def test_tor2web_warning(source_app):
     with source_app.test_client() as app:
         resp = app.get(url_for('info.tor2web_warning'))
-        assert resp.status_code == 200
+        assert resp.status_code == 403
         text = resp.data.decode('utf-8')
         assert "Tor2Web Detected" in text
 

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -537,38 +537,20 @@ def test_submit_sanitizes_filename(source_app):
                                         mtime=0)
 
 
-@flaky(rerun_filter=utils.flaky_filter_xfail)
-@pytest.mark.parametrize("locale", get_test_locales())
-def test_tor2web_warning_headers(config, source_app, locale):
+@pytest.mark.parametrize("test_url", ['main.index', 'main.create', 'main.submit'])
+def test_tor2web_warning_as_403(config, source_app, test_url):
     with source_app.test_client() as app:
-        with InstrumentedApp(app) as ins:
-            resp = app.get(url_for('main.index', l=locale), headers=[('X-tor2web', 'encrypted')])
-            assert resp.status_code == 200
-
-            assert page_language(resp.data) == language_tag(locale)
-            msgids = [
-                "WARNING:",
-                "You appear to be using Tor2Web, which does not provide anonymity.",
-                "Why is this dangerous?",
-            ]
-            with xfail_untranslated_messages(config, locale, msgids):
-                ins.assert_message_flashed(
-                    '<strong>{}</strong>&nbsp;{}&nbsp;<a href="{}">{}</a>'.format(
-                        escape(gettext(msgids[0])),
-                        escape(gettext(msgids[1])),
-                        url_for('info.tor2web_warning'),
-                        escape(gettext(msgids[2])),
-                    ),
-                    'banner-warning'
-                )
-
+        resp = app.get(url_for(test_url), headers=[('X-tor2web', 'encrypted')])
+        text = resp.data.decode('utf-8')
+        assert "Tor2Web Detected" in text
 
 def test_tor2web_warning(source_app):
     with source_app.test_client() as app:
         resp = app.get(url_for('info.tor2web_warning'))
         assert resp.status_code == 200
         text = resp.data.decode('utf-8')
-        assert "Why is there a warning about Tor2Web?" in text
+        assert "Tor2Web Detected" in text
+
 
 
 def test_why_use_tor_browser(source_app):

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -546,14 +546,14 @@ def test_redirect_when_tor2web(config, source_app, test_url):
             follow_redirects=True)
         text = resp.data.decode('utf-8')
         assert resp.status_code == 403
-        assert "Tor2Web Detected" in text
+        assert "Proxy Service Detected" in text
 
 def test_tor2web_warning(source_app):
     with source_app.test_client() as app:
         resp = app.get(url_for('info.tor2web_warning'))
         assert resp.status_code == 403
         text = resp.data.decode('utf-8')
-        assert "Tor2Web Detected" in text
+        assert "Proxy Service Detected" in text
 
 
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6291 .

Changes the SI behaviour when a tor2web request is detected. Previously, the application would display a warning flash message on the page, with a link to `info/tor2web_warning` summarizing the risks of using tor2web. Now, the application will respond with the warning page directly, served with a 403 error status.

The warning page now also contains the correct onion URL for the instance, and text has been updated:

![tor2web](https://user-images.githubusercontent.com/2782952/155197758-ab29e440-943e-46b2-8841-3caff0c85a7c.png)

Note that by itself this PR will not improve detection of tor2web proxies, preserving the current logic of checking for the `X-tor2web` header (which is rarely present anymore).

## Testing

- check out this branch and run `make dev-tor`
- connect to the docker container with `docker exec -it securedrop-dev-0 bash` and add a file `/var/lib/securedrop/source_v3_url` containing a single line with a validly-formatted v3 onion URL (`<56chars>.onion`, no protocol or slashes)
- [x] verify that the SI is available (via `localhost:8080` or over Tor) and that basic functionality works with no tor2web warnings or redirects
- [x] verify that the v3 url specified above is available via the SI `/metadata` endpoint
- add an X-tor2web header to your browser requests (eg. via a browser addon like [ModHeader](https://modheader.com/))
- [x] verify that any requests for non-static resources on the SI result in a 403 and the Tor2Web warning page in the screenshot above
- [x] verify that the v3 url you specified matches the one displayed on the warning page.
- [x] visit the Tor version of the dev environment via a tor2web proxy and verify that the v3 url in the page has *not* been rewritten.


## Deployment

 n/a

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [x] I would appreciate help with the documentation
- [ ] These changes do not require documentation
