### PR TITLE
Add Makefile target for demo landing page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,13 @@ dev-tor:  ## Run the development server with onion services in a Docker containe
 	@OFFSET_PORTS='false' DOCKER_BUILD_VERBOSE='true' USE_TOR='true' $(DEVSHELL) $(SDBIN)/run
 	@echo
 
+.PHONY: demo-landing-page
+demo-landing-page: ## Serve the landing page for the SecureDrop demo
+	@echo "███ Building Docker image..."
+	docker build -t sd-demo-landing-page -f devops/demo/landing-page/Dockerfile .
+	@echo "███ Running container and serving on port 8000..."
+	docker run -p 8000:8000 sd-demo-landing-page
+
 .PHONY: staging
 staging:  ## Create a local staging environment in virtual machines (Focal)
 	@echo "███ Creating staging environment on Ubuntu Focal..."


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Adds a simple `Makefile` target for serving up the demo landing page on port 8000 (this does not spin up the source/journalist interface, it just makes it easier to test design changes).

## Testing

1. Run `make demo-landing-page` on this branch
2. Access localhost:8000
- [ ] Observe that contents match https://demo.securedrop.org/