### PR TITLE
Update builder image hash to version tagged as 2022_03_09

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_02_17
-546c61a0c67cf3ed0aef81f32cc5326d1c9ab196239281cc256597dc1c73e114
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_03_09
+aa92785916f3d27df8b3ca8773eb9465db8f603d98d2986d257a236eeb2b3c13


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6327

Updates builder image to include latest security updates

## Testing


- [ ] CI is passing, in particular the deb-tests job
- [ ] make build-debs passes locally
