### PR TITLE
Add honeypot to Source Interface to stop very basic spambots

### DIFF
--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -308,3 +308,7 @@ p#max-file-size
     background:
       image: url(/static/icons/chevron-left.png)
       size: contain
+
+/** This is the vaguely named antispam check */
+#text-field
+  display: none

--- a/securedrop/source_app/forms.py
+++ b/securedrop/source_app/forms.py
@@ -1,7 +1,8 @@
 import wtforms
+from flask import abort
 from flask_babel import lazy_gettext as gettext
 from flask_wtf import FlaskForm
-from wtforms import FileField, PasswordField, TextAreaField
+from wtforms import FileField, PasswordField, StringField, TextAreaField
 from wtforms.validators import InputRequired, Regexp, Length, ValidationError
 
 from models import Submission, InstanceConfig
@@ -26,6 +27,7 @@ class SubmissionForm(FlaskForm):
     msg = TextAreaField("msg", render_kw={"placeholder": gettext("Write a message."),
                                           "aria-label": gettext("Write a message.")})
     fh = FileField("fh", render_kw={"aria-label": gettext("Select a file to upload.")})
+    antispam = StringField(id="text", name="text")
 
     def validate_msg(self, field: wtforms.Field) -> None:
         if len(field.data) > Submission.MAX_MESSAGE_LEN:
@@ -38,3 +40,8 @@ class SubmissionForm(FlaskForm):
                     )
                 )
             raise ValidationError(message)
+
+    def validate_antispam(self, field: wtforms.Field) -> None:
+        """If the antispam field has any contents, abort with a 403"""
+        if field.data:
+            abort(403)

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -58,6 +58,10 @@
         {{ gettext('CANCEL') }}
       </a>
     </div>
+    <div id="text-field">
+      <label for="text">{{ gettext('Anti-spam check. Do not fill this in!') }}</label>
+      {{ form.antispam() }}
+    </div>
   </form>
 </section>
 

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -445,6 +445,20 @@ def test_submit_both(source_app):
         assert "Thanks! We received your message and document" in text
 
 
+def test_submit_antispam(source_app):
+    """
+    Test the antispam check.
+    """
+    with source_app.test_client() as app:
+        new_codename(app, session)
+        _dummy_submission(app)
+        resp = app.post(
+            url_for('main.submit'),
+            data=dict(msg="Test", fh=(StringIO(''), ''), text="blah"),
+            follow_redirects=True)
+        assert resp.status_code == 403
+
+
 def test_delete_all_successfully_deletes_replies(source_app, app_storage):
     with source_app.app_context():
         journalist, _ = utils.db_helper.init_journalist()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Add a hidden, empty input field to the Source Interface form that will
abort if anything is submitted in it. This will hopefully stop the most
basic of spambots that fill in spam in every form field they see and
submit the form. It is unlikely to stop any spambot specifically
designed for SecureDrop, as those will adapt as necessary.

This is inspired by and copied from MediaWiki's "SimpleAntiSpam"
functionality originally written by Ryan Schmidt[1].

[1] https://www.mediawiki.org/w/index.php?oldid=797352

Fixes #6295.

## Testing

- [ ] Create a new source and submit a dummy message in the SI, observe that it works fine
- [ ] Use the browser's inspector to disable the "display: none", write something in the antispam input field, and submit. You should get a 403 error screen.

## Deployment

No concerns.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation