### PR TITLE
Update old venv deleting logic for Tails 5 (bullseye)

### DIFF
--- a/admin/tests/test_securedrop-admin-setup.py
+++ b/admin/tests/test_securedrop-admin-setup.py
@@ -79,16 +79,26 @@ class TestSecureDropAdmin(object):
                 bootstrap.install_pip_dependencies(args)
         assert 'Failed to install' in caplog.text
 
-    def test_python3_stretch_venv_deleted_in_buster(self, tmpdir, caplog):
+    def test_python3_buster_venv_deleted_in_bullseye(self, tmpdir, caplog):
         venv_path = str(tmpdir)
-        python_lib_path = os.path.join(str(tmpdir), 'lib/python3.5')
+        python_lib_path = os.path.join(str(tmpdir), 'lib/python3.7')
         os.makedirs(python_lib_path)
         with mock.patch('bootstrap.is_tails', return_value=True):
-            with mock.patch('subprocess.check_output', return_value=b"buster"):
-                bootstrap.clean_up_tails3_venv(venv_path)
-                assert 'Tails 3 Python 3 virtualenv detected.' in caplog.text
-                assert 'Tails 3 Python 3 virtualenv deleted.' in caplog.text
+            with mock.patch('subprocess.check_output', return_value=b"bullseye"):
+                bootstrap.clean_up_old_tails_venv(venv_path)
+                assert 'Tails 4 virtualenv detected.' in caplog.text
+                assert 'Tails 4 virtualenv deleted.' in caplog.text
                 assert not os.path.exists(venv_path)
+
+    def test_python3_bullseye_venv_not_deleted_in_bullseye(self, tmpdir, caplog):
+        venv_path = str(tmpdir)
+        python_lib_path = os.path.join(venv_path, 'lib/python3.9')
+        os.makedirs(python_lib_path)
+        with mock.patch('bootstrap.is_tails', return_value=True):
+            with mock.patch('subprocess.check_output', return_value="bullseye"):
+                bootstrap.clean_up_old_tails_venv(venv_path)
+                assert 'Tails 4 virtualenv detected' not in caplog.text
+                assert os.path.exists(venv_path)
 
     def test_python3_buster_venv_not_deleted_in_buster(self, tmpdir, caplog):
         venv_path = str(tmpdir)
@@ -96,30 +106,18 @@ class TestSecureDropAdmin(object):
         os.makedirs(python_lib_path)
         with mock.patch('bootstrap.is_tails', return_value=True):
             with mock.patch('subprocess.check_output', return_value="buster"):
-                bootstrap.clean_up_tails3_venv(venv_path)
-                assert (
-                    'Tails 3 Python 3 virtualenv detected' not in caplog.text
-                )
-                assert os.path.exists(venv_path)
-
-    def test_python3_stretch_venv_not_deleted_in_stretch(self, tmpdir, caplog):
-        venv_path = str(tmpdir)
-        python_lib_path = os.path.join(venv_path, 'lib/python3.5')
-        os.makedirs(python_lib_path)
-        with mock.patch('bootstrap.is_tails', return_value=True):
-            with mock.patch('subprocess.check_output', return_value="stretch"):
-                bootstrap.clean_up_tails3_venv(venv_path)
+                bootstrap.clean_up_old_tails_venv(venv_path)
                 assert os.path.exists(venv_path)
 
     def test_venv_cleanup_subprocess_exception(self, tmpdir, caplog):
         venv_path = str(tmpdir)
-        python_lib_path = os.path.join(venv_path, 'lib/python3.5')
+        python_lib_path = os.path.join(venv_path, 'lib/python3.7')
         os.makedirs(python_lib_path)
         with mock.patch('bootstrap.is_tails', return_value=True):
             with mock.patch('subprocess.check_output',
                             side_effect=subprocess.CalledProcessError(1,
                                                                       ':o')):
-                bootstrap.clean_up_tails3_venv(venv_path)
+                bootstrap.clean_up_old_tails_venv(venv_path)
                 assert os.path.exists(venv_path)
 
     def test_envsetup_cleanup(self, tmpdir, caplog):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The bootstrap detects when a legacy venv is being used on a newer
major Tails version, but the logic was still using stretch → buster
versions. Update it for buster → bullseye, renaming functions and
error messages as appropriate.

Refs #6400.

## Testing

* [ ] Set up securedrop-admin venv on a Tails 4.x stick
* [ ] Upgrade said USB stick to Tails 5.0
* [ ] Run `./securedrop-admin [whatever]`, observe it deletes the venv and asks you to run `./securedrop-admin setup`. It does not give you an obscure error message about being unable to load Python modules and aborting.
* [ ] CI passes.

## Deployment

Any special considerations for deployment? Not strictly necessary, but makes the Tails 5 migration much nicer.

## Checklist

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container
- [ ] I have written a test plan and validated it for this PR
- [ ] These changes do not require documentation
