### PR TITLE
Add basic message filtering in the SI

### DIFF
--- a/securedrop/alembic/versions/55f26cd22043_remove_partial_index_on_valid_until_set_.py
+++ b/securedrop/alembic/versions/55f26cd22043_remove_partial_index_on_valid_until_set_.py
@@ -1,0 +1,57 @@
+"""remove partial_index on valid_until, set it to nullable=false, add message filter fields
+
+Revision ID: 55f26cd22043
+Revises: 2e24fc7536e8
+Create Date: 2022-03-03 22:40:36.149638
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from datetime import datetime
+
+# revision identifiers, used by Alembic.
+revision = '55f26cd22043'
+down_revision = '2e24fc7536e8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # remove the old partial index on valid_until, as alembic can't handle it.
+    op.execute(sa.text('DROP INDEX IF EXISTS ix_one_active_instance_config'))
+
+    # valid_until will be non-nullable after batch, so set existing nulls to
+    # the new default unix epoch datetime
+    op.execute(sa.text(
+        'UPDATE OR IGNORE instance_config SET '
+        'valid_until=:epoch WHERE valid_until IS NULL;'
+    ).bindparams(epoch=datetime.fromtimestamp(0)))
+    with op.batch_alter_table('instance_config', schema=None) as batch_op:
+        batch_op.alter_column('valid_until',
+                              existing_type=sa.DATETIME(),
+                              nullable=False)
+        batch_op.add_column(sa.Column('initial_message_min_len', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('reject_message_with_codename', sa.Boolean(), nullable=True))
+
+    # remove the old partial index *again* in case the batch op recreated it.
+    op.execute(sa.text('DROP INDEX IF EXISTS ix_one_active_instance_config'))
+
+
+def downgrade():
+    with op.batch_alter_table('instance_config', schema=None) as batch_op:
+        batch_op.alter_column('valid_until',
+                              existing_type=sa.DATETIME(),
+                              nullable=True)
+        batch_op.drop_column('reject_message_with_codename')
+        batch_op.drop_column('initial_message_min_len')
+
+    # valid_until is nullable again, set entries with unix epoch datetime value to NULL
+    op.execute(sa.text(
+        'UPDATE OR IGNORE instance_config SET '
+        'valid_until = NULL WHERE valid_until=:epoch;'
+            ).bindparams(epoch=datetime.fromtimestamp(0)))
+
+    # manually restore the partial index
+    op.execute(sa.text('CREATE UNIQUE INDEX IF NOT EXISTS ix_one_active_instance_config ON '
+                       'instance_config (valid_until IS NULL) WHERE valid_until IS NULL'))

--- a/securedrop/journalist_templates/config.html
+++ b/securedrop/journalist_templates/config.html
@@ -55,9 +55,28 @@
 
   <form action="{{ url_for('admin.update_submission_preferences') }}" method="post">
     <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-    {{ submission_preferences_form.prevent_document_uploads() }}
-    <label
+
+      <div class="config_form_element">
+        {{ submission_preferences_form.prevent_document_uploads() }}
+        <label
       for="prevent_document_uploads">{{ gettext('Prevent sources from uploading documents. Sources will still be able to send messages.') }}</label>
+      </div>
+
+      <div class="config_form_element">
+        {{ submission_preferences_form.prevent_short_messages() }}
+        <label
+      for="prevent_short_messages">{{ gettext('Prevent sources from sending initial messages shorter than the minimum required length:') }}</label>
+          <div class="config_form_subelement">
+            {{ submission_preferences_form.min_message_length(min=0, max=max_len) }}
+            <label class="form-field-hint"
+          for="min_message_length">{{ gettext('Minimum number of characters.') }}</label>
+          </div>
+      </div>
+      <div class="config_form_element">
+        {{ submission_preferences_form.reject_codename_messages() }}
+        <label
+      for="reject_codename_messages">{{ gettext('Prevent sources from submitting their codename as an initial message.') }}</label>
+      </div>
     <div class="section-spacing">
       <button type="submit" id="submit-submission-preferences" class="icon icon-edit"
         aria-label="{{ gettext('Update Submission Preferences') }}">

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -19,7 +19,7 @@ from jinja2 import Markup
 from passlib.hash import argon2
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import relationship, backref, Query, RelationshipProperty
-from sqlalchemy import Column, Index, Integer, String, Boolean, DateTime, LargeBinary
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, LargeBinary
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
@@ -932,7 +932,7 @@ class RevokedToken(db.Model):
 
 class InstanceConfig(db.Model):
     '''Versioned key-value store of settings configurable from the journalist
-    interface.  The current version has valid_until=None.
+    interface.  The current version has valid_until=0 (unix epoch start)
     '''
 
     # Limits length of org name used in SI and JI titles, image alt texts etc.
@@ -940,16 +940,28 @@ class InstanceConfig(db.Model):
 
     __tablename__ = 'instance_config'
     version = Column(Integer, primary_key=True)
-    valid_until = Column(DateTime, default=None, unique=True)
+    valid_until = Column(DateTime, default=datetime.datetime.fromtimestamp(0),
+                         nullable=False, unique=True)
     allow_document_uploads = Column(Boolean, default=True)
     organization_name = Column(String(255), nullable=True, default="SecureDrop")
+    initial_message_min_len = Column(Integer, default=0)
+    reject_message_with_codename = Column(Boolean, default=False)
 
     # Columns not listed here will be included by InstanceConfig.copy() when
     # updating the configuration.
     metadata_cols = ['version', 'valid_until']
 
     def __repr__(self) -> str:
-        return "<InstanceConfig(version=%s, valid_until=%s)>" % (self.version, self.valid_until)
+        return "<InstanceConfig(version=%s, valid_until=%s, " \
+            "allow_document_uploads=%s, organization_name=%s, " \
+            "initial_message_min_len=%s, reject_message_with_codename=%s)>" % (
+                                                   self.version,
+                                                   self.valid_until,
+                                                   self.allow_document_uploads,
+                                                   self.organization_name,
+                                                   self.initial_message_min_len,
+                                                   self.reject_message_with_codename
+                                                  )
 
     def copy(self) -> "InstanceConfig":
         '''Make a copy of only the configuration columns of the given
@@ -981,7 +993,7 @@ class InstanceConfig(db.Model):
         '''
 
         try:
-            return cls.query.filter(cls.valid_until == None).one()  # lgtm [py/test-equals-none]  # noqa: E711, E501
+            return cls.query.filter(cls.valid_until == datetime.datetime.fromtimestamp(0)).one()
         except NoResultFound:
             try:
                 current = cls()
@@ -989,7 +1001,7 @@ class InstanceConfig(db.Model):
                 db.session.commit()
                 return current
             except IntegrityError:
-                return cls.query.filter(cls.valid_until == None).one()  # lgtm [py/test-equals-none]  # noqa: E711, E501
+                return cls.query.filter(cls.valid_until == datetime.datetime.fromtimestamp(0)).one()
 
     @classmethod
     def check_name_acceptable(cls, name: str) -> None:
@@ -1017,9 +1029,14 @@ class InstanceConfig(db.Model):
         db.session.commit()
 
     @classmethod
-    def set_allow_document_uploads(cls, value: bool) -> None:
+    def update_submission_prefs(
+            cls,
+            allow_uploads: bool,
+            min_length: int,
+            reject_codenames: bool
+            ) -> None:
         '''Invalidate the current configuration and append a new one with the
-        requested change.
+        updated submission preferences.
         '''
 
         old = cls.get_current()
@@ -1027,15 +1044,9 @@ class InstanceConfig(db.Model):
         db.session.add(old)
 
         new = old.copy()
-        new.allow_document_uploads = value
+        new.allow_document_uploads = allow_uploads
+        new.initial_message_min_len = min_length
+        new.reject_message_with_codename = reject_codenames
         db.session.add(new)
 
         db.session.commit()
-
-
-one_active_instance_config_index = Index(
-    'ix_one_active_instance_config',
-    InstanceConfig.valid_until.is_(None),
-    unique=True,
-    sqlite_where=(InstanceConfig.valid_until.is_(None))
-)

--- a/securedrop/sass/journalist.sass
+++ b/securedrop/sass/journalist.sass
@@ -16,6 +16,21 @@
 .content div
   align-content: center
 
+.config_form_subelement
+  margin-left: 1.5em
+  margin-bottom: 0
+
+.config_form_element
+  padding: 3px
+  margin-bottom: 1.0em
+
+#min_message_length
+  width: 6em
+
+.form-field-hint
+  font-size: 0.9em
+  font-style: italic
+
 #replies
   .reply
     border: 1px solid $color_grey_medium
@@ -203,7 +218,7 @@ button.button-star.un-starred
     background-image: url(/static/icons/unstarred.png)
     width: 16px
     height: 15px
-  
+
   &:active, &:hover
     span:before
       background-image: url(/static/icons/starred.png)
@@ -232,7 +247,7 @@ button.icon-reset:not([data-tooltip]), button.icon-reset[data-tooltip] > span.la
     width: 15px
     height: 15px
 
-.icon-bell 
+.icon-bell
   &:before
     background-image: url(/static/icons/bell.png)
     width: 13px

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -259,6 +259,11 @@ p#max-file-size
   font-style: italic
   margin-bottom: 0
 
+p#min-msg-length
+  font-size: 10px
+  font-style: italic
+  margin-bottom: 12px
+
 .bubble
   width: 415px
   position: absolute

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Union
 
 import werkzeug
-from flask import (Blueprint, render_template, flash, redirect, url_for,
+from flask import (Blueprint, render_template, flash, redirect, url_for, escape,
                    session, current_app, request, Markup, abort, g, make_response)
 from flask_babel import gettext
 
@@ -24,7 +24,7 @@ from sdconfig import SDConfig
 from source_app.decorators import login_required
 from source_app.session_manager import SessionManager
 from source_app.utils import normalize_timestamps, fit_codenames_into_cookie, \
-    clear_session_and_redirect_to_logged_out_page
+    clear_session_and_redirect_to_logged_out_page, codename_detected
 from source_app.forms import LoginForm, SubmissionForm
 from source_user import InvalidPassphraseError, create_source_user, \
     SourcePassphraseCollisionError, SourceDesignationCollisionError, SourceUser
@@ -119,6 +119,13 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             source_id=logged_in_source_in_db.id, deleted_by_source=False
         ).all()
 
+        first_submission = logged_in_source_in_db.interaction_count == 0
+
+        if first_submission:
+            min_message_length = InstanceConfig.get_default().initial_message_min_len
+        else:
+            min_message_length = 0
+
         for reply in source_inbox:
             reply_path = Storage.get_default().path(
                 logged_in_source.filesystem_id,
@@ -158,6 +165,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             is_user_logged_in=True,
             allow_document_uploads=InstanceConfig.get_default().allow_document_uploads,
             replies=replies,
+            min_len=min_message_length,
             new_user_codename=session.get('new_user_codename', None),
             form=SubmissionForm(),
         )
@@ -191,6 +199,23 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         fnames = []
         logged_in_source_in_db = logged_in_source.get_db_record()
         first_submission = logged_in_source_in_db.interaction_count == 0
+
+        if first_submission:
+            min_len = InstanceConfig.get_default().initial_message_min_len
+            if (min_len > 0) and (msg and not fh) and (len(msg) < min_len):
+                flash(gettext(
+                    "Your first message must be at least {} characters long.".format(min_len)),
+                    "error")
+                return redirect(url_for('main.lookup'))
+
+            codenames_rejected = InstanceConfig.get_default().reject_message_with_codename
+            if codenames_rejected and codename_detected(msg, session['new_user_codename']):
+                flash(Markup('{}<br>{}'.format(
+                    escape(gettext("Please do not submit your codename!")),
+                    escape(gettext("Keep your codename secret, and use it to log in later"
+                                   " to check for replies."))
+                    )), "error")
+                return redirect(url_for('main.lookup'))
 
         if not os.path.exists(Storage.get_default().path(logged_in_source.filesystem_id)):
             current_app.logger.debug("Store directory not found for source '{}', creating one."

--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -10,6 +10,8 @@ from flask import url_for
 from flask.sessions import SessionMixin
 from markupsafe import Markup
 from store import Storage
+from hmac import compare_digest
+from flask_babel import gettext
 
 import typing
 
@@ -19,6 +21,19 @@ from source_user import SourceUser
 
 if typing.TYPE_CHECKING:
     from typing import Optional
+
+
+def codename_detected(message: str, codename: str) -> bool:
+    """
+    Check for codenames in incoming messages. including case where user copy/pasted
+    from /generate and the visually-hidden codename heading was included
+    """
+    message = message.strip()
+    localised_label = gettext("Codename")
+    if message.startswith(localised_label):
+        message = message[len(localised_label):]
+
+    return compare_digest(message.strip(), codename)
 
 
 def clear_session_and_redirect_to_logged_out_page(flask_session: SessionMixin) -> werkzeug.Response:

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -44,6 +44,15 @@
       {% endif %}
       <div class="message grid-item{% if not allow_document_uploads %} wide{% endif %}">
         {{ form.msg(class="fill-parent") }}
+  {% if allow_document_uploads %}
+      {% if min_len > 0 %}
+         <p class="center" id="min-msg-length">{{ gettext('If you are only sending a message, it must be at least {} characters long.'.format(min_len)) }}</p>
+      {% endif %}
+  {% else %}
+      {% if min_len > 0 %}
+        <p class="center" id="min-msg-length">{{ gettext('Your first message must be at least {} characters long.'.format(min_len)) }}</p>
+      {% endif %}
+  {% endif %}
       </div>
     </div>
 
@@ -51,8 +60,6 @@
       <button type="submit" id="submit-doc-button" aria-label="{{ gettext('Submit') }}">
         {{ gettext('SUBMIT') }}
       </button>
-
-
 
       <a href="{{ url_for('main.lookup') }}" class="btn secondary" id="cancel" role="button"
         aria-label="{{ gettext('Cancel') }}">

--- a/securedrop/tests/migrations/migration_55f26cd22043.py
+++ b/securedrop/tests/migrations/migration_55f26cd22043.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+from db import db
+from journalist_app import create_app
+import sqlalchemy
+import pytest
+import secrets
+
+from .helpers import random_bool, random_datetime, random_ascii_chars
+
+
+index_definition = (
+    "index",
+    "ix_one_active_instance_config",
+    "instance_config",
+    (
+        "CREATE UNIQUE INDEX ix_one_active_instance_config "
+        "ON instance_config (valid_until IS NULL) WHERE valid_until IS NULL"
+    ),
+)
+
+
+def get_schema(app):
+    with app.app_context():
+        result = list(
+           db.engine.execute(sqlalchemy.text("SELECT type, name, tbl_name, sql FROM sqlite_master"))
+        )
+
+    return ((x[0], x[1], x[2], x[3]) for x in result)
+
+
+class UpgradeTester:
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            self.update_config()
+            db.session.commit()
+
+    @staticmethod
+    def update_config():
+        params = {
+            "valid_until": random_datetime(nullable=False),
+            "allow_document_uploads": random_bool(),
+            "organization_name": random_ascii_chars(secrets.randbelow(75))
+        }
+        sql = """
+        INSERT INTO instance_config (
+            valid_until, allow_document_uploads, organization_name
+        ) VALUES (
+            :valid_until, :allow_document_uploads, :organization_name
+        )
+        """
+
+        db.engine.execute(sqlalchemy.text(sql), **params)
+
+    def check_upgrade(self):
+        schema = get_schema(self.app)
+        print(schema)
+        assert index_definition not in schema
+
+        with self.app.app_context():
+            for query in [
+                         "SELECT * FROM instance_config WHERE initial_message_min_len != 0",
+                         "SELECT * FROM instance_config WHERE reject_message_with_codename != 0"
+                         ]:
+                result = db.engine.execute(sqlalchemy.text(query)).fetchall()
+                assert len(result) == 0
+
+
+class DowngradeTester:
+
+    def __init__(self, config):
+        self.app = create_app(config)
+
+    def load_data(self):
+        pass
+
+    def check_downgrade(self):
+        assert index_definition in get_schema(self.app)
+
+        with self.app.app_context():
+            for query in [
+                 "SELECT * FROM instance_config WHERE initial_message_min_len IS NOT NULL",
+                 "SELECT * FROM instance_config WHERE reject_message_with_codename IS NOT NULL"
+                 ]:
+                with pytest.raises(sqlalchemy.exc.OperationalError):
+                    db.engine.execute(sqlalchemy.text(query)).fetchall()

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -644,7 +644,8 @@ def test_prevent_document_uploads(source_app, journalist_app, test_admin):
     with journalist_app.test_client() as app:
         _login_user(app, test_admin)
         form = journalist_app_module.forms.SubmissionPreferencesForm(
-            prevent_document_uploads=True)
+            prevent_document_uploads=True,
+            min_message_length=0)
         resp = app.post('/admin/update-submission-preferences',
                         data=form.data,
                         follow_redirects=True)
@@ -672,7 +673,11 @@ def test_no_prevent_document_uploads(source_app, journalist_app, test_admin):
     # Set allow_document_uploads = True:
     with journalist_app.test_client() as app:
         _login_user(app, test_admin)
+        form = journalist_app_module.forms.SubmissionPreferencesForm(
+            prevent_document_uploads=False,
+            min_message_length=0)
         resp = app.post('/admin/update-submission-preferences',
+                        data=form.data,
                         follow_redirects=True)
         assert resp.status_code == 200
 

--- a/securedrop/tests/test_source_utils.py
+++ b/securedrop/tests/test_source_utils.py
@@ -2,9 +2,10 @@
 import json
 import os
 
+import pytest
 import werkzeug
 
-from source_app.utils import check_url_file, fit_codenames_into_cookie
+from source_app.utils import check_url_file, codename_detected, fit_codenames_into_cookie
 from .test_journalist import VALID_PASSWORD
 
 
@@ -61,3 +62,14 @@ def test_fit_codenames_into_cookie(config):
     assert(len(serialized) > werkzeug.Response.max_cookie_size)
     serialized = json.dumps(fit_codenames_into_cookie(codenames)).encode()
     assert(len(serialized) < werkzeug.Response.max_cookie_size)
+
+
+@pytest.mark.parametrize('message,expected', (
+    ('Foo', False),
+    ('codename', True),
+    (' codename ', True),
+    ('Codename codename', True),
+    ('foocodenamebar', False),
+))
+def test_codename_detected(message, expected):
+    assert codename_detected(message, 'codename') is expected


### PR DESCRIPTION
## Status

 Work in progress (tests required)

## Description of Changes

Fixes #6297.
Fixes #6298.

adds options in the JI instance config, and in the SI,  to:
- set a minimum message length for source's initial messages, as per #6297 
- reject initial messages that consist of the source's codename, as per #6298

## Testing
- check out this branch and run `make dev`

### minimum message length
- in the JI, navigate to the Instance Config page via the Admin page
  - [x] verify that the Submission Preferences  section includes a "Prevent sources from sending initial messages shorter than the minimum required length" option, currently unchecked and with the length field set to 0.
- check the "Prevent sources from sending initial messages shorter than..." checkbox but do not set a length. Click **Update Submission Preferences**
  - [x] verify that the checkbox is unchecked and an error message is displayed asking you to set a length.
 - check the "Prevent sources from sending initial messages shorter than..." checkbox and set a length of between 5 and 20 chars. Click **Update Submission Preferences**
   - [x] verify that the checkbox is checked, the length you chose is set, and a success message is displayed.
- Create a new source account on the SI, navigating through to the /lookup page
  - [x] verify that a notice is displayed under the message textfield like "If you are only sending a message, it must be at least N characters long" where N is the length you chose above
  - [x] Verify that if you try to submit  too short a message, the submission fails with a flashed error like "Your first message must be at least N characters long"
  - [x] Verify that a message N characters long can be submitted successfully
  - [x] after a successful first submission, verify that the  notice under the text field is no longer displayed and you can submit message shorter than N chars
  - [x] in the JI, uncheck the "Prevent sources from sending initial messages shorter than..." checkbox,, click **Update Submission Prefs** and verify that the length is set to zero and a success message is displayed
  - [x] Create a new source account in the SI and verify that no message length limit is mentioned or set

### codename messages

- in the JI, navigate to the Instance Config page via the Admin page
  - [x] verify that the Submission Preferences  section includes a "Prevent sources from submitting their codename as an initial message." option, currently unchecked.
- check the "Prevent sources from submitting their codename as an initial message" checkbox. Click **Update Submission Preferences**
   - [x] verify that the checkbox is checked and a success message is displayed.
 - Create a new source account on the SI, navigating through to the /lookup page
   - [x] Enter the codename as a message and click **Submit** - verify that the message is not submitted and an error is flashed like "Please do not submit your codename.."
   - [x] Enter anything else as a message and click **Submit** - verify that the message was submitted correctly
   - [x]  Enter your codename again and click **Submit** - verify that the message was submitted correctly.

## Deployment

DB migration script required, but new functionality is disabled by default.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [x] I would appreciate help with the documentation
- [ ] These changes do not require documentation
