### PR TITLE
feat: validate `SDConfig.SUPPORTED_LANGUAGES` for usable locales

### DIFF
--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -17,7 +17,7 @@
 #
 import collections
 
-from typing import Dict, List, Set
+from typing import List, Set
 
 from babel.core import (
     Locale,
@@ -177,22 +177,19 @@ def map_locale_display_names(config: SDConfig) -> None:
     to distinguish them. For languages with more than one translation,
     like Chinese, we do need the additional detail.
     """
-    language_locale_counts = collections.defaultdict(int)  # type: Dict[str, int]
-    for l in sorted(config.SUPPORTED_LOCALES):
-        if Locale.parse(l) not in USABLE_LOCALES:
-            continue
-
-        locale = RequestLocaleInfo(l)
-        language_locale_counts[locale.language] += 1
-
+    seen: Set[str] = set()
     locale_map = collections.OrderedDict()
     for l in sorted(config.SUPPORTED_LOCALES):
         if Locale.parse(l) not in USABLE_LOCALES:
             continue
 
         locale = RequestLocaleInfo(l)
-        if language_locale_counts[locale.language] > 1:
+        if locale.language in seen:
+            # Disambiguate translations for this language.
             locale.use_display_name = True
+        else:
+            seen.add(locale.language)
+
         locale_map[str(locale)] = locale
 
     global LOCALES

--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -233,10 +233,12 @@ def get_locale(config: SDConfig) -> str:
     - browser suggested locale, from the Accept-Languages header
     - config.DEFAULT_LOCALE
     """
-    # Default to any locale set in the session.
+    # Default to any usable locale set in the session.
     locale = session.get("locale")
+    if locale:
+        locale = negotiate_locale([locale], LOCALES.keys())
 
-    # A valid locale specified in request.args takes precedence.
+    # A usable locale specified in request.args takes precedence.
     if request.args.get("l"):
         negotiated = negotiate_locale([request.args["l"]], LOCALES.keys())
         if negotiated:

--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -179,11 +179,17 @@ def map_locale_display_names(config: SDConfig) -> None:
     """
     language_locale_counts = collections.defaultdict(int)  # type: Dict[str, int]
     for l in sorted(config.SUPPORTED_LOCALES):
+        if Locale.parse(l) not in USABLE_LOCALES:
+            continue
+
         locale = RequestLocaleInfo(l)
         language_locale_counts[locale.language] += 1
 
     locale_map = collections.OrderedDict()
     for l in sorted(config.SUPPORTED_LOCALES):
+        if Locale.parse(l) not in USABLE_LOCALES:
+            continue
+
         locale = RequestLocaleInfo(l)
         if language_locale_counts[locale.language] > 1:
             locale.use_display_name = True

--- a/securedrop/sdconfig.py
+++ b/securedrop/sdconfig.py
@@ -8,6 +8,9 @@ import config as _config
 from typing import Set
 
 
+FALLBACK_LOCALE = "en_US"
+
+
 class SDConfig:
     def __init__(self) -> None:
         try:
@@ -120,7 +123,7 @@ class SDConfig:
         # Config entries used by i18n.py
         # Use en_US as the default locale if the key is not defined in _config
         self.DEFAULT_LOCALE = getattr(
-            _config, "DEFAULT_LOCALE", "en_US"
+            _config, "DEFAULT_LOCALE", FALLBACK_LOCALE,
         )  # type: str
         supported_locales = set(getattr(
             _config, "SUPPORTED_LOCALES", [self.DEFAULT_LOCALE]

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -32,11 +32,15 @@ from flask import render_template_string
 from flask import request
 from flask import session
 from flask_babel import gettext
-from sdconfig import SDConfig
+from i18n import parse_locale_set, resolve_fallback_locale
+from sdconfig import FALLBACK_LOCALE, SDConfig
 from sh import pybabel
 from sh import sed
 from .utils.env import TESTS_DIR
 from werkzeug.datastructures import Headers
+
+
+NEVER_LOCALE = 'eo'  # Esperanto
 
 
 def verify_i18n(app):
@@ -225,12 +229,79 @@ def test_i18n(journalist_app, config):
         verify_i18n(app)
 
 
-def test_supported_locales(config):
+def test_parse_locale_set():
+    assert parse_locale_set([FALLBACK_LOCALE]) == set([Locale.parse(FALLBACK_LOCALE)])
+
+
+def test_resolve_fallback_locale(config):
+    """
+    Only a usable default or fallback locale is returned.
+    """
+    i18n.USABLE_LOCALES = parse_locale_set([FALLBACK_LOCALE, 'es_ES'])
     fake_config = SDConfig()
 
-    # Check that an invalid locale raises an error during app
-    # configuration.
-    fake_config.SUPPORTED_LOCALES = ['en_US', 'yy_ZZ']
+    # The default locale is neither configured nor available.
+    fake_config.DEFAULT_LOCALE = NEVER_LOCALE
+    assert resolve_fallback_locale(fake_config) == FALLBACK_LOCALE
+
+    # The default locale is configured but not available.
+    fake_config.SUPPORTED_LOCALES = [FALLBACK_LOCALE, NEVER_LOCALE]
+    assert resolve_fallback_locale(fake_config) == FALLBACK_LOCALE
+
+    # The default locale is available but not configured.
+    fake_config.SUPPORTED_LOCALES = [FALLBACK_LOCALE]
+    fake_config.DEFAULT_LOCALE = NEVER_LOCALE
+    assert resolve_fallback_locale(fake_config) == FALLBACK_LOCALE
+
+    # Happy path: a non-fallback default locale is both available and configured.
+    fake_config.SUPPORTED_LOCALES = [FALLBACK_LOCALE, 'es_ES']
+    fake_config.DEFAULT_LOCALE = 'es_ES'
+    assert resolve_fallback_locale(fake_config) == 'es_ES'
+
+
+def test_no_usable_fallback_locale(journalist_app, config):
+    """
+    The apps fail if neither the default nor the fallback locale is usable.
+    """
+    fake_config = SDConfig()
+    fake_config.DEFAULT_LOCALE = NEVER_LOCALE
+    fake_config.SUPPORTED_LOCALES = [NEVER_LOCALE]
+    fake_config.TRANSLATION_DIRS = Path(config.TEMP_DIR)
+
+    i18n.USABLE_LOCALES = set()
+    with pytest.raises(ValueError, match='No usable fallback locale'):
+        resolve_fallback_locale(fake_config)
+
+    with pytest.raises(ValueError, match='in the set of usable locales'):
+        journalist_app_module.create_app(fake_config)
+
+    with pytest.raises(ValueError, match='in the set of usable locales'):
+        source_app.create_app(fake_config)
+
+
+def test_unusable_default_but_usable_fallback_locale(config, caplog):
+    """
+    The apps start even if the default locale is unusable, as along as the fallback locale is
+    usable, but log an error for OSSEC to pick up.
+    """
+    fake_config = SDConfig()
+    fake_config.DEFAULT_LOCALE = NEVER_LOCALE
+    fake_config.SUPPORTED_LOCALES = [NEVER_LOCALE, FALLBACK_LOCALE]
+    fake_config.TRANSLATION_DIRS = Path(config.TEMP_DIR)
+
+    for app in (journalist_app_module.create_app(fake_config),
+                source_app.create_app(fake_config)):
+        with app.app_context():
+            assert NEVER_LOCALE in caplog.text
+            assert 'not in the set of usable locales' in caplog.text
+
+
+def test_invalid_locales(config):
+    """
+    An invalid locale raises an error during app configuration.
+    """
+    fake_config = SDConfig()
+    fake_config.SUPPORTED_LOCALES = [FALLBACK_LOCALE, 'yy_ZZ']
     fake_config.TRANSLATION_DIRS = Path(config.TEMP_DIR)
 
     with pytest.raises(UnknownLocaleError):
@@ -239,16 +310,22 @@ def test_supported_locales(config):
     with pytest.raises(UnknownLocaleError):
         source_app.create_app(fake_config)
 
-    # Check that a valid but unsupported locale raises an error during
-    # app configuration.
-    fake_config.SUPPORTED_LOCALES = ['en_US', 'wae_CH']
+
+def test_valid_but_unusable_locales(config, caplog):
+    """
+    The apps start with one or more unusable, but still valid, locales, but log an error for
+    OSSEC to pick up.
+    """
+    fake_config = SDConfig()
+
+    fake_config.SUPPORTED_LOCALES = [FALLBACK_LOCALE, 'wae_CH']
     fake_config.TRANSLATION_DIRS = Path(config.TEMP_DIR)
 
-    with pytest.raises(ValueError, match="not in the set of translated locales"):
-        journalist_app_module.create_app(fake_config)
-
-    with pytest.raises(ValueError, match="not in the set of translated locales"):
-        source_app.create_app(fake_config)
+    for app in (journalist_app_module.create_app(fake_config),
+                source_app.create_app(fake_config)):
+        with app.app_context():
+            assert 'wae' in caplog.text
+            assert 'not in the set of usable locales' in caplog.text
 
 
 def test_language_tags():


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Closes #6366 by determining that a locale is *usable* if it is both (a) *available* in the filesystem and (b) *configured* by the administrator in `SDConfig.SUPPORTED_LANGUAGES`.  Once we've determined which configured locales are actually usable, we:

1. warn if a configured locale is not available;

2. fall back to the hard-coded `FALLBACK_LOCALE` (`en_US`) if `SDConfig.DEFAULT_LOCALE` is not usable; and

3. error out if neither the default nor the fallback locale is usable.


## Testing

### Routine testing

In the development environment:

* [x] Confirm that the language menu works normally.
    * [x] `zh_{Hans,Hant}` are each (separately) listed, selectable, and loadable.

### Configured language loses support

In the development environment:
    
1. First:

    ```sh-session

   $ rm -rf securedrop/translations/de_DE  # or the language of your choice
   $ make dev
   ```
2. [x] Observe the error:

    ```sh-session

    [2022-04-19 22:14:24,290] ERROR in i18n: Configured locales {Locale('de', territory='DE')} are not in the set of usable locales {Locale('es', territory='ES'), Locale('is'), Locale('pt', territory='BR'), Locale('zh', script='Hans'), Locale('ro'), Locale('it', territory='IT'), Locale('en', territory='US'), Locale('ca'), Locale('nl'), Locale('fr', territory='FR'), Locale('el'), Locale('sv'), Locale('ar'), Locale('cs'), Locale('ru'), Locale('hi'), Locale('nb', territory='NO'), Locale('tr'), Locale('zh', script='Hant'), Locale('sk')}

    ```

3. [x] In the Source Interface, observe that **Deutsch** is no longer available in the language menu.

### Default language loses support

In the development environment:
    
1. Apply the patch:

    ```patch

    --- a/securedrop/config.py.example

    +++ b/securedrop/config.py.example

    @@ -82,7 +82,7 @@ DATABASE_ENGINE = 'sqlite'

     DATABASE_FILE = os.path.join(SECUREDROP_DATA_ROOT, 'db.sqlite')

     

     # Which of the available locales should be displayed by default ?

    -DEFAULT_LOCALE = 'en_US'

    +DEFAULT_LOCALE = 'de_DE'

     

     # How long a session is valid before it expires and logs a user out

     SESSION_EXPIRATION_MINUTES = 120

    ```

2. Then:

    ```sh-session

    $ rm -rf securedrop/translations/de_DE # or the language of your choice

    $ make dev

    ```

3. [x] Observe the error:

    ```sh-session

    [2022-04-19 22:14:24,290] ERROR in i18n: Configured locales {Locale('de', territory='DE')} are not in the set of usable locales {Locale('es', territory='ES'), Locale('is'), Locale('pt', territory='BR'), Locale('zh', script='Hans'), Locale('ro'), Locale('it', territory='IT'), Locale('en', territory='US'), Locale('ca'), Locale('nl'), Locale('fr', territory='FR'), Locale('el'), Locale('sv'), Locale('ar'), Locale('cs'), Locale('ru'), Locale('hi'), Locale('nb', territory='NO'), Locale('tr'), Locale('zh', script='Hant'), Locale('sk')}

    ```

4. [x] In the Source Interface, observe that **Deutsch** is no longer available in the language menu.

### No usable fallback locale

In the development environment:
    
1. Apply the patch:

    ```patch

    --- a/Makefile

    +++ b/Makefile

    @@ -171,7 +171,6 @@ securedrop/config.py: ## Generate the test SecureDrop application config.

                     ctx.update(dict((k, {"stdout":v}) for k,v in os.environ.items())); \

                     ctx = open("config.py", "w").write(env.get_template("config.py.example").render(ctx))'

            @echo >> securedrop/config.py

    -       @echo "SUPPORTED_LOCALES = $$(if test -f /opt/venvs/securedrop-app-code/bin/python3; then ./securedrop/i18n_tool.py list-locales --python; else DOCKER_BUILD_VERBOSE=false $(DEVSHELL) ./i18n_tool.py list-locales --python; fi)" | sed 's/\r//' >> securedrop/config.py

            @echo

     

     .PHONY: test-config

    diff --git a/securedrop/config.py.example b/securedrop/config.py.example

    index 92544087a..508e5db66 100644

    --- a/securedrop/config.py.example

    +++ b/securedrop/config.py.example

    @@ -82,7 +82,8 @@ DATABASE_ENGINE = 'sqlite'

     DATABASE_FILE = os.path.join(SECUREDROP_DATA_ROOT, 'db.sqlite')

     

     # Which of the available locales should be displayed by default ?

    -DEFAULT_LOCALE = 'en_US'

    +DEFAULT_LOCALE = 'de_DE'

     

     # How long a session is valid before it expires and logs a user out

     SESSION_EXPIRATION_MINUTES = 120

    +SUPPORTED_LOCALES = ['de_DE']

    ```

2. Then:

    ```sh-session

    $ rm -rf securedrop/config.py
    $ rm -rf securedrop/translations/de_DE # or the language of your choice

    $ make dev

    ```

3. [x] Observe the crash:

    ```

    ValueError: None of the default locales {Locale('en', territory='US'), Locale('de', territory='DE')} is in the set of usable locales set()

    ```


### OSSEC alerts

In the staging environment:

1. On the Monitor Server, `tail -f /var/ossec/logs/alerts/alerts.log`.
2. On the Application Server:

    ```sh-session

    $ sudo rm -rf /var/www/securedrop/translations/de_DE  # or another locale configured in your staging environment

    $ sudo systemctl restart apache2

    ```

3. [x] On the Monitor Server, observe an alert like:

    ```sh-session

    ** Alert 1650408345.42633: mail  - Apache logs

    2022 Apr 19 22:45:45 (sd-staging-app-base-focal) 10.137.0.50->/var/log/apache2/journalist-error.log

    Rule: 400700 (level 7) -> 'Apache application error.'

    [2022-04-19 22:14:24,290] ERROR in i18n: Configured locales {Locale('de', territory='DE')} are not in the set of usable locales {Locale('es', territory='ES'), Locale('is'), Locale('pt', territory='BR'), Locale('zh', script='Hans'), Locale('ro'), Locale('it', territory='IT'), Locale('en', territory='US'), Locale('ca'), Locale('nl'), Locale('fr', territory='FR'), Locale('el'), Locale('sv'), Locale('ar'), Locale('cs'), Locale('ru'), Locale('hi'), Locale('nb', territory='NO'), Locale('tr'), Locale('zh', script='Hant'), Locale('sk')}

   ```


## Deployment

This is a *disruptive* change for an instance X if:

1. we remove a language L for lack of translation coverage; and
2. L is configured as X's `DEFAULT_LANGUAGE`.

This is a *breaking* change for X if, in addition:

3. the fallback locale `en_US` has been *removed* from X's `SUPPORTED_LANGUAGES`.

A report of instances' `supported_languages` from the Directory should tell us whether any instances will need proactive outreach about either of these scenarios.  Otherwise, we should make sure to warn about them in the release notes.


## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- I would appreciate help with the documentation
- [x] These changes do not require documentation