### PR TITLE
Ignore bogus pylint "security" issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 42050 \
 		--ignore 42926 \
 		--ignore 42923 \
+		--ignore 45185 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

<https://github.com/PyCQA/pylint/issues/5322> describes a crash when
using a specific extension that we don't use, and really isn't a
security issue at all.

Ideally we'd upgrade pylint anyways, but we've fallen a bit behind
and it isn't a trivial version bump.

## Testing

* [x] Run `make safety`, observe it complains about nothing

## Deployment

Any special considerations for deployment? No
## Checklist

- [x] These changes do not require documentation
