### PR TITLE
fix: `format()` outside `gettext()`

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -159,7 +159,7 @@ Deleting the account for <b>{source}</b> will:
 </ul>
 <p>
 All files, messages, and replies will also be deleted when their account is deleted.
-</p>'.format(source=source.journalist_designation)),
+</p>').format(source=source.journalist_designation),
                             "cancel_id": "cancel-collection-deletions",
                             "submit_id": "delete-collection-button",
                             "submit_btn_type": "danger",


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes another instance of the form `gettext(string.format())`, like #6368.

## Testing

- `make translate`
- [ ] Expected diff appears:
    ```sh-session
    user@sd-dev:~/securedrop$ git diff securedrop/translations/messages.pot
    diff --git a/securedrop/translations/messages.pot b/securedrop/translations/messages.pot
    index cc36b9f59..fc3f1bfdf 100644
    --- a/securedrop/translations/messages.pot
    +++ b/securedrop/translations/messages.pot
    @@ -509,6 +509,19 @@ msgstr ""
     msgid "Are you sure?"
     msgstr ""
 
    +msgid ""
    +"<p>\n"
    +"Deleting the account for <b>{source}</b> will:\n"
    +"</p>\n"
    +"<ul>\n"
    +"<li>prevent them from logging in with their codename again\n"
    +"<li>prevent your organization from sending replies\n"
    +"</ul>\n"
    +"<p>\n"
    +"All files, messages, and replies will also be deleted when their account is deleted.\n"
    +"</p>"
    +msgstr ""
    +
     msgid "Yes, Delete Source Account"
     msgstr ""
    ```


## Deployment

No special considerations.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container