### PR TITLE
Expose Linux kernel and Tor version in /metadata endpoint

### DIFF
--- a/securedrop/server_os.py
+++ b/securedrop/server_os.py
@@ -1,4 +1,5 @@
 import functools
+import re
 import subprocess
 
 FOCAL_VERSION = "20.04"
@@ -12,3 +13,25 @@ def get_os_release() -> str:
         stdout=subprocess.PIPE,
         universal_newlines=True
     ).stdout.strip()
+
+
+@functools.lru_cache()
+def get_tor_version() -> str:
+    try:
+        output = subprocess.run(
+            ["/usr/bin/tor", "--version"],
+            check=True,
+            stdout=subprocess.PIPE,
+            universal_newlines=True
+        ).stdout.strip()
+        # Output looks like: "Tor version 0.4.5.11."
+        # There might also be a warning about zstd being the wrong version, the
+        # regex should ignore that.
+        search = re.search(r"Tor version (.*)\.$", output)
+        if search:
+            return search.group(1)
+    except:  # noqa E722
+        # Avoid breaking the entire /metadata endpoint if we can't figure out
+        # the Tor version
+        pass
+    return "unknown"

--- a/securedrop/source_app/api.py
+++ b/securedrop/source_app/api.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import flask
 from flask import Blueprint, make_response
@@ -20,9 +21,11 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             'organization_name': InstanceConfig.get_default().organization_name,
             'allow_document_uploads': InstanceConfig.get_default().allow_document_uploads,
             'gpg_fpr': config.JOURNALIST_KEY,
+            'kernel_version': os.uname().release,
             'sd_version': version.__version__,
             'server_os': server_os.get_os_release(),
             'supported_languages': config.SUPPORTED_LOCALES,
+            'tor_version': server_os.get_tor_version(),
             'v3_source_url': get_sourcev3_url()
         }
         resp = make_response(json.dumps(meta))

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -591,17 +591,21 @@ def test_why_journalist_key(source_app):
 
 def test_metadata_route(config, source_app):
     with patch("server_os.get_os_release", return_value="20.04"):
-        with source_app.test_client() as app:
-            resp = app.get(url_for('api.metadata'))
-            assert resp.status_code == 200
-            assert resp.headers.get('Content-Type') == 'application/json'
-            assert resp.json.get('allow_document_uploads') ==\
-                InstanceConfig.get_current().allow_document_uploads
-            assert resp.json.get('sd_version') == version.__version__
-            assert resp.json.get('server_os') == '20.04'
-            assert resp.json.get('supported_languages') ==\
-                config.SUPPORTED_LOCALES
-            assert resp.json.get('v3_source_url') is None
+        with patch("server_os.get_tor_version", return_value="0.4.5.11"):
+            with source_app.test_client() as app:
+                resp = app.get(url_for('api.metadata'))
+                assert resp.status_code == 200
+                assert resp.headers.get('Content-Type') == 'application/json'
+                assert resp.json.get('allow_document_uploads') ==\
+                    InstanceConfig.get_current().allow_document_uploads
+                # Kernel version should start with #.##.###
+                assert re.match(r'\d\.\d{1,2}\.\d{1,3}', resp.json.get('kernel_version'))
+                assert resp.json.get('sd_version') == version.__version__
+                assert resp.json.get('server_os') == '20.04'
+                assert resp.json.get('supported_languages') ==\
+                    config.SUPPORTED_LOCALES
+                assert resp.json.get('tor_version') == "0.4.5.11"
+                assert resp.json.get('v3_source_url') is None
 
 
 def test_metadata_v3_url(source_app):


### PR DESCRIPTION
## Status

Code is ready for review, feature itself needs discussion

## Description of Changes

As discussed in #6328, we want to separate the kernel and tor version
upgrade process from SecureDrop releases. Currently we (and anyone else)
can imply the kernel + tor versions from the SecureDrop version, but
once they are separated, we'll lose that ability.

Explicitly add those version numbers to the /metadata endpoint so we can
still see/verify that the kernel or tor upgrade happened successfully
from our monitoring.

Getting the kernel version is trivial since Python has a `os.uname()`
function, while the tor version requires shelling out to `tor --version`
and processing the output. Since that's more complicated, it will return
"unknown" rather than breaking the /metadata endpoint if an exception
occurs.

## Testing

* Open the SI and go to `/metadata`, see keys for "kernel_version" and "tor_version"

## Deployment

Any special considerations for deployment?

**Yes**, this could have some security implications which are being discussed at #6328 and elsewhere.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] These changes do not require documentation
