### PR TITLE
Make Orca re-read warnings with links and alt attributes

### DIFF
--- a/securedrop/sass/source.sass
+++ b/securedrop/sass/source.sass
@@ -174,6 +174,9 @@ body > .warning
   text-align: center
   padding: 10px
 
+  p
+    margin: 0
+
   a, a:hover, a:visited, a:active, a:focus-visible, b
     color: $warning_browser_color
     border: 0

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -21,7 +21,7 @@
 
 <body id="source-index">
   <div id="browser-security-level" class="warning" role="alert">
-    {{ gettext('Your Tor Browser\'s <a id="disable-js" href=""><b>Security Level</b></a> is too low. Use the <img src="{icon}" alt="&quot;Security Level&quot;"> button in your browser’s toolbar to change it.').format(icon=url_for("static", filename="i/font-awesome/white/guard.svg")) }}
+    <p>{{ gettext('Your Tor Browser\'s <a id="disable-js" href=""><b>Security Level</b></a> is too low. Use the <img src="{icon}" alt="&quot;Security Level&quot;"> button in your browser’s toolbar to change it.').format(icon=url_for("static", filename="i/font-awesome/white/guard.svg")) }}</p>
   </div>
   {# Warning bubble to help TB users disable JavaScript with Tor Browser's Security Levels
     Included here so the images can preload while the user is first
@@ -41,12 +41,12 @@
     </p>
   </dialog>
   <div id="browser-tb" class="warning" role="alert">
-    {{ gettext('<strong>It is recommended to use Tor Browser to access SecureDrop:</strong> <a class="recommend-tor" href="{tor_browser_url}">Learn how to install it</a>, or ignore this warning to continue.').format(tor_browser_url=url_for('info.recommend_tor_browser')) }}
-    <span id="browser-tb-close" aria-label="{{ gettext('Close') }}">×</span>
+    <p>{{ gettext('<strong>It is recommended to use Tor Browser to access SecureDrop:</strong> <a class="recommend-tor" href="{tor_browser_url}">Learn how to install it</a>, or ignore this warning to continue.').format(tor_browser_url=url_for('info.recommend_tor_browser')) }}
+    <span id="browser-tb-close" aria-label="{{ gettext('Close') }}">×</span></p>
   </div>
   <div id="browser-android" class="warning" role="alert">
-    {{ gettext('<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Orfox does not provide the same level of security and anonymity as the desktop version.</strong> <a class="recommend-tor" href="{tor_browser_url}">Learn how to install it</a>, or ignore this warning to continue.').format(tor_browser_url=url_for('info.recommend_tor_browser')) }}
-    <span id="browser-android-close" aria-label="{{ gettext('Close') }}">×</span>
+    <p>{{ gettext('<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Orfox does not provide the same level of security and anonymity as the desktop version.</strong> <a class="recommend-tor" href="{tor_browser_url}">Learn how to install it</a>, or ignore this warning to continue.').format(tor_browser_url=url_for('info.recommend_tor_browser')) }}
+    <span id="browser-android-close" aria-label="{{ gettext('Close') }}">×</span></p>
   </div>
 
   <div class="content">


### PR DESCRIPTION
## Description of Changes

Orca will only read the full warnings with links and alt attributes when `p` is nested in a `div`. Since we want to expose the functionality and information to people using Orca as a screen-reader, re-introduce the `p` for the warning text.

Fixes #6452

## Testing

* Fire up Orca
* Visit Source Interface with Tor Browser while having set its **Security Level** to **Standard**
* [ ] 1st reading of the warning: confirm you can hear a "flat" alert, Orca is reading the text but leaves out the link and `alt` attribute
* [ ] 2nd reading: confirm that you can hear that there's a *Security Level* link in the warning message
* [ ] 2nd reading: confirm that you can hear that the **Security Level** button in the toolbar can be used to change that setting

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation