### PR TITLE
Refactor functional tests for journalist app filters

### DIFF
--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -142,53 +142,8 @@ class JournalistNavigationStepsMixin:
     def _journalist_clicks_on_modal(self, click_id):
         self.safe_click_by_id(click_id)
 
-    def _journalist_clicks_delete_collections_cancel_on_first_modal(self):
-        self._journalist_clicks_on_modal("delete-menu-dialog-cancel")
-
-    def _journalist_clicks_delete_collections_cancel_on_second_modal(self):
-        self._journalist_clicks_on_modal("cancel-collections-deletions")
-
     def _journalist_clicks_delete_collections_cancel_on_modal(self):
         self._journalist_clicks_on_modal("cancel-collections-deletions")
-
-    def _journalist_clicks_delete_selected_cancel_on_modal(self):
-        self._journalist_clicks_on_modal("cancel-selected-deletions")
-
-    def _journalist_clicks_delete_collection_cancel_on_modal(self):
-        self._journalist_clicks_on_modal("cancel-collection-deletions")
-
-    def _journalist_clicks_delete_files_on_first_modal(self):
-        self._journalist_clicks_on_modal("delete-files-and-messages")
-
-    def _journalist_clicks_delete_collections_on_first_modal(self):
-        self._journalist_clicks_on_modal("delete-collections")
-
-        self.wait_for(lambda: self.driver.find_element_by_id("delete-collections-confirm"))
-
-    def _journalist_clicks_delete_collections_on_second_modal(self):
-        self._journalist_clicks_on_modal("delete-collections-confirm")
-
-        def collection_deleted():
-            if not self.accept_languages:
-                flash_msg = self.driver.find_element_by_css_selector(".flash")
-                assert (
-                    "The account and all data for the source have been deleted." in flash_msg.text
-                )
-
-        self.wait_for(collection_deleted)
-
-    def _journalist_clicks_delete_selected_on_modal(self):
-        self._journalist_clicks_on_modal("delete-selected")
-
-        def submission_deleted():
-            if not self.accept_languages:
-                flash_msg = self.driver.find_element_by_css_selector(".flash")
-                assert "The item has been deleted." in flash_msg.text
-
-        self.wait_for(submission_deleted)
-
-    def _journalist_clicks_delete_collection_on_modal(self):
-        self._journalist_clicks_on_modal("delete-collection-button")
 
     def _journalist_clicks_delete_link(self, click_id, displayed_id):
         self.safe_click_by_id(click_id)
@@ -197,111 +152,6 @@ class JournalistNavigationStepsMixin:
     def _journalist_clicks_delete_selected_link(self):
         self.safe_click_by_css_selector("a#delete-selected-link")
         self.wait_for(lambda: self.driver.find_element_by_id("delete-selected-confirmation-modal"))
