### PR TITLE
Prevent viewport jumps when there's flashed messages

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -171,7 +171,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             for field, errors in form.errors.items():
                 for error in errors:
                     flash(error, "error")
-            return redirect(f"{url_for('main.lookup')}#flashed")
+            return redirect(url_for('main.lookup'))
 
         msg = request.form['msg']
         fh = None
@@ -186,7 +186,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                       "error")
             else:
                 flash(gettext("You must enter a message."), "error")
-            return redirect(f"{url_for('main.lookup')}#flashed")
+            return redirect(url_for('main.lookup'))
 
         fnames = []
         logged_in_source_in_db = logged_in_source.get_db_record()
@@ -252,7 +252,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
 
         normalize_timestamps(logged_in_source)
 
-        return redirect(f"{url_for('main.lookup')}#flashed")
+        return redirect(url_for('main.lookup'))
 
     @view.route('/delete', methods=('POST',))
     @login_required

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -22,6 +22,9 @@
   <div class="content">
     <div class="container">
       <header>
+        {% if get_flashed_messages() %}
+        <a href="#flashed" class="visually-hidden until-focus">{{ gettext('Skip to notification') }}</a>
+        {% endif %}
         <a href="#main" class="visually-hidden until-focus">{{ gettext('Skip to main content') }}</a>
         {% block header %}
         <a href="{% if is_user_logged_in %}{{ url_for('main.lookup') }}{% else %}{{ url_for('main.index') }}{% endif %}"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Jumping directly to the `#flashed` anchor on redirect introduced unintended browser behaviour that pushed the messages we wanted users to focus on out of view. Since this was in part an accessibility feature, we don't want to lose the ability for screen-reader users to jump directly to what's important immediately, so this introduces a new "Skip to notification" link, which like the "Skip to main content" link is visually hidden until in focus.

Fixes #6333.

## Testing

* Visit index with Tor Browser, JavaScript disabled
* Inspect the `html` element with the **Web Developer Tools**
* Using the layout tab, make sure that the content size of the `html` element is 1000x540 (when no scrollbar is visible)
* Add a new submission
* Browser does **not** scroll to _Success!_ flashed message
* While _Success!_ or other flashed message is visible, us tab to navigate site
* _Skip to notification_ becomes visible above the logo first, _Skip to main content_ becomes visible second

## Checklist

- [x] These changes do not require documentation