### PR TITLE
[2.3.0] Backports builder image update to release/2.3.0

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_03_09
-aa92785916f3d27df8b3ca8773eb9465db8f603d98d2986d257a236eeb2b3c13
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_03_28
+b6e6ebe29e2c8436d2976fba0b48aba7b960b1b7ffe82f115d33f77e82796210


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Backports #6363 

- [ ] #6363 has been merged to `develop`
- [ ] PR adds only commit from #6363 
- [ ] base is `release/2.3.0`
- [ ] CI passes