-
-    def _journalist_clicks_delete_collections_link(self):
-        self._journalist_clicks_delete_link("delete-collections-link", "delete-sources-modal")
-
-    def _journalist_clicks_delete_collection_link(self):
-        self._journalist_clicks_delete_link(
-            "delete-collection-link", "delete-collection-confirmation-modal"
-        )
-
-    def _journalist_uses_delete_selected_button_confirmation(self):
-        selected_count = len(self.driver.find_elements_by_name("doc_names_selected"))
-        assert selected_count > 0
-
-        self._journalist_selects_first_doc()
-        self._journalist_clicks_delete_selected_link()
-        self._journalist_clicks_delete_selected_cancel_on_modal()
-        assert selected_count == len(self.driver.find_elements_by_name("doc_names_selected"))
-
-        self._journalist_clicks_delete_selected_link()
-        self._journalist_clicks_delete_selected_on_modal()
-
-        def docs_deleted():
-            assert selected_count > len(self.driver.find_elements_by_name("doc_names_selected"))
-
-        self.wait_for(docs_deleted)
-
-    def _journalist_uses_delete_collection_button_confirmation(self):
-        self._journalist_clicks_delete_collection_link()
-        self._journalist_clicks_delete_collection_cancel_on_modal()
-        self._journalist_clicks_delete_collection_link()
-        self._journalist_clicks_delete_collection_on_modal()
-
-        # Now we should be redirected to the index.
-        assert self._is_on_journalist_homepage()
-
-    def _journalist_uses_delete_collections_button_confirmation(self):
-        sources = self.driver.find_elements_by_class_name("code-name")
-        assert len(sources) > 0
-
-        try:
-            # If JavaScript is enabled, use the select_all button.
-            self.driver.find_element_by_id("select_all")
-            self.safe_click_by_id("select_all")
-        except NoSuchElementException:
-            self.safe_click_all_by_css_selector('input[type="checkbox"][name="cols_selected"]')
-
-        self._journalist_clicks_delete_collections_link()
-        self._journalist_clicks_delete_collections_cancel_on_first_modal()
-
-        sources = self.driver.find_elements_by_class_name("code-name")
-        assert len(sources) > 0
-
-        self._journalist_clicks_delete_collections_link()
-        self._journalist_clicks_delete_collections_on_first_modal()
-        self._journalist_clicks_delete_collections_cancel_on_second_modal()
-
-        self._journalist_clicks_delete_collections_link()
-        self._journalist_clicks_delete_collections_on_first_modal()
-        self._journalist_clicks_delete_collections_on_second_modal()
-
-        # We should be redirected to the index without those boxes selected.
-        def no_sources():
-            assert len(self.driver.find_elements_by_class_name("code-name")) == 0
-
-        self.wait_for(no_sources)
-
-    def _journalist_uses_index_delete_files_button_confirmation(self):
-        sources = self.driver.find_elements_by_class_name("code-name")
-        assert len(sources) > 0
-
-        try:
-            # If JavaScript is enabled, use the select_all button.
-            self.driver.find_element_by_id("select_all")
-            self.safe_click_by_id("select_all")
-        except NoSuchElementException:
-            self.safe_click_all_by_css_selector('input[type="checkbox"][name="cols_selected"]')
-
-        self._journalist_clicks_delete_collections_link()
-        time.sleep(5)
-        self._journalist_clicks_delete_collections_cancel_on_first_modal()
-        time.sleep(5)
-
-        sources = self.driver.find_elements_by_class_name("code-name")
-        assert len(sources) > 0
-
-        self._journalist_clicks_delete_collections_link()
-        time.sleep(5)
-        self._journalist_clicks_delete_files_on_first_modal()
-        time.sleep(5)
-
-        # We should be redirected to the index with the source present, files
-        # and messages zeroed, and a success flash message present
-
-        def one_source_no_files():
-            assert len(self.driver.find_elements_by_class_name("code-name")) == 1
-            if not self.accept_languages:
-                flash_msg = self.driver.find_element_by_css_selector(".flash")
-                assert "The files and messages have been deleted" in flash_msg.text
-            if not self.accept_languages:
-                counts = self.driver.find_elements_by_css_selector(".submission-count")
-                assert "0 docs" in counts[0].text
-                assert "0 messages" in counts[1].text
-
-        self.wait_for(one_source_no_files)
-        time.sleep(5)
 
     def _admin_logs_in(self):
         self.admin = self.admin_user["name"]
@@ -775,17 +625,6 @@ class JournalistNavigationStepsMixin:
 
         self.wait_for(message_unstarred)
 
-    def _journalist_selects_all_sources_then_selects_none(self):
-        self.driver.find_element_by_id("select_all").click()
-        checkboxes = self.driver.find_elements_by_id("checkbox")
-        for checkbox in checkboxes:
-            assert checkbox.is_selected()
-
-        self.driver.find_element_by_id("select_none").click()
-        checkboxes = self.driver.find_elements_by_id("checkbox")
-        for checkbox in checkboxes:
-            assert checkbox.is_selected() is False
-
     def _journalist_selects_the_first_source(self):
         self.driver.find_element_by_css_selector("#un-starred-source-link-1").click()
 
@@ -1083,103 +922,6 @@ class JournalistNavigationStepsMixin:
         self.safe_send_keys_by_css_selector('input[name="username"]', username)
         self.safe_send_keys_by_css_selector('input[name="otp_secret"]', hotp_secret)
         self.safe_click_by_css_selector('input[name="is_hotp"]')
