### PR TITLE
Use Tor2Web's URL mangling to detect it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ flake8:  ## Validate PEP8 compliance for Python source files.
 .PHONY: html-lint
 html-lint:  ## Validate HTML in web application template files.
 	@echo "███ Linting application templates..."
-	@html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation,names \
+	@html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation,names,quotation \
 		securedrop/source_templates/*.html securedrop/journalist_templates/*.html
 	@echo
 

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -77,10 +77,14 @@
               <p class="extended-welcome-text">{{ gettext('First time submitting to our SecureDrop? Start here.') }}</p>
             </div>
             <div class="index-column-bottom-container">
-              <a href="{{ url_for('main.generate') }}" id="submit-documents-button" class="btn alt"
-                aria-label="{{ gettext('Get Started') }}">
-                {{ gettext('GET STARTED') }}
-              </a>
+              <form id="started-form" method="post" action="/generate" autocomplete="off">
+                <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                <input name="tor2web_check" type="hidden" value='href="fake.onion"'>
+                <button type="submit" class="btn alt" id="submit-documents-button"
+                  aria-label="{{ gettext('Get Started') }}">
+                  {{ gettext('GET STARTED') }}
+                </button>
+              </form>
             </div>
           </section>
           <div id="middle-separator"></div>

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -36,18 +36,22 @@ class SourceNavigationStepsMixin:
         assert j["sd_version"] == self.source_app.jinja_env.globals["version"]
         assert j["gpg_fpr"] != ""
 
-    def _source_clicks_submit_documents_on_homepage(self):
+    def _source_clicks_submit_documents_on_homepage(self, assert_success=True):
 
         # It's the source's first time visiting this SecureDrop site, so they
         # choose to "Submit Documents".
         self.safe_click_by_id("submit-documents-button")
 
-        # The source should now be on the page where they are presented with
-        # a diceware codename they can use for subsequent logins
-        assert self._is_on_generate_page()
+        if assert_success:
+            # The source should now be on the page where they are presented with
+            # a diceware codename they can use for subsequent logins
+            assert self._is_on_generate_page()
 
     def _source_regenerates_codename(self):
-        self.driver.refresh()
+        self._source_visits_source_homepage()
+        # We do not want to assert success here since it's possible they got
+        # redirected if already logged in.
+        self._source_clicks_submit_documents_on_homepage(assert_success=False)
 
     def _source_chooses_to_submit_documents(self):
         self._source_clicks_submit_documents_on_homepage()

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -275,7 +275,7 @@ def test_html_en_lang_correct(journalist_app, config):
     assert re.compile('<html lang="en-US".*>').search(html), html
 
     # check '/generate' too because '/' uses a different template
-    resp = app.get('/generate', follow_redirects=True)
+    resp = app.post('/generate', data={'tor2web_check': 'href="fake.onion"'}, follow_redirects=True)
     html = resp.data.decode('utf-8')
     assert re.compile('<html lang="en-US".*>').search(html), html
 
@@ -299,7 +299,8 @@ def test_html_fr_lang_correct(journalist_app, config):
     assert re.compile('<html lang="fr-FR".*>').search(html), html
 
     # check '/generate' too because '/' uses a different template
-    resp = app.get('/generate?l=fr_FR', follow_redirects=True)
+    resp = app.post('/generate?l=fr_FR', data={'tor2web_check': 'href="fake.onion"'},
+                    follow_redirects=True)
     html = resp.data.decode('utf-8')
     assert re.compile('<html lang="fr-FR".*>').search(html), html
 
@@ -329,9 +330,11 @@ def test_html_attributes(journalist_app, config):
     assert '<html lang="en-US" dir="ltr">' in html
 
     # check '/generate' too because '/' uses a different template
-    resp = app.get('/generate?l=ar', follow_redirects=True)
+    resp = app.post('/generate?l=ar', data={'tor2web_check': 'href="fake.onion"'},
+                    follow_redirects=True)
     html = resp.data.decode('utf-8')
     assert '<html lang="ar" dir="rtl">' in html
-    resp = app.get('/generate?l=en_US', follow_redirects=True)
+    resp = app.post('/generate?l=en_US', data={'tor2web_check': 'href="fake.onion"'},
+                    follow_redirects=True)
     html = resp.data.decode('utf-8')
     assert '<html lang="en-US" dir="ltr">' in html

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -26,6 +26,7 @@ from .utils.instrument import InstrumentedApp
 
 # Seed the RNG for deterministic testing
 random.seed('ಠ_ಠ')
+GENERATE_DATA = {'tor2web_check': 'href="fake.onion"'}
 
 
 def _login_user(app, user_dict):
@@ -44,7 +45,7 @@ def test_submit_message(journalist_app, source_app, test_journo, app_storage):
     test_msg = "This is a test message."
 
     with source_app.test_client() as app:
-        app.get('/generate')
+        app.post('/generate', data=GENERATE_DATA)
         tab_id = next(iter(session['codenames'].keys()))
         app.post('/create', data={'tab_id': tab_id}, follow_redirects=True)
         source_user = SessionManager.get_logged_in_user(db_session=db.session)
@@ -148,7 +149,7 @@ def test_submit_file(journalist_app, source_app, test_journo, app_storage):
     test_filename = "test.txt"
 
     with source_app.test_client() as app:
-        app.get('/generate')
+        app.post('/generate', data=GENERATE_DATA)
         tab_id = next(iter(session['codenames'].keys()))
         app.post('/create', data={'tab_id': tab_id}, follow_redirects=True)
         source_user = SessionManager.get_logged_in_user(db_session=db.session)
@@ -255,7 +256,7 @@ def _helper_test_reply(journalist_app, source_app, config, test_journo,
     test_msg = "This is a test message."
 
     with source_app.test_client() as app:
-        app.get('/generate')
+        app.post('/generate', data=GENERATE_DATA)
         tab_id, codename = next(iter(session['codenames'].items()))
         app.post('/create', data={'tab_id': tab_id}, follow_redirects=True)
         # redirected to submission form
@@ -446,7 +447,7 @@ def test_delete_collection(mocker, source_app, journalist_app, test_journo):
 
     # first, add a source
     with source_app.test_client() as app:
-        app.get('/generate')
+        app.post('/generate', data=GENERATE_DATA)
         tab_id = next(iter(session['codenames'].keys()))
         app.post('/create', data={'tab_id': tab_id})
         resp = app.post('/submit', data=dict(
@@ -496,7 +497,7 @@ def test_delete_collections(mocker, journalist_app, source_app, test_journo):
     with source_app.test_client() as app:
         num_sources = 2
         for i in range(num_sources):
-            app.get('/generate')
+            app.post('/generate', data=GENERATE_DATA)
             tab_id = next(iter(session['codenames'].keys()))
             app.post('/create', data={'tab_id': tab_id})
             app.post('/submit', data=dict(
@@ -553,7 +554,7 @@ def test_filenames(source_app, journalist_app, test_journo):
     and files"""
     # add a source and submit stuff
     with source_app.test_client() as app:
-        app.get('/generate')
+        app.post('/generate', data=GENERATE_DATA)
         tab_id = next(iter(session['codenames'].keys()))
         app.post('/create', data={'tab_id': tab_id})
         _helper_filenames_submit(app)
@@ -580,7 +581,7 @@ def test_filenames_delete(journalist_app, source_app, test_journo):
     """Test pretty, sequential filenames when journalist deletes files"""
     # add a source and submit stuff
     with source_app.test_client() as app:
-        app.get('/generate')
+        app.post('/generate', data=GENERATE_DATA)
         tab_id = next(iter(session['codenames'].keys()))
         app.post('/create', data={'tab_id': tab_id})
         _helper_filenames_submit(app)
@@ -692,7 +693,7 @@ def test_prevent_document_uploads(source_app, journalist_app, test_admin):
 
     # Check that the source interface accepts only messages:
     with source_app.test_client() as app:
-        app.get('/generate')
+        app.post('/generate', data=GENERATE_DATA)
         tab_id = next(iter(session['codenames'].keys()))
         resp = app.post('/create', data={'tab_id': tab_id}, follow_redirects=True)
         assert resp.status_code == 200
@@ -718,7 +719,7 @@ def test_no_prevent_document_uploads(source_app, journalist_app, test_admin):
 
     # Check that the source interface accepts both files and messages:
     with source_app.test_client() as app:
-        app.get('/generate')
+        app.post('/generate', data=GENERATE_DATA)
         tab_id = next(iter(session['codenames'].keys()))
         resp = app.post('/create', data={'tab_id': tab_id}, follow_redirects=True)
         assert resp.status_code == 200

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -186,7 +186,7 @@ def submit(storage, source, num_submissions, submission_type="message"):
 def new_codename(client, session):
     """Helper function to go through the "generate codename" flow.
     """
-    client.get('/generate')
+    client.post('/generate', data={'tor2web_check': 'href="fake.onion"'})
     tab_id, codename = next(iter(session['codenames'].items()))
     client.post('/create', data={'tab_id': tab_id})
     return codename


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Tor2Web mangles onion URLs to point to the proxy, but its implementation
is buggy and we can use that for detection. In this case, it rewrites
a literal `href="fake.onion"` (inside a hidden form `<input>`) to
something like: `href="//{$address}.onion.ly/fake.onion.ly"`. On form
submission, we can detect that it doesn't roundtrip properly and flag
the mangling as Tor2Web usage.

Since we want to show users the error as soon as possible, we turn the
initial "Get started" button link into a `<form>` with this special hidden
`<input>` that POSTs to `/generate`, which will check if Tor2Web mangles
the field and display the warning accordingly.

Fixes #6293.

## Testing

- [ ] Run `make dev-tor`, access over tor2web hit "Get Started". You should get the warning screen rather than seeing your codename.
- [ ] Try again but over the real onion rather than tor2web, you shouldn't see any errors.

## Deployment

Any special considerations for deployment? No.

## Checklist


- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
- [ ] I have written a test plan and validated it for this PR
- [ ] These changes do not require documentation
