### PR TITLE
Refactor layout tests for submission deletion in journalist app

### DIFF
--- a/securedrop/tests/functional/app_navigators.py
+++ b/securedrop/tests/functional/app_navigators.py
@@ -8,6 +8,7 @@ import pyotp
 import requests
 from encryption import EncryptionManager
 from selenium.common.exceptions import NoAlertPresentException, WebDriverException
+from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.webdriver import WebDriver
 from selenium.webdriver.remote.webelement import WebElement
@@ -436,6 +437,18 @@ class JournalistAppNavigator:
             lambda: self.driver.find_element_by_id("delete-selected-confirmation-modal")
         )
 
+    def journalist_clicks_delete_all_and_sees_confirmation(self) -> None:
+        self.nav_helper.safe_click_all_by_css_selector("[name=doc_names_selected]")
+        self.nav_helper.safe_click_by_css_selector("a#delete-selected-link")
+
+    def journalist_confirms_delete_selected(self) -> None:
+        self.nav_helper.wait_for(
+            lambda: expected_conditions.element_to_be_clickable((By.ID, "delete-selected"))
+        )
+        confirm_btn = self.driver.find_element_by_id("delete-selected")
+        confirm_btn.location_once_scrolled_into_view
+        ActionChains(self.driver).move_to_element(confirm_btn).click().perform()
+
     def get_submission_checkboxes_on_current_page(self):
         checkboxes = self.driver.find_elements_by_name("doc_names_selected")
         return checkboxes
@@ -450,3 +463,11 @@ class JournalistAppNavigator:
 
     def count_sources_on_index_page(self) -> int:
         return len(self.get_sources_on_index_page())
+
+    def journalist_confirm_delete_selected(self) -> None:
+        self.nav_helper.wait_for(
+            lambda: expected_conditions.element_to_be_clickable((By.ID, "delete-selected"))
+        )
+        confirm_btn = self.driver.find_element_by_id("delete-selected")
+        confirm_btn.location_once_scrolled_into_view
+        ActionChains(self.driver).move_to_element(confirm_btn).click().perform()

