### PR TITLE
Fix issues with token reuse:

### DIFF
--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -767,7 +767,7 @@ def test_user_edits_password_error_response(config, journalist_app, test_journo,
             # to the database and this isolates the one we want to fail
             with patch.object(Journalist, 'verify_token', return_value=True):
                 with patch.object(db.session, 'commit',
-                                  side_effect=Exception()):
+                                  side_effect=[None, Exception()]):
                     with InstrumentedApp(journalist_app) as ins:
                         resp = app.post(
                             url_for('account.new_password', l=locale),


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes an internally discovered issue.
In `models.py`, fixes two conditions in which the token reuse protection fails:

1) The token is normalized after comparison with `last_token`
2) `last_token` is updated regardless of the reult of `verify_token`

The simple fix is just to change the order of statements in order to force the intended behavior, which is nornalize before everything else and update only if valid.

## Testing

A few tests are updated to reflect the new order of operations.
 * `test_totp_reuse_protections3` checks that normalization happen before everything else
 * `test_totp_reuse_protections4` checks that an ivalid token does not update `last_token`


## Deployment
To be included in 2.4.0, no particular changes to setup or configuration are require for these changes.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] These changes do not require documentation


