### PR TITLE
Center text in reply deletion confirmation prompt

### DIFF
--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -203,6 +203,7 @@ p#codename
     background: white
     border: 1px solid $color_grey_dark
     padding: 0
+    text-align: center
 
     p
       *


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

All text for the replies was set to align to left, but the confirm-prompt ought to be centered as it looks glitched otherwise.

**Before**
![confirm-prompt-align-left](https://user-images.githubusercontent.com/201369/157107050-d992a778-b8cf-4422-9686-470258f73eab.png)

**After**
![confirm-prompt-align-center](https://user-images.githubusercontent.com/201369/157107080-31c96c29-1915-48fc-9b9b-d5eb4d20aa9e.png)

## Testing

* Either add a new submission and reply to it, or log in with a source that has pre-filled replies
* Use trash can icon to delete a reply
* Confirm that the prompt looks like the second screenshot rather than the first

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation