### PR TITLE
fix: compare bytes, not strings, in codename filter check.

### DIFF
--- a/securedrop/source_app/utils.py
+++ b/securedrop/source_app/utils.py
@@ -23,7 +23,7 @@ def codename_detected(message: str, codename: str) -> bool:
     """
     message = message.strip()
 
-    return compare_digest(message.strip(), codename)
+    return compare_digest(message.strip().encode("utf-8"), codename.encode("utf-8"))
 
 
 def flash_msg(

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -356,7 +356,10 @@ def _dummy_submission(app):
     """
     return app.post(
         url_for("main.submit"),
-        data=dict(msg="Pay no attention to the man behind the curtain.", fh=(BytesIO(b""), "")),
+        data=dict(
+            msg="Hallo! ö, ü, ä, or ß...Pay no attention to the man behind the curtain.",
+            fh=(BytesIO(b""), ""),
+        ),
         follow_redirects=True,
     )
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6491 .

When codename filtering is enabled, compares utf-encoded bytes of messages and codenames instead of raw strings, as valid messages may include non-ASCII chars.

## Testing

- run `make dev` from this branch
- visit the JI and enable codename filtering via Admin > Instance config
- visit the SI and create a new source.
- [x] attempt to submit the source's codename and verify that a flash error message is displayed instructing you to not do that
- [x] attempt to submit a message containing unicode, such as `Hallo! ö, ü, ä, or ß`, and verify that it is submitted successfully.

## Deployment

To be deployed as part of a regular or hotfix release, no special considerations.


## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation