### PR TITLE
updated mako from 1.0.7 to 1.2.2

### DIFF
--- a/securedrop/requirements/python3/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.in
@@ -11,7 +11,6 @@ Flask-SQLAlchemy
 Flask-WTF>=1.0.0
 Flask>=2.0.2
 Jinja2>=3.0.0
-mako>=1.2.2
 markupsafe>=2.0
 mod_wsgi
 passlib

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.in
@@ -11,6 +11,7 @@ Flask-SQLAlchemy
 Flask-WTF>=1.0.0
 Flask>=2.0.2
 Jinja2>=3.0.0
+mako>=1.2.2
 markupsafe>=2.0
 mod_wsgi
 passlib

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.txt
@@ -141,9 +141,7 @@ jinja2==3.0.2 \
 mako==1.2.2 \
     --hash=sha256:3724869b363ba630a272a5f89f68c070352137b8fd1757650017b7e06fda163f \
     --hash=sha256:8efcb8004681b5f71d09c983ad5a9e6f5c40601a6ec469148753292abc0da534
-    # via
-    #   -r requirements/python3/securedrop-app-code-requirements.in
-    #   alembic
+    # via alembic
 markupsafe==2.0.1 \
     --hash=sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298 \
     --hash=sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64 \

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.txt
@@ -138,9 +138,12 @@ jinja2==3.0.2 \
     #   -r requirements/python3/securedrop-app-code-requirements.in
     #   flask
     #   flask-babel
-mako==1.0.7 \
-    --hash=sha256:4e02fde57bd4abb5ec400181e4c314f56ac3e49ba4fb8b0d50bba18cb27d25ae
-    # via alembic
+mako==1.2.2 \
+    --hash=sha256:3724869b363ba630a272a5f89f68c070352137b8fd1757650017b7e06fda163f \
+    --hash=sha256:8efcb8004681b5f71d09c983ad5a9e6f5c40601a6ec469148753292abc0da534
+    # via
+    #   -r requirements/python3/securedrop-app-code-requirements.in
+    #   alembic
 markupsafe==2.0.1 \
     --hash=sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298 \
     --hash=sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64 \


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Updates `mako`, an `alembic` dependency, from v1.0.7 to 1.2.2


## Testing

- [x] verify that CI is passing
- start a dev container on this branch with `cd securedrop/; ./bin/dev-shell`
- in the container run `cd securedrop; source ./bin/dev-deps && maybe_create_config_py`
- run the following commands to create an empty database:
  ```
  sudo mkdir -p /var/lib/securedrop/
  sudo chmod 0700 /var/lib/securedrop/
  sudo chown "$(id -u):$(id -g)" /var/lib/securedrop
  rm -f /var/lib/securedrop/db.sqlite
  sqlite3 /var/lib/securedrop/db.sqlite .databases > /dev/null
  ```
- [x] verify that the command `alembic upgrade head` completes successfully
- [x] verify that the command `alembic history` completes successfully
- [x] verify that you can successfully downgrade to earlier alembic revisions and then upgrade again
- [x] try creating a new migration (`./bin/new-migration 'my migration message'`), verify it looks reasonable

## Deployment
 
n/a

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a production code dependency:

Choose one of the following:

- [x] I have performed a diff review and pasted the contents: https://github.com/freedomofpress/securedrop-debian-packaging/wiki/mako-1.0.7-to-1.2.2

```
$ gpg --verify mako.asc
gpg: Signature made Tue Sep  6 10:03:04 2022 EDT
gpg:                using RSA key A05ACE4F7E0BCA9BAD8D42F4ACFE4353173015EA
gpg: Good signature from "Kevin O'Gorman <kog@stunbunny.org>" [unknown]
gpg:                 aka "Kevin O'Gorman <kevin.ogorman@gmail.com>" [unknown]
gpg:                 aka "Kevin O'Gorman <kog@freedom.press>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: A05A CE4F 7E0B CA9B AD8D  42F4 ACFE 4353 1730 15EA
```
