### PR TITLE
Viewport shouldn't always show a scrollbar

### DIFF
--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -1169,6 +1169,7 @@ footer p
 // Preload some images we're likely to display when moving on from the index
 body::after
   position: absolute
+  top: -999px
   width: 0
   height: 0
   visibility: hidden


### PR DESCRIPTION
## Description of Changes

Because of a `body::after` element used to pre-load a couple of images was visually hidden but still part of the DOM, the element forced the viewport to always show a scrollbar.

I overlooked this visual degradation that was introduced by the most recent accessibility related changes to hide the element from screen-readers but forgot to position the element off-screen.

Fixes #6419

## Testing

* Check SI index page in full screen mode, it should *not* show a scrollbar.
