### PR TITLE
Use ProxyFix to make redirects https:// when needed

### DIFF
--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -10,6 +10,7 @@ from flask_babel import gettext
 from flask_wtf.csrf import CSRFProtect, CSRFError
 from os import path
 from werkzeug.exceptions import default_exceptions
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 import i18n
 import template_filters
@@ -59,6 +60,8 @@ def create_app(config: 'SDConfig') -> Flask:
     app = Flask(__name__,
                 template_folder=config.JOURNALIST_TEMPLATES_DIR,
                 static_folder=path.join(config.SECUREDROP_ROOT, 'static'))
+
+    app.wsgi_app = ProxyFix(app.wsgi_app)  # type: ignore
 
     app.config.from_object(config.JOURNALIST_APP_FLASK_CONFIG_CLS)
     app.session_interface = JournalistInterfaceSessionInterface()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

When returning a redirect, Flask constructs a `http://` URL. This is fine for most cases, but the demo is deployed behind HTTPS, which means another round trip to Cloudflare to be redirected from `http://` to `https://`. In particular, the infra team is monitoring for correct HTTP->HTTPS redirects by requesting `/`, and in the journalist app, unauthenticated, this is a redirect to `/login`.

(We used to paper over this on the infra end by having nginx rewrite the redirect, but I'd prefer not to port that over.)

There is a Flask middleware to address this problem: https://werkzeug.palletsprojects.com/en/2.1.x/middleware/proxy_fix/?highlight=proxyfix#werkzeug.middleware.proxy_fix.ProxyFix - in particular here we're looking for "`X-Forwarded-Proto` sets `wsgi.url_scheme`.", which makes URLs constructed with `url_for` correct.

One nit with this middleware is that we have to tell mypy to ignore the reassignment, since the `wsgi_app` member is actually a method: https://github.com/python/mypy/issues/7347 . So there's a comment that disables type checking on that.

I have only added it to the journalist app, not the source app, since there isn't any impact on our monitoring there -- should I, though?

## Testing

Compare:
- `curl -v http://localhost:8081/`
- `curl -H "X-Forwarded-Proto: https" -v http://localhost:8081/`

I see that there is an automated test of the `/` -> `/login` redirect here: https://github.com/freedomofpress/securedrop/blob/develop/securedrop/tests/test_journalist.py#L213 but I am unsure if adding this header can be mocked for both the request and the `url_for` that the resulting location is checked against. Do we need an additional test for this case, or is it sufficient that existing tests still pass with the middleware added but no `X-Forwarded` headers?

## Deployment

I do not think this middleware will interfere with normal onion/HTTP deployments.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
