### PR TITLE
Run string formatting after gettext() call

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -204,7 +204,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             min_len = InstanceConfig.get_default().initial_message_min_len
             if (min_len > 0) and (msg and not fh) and (len(msg) < min_len):
                 flash(gettext(
-                    "Your first message must be at least {} characters long.".format(min_len)),
+                    "Your first message must be at least {} characters long.").format(min_len),
                     "error")
                 return redirect(url_for('main.lookup'))
 

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -46,11 +46,11 @@
         {{ form.msg(class="fill-parent") }}
   {% if allow_document_uploads %}
       {% if min_len > 0 %}
-         <p class="center" id="min-msg-length">{{ gettext('If you are only sending a message, it must be at least {} characters long.'.format(min_len)) }}</p>
+         <p class="center" id="min-msg-length">{{ gettext('If you are only sending a message, it must be at least {} characters long.').format(min_len) }}</p>
       {% endif %}
   {% else %}
       {% if min_len > 0 %}
-        <p class="center" id="min-msg-length">{{ gettext('Your first message must be at least {} characters long.'.format(min_len)) }}</p>
+        <p class="center" id="min-msg-length">{{ gettext('Your first message must be at least {} characters long.').format(min_len) }}</p>
       {% endif %}
   {% endif %}
       </div>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Don't interpolate parameters before looking up the string in gettext,
otherwise it won't find anything and fallback to English.

Fixes #6367.

## Testing

* Rebase onto @cfm's i18n branch (which might not exist yet), enable minimum length, change language to German, verify no raw `{}` appear in the error message when inputting too short of a message, and the correct character count is shown.

## Deployment

Any special considerations for deployment? No.

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] These changes do not require documentation
