### PR TITLE
Refactor functional test for submitting and retrieving a file

### DIFF
--- a/securedrop/tests/functional/pageslayout/test_source.py
+++ b/securedrop/tests/functional/pageslayout/test_source.py
@@ -79,6 +79,7 @@ class TestSourceLayout(
         self._screenshot('source-next_submission_flashed_message.png')
         self._save_html('source-next_submission_flashed_message.html')
 
+    # TODO(AD): This should be merged with test_submit_and_retrieve_happy_path()
     def test_source_checks_for_reply(self):
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -89,13 +89,6 @@ class SourceNavigationStepsMixin:
 
         self.wait_for(lambda: self.driver.find_elements_by_id("source-login"))
 
-    def _source_hits_cancel_at_login_page(self):
-        self.safe_click_by_css_selector(".form-controls a")
-
-        self.driver.get(self.source_location)
-
-        assert self._is_on_source_homepage()
-
     def _source_proceeds_to_login(self):
         self.safe_send_keys_by_id("codename", self.source_name)
         self.safe_click_by_css_selector(".form-controls button")
@@ -110,13 +103,6 @@ class SourceNavigationStepsMixin:
         self.safe_send_keys_by_id(
             "codename", "ascension hypertext concert synopses"
         )
-
-    def _source_hits_cancel_at_submit_page(self):
-        self.safe_click_by_css_selector(".form-controls a")
-
-        if not self.accept_languages:
-            heading = self.driver.find_element_by_id("submit-heading")
-            assert "Submit Files or Messages" == heading.text
 
     def _source_continues_to_submit_page(self, files_allowed=True):
         self.safe_click_by_css_selector("#create-form button")

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -121,6 +121,12 @@ class TestSourceAppCodenamesInMultipleTabs:
         assert codename
         return codename
 
+    @staticmethod
+    def _extract_flash_message_content(navigator: SourceAppNagivator) -> str:
+        notification = navigator.driver.find_element_by_css_selector(".notification").text
+        assert notification
+        return notification
+
     def test_generate_codenames_in_multiple_tabs(self, sd_servers_v2, tor_browser_web_driver):
         navigator = SourceAppNagivator(
             source_app_base_url=sd_servers_v2.source_app_base_url,
@@ -158,9 +164,9 @@ class TestSourceAppCodenamesInMultipleTabs:
 
         # Then the submission fails and the user sees the corresponding flash message in Tab B
         self._assert_is_on_lookup_page(navigator)
-        notification = navigator.source_sees_flash_message()
+        notification = self._extract_flash_message_content(navigator)
         if not navigator.accept_languages:
-            assert "You are already logged in." in notification.text
+            assert "You are already logged in." in notification
 
         # And the user's actual codename is the one initially generated in Tab A
         assert navigator.source_retrieves_codename_from_hint() == codename_a
@@ -211,9 +217,9 @@ class TestSourceAppCodenamesInMultipleTabs:
 
         # Then they get redirected to /lookup with the corresponding flash message
         self._assert_is_on_lookup_page(navigator)
-        notification = navigator.source_sees_flash_message()
+        notification = self._extract_flash_message_content(navigator)
         if not navigator.accept_languages:
-            assert "You were redirected because you are already logged in." in notification.text
+            assert "You were redirected because you are already logged in." in notification
 
         # And the user's actual codename is the expected one
         assert navigator.source_retrieves_codename_from_hint() == codename_a2

--- a/securedrop/tests/functional/test_source_cancels.py
+++ b/securedrop/tests/functional/test_source_cancels.py
@@ -1,0 +1,35 @@
+from tests.functional.app_navigators import SourceAppNagivator
+
+
+class TestSourceUserCancels:
+
+    def test_source_cancels_at_login_page(self, sd_servers_v2, tor_browser_web_driver):
+        # Given a source user who goes to the login page
+        source_app_nav = SourceAppNagivator(
+            source_app_base_url=sd_servers_v2.source_app_base_url,
+            web_driver=tor_browser_web_driver,
+        )
+        source_app_nav.source_visits_source_homepage()
+        source_app_nav.source_chooses_to_login()
+
+        # When they click on the cancel button on the login page, it succeeds
+        source_app_nav.nav_helper.safe_click_by_css_selector(".form-controls a")
+        source_app_nav.driver.get(sd_servers_v2.source_app_base_url)
+        assert source_app_nav._is_on_source_homepage()
+
+    def test_source_cancels_at_submit_page(self, sd_servers_v2, tor_browser_web_driver):
+        # Given a source user who created an account
+        source_app_nav = SourceAppNagivator(
+            source_app_base_url=sd_servers_v2.source_app_base_url,
+            web_driver=tor_browser_web_driver,
+        )
+        source_app_nav.source_visits_source_homepage()
+        source_app_nav.source_clicks_submit_documents_on_homepage()
+        source_app_nav.source_continues_to_submit_page()
+
+        # When they click on the cancel button on the submit page, it succeeds
+        source_app_nav.nav_helper.safe_click_by_css_selector(".form-controls a")
+
+        # And the right message is displayed
+        heading = source_app_nav.driver.find_element_by_id("submit-heading")
+        assert "Submit Files or Messages" == heading.text

--- a/securedrop/tests/functional/test_submit_and_retrieve_file.py
+++ b/securedrop/tests/functional/test_submit_and_retrieve_file.py
@@ -1,40 +1,119 @@
-from . import source_navigation_steps
-from . import journalist_navigation_steps
-from . import functional_test
+from pathlib import Path
+
+import pytest
+from selenium.common.exceptions import NoSuchElementException
+
+from encryption import EncryptionManager
+from tests.functional.app_navigators import SourceAppNagivator, JournalistAppNavigator
 
 
-class TestSubmitAndRetrieveFile(
-        functional_test.FunctionalTest,
-        source_navigation_steps.SourceNavigationStepsMixin,
-        journalist_navigation_steps.JournalistNavigationStepsMixin):
+class TestSubmitAndRetrieveFile:
 
-    def test_submit_and_retrieve_happy_path(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_logs_out()
-        try:
-            self.switch_to_firefox_driver()
-            self._journalist_logs_in()
-            self._journalist_checks_messages()
-            self._journalist_stars_and_unstars_single_message()
-            self._journalist_downloads_message()
-            self._journalist_sends_reply_to_source()
-        finally:
-            self.switch_to_torbrowser_driver()
-        self._source_visits_source_homepage()
-        self._source_chooses_to_login()
-        self._source_proceeds_to_login()
-        self._source_deletes_a_journalist_reply()
+    @staticmethod
+    def _journalist_stars_and_unstars_single_message(journ_app_nav: JournalistAppNavigator) -> None:
+        # Message begins unstarred
+        with pytest.raises(NoSuchElementException):
+            journ_app_nav.driver.find_element_by_id("starred-source-link-1")
 
-    def test_source_cancels_at_login_page(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_login()
-        self._source_hits_cancel_at_login_page()
+        # Journalist stars the message
+        journ_app_nav.driver.find_element_by_class_name("button-star").click()
 
-    def test_source_cancels_at_submit_page(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_hits_cancel_at_submit_page()
+        def message_starred():
+            starred = journ_app_nav.driver.find_elements_by_id("starred-source-link-1")
+            assert 1 == len(starred)
+
+        journ_app_nav.nav_helper.wait_for(message_starred)
+
+        # Journalist unstars the message
+        journ_app_nav.driver.find_element_by_class_name("button-star").click()
+
+        def message_unstarred():
+            with pytest.raises(NoSuchElementException):
+                journ_app_nav.driver.find_element_by_id("starred-source-link-1")
+
+        journ_app_nav.nav_helper.wait_for(message_unstarred)
+
+    def test_submit_and_retrieve_happy_path(
+        self, sd_servers_v2_with_clean_state, tor_browser_web_driver, firefox_web_driver
+    ):
+        # Given a source user accessing the app from their browser
+        source_app_nav = SourceAppNagivator(
+            source_app_base_url=sd_servers_v2_with_clean_state.source_app_base_url,
+            web_driver=tor_browser_web_driver,
+        )
+
+        # And they created an account
+        source_app_nav.source_visits_source_homepage()
+        source_app_nav.source_clicks_submit_documents_on_homepage()
+        source_app_nav.source_continues_to_submit_page()
+        source_codename = source_app_nav.source_retrieves_codename_from_hint()
+
+        # And the source user submitted a file
+        submitted_content = "Confidential file with some international characters: éèö"
+        source_app_nav.source_submits_a_file(file_content=submitted_content)
+        source_app_nav.source_logs_out()
+
+        # And a journalist logs in
+        journ_app_nav = JournalistAppNavigator(
+            journalist_app_base_url=sd_servers_v2_with_clean_state.journalist_app_base_url,
+            web_driver=firefox_web_driver,
+        )
+        journ_app_nav.journalist_logs_in(
+            username=sd_servers_v2_with_clean_state.journalist_username,
+            password=sd_servers_v2_with_clean_state.journalist_password,
+            otp_secret=sd_servers_v2_with_clean_state.journalist_otp_secret,
+        )
+        journ_app_nav.journalist_checks_messages()
+
+        # When they star and unstar the submission, then it succeeds
+        self._journalist_stars_and_unstars_single_message(journ_app_nav)
+
+        # And when they try to download the file
+        # Then it succeeds and the journalist sees the correct content
+        apps_sd_config = sd_servers_v2_with_clean_state.config_in_use
+        retrieved_message = journ_app_nav.journalist_downloads_first_message(
+            encryption_mgr_to_use_for_decryption=EncryptionManager(
+                gpg_key_dir=Path(apps_sd_config.GPG_KEY_DIR),
+                journalist_key_fingerprint=apps_sd_config.JOURNALIST_KEY,
+            )
+        )
+        assert retrieved_message == submitted_content
+
+        # And when they reply to the source, it succeeds
+        journ_app_nav.journalist_sends_reply_to_source()
+
+        # And when the source user comes back
+        source_app_nav.source_visits_source_homepage()
+        source_app_nav.source_chooses_to_login()
+        source_app_nav.source_proceeds_to_login(codename=source_codename)
+
+        # When they delete the journalist's reply, it succeeds
+        self._source_deletes_journalist_reply(source_app_nav)
+
+    @staticmethod
+    def _source_deletes_journalist_reply(navigator: SourceAppNagivator) -> None:
+        # Get the reply filename so we can use IDs to select the delete buttons
+        reply_filename_element = navigator.driver.find_element_by_name("reply_filename")
+        reply_filename = reply_filename_element.get_attribute("value")
+
+        confirm_dialog_id = f"confirm-delete-{reply_filename}"
+        navigator.nav_helper.safe_click_by_css_selector(f"a[href='#{confirm_dialog_id}']")
+
+        def confirm_displayed():
+            confirm_dialog = navigator.driver.find_element_by_id(confirm_dialog_id)
+            confirm_dialog.location_once_scrolled_into_view
+            assert confirm_dialog.is_displayed()
+
+        navigator.nav_helper.wait_for(confirm_displayed)
+        # Due to the . in the filename (which is used as ID), we need to escape it because otherwise
+        # we'd select the class gpg
+        navigator.nav_helper.safe_click_by_css_selector(
+            "#{} button".format(confirm_dialog_id.replace(".", "\\."))
+        )
+
+        def reply_deleted():
+            if not navigator.accept_languages:
+                notification = navigator.driver.find_element_by_class_name("success")
+                assert "Reply deleted" in notification.text
+
+        navigator.nav_helper.wait_for(reply_deleted)

--- a/securedrop/tests/functional/test_submit_and_retrieve_message.py
+++ b/securedrop/tests/functional/test_submit_and_retrieve_message.py
@@ -8,18 +8,19 @@ class TestSubmitAndRetrieveMessage:
     def test_submit_and_retrieve_happy_path(
         self, sd_servers_v2_with_clean_state, tor_browser_web_driver, firefox_web_driver
     ):
+        # Given a source user accessing the app from their browser
         source_app_nav = SourceAppNagivator(
             source_app_base_url=sd_servers_v2_with_clean_state.source_app_base_url,
             web_driver=tor_browser_web_driver,
         )
 
-        # Given a source user who created an account
+        # And they created an account
         source_app_nav.source_visits_source_homepage()
         source_app_nav.source_clicks_submit_documents_on_homepage()
         source_app_nav.source_continues_to_submit_page()
 
         # And the source user submitted a message
-        submitted_message = "Confidential information"
+        submitted_message = "Confidential message with some international characters: éèö"
         source_app_nav.source_submits_a_message(message=submitted_message)
         source_app_nav.source_logs_out()
 


### PR DESCRIPTION
## Status

Ready.

## Description of Changes

This PR continue the work from https://github.com/freedomofpress/securedrop/pull/6382. More specifically, this PR:

* Brings the new test fixtures to the `TestSubmitAndRetrieveFile` functional test (for #3836).
* Separate the tests about a source clicking a "Cancel" button from `TestSubmitAndRetrieveFile`. 

