### PR TITLE
Make Tor Browser/Orfox UA regexes compatible with Firefox 100

### DIFF
--- a/securedrop/static/js/source.js
+++ b/securedrop/static/js/source.js
@@ -1,5 +1,5 @@
-const TBB_UA_REGEX = /Mozilla\/5\.0 \((Windows NT 10\.0|X11; Linux x86_64|Macintosh; Intel Mac OS X 10\.[0-9]{2}|Windows NT 10\.0; Win64; x64|Android; Mobile); rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/
-const ORFOX_UA_REGEX = /Mozilla\/5\.0 \(Android; Mobile; rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/;
+const TBB_UA_REGEX = /Mozilla\/5\.0 \((Windows NT 10\.0|X11; Linux x86_64|Macintosh; Intel Mac OS X 10\.[0-9]{2}|Windows NT 10\.0; Win64; x64|Android; Mobile); rv:[0-9]{2,3}\.0\) Gecko\/20100101 Firefox\/([0-9]{2,3})\.0/
+const ORFOX_UA_REGEX = /Mozilla\/5\.0 \(Android; Mobile; rv:[0-9]{2,3}\.0\) Gecko\/20100101 Firefox\/([0-9]{2,3})\.0/;
 
 function fadeIn(el, duration = 200, displayStyle = "block") {
   const frameDuration = 16;


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Per <https://hacks.mozilla.org/2022/02/version-100-in-chrome-and-firefox/>,
Firefox will soon hit version 100, which will break any regex that is
matching against a 2-digit version, like we do.

Switch the regex to match against 3-digit versions as well, which should
keep us going for another 900 versions.

Fixes #6276.

## Testing

It's not possible to really test this since there's no TBB/Orbot version based on Firefox 100 in the wild, but we can fake it:

* Copy the new regexes from source.js into your browser console. 
* Run `"Mozilla/5.0 (X11; Linux x86_64; rv:91.0) Gecko/20100101 Firefox/91.0".match(TBB_UA_REGEX)` to verify 2-digit versions still match
* Run `"Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0".match(TBB_UA_REGEX)` to verify a hypothetical 3-digit version will match.

## Deployment

Any special considerations for deployment? None.

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
