### PR TITLE
Updated builder image to version with tag 2022_07_19

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_05_23
-e206eeb8d1a307db74d7e782a505f83aa60a3455ab3dd71a496d8d7706cda615
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_07_19
+b33a676fbdaa7d7703648ca9ac8b6775dd8e51c75767af6d208c7201cb42c355


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Builder update to version `2022_07_19`.

## Testing

- [x] CI is passing, particularly `deb-tests`
- [x] image hash is updated to version with tag `2022_07_19`
