### PR TITLE
Remove old signing key from securedrop-admin

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -1019,7 +1019,7 @@ def update(args: argparse.Namespace) -> int:
         # appears on the second line of the output, and that there is a single
         # match from good_sig_text[]
         if (
-            RELEASE_KEYS[0] in gpg_lines[1]
+            any(key in gpg_lines[1] for key in RELEASE_KEYS)
             and len(good_sig_matches) == 1
             and bad_sig_text not in sig_result
         ):

--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -46,11 +46,9 @@ from prompt_toolkit.validation import ValidationError, Validator
 
 sdlog = logging.getLogger(__name__)
 
-# We list two (2) pubkeys as authorized to sign SecureDrop release artifacts,
-# to provide a transition window during key rotation. On or around v2.0.0,
-# we can remove the older of the two keys and only trust the newer going forward.
+# In the event of a key rotation, this list can be added to
+# in order to support a transition period.
 RELEASE_KEYS = [
-    "22245C81E3BAEB4138B36061310F561200F4AD77",
     "2359E6538C0613E652955E6C188EDD3B7B22E6A3",
 ]
 DEFAULT_KEYSERVER = "hkps://keys.openpgp.org"
@@ -1021,7 +1019,7 @@ def update(args: argparse.Namespace) -> int:
         # appears on the second line of the output, and that there is a single
         # match from good_sig_text[]
         if (
-            (RELEASE_KEYS[0] in gpg_lines[1] or RELEASE_KEYS[1] in gpg_lines[1])
+            RELEASE_KEYS[0] in gpg_lines[1]
             and len(good_sig_matches) == 1
             and bad_sig_text not in sig_result
         ):

--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -1002,9 +1002,6 @@ def update(args: argparse.Namespace) -> int:
         ).decode("utf-8")
 
         good_sig_text = [
-            'Good signature from "SecureDrop Release Signing ' + 'Key"',
-            'Good signature from "SecureDrop Release Signing '
-            + 'Key <securedrop-release-key@freedom.press>"',
             'Good signature from "SecureDrop Release Signing '
             + 'Key <securedrop-release-key-2021@freedom.press>"',
         ]

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -254,17 +254,7 @@ class TestSecureDropAdmin(object):
             b"2359E6538C0613E652955E6C188EDD3B7B22E6A3\n"
             b'gpg: Good signature from "SecureDrop Release '
             b"Signing Key "
-            b'<securedrop-release-key-2021@freedom.press>"\n',
-            b"gpg: Signature made Thu 20 Jul "
-            b"2022 08:12:25 PM EDT\n"
-            b"gpg:                using RSA key "
-            b"2359E6538C0613E652955E6C188EDD3B7B22E6A3\n"
-            b'gpg: Good signature from "SecureDrop Release '
-            b'Signing Key" [unknown]\n'
-            b'gpg:                 aka "SecureDrop Release '
-            b"Signing Key "
-            b'<securedrop-release-key-2021@freedom.press>" '
-            b"[unknown]\n",
+            b'<securedrop-release-key-2021@freedom.press>" [unknown]\n',
         ],
     )
     def test_update_signature_verifies(self, tmpdir, caplog, git_output):
@@ -307,7 +297,7 @@ class TestSecureDropAdmin(object):
             b"gpg:                using RSA key "
             b"2359E6538C0613E652955E6C188EDD3B7B22E6A3\n"
             b'gpg: Good signature from "SecureDrop Release '
-            b'Signing Key" [unknown]\n'
+            b'Signing Key <securedrop-release-key-2021@freedom.press>" [unknown]\n'
         )
 
         patchers = [
@@ -386,7 +376,7 @@ class TestSecureDropAdmin(object):
             b"gpg:                using RSA key "
             b"2359E6538C0613E652955E6C188EDD3B7B22E6A3\n"
             b'gpg: BAD signature from "SecureDrop Release '
-            b'Signing Key" [unknown]\n'
+            b'Signing Key <securedrop-release-key-2021@freedom.press>" [unknown]\n'
         )
 
         with mock.patch("securedrop_admin.check_for_updates", return_value=(True, "0.6.1")):
@@ -428,7 +418,8 @@ class TestSecureDropAdmin(object):
             b"gpg:                using RSA key "
             b"1234567812345678123456781234567812345678\n"
             b"gpg: Good signature from Good signature from "
-            b'"SecureDrop Release Signing Key" [unknown]\n'
+            b'"SecureDrop Release Signing Key <securedrop-release-key-2021@freedom.press>" '
+            b"[unknown]\n"
         )
 
         with mock.patch("securedrop_admin.check_for_updates", return_value=(True, "0.6.1")):
@@ -450,7 +441,8 @@ class TestSecureDropAdmin(object):
             b"1234567812345678123456781234567812345678\n"
             b"gpg: Good signature from 22245C81E3BAEB4138"
             b"955E6C188EDD3B7B22E6A3 Good signature from "
-            b'"SecureDrop Release Signing Key" [unknown]\n'
+            b'"SecureDrop Release Signing Key <securedrop-release-key-2021@freedom.press>" '
+            b"[unknown]\n"
         )
 
         with mock.patch("securedrop_admin.check_for_updates", return_value=(True, "0.6.1")):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

- Ensures the previous signing key no longer validates tags verified via `securedrop-admin`. It's still valid for old  tags, but `securedrop-admin` should never have to verify those.
- Also removes the previously used UIDs.
- Updates GPG test output to current year for clarity (the fingerprint and year combinations otherwise don't make sense); it makes no difference in terms of test results. Also updates copyright statement for consistency.
- Sprinkles in some code comments :sparkles: 

Fixes #6511

## Testing

- On an Admin Workstation, apply the changes to `__init.py__` in this PR (I manually applied them to the 2.4.1 tag, but testing on this branch should work as well for this purpose) and bounce the network. Verify that you can update to the latest tag successfully.

## Deployment considerations

- This PR removes the UID variant without an email address as valid. I believe this should be safe, but would very much appreciate additional fact-checking on this, see my comment here: https://github.com/freedomofpress/securedrop/pull/6519#issuecomment-1220113645


## Checklist

- [x] Linting and tests (`make -C admin test`) pass in the admin development container
- [x] I stepped through test plan above.