### PR TITLE
[2.4.0] Backport builder image update

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_05_05
-8a4a0671d9155b4707055069263f36be0f5276c384ad8056bcb7c71f77200c49
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_05_23
+e206eeb8d1a307db74d7e782a505f83aa60a3455ab3dd71a496d8d7706cda615


### PR DESCRIPTION
## Description of Changes

Backports #6462

## Testing

* [x] branch contains only commit(s) from #6462
* [x] base is `release/2.4.0`
* [x] CI is passing
