### PR TITLE
Remove remaining instances of text-transform: uppercase

### DIFF
--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -95,9 +95,9 @@
       </legend>
       <mark id="password" class="password">{{ password }}</mark>
     </fieldset>
-    <button type="submit" id="reset-password" class="upper icon icon-reset"
+    <button type="submit" id="reset-password" class="icon icon-reset"
       aria-label="{{ gettext('Reset Password') }}">
-      {{ gettext('Reset Password') }}
+      {{ gettext('RESET PASSWORD') }}
     </button>
   </form>
 </section>

--- a/securedrop/sass/_base.sass
+++ b/securedrop/sass/_base.sass
@@ -92,8 +92,6 @@
 @import "modules/footer"
 // Form validation error - text to help users correct errors
 @import "modules/form-validation-error"
-// Text transformation class to minimize i18n churn for capitalization changes
-@import "modules/upper"
 
 =base_rules
   // LIBRARIES
@@ -146,4 +144,3 @@
   +users-table
   +footer
   +form-validation-error
-  +upper

--- a/securedrop/sass/_source_index.sass
+++ b/securedrop/sass/_source_index.sass
@@ -76,7 +76,6 @@
       margin-left: 0
       margin-right: 10%
       white-space: nowrap
-      text-transform: uppercase
       border: 2px solid transparent
 
     #login-button

--- a/securedrop/sass/modules/_header.sass
+++ b/securedrop/sass/modules/_header.sass
@@ -5,14 +5,6 @@
     &:dir(rtl)
       float: right
 
-    .powered
-      margin-top: 10px
-      font-size: 13px
-      text-transform: uppercase
-      text-align: center
-      color: #666666
-      letter-spacing: normal
-
     h1
       margin: 0
       text-align: center

--- a/securedrop/sass/modules/_upper.sass
+++ b/securedrop/sass/modules/_upper.sass
@@ -1,3 +1,0 @@
-=upper
-  .upper
-    text-transform: uppercase


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

`text-transform: uppercase` is not compatible with some locales'
orthographic rules - we already do it right in almost all places except
one in the JI, while every other instance is dead code

Fixes #1587

## Testing

* Ensure there's no `uppercase` found in the generated `journalist.css` and `source.css` files
* Visit the source index, the two buttons are still uppercase
* "Reset Password" button in edit user part of the admin interface is shown in uppercase

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] These changes do not require documentation
