### PR TITLE
Added Tails 5 compatibility updates

### DIFF
--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -138,7 +138,6 @@ def install_apt_dependencies(args: argparse.Namespace) -> None:
                    python3-virtualenv \
                    python3-yaml \
                    python3-pip \
-                   ccontrol \
                    virtualenv \
                    libffi-dev \
                    libssl-dev \

--- a/install_files/ansible-base/roles/tails-config/tasks/configure_network_hook.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/configure_network_hook.yml
@@ -22,4 +22,4 @@
 - name: Run SecureDrop network hook
   # Writes files to /etc, so elevated privileges are required.
   become: yes
-  command: python "{{ tails_config_securedrop_dotfiles }}/securedrop_init.py"
+  command: python3 "{{ tails_config_securedrop_dotfiles }}/securedrop_init.py"


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Fixes #6400 .

- removed ccontrol package from bootstrap.py, as it is not available for Debian 11
- updated tailsconfig Ansible role to execute network hook with python 3 explicitly

## Testing

These tests assume a virtualized production environment.

### Tails 4 
- Follow the instructions to set up a Tails VM with the latest Tails 4 version: https://docs.securedrop.org/en/stable/development/virtualizing_tails.html
- check out this branch in the Tails VM
- Set up a prod VM environment and confirm that:
  - [ ] `./securedrop-admin setup` completed successfully
  - [ ] `apt-cache policy ccontrol` shows that `ccontrol` is not installed
  - [ ] the admin `sdconfig`, `install`, and `tailsconfig` commands complete successfully
  - [ ] the servers are accessible over ssh-over-tor and the SI and JI are available via desktop shortcuts
  - [ ] backup and restore work correctly
  - [ ] the GUI updater works and updates to the latest release version.
  - [ ] the JI and SSH services are still available after restarting the network connection.
  
### Tails 5
- Set up a Tails VM with the latest Tails 5 beta.
- check out this branch in the Tails 5 VM
- Set up a prod VM environment and confirm that:
  - [ ] `./securedrop-admin setup` completed successfully
  - [ ] `apt-cache policy ccontrol` shows that `ccontrol` is not installed
  - [ ] the admin `sdconfig`, `install`, and `tailsconfig` commands complete successfully
  - [ ] the servers are accessible over ssh-over-tor and the SI and JI are available via desktop shortcuts
  - [ ] backup and restore work correctly
  - [ ] the GUI updater works and updates to the latest release version.
  - [ ] the JI and SSH services are still available after restarting the network connection.

## Deployment
None - will be deployed with next release.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [x] I would appreciate help with the documentation
- [ ] These changes do not require documentation
