### PR TITLE
Bring new fixtures to admin interface functional tests pt. 2/2

### DIFF
--- a/securedrop/tests/functional/app_navigators.py
+++ b/securedrop/tests/functional/app_navigators.py
@@ -212,7 +212,10 @@ class SourceAppNagivator:
         def submit_page_loaded() -> None:
             if not self.accept_languages:
                 headline = self.driver.find_element_by_id("submit-heading")
-                assert "Submit Files or Messages" == headline.text
+                # Message will either be "Submit Messages" or "Submit Files or Messages" depending
+                #  on whether file uploads are allowed by the instance's config
+                assert "Submit" in headline.text
+                assert "Messages" in headline.text
 
         self.nav_helper.wait_for(submit_page_loaded)
 
@@ -571,3 +574,11 @@ class JournalistAppNavigator:
             assert "Login to access the journalist interface" in self.driver.page_source
 
         self.nav_helper.wait_for(login_page)
+
+    def admin_visits_system_config_page(self):
+        self.nav_helper.safe_click_by_id("update-instance-config")
+
+        def config_page_loaded():
+            assert self.driver.find_element_by_id("test-ossec-alert")
+
+        self.nav_helper.wait_for(config_page_loaded)

--- a/securedrop/tests/functional/journalist_navigation_steps.py
+++ b/securedrop/tests/functional/journalist_navigation_steps.py
@@ -192,41 +192,6 @@ class JournalistNavigationStepsMixin:
         # giving extra time for upload to complete
         self.wait_for(updated_image, timeout=self.timeout * 6)
 
-    def _admin_disallows_document_uploads(self):
-        if not self.driver.find_element_by_id("prevent_document_uploads").is_selected():
-            self.safe_click_by_id("prevent_document_uploads")
-            self.safe_click_by_id("submit-submission-preferences")
-
-        def preferences_saved():
-            flash_msg = self.driver.find_element_by_css_selector(".flash")
-            assert "Preferences saved." in flash_msg.text
-
-        self.wait_for(preferences_saved, timeout=self.timeout * 6)
-
-    def _admin_allows_document_uploads(self):
-        if self.driver.find_element_by_id("prevent_document_uploads").is_selected():
-            self.safe_click_by_id("prevent_document_uploads")
-            self.safe_click_by_id("submit-submission-preferences")
-
-        def preferences_saved():
-            flash_msg = self.driver.find_element_by_css_selector(".flash")
-            assert "Preferences saved." in flash_msg.text
-
-        self.wait_for(preferences_saved, timeout=self.timeout * 6)
-
-    def _admin_sets_organization_name(self):
-        assert self.orgname_default == self.driver.title
-        self.driver.find_element_by_id("organization_name").clear()
-        self.safe_send_keys_by_id("organization_name", self.orgname_new)
-        self.safe_click_by_id("submit-update-org-name")
-
-        def preferences_saved():
-            flash_msg = self.driver.find_element_by_css_selector(".flash")
-            assert "Preferences saved." in flash_msg.text
-
-        self.wait_for(preferences_saved, timeout=self.timeout * 6)
-        assert self.orgname_new == self.driver.title
-
     def _add_user(self, username, first_name="", last_name="", is_admin=False, hotp=None):
         self.safe_send_keys_by_css_selector('input[name="username"]', username)
 

--- a/securedrop/tests/functional/pageslayout/test_journalist_admin.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_admin.py
@@ -90,6 +90,7 @@ class TestJournalistLayoutAdmin(
         self._screenshot("journalist-admin_new_user_two_factor_totp.png")
         self._save_html("journalist-admin_new_user_two_factor_totp.html")
 
+    # TODO(AD): Merge this test with TestAdminInterfaceEditConfig.test_admin_updates_image()
     def test_admin_changes_logo(self):
         self._admin_logs_in()
         self._admin_visits_admin_interface()
@@ -100,6 +101,7 @@ class TestJournalistLayoutAdmin(
         self._screenshot("journalist-admin_changes_logo_image.png")
         self._save_html("journalist-admin_changes_logo_image.html")
 
+    # TODO(AD): Merge this test with TestAdminInterfaceEditConfig.test_ossec_alert_button()
     def test_admin_uses_ossec_alert_button(self):
         self._admin_logs_in()
         self._admin_visits_admin_interface()

--- a/securedrop/tests/functional/source_navigation_steps.py
+++ b/securedrop/tests/functional/source_navigation_steps.py
@@ -1,9 +1,6 @@
 import tempfile
 import time
 
-import pytest
-from selenium.common.exceptions import NoSuchElementException
-
 
 class SourceNavigationStepsMixin:
     def _is_on_source_homepage(self):
@@ -20,9 +17,6 @@ class SourceNavigationStepsMixin:
 
     def _is_on_logout_page(self):
         return self.wait_for(lambda: self.driver.find_element_by_id("source-logout"))
-
-    def _source_sees_orgname(self, name="SecureDrop"):
-        assert name in self.driver.title
 
     def _source_visits_source_homepage(self):
         self.driver.get(self.source_location)
@@ -116,10 +110,3 @@ class SourceNavigationStepsMixin:
     def _source_logs_out(self):
         self.safe_click_by_id("logout")
         assert self._is_on_logout_page()
-
-    def _source_sees_document_attachment_item(self):
-        assert self.driver.find_element_by_class_name("attachment") is not None
-
-    def _source_does_not_sees_document_attachment_item(self):
-        with pytest.raises(NoSuchElementException):
-            self.driver.find_element_by_class_name("attachment")


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

This PR continue the work from https://github.com/freedomofpress/securedrop/pull/6487, by bringing the new test code and fixtures to the remaining functional tests for the admin app.

More specifically, this PR:

* Brings the new test fixtures to functional tests for editing the instance's settings (logo, org name, etc.) (for #3836).