### PR TITLE
update CI image to Bullseye

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,7 +288,7 @@ jobs:
 
   deb-tests:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
     environment:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8

--- a/devops/gce-nested/gce-start.sh
+++ b/devops/gce-nested/gce-start.sh
@@ -25,7 +25,7 @@ function find_latest_ci_image() {
     #    --filter="family:fpf-securedrop AND name ~ ^ci-nested-virt" \
     #    --sort-by=~Name --limit=1 --format="value(Name)"
     # Return hardcoded image id to prevent newer builds from breaking CI
-    echo "ci-nested-virt-buster-1633365108"
+    echo "ci-nested-virt-bullseye-1651694527"
 }
 
 # Call out to GCE API and start a new instance, designating

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -74,6 +74,7 @@ function docker_run() {
 
     # If this is a CI run, pass CodeCov's required vars into the container.
     if [ -n "${CIRCLE_BRANCH:-}" ] ; then
+        : "${CIRCLE_PULL_REQUEST:=}"
         ci_env="-e CI=true \
                 -e CIRCLECI=true \
                 -e CIRCLE_BRANCH=${CIRCLE_BRANCH:-} \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

For GCE nested virt, use the new Debian 11 image created in https://github.com/freedomofpress/infrastructure/pull/3855

This also pulls in an update of the CircleCI Python image to `cimg/python:3.8` and a workaround for running tests in CircleCI without a pull request associated with a branch.

Fixes #6411.

## Testing

I used CircleCI to test, as I'm not sure how to use my own GCE credentials for this locally: https://app.circleci.com/pipelines/github/freedomofpress/securedrop/4121/workflows/ce0d5391-ba60-4d7d-a4c5-ac3a1adc8f79

## Deployment

I don't think there are any special considerations.

## Checklist

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

