### PR TITLE
Use `gpg` with `--trust-model direct`

### DIFF
--- a/securedrop/encryption.py
+++ b/securedrop/encryption.py
@@ -2,7 +2,7 @@ import typing
 from distutils.version import StrictVersion
 from io import StringIO, BytesIO
 from pathlib import Path
-from typing import Optional, Dict, List, FrozenSet
+from typing import Optional, Dict, List
 
 import pretty_bad_protocol as gnupg
 import os
@@ -43,26 +43,10 @@ def _monkey_patch_delete_handle_status() -> None:
     gnupg._parsers.DeleteResult._handle_status = _updated_handle_status
 
 
-def _monkey_patch_options_allow_list() -> None:
-    # To fix: https://github.com/freedomofpress/securedrop/issues/6389
-    unpatched_get_options_group = gnupg._parsers._get_options_group
-
-    def _allow_no_auto_check_trustdb(group: Optional[str] = None) -> Optional[FrozenSet[str]]:
-        if group in ["none_options", "allowed"]:
-            options = list(unpatched_get_options_group(group))
-            options.append("--no-auto-check-trustdb")
-            return frozenset(options)
-        else:
-            return unpatched_get_options_group(group)
-
-    gnupg._parsers._get_options_group = _allow_no_auto_check_trustdb
-
-
 def _setup_monkey_patches_for_gnupg() -> None:
     _monkey_patch_username_in_env()
     _monkey_patch_unknown_status_message()
     _monkey_patch_delete_handle_status()
-    _monkey_patch_options_allow_list()
 
 
 _setup_monkey_patches_for_gnupg()
@@ -112,14 +96,14 @@ class EncryptionManager:
         gpg = gnupg.GPG(
             binary="gpg2",
             homedir=str(self._gpg_key_dir),
-            options=["--no-auto-check-trustdb"]
+            options=["--trust-model direct"]
         )
         if StrictVersion(gpg.binary_version) >= StrictVersion("2.1"):
             # --pinentry-mode, required for SecureDrop on GPG 2.1.x+, was added in GPG 2.1.
             self._gpg = gnupg.GPG(
                 binary="gpg2",
                 homedir=str(gpg_key_dir),
-                options=["--pinentry-mode loopback", "--no-auto-check-trustdb"]
+                options=["--pinentry-mode loopback", "--trust-model direct"]
             )
         else:
             self._gpg = gpg
@@ -130,7 +114,7 @@ class EncryptionManager:
         self._gpg_for_key_deletion = gnupg.GPG(
             binary="gpg2",
             homedir=str(self._gpg_key_dir),
-            options=["--yes", "--no-auto-check-trustdb"]
+            options=["--yes", "--trust-model direct"]
         )
 
         # Ensure that the journalist public key has been previously imported in GPG


### PR DESCRIPTION
## Description of Changes

`--no-auto-check-trustdb` still glances at the trustdb, even if only to check if it's stale or not, but we really truly do not care about the WoT in our usecase, which `--trust-model direct` makes explicit. Also removes python-gnupg/pretty-bad-protocol monkey patch.

Fixes #6397

## Testing

* Source key generation
  * During `make dev` startup, run `while true; do grep "--no-auto-check-trustdb"<<<$(ps a); sleep 1; done` and confirm that `--trust-model direct` is passed to `gpg2`
  * Repeatedly generate new sources on an install with 10-20k sources, and make sure response times stay approximately the same
* Source deletion
  * Log into journalist interface
  * Run `while true; do grep "--trust-model direct"<<<$(ps a); done` (no sleep as this operation is faster than generating a key)
  * Delete source account and ensure `--trust-model direct` is in the the `grep` loop output

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan ~and validated it for this PR~
- [x] These changes do not require documentation