### PR TITLE
Refactor functional tests for journalist app when file is deleted

### DIFF
--- a/securedrop/tests/functional/app_navigators.py
+++ b/securedrop/tests/functional/app_navigators.py
@@ -312,27 +312,16 @@ class JournalistAppNavigator:
         )
 
     def journalist_logs_in(self, username: str, password: str, otp_secret: str) -> None:
+        # Submit the login form
+        self.driver.get(f"{self._journalist_app_base_url}/login")
+        self.nav_helper.safe_send_keys_by_css_selector('input[name="username"]', username)
+        self.nav_helper.safe_send_keys_by_css_selector('input[name="password"]', password)
         otp = pyotp.TOTP(otp_secret)
-        token = str(otp.now())
-        for i in range(3):
-            # Submit the login form
-            self.driver.get(f"{self._journalist_app_base_url}/login")
-            self.nav_helper.safe_send_keys_by_css_selector('input[name="username"]', username)
-            self.nav_helper.safe_send_keys_by_css_selector('input[name="password"]', password)
-            self.nav_helper.safe_send_keys_by_css_selector('input[name="token"]', token)
-            self.nav_helper.safe_click_by_css_selector('button[type="submit"]')
+        self.nav_helper.safe_send_keys_by_css_selector('input[name="token"]', str(otp.now()))
+        self.nav_helper.safe_click_by_css_selector('button[type="submit"]')
 
-            # Successful login should redirect to the index
-            self.nav_helper.wait_for(lambda: self.driver.find_element_by_id("link-logout"))
-            if self.driver.current_url != self._journalist_app_base_url:
-                new_token = str(otp.now())
-                while token == new_token:
-                    time.sleep(1)
-                    new_token = str(otp.now())
-                token = new_token
-            else:
-                break
-
+        # Successful login should redirect to the index
+        self.nav_helper.wait_for(lambda: self.driver.find_element_by_id("link-logout"))
         assert self.is_on_journalist_homepage()
 
     def journalist_checks_messages(self) -> None:

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -665,17 +665,6 @@ class JournalistNavigationStepsMixin:
 
         assert self.secret_message == submission
 
-    def _journalist_downloads_message_missing_file(self):
-        self._journalist_selects_the_first_source()
-
-        self.wait_for(lambda: self.driver.find_element_by_css_selector("table#submissions"))
-
-        submissions = self.driver.find_elements_by_css_selector("#submissions a")
-        assert 1 == len(submissions)
-
-        file_link = submissions[0]
-        file_link.click()
-
     def _journalist_composes_reply(self):
         reply_text = (
             "Thanks for the documents. Can you submit more " "information about the main program?"
@@ -922,53 +911,3 @@ class JournalistNavigationStepsMixin:
         self.safe_send_keys_by_css_selector('input[name="username"]', username)
         self.safe_send_keys_by_css_selector('input[name="otp_secret"]', hotp_secret)
         self.safe_click_by_css_selector('input[name="is_hotp"]')
-
-    def _journalist_sees_missing_file_error_message(self, single_file=False):
-        notification = self.driver.find_element_by_css_selector(".error")
-
-        # We use a definite article ("the" instead of "a") if a single file
-        # is downloaded directly.
-        if single_file:
-            error_msg = (
-                "Your download failed because the file could not be found. An admin can find "
-                + "more information in the system and monitoring logs."
-            )
-        else:
-            error_msg = (
-                "Your download failed because a file could not be found. An admin can find "
-                + "more information in the system and monitoring logs."
-            )
-
-        if self.accept_languages is None:
-            assert notification.text in error_msg
-
-    def _journalist_is_on_collection_page(self):
-        return self.wait_for(
-            lambda: self.driver.find_element_by_css_selector("div.journalist-view-single")
-        )
-
-    def _journalist_clicks_source_unread(self):
-        self.driver.find_element_by_css_selector(
-            "table#collections tr.source > td.unread a"
-            ).click()
-
-    def _journalist_selects_first_source_then_download_all(self):
-        checkboxes = self.driver.find_elements_by_name("cols_selected")
-        assert len(checkboxes) == 1
-        checkboxes[0].click()
-
-        self.driver.find_element_by_xpath("//button[@value='download-all']").click()
-
-    def _journalist_selects_first_source_then_download_unread(self):
-        checkboxes = self.driver.find_elements_by_name("cols_selected")
-        assert len(checkboxes) == 1
-        checkboxes[0].click()
-
-        self.driver.find_element_by_xpath("//button[@value='download-unread']").click()
-
-    def _journalist_selects_message_then_download_selected(self):
-        checkboxes = self.driver.find_elements_by_name("doc_names_selected")
-        assert len(checkboxes) == 1
-        checkboxes[0].click()
-
-        self.driver.find_element_by_xpath("//button[@value='download']").click()


### PR DESCRIPTION
## Status

Ready

## Description of Changes

This PR continue the work from https://github.com/freedomofpress/securedrop/pull/6481, by bringing the new test code and fixtures to a few functional tests for the journalist app.

More specifically, this PR:

* Brings the new test fixtures to `TestJournalistDelete` (for #3836).
* Introduces a new fixture, `_sd_servers_v2_with_missing_file`, which spawns the source and journalist apps with a pre-uploaded submission whose file was deleted from disk.