### PR TITLE
fix: display full locale name for all locales with shared languages

### DIFF
--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import collections
-from typing import List, Set
+from typing import Dict, List, Set
 
 from babel.core import (
     Locale,
@@ -175,18 +175,21 @@ def map_locale_display_names(config: SDConfig) -> None:
     to distinguish them. For languages with more than one translation,
     like Chinese, we do need the additional detail.
     """
-    seen: Set[str] = set()
+
+    language_locale_counts = collections.defaultdict(int)  # type: Dict[str, int]
+    for l in sorted(config.SUPPORTED_LOCALES):
+        locale = RequestLocaleInfo(l)
+        language_locale_counts[locale.language] += 1
+
     locale_map = collections.OrderedDict()
     for l in sorted(config.SUPPORTED_LOCALES):
         if Locale.parse(l) not in USABLE_LOCALES:
             continue
 
         locale = RequestLocaleInfo(l)
-        if locale.language in seen:
+        if language_locale_counts[locale.language] > 1:
             # Disambiguate translations for this language.
             locale.use_display_name = True
-        else:
-            seen.add(locale.language)
 
         locale_map[str(locale)] = locale
 

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -410,3 +410,17 @@ def test_html_attributes(journalist_app, config):
     )
     html = resp.data.decode("utf-8")
     assert '<html lang="en-US" dir="ltr">' in html
+
+
+def test_same_lang_diff_locale(journalist_app, config):
+    """
+    Verify that when two locales with the same lang are specified, the full locale
+    name is used for both.
+    """
+    del journalist_app
+    config.SUPPORTED_LOCALES = ["en_US", "pt_BR", "pt_PT"]
+    app = journalist_app_module.create_app(config).test_client()
+    resp = app.get("/", follow_redirects=True)
+    html = resp.data.decode("utf-8")
+    assert "português (Brasil)" in html
+    assert "português (Portugal)" in html


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6475 .

Updates locale config to use full locale names for locales with common languages (ie Portuguese) if both locales are enabled.

## Testing

- run `make dev` on this branch
- [ ] confirm that both Portuguese locales are listed with their full locale name including country.
- [ ] confirm that switching locales works.


## Deployment

n/a

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
