### PR TITLE
updated builder image hash to version tagged 2022_03_28

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_03_09
-aa92785916f3d27df8b3ca8773eb9465db8f603d98d2986d257a236eeb2b3c13
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_03_28
+b6e6ebe29e2c8436d2976fba0b48aba7b960b1b7ffe82f115d33f77e82796210


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Towards #6334 

Updates builder image to version tagged 2022_03_28

## Testing

- [ ] CI is passing (`deb-test` in particular)
- [ ] `make build-debs passes locally
