### PR TITLE
Update demo landing page Dockerfile

### DIFF
--- a/devops/demo/landing-page/Dockerfile
+++ b/devops/demo/landing-page/Dockerfile
@@ -1,10 +1,10 @@
-# sha256 as of 2022-02-16
-FROM nginx:mainline-alpine@sha256:050385609d832fae11b007fbbfba77d0bba12bf72bc0dca0ac03e09b1998580f
+# sha256 as of 2022-04-27
+FROM nginx:mainline-alpine@sha256:efc09388b15fb423c402f0b8b28ca70c7fd20fe31f8d7531ae1896bbb4944999
 RUN apk --no-cache upgrade
 
-COPY nginx.conf /etc/nginx
+COPY devops/demo/landing-page/nginx.conf /etc/nginx
 RUN mkdir -p /opt/nginx/run /opt/nginx/webroot && chown -R nginx:nginx /opt/nginx
-COPY --chown=nginx:nginx webroot /opt/nginx/webroot
+COPY --chown=nginx:nginx devops/demo/landing-page/webroot /opt/nginx/webroot
 
 USER nginx
 EXPOSE 8000


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Followup to #6407 

Changes proposed in this pull request:

- Small fix to the landing page Dockerfile, to allow building from the repo root (the equivalent of `docker build -t quay.io/freedomofpress/securedrop-demo-landing-page -f devops/demo/landing-page/Dockerfile .`, although this will be run in Codefresh and not manually).
- While updating, bump the nginx base image.

## Testing

- Run the above docker build command
- `docker run -p 8000:8000 -it --rm quay.io/freedomofpress/securedrop-demo-landing-page`
- view page at `localhost:8000`

## Deployment

Any special considerations for deployment? 

None, I will watch for any deploy problems on the Codefresh end.

## Checklist

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
