### PR TITLE
Make `gpg` not check the trustdb as we do not use the WoT

### DIFF
--- a/securedrop/encryption.py
+++ b/securedrop/encryption.py
@@ -128,7 +128,9 @@ class EncryptionManager:
         # invoking pinentry-mode=loopback
         # see: https://lists.gnupg.org/pipermail/gnupg-users/2016-May/055965.html
         self._gpg_for_key_deletion = gnupg.GPG(
-            binary="gpg2", homedir=str(self._gpg_key_dir), options=["--yes"]
+            binary="gpg2",
+            homedir=str(self._gpg_key_dir),
+            options=["--yes", "--no-auto-check-trustdb"]
         )
 
         # Ensure that the journalist public key has been previously imported in GPG

--- a/securedrop/encryption.py
+++ b/securedrop/encryption.py
@@ -2,7 +2,7 @@ import typing
 from distutils.version import StrictVersion
 from io import StringIO, BytesIO
 from pathlib import Path
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, FrozenSet
 
 import pretty_bad_protocol as gnupg
 import os
@@ -43,10 +43,26 @@ def _monkey_patch_delete_handle_status() -> None:
     gnupg._parsers.DeleteResult._handle_status = _updated_handle_status
 
 
+def _monkey_patch_options_allow_list() -> None:
+    # To fix: https://github.com/freedomofpress/securedrop/issues/6389
+    unpatched_get_options_group = gnupg._parsers._get_options_group
+
+    def _allow_no_auto_check_trustdb(group: Optional[str] = None) -> Optional[FrozenSet[str]]:
+        if group in ["none_options", "allowed"]:
+            options = list(unpatched_get_options_group(group))
+            options.append("--no-auto-check-trustdb")
+            return frozenset(options)
+        else:
+            return unpatched_get_options_group(group)
+
+    gnupg._parsers._get_options_group = _allow_no_auto_check_trustdb
+
+
 def _setup_monkey_patches_for_gnupg() -> None:
     _monkey_patch_username_in_env()
     _monkey_patch_unknown_status_message()
     _monkey_patch_delete_handle_status()
+    _monkey_patch_options_allow_list()
 
 
 _setup_monkey_patches_for_gnupg()
@@ -93,11 +109,17 @@ class EncryptionManager:
         self._redis = Redis(decode_responses=True)
 
         # Instantiate the "main" GPG binary
-        gpg = gnupg.GPG(binary="gpg2", homedir=str(self._gpg_key_dir))
+        gpg = gnupg.GPG(
+            binary="gpg2",
+            homedir=str(self._gpg_key_dir),
+            options=["--no-auto-check-trustdb"]
+        )
         if StrictVersion(gpg.binary_version) >= StrictVersion("2.1"):
             # --pinentry-mode, required for SecureDrop on GPG 2.1.x+, was added in GPG 2.1.
             self._gpg = gnupg.GPG(
-                binary="gpg2", homedir=str(gpg_key_dir), options=["--pinentry-mode loopback"]
+                binary="gpg2",
+                homedir=str(gpg_key_dir),
+                options=["--pinentry-mode loopback", "--no-auto-check-trustdb"]
             )
         else:
             self._gpg = gpg


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

GPG automatically checks the trustdb on the fly, an operation that can take a long time with very large keyrings as they sometimes exist on large instances. We don't use the Web of Trust at all though so we want to tell GPG to skip these checks by default.

Fixes #6389

## Testing

* Source key generation
  * During `make dev` startup, run `while true; do grep "--no-auto-check-trustdb"<<<$(ps a); sleep 1; done` and confirm that `--no-auto-check-trustdb` is actually passed to `gpg2` 
  * With a fresh install, run `loaddata.py` to generate keys for 10-20k sources
  * Repeatedly generate new sources manually and see response times stay approximately the same
* Source deletion
  * Log into journalist interface 
  * Run `while true; do grep "--no-auto-check-trustdb"<<<$(ps a); done` (no sleep as this operation is faster than generating a key)
  * Delete source account and ensure `--no-auto-check-trustdb` is in the the `grep` loop output

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan ~and validated it for this PR~
