### PR TITLE
Move reply key generation to /submit endpoint

### DIFF
--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Union
 import flask
 import werkzeug
 from db import db
-from encryption import EncryptionManager
+from encryption import EncryptionManager, GpgKeyNotFoundError
 from flask import Markup, abort, current_app, escape, flash, redirect, send_file, url_for
 from flask_babel import gettext, ngettext
 from journalist_app.sessions import session
@@ -402,8 +402,11 @@ def delete_collection(filesystem_id: str) -> None:
     if os.path.exists(path):
         Storage.get_default().move_to_shredder(path)
 
-    # Delete the source's reply keypair
-    EncryptionManager.get_default().delete_source_key_pair(filesystem_id)
+    # Delete the source's reply keypair, if it exists
+    try:
+        EncryptionManager.get_default().delete_source_key_pair(filesystem_id)
+    except GpgKeyNotFoundError:
+        pass
 
     # Delete their entry in the db
     source = get_source(filesystem_id, include_deleted=True)

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -176,13 +176,6 @@ def make_blueprint(config: SecureDropConfig) -> Blueprint:
         # Sort the replies by date
         replies.sort(key=operator.attrgetter("date"), reverse=True)
 
-        # If not done yet, generate a keypair to encrypt replies from the journalist
-        encryption_mgr = EncryptionManager.get_default()
-        try:
-            encryption_mgr.get_source_public_key(logged_in_source.filesystem_id)
-        except GpgKeyNotFoundError:
-            encryption_mgr.generate_source_key_pair(logged_in_source)
-
         return render_template(
             "lookup.html",
             is_user_logged_in=True,
@@ -312,6 +305,13 @@ def make_blueprint(config: SecureDropConfig) -> Blueprint:
             store.async_add_checksum_for_file(sub, Storage.get_default())
 
         normalize_timestamps(logged_in_source)
+
+        # If not done yet, generate a keypair to encrypt replies from the journalist
+        encryption_mgr = EncryptionManager.get_default()
+        try:
+            encryption_mgr.get_source_public_key(logged_in_source.filesystem_id)
+        except GpgKeyNotFoundError:
+            encryption_mgr.generate_source_key_pair(logged_in_source)
 
         return redirect(url_for("main.lookup"))
 

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -14,6 +14,7 @@ from unittest import mock
 import pytest
 import version
 from db import db
+from encryption import EncryptionManager
 from flaky import flaky
 from flask import escape, g, request, session, url_for
 from flask_babel import gettext
@@ -119,16 +120,19 @@ def test_generate_already_logged_in(source_app):
 
 
 def test_create_new_source(source_app):
+    """Create new source, ensuring that reply key is not created at the same time"""
     with source_app.test_client() as app:
-        resp = app.post(url_for("main.generate"), data=GENERATE_DATA)
-        assert resp.status_code == 200
-        tab_id = next(iter(session["codenames"].keys()))
-        resp = app.post(url_for("main.create"), data={"tab_id": tab_id}, follow_redirects=True)
-        assert SessionManager.is_user_logged_in(db_session=db.session)
-        # should be redirected to /lookup
-        text = resp.data.decode("utf-8")
-        assert "Submit Files" in text
-        assert "codenames" not in session
+        with patch.object(EncryptionManager, "get_source_public_key") as get_key:
+            resp = app.post(url_for("main.generate"), data=GENERATE_DATA)
+            assert resp.status_code == 200
+            tab_id = next(iter(session["codenames"].keys()))
+            resp = app.post(url_for("main.create"), data={"tab_id": tab_id}, follow_redirects=True)
+            assert SessionManager.is_user_logged_in(db_session=db.session)
+            # should be redirected to /lookup
+            text = resp.data.decode("utf-8")
+            assert "Submit Files" in text
+            assert "codenames" not in session
+            get_key.assert_not_called()
 
 
 def test_generate_as_post(source_app):
@@ -364,18 +368,22 @@ def _dummy_submission(app):
     )
 
 
-def test_initial_submission_notification(source_app):
+def test_initial_submission(source_app):
     """
     Regardless of the type of submission (message, file, or both), the
     first submission is always greeted with a notification
     reminding sources to check back later for replies.
+
+    A GPG keypair for replies should also be created.
     """
     with source_app.test_client() as app:
-        new_codename(app, session)
-        resp = _dummy_submission(app)
-        assert resp.status_code == 200
-        text = resp.data.decode("utf-8")
-        assert "Thank you for sending this information to us." in text
+        with patch.object(EncryptionManager, "generate_source_key_pair") as gen_key:
+            new_codename(app, session)
+            resp = _dummy_submission(app)
+            assert resp.status_code == 200
+            text = resp.data.decode("utf-8")
+            assert "Thank you for sending this information to us." in text
+            gen_key.assert_called_once()
 
 
 def test_submit_message(source_app):


### PR DESCRIPTION
## Status

Ready for review, but flagged as draft to block merge until `release/2.5.0` branch is created

## Description of Changes

Fixes #6489 

Reply key generation is moved in the SI from `/lookup` to `/submit`. If a key is not already present for the given source it will be created during the first submisstion.

## Testing
- Check out this branch and run `make dev`
- [ ] in another terminal, connect to the dev container with `docker exec -it securedrop-dev-0 bash` and verify that only the default dev source reply keys exist with `gpg --homedir /var/lib/securedrop/keys -k`
- Create a new source via the SI, but do not submit anything
- [ ] verify that no new key was created, with `gpg --homedir /var/lib/securedrop/keys -k`
- [ ] submit a message as the source and verify that a reply key was created
- [ ] log in to the JI and verify that the source is listed and a reply can be sent
- [ ] on the SI, verify that the reply is displayed correctly
- [ ] submit another message and verify that a new reply key was *not* created
- [ ] on the JI, verify that another reply can be submitted.
- [ ] log out of the SI, log back in as the same source, and verify that both replies can be read.

- [ ] For extra points, try to break reply key generation by doing multiple simultaneous file submissions.

## Deployment

n/a

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
