### PR TITLE
Delegate date strings formatting to datetime.isoformat()

### DIFF
--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -20,8 +20,6 @@ from werkzeug.exceptions import HTTPException, default_exceptions
 
 _insecure_views = ["main.login", "static"]
 _insecure_api_views = ["api.get_token", "api.get_endpoints"]
-# Timezone-naive datetime format expected by SecureDrop Client
-API_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
 def get_logo_url(app: Flask) -> str:
@@ -67,7 +65,7 @@ def create_app(config: SecureDropConfig) -> Flask:
 
         def default(self, obj: "Any") -> "Any":
             if isinstance(obj, datetime):
-                return obj.strftime(API_DATETIME_FORMAT)
+                return obj.isoformat()
             super().default(obj)
 
     app.json_encoder = JSONEncoder

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -20,8 +20,7 @@ random.seed("◔ ⌣ ◔")
 
 def assert_valid_timestamp(timestamp: str) -> None:
     """verify the timestamp is encoded in the format we want"""
-    dt_format = "%Y-%m-%dT%H:%M:%S.%fZ"
-    assert timestamp == datetime.strptime(timestamp, dt_format).strftime(dt_format)
+    assert timestamp == datetime.fromisoformat(timestamp).isoformat()
 
 
 def test_unauthenticated_user_gets_all_endpoints(journalist_app):

--- a/securedrop/tests/test_journalist_session.py
+++ b/securedrop/tests/test_journalist_session.py
@@ -292,7 +292,7 @@ def test_session_api_login(journalist_app, test_journo, redis):
         # Then the expiration date returned in `get_token` response also conforms to the same rules
         assert (
             datetime.now(timezone.utc)
-            < datetime.strptime(resp.json["expiration"], "%Y-%m-%dT%H:%M:%S.%f%z")
+            < datetime.fromisoformat(resp.json["expiration"])
             < (
                 datetime.now(timezone.utc)
                 + timedelta(seconds=journalist_app.config["SESSION_LIFETIME"])


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #6257 (see **Proposed plan** section in the description).

Changes proposed in this pull request:

- Remove the custom date string format (that used to be the only one supported by the SecureDrop Client)
- Use ISO8061 via `datetime.isoformat()` instead (should be easier to use consistently too)

## Testing

- [ ] Visual review: do these changes make sense given the context recapped below?

Then test here:
- [ ] Pay special attention to CI: do the tests changed here still pass?

And then check for surprises downstream:
- [ ] Run `make dev` here and `make regenerate-sdk-cassettes` in `freedomofpress/securedrop-client/client`.  It should pass.
- [ ] Run `make test` in `freedomofprses/securedrop-client/client`.  It should pass.

## Deployment

Once this change has been released, the try/except logic in <https://github.com/freedomofpress/securedrop-client/blob/7f7f60e67f7606708a6c9ef519c9657cd738be9e/client/securedrop_client/sdk/timestamps.py> can be removed in favor of just `datetime.fromisoformat()`.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container