### PR TITLE
Use JavaScript to detect if accessing SI over Tor2Web

### DIFF
--- a/securedrop/static/js/source.js
+++ b/securedrop/static/js/source.js
@@ -122,6 +122,15 @@ function suggestTor() {
   addFadingClose("use-tor-browser-close", useTorBrowser);
 }
 
+function checkClearnet() {
+  let url = new URL(location.href);
+  // Allow localhost for development
+  let localhost = ["127.0.0.1", "localhost"];
+  if (localhost.indexOf(url.hostname) === -1 && !url.host.endsWith(".onion")) {
+    location.href = "/tor2web-warning"
+  }
+}
+
 function ready(fn) {
   if (document.readyState != "loading"){
     fn();
@@ -140,4 +149,5 @@ ready(function() {
       suggestTor();
     }
   }
+  checkClearnet();
 });


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

For people who are accidentally accessing SecureDrop over Tor2Web (e.g.
by finding it in a search engine), it's probable that they are using a
normal browser and still have JavaScript installed. So we use
`location.href` to detect the URL they accessed the SecureDrop instance
over and redirect to the `/tor2web-warning` endpoint if the URL's
hostname doesn't end in `.onion` (with an exception for localhost).

This is intended to be a best-effort measure, as there's nothing
stopping the Tor2Web proxy from intercepting/modifying our JavaScript.

Fixes #6294.

## Testing

- [ ] Run `make dev`, access the SI over localhost, should not be redirected.
- [ ] Run `make dev-tor`, access the SI over the intended .onion address, should not be redirected.
- [ ] Run `make dev-tor`, access the SI over a tor2web proxy like `onion.ly`, should be redirected to tor2web warning.

You can also repeat the test plan with the changes in #6300, it should be fully compatible.

## Deployment

Any special considerations for deployment? No.

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