-
-    def _journalist_uses_js_filter_by_sources(self):
-        filter_box = self.safe_send_keys_by_id("filter", "thiswordisnotinthewordlist")
-        sources = self.driver.find_elements_by_class_name("code-name")
-        assert len(sources) > 0
-        for source in sources:
-            assert source.is_displayed() is False
-        filter_box.clear()
-        filter_box.send_keys(Keys.RETURN)
-
-        for source in sources:
-            assert source.is_displayed() is True
-
-    def _journalist_source_selection_honors_filter(self):
-        """Check that select all/none honors the filter in effect."""
-
-        self.wait_for(lambda: self.driver.find_element_by_id("filter"), 60)
-
-        # make sure the list is not filtered
-        filter_box = self.driver.find_element_by_id("filter")
-        filter_box.clear()
-        filter_box.send_keys(Keys.RETURN)
-
-        # get the journalist designation of the first source
-        sources = self.driver.find_elements_by_class_name("code-name")
-        assert len(sources) > 0
-        first_source_designation = sources[0].text
-
-        # filter the source list so only the first is visible
-        filter_box.send_keys(first_source_designation)
-        for source in sources:
-            assert source.text == first_source_designation or source.is_displayed() is False
-
-        # clicking "select all" should only select the visible source
-        select_all = self.driver.find_element_by_id("select_all")
-        select_all.click()
-
-        source_rows = self.driver.find_elements_by_css_selector("#cols li.source")
-        for source_row in source_rows:
-            source_designation = source_row.get_attribute("data-source-designation")
-            checkbox = source_row.find_element_by_css_selector("input[type=checkbox]")
-            if source_designation == first_source_designation:
-                assert checkbox.is_selected()
-            else:
-                assert not checkbox.is_selected()
-
-        # clear the filter
-        filter_box.clear()
-        filter_box.send_keys(Keys.RETURN)
-
-        # select all sources
-        select_all.click()
-        for source_row in source_rows:
-            checkbox = source_row.find_element_by_css_selector("input[type=checkbox]")
-            assert checkbox.is_selected()
-
-        # now filter again
-        filter_box.send_keys(first_source_designation)
-
-        # clicking "select none" should only deselect the visible source
-        select_none = self.driver.find_element_by_id("select_none")
-        select_none.click()
-        for source_row in source_rows:
-            source_designation = source_row.get_attribute("data-source-designation")
-            checkbox = source_row.find_element_by_css_selector("input[type=checkbox]")
-            if source_designation == first_source_designation:
-                assert not checkbox.is_selected()
-            else:
-                assert checkbox.is_selected()
-
-        # clear the filter and leave none selected
-        filter_box.clear()
-        filter_box.send_keys(Keys.RETURN)
-        select_none.click()
-
-        for source_row in source_rows:
-            assert source_row.is_displayed()
-            checkbox = source_row.find_element_by_css_selector("input[type=checkbox]")
-            assert not checkbox.is_selected()
-
-    def _journalist_uses_js_buttons_to_download_unread(self):
-        self.driver.find_element_by_id("select_all").click()
-        checkboxes = self.driver.find_elements_by_name("doc_names_selected")
-        assert len(checkboxes) > 0
-        for checkbox in checkboxes:
-            assert checkbox.is_selected()
-
-        self.driver.find_element_by_id("select_none").click()
-        checkboxes = self.driver.find_elements_by_name("doc_names_selected")
-        for checkbox in checkboxes:
-            assert checkbox.is_selected() is False
-
-        self.driver.find_element_by_id("select_unread").click()
-        checkboxes = self.driver.find_elements_by_name("doc_names_selected")
-        for checkbox in checkboxes:
-            classes = checkbox.get_attribute("class")
-            assert "unread-cb" in classes
 
     def _journalist_sees_missing_file_error_message(self, single_file=False):
         notification = self.driver.find_element_by_css_selector(".error")

--- a/securedrop/tests/functional/pageslayout/test_journalist_account.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_account.py
@@ -18,15 +18,13 @@
 import pytest
 
 from tests.functional import journalist_navigation_steps
