### PR TITLE
fix: message codename filter applied only on first login

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -208,14 +208,19 @@ def make_blueprint(config: SDConfig) -> Blueprint:
                     "error")
                 return redirect(url_for('main.lookup'))
 
+            # if the new_user_codename key is not present in the session, this is
+            # not a first session
+            new_codename = session.get('new_user_codename', None)
+
             codenames_rejected = InstanceConfig.get_default().reject_message_with_codename
-            if codenames_rejected and codename_detected(msg, session['new_user_codename']):
-                flash(Markup('{}<br>{}'.format(
-                    escape(gettext("Please do not submit your codename!")),
-                    escape(gettext("Keep your codename secret, and use it to log in later"
-                                   " to check for replies."))
-                    )), "error")
-                return redirect(url_for('main.lookup'))
+            if new_codename is not None:
+                if codenames_rejected and codename_detected(msg, new_codename):
+                    flash(Markup('{}<br>{}'.format(
+                        escape(gettext("Please do not submit your codename!")),
+                        escape(gettext("Keep your codename secret, and use it to log in later"
+                                       " to check for replies."))
+                        )), "error")
+                    return redirect(url_for('main.lookup'))
 
         if not os.path.exists(Storage.get_default().path(logged_in_source.filesystem_id)):
             current_app.logger.debug("Store directory not found for source '{}', creating one."


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6339 .

Codename filter is now only applied if the `new_user_session` key exists in the session, indicating that it is a first session.

## Testing
- `make dev` on this branch
- enable codename check in the JI Admin > Instance Config > Submission Preferences section
-  create a new source in the SI and attempt to submit its codename as a message
   - [x] verify that the codename message is rejected
- log out from the SI, then log in again as the same source, and attempt to submit the codename as a message
  - [x] verify that the codename message is accepted.
  - [x] verify that no KeyError or other errors are thrown (via a stack trace in browser or in the dev container logs)

## Deployment

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
