### PR TITLE
Update tor2web/onion site proxy warnings for SI redesign

### DIFF
--- a/securedrop/source_app/info.py
+++ b/securedrop/source_app/info.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import flask
-from flask import Blueprint, render_template, send_file, redirect, url_for, flash
+from flask import Blueprint, render_template, send_file, redirect, url_for
 from flask_babel import gettext
 import werkzeug
 
@@ -8,7 +8,7 @@ from io import BytesIO  # noqa
 
 from encryption import EncryptionManager
 from sdconfig import SDConfig
-from source_app.utils import get_sourcev3_url
+from source_app.utils import get_sourcev3_url, flash_msg
 
 
 def make_blueprint(config: SDConfig) -> Blueprint:
@@ -16,7 +16,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
 
     @view.route('/tor2web-warning')
     def tor2web_warning() -> flask.Response:
-        flash(gettext("Your connection is not anonymous right now!"), "error")
+        flash_msg("error", None, gettext("Your connection is not anonymous right now!"))
         return flask.Response(
             render_template("tor2web-warning.html", source_url=get_sourcev3_url()),
             403)

--- a/securedrop/source_templates/tor2web-warning.html
+++ b/securedrop/source_templates/tor2web-warning.html
@@ -11,7 +11,7 @@
 <p>{{ gettext('Always use <a href="www.torproject.org/projects/torbrowser.html">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:') }}
 <pre>{{ source_url }}</pre>
 </p>
-<p> {{ gettext ('If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop.') }} {{ gettext('Click the <img src={icon} alt="" width="16" height="16">&nbsp;<b>New Identity</b> button in your Tor Browser\'s toolbar. This will clear your Tor Browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom-black.png'))  }}
+<p> {{ gettext ('If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop.') }} {{ gettext('Click the <img src={icon} alt="" width="16" height="16">&nbsp;<b>New Identity</b> button in your Tor Browser\'s toolbar. This will clear your Tor Browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom.png'))  }}
 </p>
 <p>{{ gettext('If there is a reasonable risk of your Internet traffic being monitored, consider connecting from a different location or network.') }}
 </p>

--- a/securedrop/source_templates/tor2web-warning.html
+++ b/securedrop/source_templates/tor2web-warning.html
@@ -8,7 +8,7 @@
 </p>
 <p>{{ gettext('Anyone monitoring your Internet traffic &mdash; including your government, your Internet provider, or the proxy operator &mdash; may be able to identify you.') }}
 </p>
-<p>{{ gettext('Always use <a href="www.torproject.org/projects/torbrowser.html">Tor Browser</a> to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:') }}
+<p>{{ gettext('Always use Tor Browser (<code>{}</code>) to access SecureDrop. Valid SecureDrop site addresses end with <code>.onion</code>. The correct address for this site is:').format("https://www.torproject.org/download/") }}
 <pre>{{ source_url }}</pre>
 </p>
 <p> {{ gettext ('If you are already using Tor Browser, copy the address above and generate a new identity before you access SecureDrop.') }} {{ gettext('Click the <img src={icon} alt="" width="16" height="16">&nbsp;<b>New Identity</b> button in your Tor Browser\'s toolbar. This will clear your Tor Browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom.png'))  }}


### PR DESCRIPTION
## Description of Changes

Makes the tor2web page use the `flash_msg` utility function for its error flash message and fixes the address for Tor Browser's broom icon

Also, replace the broken link to  Tor Browser project page with a text-only link to the download page (the project page redirects there already) to avoid link-tracking by nasty proxy sites.

Fixes #6429 and fixes #6393

## Testing

* Visit `/tor2web-warning` page
* See icons for both the flash message and **New Identity**
* See a text-only link to the Tor Browser download page

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