-from tests.functional import source_navigation_steps
 import tests.functional.pageslayout.functional_test as pft
 
 
 @pytest.mark.pagelayout
 class TestJournalistLayoutAccount(
-        pft.FunctionalTest,
-        source_navigation_steps.SourceNavigationStepsMixin,
-        journalist_navigation_steps.JournalistNavigationStepsMixin):
+    pft.FunctionalTest, journalist_navigation_steps.JournalistNavigationStepsMixin
+):
 
     def test_account_edit_hotp_secret(self):
         self._journalist_logs_in()

--- a/securedrop/tests/functional/pageslayout/test_journalist_admin.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_admin.py
@@ -18,15 +18,13 @@
 import pytest
 
 from tests.functional import journalist_navigation_steps
-from tests.functional import source_navigation_steps
 import tests.functional.pageslayout.functional_test as pft
 
 
 @pytest.mark.pagelayout
 class TestJournalistLayoutAdmin(
-        pft.FunctionalTest,
-        source_navigation_steps.SourceNavigationStepsMixin,
-        journalist_navigation_steps.JournalistNavigationStepsMixin):
+    pft.FunctionalTest, journalist_navigation_steps.JournalistNavigationStepsMixin
+):
 
     def test_admin_add_user_hotp(self):
         self._admin_logs_in()

--- a/securedrop/tests/functional/pageslayout/test_journalist_delete.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_delete.py
@@ -24,6 +24,7 @@ from tests.functional import source_navigation_steps
 import tests.functional.pageslayout.functional_test as pft
 
 
