### PR TITLE
Update builder  image to use Jammy repo for dh-virtualenv

### DIFF
--- a/molecule/builder-focal/Dockerfile
+++ b/molecule/builder-focal/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         python3-pip \
         python3-setuptools \
         python3-venv \
+        python3-virtualenv \
         rsync \
         ruby \
         sqlite \
@@ -34,9 +35,9 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         unzip
 
 
-# TEMPORARY: install dh-virtualenv from unstable Ubuntu release, pending focal package:
+# TEMPORARY: install dh-virtualenv from Jammy Ubuntu release, pending focal package:
 # https://github.com/spotify/dh-virtualenv/issues/298
-RUN echo "deb http://archive.ubuntu.com/ubuntu/ impish universe main" > /etc/apt/sources.list.d/ubuntu-impish.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu/ jammy universe main" > /etc/apt/sources.list.d/ubuntu-jammy.list
 COPY dh-virtualenv.pref /etc/apt/preferences.d/
 
 RUN apt-get update && apt-get install -y dh-virtualenv

--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_07_19
-b33a676fbdaa7d7703648ca9ac8b6775dd8e51c75767af6d208c7201cb42c355
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_07_28
+f3b5ea1ce8948f931c28e2080d229e0123b20ded033d47e081ec76aff7d7a02e


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Updates builder to use Jammy for dh-virtualenv. This also involves pulling in python3-virtualenv explicitly before adding Jammy to the repo list, as otherwise dh-virtualenv's dependencies cannot be satisfied.

## Testing
- [x] CI is passing
- [x] `make build-debs` passes locally.
- [x] SI and JI are available on a staging (or prod vm) env provisioned with packages from this branch