### PR TITLE
Refactor functional test for submitting and retrieving a message

### DIFF
--- a/securedrop/tests/functional/test_submit_and_retrieve_message.py
+++ b/securedrop/tests/functional/test_submit_and_retrieve_message.py
@@ -1,21 +1,47 @@
-from . import functional_test
-from . import source_navigation_steps
-from . import journalist_navigation_steps
+from pathlib import Path
+
+from encryption import EncryptionManager
+from tests.functional.app_navigators import SourceAppNagivator, JournalistAppNavigator
 
 
-class TestSubmitAndRetrieveMessage(
-        functional_test.FunctionalTest,
-        source_navigation_steps.SourceNavigationStepsMixin,
-        journalist_navigation_steps.JournalistNavigationStepsMixin):
+class TestSubmitAndRetrieveMessage:
+    def test_submit_and_retrieve_happy_path(
+        self, sd_servers_v2_with_clean_state, tor_browser_web_driver, firefox_web_driver
+    ):
+        source_app_nav = SourceAppNagivator(
+            source_app_base_url=sd_servers_v2_with_clean_state.source_app_base_url,
+            web_driver=tor_browser_web_driver,
+        )
 
-    def test_submit_and_retrieve_happy_path(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_message()
-        self._source_logs_out()
-        self.switch_to_firefox_driver()
-        self._journalist_logs_in()
-        self._journalist_checks_messages()
-        self._journalist_downloads_message()
-        self.switch_to_torbrowser_driver()
+        # Given a source user who created an account
+        source_app_nav.source_visits_source_homepage()
+        source_app_nav.source_clicks_submit_documents_on_homepage()
+        source_app_nav.source_continues_to_submit_page()
+
+        # And the source user submitted a message
+        submitted_message = "Confidential information"
+        source_app_nav.source_submits_a_message(message=submitted_message)
+        source_app_nav.source_logs_out()
+
+        # When a journalist logs in
+        journ_app_nav = JournalistAppNavigator(
+            journalist_app_base_url=sd_servers_v2_with_clean_state.journalist_app_base_url,
+            web_driver=firefox_web_driver,
+        )
+        journ_app_nav.journalist_logs_in(
+            username=sd_servers_v2_with_clean_state.journalist_username,
+            password=sd_servers_v2_with_clean_state.journalist_password,
+            otp_secret=sd_servers_v2_with_clean_state.journalist_otp_secret,
+        )
+        journ_app_nav.journalist_checks_messages()
+
+        #  And they try to download the message
+        #  Then it succeeds and the journalist sees correct message
+        servers_sd_config = sd_servers_v2_with_clean_state.config_in_use
+        retrieved_message = journ_app_nav.journalist_downloads_first_message(
+            encryption_mgr_to_use_for_decryption=EncryptionManager(
+                gpg_key_dir=Path(servers_sd_config.GPG_KEY_DIR),
+                journalist_key_fingerprint=servers_sd_config.JOURNALIST_KEY,
+            )
+        )
+        assert retrieved_message == submitted_message


### PR DESCRIPTION
## Status

Ready.

## Description of Changes

This PR continue the work from https://github.com/freedomofpress/securedrop/pull/6379. More specifically, this PR:

* Brings the new test fixtures to the `TestSubmitAndRetrieveMessage` functional test (for #3836).
* Introduces a new fixture, `sd_servers_v2_with_clean_state` for functional tests that need to modify the app's state (for example by submitting a file).
* Introduces the `JournalistAppNavigator` class, which will eventually replace `JournalistNavigationStepsMixin` for navigating through the journalist app.