### PR TITLE
Bring security level instructions up to date

### DIFF
--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -35,8 +35,8 @@
       <li>
         {{ gettext('Click the <img src="{icon}" alt="&quot;Security Level&quot; button"> in the toolbar above').format(icon=url_for("static", filename="i/font-awesome/black/guard.svg"))  }}
       </li>
-      <li>{{ gettext('Select <b>Advanced Security Settings</b>') }}</li>
-      <li>{{ gettext('Select <b>Safest</b>') }}</li>
+      <li>{{ gettext('Click <b>Change</b> to open Security Level preferences') }}</li>
+      <li>{{ gettext('Select <b>Safest</b> and close the preferences tab') }}</li>
     </ol>
     <p>
       {{ gettext('<a href="/" aria-label="Follow these instructions, then refresh this page">Refresh this page</a>, and you\'re done!') }}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6319. Changes Tor Browser Security Level instruction strings to be in line with current TB user interface

## Testing

* Open Tor Browser
* Ensure the Security Level preference is set to **Standard**
* Visit source index page
* Click on the underlined _Security Level_ link in the purple warning on the top of the page
* Follow instructions of the dialog that opens up

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation