### PR TITLE
Bump expected kernel version to 5.15.57

### DIFF
--- a/install_files/ansible-base/group_vars/all/securedrop
+++ b/install_files/ansible-base/group_vars/all/securedrop
@@ -39,8 +39,8 @@ securedrop_cond_reboot_file: /tmp/sd-reboot-now
 
 # If you bump this, also remember to bump in molecule/builder-focal/tests/vars.yml
 securedrop_pkg_grsec_focal:
-  ver: "5.15.26"
-  depends: "linux-image-5.15.26-grsec-securedrop,intel-microcode"
+  ver: "5.15.57"
+  depends: "linux-image-5.15.57-grsec-securedrop,intel-microcode"
 
 # Mostly useful for local package installation
 grsec_version: "{{ securedrop_pkg_grsec_focal.ver }}"

--- a/molecule/builder-focal/tests/vars.yml
+++ b/molecule/builder-focal/tests/vars.yml
@@ -3,7 +3,7 @@ securedrop_version: "2.5.0~rc1"
 ossec_version: "3.6.0"
 keyring_version: "0.1.6"
 config_version: "0.1.4"
-grsec_version_focal: "5.15.26"
+grsec_version_focal: "5.15.57"
 
 # These values will be interpolated with values populated above
 # via helper functions in the tests.

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -179,6 +179,6 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt.freedom.press"
-grsec_version_focal: "5.15.26"
+grsec_version_focal: "5.15.57"
 
 daily_reboot_time: "4"

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -178,4 +178,4 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt.freedom.press"
-grsec_version_focal: "5.15.26"
+grsec_version_focal: "5.15.57"

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -186,6 +186,6 @@ log_events_with_ossec_alerts:
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
 
-grsec_version_focal: "5.15.26"
+grsec_version_focal: "5.15.57"
 
 daily_reboot_time: "4"

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -215,6 +215,6 @@ log_events_with_ossec_alerts:
     rule_id: "400700"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
-grsec_version_focal: "5.15.26"
+grsec_version_focal: "5.15.57"
 
 daily_reboot_time: "4"


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Towards #6496 .

Updates kernel version to 5.15.57.

## Testing

- [x] CI passes
- [x] only changes are to kernel version in `install_files/ansible-base/group_vars/all/securedrop` and test vars
- [x] make build-debs succeeds, building a `securedrop-grsec-5.15.57+focal-amd64.deb` package that depends on the 5.15.57 kernel package
