### PR TITLE
Refactor page layout tests for source app

### DIFF
--- a/securedrop/tests/functional/pageslayout/test_source.py
+++ b/securedrop/tests/functional/pageslayout/test_source.py
@@ -15,86 +15,67 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from tests.functional import journalist_navigation_steps
-from tests.functional import source_navigation_steps
-from . import functional_test
 import pytest
 
+from tests.functional.app_navigators import SourceAppNagivator
+from tests.functional.pageslayout.functional_test import list_locales
+from tests.functional.pageslayout.screenshot_utils import save_screenshot_and_html
 
+
+@pytest.mark.parametrize("locale", list_locales())
 @pytest.mark.pagelayout
-class TestSourceLayout(
-        functional_test.FunctionalTest,
-        source_navigation_steps.SourceNavigationStepsMixin,
-        journalist_navigation_steps.JournalistNavigationStepsMixin):
+class TestSourceLayout:
+    def test(self, locale, sd_servers_v2_with_clean_state, tor_browser_web_driver):
+        # Given a source user accessing the app from their browser
+        locale_with_commas = locale.replace("_", "-")
+        source_app_nav = SourceAppNagivator(
+            source_app_base_url=sd_servers_v2_with_clean_state.source_app_base_url,
+            web_driver=tor_browser_web_driver,
+            accept_languages=locale_with_commas,
+        )
 
