### PR TITLE
Update manage py to use app context

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -33,9 +33,9 @@ from pyotp import TOTP, HOTP
 from encryption import EncryptionManager, GpgKeyNotFoundError
 from passphrases import PassphraseGenerator
 from store import Storage
-
+#from flask import current_app as app
 _default_instance_config: Optional["InstanceConfig"] = None
-app = Flask(__name__)
+app = Flask(__name__, _default_instance_config)
 babel = Babel(app)
 
 LOGIN_HARDENING = True

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -12,8 +12,8 @@ from io import BytesIO
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.kdf import scrypt
-from flask import current_app, url_for
-from flask_babel import gettext, ngettext
+from flask import url_for
+from flask_babel import ngettext
 from itsdangerous import TimedJSONWebSignatureSerializer, BadData
 from markupsafe import Markup
 from passlib.hash import argon2
@@ -33,7 +33,7 @@ from pyotp import TOTP, HOTP
 from encryption import EncryptionManager, GpgKeyNotFoundError
 from passphrases import PassphraseGenerator
 from store import Storage
-#from flask import current_app as app
+
 _default_instance_config: Optional["InstanceConfig"] = None
 app = Flask(__name__, _default_instance_config)
 babel = Babel(app)

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -33,7 +33,7 @@ from pyotp import TOTP, HOTP
 from encryption import EncryptionManager, GpgKeyNotFoundError
 from passphrases import PassphraseGenerator
 from store import Storage
-#from flask import current_app as app
+
 _default_instance_config: Optional["InstanceConfig"] = None
 app = Flask(__name__, _default_instance_config)
 babel = Babel(app)


### PR DESCRIPTION
## Status

Work in progress: Raises correct exceptions,  fails test suite.

## Description of Changes

Addresses #6188.

Exceptions for invalid usernames were not being raised. Instead, there was python traceback where `ngettext` was used.
Adds an application context before exception calls.

## Testing
From the developer environment
 * exec into Securedrop container
 * `./manage.py add-admin`   # Try any 2-letter username 
 * `./manage.py add-journalist`  # Try any 2-letter username

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

