### PR TITLE
Re-add modal-x-white.png to apparmor profile

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -264,6 +264,7 @@
   /var/www/securedrop/static/i/material/trash.png r,
   /var/www/securedrop/static/i/material/trash-outline.png r,
   /var/www/securedrop/static/i/info-small.png r,
+  /var/www/securedrop/static/i/modal-x-white.png r,
   /var/www/securedrop/static/i/source.png r,
   /var/www/securedrop/static/i/torbroom.png r,
   /var/www/securedrop/static/i/upload.png r,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Re-add modal-x-white.png to apparmor profile

Was accidentally removed in #6315, but it's still used in the deletion
modal dialogs (_confirm-modal.sass).

Refs #6445.

## Testing

In a staging environment:
* [ ] Log into the JI and visit `/static/i/modal-x-white.png`
* [ ] Verify there are no apparmor denial entries

## Deployment

Any special considerations for deployment? No

## Checklist

- [x] I have updated AppArmor rules to include the change
