### PR TITLE
Disable fwupd-refresh.timer, triggers OSSEC warnings

### DIFF
--- a/install_files/securedrop-config-focal/DEBIAN/postinst
+++ b/install_files/securedrop-config-focal/DEBIAN/postinst
@@ -20,6 +20,9 @@ case "$1" in
     cp /opt/securedrop/50unattended-upgrades /etc/apt/apt.conf.d/
     cp /opt/securedrop/reboot-flag /etc/cron.d/
 
+    # Disable fwupd-refresh (#6204)
+    systemctl is-enabled fwupd-refresh.timer && systemctl disable fwupd-refresh.timer
+
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

For various reasons, the timer to run `fwupdmgr refresh` ocassionally
triggers OSSEC alerts, which admins can't do anything about.

We currently don't use fwupd for firmware updates, so the daily refresh
of metadata is useless and should be safe to disable. If in the future
we do want admins to install updates with fwupd, they can run refresh
manually as part of the process.

Fixes #6204.

## Testing

* [ ] Run `make build-debs` to get a new securedrop-config deb package
* [ ] Verify on a staging instance that `systemctl is-enabled fwupd-refresh.timer` prints "enabled", and `systemctl list-timers` shows it too
* [ ] Install the newly built package, `sudo apt install ./securedrop-config[...].deb`
* [ ] Verify package installation was successful, and the `is-enabled` command from earlier now prints "disabled"
* [ ] Re-install the package again with `sudo apt install --reinstall ./securedrop-config[...].deb`, to run the postinst again, against an already-disabled state.
* [ ] Verify package re-installation was successful, and the `is-enabled` command still prints "disabled".
* [ ] Reboot, then verify fwupd-refresh is no longer printed by `systemctl list-timers`

## Deployment

Any special considerations for deployment?

Yes, this affects the postinst of the package, which means it cannot be allowed to fail under any circumstances.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
