### PR TITLE
Update builder image_hash to 2022_04_07

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_03_28
-b6e6ebe29e2c8436d2976fba0b48aba7b960b1b7ffe82f115d33f77e82796210
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_04_07
+fd30f9a36ffbc96c5aca4234fe4e0b2fa6622db5b6581f46d2ce83bbd9c597a7


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards 2.3.1.

Updates builder image_hash to 2022_04_07.

## Testing

- [ ] Run `make build-debs` locally

## Checklist

- [x] I have written a test plan and validated it for this PR