+# TODO(AD): This should be merged with TestJournalist
 @pytest.mark.pagelayout
 class TestJournalistLayoutDelete(
         pft.FunctionalTest,
@@ -44,6 +45,8 @@ class TestJournalistLayoutDelete(
         self._screenshot('journalist-delete_none.png')
         self._save_html('journalist-delete_none.html')
 
+    # TODO(AD): This should be merged with
+    #  test_journalist_verifies_deletion_of_one_submission_modal()
     def test_delete_one_confirmation(self):
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()
@@ -59,6 +62,7 @@ class TestJournalistLayoutDelete(
         self._screenshot('journalist-delete_one_confirmation.png')
         self._save_html('journalist-delete_one_confirmation.html')
 
+    # TODO(AD): This should be merged with test_journalist_interface_ui_with_modal()
     def test_delete_all_confirmation(self):
         self._source_visits_source_homepage()
         self._source_chooses_to_submit_documents()

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -20,83 +20,358 @@ from pathlib import Path
 import pytest
 
 from source_user import _SourceScryptManager
-from . import functional_test as ft
-from . import journalist_navigation_steps
-from . import source_navigation_steps
+from tests.functional import functional_test as ft
+from tests.functional import journalist_navigation_steps
+from tests.functional import source_navigation_steps
 from store import Storage
 
-from tbselenium.utils import SECURITY_LOW
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.keys import Keys
+
+from tests.functional.app_navigators import JournalistAppNavigator
 
 
-class TestJournalist(
-    ft.FunctionalTest,
-    source_navigation_steps.SourceNavigationStepsMixin,
-    journalist_navigation_steps.JournalistNavigationStepsMixin,
-):
-    def test_journalist_verifies_deletion_of_one_submission_modal(self):
-        # This deletion button is displayed on the individual source page
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_uses_delete_selected_button_confirmation()
+class TestJournalist:
+    def test_journalist_verifies_deletion_of_one_submission_modal(
+        self, sd_servers_v2_with_submitted_file, firefox_web_driver
+    ):
+        # Given an SD server with a file submitted by a source
+        # And a journalist logged into the journalist interface
+        journ_app_nav = JournalistAppNavigator(
+            journalist_app_base_url=sd_servers_v2_with_submitted_file.journalist_app_base_url,
+            web_driver=firefox_web_driver,
+        )
+        journ_app_nav.journalist_logs_in(
+            username=sd_servers_v2_with_submitted_file.journalist_username,
+            password=sd_servers_v2_with_submitted_file.journalist_password,
+            otp_secret=sd_servers_v2_with_submitted_file.journalist_otp_secret,
+        )
 
-    def test_journalist_uses_col_delete_collection_button_modal(self):
-        # This delete button is displayed on the individual source page
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_uses_delete_collection_button_confirmation()
+        # And the journalist went to the individual source's page
+        journ_app_nav.journalist_visits_col()
 
-    def test_journalist_uses_index_delete_collections_button_modal(self):
-        # This deletion button is displayed on the index page
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_uses_delete_collections_button_confirmation()
+        # And the source has at least one submission
+        initial_submissions_count = journ_app_nav.count_submissions_on_current_page()
+        assert initial_submissions_count > 0
 
-    def test_journalist_uses_index_delete_files_button_modal(self):
-        # This deletion button is displayed on the index page
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_submits_a_message()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_uses_index_delete_files_button_confirmation()
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_message()
-        self._source_logs_out()
+        # And the journalist selected the first submission
+        journ_app_nav.journalist_selects_first_doc()
 
-    def test_journalist_interface_ui_with_modal(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_logs_out()
+        # When the journalist clicks the delete button...
+        journ_app_nav.journalist_clicks_delete_selected_link()
+        # ...but then cancels the deletion
+        journ_app_nav.nav_helper.safe_click_by_id("cancel-selected-deletions")
 
-        self.set_tbb_securitylevel(SECURITY_LOW)
+        # Then they see the same number of submissions as before
+        submissions_after_canceling_count = journ_app_nav.count_submissions_on_current_page()
+        assert submissions_after_canceling_count == initial_submissions_count
 
-        self._journalist_logs_in()
-        self._journalist_uses_js_filter_by_sources()
-        self._journalist_source_selection_honors_filter()
-        self._journalist_selects_all_sources_then_selects_none()
-        self._journalist_selects_the_first_source()
-        self._journalist_uses_js_buttons_to_download_unread()
-        self._journalist_delete_all_confirmation()
+        # And when the journalist clicks the delete button...
+        journ_app_nav.journalist_clicks_delete_selected_link()
+        # ... and then confirms the deletion
+        journ_app_nav.nav_helper.safe_click_by_id("delete-selected")
+
+        # Then they see less submissions than before because one was deleted
+        def submission_deleted():
+            submissions_after_confirming_count = journ_app_nav.count_submissions_on_current_page()
+            assert submissions_after_confirming_count < initial_submissions_count
+
+        journ_app_nav.nav_helper.wait_for(submission_deleted)
+
+    def test_journalist_uses_col_delete_collection_button_modal(
+        self, sd_servers_v2_with_submitted_file, firefox_web_driver
+    ):
+        # Given an SD server with a file submitted by a source
+        # And a journalist logged into the journalist interface
+        journ_app_nav = JournalistAppNavigator(
+            journalist_app_base_url=sd_servers_v2_with_submitted_file.journalist_app_base_url,
+            web_driver=firefox_web_driver,
+        )
+        journ_app_nav.journalist_logs_in(
+            username=sd_servers_v2_with_submitted_file.journalist_username,
+            password=sd_servers_v2_with_submitted_file.journalist_password,
+            otp_secret=sd_servers_v2_with_submitted_file.journalist_otp_secret,
+        )
+
+        # And the journalist went to the individual source's page
+        journ_app_nav.journalist_visits_col()
+
+        # And the source has at least one submission
+        initial_submissions_count = journ_app_nav.count_submissions_on_current_page()
+        assert initial_submissions_count > 0
+
+        # When the journalist clicks the delete collection button...
+        self._journalist_clicks_delete_collection_link(journ_app_nav)
+        # ...but then cancels the deletion
+        journ_app_nav.nav_helper.safe_click_by_id("cancel-collection-deletions")
+
+        # Then they see the same number of submissions as before
+        submissions_after_canceling_count = journ_app_nav.count_submissions_on_current_page()
+        assert submissions_after_canceling_count == initial_submissions_count
+
+        # When the journalist clicks the delete collection button...
+        self._journalist_clicks_delete_collection_link(journ_app_nav)
+        # ... and then confirms the deletion
+        journ_app_nav.nav_helper.safe_click_by_id("delete-collection-button")
+
+        # Then the journalist was redirected to the home page
+        assert journ_app_nav.is_on_journalist_homepage()
+
+    @staticmethod
+    def _journalist_clicks_delete_collection_link(journ_app_nav: JournalistAppNavigator) -> None:
+        journ_app_nav.nav_helper.safe_click_by_id("delete-collection-link")
+        journ_app_nav.nav_helper.wait_for(
+            lambda: journ_app_nav.driver.find_element_by_id("delete-collection-confirmation-modal")
+        )
+
+    def test_journalist_uses_index_delete_collections_button_modal(
+        self, sd_servers_v2_with_submitted_file, firefox_web_driver
+    ):
+        # Given an SD server with a file submitted by a source
+        # And a journalist logged into the journalist interface
+        journ_app_nav = JournalistAppNavigator(
+            journalist_app_base_url=sd_servers_v2_with_submitted_file.journalist_app_base_url,
+            web_driver=firefox_web_driver,
+        )
+        journ_app_nav.journalist_logs_in(
+            username=sd_servers_v2_with_submitted_file.journalist_username,
+            password=sd_servers_v2_with_submitted_file.journalist_password,
+            otp_secret=sd_servers_v2_with_submitted_file.journalist_otp_secret,
+        )
+
+        # And at least one source previously used the app
+        initial_sources_count = journ_app_nav.count_sources_on_index_page()
+        assert initial_sources_count > 0
+
+        # And the journalist selected all sources on the index page
+        try:
+            # If JavaScript is enabled, use the select_all button.
+            journ_app_nav.driver.find_element_by_id("select_all")
+            journ_app_nav.nav_helper.safe_click_by_id("select_all")
+        except NoSuchElementException:
+            journ_app_nav.nav_helper.safe_click_all_by_css_selector(
+                'input[type="checkbox"][name="cols_selected"]'
+            )
+
+        # When the journalist clicks the delete collection button...
+        self._journalist_clicks_delete_collections_link(journ_app_nav)
+        # ...but then cancels the deletion
+        self._journalist_clicks_delete_collections_cancel_on_first_modal(journ_app_nav)
+
+        # Then they see the same number of sources as before
+        assert initial_sources_count == journ_app_nav.count_sources_on_index_page()
+
+        # And when the journalist clicks the delete collection button again...
+        self._journalist_clicks_delete_collections_link(journ_app_nav)
+        # ...and then confirms the deletion...
+        self._journalist_clicks_delete_collections_on_first_modal(journ_app_nav)
+        # ... and cancels the deletion on the second modal/confirmation prompt
+        journ_app_nav.nav_helper.safe_click_by_id("cancel-collections-deletions")
+
+        # Then they see the same number of sources as before
+        assert initial_sources_count == journ_app_nav.count_sources_on_index_page()
+
+        # And when the journalist clicks the delete collection button again and confirms it
+        self._journalist_clicks_delete_collections_link(journ_app_nav)
+        self._journalist_clicks_delete_collections_on_first_modal(journ_app_nav)
+        journ_app_nav.nav_helper.safe_click_by_id("delete-collections-confirm")
+
+        # Then a message shows up to say that the collection was deleted
+        def collection_deleted():
+            flash_msg = journ_app_nav.driver.find_element_by_css_selector(".flash")
+            assert "The account and all data for the source have been deleted." in flash_msg.text
+
+        journ_app_nav.nav_helper.wait_for(collection_deleted)
+
+        # And the journalist gets redirected to the index with the source not present anymore
+        def no_sources():
+            assert journ_app_nav.count_sources_on_index_page() == 0
+
+        journ_app_nav.nav_helper.wait_for(no_sources)
+
+    @staticmethod
+    def _journalist_clicks_delete_collections_link(journ_app_nav: JournalistAppNavigator) -> None:
+        journ_app_nav.nav_helper.safe_click_by_id("delete-collections-link")
+        journ_app_nav.nav_helper.wait_for(
+            lambda: journ_app_nav.driver.find_element_by_id("delete-sources-modal")
+        )
+
+    @staticmethod
+    def _journalist_clicks_delete_collections_cancel_on_first_modal(
+        journ_app_nav: JournalistAppNavigator,
+    ) -> None:
+        journ_app_nav.nav_helper.safe_click_by_id("delete-menu-dialog-cancel")
+
+    @staticmethod
+    def _journalist_clicks_delete_collections_on_first_modal(
+        journ_app_nav: JournalistAppNavigator,
+    ) -> None:
+        journ_app_nav.nav_helper.safe_click_by_id("delete-collections")
+        journ_app_nav.nav_helper.wait_for(
+            lambda: journ_app_nav.driver.find_element_by_id("delete-collections-confirm")
+        )
+
+    def test_journalist_interface_ui_with_modal(
+        self, sd_servers_v2_with_submitted_file, firefox_web_driver
+    ):
+        # Given an SD server with a file submitted by a source
+        # And a journalist logged into the journalist interface
+        journ_app_nav = JournalistAppNavigator(
+            journalist_app_base_url=sd_servers_v2_with_submitted_file.journalist_app_base_url,
+            web_driver=firefox_web_driver,
+        )
+        journ_app_nav.journalist_logs_in(
+            username=sd_servers_v2_with_submitted_file.journalist_username,
+            password=sd_servers_v2_with_submitted_file.journalist_password,
+            otp_secret=sd_servers_v2_with_submitted_file.journalist_otp_secret,
+        )
+
+        # When the journalist uses the filter by sources to find text that doesn't match any source
+        filter_box = journ_app_nav.nav_helper.safe_send_keys_by_id(
+            "filter", "thiswordisnotinthewordlist"
+        )
+
+        # Then no sources are displayed on the page
+        sources = journ_app_nav.get_sources_on_index_page()
+        assert len(sources) > 0
+        for source in sources:
+            assert source.is_displayed() is False
+
+        # And when the journalist clears the filter
+        filter_box.clear()
+        filter_box.send_keys(Keys.RETURN)
+
+        # Then all sources are displayed
+        for source in sources:
+            assert source.is_displayed() is True
+
+        # And given the journalist designation of the first source
+        sources = journ_app_nav.get_sources_on_index_page()
+        assert len(sources) > 0
+        first_source_designation = sources[0].text
+
+        # When the journalist uses the filter find this source designation
+        filter_box.send_keys(first_source_designation)
+
+        # Then only the corresponding source is displayed
+        for source in sources:
+            assert source.text == first_source_designation or source.is_displayed() is False
+
+        # And when clicking "select all"
+        select_all = journ_app_nav.driver.find_element_by_id("select_all")
+        select_all.click()
+
+        # Then only the visible source gets selected
+        source_rows = journ_app_nav.driver.find_elements_by_css_selector("#cols li.source")
+        for source_row in source_rows:
+            source_designation = source_row.get_attribute("data-source-designation")
+            checkbox = source_row.find_element_by_css_selector("input[type=checkbox]")
+            if source_designation == first_source_designation:
+                assert checkbox.is_selected()
+            else:
+                assert not checkbox.is_selected()
+
+        # And when the journalist clears the filter and then selects all sources
+        filter_box.clear()
+        filter_box.send_keys(Keys.RETURN)
+        select_all.click()
+        for source_row in source_rows:
+            checkbox = source_row.find_element_by_css_selector("input[type=checkbox]")
+            assert checkbox.is_selected()
+
+        # And then they filter again and click "select none"
+        filter_box.send_keys(first_source_designation)
+        select_none = journ_app_nav.driver.find_element_by_id("select_none")
+        select_none.click()
+
+        # Then only the visible source gets de-selected
+        for source_row in source_rows:
+            source_designation = source_row.get_attribute("data-source-designation")
+            checkbox = source_row.find_element_by_css_selector("input[type=checkbox]")
+            if source_designation == first_source_designation:
+                assert not checkbox.is_selected()
+            else:
+                assert checkbox.is_selected()
+
+        # And when the journalist clears the filter and leaves none selected
+        filter_box.clear()
+        filter_box.send_keys(Keys.RETURN)
+        select_none.click()
+
+        for source_row in source_rows:
+            assert source_row.is_displayed()
+            checkbox = source_row.find_element_by_css_selector("input[type=checkbox]")
+            assert not checkbox.is_selected()
+
+        # And the journalist clicks "select all" then all sources are selected
+        journ_app_nav.driver.find_element_by_id("select_all").click()
+        checkboxes = journ_app_nav.driver.find_elements_by_id("checkbox")
+        for checkbox in checkboxes:
+            assert checkbox.is_selected()
+
+        # And when the journalist clicks "select none" then no sources are selected
+        journ_app_nav.driver.find_element_by_id("select_none").click()
+        checkboxes = journ_app_nav.driver.find_elements_by_id("checkbox")
+        for checkbox in checkboxes:
+            assert checkbox.is_selected() is False
+
+        # And when the journalist clicks "select unread" then all unread sources are selected
+        journ_app_nav.journalist_selects_the_first_source()
+        journ_app_nav.driver.find_element_by_id("select_unread").click()
+        checkboxes = journ_app_nav.get_submission_checkboxes_on_current_page()
+        for checkbox in checkboxes:
+            classes = checkbox.get_attribute("class")
+            assert "unread-cb" in classes
+
+        # And when the journalist clicks the delete button, it succeeds
+        journ_app_nav.nav_helper.safe_click_all_by_css_selector("[name=doc_names_selected]")
+        journ_app_nav.nav_helper.safe_click_by_css_selector("a#delete-selected-link")
+
+    def test_journalist_uses_index_delete_files_button_modal(
+        self, sd_servers_v2_with_submitted_file, firefox_web_driver
+    ):
+        # Given an SD server with a file submitted by a source
+        # And a journalist logged into the journalist interface
+        journ_app_nav = JournalistAppNavigator(
+            journalist_app_base_url=sd_servers_v2_with_submitted_file.journalist_app_base_url,
+            web_driver=firefox_web_driver,
+        )
+        journ_app_nav.journalist_logs_in(
+            username=sd_servers_v2_with_submitted_file.journalist_username,
+            password=sd_servers_v2_with_submitted_file.journalist_password,
+            otp_secret=sd_servers_v2_with_submitted_file.journalist_otp_secret,
+        )
+
+        # And at least one source previously used the app
+        initial_sources_count = journ_app_nav.count_sources_on_index_page()
+        assert initial_sources_count > 0
+
+        # And the journalist selected all sources on the index page
+        try:
+            # If JavaScript is enabled, use the select_all button.
+            journ_app_nav.driver.find_element_by_id("select_all")
+            journ_app_nav.nav_helper.safe_click_by_id("select_all")
+        except NoSuchElementException:
+            journ_app_nav.nav_helper.safe_click_all_by_css_selector(
+                'input[type="checkbox"][name="cols_selected"]'
+            )
+
+        # When the journalist clicks the delete collection button...
+        self._journalist_clicks_delete_collections_link(journ_app_nav)
+        # ...and then clicks the delete files button on the first modal
+        journ_app_nav.nav_helper.safe_click_by_id("delete-files-and-messages")
+
+        # Then they are redirected to the index with the source present, files
+        # and messages zeroed, and a success flash message present
+        def one_source_no_files():
+            assert journ_app_nav.count_sources_on_index_page() == 1
+            flash_msg = journ_app_nav.driver.find_element_by_css_selector(".flash")
+            assert "The files and messages have been deleted" in flash_msg.text
+            counts = journ_app_nav.driver.find_elements_by_css_selector(".submission-count")
+            assert "0 docs" in counts[0].text
+            assert "0 messages" in counts[1].text
+
+        journ_app_nav.nav_helper.wait_for(one_source_no_files)
 
 
 class TestJournalistMissingFile(


### PR DESCRIPTION
## Status

Ready

## Description of Changes

This PR continue the work from https://github.com/freedomofpress/securedrop/pull/6476, by bringing the new test code and fixtures to a few functional tests for the journalist app.

More specifically, this PR:

* Brings the new test fixtures to `TestJournalist` (for #3836).
  * It also moves a lot of the testing code back to `TestJournalist` instead of having it in `journalist_navigation_steps.py`, which made it hard to follow the tests as it required constantly jumping between the two files.
  * Only code that's shared across multiple tests should go in the "common" classes/files (`journalist_navigation_steps.py`, `app_navigators.py`, etc.).
* Introduces a new fixture, `sd_servers_v2_with_submitted_file`, which spawns the source and journalist apps with a pre-uploaded submission.
  * This fixture directly creates the submission in the app's DB, instead of using Selenium to upload a submission as a source (as done previously). This new approach reduces setup time by ~7 seconds per test.
