### PR TITLE
[2.3.0] fix - update apache2 apparmor profile to include new template file 

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -236,6 +236,7 @@
   /var/www/securedrop/source_templates/notfound.html r,
   /var/www/securedrop/source_templates/session_timeout.html r,
   /var/www/securedrop/source_templates/tor2web-warning.html r,
+  /var/www/securedrop/source_templates/utils.html r,
   /var/www/securedrop/source_templates/use-tor-browser.html r,
   /var/www/securedrop/source_templates/why-public-key.html r,
   /var/www/securedrop/static/.webassets-cache/** rw,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6341  .

Adds `securedrop/source_templates/utils.html` to apache2 apparmor profile

## Testing

- [ ] CI is passing
- [ ] in a staging environment or visually in the repo, confirm that `usr.sbin.apache2` contains a line allowing reads of the file mentioned above
