### PR TITLE
Update translations for 2.3.0

### DIFF
--- a/securedrop/babel.cfg
+++ b/securedrop/babel.cfg
@@ -9,4 +9,4 @@ silent=False
 
 [jinja2: */*.html]
 silent=False
-extensions=jinja2.ext.autoescape,jinja2.ext.with_,webassets.ext.jinja2.AssetsExtension
+extensions=jinja2.ext.autoescape,jinja2.ext.with_,webassets.ext.jinja2.AssetsExtension,jinja2.ext.do

--- a/securedrop/translations/ar/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ar/LC_MESSAGES/messages.po
@@ -4,7 +4,20 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 # Ahmad Gharbeia أحمد غربية <ahmad@gharbeia.org>, 2017.
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.3.12\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPOT-Creation-Date: 2017-09-02 07:28+0000\nPO-Revision-Date: 2022-02-15 22:04+0000\nLast-Translator: Ahmed Essam <ahmedessamdev@gmail.com>\nLanguage-Team: Arabic <https://weblate.securedrop.org/projects/securedrop/securedrop/ar/>\nLanguage: ar\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.3.12\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"POT-Creation-Date: 2017-09-02 07:28+0000\n"
+"PO-Revision-Date: 2022-02-15 22:04+0000\n"
+"Last-Translator: Ahmed Essam <ahmedessamdev@gmail.com>\n"
+"Language-Team: Arabic <https://weblate.securedrop.org/projects/securedrop/securedrop/ar/>\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "الاسم طويلٌ جداً"
@@ -146,11 +159,17 @@ msgstr[3] "هذا الحقل لا يقبل أكثر من {num} حروف."
 msgstr[4] "هذا الحقل لا يقبل أكثر من {num} حرفًا."
 msgstr[5] "هذا الحقل لا يقبل أكثر من {num} حرفًا."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "هذا الحقل مطلوب."
 
 msgid "You cannot send an empty reply."
 msgstr "لا يمكن إرسال ردّ فارغ."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "يجب اختيار ملف."
@@ -449,6 +468,9 @@ msgstr "بعد إتمام ضبط مفتاح الاستيثاق \"YubiKey\" أد�
 msgid "Navigation"
 msgstr "التنقل"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "والج باسم"
 
@@ -572,6 +594,15 @@ msgstr "تفضيلات الإرسال"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "منع المصادر من رفع وثائق. سوف تظل المصادر قادرة على توجيه رسائل."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "تحديث تفضيلات الإرسال"
 
@@ -589,24 +620,6 @@ msgstr "إرسال الإنذار الخاص بإختبار OSSEC"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "أرسل تنبيه OSSEC تجريبي"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "لم يُختر أيّ ملف<strong> لحذفه نهائيا</strong>:"
-msgstr[1] "اختير الملف التالي <strong>لحذفه نهائيا</strong>:"
-msgstr[2] "اختير الملفان التاليان <strong>لحذفهما نهائيا</strong>:"
-msgstr[3] "اختيرت الملفات {num} التالية <strong>لحذفها نهائيا</strong>:"
-msgstr[4] "اختيرت الملفات {num} التالية <strong>لحذفها نهائيا</strong>:"
-msgstr[5] "اختيرت الملفات {num} التالية <strong>لحذفها نهائيا</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "حذف الملفات نهائيا"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "احذف الملفات نهائيا"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "العودة إلى قائمة مستندات {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "تعديل حساب المستخدم \"{user}\""
@@ -749,15 +762,6 @@ msgstr "تسجيل الدخول"
 msgid "LOG IN"
 msgstr "لِج"
 
-msgid "WARNING:"
-msgstr "تحذير:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "يبدو أنك تستخدم Tor2Web الذي لا يوفر خاصية إخفاء الهوية."
-
-msgid "Why is this dangerous?"
-msgstr "لماذا يُعد هذا خطيرًا؟"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "يجب أن يتراوح طول الحقل بين محرف واحد و&nbsp;{max_codename_len} محرفا."
 
@@ -776,6 +780,9 @@ msgstr "إن نص الرسالة طويلٌ جداً."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "يجب تحميل النصوص الكبيرة والطويلة كملفات مرفقة وبالتالي عدم نسخها ولصقها."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "تمت إعادة توجيهك إلى حسابك لأنّك والج إليه بالفعل. إنَ كنت تريد إنشاء حساب جديد فعليك الخروج من هذا الحساب أوّلا."
 
@@ -790,6 +797,22 @@ msgstr "يجب إدخال نصّ رسالة أو اختيار ملف لإيدا�
 
 msgid "You must enter a message."
 msgstr "يجب إدخال نصّ رسالة."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "يجب ألا يحوي أي حرف."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "هل نسيت اسمك الرمزي بك؟"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "إذا كنت قد أودعت مسبقًا مستندات لدى صحافيينا فلِج هنا لترى إن وصلتك منهم ردود."
 
 msgid "Thanks! We received your message."
 msgstr "شكرا! لقد تلقينا الرسالة."
@@ -809,8 +832,14 @@ msgstr "حُذِفَت كُلّ الردود"
 msgid "Sorry, that is not a recognized codename."
 msgstr "عذرًا، لا يمكن التعرف على الاسم الرمزي."
 
+msgid "Codename"
+msgstr "الاسم الرمزي"
+
 msgid "Protecting Journalists and Sources"
 msgstr "لحماية الصحافيين و&nbsp;المصادر"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "عذرا، SecureDrop الخاص بنا غير متصل حاليا."
@@ -845,32 +874,25 @@ msgstr "يرجى الانتباه: قد تعرّضك مشاركة وثائق ح�
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "إن سيكيور دروب SecureDrop لمشروع من مؤسسة حرية الصحافة Freedom of the Press Foundation."
 
-msgid "Welcome"
-msgstr "أهلا بك"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "أدخل اسمك الرمزي"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "يجب عليك إمّا تدوين هذا الاسم الرمزي و&nbsp;حفظه في مكان آمن، أو التيقّن من حفظه في ذاكرتك."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "هذا الاسم الرمزي هو ما ستستعمله في زياراتك المقبلة لتلقي الرسائل من فريقنا ردّا على ما ستودعه في الخطوة التالية."
-
-msgid "Codename"
-msgstr "الاسم الرمزي"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"لاحظ أننا لا نتتبّع مستخدمي خدمة <b>SecureDrop</b>،\n"
-"لذا فاستعمال الاسم الرمزي في الزيارات المقبلة هو الوسيلة الوحيدة التي يمكننا بها التواصل معك في حال وجود أسئلة\n"
-" أو اهتمام بمزيد من المعلومات. وعلى خلاف كلمات السر، لا توجد أيّة وسيلة لاسترجاع الاسم الرمزي في حال فقدانه."
 
-msgid "Submit Documents"
-msgstr "إرسال المستندات"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "أودع مستندات"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "الاستمرار"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "حاليًا <a id=\"disable-js\" href=\"\"><b>مستوى الأمان</b></a> في متصفّح تور أضعف مما ينبغي. اضغط على زرّ <img src=\"{icon}\" alt=\"&quot;مستوى الأمان&quot;\"> &nbsp في شريط أدوات متصفحك لتغييرها."
@@ -881,11 +903,11 @@ msgstr "كيفية تغيير مستوى الأمان الخاص بك"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "اضغط على زرّ <img src=\"{icon}\" alt=\"&quot;مستوى الأمان&quot; زرر\"> في شريط الأدوات أعلاه"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "اختَر <b>إعدادات الأمان المتقدمة</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "اختَر <b>أقصى أمان</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"اتبع هذه التعليمات ثم قم بانعاش هذه الصفحة\">أنعش هذه الصفحة</a> فتكون قد أنجزت!"
@@ -920,9 +942,6 @@ msgstr "أدخل الاسم الرمزي"
 msgid "Enter your codename"
 msgstr "أدخل اسمك الرمزي"
 
-msgid "Continue"
-msgstr "الاستمرار"
-
 msgid "CANCEL"
 msgstr "ألغ"
 
@@ -931,6 +950,12 @@ msgstr "هناك أمرٌ آخر نود أن نلفت نظرك إليه..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "اضغط على الزر <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>هوية جديدة</b> في شريط متصفحك تور إذ أن ذلك من شأنه أن يمسح أي نشاط قمت به على متصفح تور من هذا الجهاز."
+
+msgid "Show"
+msgstr "أظهر"
+
+msgid "Hide"
+msgstr "اخفِ"
 
 msgid "Remember, your codename is:"
 msgstr "تذكر أنّ اسمك الرمزي:"
@@ -959,6 +984,9 @@ msgstr "الحجم الأقصى الممكن رفعه: 500 ميجابايت"
 msgid "Submit"
 msgstr "إرسال"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "قراءة الردود"
 
@@ -967,6 +995,9 @@ msgstr "لقد تلقيت ردّا. لدواعي حماية هويتك إذا ح
 
 msgid "Delete this reply"
 msgstr "أتريد حذف هذا الرد"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "أتريد حذف هذا الرد؟"
@@ -1001,17 +1032,27 @@ msgstr "هام"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "لقد تم إخراجك من الحساب نظراً لعدم نشاطك. اضغط على زر <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>هوية جديدة</b>في متصفحك تور. إن ذلك سيمسح أي نشاط لك على متصفح تور في هذا الجهاز."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "لماذا يوجد تحذير بشأن Tor2Web؟"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "إنّ استخدام Tor2Web للنفاذ إلى SecureDrop لا يحقّق لك المجهولية."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "بوسع أي جهة تراقب الإنترنت (مثل مقدم خدمة الاتصال بالإنترنت أو السُّلطات) معرفة هويتك."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "<strong>نحثّكم بشدة</strong> على استخدام <a href=\"www.torproject.org/projects/torbrowser.html\">متصفح تور</a> عِوضًا عن غيره."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "الأحرى بك استخدام متصفح تور"
@@ -1068,6 +1109,69 @@ msgstr "<strong>هام:</strong> إذا كنت ترغب في البقاء مجه
 msgid "Back to submission page"
 msgstr "الرجوع إلى صفحة الإيداع"
 
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "لم يُختر أيّ ملف<strong> لحذفه نهائيا</strong>:"
+#~ msgstr[1] "اختير الملف التالي <strong>لحذفه نهائيا</strong>:"
+#~ msgstr[2] "اختير الملفان التاليان <strong>لحذفهما نهائيا</strong>:"
+#~ msgstr[3] "اختيرت الملفات {num} التالية <strong>لحذفها نهائيا</strong>:"
+#~ msgstr[4] "اختيرت الملفات {num} التالية <strong>لحذفها نهائيا</strong>:"
+#~ msgstr[5] "اختيرت الملفات {num} التالية <strong>لحذفها نهائيا</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "حذف الملفات نهائيا"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "احذف الملفات نهائيا"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "العودة إلى قائمة مستندات {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "تحذير:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "يبدو أنك تستخدم Tor2Web الذي لا يوفر خاصية إخفاء الهوية."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "لماذا يُعد هذا خطيرًا؟"
+
+#~ msgid "Welcome"
+#~ msgstr "أهلا بك"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "يجب عليك إمّا تدوين هذا الاسم الرمزي و&nbsp;حفظه في مكان آمن، أو التيقّن من حفظه في ذاكرتك."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "هذا الاسم الرمزي هو ما ستستعمله في زياراتك المقبلة لتلقي الرسائل من فريقنا ردّا على ما ستودعه في الخطوة التالية."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "لاحظ أننا لا نتتبّع مستخدمي خدمة <b>SecureDrop</b>،\n"
+#~ "لذا فاستعمال الاسم الرمزي في الزيارات المقبلة هو الوسيلة الوحيدة التي يمكننا بها التواصل معك في حال وجود أسئلة\n"
+#~ " أو اهتمام بمزيد من المعلومات. وعلى خلاف كلمات السر، لا توجد أيّة وسيلة لاسترجاع الاسم الرمزي في حال فقدانه."
+
+#~ msgid "Submit Documents"
+#~ msgstr "إرسال المستندات"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "أودع مستندات"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "اختَر <b>إعدادات الأمان المتقدمة</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "اختَر <b>أقصى أمان</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "لماذا يوجد تحذير بشأن Tor2Web؟"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "<strong>نحثّكم بشدة</strong> على استخدام <a href=\"www.torproject.org/projects/torbrowser.html\">متصفح تور</a> عِوضًا عن غيره."
+
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "صيغة البيانات السرية غير صحيحة: عدد كلمات العبارة السرية يجب أن يكون زوجيًّا لا فرديًّا. هل أخطأت في كتابة العبارة السرية؟"
 
@@ -1117,12 +1221,6 @@ msgstr "الرجوع إلى صفحة الإيداع"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "SecureDrop الصفحة الرئيسية"
-
-#~ msgid "Show"
-#~ msgstr "أظهر"
-
-#~ msgid "Hide"
-#~ msgstr "اخفِ"
 
 #~ msgid "— No Messages —"
 #~ msgstr "—ليس هناك أي رسالة—"
@@ -1294,9 +1392,6 @@ msgstr "الرجوع إلى صفحة الإيداع"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "هل سبق لك إيداع شيء؟"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "إذا كنت قد أودعت مسبقًا مستندات لدى صحافيينا فلِج هنا لترى إن وصلتك منهم ردود."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "تَفحَّص إنْ وصلك رَدّ منّا"

--- a/securedrop/translations/ca/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ca/LC_MESSAGES/messages.po
@@ -4,7 +4,19 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.5-rc4\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPO-Revision-Date: 2022-02-12 22:04+0000\nLast-Translator: John Smith <ecron_89@hotmail.com>\nLanguage-Team: Catalan <https://weblate.securedrop.org/projects/securedrop/securedrop/ca/>\nLanguage: ca\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n != 1;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.5-rc4\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"PO-Revision-Date: 2022-02-12 22:04+0000\n"
+"Last-Translator: John Smith <ecron_89@hotmail.com>\n"
+"Language-Team: Catalan <https://weblate.securedrop.org/projects/securedrop/securedrop/ca/>\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "El nom és massa llarg"
@@ -130,11 +142,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "No pot tenir més d'{num} caràcter."
 msgstr[1] "No pot tenir més de {num} caràcters."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Aquest camp és obligatori."
 
 msgid "You cannot send an empty reply."
 msgstr "No podeu enviar una resposta buida."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "El fitxer és obligatori."
@@ -409,6 +427,9 @@ msgstr "Quan hàgiu configurat la YubiKey, introduïu aquest codi de sis dígits
 msgid "Navigation"
 msgstr "Navegació"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Sessió iniciada com a"
 
@@ -532,6 +553,15 @@ msgstr "Preferències de l'enviament"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Evita que les fonts puguin pujar documents. Les fonts encara podran enviar missatges."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Actualitza les preferències d'enviament"
 
@@ -549,20 +579,6 @@ msgstr "Envia una alerta OSSEC de prova"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "ENVIA UNA ALERTA OSSEC DE PROVA"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "S'ha seleccionat el fitxer següent per <strong>suprimir definitivament</strong>:"
-msgstr[1] "S'han seleccionat els {num} fitxers següents per <strong>suprimir definitivament</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "Suprimeix els fitxers de forma permanent"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "SUPRIMEIX ELS FITXERS DEFINITIVAMENT"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Torna a la llista de documents de {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Edita l'usuari «{user}»"
@@ -705,15 +721,6 @@ msgstr "Inicia la sessió"
 msgid "LOG IN"
 msgstr "INICIA LA SESSIÓ"
 
-msgid "WARNING:"
-msgstr "ADVERTÈNCIA:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Sembla que feu servir Tor2Web, que no garanteix l'anonimat."
-
-msgid "Why is this dangerous?"
-msgstr "Per què això és perillós?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "El camp ha de tenir entre 1 i {max_codename_len} caràcters."
 
@@ -732,6 +739,9 @@ msgstr "El missatge de text és massa llarg."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Els blocs de text grans s'han de pujar en un fitxer, no copiant-los i enganxant-los."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Si us ha redirigit perquè ja teniu una sessió iniciada. Si voleu crear un compte nou, primer heu de tancar la sessió."
 
@@ -746,6 +756,22 @@ msgstr "Cal que introduïu un missatge o trieu un fitxer per enviar."
 
 msgid "You must enter a message."
 msgstr "Cal que introduïu un missatge."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Cal que tingui com a mínim {num} caràcter."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Heu oblidat el vostre nom en clau?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Si ja heu enviat informació a periodistes, inicieu sessió per revisar les respostes."
 
 msgid "Thanks! We received your message."
 msgstr "Gràcies! Hem rebut el missatge."
@@ -765,8 +791,14 @@ msgstr "S'han suprimit totes les respostes"
 msgid "Sorry, that is not a recognized codename."
 msgstr "No es reconeix aquest nom en clau."
 
+msgid "Codename"
+msgstr "Nom en clau"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Protegeix els periodistes i les fonts"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Vaja, el nostre SecureDrop és fora de línia."
@@ -801,32 +833,25 @@ msgstr "Atenció: Si compartiu documents sensibles, podríeu posar-vos en risc, 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "El SecureDrop és un projecte de la Fundació «Freedom of the Press»."
 
-msgid "Welcome"
-msgstr "Us donem la benvinguda"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Introduïu el vostre nom en clau"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Escriviu aquest nom en clau i conserveu-lo en un lloc segur, o memoritzeu-lo."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Aquest nom en clau és el que usareu en visites futures per a rebre missatges del nostre equip, en resposta a allò que envieu en la pantalla següent."
-
-msgid "Codename"
-msgstr "Nom en clau"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"Atès que no rastregem els usuaris del nostre servei <b>SecureDrop</b>, \n"
-"en visites futures, només podrem contactar amb vós a través d'aquest nom en clau, en cas que tinguem preguntes\n"
-"o interès en informació addicional. A diferència de les contrasenyes, no hi ha cap forma de recuperar un nom en clau perdut."
 
-msgid "Submit Documents"
-msgstr "Envia els documents"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "ENVIA DOCUMENTS"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "Continua"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "El <a id=\"disable-js\" href=\"\"><b>nivell de seguretat</b></a> del vostre navegador Tor és massa baix. Useu el botó <img src=\"{icon}\" alt=\"&quot;Nivell de seguretat&quot;\"> de la barra d'eines del navegador per a canviar-ho."
@@ -837,11 +862,11 @@ msgstr "Com canviar el nivell de seguretat"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Feu clic en el botó <img src=\"{icon}\" alt=\"Botó &quot;Nivell de seguretat&quot;\"> de la barra d'eines superior"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Seleccioneu <b>Configuració avançada de seguretat</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Seleccioneu <b>El més segur</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Seguiu les instruccions, actualitzeu la pàgina\">Actualitzeu aquesta pàgina</a>, i ja heu acabat!"
@@ -876,9 +901,6 @@ msgstr "Introduïu el nom en clau"
 msgid "Enter your codename"
 msgstr "Introduïu el vostre nom en clau"
 
-msgid "Continue"
-msgstr "Continua"
-
 msgid "CANCEL"
 msgstr "CANCEL·LA"
 
@@ -887,6 +909,12 @@ msgstr "Una cosa més..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Feu clic al botó <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Identitat nova</b> de la barra d'eines del navegador Tor. Això buidarà les dades d'activitat en el navegador Tor en aquest aparell."
+
+msgid "Show"
+msgstr "Mostra"
+
+msgid "Hide"
+msgstr "Amaga"
 
 msgid "Remember, your codename is:"
 msgstr "Recordeu, el vostre nom en clau és:"
@@ -915,6 +943,9 @@ msgstr "Mida màx. de pujada: 500 MB"
 msgid "Submit"
 msgstr "Envia"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Llegiu les respostes"
 
@@ -923,6 +954,9 @@ msgstr "Heu demanat una resposta. Per protegir la vostra identitat en l'improbab
 
 msgid "Delete this reply"
 msgstr "Suprimeix aquesta resposta"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Voleu suprimir aquesta resposta?"
@@ -957,17 +991,27 @@ msgstr "Important"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "S'ha tancat la sessió per inactivitat. Feu clic en el botó <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Identitat nova</b> en la barra d'eines del navegador Tor abans d'anar-vos-en. Això buidarà les dades d'activitat en el navegador Tor d'aquest aparell."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Per què hi ha un avís sobre el Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "L'ús de Tor2Web per connectar a SecureDrop no protegeix el vostre anonimat."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "És possible que qualsevol persona que faci seguiment del vostre trànsit d'Internet (govern, proveïdor d'Internet) us identifiqui."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "Us <strong>encoratgem</strong> que utilitzeu el <a href=\"www.torproject.org/projects/torbrowser.html\">navegador Tor</a> com a alternativa."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Hauríeu d'usar el navegador Tor"
@@ -1023,6 +1067,65 @@ msgstr "<strong>Important:</strong> si voleu romandre en l'anonimat, <strong>no<
 
 msgid "Back to submission page"
 msgstr "Torna a la pàgina d'enviaments"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "S'ha seleccionat el fitxer següent per <strong>suprimir definitivament</strong>:"
+#~ msgstr[1] "S'han seleccionat els {num} fitxers següents per <strong>suprimir definitivament</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Suprimeix els fitxers de forma permanent"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "SUPRIMEIX ELS FITXERS DEFINITIVAMENT"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Torna a la llista de documents de {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "ADVERTÈNCIA:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Sembla que feu servir Tor2Web, que no garanteix l'anonimat."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Per què això és perillós?"
+
+#~ msgid "Welcome"
+#~ msgstr "Us donem la benvinguda"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Escriviu aquest nom en clau i conserveu-lo en un lloc segur, o memoritzeu-lo."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Aquest nom en clau és el que usareu en visites futures per a rebre missatges del nostre equip, en resposta a allò que envieu en la pantalla següent."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Atès que no rastregem els usuaris del nostre servei <b>SecureDrop</b>, \n"
+#~ "en visites futures, només podrem contactar amb vós a través d'aquest nom en clau, en cas que tinguem preguntes\n"
+#~ "o interès en informació addicional. A diferència de les contrasenyes, no hi ha cap forma de recuperar un nom en clau perdut."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Envia els documents"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "ENVIA DOCUMENTS"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Seleccioneu <b>Configuració avançada de seguretat</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Seleccioneu <b>El més segur</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Per què hi ha un avís sobre el Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "Us <strong>encoratgem</strong> que utilitzeu el <a href=\"www.torproject.org/projects/torbrowser.html\">navegador Tor</a> com a alternativa."
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "El format del secret no és vàlid: la mida no coincideix. L’heu inserit correctament?"
@@ -1080,12 +1183,6 @@ msgstr "Torna a la pàgina d'enviaments"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "Inici del SecureDrop"
-
-#~ msgid "Show"
-#~ msgstr "Mostra"
-
-#~ msgid "Hide"
-#~ msgstr "Amaga"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— No hi ha cap missatge —"
@@ -1242,9 +1339,6 @@ msgstr "Torna a la pàgina d'enviaments"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Ja heu enviat alguna cosa?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Si ja heu enviat informació a periodistes, inicieu sessió per revisar les respostes."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "COMPROVA SI HI HA RESPOSTES"

--- a/securedrop/translations/cs/LC_MESSAGES/messages.po
+++ b/securedrop/translations/cs/LC_MESSAGES/messages.po
@@ -4,7 +4,19 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.14.0~rc1\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPO-Revision-Date: 2022-02-14 12:04+0000\nLast-Translator: Honza Cibulka <honza@datastory.cz>\nLanguage-Team: Czech <https://weblate.securedrop.org/projects/securedrop/securedrop/cs/>\nLanguage: cs\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.5.1\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.14.0~rc1\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"PO-Revision-Date: 2022-02-14 12:04+0000\n"
+"Last-Translator: Honza Cibulka <honza@datastory.cz>\n"
+"Language-Team: Czech <https://weblate.securedrop.org/projects/securedrop/securedrop/cs/>\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.5.1\n"
 
 msgid "Name too long"
 msgstr "Uživatelské jméno je příliš dlouhé"
@@ -134,11 +146,17 @@ msgstr[0] "Uživatelské jméno nemůže obsahovat více než {num} znak."
 msgstr[1] "Uživatelské jméno nemůže obsahovat více než {num} znaky."
 msgstr[2] "Uživatelské jméno nemůže obsahovat více než {num} znaků."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Toto pole je povinné."
 
 msgid "You cannot send an empty reply."
 msgstr "Nemůžete odeslat prázdnou odpověď."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Soubor je povinný."
@@ -419,6 +437,9 @@ msgstr "Jakmile nastavíte svůj YubiKey, zadejte šesticiferný kód níže:"
 msgid "Navigation"
 msgstr "Navigace"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Přihlášen/a jako"
 
@@ -542,6 +563,15 @@ msgstr "Preference podání"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Zabraňte zdrojům nahrávat dokumenty. Zdroje budou stále moci posílat zprávy."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Aktualizujte preference podání"
 
@@ -559,21 +589,6 @@ msgstr "Pošlete testovací OSSEC upozornění"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "POSLAT TESTOVACÍ UPOZORNĚNÍ OSSEC"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Následující soubor byl vybrán pro <strong>trvalé smazání</strong>:"
-msgstr[1] "Následující {num} soubory byly vybrány pro <strong>trvalé smazání</strong>:"
-msgstr[2] "Následujících {num} souborů bylo vybráno pro <strong>trvalé smazání</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "Trvale smazat soubory"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "TRVALE SMAZAT SOUBORY"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Vrátit se do seznamu dokumentů od „{source_name}“…"
 
 msgid "Edit user \"{user}\""
 msgstr "Upravit uživatele „{user}“"
@@ -716,15 +731,6 @@ msgstr "Přihlásit se"
 msgid "LOG IN"
 msgstr "PŘIHLÁSIT SE"
 
-msgid "WARNING:"
-msgstr "VAROVÁNÍ:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Vypadá to, že používáte Tor2Web, který neposkytuje anonymitu."
-
-msgid "Why is this dangerous?"
-msgstr "Proč je tohle nebezpečné?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Pole musí mít mezi 1 a {max_codename_len} znaky."
 
@@ -743,6 +749,9 @@ msgstr "Zpráva je příliš dlouhá."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Rozsáhlé bloky textu musí být nahrány jako soubor, ne zkopírovány a vloženy."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Protože jste již přihlášen/a, byl/a jste přesměrován/a na tuto stránku. Pokud chcete vytvořit nový účet, nejprve se odhlaste."
 
@@ -757,6 +766,20 @@ msgstr "Musíte napsat zprávu nebo vybrat soubor pro nahrání."
 
 msgid "You must enter a message."
 msgstr "Musíte vložit zprávu."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Uživatelské jméno musí mít alespoň {num} znak."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Zapomněli jste své krycí jméno?"
+
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr ""
 
 msgid "Thanks! We received your message."
 msgstr "Děkujeme! Obdrželi jsme vaši zprávu."
@@ -776,8 +799,14 @@ msgstr "Všechny odpovědi byly smazány"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Promiňte, toto krycí jméno nikdo nepoužívá."
 
+msgid "Codename"
+msgstr "Krycí jméno"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Chráníme novináře a jejich zdroje"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Omlouváme se, náš SecureDrop je aktuálně offline."
@@ -812,29 +841,25 @@ msgstr "Uvědomte si prosím, že sdílení citlivých dokumentů Vás může oh
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop je projekt Freedom of the Press Foundation."
 
-msgid "Welcome"
-msgstr "Vítejte"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Zadejte své krycí jméno"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Zapište si prosím toto krycí jméno a uchovávejte ho na bezpečném místě, nebo si jej zapamatujte."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
+msgstr ""
 
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Toto krycí jméno budete v budoucnu využívat pro komunikaci s naším týmem na základě toho, co pošlete na příští obrazovce."
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "Codename"
-msgstr "Krycí jméno"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
 
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
-msgstr "Protože nesledujeme uživatele naší služby <b>SecureDrop</b>\n pro Vaše příští návštěvy bude použití tohoto krycího jména jedinou možností, jak s Vámi můžeme komunikovat,\n budete-li se chtít na něco zeptat. Na rozdíl od hesla neexistuje způsob, jak zapomenuté krycí jméno získat zpět."
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
 
-msgid "Submit Documents"
-msgstr "Odeslat dokumenty"
-
-msgid "SUBMIT DOCUMENTS"
-msgstr "ODESLAT DOKUMENTY"
+msgid "Continue"
+msgstr "Pokračovat"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "<a id=\"disable-js\" href=\"\"><b>Úroveň zabezpečení</b></a> vašeho prohlížeče Tor je příliš nízká. Pro jeho změnu použijte tlačítko&nbsp;<img src=\"{icon}\" alt=\"&quot;Úroveň zabezpečení&quot;\"> na liště prohlížeče."
@@ -845,11 +870,11 @@ msgstr "Jak změnit úroveň vašeho zabezpečení"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Klepněte na <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> v panelu nástrojů výše"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Vyberte <b>Rozšířené bezpečnostní nastavení</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Zvolte <b>Nejbezpečnější</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Postupujte podle instrukcí, obnovte tuto stránku\">Obnovte stránku</a> a máte hotovo!"
@@ -884,9 +909,6 @@ msgstr "Zadat krycí jméno"
 msgid "Enter your codename"
 msgstr "Zadejte své krycí jméno"
 
-msgid "Continue"
-msgstr "Pokračovat"
-
 msgid "CANCEL"
 msgstr "ZRUŠIT"
 
@@ -895,6 +917,12 @@ msgstr "Ještě jedna věc..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Klepněte na <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Nová identita</b> na liště svého prohlížeče Tor. Smažete tím data o aktivitě prohlížeče Tor na tomto zařízení."
+
+msgid "Show"
+msgstr "Zobrazit"
+
+msgid "Hide"
+msgstr "Skrýt"
 
 msgid "Remember, your codename is:"
 msgstr "Pamatujte, vaše krycí jméno je:"
@@ -923,6 +951,9 @@ msgstr "Maximální velikost uploadu: 500 MB"
 msgid "Submit"
 msgstr "Odeslat"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Přečtěte si odpovědi"
 
@@ -931,6 +962,9 @@ msgstr "Obdržel/a jste odpověď. Pro případ, že by se někdo dozvěděl va�
 
 msgid "Delete this reply"
 msgstr "Smazat tuto odpověď"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Smazat tuto odpověď?"
@@ -965,17 +999,27 @@ msgstr "Důležité"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "Z důvodu neaktivity jste byli odhlášeni. Než budete pokračovat, klepněte na <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Nová identita</b> na liště svého prohlížeče Tor. Smažete tím data o aktivitě Toru na tomto zařízení."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Proč je tady upozornění o Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Používaní Tor2Web pro připojení k SecureDropu neochrání vaši anonymitu."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Kdokoliv, kdo sleduje vaši aktivitu na internetu (vláda nebo poskytovatel připojení) vás může identifikovat."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "<strong>Velmi doporučujeme</strong> použití <a href=\"www.torproject.org/projects/torbrowser.html\">prohlížeče Tor</a>."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Doporučujeme použít prohlížeč Tor"
@@ -1031,6 +1075,66 @@ msgstr "<strong>Důležité:</strong> Chcete-li zůstat v anonymitě, <strong>ne
 
 msgid "Back to submission page"
 msgstr "Zpátky na stránku podání"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Následující soubor byl vybrán pro <strong>trvalé smazání</strong>:"
+#~ msgstr[1] "Následující {num} soubory byly vybrány pro <strong>trvalé smazání</strong>:"
+#~ msgstr[2] "Následujících {num} souborů bylo vybráno pro <strong>trvalé smazání</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Trvale smazat soubory"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "TRVALE SMAZAT SOUBORY"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Vrátit se do seznamu dokumentů od „{source_name}“…"
+
+#~ msgid "WARNING:"
+#~ msgstr "VAROVÁNÍ:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Vypadá to, že používáte Tor2Web, který neposkytuje anonymitu."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Proč je tohle nebezpečné?"
+
+#~ msgid "Welcome"
+#~ msgstr "Vítejte"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Zapište si prosím toto krycí jméno a uchovávejte ho na bezpečném místě, nebo si jej zapamatujte."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Toto krycí jméno budete v budoucnu využívat pro komunikaci s naším týmem na základě toho, co pošlete na příští obrazovce."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Protože nesledujeme uživatele naší služby <b>SecureDrop</b>\n"
+#~ " pro Vaše příští návštěvy bude použití tohoto krycího jména jedinou možností, jak s Vámi můžeme komunikovat,\n"
+#~ " budete-li se chtít na něco zeptat. Na rozdíl od hesla neexistuje způsob, jak zapomenuté krycí jméno získat zpět."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Odeslat dokumenty"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "ODESLAT DOKUMENTY"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Vyberte <b>Rozšířené bezpečnostní nastavení</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Zvolte <b>Nejbezpečnější</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Proč je tady upozornění o Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "<strong>Velmi doporučujeme</strong> použití <a href=\"www.torproject.org/projects/torbrowser.html\">prohlížeče Tor</a>."
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Nesprávná forma hesla: lichá délka hesla. Neudělal/a jste překlep?"
@@ -1088,12 +1192,6 @@ msgstr "Zpátky na stránku podání"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "Domovská stránka SecureDrop"
-
-#~ msgid "Show"
-#~ msgstr "Zobrazit"
-
-#~ msgid "Hide"
-#~ msgstr "Skrýt"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Žádné zprávy —"

--- a/securedrop/translations/de_DE/LC_MESSAGES/messages.po
+++ b/securedrop/translations/de_DE/LC_MESSAGES/messages.po
@@ -1,5 +1,18 @@
 msgid ""
-msgstr "Project-Id-Version: SecureDrop \\'0.3.5\\'\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPOT-Creation-Date: 2017-09-02 07:28+0000\nPO-Revision-Date: 2022-02-11 16:04+0000\nLast-Translator: Ettore Atalan <atalanttore@googlemail.com>\nLanguage-Team: German <https://weblate.securedrop.org/projects/securedrop/securedrop/de/>\nLanguage: de_DE\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n != 1;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop \\'0.3.5\\'\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"POT-Creation-Date: 2017-09-02 07:28+0000\n"
+"PO-Revision-Date: 2022-02-11 16:04+0000\n"
+"Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
+"Language-Team: German <https://weblate.securedrop.org/projects/securedrop/securedrop/de/>\n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "Name zu lang"
@@ -125,11 +138,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "Darf nicht länger als {num} Zeichen sein."
 msgstr[1] "Darf nicht länger als {num} Zeichen sein."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Dieses Feld ist erforderlich."
 
 msgid "You cannot send an empty reply."
 msgstr "Sie können keine leere Antwort senden."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Datei erforderlich."
@@ -404,6 +423,9 @@ msgstr "Geben sie den folgenden 6-stelligen Code unten ein, sobald Sie Ihren Yub
 msgid "Navigation"
 msgstr "Navigation"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Angemeldet als"
 
@@ -527,6 +549,15 @@ msgstr "Einreichungseinstellungen"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Quellen am Hochladen von Dokumenten hindern. Quellen werden weiterhin Nachrichten senden können."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Einreichungseinstellungen aktualisieren"
 
@@ -544,20 +575,6 @@ msgstr "Test-OSSEC-Alarm senden"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "TESTWEISEN OSSEC-ALARM SENDEN"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Die folgende Datei wurde zum <strong>endgültigen Löschen</strong> ausgewählt:"
-msgstr[1] "Die folgenden {num} Dateien wurden zum <strong>endgültigen Löschen</strong> ausgewählt:"
-
-msgid "Permanently Delete Files"
-msgstr "Dateien endgültig löschen"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "DATEIEN PERMANENT LÖSCHEN"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Zurück zur Dokumentenliste für {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Benutzer \"{user}\" bearbeiten"
@@ -700,15 +717,6 @@ msgstr "Anmelden"
 msgid "LOG IN"
 msgstr "ANMELDEN"
 
-msgid "WARNING:"
-msgstr "WARNUNG:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Sie scheinen Tor2Web zu benutzen, das keine Anonymität bietet."
-
-msgid "Why is this dangerous?"
-msgstr "Warum ist das gefährlich?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Feld muss zwischen 1 und {max_codename_len} Zeichen lang sein."
 
@@ -727,6 +735,9 @@ msgstr "Nachricht zu lang."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Längere Texte müssen als Datei hochgeladen, und nicht kopiert und eingefügt werden."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Sie wurden umgeleitet, weil Sie bereits angemeldet sind. Wenn Sie ein neues Konto erstellen möchten, müssen Sie sich zuerst abmelden."
 
@@ -741,6 +752,22 @@ msgstr "Sie müssen eine Nachricht eingeben oder eine Datei zum Versenden auswä
 
 msgid "You must enter a message."
 msgstr "Sie müssen eine Nachricht eingeben."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Muss mindestens {num} Zeichen lang sein."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Decknamen vergessen?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Wenn Sie bereits an Journalisten versendet haben, melden Sie sich hier an, um nach Antworten zu schauen."
 
 msgid "Thanks! We received your message."
 msgstr "Danke! Wir haben Ihre Nachricht erhalten."
@@ -760,8 +787,14 @@ msgstr "Alle Antworten wurden gelöscht"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Entschuldigung, das ist kein erkannter Deckname."
 
+msgid "Codename"
+msgstr "Deckname"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Schützt Journalisten und Quellen"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Es tut uns leid, unser SecureDrop ist derzeit offline."
@@ -796,32 +829,25 @@ msgstr "Achtung: Das Teilen von vertraulichen Dokumenten kann Sie in Gefahr brin
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop ist ein Projekt der Freedom of the Press Foundation."
 
-msgid "Welcome"
-msgstr "Willkommen"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Geben Sie Ihren Decknamen ein"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Bitte notieren Sie sich diesen Decknamen und bewahren Sie ihn an einem sicheren Ort auf, oder merken Sie ihn sich."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Diesen Decknamen benutzen Sie, um bei zukünftigen Besuchen Nachrichten von unserem Team zu erhalten, die darauf antworten, was Sie im nächsten Schritt versenden."
-
-msgid "Codename"
-msgstr "Deckname"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"Wir verfolgen keine Nutzer unseres <b>SecureDrop</b>-Dienstes.\n"
-"Daher ist dieser Deckname die einzige Möglichkeit, um in Zukunft mit Ihnen zu kommunizieren, sollten wir Fragen haben oder an weiteren Information interessiert sein.\n"
-"Anders als bei Passwörtern gibt es keine Möglichkeit, einen verlorenen Decknamen wiederherzustellen."
 
-msgid "Submit Documents"
-msgstr "Dokumente einreichen"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "DOKUMENTE VERSENDEN"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "Fortsetzen"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "Die <a id=\"disable-js\" href=\"\"><b>Sicherheitsstufe</b></a> Ihres Tor-Browsers ist zu niedrig. Nutzen Sie die Schaltfläche <img src=\"{icon}\" alt=\"&quot;Sicherheitsstufe&quot;\"> in der Werkzeugleiste Ihres Browsers, um sie zu ändern."
@@ -832,11 +858,11 @@ msgstr "Wie Sie Ihre Sicherheitsstufe ändern"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Klicken Sie auf <img src=\"{icon}\" alt=\"Schaltfläche &quot;Sicherheitsstufe&quot;\"> in der Werkzeugleiste oben"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Wählen Sie <b>Erweiterte Sicherheitseinstellungen</b> aus"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Wählen Sie <b>Am sichersten</b> aus"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Befolgen Sie diese Anweisungen und aktualisieren Sie dann diese Seite\">Aktualisieren Sie diese Seite</a>, und Sie sind fertig!"
@@ -871,9 +897,6 @@ msgstr "Deckname eingeben"
 msgid "Enter your codename"
 msgstr "Geben Sie Ihren Decknamen ein"
 
-msgid "Continue"
-msgstr "Fortsetzen"
-
 msgid "CANCEL"
 msgstr "ABBRECHEN"
 
@@ -882,6 +905,12 @@ msgstr "Eine Sache noch..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Klicken Sie auf die Schaltfläche <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Neue Identität</b> in der Werkzeugleiste Ihres Tor-Browsers. Dies löscht Ihre Tor-Browser-Aktivitätsdaten auf diesem Gerät."
+
+msgid "Show"
+msgstr "Anzeigen"
+
+msgid "Hide"
+msgstr "Verstecken"
 
 msgid "Remember, your codename is:"
 msgstr "Denken Sie daran, Ihr Deckname ist:"
@@ -910,6 +939,9 @@ msgstr "Maximale Upload-Größe: 500 MB"
 msgid "Submit"
 msgstr "Absenden"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Antworten lesen"
 
@@ -918,6 +950,9 @@ msgstr "Sie haben eine Antwort erhalten. Um Ihre Identität in dem unwahrscheinl
 
 msgid "Delete this reply"
 msgstr "Diese Antwort löschen"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Diese Antwort löschen?"
@@ -952,17 +987,27 @@ msgstr "Wichtig"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "Sie wurden wegen Inaktivität abgemeldet. Klicken Sie auf die Schaltfläche <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Neue Identität</b> in der Werkzeugleiste Ihres Tor-Browsers bevor Sie weitermachen. Dies löscht Ihre Tor-Browser-Aktivitätsdaten auf diesem Gerät."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Warum gibt es eine Warnung über Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Die Verwendung von Tor2Web, um sich mit SecureDrop zu verbinden, schützt Ihre Anonymität nicht."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Es könnte für jeden möglich sein, Ihren Internetverkehr zu überwachen (Ihre Regierung, Ihr Internetanbieter), um Sie zu identifizieren."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "Wir <strong>empfehlen Ihnen dringend</strong>, stattdessen den <a href=\"www.torproject.org/projects/torbrowser.html\">Tor-Browser</a> zu verwenden."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Sie sollten den Tor-Browser benutzen"
@@ -1018,6 +1063,65 @@ msgstr "<strong>Wichtig:</strong> Verwenden Sie <strong>nicht</strong> GPG, um d
 
 msgid "Back to submission page"
 msgstr "Zurück zur Einreichungsseite"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Die folgende Datei wurde zum <strong>endgültigen Löschen</strong> ausgewählt:"
+#~ msgstr[1] "Die folgenden {num} Dateien wurden zum <strong>endgültigen Löschen</strong> ausgewählt:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Dateien endgültig löschen"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "DATEIEN PERMANENT LÖSCHEN"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Zurück zur Dokumentenliste für {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "WARNUNG:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Sie scheinen Tor2Web zu benutzen, das keine Anonymität bietet."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Warum ist das gefährlich?"
+
+#~ msgid "Welcome"
+#~ msgstr "Willkommen"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Bitte notieren Sie sich diesen Decknamen und bewahren Sie ihn an einem sicheren Ort auf, oder merken Sie ihn sich."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Diesen Decknamen benutzen Sie, um bei zukünftigen Besuchen Nachrichten von unserem Team zu erhalten, die darauf antworten, was Sie im nächsten Schritt versenden."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Wir verfolgen keine Nutzer unseres <b>SecureDrop</b>-Dienstes.\n"
+#~ "Daher ist dieser Deckname die einzige Möglichkeit, um in Zukunft mit Ihnen zu kommunizieren, sollten wir Fragen haben oder an weiteren Information interessiert sein.\n"
+#~ "Anders als bei Passwörtern gibt es keine Möglichkeit, einen verlorenen Decknamen wiederherzustellen."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Dokumente einreichen"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "DOKUMENTE VERSENDEN"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Wählen Sie <b>Erweiterte Sicherheitseinstellungen</b> aus"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Wählen Sie <b>Am sichersten</b> aus"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Warum gibt es eine Warnung über Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "Wir <strong>empfehlen Ihnen dringend</strong>, stattdessen den <a href=\"www.torproject.org/projects/torbrowser.html\">Tor-Browser</a> zu verwenden."
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Ungültiges Geheimnisformat: ungerade Geheimnislänge. Haben Sie das Geheimnis falsch eingetippt?"
@@ -1075,12 +1179,6 @@ msgstr "Zurück zur Einreichungsseite"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "SecureDrop Startseite"
-
-#~ msgid "Show"
-#~ msgstr "Anzeigen"
-
-#~ msgid "Hide"
-#~ msgstr "Verstecken"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Keine Nachrichten —"
@@ -1240,9 +1338,6 @@ msgstr "Zurück zur Einreichungsseite"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Haben Sie bereits etwas versendet?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Wenn Sie bereits an Journalisten versendet haben, melden Sie sich hier an, um nach Antworten zu schauen."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "NACH EINER ANTWORT SCHAUEN"

--- a/securedrop/translations/el/LC_MESSAGES/messages.po
+++ b/securedrop/translations/el/LC_MESSAGES/messages.po
@@ -4,7 +4,19 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.8.0~rc1\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPO-Revision-Date: 2022-02-09 21:04+0000\nLast-Translator: Dimitris Maroulidis <dmaroulidis@dimitrismaroulidis.com>\nLanguage-Team: Greek <https://weblate.securedrop.org/projects/securedrop/securedrop/el/>\nLanguage: el\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n != 1;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.5.1\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.8.0~rc1\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"PO-Revision-Date: 2022-02-09 21:04+0000\n"
+"Last-Translator: Dimitris Maroulidis <dmaroulidis@dimitrismaroulidis.com>\n"
+"Language-Team: Greek <https://weblate.securedrop.org/projects/securedrop/securedrop/el/>\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.5.1\n"
 
 msgid "Name too long"
 msgstr "Το όνομα είναι πολύ μεγάλο"
@@ -130,11 +142,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "Δεν μπορεί να περιέχει παραπάνω από {num} χαρακτήρα."
 msgstr[1] "Δεν μπορεί να περιέχει παραπάνω από {num} χαρακτήρες."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Αυτό το πεδίο είναι υποχρεωτικό."
 
 msgid "You cannot send an empty reply."
 msgstr "Δεν μπορείτε να στείλετε κενή απάντηση."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Απαιτείται αρχείο."
@@ -409,6 +427,9 @@ msgstr "Όταν ολοκληρώσετε την παραμετροποίηση 
 msgid "Navigation"
 msgstr "Πλοήγηση"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Συνδεδεμένος/η ως"
 
@@ -532,6 +553,15 @@ msgstr "Ρυθμίσεις καταχωρήσεων"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Να μην επιτρέπεται σε πηγές να ανεβάζουν έγγραφα. Οι πηγές θα μπορούν παρ' όλα αυτά να στέλνουν μηνύματα."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Ενημέρωση ρυθμίσεων υποβολών"
 
@@ -549,20 +579,6 @@ msgstr "Αποστολή δοκιμαστικής ειδοποίησης OSSEC"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "ΑΠΟΣΤΟΛΗ ΔΟΚΙΜΑΣΤΙΚΗΣ ΕΙΔΟΠΟΙΗΣΗΣ OSSEC"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Το ακόλουθο αρχείο έχει επιλεχθεί για <strong>μόνιμη διαγραφή</strong>:"
-msgstr[1] "Τα ακόλουθα {num} αρχεία έχουν επιλεχθεί για <strong>μόνιμη διαγραφή</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "Μόνιμη διαγραφή αρχείων"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "ΜΟΝΙΜΗ ΔΙΑΓΡΑΦΗ ΑΡΧΕΙΩΝ"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Επιστροφή στη λίστα εγγράφων για τον/την {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Επεξεργασία χρήστη \"{user}\""
@@ -705,15 +721,6 @@ msgstr "Σύνδεση"
 msgid "LOG IN"
 msgstr "ΣΥΝΔΕΣΗ"
 
-msgid "WARNING:"
-msgstr "ΠΡΟΣΟΧΗ:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Φαίνεται πως χρησιμοποιείτε το Tor2Web, το οποίο δεν παρέχει ανωνυμία."
-
-msgid "Why is this dangerous?"
-msgstr "Γιατί είναι επικίνδυνο;"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Το πεδίο πρέπει να περιέχει μεταξύ 1 και {max_codename_len} χαρακτήρες."
 
@@ -732,6 +739,9 @@ msgstr "Το κείμενο του μηνύματος είναι πολύ μεγ
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Μεγάλα κείμενα πρέπει να ανεβαίνουν ως αρχεία, και όχι να αντιγράφονται και να επικολλούνται."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Ανακατευθυνθήκατε επειδή είστε ήδη συνδεδεμένος. Αν θέλετε να δημιουργήσετε έναν νέο λογαριασμό, πρέπει πρώτα να αποσυνδεθείτε."
 
@@ -746,6 +756,22 @@ msgstr "Πρέπει να πληκτρολογήσετε ένα μήνυμα ή 
 
 msgid "You must enter a message."
 msgstr "Πρέπει να πληκτρολογήσετε ένα μήνυμα."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Πρέπει να έχει τουλάχιστον {num} χαρακτήρα."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Ξεχάσατε το κωδικό όνομά σας;"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Αν έχετε ήδη υποβάλλει κάτι στους δημοσιογράφους, συνδεθείτε για να ελέγξετε για απαντήσεις."
 
 msgid "Thanks! We received your message."
 msgstr "Ευχαριστούμε! Λάβαμε το μήνυμά σας."
@@ -765,8 +791,14 @@ msgstr "Όλες οι απαντήσεις διαγράφτηκαν"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Συγγνώμη, το κωδικό όνομα δεν αναγνωρίζεται."
 
+msgid "Codename"
+msgstr "Κωδικό όνομα"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Προστατεύοντας δημοσιογράφους και πηγές"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Συγγνώμη, αυτή τη στιγμή το SecureDrop μας είναι εκτός σύνδεσης."
@@ -801,29 +833,25 @@ msgstr "Σημείωση: Η κοινοποίηση ευαίσθητων αρχ�
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "Το SecureDrop είναι έργο του ιδρύματος Freedom of the Press."
 
-msgid "Welcome"
-msgstr "Καλωσήλθατε"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Γράψτε το κωδικό όνομά σας"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Παρακαλώ είτε γράψτε και αποθηκεύστε το κωδικό όνομά σας σε κάποιο ασφαλές σημείο, ή αποστηθίστε το."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
+msgstr ""
 
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Θα χρησιμοποιείτε αυτό το κωδικό όνομα σε μελλοντικές επισκέψεις σας, για να λαμβάνετε μηνύματα από την ομάδα μας, που θα απαντούν σε αυτά που θα υποβάλετε στην επόμενη οθόνη."
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "Codename"
-msgstr "Κωδικό όνομα"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
 
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
-msgstr "Επειδή δεν παρακολουθούμε τους χρήστες της υπηρεσίας <b>SecureDrop</b> μας,\nσε μελλοντικές επισκέψεις σας, η χρήση αυτού του κωδικού ονόματος είναι ο μοναδικός τρόπος για να επικοινωνήσουμε μαζί σας αν έχουμε απορίες ή ενδιαφερόμαστε για περισσότερες πληροφορίες. Σε αντίθεση με τους κωδικούς, δεν υπάρχει τρόπος να ανακτήσετε το κωδικό όνομα αν το χάσετε ή το ξεχάσετε."
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
 
-msgid "Submit Documents"
-msgstr "Υποβολή εγγράφων"
-
-msgid "SUBMIT DOCUMENTS"
-msgstr "ΥΠΟΒΟΛΗ ΕΓΓΡΑΦΩΝ"
+msgid "Continue"
+msgstr "Συνέχεια"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "Το <a id=\"disable-js\" href=\"\"><b>Επίπεδο ασφαλείας</b></a> του Tor Browser σας είναι πολύ χαμηλό. Χρησιμοποιήστε το κουμπί <img src=\"{icon}\" alt=\"&quot;Επίπεδο ασφαλείας&quot;\"> στη γραμμή εργαλειών για να το αλλάξετε."
@@ -834,11 +862,11 @@ msgstr "Πως να αλλάξετε το επίπεδο ασφαλείας σα
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Πατήστε το <img src=\"{icon}\" alt=\"κουμπί &quot;Επίπεδο ασφαλείας&quot;\">στη γραμμή εργαλειών παραπάνω"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Επιλέξτε τις <b>Ρυθμίσεις ασφαλείας για προχωρημένους</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Επιλέξτε <b>Ασφαλέστατο</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Ακολουθήστε αυτές τις οδηγίες, και μετά ανανεώστε τη σελίδα\">Ανανεώστε τη σελίδα</a> και τελειώσατε!"
@@ -873,9 +901,6 @@ msgstr "Εισαγωγή κωδικού ονόματος"
 msgid "Enter your codename"
 msgstr "Γράψτε το κωδικό όνομά σας"
 
-msgid "Continue"
-msgstr "Συνέχεια"
-
 msgid "CANCEL"
 msgstr "ΆΚΥΡΟ"
 
@@ -884,6 +909,12 @@ msgstr "Κάτι ακόμα..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Πατήστε το κουμπί <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Νέα Ταυτότητα</b> στη γραμμη εργαλείων του Tor Browser σας. Αυτό θα διαγράψει τα δεδομένα δραστηριότητας του Tor Browser σας σε αυτή τη συσκευή."
+
+msgid "Show"
+msgstr "Εμφάνιση"
+
+msgid "Hide"
+msgstr "Απόκρυψη"
 
 msgid "Remember, your codename is:"
 msgstr "Θυμήσου, το κωδικό όνομά σου είναι:"
@@ -912,6 +943,9 @@ msgstr "Μέγιστο μέγεθος υποβολής: 500 MB"
 msgid "Submit"
 msgstr "Υποβολή"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Ανάγνωση απαντήσεων"
 
@@ -920,6 +954,9 @@ msgstr "Έχετε λάβει μια απάντηση. Για να προστα�
 
 msgid "Delete this reply"
 msgstr "Διαγραφή αυτής της απάντησης"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Διαγραφή αυτής της απάντησης;"
@@ -954,17 +991,27 @@ msgstr "Σημαντικό"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "Αποσυνδεθήκατε λόγω αδράνειας. Πατήστε το κουμπί <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Νέα Ταυτότητα</b> στη γραμμή εργαλείων του Tor Browser σας πριν συνεχίσετε. Αυτό θα διαγράψει τα δεδομένα δραστηριότητας του Tor Browser σε αυτή τη συσκευή."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Γιατί υπάρχει προειδοποίηση για το Tor2Web;"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Η χρήση του Tor2Web για να συνδεθείτε στο SecureDrop δεν θα προστατεύσει την ανωνυμία σας."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Είναι δυνατό να παρακολουθεί ο οποιοσδήποτε την κίνηση δικτύου σας (η κυβέρνηση, ο πάροχός σας) για να σας ταυτοποιήσει."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "<strong>Προτείνουμε ανεπιφύλακτα</strong> να χρησιμοποιήσετε τον <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> καλύτερα."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Καλό θα ήταν να χρησιμοποιήσετε τον Tor Browser"
@@ -1020,6 +1067,64 @@ msgstr "<strong>Σημαντικό:</strong> Αν επιθυμείτε να δι
 
 msgid "Back to submission page"
 msgstr "Πίσω στη σελίδα υποβολών"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Το ακόλουθο αρχείο έχει επιλεχθεί για <strong>μόνιμη διαγραφή</strong>:"
+#~ msgstr[1] "Τα ακόλουθα {num} αρχεία έχουν επιλεχθεί για <strong>μόνιμη διαγραφή</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Μόνιμη διαγραφή αρχείων"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "ΜΟΝΙΜΗ ΔΙΑΓΡΑΦΗ ΑΡΧΕΙΩΝ"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Επιστροφή στη λίστα εγγράφων για τον/την {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "ΠΡΟΣΟΧΗ:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Φαίνεται πως χρησιμοποιείτε το Tor2Web, το οποίο δεν παρέχει ανωνυμία."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Γιατί είναι επικίνδυνο;"
+
+#~ msgid "Welcome"
+#~ msgstr "Καλωσήλθατε"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Παρακαλώ είτε γράψτε και αποθηκεύστε το κωδικό όνομά σας σε κάποιο ασφαλές σημείο, ή αποστηθίστε το."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Θα χρησιμοποιείτε αυτό το κωδικό όνομα σε μελλοντικές επισκέψεις σας, για να λαμβάνετε μηνύματα από την ομάδα μας, που θα απαντούν σε αυτά που θα υποβάλετε στην επόμενη οθόνη."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Επειδή δεν παρακολουθούμε τους χρήστες της υπηρεσίας <b>SecureDrop</b> μας,\n"
+#~ "σε μελλοντικές επισκέψεις σας, η χρήση αυτού του κωδικού ονόματος είναι ο μοναδικός τρόπος για να επικοινωνήσουμε μαζί σας αν έχουμε απορίες ή ενδιαφερόμαστε για περισσότερες πληροφορίες. Σε αντίθεση με τους κωδικούς, δεν υπάρχει τρόπος να ανακτήσετε το κωδικό όνομα αν το χάσετε ή το ξεχάσετε."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Υποβολή εγγράφων"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "ΥΠΟΒΟΛΗ ΕΓΓΡΑΦΩΝ"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Επιλέξτε τις <b>Ρυθμίσεις ασφαλείας για προχωρημένους</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Επιλέξτε <b>Ασφαλέστατο</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Γιατί υπάρχει προειδοποίηση για το Tor2Web;"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "<strong>Προτείνουμε ανεπιφύλακτα</strong> να χρησιμοποιήσετε τον <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> καλύτερα."
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Άκυρη μορφή μυστικού: το μυστικό έχει μονό αριθμό ψηφίων. Μήπως κάνατε κάποιο λάθος στην πληκτρολόγηση;"
@@ -1077,12 +1182,6 @@ msgstr "Πίσω στη σελίδα υποβολών"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "Κεντρική σελίδα SecureDrop"
-
-#~ msgid "Show"
-#~ msgstr "Εμφάνιση"
-
-#~ msgid "Hide"
-#~ msgstr "Απόκρυψη"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Δεν υπάρχουν μηνύματα —"
@@ -1239,9 +1338,6 @@ msgstr "Πίσω στη σελίδα υποβολών"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Έχετε ήδη υποβάλλει κάτι;"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Αν έχετε ήδη υποβάλλει κάτι στους δημοσιογράφους, συνδεθείτε για να ελέγξετε για απαντήσεις."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "ΕΛΕΓΧΟΣ ΓΙΑ ΑΠΑΝΤΗΣΕΙΣ"

--- a/securedrop/translations/es_ES/LC_MESSAGES/messages.po
+++ b/securedrop/translations/es_ES/LC_MESSAGES/messages.po
@@ -4,7 +4,20 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.3.12\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPOT-Creation-Date: 2017-09-02 07:28+0000\nPO-Revision-Date: 2022-02-10 04:04+0000\nLast-Translator: Zuhualime Akoochimoya <zakooch@protonmail.ch>\nLanguage-Team: Spanish <https://weblate.securedrop.org/projects/securedrop/securedrop/es/>\nLanguage: es_ES\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n != 1;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.3.12\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"POT-Creation-Date: 2017-09-02 07:28+0000\n"
+"PO-Revision-Date: 2022-02-10 04:04+0000\n"
+"Last-Translator: Zuhualime Akoochimoya <zakooch@protonmail.ch>\n"
+"Language-Team: Spanish <https://weblate.securedrop.org/projects/securedrop/securedrop/es/>\n"
+"Language: es_ES\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "Nombre demasiado largo"
@@ -130,11 +143,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "No puede tener más que {num} carácter."
 msgstr[1] "No puede tener más que {num} caracteres."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Este campo es obligatorio."
 
 msgid "You cannot send an empty reply."
 msgstr "No puedes enviar una respuesta vacía."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Archivo requerido."
@@ -409,6 +428,9 @@ msgstr "Una vez que hayas configurado tu YubiKey, ingresa abajo el código de ve
 msgid "Navigation"
 msgstr "Navegación"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Sesión iniciada como"
 
@@ -532,6 +554,15 @@ msgstr "Preferencias de envío"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Impide que las fuentes suban documentos. Las fuentes todavía podrán seguir enviando mensajes."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Actualizar preferencias de envío"
 
@@ -549,20 +580,6 @@ msgstr "Enviar alerta OSSEC de prueba"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "ENVIAR ALERTA DE PRUEBA OSSEC"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "El siguiente archivo ha sido seleccionado para <strong>eliminación permanente</strong>:"
-msgstr[1] "Los siguientes {num} archivos han sido seleccionados para <strong>eliminación permanente</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "Borrar archivos permanentemente"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "ELIMINAR ARCHIVOS PERMANENTEMENTE"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Volver a la lista de documentos de {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Editar usuario \"{user}\""
@@ -705,15 +722,6 @@ msgstr "Iniciar Sesión"
 msgid "LOG IN"
 msgstr "INICIAR SESIÓN"
 
-msgid "WARNING:"
-msgstr "ADVERTENCIA:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Aparentemente estás usando Tor2Web, el cual no provee anonimato."
-
-msgid "Why is this dangerous?"
-msgstr "¿Por qué es peligroso esto?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Este campo debe tener de 1 a {max_codename_len} caracteres de longitud."
 
@@ -732,6 +740,9 @@ msgstr "Texto del mensaje demasiado largo."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Bloques de texto grandes deben ser cargados como archivo, no copiados y pegados."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Fuiste redirigido porque ya tenías una sesión iniciada. Si deseas crear una cuenta nueva, debes cerrar la sesión primero."
 
@@ -746,6 +757,22 @@ msgstr "Debes escribir un mensaje o elegir un archivo para enviar."
 
 msgid "You must enter a message."
 msgstr "Debes escribir un mensaje."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Debe tener por lo menos {num} carácter de longitud."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "¿Olvidaste tu nombre clave?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Si usted ya ha enviado a periodistas en el pasado, inicie sesión para verificar si tiene respuestas."
 
 msgid "Thanks! We received your message."
 msgstr "¡Gracias! Recibimos tu mensaje."
@@ -765,8 +792,14 @@ msgstr "Todas las repuestas han sido eliminadas"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Lo sentimos, ese nombre clave no es reconocido."
 
+msgid "Codename"
+msgstr "Nombre Clave"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Protegiendo a Periodistas y Fuentes"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Lo sentimos, nuestro SecureDrop no está en línea en este momento."
@@ -801,32 +834,25 @@ msgstr "Por favor ten en cuenta: compartir documentos confidenciales puede poner
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop es un proyecto de la Freedom of the Press Foundation."
 
-msgid "Welcome"
-msgstr "Bienvenido"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Ingresa tu Nombre Clave"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Por favor, escribe este nombre clave y guárdalo en un lugar seguro, o memorízalo."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Este nombre clave es el que usarás en futuras visitas para recibir mensajes de nuestro equipo en respuesta a lo que envíes en la siguiente pantalla."
-
-msgid "Codename"
-msgstr "Nombre Clave"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"Debido a que no rastreamos a los usuarios de nuestro servicio <b>SecureDrop</b>,\n"
-"usar este nombre clave es la única manera que tenemos de comunicarnos contigo en futuras visitas, en caso que tuviéramos\n"
-"preguntas o estuviéramos interesados en información adicional. A diferencia de las contraseñas, no hay forma de recuperar un nombre clave perdido."
 
-msgid "Submit Documents"
-msgstr "Enviar Documentos"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "ENVIAR DOCUMENTOS"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "Continuar"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "El <a id=\"disable-js\" href=\"\"><b>Nivel de Seguridad</b></a> de tu Navegador Tor está demasiado bajo. Usa el botón <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> en la barra de herramientas de tu navegador para cambiarlo."
@@ -837,11 +863,11 @@ msgstr "Cómo cambiar tu nivel de seguridad"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Haz clic en el botón <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\">, arriba en la barra de herramientas"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Selecciona <b>Configuración de seguridad avanzada</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Selecciona <b>El más seguro de todos</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "¡<a href=\"/\" aria-label=\"Sigue estas instrucciones, luego refresca esta página\">Refresca esta página</a>, y está listo!"
@@ -876,9 +902,6 @@ msgstr "Introduce Nombre Clave"
 msgid "Enter your codename"
 msgstr "Ingresa tu Nombre Clave"
 
-msgid "Continue"
-msgstr "Continuar"
-
 msgid "CANCEL"
 msgstr "CANCELAR"
 
@@ -887,6 +910,12 @@ msgstr "Una cosa más..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Haz clic en el botón <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Nueva identidad</b> en la barra de herramientas del Navegador Tor. Esto borrará los datos de actividad del Navegador Tor en este dispositivo."
+
+msgid "Show"
+msgstr "Mostrar"
+
+msgid "Hide"
+msgstr "Esconder"
 
 msgid "Remember, your codename is:"
 msgstr "Recuerda que tu nombre clave es:"
@@ -915,6 +944,9 @@ msgstr "Tamaño máximo de carga: 500 MB"
 msgid "Submit"
 msgstr "Enviar"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Leer Respuestas"
 
@@ -923,6 +955,9 @@ msgstr "Has recibido una respuesta. Para proteger tu identidad en el caso improb
 
 msgid "Delete this reply"
 msgstr "Eliminar esta respuesta"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "¿Deseas eliminar esta respuesta?"
@@ -957,17 +992,27 @@ msgstr "Importante"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "Tu sesión ha terminado debido a inactividad. Haz clic en el botón <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Nueva identidad</b> en la barra de herramientas del Navegador Tor antes de proseguir. Esto borrará los datos de actividad del Navegador Tor en este dispositivo."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "¿Por qué hay una advertencia acerca de Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Usar Tor2Web para conectar a SecureDrop no protegerá tu anonimato."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Es posible que cualquiera que esté monitoreando tu tráfico de Internet (tu gobierno, tu proveedor de Internet) te identifique."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "<strong>Recomendamos encarecidamente</strong> que uses el <a href=\"www.torproject.org/projects/torbrowser.html\">Navegador Tor</a> en su lugar."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Deberías Usar el Navegador Tor"
@@ -1023,6 +1068,65 @@ msgstr "<strong>Importante:</strong> Si deseas permanecer anónimo, <strong>no</
 
 msgid "Back to submission page"
 msgstr "Regresar a la página de envío"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "El siguiente archivo ha sido seleccionado para <strong>eliminación permanente</strong>:"
+#~ msgstr[1] "Los siguientes {num} archivos han sido seleccionados para <strong>eliminación permanente</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Borrar archivos permanentemente"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "ELIMINAR ARCHIVOS PERMANENTEMENTE"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Volver a la lista de documentos de {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "ADVERTENCIA:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Aparentemente estás usando Tor2Web, el cual no provee anonimato."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "¿Por qué es peligroso esto?"
+
+#~ msgid "Welcome"
+#~ msgstr "Bienvenido"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Por favor, escribe este nombre clave y guárdalo en un lugar seguro, o memorízalo."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Este nombre clave es el que usarás en futuras visitas para recibir mensajes de nuestro equipo en respuesta a lo que envíes en la siguiente pantalla."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Debido a que no rastreamos a los usuarios de nuestro servicio <b>SecureDrop</b>,\n"
+#~ "usar este nombre clave es la única manera que tenemos de comunicarnos contigo en futuras visitas, en caso que tuviéramos\n"
+#~ "preguntas o estuviéramos interesados en información adicional. A diferencia de las contraseñas, no hay forma de recuperar un nombre clave perdido."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Enviar Documentos"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "ENVIAR DOCUMENTOS"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Selecciona <b>Configuración de seguridad avanzada</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Selecciona <b>El más seguro de todos</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "¿Por qué hay una advertencia acerca de Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "<strong>Recomendamos encarecidamente</strong> que uses el <a href=\"www.torproject.org/projects/torbrowser.html\">Navegador Tor</a> en su lugar."
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "El formato del secreto es inválido: secreto de longitud impar. ¿Has escrito mal el secreto?"
@@ -1080,12 +1184,6 @@ msgstr "Regresar a la página de envío"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "Inicio de SecureDrop"
-
-#~ msgid "Show"
-#~ msgstr "Mostrar"
-
-#~ msgid "Hide"
-#~ msgstr "Esconder"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— No hay mensajes —"
@@ -1248,9 +1346,6 @@ msgstr "Regresar a la página de envío"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "¿Ya ha enviado algo?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Si usted ya ha enviado a periodistas en el pasado, inicie sesión para verificar si tiene respuestas."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "VERIFICAR SI HAY RESPUESTAS"

--- a/securedrop/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/securedrop/translations/fr_FR/LC_MESSAGES/messages.po
@@ -4,7 +4,20 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.3.12\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPOT-Creation-Date: 2017-09-02 07:28+0000\nPO-Revision-Date: 2022-02-09 21:04+0000\nLast-Translator: AO Localization Lab <ao@localizationlab.org>\nLanguage-Team: French <https://weblate.securedrop.org/projects/securedrop/securedrop/fr/>\nLanguage: fr_FR\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n > 1;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.3.12\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"POT-Creation-Date: 2017-09-02 07:28+0000\n"
+"PO-Revision-Date: 2022-02-09 21:04+0000\n"
+"Last-Translator: AO Localization Lab <ao@localizationlab.org>\n"
+"Language-Team: French <https://weblate.securedrop.org/projects/securedrop/securedrop/fr/>\n"
+"Language: fr_FR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "Le nom est trop long"
@@ -130,11 +143,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "Ne peut pas dépasser {num} caractère."
 msgstr[1] "Ne peut pas dépasser {num} caractères."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Ce champ est exigé."
 
 msgid "You cannot send an empty reply."
 msgstr "Vous ne pouvez pas envoyer une réponse vide."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Un fichier est exigé."
@@ -409,6 +428,9 @@ msgstr "Après avoir configuré votre YubiKey, saisissez le code à 6 chiffres c
 msgid "Navigation"
 msgstr "Navigation"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Connecté en tant que"
 
@@ -532,6 +554,15 @@ msgstr "Préférences des envois"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Empêcher les sources de téléverser des documents. Les sources pourront encore envoyer des messages."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Mettre à jours les préférences des envois"
 
@@ -549,20 +580,6 @@ msgstr "Envoyer une alerte OSSEC de test"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "ENVOYER UNE ALERTE DE TEST OSSEC"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Le fichier suivant a été sélectionné pour être <strong>supprimé irrémédiablement</strong> :"
-msgstr[1] "Les {num} fichiers suivants ont été sélectionnés pour être <strong>supprimés irrémédiablement</strong> :"
-
-msgid "Permanently Delete Files"
-msgstr "Supprimer irrémédiablement les fichiers"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "SUPPRIMER IRRÉMÉDIABLEMENT LES FICHIERS"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Revenir à la liste de documents de {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Modifier l’utilisateur « {user} »"
@@ -705,15 +722,6 @@ msgstr "Connexion"
 msgid "LOG IN"
 msgstr "CONNEXION"
 
-msgid "WARNING:"
-msgstr "AVERTISSEMENT :"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Il semble que vous utilisez Tor2Web, qui n’assure pas l’anonymat."
-
-msgid "Why is this dangerous?"
-msgstr "Pourquoi cela est-il dangereux ?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Le champ doit comporter entre 1 et {max_codename_len} caractères."
 
@@ -732,6 +740,9 @@ msgstr "Le texte du message est trop long."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Les grands blocs de texte doivent être téléversés en tant que fichier et non copiés et collés."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Vous avez été redirigé, car vous êtes déjà connecté. Si vous souhaitez créer un nouveau compte, vous devriez d’abord vous déconnecter."
 
@@ -746,6 +757,22 @@ msgstr "Vous devez saisir un message ou sélectionner un fichier à envoyer."
 
 msgid "You must enter a message."
 msgstr "Vous devez saisir un message."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Doit comporter au moins {num} caractère."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Avez-vous oublié votre nom de code ?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Si vous avez déjà effectué des envois à des journalistes, connectez-vous ici pour consulter les réponses."
 
 msgid "Thanks! We received your message."
 msgstr "Merci ! Nous avons reçu votre message."
@@ -765,8 +792,14 @@ msgstr "Toutes les réponses ont été supprimées"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Désolé, ce nom de code n’est pas reconnu."
 
+msgid "Codename"
+msgstr "Nom de code"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Protège les journalistes et les sources"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Nous sommes désolés, notre SecureDrop est actuellement hors service."
@@ -801,32 +834,25 @@ msgstr "Veuillez noter : le partage de documents délicats pourrait vous mettre
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop est un projet de la fondation « Freedom of the Press » (liberté des médias)."
 
-msgid "Welcome"
-msgstr "Bienvenue"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Saisissez votre nom de code"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Veuillez soit prendre ce nom de code par écrit et le conserver en lieu sûr, soit le mémoriser."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Vous utiliserez ce nom de code lors de vos prochaines visites pour recevoir les messages de notre équipe en réponse à ce que vous aurez envoyé sur la page suivante."
-
-msgid "Codename"
-msgstr "Nom de code"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"Dans la mesure où nous ne suivons pas les utilisateurs de notre service <b>SecureDrop</b> à la trace,\n"
-"lors de prochaines visites, l’utilisation de ce nom de code sera la seule façon dont nous disposerons pour communiquer avec vous si\n"
-"nous avions des questions ou si nous étions intéressés par d’autres renseignements. Contrairement aux mots de passe, un nom de code perdu ne peut pas être récupéré."
 
-msgid "Submit Documents"
-msgstr "Envoyer des documents"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "ENVOYER DES DOCUMENTS"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "Poursuivre"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "Le <a id=\"disable-js\" href=\"\"><b>niveau de sécurité</b></a> de votre Navigateur Tor est trop faible. Veuillez utiliser le bouton <img src=\"{icon}\" alt=\"« Niveau de sécurité »\"> de la barre d’outils de votre navigateur pour le changer."
@@ -837,11 +863,11 @@ msgstr "Comment changer votre niveau de sécurité"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Cliquez sur le bouton <img src=\"{icon}\" alt=\"« Niveau de sécurité »\"> dans la barre d’outils ci-dessus"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Sélectionnez <b>Paramètres de sécurité avancés</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Sélectionnez <b>Le plus sûr</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Suivez ces instructions, puis actualisez cette page\">Actualisez cette page</a> et tout est prêt ."
@@ -876,9 +902,6 @@ msgstr "Saisir le nom de code"
 msgid "Enter your codename"
 msgstr "Saisissez votre nom de code"
 
-msgid "Continue"
-msgstr "Poursuivre"
-
 msgid "CANCEL"
 msgstr "ANNULER"
 
@@ -887,6 +910,12 @@ msgstr "Une dernière chose…"
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Cliquez sur le bouton <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<strong>Nouvelle identité</strong> de la barre d’outils de votre Navigateur Tor. Cela effacera les données d’activité de votre Navigateur Tor sur cet appareil."
+
+msgid "Show"
+msgstr "Afficher"
+
+msgid "Hide"
+msgstr "Cacher"
 
 msgid "Remember, your codename is:"
 msgstr "Souvenez-vous que votre nom de code est :"
@@ -915,6 +944,9 @@ msgstr "Taille maximale de téléversement : 500 Mo"
 msgid "Submit"
 msgstr "Envoyer"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Consulter les réponses"
 
@@ -923,6 +955,9 @@ msgstr "Vous avez reçu une réponse. Pour protéger votre identité dans le cas
 
 msgid "Delete this reply"
 msgstr "Supprimer cette réponse"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Supprimer cette réponse ?"
@@ -957,17 +992,27 @@ msgstr "Important"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "La session a été déconnectée pour cause d’inactivité. Cliquez sur le bouton <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<strong>Nouvelle identité</strong> dans la barre d’outils de votre Navigateur Tor avant de poursuivre. Cela effacera les données d’activités de votre Navigateur sur cette appareil."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Pourquoi y a-t-il un avertissement au sujet de Tor2Web ?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Utiliser Tor2Web pour vous connecter à SecureDrop ne protégera pas votre anonymat."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Toute personne surveillant votre trafic Internet (votre gouvernement, votre fournisseur d’accès) pourrait vous identifier."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "Nous vous <strong>recommandons fortement</strong> d’utiliser plutôt le <a href=\"www.torproject.org/projects/torbrowser.html\">Navigateur Tor</a>."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Vous devriez utiliser le Navigateur Tor"
@@ -1023,6 +1068,65 @@ msgstr "<strong>Important :</strong> Si vous souhaitez rester anonyme, <strong>
 
 msgid "Back to submission page"
 msgstr "Revenir à la page d'envoi"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Le fichier suivant a été sélectionné pour être <strong>supprimé irrémédiablement</strong> :"
+#~ msgstr[1] "Les {num} fichiers suivants ont été sélectionnés pour être <strong>supprimés irrémédiablement</strong> :"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Supprimer irrémédiablement les fichiers"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "SUPPRIMER IRRÉMÉDIABLEMENT LES FICHIERS"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Revenir à la liste de documents de {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "AVERTISSEMENT :"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Il semble que vous utilisez Tor2Web, qui n’assure pas l’anonymat."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Pourquoi cela est-il dangereux ?"
+
+#~ msgid "Welcome"
+#~ msgstr "Bienvenue"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Veuillez soit prendre ce nom de code par écrit et le conserver en lieu sûr, soit le mémoriser."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Vous utiliserez ce nom de code lors de vos prochaines visites pour recevoir les messages de notre équipe en réponse à ce que vous aurez envoyé sur la page suivante."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Dans la mesure où nous ne suivons pas les utilisateurs de notre service <b>SecureDrop</b> à la trace,\n"
+#~ "lors de prochaines visites, l’utilisation de ce nom de code sera la seule façon dont nous disposerons pour communiquer avec vous si\n"
+#~ "nous avions des questions ou si nous étions intéressés par d’autres renseignements. Contrairement aux mots de passe, un nom de code perdu ne peut pas être récupéré."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Envoyer des documents"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "ENVOYER DES DOCUMENTS"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Sélectionnez <b>Paramètres de sécurité avancés</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Sélectionnez <b>Le plus sûr</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Pourquoi y a-t-il un avertissement au sujet de Tor2Web ?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "Nous vous <strong>recommandons fortement</strong> d’utiliser plutôt le <a href=\"www.torproject.org/projects/torbrowser.html\">Navigateur Tor</a>."
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Le format du secret est invalide : le nombre de caractères est impair. Le secret serait-il mal orthographié ?"
@@ -1080,12 +1184,6 @@ msgstr "Revenir à la page d'envoi"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "Page d’accueil de SecureDrop"
-
-#~ msgid "Show"
-#~ msgstr "Afficher"
-
-#~ msgid "Hide"
-#~ msgstr "Cacher"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Aucun message —"
@@ -1245,9 +1343,6 @@ msgstr "Revenir à la page d'envoi"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Avez-vous déjà envoyé quelque chose ?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Si vous avez déjà effectué des envois à des journalistes, connectez-vous ici pour consulter les réponses."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "CONSULTER LES RÉPONSES"

--- a/securedrop/translations/hi/LC_MESSAGES/messages.po
+++ b/securedrop/translations/hi/LC_MESSAGES/messages.po
@@ -146,11 +146,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "{num} वर्ण से अधिक लंबा नहीं होना चाहिए।"
 msgstr[1] "{num} अक्षर से लंबा नहीं होना चाहिए।"
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "यह फ़ील्ड आवश्यक है।"
 
 msgid "You cannot send an empty reply."
 msgstr "आप एक खाली जवाब नहीं भेज सकते।"
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "आवश्यक फाइल।"
@@ -437,6 +443,9 @@ msgstr "एक बार जब आप अपने YubiKey को कॉन्�
 msgid "Navigation"
 msgstr "प्रमाणीकरण संख्या"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "जैसे लॉग ऑन"
 
@@ -572,6 +581,15 @@ msgstr "सबमिशन पसंदगी"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "दस्तावेज़ अपलोड करने से स्रोतों को रोकें। स्रोत अभी भी संदेश भेजने में सक्षम होंगे।"
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 #, fuzzy
 #| msgid "Submission Preferences"
 msgid "Update Submission Preferences"
@@ -591,20 +609,6 @@ msgstr ""
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "परीक्षण OSSEC अलर्ट भेजें"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "निम्न फ़ाइल को <strong>स्थायी </strong>रूप से मिटने के लिए लिए चुना गया है:"
-msgstr[1] "निम्न {num} फाइलों को <strong>स्थायी </strong>रूप से मिटने के लिए लिए चुना गया है:"
-
-msgid "Permanently Delete Files"
-msgstr ""
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "स्थायी रूप से फ़ाइलें हटाएं"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "{source_name} के लिए दस्तावेज़ों की सूची पर लौटें…"
 
 msgid "Edit user \"{user}\""
 msgstr "उपयोगकर्ता \"{user}\" संपादित करें"
@@ -759,15 +763,6 @@ msgstr "लोग आउट"
 msgid "LOG IN"
 msgstr "लॉग इन"
 
-msgid "WARNING:"
-msgstr "चेतावनी:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "आप Tor2Web का उपयोग कर रहे हैं, जो गुमनामी प्रदान नहीं करता है।"
-
-msgid "Why is this dangerous?"
-msgstr "यह असुरक्षित क्यों है?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "फ़ील्ड 1 और {max_codename_len} वर्णों के बीच लंबा होना चाहिए।"
 
@@ -786,6 +781,9 @@ msgstr "संदेश पाठ बहुत लंबा है |"
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "पाठ के बड़े ब्लॉक को एक फ़ाइल के रूप में अपलोड किया जाना चाहिए, कॉपी और पेस्ट नहीं किया जाना चाहिए।"
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "आपको पुनर्निर्देशित किया गया था क्योंकि आप पहले ही लॉग इन हैं। यदि आप एक नया खाता बनाना चाहते हैं, तो आपको पहले लॉग आउट करना चाहिए।"
 
@@ -800,6 +798,22 @@ msgstr "सबमिट करने के लिए आपको कोई स
 
 msgid "You must enter a message."
 msgstr "आपको कोई संदेश दर्ज करना होगा |"
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "कम से कम {num} वर्ण लंबा होना चाहिए।"
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "अपना संकेत नाम भूल गए?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "यदि आप पहले से ही पत्रकारों को जमा कर चुके हैं, तो प्रतिक्रियाओं की जांच के लिए यहां लॉग इन करें।"
 
 msgid "Thanks! We received your message."
 msgstr "धन्यवाद! हमें आपका संदेशा मिला|"
@@ -819,8 +833,16 @@ msgstr "सभी उत्तर हटा दिए गए हैं"
 msgid "Sorry, that is not a recognized codename."
 msgstr "क्षमा करें, वह एक मान्यता प्राप्त कोडनाम नहीं है |"
 
+#, fuzzy
+#| msgid "Enter Codename"
+msgid "Codename"
+msgstr "संकेत नाम दर्ज करें"
+
 msgid "Protecting Journalists and Sources"
 msgstr "पत्रकारों और स्रोतों की रक्षा करते हुए"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "हमें खेद है, हमारा SecureDrop वर्तमान में ऑफ़लाइन है।"
@@ -855,34 +877,25 @@ msgstr "कृपया ध्यान दें: Tor और SecureDrop द्�
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "Securedrop Freedom of the Press Foundation का एक प्रोजेक्ट है।"
 
-msgid "Welcome"
-msgstr "स्वागत हे"
-
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "कृपया यह संकेत नाम नीचे लिखें और इसे किसी सुरक्षित स्थान पर रखें, या इसे याद रखें।"
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "यह संकेत नाम आप अगली स्क्रीन पर सबमिट की गई प्रतिक्रिया के उत्तर में हमारे टीम से संदेश प्राप्त करने के लिए भविष्य में आने वाले दौरा में उपयोग करें।"
-
 #, fuzzy
-#| msgid "Enter Codename"
-msgid "Codename"
-msgstr "संकेत नाम दर्ज करें"
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "आपका संकेत नाम दर्ज करें"
 
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
-msgstr ""
-"क्योंकि हम हमारे उपयोगकर्ताओं को ट्रैक नहीं करते हैं <b>SecureDrop</b>\n"
-"सेवा, भविष्य के दौरे में, इस संकेत नाम का उपयोग करने का एकमात्र तरीका है कि हमारे साथ संवाद करना चाहिए था हमारे पास होना चाहिए प्रश्न या \n"
-"अतिरिक्त जानकारी में रुचि रखते हैं। पासवर्ड के विपरीत, खोई हुई कोडनाम को पुनः प्राप्त करने का कोई तरीका नहीं है।"
-
-msgid "Submit Documents"
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "दस्तावेज़ जमा करें"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
+
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr ""
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "आपके Tor ब्राउज़र का <a id=\"disable-js\" href=\"\"><b>सुरक्षा स्तर</b></a> बहुत कम है। ब्राउज़र टूलबार के <img src=\"{icon}\" alt=\"&quot;सुरक्षा स्तर&quot;\"> &nbsp;बटन से इसे बदलें।"
@@ -893,11 +906,11 @@ msgstr ""
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "ऊपर दिये गये टूलबार मे <img src=\"{icon}\" alt=\"&quot;सुरक्षा स्तर&quot;\"> &nbsp; पर क्लिक करें"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "<b>उन्न्त सुरक्षा स्तर</b> चुनें"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "<b>सबसे सुरक्षित</b> चुनें"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 #, fuzzy
 #| msgid "<a href=\"/\">Refresh this page</a>, and you're done!"
@@ -934,9 +947,6 @@ msgstr "संकेत नाम दर्ज करें"
 msgid "Enter your codename"
 msgstr "आपका संकेत नाम दर्ज करें"
 
-msgid "Continue"
-msgstr ""
-
 msgid "CANCEL"
 msgstr "रद्द करें"
 
@@ -945,6 +955,12 @@ msgstr "एक और चीज़..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "अपने Tor ब्राउज़र के टूलबार में <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>नई पहचान </b> बटन पर क्लिक करें. यह इस उपकरण पर आपके Tor ब्राउज़र गतिविधि डेटा को साफ़ कर देगा."
+
+msgid "Show"
+msgstr "दिखाएं"
+
+msgid "Hide"
+msgstr "छुपाएं"
 
 msgid "Remember, your codename is:"
 msgstr "याद रखें, आपका संकेत नाम है:"
@@ -973,6 +989,9 @@ msgstr "अधिकतम अपलोड माप: 500 MB"
 msgid "Submit"
 msgstr ""
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "उत्तर पढ़ें"
 
@@ -981,6 +1000,9 @@ msgstr "आपको एक उत्तर मिला है| किसी �
 
 msgid "Delete this reply"
 msgstr "यह उत्तर हटाएं"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "यह उत्तर हटाएं?"
@@ -1019,17 +1041,27 @@ msgstr "जरूरी"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "आप निष्क्रियता के कारण लॉग आउट हो गया. आगे बढ़ने से पहले अपने Tor ब्राउज़र के टूलबार में <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b> नई पहचान </b> बटन पर क्लिक करें."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Tor2Web के बारे में चेतावनी क्यों है?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "SecureDrop से कनेक्ट करने के लिए Tor2Web का उपयोग करने से आपकी अनामिकता की रक्षा नहीं होगी।"
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "आपकी पहचान करने के लिए किसी भी व्यक्ति के लिए आपके इंटरनेट यातायात (आपकी सरकार, आपका इंटरनेट प्रदाता) की निगरानी करना संभव हो सकता है।"
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "हम <strong>दृढ़ता से सलाह देते हैं</strong> आप <a href=\"www.torproject.org/projects/torbrowser.html\">Tor browser</a> ब्राउज़र का उपयोग करने के लिए।"
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "आपको Tor ब्राउज़र का इस्तेमाल करना चाहिए"
@@ -1086,6 +1118,59 @@ msgstr "<strong>महत्वपूर्ण:</strong> यदि आप गु
 msgid "Back to submission page"
 msgstr "सबमिशन पृष्ठ पर वापस जाएं"
 
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "निम्न फ़ाइल को <strong>स्थायी </strong>रूप से मिटने के लिए लिए चुना गया है:"
+#~ msgstr[1] "निम्न {num} फाइलों को <strong>स्थायी </strong>रूप से मिटने के लिए लिए चुना गया है:"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "स्थायी रूप से फ़ाइलें हटाएं"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "{source_name} के लिए दस्तावेज़ों की सूची पर लौटें…"
+
+#~ msgid "WARNING:"
+#~ msgstr "चेतावनी:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "आप Tor2Web का उपयोग कर रहे हैं, जो गुमनामी प्रदान नहीं करता है।"
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "यह असुरक्षित क्यों है?"
+
+#~ msgid "Welcome"
+#~ msgstr "स्वागत हे"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "कृपया यह संकेत नाम नीचे लिखें और इसे किसी सुरक्षित स्थान पर रखें, या इसे याद रखें।"
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "यह संकेत नाम आप अगली स्क्रीन पर सबमिट की गई प्रतिक्रिया के उत्तर में हमारे टीम से संदेश प्राप्त करने के लिए भविष्य में आने वाले दौरा में उपयोग करें।"
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "क्योंकि हम हमारे उपयोगकर्ताओं को ट्रैक नहीं करते हैं <b>SecureDrop</b>\n"
+#~ "सेवा, भविष्य के दौरे में, इस संकेत नाम का उपयोग करने का एकमात्र तरीका है कि हमारे साथ संवाद करना चाहिए था हमारे पास होना चाहिए प्रश्न या \n"
+#~ "अतिरिक्त जानकारी में रुचि रखते हैं। पासवर्ड के विपरीत, खोई हुई कोडनाम को पुनः प्राप्त करने का कोई तरीका नहीं है।"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "दस्तावेज़ जमा करें"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "<b>उन्न्त सुरक्षा स्तर</b> चुनें"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "<b>सबसे सुरक्षित</b> चुनें"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Tor2Web के बारे में चेतावनी क्यों है?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "हम <strong>दृढ़ता से सलाह देते हैं</strong> आप <a href=\"www.torproject.org/projects/torbrowser.html\">Tor browser</a> ब्राउज़र का उपयोग करने के लिए।"
+
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "अवैध गुप्त स्वरूप: विषम-लंबाई रहस्य| क्या आपने गुप्त टेक्स्ट को गलत तरीके से लिखा है?"
 
@@ -1135,12 +1220,6 @@ msgstr "सबमिशन पृष्ठ पर वापस जाएं"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "SecureDrop होम"
-
-#~ msgid "Show"
-#~ msgstr "दिखाएं"
-
-#~ msgid "Hide"
-#~ msgstr "छुपाएं"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— कोई संदेश नहीं —"
@@ -1294,9 +1373,6 @@ msgstr "सबमिशन पृष्ठ पर वापस जाएं"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "पहले से कुछ जमा किया है?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "यदि आप पहले से ही पत्रकारों को जमा कर चुके हैं, तो प्रतिक्रियाओं की जांच के लिए यहां लॉग इन करें।"
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "जवाब के लिए जाँच करें"

--- a/securedrop/translations/is/LC_MESSAGES/messages.po
+++ b/securedrop/translations/is/LC_MESSAGES/messages.po
@@ -4,7 +4,19 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.12.0~rc1\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPO-Revision-Date: 2022-02-09 21:04+0000\nLast-Translator: Oktavia <oktaviahrund@gmail.com>\nLanguage-Team: Icelandic <https://weblate.securedrop.org/projects/securedrop/securedrop/is/>\nLanguage: is\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n % 10 != 1 || n % 100 == 11;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.5.1\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.12.0~rc1\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"PO-Revision-Date: 2022-02-09 21:04+0000\n"
+"Last-Translator: Oktavia <oktaviahrund@gmail.com>\n"
+"Language-Team: Icelandic <https://weblate.securedrop.org/projects/securedrop/securedrop/is/>\n"
+"Language: is\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n % 10 != 1 || n % 100 == 11;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.5.1\n"
 
 msgid "Name too long"
 msgstr "Nafnið er of langt"
@@ -130,11 +142,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "Má ekki vera meira en {num} stafur."
 msgstr[1] "Má ekki vera meira en {num} stafir."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Það er nauðsynlegt að fylla þennan reit út."
 
 msgid "You cannot send an empty reply."
 msgstr "Þú mátt ekki senda tómt svar."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Skrá er nauðsynleg."
@@ -409,6 +427,9 @@ msgstr "Þegar þú hefur sett upp YubiKey (dulritunarlykill), settu inn 6-stafa
 msgid "Navigation"
 msgstr "Flakk"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Innskráður sem"
 
@@ -532,6 +553,15 @@ msgstr "Kjörstillingar fyrir innsendingu"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Koma í veg fyrir að heimildarmenn geti sent inn skjöl. Heimildamenn geta eftir sem áður sent skilaboð."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Uppfæra kjörstillingar fyrir innsendingu"
 
@@ -549,20 +579,6 @@ msgstr "Senda OSSEC-aðvörun til prófunar"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "SENDA OSSEC PRUFUVIÐVÖRUN"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Eftirfarandi skrá hefur verið valin til að <strong>eyða varanlega</strong>:"
-msgstr[1] "Eftirfarandi {num} skrár hafa verið valdar til að <strong>eyða varanlega</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "Eyða skrám endanlega"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "EYÐA SKRÁM VARANLEGA"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Fara aftur í lista yfir skjöl fyrir {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Breyta notandanum \"{user}\""
@@ -705,15 +721,6 @@ msgstr "Skrá inn"
 msgid "LOG IN"
 msgstr "SKRÁ INN"
 
-msgid "WARNING:"
-msgstr "AÐVÖRUN:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Það lítur út fyrir að þú sért að nota Tor2Web, sem gefur ekki nafnleysi."
-
-msgid "Why is this dangerous?"
-msgstr "Af hverju er þetta hættulegt?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Gagnasvið verður að vera á milli 1 og {max_codename_len} stafa langt."
 
@@ -732,6 +739,9 @@ msgstr "Texti skilaboðanna er of langur."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Langa texta verður að senda inn sem skrá, ekki afritað og límt."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Þér var endurbeint vegna þess að þú ert þegar með innskráningu í gangi. Ef þú ætlar að útbúa annan aðgang, ættirðu að skrá þig fyrst út."
 
@@ -746,6 +756,22 @@ msgstr "Þú verður að setja inn skilaboð eða velja skrá til að senda inn.
 
 msgid "You must enter a message."
 msgstr "Þú verður að setja inn skilaboð."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Verður að vera a.m.k. {num} stafur að lengd."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Gleymdirðu kóðanafninu þínu?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Ef þú hefur þegar sent inn til fréttamanna, skráðu þig þá inn hér til að athuga með svör."
 
 msgid "Thanks! We received your message."
 msgstr "Takk fyrir! Við fengum skilaboðin þín."
@@ -765,8 +791,14 @@ msgstr "Öllum svörum hefur verið eytt"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Því miður, þetta er ekki þekkt kóðanafn."
 
+msgid "Codename"
+msgstr "Kóðanafn"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Verndum frétta- og heimildarmenn"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Því miður, SecureDrop-netþjónninn okkar er ótengdur þessa stundina."
@@ -801,32 +833,25 @@ msgstr "Athugaðu: Að deila viðkvæmum upplýsingum getur falið í sér áhæ
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop er verkefni á vegum Freedom of the Press stofnuninnar."
 
-msgid "Welcome"
-msgstr "Velkomin"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Settu inn kóðanafnið þitt"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Þú skalt endilega skrifa þetta kóðanafn niður og geyma það á öruggum stað, eða leggja það á minnið."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Þetta kóðanafn er það sem þú munt framvegis nota við heimsóknir á vefsvæðið þegar þú athugar með svör og skilaboð frá teyminu okkar, varðandi það sem þú sendir inn á næsta skjá."
-
-msgid "Codename"
-msgstr "Kóðanafn"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"Vegna þess að við skráum ekki notendur <b>SecureDrop</b>\n"
-"þjónustunnar, verður þetta kóðanafn framvegis eina leiðin sem við höfum til að eiga í samskiptum við þig, ef við\n"
-"skyldum vera með spurningar eða höfum áhuga á viðbótarupplýsingum. Ólíkt lykilorðum, þá er engin leið til að endurheimta kóðanafn."
 
-msgid "Submit Documents"
-msgstr "Senda inn skjöl"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "SENDA INN SKJÖL"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "Halda áfram"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "<a id=\"disable-js\" href=\"\"><b>Öryggisstig</b></a> Tor-vafrans þíns er of vægt stillt. Notaðu <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> hnappinn í verkfærastiku vafrans þíns til að breyta því."
@@ -837,11 +862,11 @@ msgstr "Hvernig á að breyta öryggisstigi þínu"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Smelltu á <img src=\"{icon}\" alt=\"&quot;Security Level&quot; hnappinn\"> í verkfærastikunni hér fyrir ofan"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Veldu <b>Ítarlegar öryggisstillingar</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Veldu <b>Öruggast</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Farðu eftir þessum leiðbeiningum og endurlestu síðuna\">Endurlestu þessa síðu</a>, og þetta er komið!"
@@ -876,9 +901,6 @@ msgstr "Settu inn kóðanafn"
 msgid "Enter your codename"
 msgstr "Settu inn kóðanafnið þitt"
 
-msgid "Continue"
-msgstr "Halda áfram"
-
 msgid "CANCEL"
 msgstr "HÆTTA VIÐ"
 
@@ -887,6 +909,12 @@ msgstr "Eitt í viðbót..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Smelltu á hnappinn <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Nýtt auðkenni</b> í verkfærastiku Tor-vafrans. Það mun hreinsa út allar fyrri aðgerðir Tor-vafrans á þessu tæki."
+
+msgid "Show"
+msgstr "Sýna"
+
+msgid "Hide"
+msgstr "Fela"
 
 msgid "Remember, your codename is:"
 msgstr "Mundu, kóðanafnið þitt er:"
@@ -915,6 +943,9 @@ msgstr "Hámarksstærð innsendingar: 500 MB"
 msgid "Submit"
 msgstr "Senda inn"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Lesa svör"
 
@@ -923,6 +954,9 @@ msgstr "Þú hefur fengið svar. Til að vernda persónuauðkenni þitt, fari sv
 
 msgid "Delete this reply"
 msgstr "Eyða þessu svari"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Eyða þessu svari?"
@@ -957,17 +991,27 @@ msgstr "Mikilvægt"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "Þú varst skráð/ur út vegna ónógrar virkni. Smelltu á hnappinn <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Nýtt auðkenni</b> í verkfærastiku Tor-vafrans áður en haldið er áfram. Það mun hreinsa út allar fyrri aðgerðir Tor-vafrans á þessu tæki."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Hversvegna er aðvörun vegna Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Að nota Tor2Web til að tengjast SecureDrop verndar ekki nafnleynd þína."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Það er hugsanlegt að hver sá sem fylgist með netumferðinni þinni (t.d. stjórnvöld, netþjónustan þín, o.fl.) geti greint hver þú ert."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "Við <strong>mælum eindregið með</strong> því að þú notir frekar<a href=\"www.torproject.org/projects/torbrowser.html\">Tor-vafrann</a>."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Þú ættir að nota Tor-vafrann"
@@ -1023,6 +1067,65 @@ msgstr "<strong>Mikilvægt:</strong> Ef þú óskar áframhaldandi nafnleyndar, 
 
 msgid "Back to submission page"
 msgstr "Til baka á innsendingasíðuna"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Eftirfarandi skrá hefur verið valin til að <strong>eyða varanlega</strong>:"
+#~ msgstr[1] "Eftirfarandi {num} skrár hafa verið valdar til að <strong>eyða varanlega</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Eyða skrám endanlega"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "EYÐA SKRÁM VARANLEGA"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Fara aftur í lista yfir skjöl fyrir {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "AÐVÖRUN:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Það lítur út fyrir að þú sért að nota Tor2Web, sem gefur ekki nafnleysi."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Af hverju er þetta hættulegt?"
+
+#~ msgid "Welcome"
+#~ msgstr "Velkomin"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Þú skalt endilega skrifa þetta kóðanafn niður og geyma það á öruggum stað, eða leggja það á minnið."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Þetta kóðanafn er það sem þú munt framvegis nota við heimsóknir á vefsvæðið þegar þú athugar með svör og skilaboð frá teyminu okkar, varðandi það sem þú sendir inn á næsta skjá."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Vegna þess að við skráum ekki notendur <b>SecureDrop</b>\n"
+#~ "þjónustunnar, verður þetta kóðanafn framvegis eina leiðin sem við höfum til að eiga í samskiptum við þig, ef við\n"
+#~ "skyldum vera með spurningar eða höfum áhuga á viðbótarupplýsingum. Ólíkt lykilorðum, þá er engin leið til að endurheimta kóðanafn."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Senda inn skjöl"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "SENDA INN SKJÖL"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Veldu <b>Ítarlegar öryggisstillingar</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Veldu <b>Öruggast</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Hversvegna er aðvörun vegna Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "Við <strong>mælum eindregið með</strong> því að þú notir frekar<a href=\"www.torproject.org/projects/torbrowser.html\">Tor-vafrann</a>."
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Ógilt snið leynilykils: óvenjuleg lengd leynilykils. Slóstu leynilykilinn rétt inn?"
@@ -1080,12 +1183,6 @@ msgstr "Til baka á innsendingasíðuna"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "Forsíða SecureDrop"
-
-#~ msgid "Show"
-#~ msgstr "Sýna"
-
-#~ msgid "Hide"
-#~ msgstr "Fela"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Engin skilaboð —"
@@ -1245,9 +1342,6 @@ msgstr "Til baka á innsendingasíðuna"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Þegar búið að senda eitthvað inn?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Ef þú hefur þegar sent inn til fréttamanna, skráðu þig þá inn hér til að athuga með svör."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "ATHUGA MEÐ SVÖR"

--- a/securedrop/translations/it_IT/LC_MESSAGES/messages.po
+++ b/securedrop/translations/it_IT/LC_MESSAGES/messages.po
@@ -7,7 +7,20 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 # gio <gdamiola@gmail.com>, 2014
 msgid ""
-msgstr "Project-Id-Version: SecureDrop\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPOT-Creation-Date: 2017-09-02 07:28+0000\nPO-Revision-Date: 2022-02-17 11:04+0000\nLast-Translator: lsd-cat <giulio@gmx.com>\nLanguage-Team: Italian <https://weblate.securedrop.org/projects/securedrop/securedrop/it/>\nLanguage: it_IT\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n != 1;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"POT-Creation-Date: 2017-09-02 07:28+0000\n"
+"PO-Revision-Date: 2022-02-17 11:04+0000\n"
+"Last-Translator: lsd-cat <giulio@gmx.com>\n"
+"Language-Team: Italian <https://weblate.securedrop.org/projects/securedrop/securedrop/it/>\n"
+"Language: it_IT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "Nome troppo lungo"
@@ -133,11 +146,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "Non può contenere più di {num} carattere."
 msgstr[1] "Non può contenere più di {num} caratteri."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Questo campo è obbligatorio."
 
 msgid "You cannot send an empty reply."
 msgstr "Non è possibile inviare una risposta vuota."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "File obbligatorio."
@@ -412,6 +431,9 @@ msgstr "Una volta configurata la tua Yubikey, inserisci il codice di 6 cifre qui
 msgid "Navigation"
 msgstr "Navigazione"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Accesso eseguito come"
 
@@ -535,6 +557,15 @@ msgstr "Preferenze di invio"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Impedire alle fonti di caricare documenti. Le stesse potranno comunque continuare a inviare messaggi."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Aggiorna Preferenze di Invio"
 
@@ -552,20 +583,6 @@ msgstr "Invia Avviso OSSEC di Test"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "INVIA AVVISO OSSEC DI PROVA"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Il file seguente è stato selezionato per la <strong>definitiva eliminazione</strong>:"
-msgstr[1] "I {num} file seguenti sono stati selezionati per la <strong>definitiva eliminazione</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "Elimina Files Permanentemente"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "ELIMINA DEFINITIVAMENTE I FILE"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Ritorna all'elenco dei documenti di {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Modifica utente \"{user}\""
@@ -708,15 +725,6 @@ msgstr "Accedi"
 msgid "LOG IN"
 msgstr "ACCEDI"
 
-msgid "WARNING:"
-msgstr "ATTENZIONE:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Sembra che si stia utilizzando Tor2Web, che non garantisce l'anonimato."
-
-msgid "Why is this dangerous?"
-msgstr "Perché questo è pericoloso?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Il campo deve avere una lunghezza tra 1 e {max_codename_len} caratteri."
 
@@ -735,6 +743,9 @@ msgstr "Testo del messaggio troppo lungo."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "I blocchi di testo di grandi dimensioni devono essere caricati come file, non copiati e incollati."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "È stato eseguito il reindirizzamento perché era già stato eseguito l'accesso. Per creare un nuovo account bisogna prima terminare la sessione corrente."
 
@@ -749,6 +760,22 @@ msgstr "È necessario inserire un messaggio o scegliere un file da inviare."
 
 msgid "You must enter a message."
 msgstr "È necessario inserire un messaggio."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Deve essere lungo almeno {num} carattere."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Nome in codice dimenticato?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Se hai già inviato qualcosa ai giornalisti, accedi qui per controllare le risposte."
 
 msgid "Thanks! We received your message."
 msgstr "Grazie! Abbiamo ricevuto il tuo messaggio."
@@ -768,8 +795,14 @@ msgstr "Tutte le risposte sono state eliminate"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Questo nome in codice non è riconosciuto."
 
+msgid "Codename"
+msgstr "Nome in codice"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Proteggi giornalisti e fonti"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Spiacenti, SecureDrop è attualmente offline."
@@ -804,32 +837,25 @@ msgstr "Nota: la condivisione di documenti riservati può comportare un rischio,
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop è un progetto della Freedom of the Press Foundation."
 
-msgid "Welcome"
-msgstr "Benvenuti"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Inserire il proprio nome in codice"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Trascrivere questo nome in codice e conservarlo in un posto sicuro, o memorizzalo."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Questo nome in codice è quello che userai in futuro per ricevere messaggi dal nostro gruppo, in risposta a ciò che invierai dalla prossima schermata."
-
-msgid "Codename"
-msgstr "Nome in codice"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"Dato che non tracciamo gli utenti del nostro servizio <b>SecureDrop</b>,\n"
-"nelle visite successive, usare questo nome in codice sarà l'unico modo con cui potremo comunicare con te se dovessimo avere\n"
-"domande o essere interessati a informazioni aggiuntive. A differenza delle password, non c'è alcun modo di recuperare un nome in codice perso."
 
-msgid "Submit Documents"
-msgstr "Invia documenti"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "INVIA DOCUMENTI"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "Continua"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "Il <a id=\"disable-js\" href=\"\"><b>livello di sicurezza</b></a> del Browser Tor è troppo basso. Usare il pulsante <img src=\"{icon}\" alt=\"&quot;Livello di sicurezza&quot;\"> nella barra degli strumenti del browser per modificarlo."
@@ -840,11 +866,11 @@ msgstr "Come modificare il livello di sicurezza"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Fare clic su <img src=\"{icon}\" alt=\"Livello sicurezza\"> nella barra degli strumenti qui sopra"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Selezionare <b>Impostazioni avanzate di sicurezza</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Selezionare <b>Massima sicurezza</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Segui queste istruzioni, quindi aggiorna questa pagina\">Aggiorna questa pagina</a>, e il gioco è fatto!"
@@ -879,9 +905,6 @@ msgstr "Inserire nome in codice"
 msgid "Enter your codename"
 msgstr "Inserire il proprio nome in codice"
 
-msgid "Continue"
-msgstr "Continua"
-
 msgid "CANCEL"
 msgstr "ANNULLA"
 
@@ -890,6 +913,12 @@ msgstr "Ancora una cosa..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Fare clic sul pulsante <img src={icon} alt=\"\" width=\"16\" height=\"16\"> <b>Nuova identità</b> nella barra degli strumenti del Browser Tor. Questo cancellerà i dati dell'attività del Browser Tor su questo dispositivo."
+
+msgid "Show"
+msgstr "Mostra"
+
+msgid "Hide"
+msgstr "Nascondi"
 
 msgid "Remember, your codename is:"
 msgstr "Ricorda, il tuo nome in codice è:"
@@ -918,6 +947,9 @@ msgstr "Dimensione massima di caricamento: 500 MB"
 msgid "Submit"
 msgstr "Invia"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Leggi risposte"
 
@@ -926,6 +958,9 @@ msgstr "Hai ricevuto una risposta. Per proteggere la tua identità nel remoto ca
 
 msgid "Delete this reply"
 msgstr "Elimina questa risposta"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Eliminare questa risposta?"
@@ -960,17 +995,27 @@ msgstr "Importante"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "Disconnesso per inattività. Fare clic sul pulsante <img src={icon} alt=\"\" width=\"16\" height=\"16\"> <b>Nuova identità</b> nella barra degli strumenti del Browser Tor prima di proseguire. Questo cancellerà i dati dell'attività del Browser Tor su questo dispositivo."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Perché c'è un avviso su Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Usare Tor2Web per connettersi a SecureDrop non proteggerà il proprio anonimato."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Potrebbe essere possibile per chiunque stia monitorando il traffico Internet (il governo, il fornitore dei servizi Internet), identificarti."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "<strong>Consigliamo vivamente</strong> di usare invece il <a href=\"www.torproject.org/projects/torbrowser.html\">browser Tor</a>."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Dovresti usare il browser Tor"
@@ -1026,6 +1071,65 @@ msgstr "<strong>Importante:</strong> per rimanere anonimi <strong>non usare</str
 
 msgid "Back to submission page"
 msgstr "Torna alla pagina di invio documenti e messaggi"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Il file seguente è stato selezionato per la <strong>definitiva eliminazione</strong>:"
+#~ msgstr[1] "I {num} file seguenti sono stati selezionati per la <strong>definitiva eliminazione</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Elimina Files Permanentemente"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "ELIMINA DEFINITIVAMENTE I FILE"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Ritorna all'elenco dei documenti di {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "ATTENZIONE:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Sembra che si stia utilizzando Tor2Web, che non garantisce l'anonimato."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Perché questo è pericoloso?"
+
+#~ msgid "Welcome"
+#~ msgstr "Benvenuti"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Trascrivere questo nome in codice e conservarlo in un posto sicuro, o memorizzalo."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Questo nome in codice è quello che userai in futuro per ricevere messaggi dal nostro gruppo, in risposta a ciò che invierai dalla prossima schermata."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Dato che non tracciamo gli utenti del nostro servizio <b>SecureDrop</b>,\n"
+#~ "nelle visite successive, usare questo nome in codice sarà l'unico modo con cui potremo comunicare con te se dovessimo avere\n"
+#~ "domande o essere interessati a informazioni aggiuntive. A differenza delle password, non c'è alcun modo di recuperare un nome in codice perso."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Invia documenti"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "INVIA DOCUMENTI"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Selezionare <b>Impostazioni avanzate di sicurezza</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Selezionare <b>Massima sicurezza</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Perché c'è un avviso su Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "<strong>Consigliamo vivamente</strong> di usare invece il <a href=\"www.torproject.org/projects/torbrowser.html\">browser Tor</a>."
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Formato del segreto non valido: segreto di lunghezza dispari. Forse non è stato digitato correttamente?"
@@ -1083,12 +1187,6 @@ msgstr "Torna alla pagina di invio documenti e messaggi"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "Home di SecureDrop"
-
-#~ msgid "Show"
-#~ msgstr "Mostra"
-
-#~ msgid "Hide"
-#~ msgstr "Nascondi"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Nessun messaggio —"
@@ -1251,9 +1349,6 @@ msgstr "Torna alla pagina di invio documenti e messaggi"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Hai già inviato qualcosa?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Se hai già inviato qualcosa ai giornalisti, accedi qui per controllare le risposte."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "CONTROLLA RIPOSTE"

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: SecureDrop 2.2.0~rc1\n"
+"Project-Id-Version: SecureDrop 2.3.0~rc1\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
@@ -140,10 +140,16 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr ""
 
 msgid "You cannot send an empty reply."
+msgstr ""
+
+msgid "To configure a minimum message length, you must set the required number of characters."
 msgstr ""
 
 msgid "File required."
@@ -419,6 +425,9 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr ""
 
@@ -542,6 +551,15 @@ msgstr ""
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr ""
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr ""
 
@@ -558,20 +576,6 @@ msgid "Send Test OSSEC Alert"
 msgstr ""
 
 msgid "SEND TEST OSSEC ALERT"
-msgstr ""
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "Permanently Delete Files"
-msgstr ""
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr ""
-
-msgid "Return to the list of documents for {source_name}…"
 msgstr ""
 
 msgid "Edit user \"{user}\""
@@ -715,15 +719,6 @@ msgstr ""
 msgid "LOG IN"
 msgstr ""
 
-msgid "WARNING:"
-msgstr ""
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr ""
-
-msgid "Why is this dangerous?"
-msgstr ""
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr ""
 
@@ -742,6 +737,9 @@ msgstr ""
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr ""
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr ""
 
@@ -755,6 +753,15 @@ msgid "You must enter a message or choose a file to submit."
 msgstr ""
 
 msgid "You must enter a message."
+msgstr ""
+
+msgid "Your first message must be at least {} characters long."
+msgstr ""
+
+msgid "Please do not submit your codename!"
+msgstr ""
+
+msgid "Keep your codename secret, and use it to log in later to check for replies."
 msgstr ""
 
 msgid "Thanks! We received your message."
@@ -775,7 +782,13 @@ msgstr ""
 msgid "Sorry, that is not a recognized codename."
 msgstr ""
 
+msgid "Codename"
+msgstr ""
+
 msgid "Protecting Journalists and Sources"
+msgstr ""
+
+msgid "Skip to notification"
 msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
@@ -811,28 +824,22 @@ msgstr ""
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr ""
 
-msgid "Welcome"
+msgid "Get Your Codename"
 msgstr ""
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
 
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+msgid "You will need this codename to log into our SecureDrop later:"
 msgstr ""
 
-msgid "Codename"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
 msgstr ""
 
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
 msgstr ""
 
-msgid "Submit Documents"
-msgstr ""
-
-msgid "SUBMIT DOCUMENTS"
+msgid "Continue"
 msgstr ""
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
@@ -844,10 +851,10 @@ msgstr ""
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr ""
 
-msgid "Select <b>Advanced Security Settings</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
 msgstr ""
 
-msgid "Select <b>Safest</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
 msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
@@ -883,9 +890,6 @@ msgstr ""
 msgid "Enter your codename"
 msgstr ""
 
-msgid "Continue"
-msgstr ""
-
 msgid "CANCEL"
 msgstr ""
 
@@ -893,6 +897,12 @@ msgid "One more thing..."
 msgstr ""
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
+msgstr ""
+
+msgid "Show"
+msgstr ""
+
+msgid "Hide"
 msgstr ""
 
 msgid "Remember, your codename is:"
@@ -922,6 +932,9 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr ""
 
@@ -929,6 +942,9 @@ msgid "You have received a reply. To protect your identity in the unlikely event
 msgstr ""
 
 msgid "Delete this reply"
+msgstr ""
+
+msgid "Delete reply from {timestamp}?"
 msgstr ""
 
 msgid "Delete this reply?"
@@ -964,16 +980,22 @@ msgstr ""
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr ""
 
-msgid "Why is there a warning about Tor2Web?"
+msgid "Proxy Service Detected"
 msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr ""
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr ""
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
 msgstr ""
 
 msgid "You Should Use Tor Browser"

--- a/securedrop/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/securedrop/translations/nb_NO/LC_MESSAGES/messages.po
@@ -4,7 +4,20 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.3.12\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPOT-Creation-Date: 2017-09-02 07:28+0000\nPO-Revision-Date: 2022-02-11 19:04+0000\nLast-Translator: Øyvind Bye Skille <oyvind@byeskille.net>\nLanguage-Team: Norwegian Bokmål <https://weblate.securedrop.org/projects/securedrop/securedrop/nb_NO/>\nLanguage: nb_NO\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n != 1;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.3.12\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"POT-Creation-Date: 2017-09-02 07:28+0000\n"
+"PO-Revision-Date: 2022-02-11 19:04+0000\n"
+"Last-Translator: Øyvind Bye Skille <oyvind@byeskille.net>\n"
+"Language-Team: Norwegian Bokmål <https://weblate.securedrop.org/projects/securedrop/securedrop/nb_NO/>\n"
+"Language: nb_NO\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "Navnet er for langt"
@@ -130,11 +143,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "Kan ikke inneholde mer enn {num} tegn."
 msgstr[1] "Kan ikke inneholde mer enn {num} tegn."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Dette feltet er påkrevd."
 
 msgid "You cannot send an empty reply."
 msgstr "Du kan ikke sende et tomt svar."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Fil påkrevd."
@@ -409,6 +428,9 @@ msgstr "Når du har satt opp din YubiKey, skriv inn den 6 tegn lange koden neden
 msgid "Navigation"
 msgstr "Navigasjon"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Innlogget som"
 
@@ -532,6 +554,15 @@ msgstr "Forsendelsesinnstillinger"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Forhindre kilder i å laste opp filer. De vil fortsatt kunne sende inn meldinger."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Oppdater forsendelsesinnstillinger"
 
@@ -549,20 +580,6 @@ msgstr "Send test-alarm fra OSSEC"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "SEND TEST OSSEC-VARSEL"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Følgende fil er markert for <strong>permanent sletting</strong>:"
-msgstr[1] "Følgende {num} filer er markert for <strong>permanent sletting</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "Permanent slett filer"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "PERMANENT SLETTING AV FILER"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Tilbake til listen over filer for {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Rediger brukeren \"{user}\""
@@ -705,15 +722,6 @@ msgstr "Logg inn"
 msgid "LOG IN"
 msgstr "LOGG INN"
 
-msgid "WARNING:"
-msgstr "ADVARSEL:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Det virker som du bruker Tor2Web, som ikke gir anonymitet."
-
-msgid "Why is this dangerous?"
-msgstr "Hvorfor utgjør dette en fare?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Feltet må være mellom ett og {max_codename_len} tegn langt."
 
@@ -732,6 +740,9 @@ msgstr "Meldingsteksten er for lang."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Store mengder tekst må lastes opp som fil, ikke klippes og limes inn."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Du ble omdirigert fordi du allerede er logget inn. Om du ønsker å lage en ny konto må du først logge ut."
 
@@ -746,6 +757,22 @@ msgstr "Du må skrive inn en melding eller velge ei fil å sende inn."
 
 msgid "You must enter a message."
 msgstr "Du må skrive inn en melding."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Må være minst {num} tegn langt."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Glemt kodenavnet ditt?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Om du har sendt inn noe tidligere, logg inn her for å se etter svar og tilbakemeldinger."
 
 msgid "Thanks! We received your message."
 msgstr "Takk! Vi mottok meldingen din."
@@ -765,8 +792,14 @@ msgstr "Alle svar har blitt slettet"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Beklager, det er ikke et gjenkjent kodenavn."
 
+msgid "Codename"
+msgstr "Kodenavn"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Sikkerhet for journalister og kilder"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Vi beklager, vår SecureDrop er for tiden ute av drift."
@@ -801,32 +834,25 @@ msgstr "Obs: Deling av sensitive dokumenter kan innebære risiko for deg, også 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop er et prosjekt drevet av Freedom of the Press Foundation."
 
-msgid "Welcome"
-msgstr "Velkommen"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Skriv inn ditt kodenavn"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Husk, eller skriv ned kodenavnet på et sikkert sted."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Dette er kodenavnet du kan bruke i fremtiden for å fortsette kommunikasjonen med oss, f.eks. for å sjekke om vi har besvart det du sender inn i neste dialogvindu."
-
-msgid "Codename"
-msgstr "Kodenavn"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"Fordi vi ikke sporer brukerne på vår <b>SecureDrop</b>-tjeneste, \n"
-"er dette kodenavnet den eneste måten for senere kommunikasjon om vi har spørsmål eller vil vise interesse \n"
-"for mer informasjon. I motsetning til passord, er det umulig å finne tilbake til kodenavnet om du glemmer det."
 
-msgid "Submit Documents"
-msgstr "Send inn dokumenter"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "SEND INN DOKUMENTER"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "Fortsett"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "<a id=\"disable-js\" href=\"\"><b>Sikkerhetsinnstillingene</b></a> i din Tor-nettleser er satt for lavt. Bruk <img src=\"{icon}\" alt=\"&quot;Sikkerhetsnivå&quot;\"\">knappen i nettleserens verktøylinje for å endre nivået."
@@ -837,11 +863,11 @@ msgstr "Hvordan endre sikkerhetsnivået"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Klikk på <img src=\"{icon}\" alt=\"&quot;Sikkerhetsnivå&quot; button\"> i verktøylinjen ovenfor"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Velg <b>Avanserte sikkerhetsinnstillinger</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Velg <b>Tryggest</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Følg disse instruksjonene, deretter oppdater siden\">Last inn siden igjen</a>, og så er du ferdig!"
@@ -876,9 +902,6 @@ msgstr "Skriv inn kodenavn"
 msgid "Enter your codename"
 msgstr "Skriv inn ditt kodenavn"
 
-msgid "Continue"
-msgstr "Fortsett"
-
 msgid "CANCEL"
 msgstr "AVBRYT"
 
@@ -887,6 +910,12 @@ msgstr "Én ting til…"
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Klikk på <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Ny identitet</b>-knappen i Tor-nettleserens verktøylinje. Det vil slette loggføringen av din Tor-bruk på denne enheten."
+
+msgid "Show"
+msgstr "Vis"
+
+msgid "Hide"
+msgstr "Skjul"
 
 msgid "Remember, your codename is:"
 msgstr "Husk, kodenavnet ditt er:"
@@ -915,6 +944,9 @@ msgstr "Maksimal opplastningsstørrelse: 500MB"
 msgid "Submit"
 msgstr "Send inn"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Les svar"
 
@@ -923,6 +955,9 @@ msgstr "Du har mottatt et svar. For å beskytte din egen identitet i tilfelle no
 
 msgid "Delete this reply"
 msgstr "Slett dette svaret"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Slett dette svaret?"
@@ -957,17 +992,27 @@ msgstr "Viktig"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "Du ble utlogget som følge av inaktivitet. Klikk på <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Ny identitiet</b>-knappen i Tor-nettleserens verktøylinje før du fortsetter. Dette vil slette loggen over aktivitet i Tor-nettleseren på denne enheten."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Hvorfor er det en advarsel om Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Bruk av Tor2Web for å kommunisere med SecureDrop vil ikke beskytte din anonymitet."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Det er en mulighet for at alle som kan følge med på internettbruken din (myndigheter, internettilbyderen din) kan identifisere deg."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "Vi <strong>anbefaler sterkt</strong> at du bruker <a href=\"www.torproject.org/projects/torbrowser.html\">Tor-nettleseren</a> i stedet."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Du burde bruke Tor-nettleseren"
@@ -1023,6 +1068,65 @@ msgstr "<strong>Viktig:</strong> Om du ønsker å være helt anonym, <strong>ikk
 
 msgid "Back to submission page"
 msgstr "Tilbake til innsendelsesside"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Følgende fil er markert for <strong>permanent sletting</strong>:"
+#~ msgstr[1] "Følgende {num} filer er markert for <strong>permanent sletting</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Permanent slett filer"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "PERMANENT SLETTING AV FILER"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Tilbake til listen over filer for {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "ADVARSEL:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Det virker som du bruker Tor2Web, som ikke gir anonymitet."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Hvorfor utgjør dette en fare?"
+
+#~ msgid "Welcome"
+#~ msgstr "Velkommen"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Husk, eller skriv ned kodenavnet på et sikkert sted."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Dette er kodenavnet du kan bruke i fremtiden for å fortsette kommunikasjonen med oss, f.eks. for å sjekke om vi har besvart det du sender inn i neste dialogvindu."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Fordi vi ikke sporer brukerne på vår <b>SecureDrop</b>-tjeneste, \n"
+#~ "er dette kodenavnet den eneste måten for senere kommunikasjon om vi har spørsmål eller vil vise interesse \n"
+#~ "for mer informasjon. I motsetning til passord, er det umulig å finne tilbake til kodenavnet om du glemmer det."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Send inn dokumenter"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "SEND INN DOKUMENTER"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Velg <b>Avanserte sikkerhetsinnstillinger</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Velg <b>Tryggest</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Hvorfor er det en advarsel om Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "Vi <strong>anbefaler sterkt</strong> at du bruker <a href=\"www.torproject.org/projects/torbrowser.html\">Tor-nettleseren</a> i stedet."
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Feil hemmelighet, du har lagt til eller glemt noe."
@@ -1080,12 +1184,6 @@ msgstr "Tilbake til innsendelsesside"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "SecureDrop hjem"
-
-#~ msgid "Show"
-#~ msgstr "Vis"
-
-#~ msgid "Hide"
-#~ msgstr "Skjul"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Ingen meldinger —"
@@ -1245,9 +1343,6 @@ msgstr "Tilbake til innsendelsesside"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Har du allerede sendt inn noe?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Om du har sendt inn noe tidligere, logg inn her for å se etter svar og tilbakemeldinger."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "SE ETTER SVAR"

--- a/securedrop/translations/nl/LC_MESSAGES/messages.po
+++ b/securedrop/translations/nl/LC_MESSAGES/messages.po
@@ -4,7 +4,20 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.3.12\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPOT-Creation-Date: 2017-09-02 07:28+0000\nPO-Revision-Date: 2022-02-17 11:04+0000\nLast-Translator: kwadronaut <kwadronaut@autistici.org>\nLanguage-Team: Dutch <https://weblate.securedrop.org/projects/securedrop/securedrop/nl/>\nLanguage: nl\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n != 1;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.3.12\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"POT-Creation-Date: 2017-09-02 07:28+0000\n"
+"PO-Revision-Date: 2022-02-17 11:04+0000\n"
+"Last-Translator: kwadronaut <kwadronaut@autistici.org>\n"
+"Language-Team: Dutch <https://weblate.securedrop.org/projects/securedrop/securedrop/nl/>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "Naam is te lang"
@@ -130,11 +143,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "Kan niet langer dan {num} teken zijn."
 msgstr[1] "Kan niet langer dan {num} tekens zijn."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Dit veld is verplicht."
 
 msgid "You cannot send an empty reply."
 msgstr "U kunt geen lege reactie versturen."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Bestand verplicht."
@@ -409,6 +428,9 @@ msgstr "Zodra u uw YubiKey geconfigureerd heeft, voert u de zescijferige code hi
 msgid "Navigation"
 msgstr "Navigatie"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Aangemeld als"
 
@@ -532,6 +554,15 @@ msgstr "Inzendingsvoorkeuren"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Voorkom dat bronnen documenten kunnen uploaden. Bronnen kunnen wel nog berichten verzenden."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Inzendingsvoorkeuren bijwerken"
 
@@ -549,20 +580,6 @@ msgstr "Stuur een OSSEC-alarm test"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "VERSTUUR OSSEC WAARSCHUWINGSTESTMAIL"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Het onderstaande bestand is geselecteerd voor <strong>permanente verwijdering</strong>:"
-msgstr[1] "De onderstaande {num} bestanden zijn geselecteerd voor <strong>permanente verwijdering</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "Bestand permanent verwijderen"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "BESTANDEN PERMANENT VERWIJDEREN"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Ga terug naar de documentenlijst voor {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Gebruiker \"{user}\" bewerken"
@@ -705,15 +722,6 @@ msgstr "Inloggen"
 msgid "LOG IN"
 msgstr "INLOGGEN"
 
-msgid "WARNING:"
-msgstr "PAS OP:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "U lijkt Tor2Web te gebruiken, wat geen anonimiteit biedt."
-
-msgid "Why is this dangerous?"
-msgstr "Waarom is dit gevaarlijk?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Veld moet tussen de 1 en {max_codename_len} tekens lang zijn."
 
@@ -732,6 +740,9 @@ msgstr "Bericht is te lang."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Grote stukken teksten moeten als bestand worden geüpload, niet gekopieerd en geplakt."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "U bent omgeleid omdat u al ingelogd bent. Indien u een nieuw account wilt aanmaken, moet u eerst uitloggen."
 
@@ -746,6 +757,22 @@ msgstr "U moet een bericht invoeren of een bestand selecteren om te versturen."
 
 msgid "You must enter a message."
 msgstr "U moet een bericht invoeren ."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Moet ten minste {num} teken lang zijn."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Uw codenaam vergeten?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Als u al eerder documenten heeft verstuurd, log dan hier in om te kijken of u reacties heeft."
 
 msgid "Thanks! We received your message."
 msgstr "Bedankt! We hebben uw bericht ontvangen."
@@ -765,8 +792,14 @@ msgstr "Alle reacties zijn verwijderd"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Helaas is dit een onbekende codenaam."
 
+msgid "Codename"
+msgstr "Codenaam"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Journalisten en bronnen beschermen"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Het spijt ons, onze SecureDrop is momenteel offline."
@@ -801,32 +834,25 @@ msgstr "Let op: het delen van gevoelige documenten kan u in gevaar brengen, zelf
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop is een project van Freedom of the Press Foundation."
 
-msgid "Welcome"
-msgstr "Welkom"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Voer uw codenaam in"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Noteer deze codenaam en bewaar op een veilige plaats of leer hem uit het hoofd."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Dit is de codenaam die u gebruikt voor toekomstige bezoeken om berichten te ontvangen ons team in antwoord op wat u op het volgende scherm inzendt."
-
-msgid "Codename"
-msgstr "Codenaam"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"Omdat we gebruikers van onze <b>SecureDrop</b>-service niet volgen,\n"
-" is het gebruik van deze codenaam de enige manier die we hebben om met u te communiceren mochten we vragen hebben of geïnteresseerd zijn in extra informatie. In tegenstelling tot wachtwoorden\n"
-" kunnen verloren codenamen niet teruggehaald worden."
 
-msgid "Submit Documents"
-msgstr "Documenten versturen"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "DOCUMENTEN INZENDEN"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "Ga verder"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "De <a id=\"disable-js\" href=\"\"><b>veiligheidsinstellingen</b></a> van uw Tor-browser zijn niet strikt genoeg. Gebruik de <img src=\"{icon}\" alt=\"&quot;beveiligingsniveau&quot;\">-knop in de werkbalk van uw browser om dit te wijzigen."
@@ -837,11 +863,11 @@ msgstr "Hoe wijzigt u uw beveiligingsniveau"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Klik op het <img src=\"{icon}\" alt=\"&quot;beveiligingsniveau&quot;\"> in de werkbalk hierboven"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Klik op <b>geavanceerde beveiligingsinstellingen</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Selecteer <b>veiligst</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Volg deze instructies en ververs dan deze pagina\">Ververs deze pagina</a> en u bent klaar!"
@@ -876,9 +902,6 @@ msgstr "Codenaam invoeren"
 msgid "Enter your codename"
 msgstr "Voer uw codenaam in"
 
-msgid "Continue"
-msgstr "Ga verder"
-
 msgid "CANCEL"
 msgstr "ANNULEREN"
 
@@ -887,6 +910,12 @@ msgstr "Nog één ding…"
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Klik op de <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Nieuwe identiteit</b>-knop in de werkbalk van uw Tor Browser. Hierdoor wordt uw Tor Browser geschiedenis van dit apparaat gewist."
+
+msgid "Show"
+msgstr "Tonen"
+
+msgid "Hide"
+msgstr "Verbergen"
 
 msgid "Remember, your codename is:"
 msgstr "Vergeet niet, uw codenaam is:"
@@ -915,6 +944,9 @@ msgstr "Maximale bestandsgrootte: 500 MB"
 msgid "Submit"
 msgstr "Versturen"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Reacties lezen"
 
@@ -923,6 +955,9 @@ msgstr "U heeft een reactie ontvangen. Om uw identiteit te beschermen voor het o
 
 msgid "Delete this reply"
 msgstr "Deze reactie verwijderen"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Deze reactie verwijderen?"
@@ -957,17 +992,27 @@ msgstr "Belangrijk"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "U bent uitgelogd vanwege inactiviteit. Klik op de <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Nieuwe identiteit</b>-knop in de werkbalk van uw Tor Browser voordat u verder gaat. Hierdoor wordt uw Tor Browser geschiedenis van dit apparaat gewist."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Waarom zie ik een waarschuwing over Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Het gebruik van Tor2Web om met SecureDrop te verbinden, zal uw anonimiteit niet beschermen."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Het is mogelijk voor iedereen die uw internetverkeer in de gaten houdt (uw overheid, uw internetprovider) om u te identificeren."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "We <strong>raden u ten zeerste aan</strong> om in plaats daarvan de <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> te gebruiken."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Gebruik de Tor Browser"
@@ -1024,6 +1069,65 @@ msgstr "<strong>Belangrijk:</strong> Als u anoniem wilt blijven, gebruik dan <st
 msgid "Back to submission page"
 msgstr "Terug naar inzendingenpagina"
 
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Het onderstaande bestand is geselecteerd voor <strong>permanente verwijdering</strong>:"
+#~ msgstr[1] "De onderstaande {num} bestanden zijn geselecteerd voor <strong>permanente verwijdering</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Bestand permanent verwijderen"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "BESTANDEN PERMANENT VERWIJDEREN"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Ga terug naar de documentenlijst voor {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "PAS OP:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "U lijkt Tor2Web te gebruiken, wat geen anonimiteit biedt."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Waarom is dit gevaarlijk?"
+
+#~ msgid "Welcome"
+#~ msgstr "Welkom"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Noteer deze codenaam en bewaar op een veilige plaats of leer hem uit het hoofd."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Dit is de codenaam die u gebruikt voor toekomstige bezoeken om berichten te ontvangen ons team in antwoord op wat u op het volgende scherm inzendt."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Omdat we gebruikers van onze <b>SecureDrop</b>-service niet volgen,\n"
+#~ " is het gebruik van deze codenaam de enige manier die we hebben om met u te communiceren mochten we vragen hebben of geïnteresseerd zijn in extra informatie. In tegenstelling tot wachtwoorden\n"
+#~ " kunnen verloren codenamen niet teruggehaald worden."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Documenten versturen"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "DOCUMENTEN INZENDEN"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Klik op <b>geavanceerde beveiligingsinstellingen</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Selecteer <b>veiligst</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Waarom zie ik een waarschuwing over Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "We <strong>raden u ten zeerste aan</strong> om in plaats daarvan de <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> te gebruiken."
+
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Ongeldig geheim: oneven lengte van geheim. Is het geheim correct gespeld?"
 
@@ -1073,12 +1177,6 @@ msgstr "Terug naar inzendingenpagina"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "SecureDrop home"
-
-#~ msgid "Show"
-#~ msgstr "Tonen"
-
-#~ msgid "Hide"
-#~ msgstr "Verbergen"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Geen berichten —"
@@ -1238,9 +1336,6 @@ msgstr "Terug naar inzendingenpagina"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Al eerder iets verstuurd?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Als u al eerder documenten heeft verstuurd, log dan hier in om te kijken of u reacties heeft."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "CHECK OF U ANTWOORD HEEFT"

--- a/securedrop/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/securedrop/translations/pt_BR/LC_MESSAGES/messages.po
@@ -4,7 +4,19 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.4.3\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPO-Revision-Date: 2022-02-17 07:04+0000\nLast-Translator: leilane <leilane.a@protonmail.com>\nLanguage-Team: Portuguese (Brazil) <https://weblate.securedrop.org/projects/securedrop/securedrop/pt_BR/>\nLanguage: pt_BR\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n > 1;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.4.3\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"PO-Revision-Date: 2022-02-17 07:04+0000\n"
+"Last-Translator: leilane <leilane.a@protonmail.com>\n"
+"Language-Team: Portuguese (Brazil) <https://weblate.securedrop.org/projects/securedrop/securedrop/pt_BR/>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "Nome muito longo"
@@ -130,11 +142,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "Não pode conter mais do que {num} caracteres."
 msgstr[1] "Não pode conter mais do que {num} caracteres."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Este campo é obrigatório."
 
 msgid "You cannot send an empty reply."
 msgstr "Não é possível enviar uma resposta em branco."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Arquivo obrigatório."
@@ -409,6 +427,9 @@ msgstr "Após configurar a sua YubiKey, insira o código de seis dígitos abaixo
 msgid "Navigation"
 msgstr "Navegação"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Conectado(a) como"
 
@@ -532,6 +553,15 @@ msgstr "Configurações de Envio"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Impedir que as fontes carreguem documentos. Elas continuarão a ter permissão para enviar mensagens."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Atualizar Configurações de Envio"
 
@@ -549,20 +579,6 @@ msgstr "Envie um alerta OSSEC de teste"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "ENVIAR ALERTA DE VERIFICAÇÃO DO OSSEC"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "O seguinte arquivo será <strong>apagado definitivamente</strong>:"
-msgstr[1] "Os seguintes {num} arquivos serão <strong>apagados definitivamente</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "Apagar arquivos permanentemente"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "APAGAR ARQUIVOS DEFINITIVAMENTE"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Voltar para a lista de documentos de {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Editar usuário \"{user}\""
@@ -705,15 +721,6 @@ msgstr "Conectar"
 msgid "LOG IN"
 msgstr "ACESSAR"
 
-msgid "WARNING:"
-msgstr "AVISO:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Você parece estar usando o Tor2Web, que não fornece anonimato."
-
-msgid "Why is this dangerous?"
-msgstr "Por que isso é perigoso?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Este campo deve conter entre 1 e {max_codename_len} caracteres."
 
@@ -732,6 +739,9 @@ msgstr "Mensagem de texto muito longa."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Longos textos devem ser carregados como arquivos, não simplesmente copiados e colados."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Sessão já iniciada. Para criar uma nova conta, é preciso encerrar esta sessão."
 
@@ -746,6 +756,22 @@ msgstr "É preciso escrever uma mensagem ou escolher um arquivo para enviar."
 
 msgid "You must enter a message."
 msgstr "Você deve escrever uma mensagem."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Deve conter pelo menos {num} caractere."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Esqueceu o seu codinome?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Se você já tiver feito algum envio, faça login aqui para ler as respostas."
 
 msgid "Thanks! We received your message."
 msgstr "Agradecemos a contribuição. Recebemos a sua mensagem."
@@ -765,8 +791,14 @@ msgstr "Todas as respostas foram apagadas"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Desculpe, este codinome não foi reconhecido."
 
+msgid "Codename"
+msgstr "Codinome"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Protegendo Jornalistas e Fontes"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Desculpas, o nosso SecureDrop está offline atualmente."
@@ -801,32 +833,25 @@ msgstr "Por favor, preste atenção: Ao compartilhar documentos confidenciais, v
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop é um projeto da Freedom of the Press Foundation (Fundação pela Liberdade de Imprensa)."
 
-msgid "Welcome"
-msgstr "Bem-vindo(a)"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Digite o seu codinome"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Por favor, anote o seu codinome e guarde-o em um lugar seguro, ou memorize-o."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Este codinome é o que você usará em futuras visitas para receber mensagens de nossos jornalistas em resposta ao que você enviar na próxima tela."
-
-msgid "Codename"
-msgstr "Codinome"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"Como não rastreamos as pessoas que utilizam <b>SecureDrop</b>, \n"
-"este codinome é a nossa única maneira de entrar em contato com você para fazer perguntas ou pedir mais \n"
-"informações. Contrariamente a uma senha, não é possível recuperar um codinome perdido."
 
-msgid "Submit Documents"
-msgstr "Enviar Documentos"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "ENVIAR DOCUMENTOS"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "Continuar"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "O <a id=\"disable-js\" href=\"\"><b>nível de segurança</b></a> do seu navegador Tor está muito baixo. Use o botão <img src=\"{icon}\" alt=\"&quot;nível de segurança&quot;\"> &nbsp;no seu navegador para modificá-lo."
@@ -837,11 +862,11 @@ msgstr "Como mudar seu nível de segurança"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Clique no <img src=\"{icon}\" alt=\"&quot;nível de segurança&quot;\"> na barra de ferramentas, acima"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Selecionar <b> Configurações de Segurança Avançadas </b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Selecionar <b>O mais seguro (Superlative)</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Siga estas instruções para então atualizar esta página\">Refresh this page</a>, e pronto!"
@@ -876,9 +901,6 @@ msgstr "Inserir Codinome"
 msgid "Enter your codename"
 msgstr "Digite o seu codinome"
 
-msgid "Continue"
-msgstr "Continuar"
-
 msgid "CANCEL"
 msgstr "CANCELAR"
 
@@ -887,6 +909,12 @@ msgstr "Uma última coisa..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Clique no botão <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Nova identidade</b> na barra de ferramentas do Tor Browser. Assim, os dados da sua atividade no navegador Tor serão eliminados deste aparelho."
+
+msgid "Show"
+msgstr "Mostrar"
+
+msgid "Hide"
+msgstr "Ocultar"
 
 msgid "Remember, your codename is:"
 msgstr "Lembre-se, o seu codinome é:"
@@ -915,6 +943,9 @@ msgstr "Tamanho máximo de envio: 500 MB"
 msgid "Submit"
 msgstr "Enviar"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Ler Respostas"
 
@@ -923,6 +954,9 @@ msgstr "Você recebeu uma resposta. Para proteger a sua identidade caso alguém 
 
 msgid "Delete this reply"
 msgstr "Apagar esta resposta"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Apagar esta resposta?"
@@ -957,17 +991,27 @@ msgstr "Importante"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "A sua sessão foi encerrada por inatividade. Clique no botão <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Nova identidade</b> na barra de ferramentas do Tor Browser. Assim, os dados da sua atividade no navegador Tor serão eliminados deste aparelho."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Por que há uma advertência sobre o Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "O uso de Tor2Web para conectar-se ao SecureDrop não protege o seu anonimato."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Assim, a sua identidade pode ser descoberta por qualquer pessoa que monitore a sua atividade na Internet (seu governo, seu provedor de Internet)."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "Nós <strong>recomendamos fortemente</strong> que você use o <a href=\"www.torproject.org/projects/torbrowser.html\">Navegador Tor</a> em vez do Tor2Web."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Recomendamos o uso do navegador Tor"
@@ -1024,6 +1068,65 @@ msgstr "<strong>Importante:</strong> Para manter o seu anonimato, <strong>não</
 msgid "Back to submission page"
 msgstr "Voltar à página de envio"
 
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "O seguinte arquivo será <strong>apagado definitivamente</strong>:"
+#~ msgstr[1] "Os seguintes {num} arquivos serão <strong>apagados definitivamente</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Apagar arquivos permanentemente"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "APAGAR ARQUIVOS DEFINITIVAMENTE"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Voltar para a lista de documentos de {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "AVISO:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Você parece estar usando o Tor2Web, que não fornece anonimato."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Por que isso é perigoso?"
+
+#~ msgid "Welcome"
+#~ msgstr "Bem-vindo(a)"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Por favor, anote o seu codinome e guarde-o em um lugar seguro, ou memorize-o."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Este codinome é o que você usará em futuras visitas para receber mensagens de nossos jornalistas em resposta ao que você enviar na próxima tela."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Como não rastreamos as pessoas que utilizam <b>SecureDrop</b>, \n"
+#~ "este codinome é a nossa única maneira de entrar em contato com você para fazer perguntas ou pedir mais \n"
+#~ "informações. Contrariamente a uma senha, não é possível recuperar um codinome perdido."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Enviar Documentos"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "ENVIAR DOCUMENTOS"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Selecionar <b> Configurações de Segurança Avançadas </b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Selecionar <b>O mais seguro (Superlative)</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Por que há uma advertência sobre o Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "Nós <strong>recomendamos fortemente</strong> que você use o <a href=\"www.torproject.org/projects/torbrowser.html\">Navegador Tor</a> em vez do Tor2Web."
+
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Formato do segredo inválido: número ímpar de caracteres. O segredo foi digitado corretamente?"
 
@@ -1073,12 +1176,6 @@ msgstr "Voltar à página de envio"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "Página inicial do SecureDrop"
-
-#~ msgid "Show"
-#~ msgstr "Mostrar"
-
-#~ msgid "Hide"
-#~ msgstr "Ocultar"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Nenhuma Mensagem —"
@@ -1241,9 +1338,6 @@ msgstr "Voltar à página de envio"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Já enviou algum material?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Se você já tiver feito algum envio, faça login aqui para ler as respostas."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "LER RESPOSTAS"

--- a/securedrop/translations/ro/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ro/LC_MESSAGES/messages.po
@@ -150,11 +150,17 @@ msgstr[0] "Nu poate avea mai mult de {num} caracter."
 msgstr[1] "Nu poate avea mai mult de {num} caractere."
 msgstr[2] "Nu poate avea mai mult de {num} de caractere."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Acest câmp este obligatoriu."
 
 msgid "You cannot send an empty reply."
 msgstr "Nu poți trimite un răspuns gol."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Trebuie să existe un fișier."
@@ -447,6 +453,9 @@ msgstr "După ce ai configurat cheia fizică YubiKey, introdu codul de 6 cifre d
 msgid "Navigation"
 msgstr "Cod de verificare"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Autentificat ca"
 
@@ -582,6 +591,15 @@ msgstr "Preferințe de trimitere"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Împiedică sursele să încarce documente. Sursele vor putea să trimită mesaje în continuare."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 #, fuzzy
 #| msgid "Submission Preferences"
 msgid "Update Submission Preferences"
@@ -601,21 +619,6 @@ msgstr ""
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "TRIMITE ALERTĂ OSSEC DE PROBĂ"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Următorul fișier a fost selectat pentru <strong>ștergere definitivă</strong>:"
-msgstr[1] "Următoarele {num} fișiere au fost selectate pentru <strong>ștergere definitivă</strong>:"
-msgstr[2] "Următoarele {num} de fișiere au fost selectate pentru <strong>ștergere definitivă</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr ""
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "ȘTERGE DEFINITIV FIȘIERELE"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Întoarcere la lista de documente pentru {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Editează utilizatorul „{user}”"
@@ -770,15 +773,6 @@ msgstr "Deconectare"
 msgid "LOG IN"
 msgstr "CONECTARE"
 
-msgid "WARNING:"
-msgstr "AVERTISMENT:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Se pare că folosiți Tor2Web, care nu asigură anonimitate."
-
-msgid "Why is this dangerous?"
-msgstr "De ce este periculos?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Câmpul trebuie să aibă între 1 și {max_codename_len} caractere."
 
@@ -797,6 +791,9 @@ msgstr "Textul mesajului este prea lung."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Blocurile mari de text trebuie încărcate ca fișier, nu copiate și lipite."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Ai fost redirecționat(ă) pentru că ești deja autentificat(ă). Dacă vrei să creezi un cont nou trebuie să te deconectezi mai întâi."
 
@@ -811,6 +808,22 @@ msgstr "Trebuie să introduci un mesaj sau să alegi un fișier de trimis."
 
 msgid "You must enter a message."
 msgstr "Trebuie să introduci un mesaj."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Trebuie să aibă cel puțin {num} caracter."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Ți-ai uitat numele de cod?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Dacă ai mai trimis ceva înainte jurnaliștilor, autentifică-te aici pentru a citi răspunsurile."
 
 msgid "Thanks! We received your message."
 msgstr "Îți mulțumim! Am primit mesajul tău."
@@ -830,8 +843,16 @@ msgstr "Toate răspunsurile au fost șterse"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Ne pare rău, acesta nu este un nume de cod recunoscut."
 
+#, fuzzy
+#| msgid "Enter Codename"
+msgid "Codename"
+msgstr "Introdu numele de cod"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Pentru protecția jurnaliștilor și a surselor"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Ne pare rău, contul nostru SecureDrop este acum offline."
@@ -866,34 +887,25 @@ msgstr "Notă: Partajarea de documente sensibile te poate supune la riscuri, chi
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop este un proiect al Fundației Freedom of the Press."
 
-msgid "Welcome"
-msgstr "Bine ai venit"
-
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Te rugăm să îți notezi acest nume de cod și să-l păstrezi într-un loc sigur sau să-l memorezi."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Pe viitor, vei folosi acest nume de cod pentru a primi mesaje de la echipa noastră ca răspuns la ce vei transmite în ecranul următor."
-
 #, fuzzy
-#| msgid "Enter Codename"
-msgid "Codename"
-msgstr "Introdu numele de cod"
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Introdu numele tău de cod"
 
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
-msgstr ""
-"Deoarece noi nu urmărim utilizatorii serviciului nostru <b>SecureDrop</b>,\n"
-"în vizitele tale ulterioare, acest nume de cod va fi singura metodă prin care vom putea comunica cu tine\n"
-"în caz că avem întrebări sau dorim să ne trimiți informații suplimentare. Spre deosebire de parole, numele de cod pierdute nu mai pot fi recuperate."
-
-msgid "Submit Documents"
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "TRIMITE DOCUMENTE"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
+
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr ""
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "<a id=\"disable-js\" href=\"\"><b>Nivelul de securitate</b></a> din browserul tău Tor este prea slab. Folosește butonul <img src=\"{icon}\" alt=\"&quot;Nivelul de securitate&quot;\"> &nbsp;din bara de instrumente a browserului pentru a-l schimba."
@@ -906,11 +918,11 @@ msgstr ""
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Dă click pe <img src=\"{icon}\" alt=\"shield icon\"> în bara de instrumente de mai sus"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Selectează <b>Setări avansate de securitate</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Selectează <b>Cele mai sigure</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 #, fuzzy
 #| msgid "<a href=\"/\">Refresh this page</a>, and you're done!"
@@ -947,9 +959,6 @@ msgstr "Introdu numele de cod"
 msgid "Enter your codename"
 msgstr "Introdu numele tău de cod"
 
-msgid "Continue"
-msgstr ""
-
 msgid "CANCEL"
 msgstr "RENUNȚĂ"
 
@@ -958,6 +967,12 @@ msgstr "Încă ceva..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Dă clic pe butonul <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Identitate nouă</b> din bara de instrumente a browserului Tor. Îți va șterge activitatea din browserul Tor de pe acest dispozitiv."
+
+msgid "Show"
+msgstr "Arată"
+
+msgid "Hide"
+msgstr "Ascunde"
 
 msgid "Remember, your codename is:"
 msgstr "Reține, numele tău de cod este:"
@@ -986,6 +1001,9 @@ msgstr "Mărime maximă fișiere la încărcare: 500 MB"
 msgid "Submit"
 msgstr ""
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Citește răspunsurile"
 
@@ -994,6 +1012,9 @@ msgstr "Ai primit un răspuns. Pentru a-ți proteja identitatea în cazul improb
 
 msgid "Delete this reply"
 msgstr "Ștergi acest răspuns"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Ștergi acest răspuns?"
@@ -1032,17 +1053,27 @@ msgstr "Important"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "Ai fost deconectat(ă) din cauza inactivității. Dă clic pe butonul <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Identitate nouă</b> din bara de instrumente a browserului Tor înainte de a merge mai departe. Îți va șterge activitatea din browserul Tor de pe acest dispozitiv."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "De ce sunt avertizat(ă) despre Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Folosirea Tor2Web pentru a te conecta la SecureDrop nu îți va proteja anonimitatea."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Oricine îți monitorizează traficul pe internet (statul, furnizorul de internet) poate să te identifice."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "<strong>Îți recomandăm puternic</strong> să folosești <a href=\"www.torproject.org/projects/torbrowser.html\">browserul Tor</a> în schimb."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Ar trebui să folosești browserul Tor"
@@ -1099,6 +1130,60 @@ msgstr "<strong>Important:</strong> Dacă vrei să rămâi anonim(ă), <strong>n
 msgid "Back to submission page"
 msgstr "Înapoi la pagina de trimitere"
 
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Următorul fișier a fost selectat pentru <strong>ștergere definitivă</strong>:"
+#~ msgstr[1] "Următoarele {num} fișiere au fost selectate pentru <strong>ștergere definitivă</strong>:"
+#~ msgstr[2] "Următoarele {num} de fișiere au fost selectate pentru <strong>ștergere definitivă</strong>:"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "ȘTERGE DEFINITIV FIȘIERELE"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Întoarcere la lista de documente pentru {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "AVERTISMENT:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Se pare că folosiți Tor2Web, care nu asigură anonimitate."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "De ce este periculos?"
+
+#~ msgid "Welcome"
+#~ msgstr "Bine ai venit"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Te rugăm să îți notezi acest nume de cod și să-l păstrezi într-un loc sigur sau să-l memorezi."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Pe viitor, vei folosi acest nume de cod pentru a primi mesaje de la echipa noastră ca răspuns la ce vei transmite în ecranul următor."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Deoarece noi nu urmărim utilizatorii serviciului nostru <b>SecureDrop</b>,\n"
+#~ "în vizitele tale ulterioare, acest nume de cod va fi singura metodă prin care vom putea comunica cu tine\n"
+#~ "în caz că avem întrebări sau dorim să ne trimiți informații suplimentare. Spre deosebire de parole, numele de cod pierdute nu mai pot fi recuperate."
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "TRIMITE DOCUMENTE"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Selectează <b>Setări avansate de securitate</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Selectează <b>Cele mai sigure</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "De ce sunt avertizat(ă) despre Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "<strong>Îți recomandăm puternic</strong> să folosești <a href=\"www.torproject.org/projects/torbrowser.html\">browserul Tor</a> în schimb."
+
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Secret cu format nevalid: lungimea este impară. Ai tastat greșit secretul?"
 
@@ -1148,12 +1233,6 @@ msgstr "Înapoi la pagina de trimitere"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "Acasă SecureDrop"
-
-#~ msgid "Show"
-#~ msgstr "Arată"
-
-#~ msgid "Hide"
-#~ msgstr "Ascunde"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Niciun mesaj —"
@@ -1313,9 +1392,6 @@ msgstr "Înapoi la pagina de trimitere"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Ai trimis deja ceva?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Dacă ai mai trimis ceva înainte jurnaliștilor, autentifică-te aici pentru a citi răspunsurile."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "VERIFICĂ DACĂ AI UN RĂSPUNS"

--- a/securedrop/translations/ru/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ru/LC_MESSAGES/messages.po
@@ -4,7 +4,19 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.4.3\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPO-Revision-Date: 2022-02-12 15:04+0000\nLast-Translator: Andrey <andrey@mailbox.org>\nLanguage-Team: Russian <https://weblate.securedrop.org/projects/securedrop/securedrop/ru/>\nLanguage: ru\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.4.3\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"PO-Revision-Date: 2022-02-12 15:04+0000\n"
+"Last-Translator: Andrey <andrey@mailbox.org>\n"
+"Language-Team: Russian <https://weblate.securedrop.org/projects/securedrop/securedrop/ru/>\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "Название слишком длинное"
@@ -134,11 +146,17 @@ msgstr[0] "Длина не может превышать {num} символ."
 msgstr[1] "Длина не может превышать {num} символа."
 msgstr[2] "Длина не может превышать {num} символов."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Это обязательное поле."
 
 msgid "You cannot send an empty reply."
 msgstr "Вы не можете отправить пустой ответ."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Файл обязателен."
@@ -419,6 +437,9 @@ msgstr "После того, как вы настроили ваш YubiKey, вв
 msgid "Navigation"
 msgstr "Навигация"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Вы вошли как"
 
@@ -542,6 +563,15 @@ msgstr "Параметры публикации"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Запретить источникам загрузку документов. Источники все ещё смогут отправлять сообщения."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Обновить настройки доставки"
 
@@ -559,21 +589,6 @@ msgstr "Отправить тестовое оповещение OSSEC"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "ОТПРАВИТЬ ТЕСТОВОЕ ПРЕДУПРЕЖДЕНИЕ OSSEC"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Следующий {num} файл был выбран для <strong>безвозвратного удаления</strong>:"
-msgstr[1] "Следующие {num} файла были выбраны для <strong>безвозвратного удаления</strong>:"
-msgstr[2] "Следующие {num} файлов были выбраны для <strong>безвозвратного удаления</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "Безвозвратно удалить файлы"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "УДАЛИТЬ ФАЙЛЫ БЕЗВОЗВРАТНО"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Вернуться к списку документов для {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Редактировать пользователя \"{user}\""
@@ -716,15 +731,6 @@ msgstr "Авторизация"
 msgid "LOG IN"
 msgstr "Войти"
 
-msgid "WARNING:"
-msgstr "ПРЕДУПРЕЖДЕНИЕ:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Похоже, что вы используете Tor2Web, который не обеспечивает анонимность."
-
-msgid "Why is this dangerous?"
-msgstr "Почему это опасно?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Поле должно содержать от 1 до {max_codename_len} символов."
 
@@ -743,6 +749,9 @@ msgstr "Текст сообщения слишком длинный."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Большие блоки текста следует загружать в виде файла, а не копировать и вставлять."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Вы были перенаправлены, так как уже выполнили вход в систему. Если вы хотите создать новый аккаунт, то сначала нужно выйти из системы."
 
@@ -757,6 +766,22 @@ msgstr "Вы должны ввести сообщение или выбрать 
 
 msgid "You must enter a message."
 msgstr "Вы должны ввести сообщение."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Должно быть не менее {num} символ."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Забыли ваше кодовое имя?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Если вы уже отправляли журналистам, войдите в систему, чтобы проверить ответы."
 
 msgid "Thanks! We received your message."
 msgstr "Спасибо! Мы получили ваше сообщение."
@@ -776,8 +801,14 @@ msgstr "Все ответы были удалены"
 msgid "Sorry, that is not a recognized codename."
 msgstr "К сожалению, это кодовое имя не распознано."
 
+msgid "Codename"
+msgstr "Кодовое название"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Защита журналистов и источников"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Упс, наш SecureDrop сейчас без интернета."
@@ -812,32 +843,25 @@ msgstr "Пометка: выкладывать секретными докуме
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop - Это проект Фонда поддержки свободы прессы."
 
-msgid "Welcome"
-msgstr "Добро пожаловать"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Введите ваше кодовое имя"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Пожалуйста, запишите это кодовое имя и сохраните его в надежном месте или запомните его."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Вы будете использовать это кодовое имя при последующих посещениях для получения сообщений от нашей команды в ответ на то, что вы отправите на следующей странице."
-
-msgid "Codename"
-msgstr "Кодовое название"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"Потому что мы не отслеживаем пользователей нашего сервиса <b>SecureDrop</b>.\n"
-"При будущих посещениях используется кодовое имя - это единственный способ связаться с вами, если у нас появятся\n"
-"вопросы или заинтересованость в дополнительной информации. Кодовое имя в отличие от пароля восстановить невозможно."
 
-msgid "Submit Documents"
-msgstr "Подать документы"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "ОТПРАВИТЬ ДОКУМЕНТЫ"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "Продолжить"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "<a id=\"disable-js\" href=\"\"><b>Уровень безопасности</b></a> вашего Tor-браузера слишком низкий. Используйте кнопку <img src=\"{icon}\" alt=\"&quot;Уровень безопасности&quot;\"> на панели инструментов браузера, чтобы изменить его."
@@ -848,11 +872,11 @@ msgstr "Как изменить уровень безопасности"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Нажмите <img src=\"{icon}\" alt=\"&quote;Уровень безопасности&quot;\"> на панели инструментов выше"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Выберите <b>Дополнительные настройки безопасности</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Выберите <b>Самый безопасный</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Следуйте этим инструкциям, затем обновите эту страницу\">Обновить страницу</a>, и все!"
@@ -887,9 +911,6 @@ msgstr "Введите кодовое имя"
 msgid "Enter your codename"
 msgstr "Введите ваше кодовое имя"
 
-msgid "Continue"
-msgstr "Продолжить"
-
 msgid "CANCEL"
 msgstr "ОТМЕНИТЬ"
 
@@ -898,6 +919,12 @@ msgstr "И еще кое-что..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Нажмите кнопку <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Новая идентичность</b> button в панели инструментов вашего браузера Tor. Это очистит данные об активности вашего браузера Tor на этом устройстве."
+
+msgid "Show"
+msgstr "Показать"
+
+msgid "Hide"
+msgstr "Скрыть"
 
 msgid "Remember, your codename is:"
 msgstr "Запомните, что ваше кодовое имя:"
@@ -926,6 +953,9 @@ msgstr "Максимальный размер для загрузки: 500МБ"
 msgid "Submit"
 msgstr "Принять"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Читать ответы"
 
@@ -934,6 +964,9 @@ msgstr "У вас есть ответ. Чтобы защитить вашу ли
 
 msgid "Delete this reply"
 msgstr "Удалить этот ответ"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Удалить этот ответ?"
@@ -968,17 +1001,27 @@ msgstr "Важно"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "Вы были деавторизованы из-за неактивности. Нажмите кнопку <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Новая идентичность</b> в панели инструментов вашего браузера Tor перед тем, как продолжить. Это очистит данные об активности вашего браузера Tor на этом устройстве."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Почему здесь предупреждение о Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Использование Tor2Web при подключении к SecureDrop не добавит вам анонимности."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Контролирующие интернет-трафик организации (правительство, интернет-провайдер) легко могут вас идентифицировать."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "Мы <strong>настоятельно рекомендуем</strong> вам использовать <a href=\"www.torproject.org/projects/torbrowser.html\">Браузер Tor</a>."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Вы должны использовать Tor Browser"
@@ -1035,6 +1078,66 @@ msgstr "<strong>Внимание:</strong> Если вы хотите сохра
 msgid "Back to submission page"
 msgstr "Вернуться на страницу отправки"
 
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Следующий {num} файл был выбран для <strong>безвозвратного удаления</strong>:"
+#~ msgstr[1] "Следующие {num} файла были выбраны для <strong>безвозвратного удаления</strong>:"
+#~ msgstr[2] "Следующие {num} файлов были выбраны для <strong>безвозвратного удаления</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Безвозвратно удалить файлы"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "УДАЛИТЬ ФАЙЛЫ БЕЗВОЗВРАТНО"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Вернуться к списку документов для {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "ПРЕДУПРЕЖДЕНИЕ:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Похоже, что вы используете Tor2Web, который не обеспечивает анонимность."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Почему это опасно?"
+
+#~ msgid "Welcome"
+#~ msgstr "Добро пожаловать"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Пожалуйста, запишите это кодовое имя и сохраните его в надежном месте или запомните его."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Вы будете использовать это кодовое имя при последующих посещениях для получения сообщений от нашей команды в ответ на то, что вы отправите на следующей странице."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Потому что мы не отслеживаем пользователей нашего сервиса <b>SecureDrop</b>.\n"
+#~ "При будущих посещениях используется кодовое имя - это единственный способ связаться с вами, если у нас появятся\n"
+#~ "вопросы или заинтересованость в дополнительной информации. Кодовое имя в отличие от пароля восстановить невозможно."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Подать документы"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "ОТПРАВИТЬ ДОКУМЕНТЫ"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Выберите <b>Дополнительные настройки безопасности</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Выберите <b>Самый безопасный</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Почему здесь предупреждение о Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "Мы <strong>настоятельно рекомендуем</strong> вам использовать <a href=\"www.torproject.org/projects/torbrowser.html\">Браузер Tor</a>."
+
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Неверный формат: количество символов нечетное. Вы ошиблись?"
 
@@ -1084,12 +1187,6 @@ msgstr "Вернуться на страницу отправки"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "Главная SecureDrop"
-
-#~ msgid "Show"
-#~ msgstr "Показать"
-
-#~ msgid "Hide"
-#~ msgstr "Скрыть"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Нет сообщений —"
@@ -1252,9 +1349,6 @@ msgstr "Вернуться на страницу отправки"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Уже что-то отправляли?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Если вы уже отправляли журналистам, войдите в систему, чтобы проверить ответы."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "ПРОВЕРИТЬ ОТВЕТЫ"

--- a/securedrop/translations/sk/LC_MESSAGES/messages.po
+++ b/securedrop/translations/sk/LC_MESSAGES/messages.po
@@ -4,7 +4,19 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.14.0~rc1\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPO-Revision-Date: 2022-02-09 21:04+0000\nLast-Translator: Katarina Kasalova <katka.kasalova@gmail.com>\nLanguage-Team: Slovak <https://weblate.securedrop.org/projects/securedrop/securedrop/sk/>\nLanguage: sk\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.5.1\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.14.0~rc1\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"PO-Revision-Date: 2022-02-09 21:04+0000\n"
+"Last-Translator: Katarina Kasalova <katka.kasalova@gmail.com>\n"
+"Language-Team: Slovak <https://weblate.securedrop.org/projects/securedrop/securedrop/sk/>\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.5.1\n"
 
 msgid "Name too long"
 msgstr "Meno je príliš dlhé"
@@ -134,11 +146,17 @@ msgstr[0] "Nesmie byť dlhšie ako {num} znak."
 msgstr[1] "Nesmie byť dlhšie ako {num} znaky."
 msgstr[2] "Nesmie byť dlhšie ako {num} znakov."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Toto pole je povinné."
 
 msgid "You cannot send an empty reply."
 msgstr "Nemôžete poslať prázdnu odpoveď."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Súbor je povinný."
@@ -419,6 +437,9 @@ msgstr "Akonáhle nastavíte svoj YubiKey, zadajte šesťmiestny kód nižšie:"
 msgid "Navigation"
 msgstr "Navigácia"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Ste prihlásení ako"
 
@@ -542,6 +563,15 @@ msgstr "Preferencie podania"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Zabráňte zdrojom v nahrávaní dokumentov. Zdroje budú môcť naďalej posielať správy."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Aktualizovať preferencie podaní"
 
@@ -559,21 +589,6 @@ msgstr "Poslať testovacie OSSEC upozornenie"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "POSLAŤ TESTOVACIE UPOZORNENIE OSSEC"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Nasledujúci súbor bol označený na <strong>permanentné vymazanie</strong>:"
-msgstr[1] "Nasledujúce {num} súbory boli označené na <strong>permanentné vymazanie</strong>:"
-msgstr[2] "Nasledujúcich {num} súborov bolo označených na <strong>permanentné vymazanie</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "Natrvalo zmazať súbory"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "VYMAZAŤ SÚBORY NAVŽDY"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Vrátiť sa na zoznam dokumentov od {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Upraviť používateľa „{user}“"
@@ -716,15 +731,6 @@ msgstr "Prihlásiť sa"
 msgid "LOG IN"
 msgstr "PRIHLÁSIŤ SA"
 
-msgid "WARNING:"
-msgstr "POZOR:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Vyzerá to, že používate Tor2Web, ktorý nechráni anonymitu."
-
-msgid "Why is this dangerous?"
-msgstr "Prečo je to nebezpečné?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Pole musí mať 1 až {max_codename_len} znakov."
 
@@ -743,6 +749,9 @@ msgstr "Správa je príliš dlhá."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Veľké bloky textu musia byť nahraté ako súbor, nie skopírované a vložené."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Boli ste presmerovaní, pretože už ste prihlásení. Ak chcete vytvoriť nový účet, musíte sa najprv odhlásiť."
 
@@ -757,6 +766,22 @@ msgstr "Musíte napísať správu alebo vybrať súbor na odoslanie."
 
 msgid "You must enter a message."
 msgstr "Musíte napísať správu."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Musí byť aspoň {num} znak dlhé."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Zabudli ste svoje krycie meno?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Ak ste už niečo posielali žurnalistom, prihláste sa tu pre kontrolu odpovedí."
 
 msgid "Thanks! We received your message."
 msgstr "Vďaka! Prijali sme vašu správu."
@@ -776,8 +801,14 @@ msgstr "Všetky odpovede boli zmazané"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Prepáčte, toto krycie meno nie je používané."
 
+msgid "Codename"
+msgstr "Krycie meno"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Chránime novinárov a zdroje"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Prepáčte, náš SecureDrop je v súčasnosti offline."
@@ -812,29 +843,25 @@ msgstr "Nezabúdajte na to, že zdieľaním dokumentov s citlivým obsahom sa vy
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop je projekt organizácie Freedom of the Press Foundation."
 
-msgid "Welcome"
-msgstr "Vitajte"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Zadajte svoje krycie meno"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Prosím zapíšte si toto krycie meno a uložte ho na bezpečnom mieste, alebo sa ho naučte naspamäť."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
+msgstr ""
 
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Toto krycie meno budete v budúcnosti používať na prijímanie odpovedí od nášho tímu ako odpoveď k tomu, čo zašlete na nasledujúcej obrazovke."
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "Codename"
-msgstr "Krycie meno"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
 
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
-msgstr "Keďže nesledujeme používateľov služby <b>SecureDrop</b>\n, toto krycie meno je jediný spôsob ako s vami budeme môcť v budúcnosti komunikovať, ak budeme mať otázky, alebo budeme potrebovať ďalšie informácie. Narozdiel od hesiel sa stratené krycie meno nedá obnoviť."
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
 
-msgid "Submit Documents"
-msgstr "Odoslať dokumenty"
-
-msgid "SUBMIT DOCUMENTS"
-msgstr "ODOSLAŤ DOKUMENTY"
+msgid "Continue"
+msgstr "Pokračovať"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "<a id=\"disable-js\" href=\"\"><b>Úroveň zabezpečenia</b></a> vo Vašom Tor prehliadači je príliš nízka. Zmeňte to použím tlačidla s <img src=\"{icon}\" alt=\"&quot;Úroveň zabezpečenia&quot;\"> &nbsp;v paneli nástrojov prehliadača."
@@ -845,11 +872,11 @@ msgstr "Ako zmeniť úroveň vášho zabezpečenia"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Kliknite na <img src=\"{icon}\" alt=\"&quot;Úroveň zabezpečenia&quot; tlačidlo\"> v paneli nástrojov vyššie"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Vyberte <b>Rozšírené bezpečnostné nastavenia</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Vyberte <b>Najbezpečnejšie</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Postupujte podľa inštrukcií a potom obnovte túto stránku\">Obnovte túto stránku</a> a to je všetko!"
@@ -884,9 +911,6 @@ msgstr "Zadať krycie meno"
 msgid "Enter your codename"
 msgstr "Zadajte svoje krycie meno"
 
-msgid "Continue"
-msgstr "Pokračovať"
-
 msgid "CANCEL"
 msgstr "ZRUŠIŤ"
 
@@ -895,6 +919,12 @@ msgstr "Ešte posledná vec..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Kliknite na ikonu <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Nová identita</b> na lište vášho prehliadača Tor. Zmažete tým dáta o aktivite prehliadača Tor na tomto zariadení."
+
+msgid "Show"
+msgstr "Zobraziť"
+
+msgid "Hide"
+msgstr "Skryť"
 
 msgid "Remember, your codename is:"
 msgstr "Pamätajte, vaše krycie meno je:"
@@ -923,6 +953,9 @@ msgstr "Maximálna veľkosť uploadu: 500 MB"
 msgid "Submit"
 msgstr "Odoslať"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Prečítať si odpovede"
 
@@ -931,6 +964,9 @@ msgstr "Dostali ste odpoveď. Aby sme ochránili vašu identitu v prípade že b
 
 msgid "Delete this reply"
 msgstr "Zmazať túto odpoveď"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Zmazať túto odpoveď?"
@@ -965,17 +1001,27 @@ msgstr "Dôležité"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "Boli ste odhlásení z dôvodu nečinnosti. Skôr než budete pokračovať, kliknite na ikonu <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Nová identita</b> na lište prehliadača Tor. Tým sa vymažú dáta o aktivite Tor prehliadača na tomto zariadení."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Prečo je tu upozornenie o Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Používanie Tor2Web na pripojenie k SecureDrop neochráni vašu anonymitu."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Ktokoľvek moniturujúci vašu internetovú komunikáciu (vláda, poskytovateľ pripojenia) vás môže identifikovať."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "<strong>Odporúčame</strong>použiť <a href=\"www.torproject.org/projects/torbrowser.html\">prehliadač Tor</a>."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Odporúčame použiť prehliadač Tor"
@@ -1031,6 +1077,65 @@ msgstr "<strong>Dôležité:</strong> Ak chcete zostať v anonymite, <strong>nep
 
 msgid "Back to submission page"
 msgstr "Späť na stránku podania"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Nasledujúci súbor bol označený na <strong>permanentné vymazanie</strong>:"
+#~ msgstr[1] "Nasledujúce {num} súbory boli označené na <strong>permanentné vymazanie</strong>:"
+#~ msgstr[2] "Nasledujúcich {num} súborov bolo označených na <strong>permanentné vymazanie</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Natrvalo zmazať súbory"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "VYMAZAŤ SÚBORY NAVŽDY"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Vrátiť sa na zoznam dokumentov od {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "POZOR:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Vyzerá to, že používate Tor2Web, ktorý nechráni anonymitu."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Prečo je to nebezpečné?"
+
+#~ msgid "Welcome"
+#~ msgstr "Vitajte"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Prosím zapíšte si toto krycie meno a uložte ho na bezpečnom mieste, alebo sa ho naučte naspamäť."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Toto krycie meno budete v budúcnosti používať na prijímanie odpovedí od nášho tímu ako odpoveď k tomu, čo zašlete na nasledujúcej obrazovke."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Keďže nesledujeme používateľov služby <b>SecureDrop</b>\n"
+#~ ", toto krycie meno je jediný spôsob ako s vami budeme môcť v budúcnosti komunikovať, ak budeme mať otázky, alebo budeme potrebovať ďalšie informácie. Narozdiel od hesiel sa stratené krycie meno nedá obnoviť."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Odoslať dokumenty"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "ODOSLAŤ DOKUMENTY"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Vyberte <b>Rozšírené bezpečnostné nastavenia</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Vyberte <b>Najbezpečnejšie</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Prečo je tu upozornenie o Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "<strong>Odporúčame</strong>použiť <a href=\"www.torproject.org/projects/torbrowser.html\">prehliadač Tor</a>."
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Nesprávny formát hesla: nepárna dĺžka hesla. Spravili ste preklep?"
@@ -1088,12 +1193,6 @@ msgstr "Späť na stránku podania"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "Domovská stránka SecureDrop"
-
-#~ msgid "Show"
-#~ msgstr "Zobraziť"
-
-#~ msgid "Hide"
-#~ msgstr "Skryť"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Žiadne správy —"
@@ -1253,9 +1352,6 @@ msgstr "Späť na stránku podania"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Už ste niečo odoslali?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Ak ste už niečo posielali žurnalistom, prihláste sa tu pre kontrolu odpovedí."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "SKONTROLOVAŤ ODPOVEDE"

--- a/securedrop/translations/sv/LC_MESSAGES/messages.po
+++ b/securedrop/translations/sv/LC_MESSAGES/messages.po
@@ -4,7 +4,19 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.5-rc4\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPO-Revision-Date: 2022-02-15 11:04+0000\nLast-Translator: Jonas Waga <jonas.waga@schibsted.com>\nLanguage-Team: Swedish <https://weblate.securedrop.org/projects/securedrop/securedrop/sv/>\nLanguage: sv\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n != 1;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.5-rc4\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"PO-Revision-Date: 2022-02-15 11:04+0000\n"
+"Last-Translator: Jonas Waga <jonas.waga@schibsted.com>\n"
+"Language-Team: Swedish <https://weblate.securedrop.org/projects/securedrop/securedrop/sv/>\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "Namnet är för långt"
@@ -130,11 +142,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "Kan inte vara längre än {num} tecken."
 msgstr[1] "Kan inte vara längre än {num} tecken."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Detta fält är obligatoriskt."
 
 msgid "You cannot send an empty reply."
 msgstr "Du kan inte skicka ett tomt svar."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Fil krävs."
@@ -409,6 +427,9 @@ msgstr "När du har konfigurerat din Yubikey, ange den sexsiffriga koden nedan:"
 msgid "Navigation"
 msgstr "Navigering"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Inloggad som"
 
@@ -532,6 +553,15 @@ msgstr "Inlämningsinställningar"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Förhindra källor från att ladda upp dokument. Källor kommer fortfarande kunna skicka meddelanden."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Uppdatera inlämningsinställningar"
 
@@ -549,20 +579,6 @@ msgstr "Skicka ett test OSSEC-meddelande"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "SKICKA TEST OSSEC-LARM"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Följande fil har valts för <strong> permanent borttagning</strong>:"
-msgstr[1] "Följande {num} filer har valts för <strong> permanent borttagning</strong>:"
-
-msgid "Permanently Delete Files"
-msgstr "Radera filer permanent"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "TA BORT FILER PERMANENT"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "Återvänd till listan av dokument för {source_name}…"
 
 msgid "Edit user \"{user}\""
 msgstr "Redigera användaren \"{user}\""
@@ -705,15 +721,6 @@ msgstr "Logga in"
 msgid "LOG IN"
 msgstr "LOGGA IN"
 
-msgid "WARNING:"
-msgstr "VARNING:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Det ser ut som att du använder Tor2Web, detta ger inte någon anonymitet."
-
-msgid "Why is this dangerous?"
-msgstr "Varför är detta osäkert?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Fältet måste innehålla mellan 1 och {max_codename_len} tecken."
 
@@ -732,6 +739,9 @@ msgstr "Meddelandet är för långt."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Stora block med text måste laddas upp som en fil, inte kopieras och klistras in."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Du omdirigerades eftersom du redan är inloggad. Ifall du vill skapa ett nytt konto, logga ut först."
 
@@ -746,6 +756,22 @@ msgstr "Du måste ange ett meddelande eller välja en fil att lämna in."
 
 msgid "You must enter a message."
 msgstr "Du måste ange ett meddelande."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "Måste vara minst {num} tecken långt."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Har du glömt ditt kodnamn?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Ifall du redan har skickat in information till journalisterna, logga in här för att kontrollera om du fått svar."
 
 msgid "Thanks! We received your message."
 msgstr "Tack! Vi har tagit emot ditt meddelande."
@@ -765,8 +791,14 @@ msgstr "Alla svar har tagits bort"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Tyvärr, detta kodnamn är okänt."
 
+msgid "Codename"
+msgstr "Kodnamn"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Skyddar journalister och källor"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Vi ber om ursäkt, men vår SecureDrop är för närvarande offline."
@@ -801,32 +833,25 @@ msgstr "Observera: Delning av känsliga dokument kan utsätta dig för risk, äv
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop är ett projekt från Freedom of the Press Foundation."
 
-msgid "Welcome"
-msgstr "Välkommen"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Ange ditt kodnamn"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Vänligen skriv ner detta kodnamn och spara det på en säker plats eller memorera det."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Detta kodnamn är det du kommer att använda vid framtida besök för att ta emot meddelanden från vårt team som svar på det du skickar in på nästa skärm."
-
-msgid "Codename"
-msgstr "Kodnamn"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"Eftersom vi inte spårar användare av vår <b> SecureDrop</b>-tjänst,\n"
-"vid framtida besök, kommer användningen av detta kodnamn att vara det enda sättet vi har att kommunicera med dig ifall vi har\n"
-"frågor eller är intresserade av mer information. Till skillnad från lösenord, finns det inget sätt att återställa ett försvunnet kodnamn."
 
-msgid "Submit Documents"
-msgstr "Ladda upp dokument"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "LÄMNA IN DOKUMENT"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "Fortsätt"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "Din Tor Browsers <a id=\"disable-js\" href=\"\"><b>Säkerhetsnivå</b></a> är ställd för låg. Använd <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\">-knappen i din Tor Browsers menyrad för att ändra det."
@@ -837,11 +862,11 @@ msgstr "Så här ändrar du din säkerhetsnivå"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Klicka på <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> i menyraden ovan"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "Välj <b>Avancerade säkerhetsinställningar</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "Välj <b>Säkrast</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Följ dessa instruktioner och uppdatera sedan sidan\">Uppdatera sidan</a> och sedan är du klar!"
@@ -876,9 +901,6 @@ msgstr "Ange kodnamn"
 msgid "Enter your codename"
 msgstr "Ange ditt kodnamn"
 
-msgid "Continue"
-msgstr "Fortsätt"
-
 msgid "CANCEL"
 msgstr "AVBRYT"
 
@@ -887,6 +909,12 @@ msgstr "En sak till…"
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Klicka på knappen <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Ny identitet</b> i din Tor Browsers verktygsfält. Detta kommer att rensa dina Tor Browsers aktiviteter på den här enheten."
+
+msgid "Show"
+msgstr "Visa"
+
+msgid "Hide"
+msgstr "Göm"
 
 msgid "Remember, your codename is:"
 msgstr "Kom ihåg, ditt kodnamn är:"
@@ -915,6 +943,9 @@ msgstr "Maximal storlek för uppladdningar: 500 MB"
 msgid "Submit"
 msgstr "Skicka in"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Läs svar"
 
@@ -923,6 +954,9 @@ msgstr "Du har fått ett svar. För att skydda din identitet vid det osannolika 
 
 msgid "Delete this reply"
 msgstr "Ta bort detta svar"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Ta bort detta svar?"
@@ -957,17 +991,27 @@ msgstr "Viktigt"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "Du loggades ut på grund av inaktivitet. Klicka på knappen <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Ny identitet</b> i ditt Tor Browser-verktygsfält innan du går vidare. Detta rensar dina Tor Browser-aktivitetsdata på den här enheten."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Varför finns det en varning om Tor2Web?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "Att använda Tor2Web för att ansluta till SecureDrop kommer inte att skydda din anonymitet."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "Det kan vara möjligt för någon som övervakar din Internettrafik (dina myndigheter, din internetleverantör), att identifiera dig."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "Vi <strong>rekommenderar starkt</strong> att du använder <a href=\"www.torproject.org/projects/torbrowser.html\"> Tor Browser</a> istället."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Du borde använda Tor Browser"
@@ -1023,6 +1067,65 @@ msgstr "<strong> Viktigt:</strong> Ifall du önskar att förbli anonym, <strong>
 
 msgid "Back to submission page"
 msgstr "Tillbaka till inlämningssidan"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Följande fil har valts för <strong> permanent borttagning</strong>:"
+#~ msgstr[1] "Följande {num} filer har valts för <strong> permanent borttagning</strong>:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Radera filer permanent"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "TA BORT FILER PERMANENT"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "Återvänd till listan av dokument för {source_name}…"
+
+#~ msgid "WARNING:"
+#~ msgstr "VARNING:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Det ser ut som att du använder Tor2Web, detta ger inte någon anonymitet."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Varför är detta osäkert?"
+
+#~ msgid "Welcome"
+#~ msgstr "Välkommen"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Vänligen skriv ner detta kodnamn och spara det på en säker plats eller memorera det."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Detta kodnamn är det du kommer att använda vid framtida besök för att ta emot meddelanden från vårt team som svar på det du skickar in på nästa skärm."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "Eftersom vi inte spårar användare av vår <b> SecureDrop</b>-tjänst,\n"
+#~ "vid framtida besök, kommer användningen av detta kodnamn att vara det enda sättet vi har att kommunicera med dig ifall vi har\n"
+#~ "frågor eller är intresserade av mer information. Till skillnad från lösenord, finns det inget sätt att återställa ett försvunnet kodnamn."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Ladda upp dokument"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "LÄMNA IN DOKUMENT"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "Välj <b>Avancerade säkerhetsinställningar</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "Välj <b>Säkrast</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Varför finns det en varning om Tor2Web?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "Vi <strong>rekommenderar starkt</strong> att du använder <a href=\"www.torproject.org/projects/torbrowser.html\"> Tor Browser</a> istället."
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Ogiltigt format i hemlighet: ojämn längd. Skrev du fel?"
@@ -1080,12 +1183,6 @@ msgstr "Tillbaka till inlämningssidan"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "SecureDrop Hem"
-
-#~ msgid "Show"
-#~ msgstr "Visa"
-
-#~ msgid "Hide"
-#~ msgstr "Göm"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Inga medelanden —"
@@ -1248,9 +1345,6 @@ msgstr "Tillbaka till inlämningssidan"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Har du redan skickat in information?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Ifall du redan har skickat in information till journalisterna, logga in här för att kontrollera om du fått svar."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "KONTROLLERA OM DU FÅTT ETT SVAR"

--- a/securedrop/translations/tr/LC_MESSAGES/messages.po
+++ b/securedrop/translations/tr/LC_MESSAGES/messages.po
@@ -4,7 +4,19 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.5-rc4\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPO-Revision-Date: 2022-02-16 21:04+0000\nLast-Translator: Kaya Zeren <kayazeren@gmail.com>\nLanguage-Team: Turkish <https://weblate.securedrop.org/projects/securedrop/securedrop/tr/>\nLanguage: tr\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n != 1;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.5-rc4\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"PO-Revision-Date: 2022-02-16 21:04+0000\n"
+"Last-Translator: Kaya Zeren <kayazeren@gmail.com>\n"
+"Language-Team: Turkish <https://weblate.securedrop.org/projects/securedrop/securedrop/tr/>\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "İsim çok uzun"
@@ -130,11 +142,17 @@ msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "{num} karakterden uzun olamaz."
 msgstr[1] "{num} karakterden uzun olamaz."
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "Bu alanın doldurulması zorunludur."
 
 msgid "You cannot send an empty reply."
 msgstr "Boş bir yanıt gönderemezsiniz."
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "Dosya gerekli."
@@ -409,6 +427,9 @@ msgstr "YubiKey yapılandırmasını tamamladığınızda, aşağıdaki 6 haneli
 msgid "Navigation"
 msgstr "Gezinme"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "Oturum açan"
 
@@ -532,6 +553,15 @@ msgstr "Gönderim Tercihleri"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "Kaynakların belge yüklemelerini engeller. Kaynaklar halen ileti gönderebilir."
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "Gönderim tercihlerini ayarla"
 
@@ -549,20 +579,6 @@ msgstr "OSSEC uyarı denemesi gönder"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "OSSEC UYARI GÖNDERME DENEMESİ"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "Aşağıdaki dosya <strong>kalıcı bir şekilde silinmek</strong> üzere seçilmiş:"
-msgstr[1] "Aşağıdaki {num} dosya <strong>kalıcı bir şekilde silinmek</strong> üzere seçilmiş:"
-
-msgid "Permanently Delete Files"
-msgstr "Dosyaları kalıcı olarak sil"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "DOSYALARI KALICI OLARAK SİL"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "{source_name} belgelerinin listesine geri dön…"
 
 msgid "Edit user \"{user}\""
 msgstr "\"{user}\" kullanıcısını düzenle"
@@ -705,15 +721,6 @@ msgstr "Oturum aç"
 msgid "LOG IN"
 msgstr "OTURUM AÇ"
 
-msgid "WARNING:"
-msgstr "UYARI:"
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "Anonimlik sağlamayan Tor2Web kullanıyor gibisiniz."
-
-msgid "Why is this dangerous?"
-msgstr "Bu neden tehlikeli?"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "Alanda 1 ile {max_codename_len} arasında karakter bulunmalıdır."
 
@@ -732,6 +739,9 @@ msgstr "İleti metni çok uzun."
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "Büyük metin gövdeleri dosya olarak yüklenmelidir, kopyala ve yapıştır yapılmamalıdır."
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "Oturumunuz zaten açık olduğundan buraya yönlendirildiniz. Yeni bir hesap açmak istiyorsanız, önce oturumunuzu kapatmalısınız."
 
@@ -746,6 +756,22 @@ msgstr "Bir ileti yazmalı ya da gönderilecek bir dosya seçmelisiniz."
 
 msgid "You must enter a message."
 msgstr "Bir ileti yazmalısınız."
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "{num} karakterden az olamaz."
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "Kod adınızı mı unuttunuz?"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "Daha önce de gazetecilere bir şey gönderdiyseniz, oturum açarak yanıtları kontrol edin."
 
 msgid "Thanks! We received your message."
 msgstr "Teşekkürler! İletiniz alındı."
@@ -765,8 +791,14 @@ msgstr "Bütün yanıtlar silindi"
 msgid "Sorry, that is not a recognized codename."
 msgstr "Maalesef, kod adı anlaşılamadı."
 
+msgid "Codename"
+msgstr "Kod adı"
+
 msgid "Protecting Journalists and Sources"
 msgstr "Gazetecileri ve Kaynakları Korumak"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "Maalesef, SecureDrop şu anda çevrimdışı."
@@ -801,32 +833,25 @@ msgstr "Lütfen unutmayın: Tor ve SecureDrop kullanıyor olsanız bile önemli 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop, Freedom of the Press (Basın Özgürlüğü) vakfının bir projesidir."
 
-msgid "Welcome"
-msgstr "Hoş Geldiniz"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "Kod adınızı yazın"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "Lütfen bu kod adını bir yere yazın ve güvenli bir şekilde saklayın ya da ezberleyin."
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "Bir sonraki sayfada göndereceğiniz bilgilere, ekibimizin gönderdiği yanıtları almak için yeniden geldiğinizde bu kod adını kullanacaksınız."
-
-msgid "Codename"
-msgstr "Kod adı"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"<b>SecureDrop</b> hizmetimizin kullanıcılarını izlemediğimiz için, \n"
-"sizinle iletişim kurabilmemiz, soru sorabilmemiz ya da ek bilgi gereksinimlerini bildirebilmemiz için kullanılabilecek\n"
-"tek yol sonraki ziyaretlerinizde bu kod adını kullanmanızdır. Parolaların aksine kod adı kaybolduğunda geri alınamaz."
 
-msgid "Submit Documents"
-msgstr "Belgeleri gönder"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "BELGE GÖNDER"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "Devam"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "Tor Browser <a id=\"disable-js\" href=\"\"><b>Güvenlik Düzeyi</b></a> çok düşük. Tor Browser araç çubuğundaki <img src=\"{icon}\" alt=\"&quot;Güvenlik Düzeyi&quot;\"> &nbsp;düğmesini kullanarak değiştirebilirsiniz."
@@ -837,11 +862,11 @@ msgstr "Güvenlik düzeyi nasıl değiştirilir"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "Yukarıdaki araç çubuğundan <img src=\"{icon}\" alt=\"&quot;Güvenlik Düzeyi&quot;\"> düğmesine tıklayın"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "<b>Gelişmiş Güvenlik Ayarlarını</b> seçin"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "<b>En güvenli</b> seçeneğini seçin"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Bu yönergeleri izleyin ve sayfayı yenileyin\">Bu sayfayı yenileyin</a> ve işlemi tamamlayın!"
@@ -876,9 +901,6 @@ msgstr "Kod Adını Yazın"
 msgid "Enter your codename"
 msgstr "Kod adınızı yazın"
 
-msgid "Continue"
-msgstr "Devam"
-
 msgid "CANCEL"
 msgstr "İPTAL"
 
@@ -887,6 +909,12 @@ msgstr "Bir şey daha var..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "Tor Browser araç çubuğundan <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Kimliği yenile</b> üzerine tıklayın. Bu işlem bu aygıt üzerindeki Tor Browser etkinliklerini siler."
+
+msgid "Show"
+msgstr "Göster"
+
+msgid "Hide"
+msgstr "Gizle"
 
 msgid "Remember, your codename is:"
 msgstr "Unutmayın, kod adınız:"
@@ -915,6 +943,9 @@ msgstr "En büyük yükleme boyutu: 500 MB"
 msgid "Submit"
 msgstr "Gönder"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "Yanıtları Okuyun"
 
@@ -923,6 +954,9 @@ msgstr "Bir yanıt aldınız. Pek mümkün olmasa da birinin kod adınızı öğ
 
 msgid "Delete this reply"
 msgstr "Bu yanıtı sil"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "Bu yanıt silinsin mi?"
@@ -957,17 +991,27 @@ msgstr "Önemli"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "Bir süredir işlem yapmadığınız için oturumunuz kapatıldı. İlerlemeden önce Tor Browser araç çubuğundan <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>Kimliği yenile</b> üzerine tıklayın. Bu işlem bu aygıttaki Tor Browser etkinlik bilgilerini siler."
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "Neden Tor2Web hakkında bir uyarı var?"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "SecureDrop uygulamasına Tor2Web kullanarak bağlanmak anonim kalmanızı sağlamaz."
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "İnternet kullanımını gözetleyen herhangi birinin (hükümetiniz, İnternet sağlayıcınız) sizin kim olduğunuzu belirleyebilir."
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "Bunun yerine <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> kullanmanızı <strong>önemle öneririz</strong>."
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "Tor Browser kullanmalısınız"
@@ -1023,6 +1067,65 @@ msgstr "<strong>Önemli:</strong> Anonim kalmak istiyorsanız, dosyanın GPG tar
 
 msgid "Back to submission page"
 msgstr "Gönderi sayfasına geri dön"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "Aşağıdaki dosya <strong>kalıcı bir şekilde silinmek</strong> üzere seçilmiş:"
+#~ msgstr[1] "Aşağıdaki {num} dosya <strong>kalıcı bir şekilde silinmek</strong> üzere seçilmiş:"
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "Dosyaları kalıcı olarak sil"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "DOSYALARI KALICI OLARAK SİL"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "{source_name} belgelerinin listesine geri dön…"
+
+#~ msgid "WARNING:"
+#~ msgstr "UYARI:"
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "Anonimlik sağlamayan Tor2Web kullanıyor gibisiniz."
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "Bu neden tehlikeli?"
+
+#~ msgid "Welcome"
+#~ msgstr "Hoş Geldiniz"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "Lütfen bu kod adını bir yere yazın ve güvenli bir şekilde saklayın ya da ezberleyin."
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "Bir sonraki sayfada göndereceğiniz bilgilere, ekibimizin gönderdiği yanıtları almak için yeniden geldiğinizde bu kod adını kullanacaksınız."
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "<b>SecureDrop</b> hizmetimizin kullanıcılarını izlemediğimiz için, \n"
+#~ "sizinle iletişim kurabilmemiz, soru sorabilmemiz ya da ek bilgi gereksinimlerini bildirebilmemiz için kullanılabilecek\n"
+#~ "tek yol sonraki ziyaretlerinizde bu kod adını kullanmanızdır. Parolaların aksine kod adı kaybolduğunda geri alınamaz."
+
+#~ msgid "Submit Documents"
+#~ msgstr "Belgeleri gönder"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "BELGE GÖNDER"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "<b>Gelişmiş Güvenlik Ayarlarını</b> seçin"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "<b>En güvenli</b> seçeneğini seçin"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "Neden Tor2Web hakkında bir uyarı var?"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "Bunun yerine <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> kullanmanızı <strong>önemle öneririz</strong>."
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "Gizli biçim hatalı: Gizli kod tek uzunlukta. Gizli kodu yanlış mı yazdınız?"
@@ -1080,12 +1183,6 @@ msgstr "Gönderi sayfasına geri dön"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "SecureDrop Anasayfa"
-
-#~ msgid "Show"
-#~ msgstr "Göster"
-
-#~ msgid "Hide"
-#~ msgstr "Gizle"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— Henüz Bir İleti Yok —"
@@ -1248,9 +1345,6 @@ msgstr "Gönderi sayfasına geri dön"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "Daha önce bir şeyler gönderdiniz mi?"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "Daha önce de gazetecilere bir şey gönderdiyseniz, oturum açarak yanıtları kontrol edin."
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "YANITLARI KONTROL EDİN"

--- a/securedrop/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/securedrop/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -4,7 +4,19 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.6~rc2\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPO-Revision-Date: 2022-02-10 17:04+0000\nLast-Translator: ff98sha <ff98sha@163.com>\nLanguage-Team: Chinese (Simplified) <https://weblate.securedrop.org/projects/securedrop/securedrop/zh_Hans/>\nLanguage: zh_Hans\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=1; plural=0;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.5.1\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.6~rc2\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"PO-Revision-Date: 2022-02-10 17:04+0000\n"
+"Last-Translator: ff98sha <ff98sha@163.com>\n"
+"Language-Team: Chinese (Simplified) <https://weblate.securedrop.org/projects/securedrop/securedrop/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.5.1\n"
 
 msgid "Name too long"
 msgstr "名字太长"
@@ -126,11 +138,17 @@ msgid "Cannot be longer than {num} character."
 msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "字段长度需小于 {num} 个字符。"
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "这是必填项。"
 
 msgid "You cannot send an empty reply."
 msgstr "回复内容不可空白。"
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "该文件是必选项。"
@@ -399,6 +417,9 @@ msgstr "当你配置好 YubiKey 后，输入下面的 6 位口令："
 msgid "Navigation"
 msgstr "导航"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "以身份登录"
 
@@ -522,6 +543,15 @@ msgstr "提交设置"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "阻止线人上传文件，其将仍可发送信息。"
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "更新提交设置"
 
@@ -539,19 +569,6 @@ msgstr "发送 OSSEC 警告测试"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "发送测试OSSEC警报"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "下列选中的 {num} 个文件将被<strong>永久删除</strong>："
-
-msgid "Permanently Delete Files"
-msgstr "永久删除文件"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "永久删除文件"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "返回 {source_name} 的文件列表…"
 
 msgid "Edit user \"{user}\""
 msgstr "编辑账户 \"{user}\""
@@ -694,15 +711,6 @@ msgstr "登录"
 msgid "LOG IN"
 msgstr "登录"
 
-msgid "WARNING:"
-msgstr "警告："
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "您似乎正在使用 Tor2Web，其不具备匿名性。"
-
-msgid "Why is this dangerous?"
-msgstr "为什么这样做很危险？"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "字段长度必须介于 1 至 {max_codename_len} 字节之间。"
 
@@ -721,6 +729,9 @@ msgstr "消息文本太长。"
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "大量的文本必须以文件方式上传，而不是复制粘贴。"
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "您由于已经登录而被重定向。若您想要创建新账户，请先登出。"
 
@@ -735,6 +746,20 @@ msgstr "您必须输入要提交的信息或选择要提交的文件。"
 
 msgid "You must enter a message."
 msgstr "您必须输入信息。"
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "该字段需要至少 {num} 个字符。"
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "忘记了您的代号？"
+
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr ""
 
 msgid "Thanks! We received your message."
 msgstr "万分感谢！我们收到了您的信息。"
@@ -754,8 +779,14 @@ msgstr "已删除全部回复"
 msgid "Sorry, that is not a recognized codename."
 msgstr "很抱歉，此代号无效。"
 
+msgid "Codename"
+msgstr "代号"
+
 msgid "Protecting Journalists and Sources"
 msgstr "庇护记者及线人"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "抱歉，SecureDrop目前不可用。"
@@ -790,32 +821,25 @@ msgstr "请注意：分享敏感文档可能会让您危在旦夕，即便您正
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop 是媒体自由基金会的项目。"
 
-msgid "Welcome"
-msgstr "欢迎"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "输入您的代号"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "请写下并妥善保管或牢记此代号。"
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "此代号将是您之后接收我们团队对您在下一界面提交的信息的反馈途径。"
-
-msgid "Codename"
-msgstr "代号"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"由于我们不追踪 <b>SecureDrop</b> 的用户，\n"
-" 在未来的访问中，使用此代号将是我们与您交流的唯一途径。\n"
-" 与密码不同，您无法重设代号。"
 
-msgid "Submit Documents"
-msgstr "提交文件"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "提交文档"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "继续"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "您洋葱浏览器的<a id=\"disable-js\" href=\"\"><b>安全等级</b></a>过低。请点选您浏览器工具栏的 <img src=\"{icon}\" alt=\"&quot;安全等级&quot;\">以更改。"
@@ -826,11 +850,11 @@ msgstr "如何更改安全等级"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "点选上方工具栏的 <img src=\"{icon}\" alt=\"安全等级\">"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "选择<b>高级安全设置</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "选择<b>最为安全</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"根据指引操作后刷新页面\">刷新此页面</a>，大功告成！"
@@ -865,9 +889,6 @@ msgstr "输入代码"
 msgid "Enter your codename"
 msgstr "输入您的代号"
 
-msgid "Continue"
-msgstr "继续"
-
 msgid "CANCEL"
 msgstr "取消"
 
@@ -876,6 +897,12 @@ msgstr "还有一件事..."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "点击 Tor 浏览器工具栏的<img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>新身份</b>按钮。这能清除此设备上的 Tor 浏览器活动记录。"
+
+msgid "Show"
+msgstr "显示"
+
+msgid "Hide"
+msgstr "隐藏"
 
 msgid "Remember, your codename is:"
 msgstr "请牢记您的代号："
@@ -904,6 +931,9 @@ msgstr "最大文件上传尺寸：500 MB"
 msgid "Submit"
 msgstr "提交"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "阅读回复"
 
@@ -912,6 +942,9 @@ msgstr "您收到了新回复。为避免您的代码不慎泄露进而暴露您
 
 msgid "Delete this reply"
 msgstr "是否删除此回复"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "是否删除此回复？"
@@ -946,17 +979,27 @@ msgstr "重中之重"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "您因为长时间无操作而被注销。再继续操作前，点击 Tor 浏览器工具栏上的<img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>新身份</b>按钮。这能清除此设备上 Tor 浏览器的活动记录。"
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "为何使用 Tor2Web 会有警告信息？"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "使用 Tor2Web 来连接至 SecureDrop 将无法保护您的匿名身份。"
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "监听您网络流量的人（如您的政府、互联网提供商）将可以识别您的身份。"
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "我们<strong>强烈建议</strong>您使用 <a href=\"www.torproject.org/projects/torbrowser.html\">Tor 浏览器</a>。"
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "您应该使用洋葱浏览器"
@@ -1012,6 +1055,64 @@ msgstr "<strong>重要提示：</strong>若您想保持匿名身份，<strong>�
 
 msgid "Back to submission page"
 msgstr "返回提交页面"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "下列选中的 {num} 个文件将被<strong>永久删除</strong>："
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "永久删除文件"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "永久删除文件"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "返回 {source_name} 的文件列表…"
+
+#~ msgid "WARNING:"
+#~ msgstr "警告："
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "您似乎正在使用 Tor2Web，其不具备匿名性。"
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "为什么这样做很危险？"
+
+#~ msgid "Welcome"
+#~ msgstr "欢迎"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "请写下并妥善保管或牢记此代号。"
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "此代号将是您之后接收我们团队对您在下一界面提交的信息的反馈途径。"
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "由于我们不追踪 <b>SecureDrop</b> 的用户，\n"
+#~ " 在未来的访问中，使用此代号将是我们与您交流的唯一途径。\n"
+#~ " 与密码不同，您无法重设代号。"
+
+#~ msgid "Submit Documents"
+#~ msgstr "提交文件"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "提交文档"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "选择<b>高级安全设置</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "选择<b>最为安全</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "为何使用 Tor2Web 会有警告信息？"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "我们<strong>强烈建议</strong>您使用 <a href=\"www.torproject.org/projects/torbrowser.html\">Tor 浏览器</a>。"
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "无效密码格式：奇数长度的密钥。您是不是输错了？"
@@ -1069,12 +1170,6 @@ msgstr "返回提交页面"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "SecureDrop 首页"
-
-#~ msgid "Show"
-#~ msgstr "显示"
-
-#~ msgid "Hide"
-#~ msgstr "隐藏"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— 无新信息 —"

--- a/securedrop/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/securedrop/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -4,7 +4,20 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: SecureDrop 0.3.12\nReport-Msgid-Bugs-To: securedrop@freedom.press\nPOT-Creation-Date: 2017-09-02 07:28+0000\nPO-Revision-Date: 2022-02-10 04:04+0000\nLast-Translator: Chi-Hsun Tsai <chihsun.tsai@gmail.com>\nLanguage-Team: Chinese (Traditional) <https://weblate.securedrop.org/projects/securedrop/securedrop/zh_Hant/>\nLanguage: zh_Hant\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=1; plural=0;\nX-Generator: Weblate 4.6\nGenerated-By: Babel 2.4.0\n"
+msgstr ""
+"Project-Id-Version: SecureDrop 0.3.12\n"
+"Report-Msgid-Bugs-To: securedrop@freedom.press\n"
+"POT-Creation-Date: 2017-09-02 07:28+0000\n"
+"PO-Revision-Date: 2022-02-10 04:04+0000\n"
+"Last-Translator: Chi-Hsun Tsai <chihsun.tsai@gmail.com>\n"
+"Language-Team: Chinese (Traditional) <https://weblate.securedrop.org/projects/securedrop/securedrop/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 4.6\n"
+"Generated-By: Babel 2.4.0\n"
 
 msgid "Name too long"
 msgstr "名稱過長"
@@ -126,11 +139,17 @@ msgid "Cannot be longer than {num} character."
 msgid_plural "Cannot be longer than {num} characters."
 msgstr[0] "不可多於 {num} 字元。"
 
+msgid "Please specify an integer value greater than 0."
+msgstr ""
+
 msgid "This field is required."
 msgstr "這是必填項目。"
 
 msgid "You cannot send an empty reply."
 msgstr "回覆內容不可空白。"
+
+msgid "To configure a minimum message length, you must set the required number of characters."
+msgstr ""
 
 msgid "File required."
 msgstr "檔案欄為必要。"
@@ -399,6 +418,9 @@ msgstr "設定 Yubikey 後，請在下面輸入 6 位數字代碼："
 msgid "Navigation"
 msgstr "導覽"
 
+msgid "Skip to main content"
+msgstr ""
+
 msgid "Logged on as"
 msgstr "登入為"
 
@@ -522,6 +544,15 @@ msgstr "提交偏好"
 msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
 msgstr "防止消息來源上傳文件，但來源仍可以傳送訊息。"
 
+msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
+msgstr ""
+
+msgid "Minimum number of characters."
+msgstr ""
+
+msgid "Prevent sources from submitting their codename as an initial message."
+msgstr ""
+
 msgid "Update Submission Preferences"
 msgstr "更新提交偏好"
 
@@ -539,19 +570,6 @@ msgstr "發送 OSSEC 警告測試"
 
 msgid "SEND TEST OSSEC ALERT"
 msgstr "傳送測試 OSSEC 警報"
-
-msgid "The following file has been selected for <strong>permanent deletion</strong>:"
-msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
-msgstr[0] "下方被挑選的 {num} 文件，將被<strong>永久删除</strong>："
-
-msgid "Permanently Delete Files"
-msgstr "永久刪除檔案"
-
-msgid "PERMANENTLY DELETE FILES"
-msgstr "永久地删除文件"
-
-msgid "Return to the list of documents for {source_name}…"
-msgstr "返回 {source_name} 的文件列表…"
 
 msgid "Edit user \"{user}\""
 msgstr "編輯帳户 \"{user}\""
@@ -694,15 +712,6 @@ msgstr "登入"
 msgid "LOG IN"
 msgstr "登錄"
 
-msgid "WARNING:"
-msgstr "警告："
-
-msgid "You appear to be using Tor2Web, which does not provide anonymity."
-msgstr "您似乎正在使用 Tor2Web，其不提供匿名性。"
-
-msgid "Why is this dangerous?"
-msgstr "這樣為什麼很危險？"
-
 msgid "Field must be between 1 and {max_codename_len} characters long."
 msgstr "此處字段長度必須在 1 和 {max_codename_len} 個字符之間。"
 
@@ -721,6 +730,9 @@ msgstr "訊息文字過長。"
 msgid "Large blocks of text must be uploaded as a file, not copied and pasted."
 msgstr "大量文字必須以檔案方式上傳，不要用複製貼上的作法。"
 
+msgid "Your connection is not anonymous right now!"
+msgstr ""
+
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "你被重定向了， 因為已在登錄狀態。如果想創建一個新帳戶，請先登出。"
 
@@ -735,6 +747,22 @@ msgstr "你必须輸入一則訊息，或是選擇一個文件來提交。"
 
 msgid "You must enter a message."
 msgstr "您必須輸入訊息。"
+
+#, fuzzy
+#| msgid "Must be at least {num} character long."
+#| msgid_plural "Must be at least {num} characters long."
+msgid "Your first message must be at least {} characters long."
+msgstr "须至少有 {num} 個字符長度。"
+
+#, fuzzy
+#| msgid "Forgot your codename?"
+msgid "Please do not submit your codename!"
+msgstr "忘記你的代號？"
+
+#, fuzzy
+#| msgid "If you have already submitted to journalists, log in here to check for responses."
+msgid "Keep your codename secret, and use it to log in later to check for replies."
+msgstr "如果您已提交過文件，您可在此登入來查閱回覆。"
 
 msgid "Thanks! We received your message."
 msgstr "謝謝！我們已收到你的訊息。"
@@ -754,8 +782,14 @@ msgstr "所有的回覆都已被删除"
 msgid "Sorry, that is not a recognized codename."
 msgstr "對不起，無法識別這個代號。"
 
+msgid "Codename"
+msgstr "代號名稱"
+
 msgid "Protecting Journalists and Sources"
 msgstr "保護新聞記者與消息來源線人"
+
+msgid "Skip to notification"
+msgstr ""
 
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr "抱歉，目前 SecureDrop 關機維修。"
@@ -790,32 +824,25 @@ msgstr "請注意：即便利用 Tor 或 SecureDrop，但分享敏感文件還�
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
 msgstr "SecureDrop 為新聞自由基金會(Freedom of the Press Foundation)的專案。"
 
-msgid "Welcome"
-msgstr "歡迎"
+#, fuzzy
+#| msgid "Enter your codename"
+msgid "Get Your Codename"
+msgstr "請輸入您的代號"
 
-msgid "Please either write this codename down and keep it in a safe place, or memorize it."
-msgstr "請抄下代號並妥善保管，或牢牢記住它。"
-
-msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
-msgstr "之後你將使用這個代號來讀取本站團隊對你（在下一個畫面所提交資訊）的回應。"
-
-msgid "Codename"
-msgstr "代號名稱"
-
-msgid ""
-"Because we do not track users of our <b>SecureDrop</b>\n"
-" service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
-" questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+msgid "A <em>codename</em> in SecureDrop functions as both your username and your password."
 msgstr ""
-"因為我們不會追蹤<b> SecureDrop</b> 用戶，日後要再訪問，您須提供此代號以供登入，它也是將來我們若有疑問或需要更多資訊時要求，和您溝通的唯一管道。\n"
-"\n"
-"代號和密碼不同，一旦遺失便無法再恢復獲取。"
 
-msgid "Submit Documents"
-msgstr "提交文件"
+msgid "You will need this codename to log into our SecureDrop later:"
+msgstr ""
 
-msgid "SUBMIT DOCUMENTS"
-msgstr "提交文件"
+msgid "<strong>Keep it secret.</strong> Do not share it with anyone."
+msgstr ""
+
+msgid "<strong>Keep it safe.</strong> There is no account recovery option."
+msgstr ""
+
+msgid "Continue"
+msgstr "繼續"
 
 msgid "Your Tor Browser's <a id=\"disable-js\" href=\"\"><b>Security Level</b></a> is too low. Use the <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\"> button in your browser’s toolbar to change it."
 msgstr "Tor 瀏覽器的 <a id=\"disable-js\" href=\"\"><b>安全性</b></a>等級過低。請使用瀏覽器工具列中的 <img src=\"{icon}\" alt=\"&quot;Security Level&quot;\">按鈕來變更它。"
@@ -826,11 +853,11 @@ msgstr "如何變更安全層級"
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr "在上方工具列點擊 <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\">"
 
-msgid "Select <b>Advanced Security Settings</b>"
-msgstr "選取 <b>進階安全設置</b>"
+msgid "Click <b>Change</b> to open Security Level preferences"
+msgstr ""
 
-msgid "Select <b>Safest</b>"
-msgstr "選取 <b>最安全等級</b>"
+msgid "Select <b>Safest</b> and close the preferences tab"
+msgstr ""
 
 msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
 msgstr "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">重新載入本頁</a>後，一切已完緒!"
@@ -865,9 +892,6 @@ msgstr "輸入代號"
 msgid "Enter your codename"
 msgstr "請輸入您的代號"
 
-msgid "Continue"
-msgstr "繼續"
-
 msgid "CANCEL"
 msgstr "取消"
 
@@ -876,6 +900,12 @@ msgstr "還有一件事...."
 
 msgid "Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar. This will clear your Tor Browser activity data on this device."
 msgstr "點擊 Tor 瀏覽器工具列 <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b>按鈕，將可清除此設備上的瀏覽資料記錄。"
+
+msgid "Show"
+msgstr "顯示"
+
+msgid "Hide"
+msgstr "隱藏"
 
 msgid "Remember, your codename is:"
 msgstr "記住，您的代號是："
@@ -904,6 +934,9 @@ msgstr "檔案上傳限制：500 MB"
 msgid "Submit"
 msgstr "提交"
 
+msgid "Anti-spam check. Do not fill this in!"
+msgstr ""
+
 msgid "Read Replies"
 msgstr "閱讀回覆"
 
@@ -912,6 +945,9 @@ msgstr "您已經收到一則回覆。為保護您的身份，防止某人知道
 
 msgid "Delete this reply"
 msgstr "刪除這條回覆"
+
+msgid "Delete reply from {timestamp}?"
+msgstr ""
 
 msgid "Delete this reply?"
 msgstr "刪除這條回覆嗎？"
@@ -946,17 +982,27 @@ msgstr "重要"
 msgid "You were logged out due to inactivity. Click the <img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b> button in your Tor Browser's toolbar before moving on. This will clear your Tor Browser activity data on this device."
 msgstr "因聞置過久已遭系統登出，可先點擊 Tor 瀏覽器工具列<img src={icon} alt=\"\" width=\"16\" height=\"16\">&nbsp;<b>New Identity</b>按鍵來清除此設備上的瀏覽記錄。"
 
-msgid "Why is there a warning about Tor2Web?"
-msgstr "為什麼出現一個 Tor2Web 的警告？"
+msgid "Proxy Service Detected"
+msgstr ""
 
-msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+#, fuzzy
+#| msgid "Using Tor2Web to connect to SecureDrop will not protect your anonymity."
+msgid "You appear to be using a Tor proxy service to access SecureDrop. Proxy services do not protect your anonymity."
 msgstr "使用 Tor2Web 連至 SecureDrop 將無法保護您的匿名安全。"
 
-msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+#, fuzzy
+#| msgid "It could be possible for anyone monitoring your Internet traffic (your government, your Internet provider), to identify you."
+msgid "Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you."
 msgstr "任何網路流量監控者（如政府、網路服務業者）都有可能認出您。"
 
-msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
-msgstr "<strong>強烈建議</strong>以<a href=\"www.torproject.org/projects/torbrowser.html\">Tor 瀏覽器</a>為替代。"
+msgid "Always use <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:"
+msgstr ""
+
+msgid "If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop."
+msgstr ""
+
+msgid "If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network."
+msgstr ""
 
 msgid "You Should Use Tor Browser"
 msgstr "您應使用 Tor 瀏覽器"
@@ -1012,6 +1058,64 @@ msgstr "<strong>重要：</strong>如果您希望保持匿名，<strong>請勿</
 
 msgid "Back to submission page"
 msgstr "返回提交文件頁面"
+
+#~ msgid "The following file has been selected for <strong>permanent deletion</strong>:"
+#~ msgid_plural "The following {num} files have been selected for <strong>permanent deletion</strong>:"
+#~ msgstr[0] "下方被挑選的 {num} 文件，將被<strong>永久删除</strong>："
+
+#~ msgid "Permanently Delete Files"
+#~ msgstr "永久刪除檔案"
+
+#~ msgid "PERMANENTLY DELETE FILES"
+#~ msgstr "永久地删除文件"
+
+#~ msgid "Return to the list of documents for {source_name}…"
+#~ msgstr "返回 {source_name} 的文件列表…"
+
+#~ msgid "WARNING:"
+#~ msgstr "警告："
+
+#~ msgid "You appear to be using Tor2Web, which does not provide anonymity."
+#~ msgstr "您似乎正在使用 Tor2Web，其不提供匿名性。"
+
+#~ msgid "Why is this dangerous?"
+#~ msgstr "這樣為什麼很危險？"
+
+#~ msgid "Welcome"
+#~ msgstr "歡迎"
+
+#~ msgid "Please either write this codename down and keep it in a safe place, or memorize it."
+#~ msgstr "請抄下代號並妥善保管，或牢牢記住它。"
+
+#~ msgid "This codename is what you will use in future visits to receive messages from our team in response to what you submit on the next screen."
+#~ msgstr "之後你將使用這個代號來讀取本站團隊對你（在下一個畫面所提交資訊）的回應。"
+
+#~ msgid ""
+#~ "Because we do not track users of our <b>SecureDrop</b>\n"
+#~ " service, in future visits, using this codename will be the only way we have to communicate with you should we have\n"
+#~ " questions or are interested in additional information. Unlike passwords, there is no way to retrieve a lost codename."
+#~ msgstr ""
+#~ "因為我們不會追蹤<b> SecureDrop</b> 用戶，日後要再訪問，您須提供此代號以供登入，它也是將來我們若有疑問或需要更多資訊時要求，和您溝通的唯一管道。\n"
+#~ "\n"
+#~ "代號和密碼不同，一旦遺失便無法再恢復獲取。"
+
+#~ msgid "Submit Documents"
+#~ msgstr "提交文件"
+
+#~ msgid "SUBMIT DOCUMENTS"
+#~ msgstr "提交文件"
+
+#~ msgid "Select <b>Advanced Security Settings</b>"
+#~ msgstr "選取 <b>進階安全設置</b>"
+
+#~ msgid "Select <b>Safest</b>"
+#~ msgstr "選取 <b>最安全等級</b>"
+
+#~ msgid "Why is there a warning about Tor2Web?"
+#~ msgstr "為什麼出現一個 Tor2Web 的警告？"
+
+#~ msgid "We <strong>strongly advise</strong> you to use the <a href=\"www.torproject.org/projects/torbrowser.html\">Tor Browser</a> instead."
+#~ msgstr "<strong>強烈建議</strong>以<a href=\"www.torproject.org/projects/torbrowser.html\">Tor 瀏覽器</a>為替代。"
 
 #~ msgid "Invalid secret format: odd-length secret. Did you mistype the secret?"
 #~ msgstr "動態密碼格式不符：輸入長度為奇數。是否輸入錯誤？"
@@ -1069,12 +1173,6 @@ msgstr "返回提交文件頁面"
 
 #~ msgid "SecureDrop Home"
 #~ msgstr "SecureDrop 首頁"
-
-#~ msgid "Show"
-#~ msgstr "顯示"
-
-#~ msgid "Hide"
-#~ msgstr "隱藏"
 
 #~ msgid "— No Messages —"
 #~ msgstr "— 無新訊息 —"
@@ -1231,9 +1329,6 @@ msgstr "返回提交文件頁面"
 
 #~ msgid "Already submitted something?"
 #~ msgstr "已曾提交過文件？"
-
-#~ msgid "If you have already submitted to journalists, log in here to check for responses."
-#~ msgstr "如果您已提交過文件，您可在此登入來查閱回覆。"
 
 #~ msgid "CHECK FOR A RESPONSE"
 #~ msgstr "檢查回應"


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Towards #6334 

- adds new `jinja2.ext.do` extension in `babel.cfg`
- updates translation strings for 2.3.0

## Testing
- [x] Check the changes in securedrop/translations/messages.pot and the messages.po changes for one language of your choice.

