### PR TITLE
Refactor source layout tests for tor browser

### DIFF
--- a/securedrop/tests/functional/functional_test.py
+++ b/securedrop/tests/functional/functional_test.py
@@ -30,7 +30,7 @@ from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 from sqlalchemy.exc import IntegrityError
 from tbselenium.tbdriver import TorBrowserDriver
-from tbselenium.utils import disable_js, set_security_level
+from tbselenium.utils import set_security_level
 from tbselenium.utils import SECURITY_LOW, SECURITY_MEDIUM, SECURITY_HIGH
 
 import journalist_app
@@ -166,10 +166,6 @@ class FunctionalTest(object):
             self.create_torbrowser_driver()
         self.driver = self.torbrowser_driver
         logging.info("Switched %s to TorBrowser driver: %s", self, self.driver)
-
-    def disable_js_torbrowser_driver(self):
-        if hasattr(self, 'torbrowser_driver'):
-            disable_js(self.torbrowser_driver)
 
     def start_source_server(self, source_port):
         from sdconfig import config


### PR DESCRIPTION
## Status

Ready

## Description of Changes

This PR continue the work from https://github.com/freedomofpress/securedrop/pull/6365, by bringing the new test code and fixtures to a few more functional tests for the source app.

More specifically, this PR:

* Brings the new test fixtures to a couple layout tests (for #3836).
* Combine the two layout tests into one, for a slightly faster test suite.
