### PR TITLE
fix: allow GET and POST methods for /generate, to accomodate locale switching

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -37,15 +37,17 @@ def make_blueprint(config: SDConfig) -> Blueprint:
     def index() -> str:
         return render_template('index.html')
 
-    @view.route('/generate', methods=('POST',))
+    @view.route('/generate', methods=('POST', 'GET'))
     def generate() -> Union[str, werkzeug.Response]:
-        # Try to detect Tor2Web usage by looking to see if tor2web_check got mangled
-        tor2web_check = request.form.get('tor2web_check')
-        if tor2web_check is None:
-            # Missing form field
-            abort(403)
-        elif tor2web_check != 'href="fake.onion"':
-            return redirect(url_for('info.tor2web_warning'))
+        if request.method == 'POST':
+            # Try to detect Tor2Web usage by looking to see if tor2web_check got mangled
+            tor2web_check = request.form.get('tor2web_check')
+            if tor2web_check is None:
+                # Missing form field
+                abort(403)
+            elif tor2web_check != 'href="fake.onion"':
+                return redirect(url_for('info.tor2web_warning'))
+
         if SessionManager.is_user_logged_in(db_session=db.session):
             flash(gettext(
                 "You were redirected because you are already logged in. "

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -133,7 +133,7 @@ def test_create_new_source(source_app):
         assert 'codenames' not in session
 
 
-def test_generate(source_app):
+def test_generate_as_post(source_app):
     with source_app.test_client() as app:
         resp = app.post(url_for('main.generate'), data=GENERATE_DATA)
         assert resp.status_code == 200
@@ -146,6 +146,21 @@ def test_generate(source_app):
     # codename is also stored in the session - make sure it matches the
     # codename displayed to the source
     assert codename == escape(session_codename)
+
+def test_generate_as_get(source_app):
+    with source_app.test_client() as app:
+        resp = app.get(url_for('main.generate'))
+        assert resp.status_code == 200
+        session_codename = next(iter(session['codenames'].values()))
+
+    text = resp.data.decode('utf-8')
+    assert "functions as both your username and your password" in text
+
+    codename = _find_codename(resp.data.decode('utf-8'))
+    # codename is also stored in the session - make sure it matches the
+    # codename displayed to the source
+    assert codename == escape(session_codename)
+
 
 
 def test_create_duplicate_codename_logged_in_not_in_session(source_app):


### PR DESCRIPTION
## Status

Ready for review 

Fixes #6373 .

## Testing

- check out this branch and run `make dev-tor`
- visit the SI on localhost:8080 and verify that:
  - [x] you can navigate normally to /generate via the GET STARTED link
  - [x] if you reload the /generate page, it asks to resubmit POST data, and generates a new codemame
  - [x] if you choose another language in the dropdown the /gnerate page reloads without prompting for the POST resubmit and generates a new codename
- in Tor Browser with the security level set to safest, visit the Tor version of the  SI via a tor2web proxy, and click GET STARTED
  - [x] Confirm that the /generate page is not displayed and the tor2web warning page is displayed instead.

## Deployment


## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