--- a/securedrop/tests/functional/conftest.py
+++ b/securedrop/tests/functional/conftest.py
@@ -159,7 +159,7 @@ def spawn_sd_servers(
                 response_journalist = requests.get(journalist_app_base_url, timeout=1)
                 response_journalist_status_code = response_journalist.status_code
                 break
-            except requests.ConnectionError:
+            except (requests.ConnectionError, requests.Timeout):
                 time.sleep(0.25)
         assert response_source_status_code == 200
         assert response_journalist_status_code == 200

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -886,13 +886,6 @@ class JournalistNavigationStepsMixin:
         actions.move_to_element(continue_link).perform()
         continue_link.click()
 
-    def _journalist_delete_none(self):
-        self.driver.find_element_by_id("delete-selected-link").click()
-
-    def _journalist_delete_all_confirmation(self):
-        self.safe_click_all_by_css_selector("[name=doc_names_selected]")
-        self.safe_click_by_css_selector("a#delete-selected-link")
-
     def _journalist_delete_one(self):
         self.safe_click_by_css_selector("[name=doc_names_selected]")
 

--- a/securedrop/tests/functional/pageslayout/test_journalist_delete.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_delete.py
@@ -15,90 +15,136 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-import time
-
 import pytest
-import tests.functional.pageslayout.functional_test as pft
-from tests.functional import journalist_navigation_steps, source_navigation_steps
+from tests.functional.app_navigators import JournalistAppNavigator
+from tests.functional.pageslayout.functional_test import list_locales
+from tests.functional.pageslayout.screenshot_utils import save_screenshot_and_html
 
 
-# TODO(AD): This should be merged with TestJournalist
+@pytest.mark.parametrize("locale", list_locales())
 @pytest.mark.pagelayout
-class TestJournalistLayoutDelete(
-    pft.FunctionalTest,
-    source_navigation_steps.SourceNavigationStepsMixin,
-    journalist_navigation_steps.JournalistNavigationStepsMixin,
-):
-    def test_delete_none(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_submits_a_message()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_clicks_delete_selected_link()
-        self._journalist_confirm_delete_selected()
-        self._screenshot("journalist-delete_none.png")
-        self._save_html("journalist-delete_none.html")
+class TestJournalistLayoutDelete:
+    def test_delete_none(self, locale, sd_servers_v2_with_submitted_file, firefox_web_driver):
+        # Given an SD server with a file submitted by a source
+        # And a journalist logged into the journalist interface
+        locale_with_commas = locale.replace("_", "-")
+        journ_app_nav = JournalistAppNavigator(
+            journalist_app_base_url=sd_servers_v2_with_submitted_file.journalist_app_base_url,
+            web_driver=firefox_web_driver,
+            accept_languages=locale_with_commas,
+        )
+        journ_app_nav.journalist_logs_in(
+            username=sd_servers_v2_with_submitted_file.journalist_username,
+            password=sd_servers_v2_with_submitted_file.journalist_password,
+            otp_secret=sd_servers_v2_with_submitted_file.journalist_otp_secret,
+        )
 
-    # TODO(AD): This should be merged with
-    #  test_journalist_verifies_deletion_of_one_submission_modal()
-    def test_delete_one_confirmation(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_submits_a_message()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_selects_first_doc()
-        self._journalist_clicks_delete_selected_link()
-        time.sleep(1)
-        self._screenshot("journalist-delete_one_confirmation.png")
-        self._save_html("journalist-delete_one_confirmation.html")
+        # And the journalist went to the individual source's page
+        journ_app_nav.journalist_visits_col()
 
-    # TODO(AD): This should be merged with test_journalist_interface_ui_with_modal()
-    def test_delete_all_confirmation(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_submits_a_message()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_delete_all_confirmation()
-        time.sleep(1)
-        self._screenshot("journalist-delete_all_confirmation.png")
-        self._save_html("journalist-delete_all_confirmation.html")
+        journ_app_nav.journalist_clicks_delete_selected_link()
 
-    def test_delete_one(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_submits_a_message()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_delete_one()
-        self._journalist_confirm_delete_selected()
-        self._screenshot("journalist-delete_one.png")
-        self._save_html("journalist-delete_one.html")
+        journ_app_nav.journalist_confirm_delete_selected()
+        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-delete_none")
 
-    def test_delete_all(self):
-        self._source_visits_source_homepage()
-        self._source_chooses_to_submit_documents()
-        self._source_continues_to_submit_page()
-        self._source_submits_a_file()
-        self._source_submits_a_message()
-        self._source_logs_out()
-        self._journalist_logs_in()
-        self._journalist_visits_col()
-        self._journalist_delete_all()
-        self._journalist_confirm_delete_selected()
-        self._screenshot("journalist-delete_all.png")
-        self._save_html("journalist-delete_all.html")
+    def test_delete_one_confirmation(
+        self, locale, sd_servers_v2_with_submitted_file, firefox_web_driver
+    ):
+        # Given an SD server with a file submitted by a source
+        # And a journalist logged into the journalist interface
+        locale_with_commas = locale.replace("_", "-")
+        journ_app_nav = JournalistAppNavigator(
+            journalist_app_base_url=sd_servers_v2_with_submitted_file.journalist_app_base_url,
+            web_driver=firefox_web_driver,
+            accept_languages=locale_with_commas,
+        )
+        journ_app_nav.journalist_logs_in(
+            username=sd_servers_v2_with_submitted_file.journalist_username,
+            password=sd_servers_v2_with_submitted_file.journalist_password,
+            otp_secret=sd_servers_v2_with_submitted_file.journalist_otp_secret,
+        )
+
+        # And the journalist went to the individual source's page
+        journ_app_nav.journalist_visits_col()
+
+        # And the journalist selected the first submission
+        journ_app_nav.journalist_selects_first_doc()
+
+        # Take a screenshot of the confirmation prompt when the journalist clicks the delete button
+        journ_app_nav.journalist_clicks_delete_selected_link()
+        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-delete_one_confirmation")
+
+    def test_delete_all_confirmation(
+        self, locale, sd_servers_v2_with_submitted_file, firefox_web_driver
+    ):
+        # Given an SD server with a file submitted by a source
+        # And a journalist logged into the journalist interface
+        locale_with_commas = locale.replace("_", "-")
+        journ_app_nav = JournalistAppNavigator(
+            journalist_app_base_url=sd_servers_v2_with_submitted_file.journalist_app_base_url,
+            web_driver=firefox_web_driver,
+            accept_languages=locale_with_commas,
+        )
+        journ_app_nav.journalist_logs_in(
+            username=sd_servers_v2_with_submitted_file.journalist_username,
+            password=sd_servers_v2_with_submitted_file.journalist_password,
+            otp_secret=sd_servers_v2_with_submitted_file.journalist_otp_secret,
+        )
+
+        # And the journalist went to the individual source's page
+        journ_app_nav.journalist_visits_col()
+
+        # Take a screenshot of the prompt when the journalist clicks the delete all button
+        journ_app_nav.journalist_clicks_delete_all_and_sees_confirmation()
+        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-delete_all_confirmation")
+
+    def test_delete_one(self, locale, sd_servers_v2_with_submitted_file, firefox_web_driver):
+        # Given an SD server with a file submitted by a source
+        # And a journalist logged into the journalist interface
+        locale_with_commas = locale.replace("_", "-")
+        journ_app_nav = JournalistAppNavigator(
+            journalist_app_base_url=sd_servers_v2_with_submitted_file.journalist_app_base_url,
+            web_driver=firefox_web_driver,
+            accept_languages=locale_with_commas,
+        )
+        journ_app_nav.journalist_logs_in(
+            username=sd_servers_v2_with_submitted_file.journalist_username,
+            password=sd_servers_v2_with_submitted_file.journalist_password,
+            otp_secret=sd_servers_v2_with_submitted_file.journalist_otp_secret,
+        )
+
+        # And the journalist went to the individual source's page
+        journ_app_nav.journalist_visits_col()
+
+        journ_app_nav.journalist_selects_first_doc()
+
+        # And the journalist clicked the delete button and confirmed
+        journ_app_nav.journalist_clicks_delete_selected_link()
+        journ_app_nav.nav_helper.safe_click_by_id("delete-selected")
+
+        # Take a screenshot
+        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-delete_one")
+
+    def test_delete_all(self, locale, sd_servers_v2_with_submitted_file, firefox_web_driver):
+        # Given an SD server with a file submitted by a source
+        # And a journalist logged into the journalist interface
+        locale_with_commas = locale.replace("_", "-")
+        journ_app_nav = JournalistAppNavigator(
+            journalist_app_base_url=sd_servers_v2_with_submitted_file.journalist_app_base_url,
+            web_driver=firefox_web_driver,
+            accept_languages=locale_with_commas,
+        )
+        journ_app_nav.journalist_logs_in(
+            username=sd_servers_v2_with_submitted_file.journalist_username,
+            password=sd_servers_v2_with_submitted_file.journalist_password,
+            otp_secret=sd_servers_v2_with_submitted_file.journalist_otp_secret,
+        )
+
+        # And the journalist went to the individual source's page
+        journ_app_nav.journalist_visits_col()
+
+        journ_app_nav.journalist_clicks_delete_all_and_sees_confirmation()
+        journ_app_nav.journalist_confirms_delete_selected()
+
+        # Take a screenshot
+        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-delete_all")

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -70,7 +70,7 @@ class TestJournalist:
         # And when the journalist clicks the delete button...
         journ_app_nav.journalist_clicks_delete_selected_link()
         # ... and then confirms the deletion
-        journ_app_nav.nav_helper.safe_click_by_id("delete-selected")
+        journ_app_nav.journalist_confirms_delete_selected()
 
         # Then they see less submissions than before because one was deleted
         def submission_deleted():
@@ -325,8 +325,7 @@ class TestJournalist:
             assert "unread-cb" in classes
 
         # And when the journalist clicks the delete button, it succeeds
-        journ_app_nav.nav_helper.safe_click_all_by_css_selector("[name=doc_names_selected]")
-        journ_app_nav.nav_helper.safe_click_by_css_selector("a#delete-selected-link")
+        journ_app_nav.journalist_clicks_delete_all_and_sees_confirmation()
 
     def test_journalist_uses_index_delete_files_button_modal(
         self, sd_servers_v2_with_submitted_file, firefox_web_driver


### PR DESCRIPTION
## Status

Ready

## Description of Changes

This PR continue the work from https://github.com/freedomofpress/securedrop/pull/6482, by bringing the new test code and fixtures to a few layout tests for the journalist app.

More specifically, this PR:

* Brings the new test fixtures to `TestJournalistLayoutDelete` (for #3836).
