### PR TITLE
Updated SI index page to reflow to single vertical column on small screens.

### DIFF
--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -297,8 +297,24 @@ header
       padding-top: 0
       min-height: unset
 
-    p
+    &> section:not(#locales-menu):not(#flashed)
+
+      width: 100%
+      padding-top: 10px
+      min-height: unset
+
+      &:first-child
+        @include ltr
+          border-right: 0
+        @include rtl
+          border-left: 0
+
+      &#return-visit
+        padding-left: 50px
+
+    p, hr
       width: auto
+      max-width: 500px
 
     button, .btn
       width: 80%
@@ -314,6 +330,10 @@ header
 
       div
         width: auto
+
+
+
+
 
 // Logo is a simple anchor on all pages except index
 header h1, header h1 a

--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -285,22 +285,15 @@ header
   html #upload .attachment input
     font-size: 130%
 
-  html #source-index > .content > main
+  // no html selector here because we use the ltr/rtl includes here
+  #source-index > .content > main
     display: block
     width: 100%
 
-    &> section
-      border: 0
+    &> section:not(#locales-menu):not(#flashed)
       width: auto
       margin: 0
-      padding-left: 30px
       padding-top: 0
-      min-height: unset
-
-    &> section:not(#locales-menu):not(#flashed)
-
-      width: 100%
-      padding-top: 10px
       min-height: unset
 
       &:first-child
@@ -310,9 +303,9 @@ header
           border-left: 0
 
       &#return-visit
-        padding-left: 50px
+        padding-left: 45px
 
-    p, hr
+    p
       width: auto
       max-width: 500px
 
@@ -330,10 +323,6 @@ header
 
       div
         width: auto
-
-
-
-
 
 // Logo is a simple anchor on all pages except index
 header h1, header h1 a


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6443 .

CSS update to restore the source interfaces index page's vertical layout on screens <= 768px 

## Testing

- spin up a dev instance from this branch and from the 2.4.0-rc1 tag
 - [ ] Compare with screen sizes at >768px and confirm no layout differences
 - [ ] Compare with screen sizes at <=768px and confirm that the version on this branch displays all sections in a single column using the full screen width and with no separator on the `First Submission` section.

## Deployment
n/a

## Checklist
### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
