### PR TITLE
[2.3.2] Backport builder image update

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_04_07
-fd30f9a36ffbc96c5aca4234fe4e0b2fa6622db5b6581f46d2ce83bbd9c597a7
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_05_05
+8a4a0671d9155b4707055069263f36be0f5276c384ad8056bcb7c71f77200c49


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Backports #6432 .


## Testing

- [x] branch contains only commit(s) from #6432 
- [x] base is `release/2.3.2`
- [x] CI is passing.
