### PR TITLE
Added boundary check on image crop in pagelayout tests

### DIFF
--- a/securedrop/tests/pageslayout/functional_test.py
+++ b/securedrop/tests/pageslayout/functional_test.py
@@ -48,7 +48,7 @@ def autocrop_btm(img, bottom_padding=12):
     bg = gray.getpixel((0, btm))
 
     # Move up until the full row is not of the background luminance
-    while all([gray.getpixel((col, btm)) == bg for col in range(gray.width)]):
+    while btm > 0 and all([gray.getpixel((col, btm)) == bg for col in range(gray.width)]):
         btm -= 1
 
     btm = min(btm + bottom_padding, img.height)


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes intermittent failure in `test_account_edit_hotp_secret` pagelayout test.



## Testing

- [x] CI is passing
- [x] `securedrop/bin/dev-shell bin/run-test -m pagelayout` completes successfully locally
- [ ] screenshots in `securedrop/tests/pagelayouts/screenshots` look correct.