-    def test_lookup(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._screenshot('source-lookup.png')
-        self._save_html('source-lookup.html')
+        # And they created an account
+        source_app_nav.source_visits_source_homepage()
 
-    def test_lookup_shows_codename(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_shows_codename()
-        self._screenshot('source-lookup-shows-codename.png')
-        self._save_html('source-lookup-shows-codename.html')
+        # Take a screenshot of the "account created" page
+        source_app_nav.source_clicks_submit_documents_on_homepage()
+        save_screenshot_and_html(source_app_nav.driver, locale, "source-generate")
 
-    def test_login(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_login()
-        self._screenshot('source-login.png')
-        self._save_html('source-login.html')
+        # Take a screenshot of showing the codename hint
+        source_app_nav.source_continues_to_submit_page()
+        source_app_nav.source_retrieves_codename_from_hint()
+        save_screenshot_and_html(source_app_nav.driver, locale, "source-lookup-shows-codename")
 
-    def test_enters_text_in_login_form(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_login()
-        self._source_enters_codename_in_login_form()
-        self._screenshot('source-enter-codename-in-login.png')
-        self._save_html('source-enter-codename-in-login.html')
+        # Take a screenshot of entering text in the message field
+        source_app_nav.nav_helper.safe_send_keys_by_id("msg", "Secret message éè")
+        save_screenshot_and_html(source_app_nav.driver, locale, "source-submission_entered_text")
 
-    def test_generate(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._screenshot('source-generate.png')
-        self._save_html('source-generate.html')
+        # Take a screenshot of submitting a file
+        source_app_nav.source_submits_a_file()
+        save_screenshot_and_html(source_app_nav.driver, locale, "source-lookup")
 
-    def test_submission_entered_text(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_enters_text_in_message_field()
-        self._screenshot('source-submission_entered_text.png')
-        self._save_html('source-submission_entered_text.html')
+        # Take a screenshot of doing a second submission
+        source_app_nav.source_submits_a_message()
+        save_screenshot_and_html(
+            source_app_nav.driver, locale, "source-next_submission_flashed_message"
+        )
 
-    def test_next_submission_flashed_message(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_submits_a_message()
-        self._screenshot('source-next_submission_flashed_message.png')
-        self._save_html('source-next_submission_flashed_message.html')
+    def test_login(self, locale, sd_servers_v2_with_clean_state, tor_browser_web_driver):
+        # Given a source user accessing the app from their browser
+        source_app_nav = SourceAppNagivator(
+            source_app_base_url=sd_servers_v2_with_clean_state.source_app_base_url,
+            web_driver=tor_browser_web_driver,
+        )
 
-    # TODO(AD): This should be merged with test_submit_and_retrieve_happy_path()
-    def test_source_checks_for_reply(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_checks_messages()
-        self._journalist_downloads_message()
-        self._journalist_sends_reply_to_source()
-        self._source_visits_source_homepage()
-        self._source_chooses_to_login()
-        self._source_proceeds_to_login()
-        self._screenshot('source-checks_for_reply.png')
-        self._save_html('source-checks_for_reply.html')
-        self._source_deletes_a_journalist_reply()
-        self._screenshot('source-deletes_reply.png')
-        self._save_html('source-deletes_reply.html')
+        # And they created an account
+        source_app_nav.source_visits_source_homepage()
+
+        # Take a screenshot of the login page
+        source_app_nav.source_chooses_to_login()
+        save_screenshot_and_html(source_app_nav.driver, locale, "source-login")
+
+        # Take a screenshot of entering text in the login form
+        source_app_nav.nav_helper.safe_send_keys_by_id(
+            "codename", "ascension hypertext concert synopses"
+        )
+        save_screenshot_and_html(source_app_nav.driver, locale, "source-enter-codename-in-login")

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -39,12 +39,6 @@ class SourceNavigationStepsMixin:
             # a diceware codename they can use for subsequent logins
             assert self._is_on_generate_page()
 
-    def _source_regenerates_codename(self):
-        self._source_visits_source_homepage()
-        # We do not want to assert success here since it's possible they got
-        # redirected if already logged in.
-        self._source_clicks_submit_documents_on_homepage(assert_success=False)
-
     def _source_chooses_to_submit_documents(self):
         self._source_clicks_submit_documents_on_homepage()
 
@@ -52,57 +46,6 @@ class SourceNavigationStepsMixin:
 
         assert len(codename.text) > 0
         self.source_name = codename.text
-
-    def _source_shows_codename(self, verify_source_name=True):
-        # We use inputs to change CSS states for subsequent elements in the DOM, if it is unchecked
-        # the codename is hidden
-        content = self.driver.find_element_by_id("codename-show-checkbox")
-        assert content.get_attribute("checked") is None
-
-        # In the UI, the label is actually the element that is being clicked, altering the state
-        # of the input
-        self.safe_click_by_id("codename-show")
-
-        assert content.get_attribute("checked") is not None
-        content_content = self.driver.find_element_by_css_selector("#codename span")
-        if verify_source_name:
-            assert content_content.text == self.source_name
-
-    def _source_hides_codename(self):
-        # We use inputs to change CSS states for subsequent elements in the DOM, if it is checked
-        # the codename is visible
-        content = self.driver.find_element_by_id("codename-show-checkbox")
-        assert content.get_attribute("checked") is not None
-
-        # In the UI, the label is actually the element that is being clicked, altering the state
-        # of the input
-        self.safe_click_by_id("codename-show")
-
-        assert content.get_attribute("checked") is None
-
-    def _source_sees_no_codename(self):
-        codename = self.driver.find_elements_by_css_selector("#codename span")
-        assert len(codename) == 0
-
-    def _source_chooses_to_login(self):
-        self.safe_click_by_css_selector("#return-visit a")
-
-        self.wait_for(lambda: self.driver.find_elements_by_id("source-login"))
-
-    def _source_proceeds_to_login(self):
-        self.safe_send_keys_by_id("codename", self.source_name)
-        self.safe_click_by_css_selector(".form-controls button")
-
-        # Check that we've logged in
-        assert self._is_logged_in()
-
-        replies = self.driver.find_elements_by_id("replies")
-        assert len(replies) == 1
-
-    def _source_enters_codename_in_login_form(self):
-        self.safe_send_keys_by_id(
-            "codename", "ascension hypertext concert synopses"
-        )
 
     def _source_continues_to_submit_page(self, files_allowed=True):
         self.safe_click_by_css_selector("#create-form button")
@@ -170,31 +113,6 @@ class SourceNavigationStepsMixin:
     def _source_enters_text_in_message_field(self):
         self.safe_send_keys_by_id("msg", self.secret_message)
 
-    def _source_deletes_a_journalist_reply(self):
-        # Get the reply filename so we can use IDs to select the delete buttons
-        reply_filename_element = self.driver.find_element_by_name("reply_filename")
-        reply_filename = reply_filename_element.get_attribute("value")
-
-        confirm_dialog_id = "confirm-delete-{}".format(reply_filename)
-        self.safe_click_by_css_selector("a[href='#{}']".format(confirm_dialog_id))
-
-        def confirm_displayed():
-            confirm_dialog = self.driver.find_element_by_id(confirm_dialog_id)
-            confirm_dialog.location_once_scrolled_into_view
-            assert confirm_dialog.is_displayed()
-
-        self.wait_for(confirm_displayed)
-        # Due to the . in the filename (which is used as ID), we need to escape it because otherwise
-        # we'd select the class gpg
-        self.safe_click_by_css_selector("#{} button".format(confirm_dialog_id.replace(".", "\\.")))
-
-        def reply_deleted():
-            if not self.accept_languages:
-                notification = self.driver.find_element_by_class_name("success")
-                assert "Reply deleted" in notification.text
-
-        self.wait_for(reply_deleted)
-
     def _source_logs_out(self):
         self.safe_click_by_id("logout")
         assert self._is_on_logout_page()
@@ -205,17 +123,3 @@ class SourceNavigationStepsMixin:
     def _source_does_not_sees_document_attachment_item(self):
         with pytest.raises(NoSuchElementException):
             self.driver.find_element_by_class_name("attachment")
-
-    def _source_sees_already_logged_in_in_other_tab_message(self):
-        notification = self.driver.find_element_by_class_name("notification")
-
-        if not self.accept_languages:
-            expected_text = "You are already logged in."
-            assert expected_text in notification.text
-
-    def _source_sees_redirect_already_logged_in_message(self):
-        notification = self.driver.find_element_by_class_name("notification")
-
-        if not self.accept_languages:
-            expected_text = "You were redirected because you are already logged in."
-            assert expected_text in notification.text


### PR DESCRIPTION
## Status

Ready

## Description of Changes

This PR continue the work from https://github.com/freedomofpress/securedrop/pull/6383, by bringing the new test code and fixtures to a few more functional tests for the source app.

More specifically, this PR:

* Brings the new test fixtures to a couple layout tests (for #3836).
* Combine a few layout tests into one, for a slightly faster test suite.