### PR TITLE
Update builder hash to version tagged 2022_05_23

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_05_05
-8a4a0671d9155b4707055069263f36be0f5276c384ad8056bcb7c71f77200c49
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_05_23
+e206eeb8d1a307db74d7e782a505f83aa60a3455ab3dd71a496d8d7706cda615


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Towards #6440 

Update builder image to version tagged 2022_05_23

## Testing
- [x] only image_hash is updated
- [x] CI is passing, particularly `deb-tests`
- [x] `make build-debs` passes locally