### PR TITLE
Translate string found in SI replies

### DIFF
--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import 'utils.html' as utils %}
 
 {% block body %}
 {% if new_user_codename %}
@@ -74,9 +75,9 @@
       {{ gettext("You have received a reply. To protect your identity in the unlikely event someone learns your codename, please delete all replies when you're done with them. This also lets us know that you are aware of our reply. You can respond by submitting new files and messages above.") }}
     </p>
     {% for reply in replies %}
+    {%- set timestamp = utils.relative_time(reply.date) -%}
     <article class="reply">
-      <h3 class="date"><time title="{{ reply.date|rel_datetime_format }}"
-          datetime="{{ reply.date|html_datetime_format }}">{{ reply.date|rel_datetime_format(relative=True) }}</time></h3>
+      <h3 class="date">{{ timestamp }}</h3>
       <form id="delete" class="message" method="post" action="{{ url_for('main.delete') }}" autocomplete="off">
         <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         <input type="hidden" name="reply_filename" value="{{ reply.filename }}" autocomplete="off">
@@ -86,8 +87,9 @@
         </a>
         <dialog open id="confirm-delete-{{ reply.filename }}" class="confirm-prompt"
           aria-labelledby="delete-heading-{{ reply.filename }}">
-          <h3 id="delete-heading-{{ reply.filename }}" hidden>Delete reply from
-            {{ reply.date|rel_datetime_format(relative=True) }}?</h3>
+          <h3 id="delete-heading-{{ reply.filename }}" hidden>
+            {{ gettext('Delete reply from {timestamp}?').format(timestamp=timestamp) }}
+          </h3>
           <p>{{ gettext('Delete this reply?') }}
             <a href="#delete" role="button">{{ gettext('Cancel') }}</a>
             <button type="submit" class="danger" id="confirm-delete-reply-button-{{ reply.filename }}" role="button"

--- a/securedrop/source_templates/utils.html
+++ b/securedrop/source_templates/utils.html
@@ -1,0 +1,4 @@
+{%- macro relative_time(date) -%}
+<time title="{{ date|rel_datetime_format }}"
+      datetime="{{ date|html_datetime_format }}">{{ date|rel_datetime_format(relative=True) }}</time>
+{%- endmacro -%}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6279.

We recently caught an untranslated string in the source interface. It involves a reference to a relative timestamp, so instead of duplicating code, I added a macro and use its output on two different occasions.

## Testing

* Either add a new submission and reply to it, or log in with a source that has pre-filled replies 
* Change language to something other than English
* Use **Web Developer Tools** to inspect the DOM
* Navigate to (in CSS notation) `.reply dialog h3`
* Inside that `h3` you should find an English *Delete reply from*, but a translated timestamp in a `time` tag

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation