### PR TITLE
Accessibility improvements for links and buttons

### DIFF
--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -45,7 +45,7 @@
       {{ ngettext('1 unread', '{num} unread', source.num_unread).format(num=source.num_unread) }}
     </a>
     {% else %}
-    <span class="visually-hidden" >
+    <span class="visually-hidden">
       {{ ngettext('1 unread', '{num} unread', source.num_unread).format(num=source.num_unread) }}
     </span>
     {% endif %}

--- a/securedrop/journalist_templates/_source_row.html
+++ b/securedrop/journalist_templates/_source_row.html
@@ -40,11 +40,12 @@
   </td>
   <td class="unread">
     {% if source.num_unread > 0 %}
-    <a class="btn small icon download" href="/download_unread/{{ source.filesystem_id }}">
+    <a class="btn small icon download" href="/download_unread/{{ source.filesystem_id }}" 
+      aria-label="{{ ngettext('1 unread', '{num} unread', source.num_unread).format(num=source.num_unread) }}">
       {{ ngettext('1 unread', '{num} unread', source.num_unread).format(num=source.num_unread) }}
     </a>
     {% else %}
-    <span class="visually-hidden">
+    <span class="visually-hidden" >
       {{ ngettext('1 unread', '{num} unread', source.num_unread).format(num=source.num_unread) }}
     </span>
     {% endif %}

--- a/securedrop/journalist_templates/admin.html
+++ b/securedrop/journalist_templates/admin.html
@@ -84,7 +84,7 @@
 </section>
 
 <a href="{{ url_for('admin.manage_config') }}" class="btn icon icon-edit section-spacing-inline"
-  id="update-instance-config" aria-label="{{ gettext('Update instance config') }}">
+  id="update-instance-config" aria-label="{{ gettext('Update instance configuration') }}">
   {{ gettext('INSTANCE CONFIG') }}
 </a>
 

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -33,7 +33,7 @@
     <div class="container">
       {% block header %}
       <header>
-        <a href="{{ url_for('main.index') }}" class="no-bottom-border"><img src="{{ g.logo }}" class="logo small"
+        <a aria-label="{{ gettext('Return to Main View') }}" href="{{ url_for('main.index') }}" class="no-bottom-border"><img src="{{ g.logo }}" class="logo small"
             alt="{{ g.organization_name }} logo" width="250"></a>
         {% include 'locales.html' %}
       </header>

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -33,7 +33,7 @@
     <div class="container">
       {% block header %}
       <header>
-        <a aria-label="{{ gettext('Return to Main View') }}" href="{{ url_for('main.index') }}" class="no-bottom-border"><img src="{{ g.logo }}" class="logo small"
+        <a aria-label="{{ gettext('Return to All Sources') }}" href="{{ url_for('main.index') }}" class="no-bottom-border"><img src="{{ g.logo }}" class="logo small"
             alt="{{ g.organization_name }} logo" width="250"></a>
         {% include 'locales.html' %}
       </header>

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -22,10 +22,10 @@
   <form action="/bulk" method="post">
     <div>
       <div id="select-container"></div>
-      <button type="submit" name="action" value="download" class="small icon">
+      <button aria-label="{{ gettext('Download Selected Files') }}" type="submit" name="action" value="download" class="small icon">
         {{ gettext('Download Selected') }}
       </button>
-      <a href="#delete-selected-confirmation-modal" id="delete-selected-link" class="btn small danger">
+      <a aria-label="{{ gettext('Delete Selected Files') }}" href="#delete-selected-confirmation-modal" id="delete-selected-link" class="btn small danger">
         {{ gettext('Delete Selected') }}
       </a>
     </div>

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -11,16 +11,16 @@
     <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
     <div>
       <div id="index-select-container"></div>
-      <button type="submit" name="action" value="download-unread" class="small icon">
+      <button aria-label="{{ gettext('Download Selected Unread Submissions') }}" type="submit" name="action" value="download-unread" class="small icon">
         {{ gettext('Download Unread') }}
       </button>
-      <button type="submit" name="action" value="download-all" class="small icon">
+      <button aria-label="{{ gettext('Download Selected Submissions') }}" type="submit" name="action" value="download-all" class="small icon">
         {{ gettext('Download') }}
       </button>
-      <button type="submit" name="action" value="star" class="small icon">
+      <button aria-label="{{ gettext('Star Selected Submissions') }}" type="submit" name="action" value="star" class="small icon">
         {{ gettext('Star') }}
       </button>
-      <button type="submit" name="action" value="un-star" class="small icon">
+      <button aria-label="{{ gettext('Un-star Selected Submissions') }}" type="submit" name="action" value="un-star" class="small icon">
         {{ gettext('Un-star') }}
       </button>
       <div class="delete-menu-button"><a href="#delete-sources-modal" id="delete-collections-link"

--- a/securedrop/journalist_templates/login.html
+++ b/securedrop/journalist_templates/login.html
@@ -24,7 +24,7 @@
     <label for="token" class="visually-hidden">{{ gettext('Two-factor Code') }}</label>
     <input class="login-token" name="token" id="token" type="text" placeholder="{{ gettext('Two-factor Code') }}">
   </div>
-  <button type="submit" aria-label="{{ gettext('Log In') }}">{{ gettext('LOG IN') }}</button>
+  <button type="submit" aria-label="{{ gettext('Log In to Journalist Interface') }}">{{ gettext('LOG IN') }}</button>
 </form>
 
 {% endblock %}

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -24,7 +24,7 @@
         {% endif %}
         <a href="#main">{{ gettext('Skip to main content') }}</a>
         {% block header %}
-        <h1><a aria-label="{{ gettext('Return to Main View') }}"  href="{% if is_user_logged_in %}{{ url_for('main.lookup') }}{% else %}{{ url_for('main.index') }}{% endif %}">
+        <h1><a aria-label="{% if is_user_logged_in %}{{ gettext('Return to Submission Page') }}{% else %}{{ gettext('Return to Home Page') }}{% endif %}"  href="{% if is_user_logged_in %}{{ url_for('main.lookup') }}{% else %}{{ url_for('main.index') }}{% endif %}">
           <img src="{{ g.logo }}" alt="{{ g.organization_name }} logo">
         </a></h1>
         {% include 'locales.html' %}

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -24,7 +24,7 @@
         {% endif %}
         <a href="#main">{{ gettext('Skip to main content') }}</a>
         {% block header %}
-        <h1><a href="{% if is_user_logged_in %}{{ url_for('main.lookup') }}{% else %}{{ url_for('main.index') }}{% endif %}">
+        <h1><a aria-label="{{ gettext('Return to Main View') }}"  href="{% if is_user_logged_in %}{{ url_for('main.lookup') }}{% else %}{{ url_for('main.index') }}{% endif %}">
           <img src="{{ g.logo }}" alt="{{ g.organization_name }} logo">
         </a></h1>
         {% include 'locales.html' %}

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -24,7 +24,7 @@
 <form id="create-form" method="post" action="/create" autocomplete="off">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   <input name="tab_id" type="hidden" value="{{ tab_id }}">
-  <button type="submit" aria-label="{{ gettext('Continue') }}">
+  <button type="submit" aria-label="{{ gettext('Continue to Submissions Page') }}">
     {{ gettext('CONTINUE') }}
   </button>
 </form>

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -24,7 +24,7 @@
 <form id="create-form" method="post" action="/create" autocomplete="off">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
   <input name="tab_id" type="hidden" value="{{ tab_id }}">
-  <button type="submit" aria-label="{{ gettext('Continue to Submissions Page') }}">
+  <button type="submit" aria-label="{{ gettext('Continue to Submission Page') }}">
     {{ gettext('CONTINUE') }}
   </button>
 </form>

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -72,7 +72,7 @@
           <h2 id="return-visit-heading">{{ gettext('Return visit') }}</h2>
           <p>{{ gettext('Already have a codename? Check for replies or submit something new.') }}</p>
           <a href="{{ url_for('main.login') }}" class="btn secondary"
-            aria-label="{{ gettext('Log In Again Using A Previous Codename') }}">
+            aria-label="{{ gettext('Log In Using Your Codename') }}">
             {{ gettext('LOG IN') }}
           </a>
       </section>

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -44,7 +44,7 @@
     <span id="browser-tb-close" aria-label="{{ gettext('Close') }}">×</span></p>
   </div>
   <div id="browser-android" class="warning" role="alert">
-    <p>{{ gettext('<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Orfox does not provide the same level of security and anonymity as the desktop version.</strong> <a class="recommend-tor" href="{tor_browser_url}">Learn how to install it</a>, or ignore this warning to continue.').format(tor_browser_url=url_for('info.recommend_tor_browser')) }}
+    <p>{{ gettext('<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Orfox does not provide the same level of security and anonymity as the desktop version.</strong> <a class="recommend-tor" aria-label="{{ gettext('Learn how to install Tor Browser') }}" href="{tor_browser_url}">Learn how to install it</a>, or ignore this warning to continue.').format(tor_browser_url=url_for('info.recommend_tor_browser')) }}
     <span id="browser-android-close" aria-label="{{ gettext('Close') }}">×</span></p>
   </div>
 
@@ -62,7 +62,7 @@
         <form id="started-form" method="post" action="/generate" autocomplete="off">
           <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
           <input name="tor2web_check" type="hidden" value='href="fake.onion"'>
-          <button type="submit" aria-label="{{ gettext('Get Started') }}">
+          <button type="submit" aria-label="{{ gettext('Get Started With Your First Submission') }}">
             {{ gettext('GET STARTED') }}
           </button>
         </form>
@@ -72,7 +72,7 @@
           <h2 id="return-visit-heading">{{ gettext('Return visit') }}</h2>
           <p>{{ gettext('Already have a codename? Check for replies or submit something new.') }}</p>
           <a href="{{ url_for('main.login') }}" class="btn secondary"
-            aria-label="{{ gettext('Log In') }}">
+            aria-label="{{ gettext('Log In Again Using A Previous Codename') }}">
             {{ gettext('LOG IN') }}
           </a>
       </section>

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -44,7 +44,7 @@
     <span id="browser-tb-close" aria-label="{{ gettext('Close') }}">×</span></p>
   </div>
   <div id="browser-android" class="warning" role="alert">
-    <p>{{ gettext('<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Orfox does not provide the same level of security and anonymity as the desktop version.</strong> <a class="recommend-tor" aria-label="{{ gettext('Learn how to install Tor Browser') }}" href="{tor_browser_url}">Learn how to install it</a>, or ignore this warning to continue.').format(tor_browser_url=url_for('info.recommend_tor_browser')) }}
+    <p>{{ gettext('<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Orfox does not provide the same level of security and anonymity as the desktop version.</strong> <a class="recommend-tor" aria-label="Learn how to install Tor Browser" href="{tor_browser_url}" >Learn how to install it</a>, or ignore this warning to continue.').format(tor_browser_url=url_for('info.recommend_tor_browser')) }}
     <span id="browser-android-close" aria-label="{{ gettext('Close') }}">×</span></p>
   </div>
 

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -29,7 +29,7 @@
   <div class="form-controls">
     <a href="{{ url_for('main.index') }}" class="btn secondary" aria-label="{{ gettext('Cancel and Return to Previous Page') }}">
       {{ gettext('CANCEL') }}</a>
-    <button type="submit" aria-label="{{ gettext('Continue to Submissions Page') }}">
+    <button type="submit" aria-label="{{ gettext('Continue to Submission Page') }}">
       {{ gettext('CONTINUE') }}
     </button>
   </div>

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -27,9 +27,9 @@
   </div>
 
   <div class="form-controls">
-    <a href="{{ url_for('main.index') }}" class="btn secondary" aria-label="{{ gettext('Cancel') }}">
+    <a href="{{ url_for('main.index') }}" class="btn secondary" aria-label="{{ gettext('Cancel and Return to Previous Page') }}">
       {{ gettext('CANCEL') }}</a>
-    <button type="submit" aria-label="{{ gettext('Continue') }}">
+    <button type="submit" aria-label="{{ gettext('Continue to Submissions Page') }}">
       {{ gettext('CONTINUE') }}
     </button>
   </div>

--- a/securedrop/source_templates/logout.html
+++ b/securedrop/source_templates/logout.html
@@ -4,7 +4,7 @@
 
 {% block body %}
 <nav>
-  <a href="{{ url_for('main.login') }}" class="btn" aria-label="{{ gettext('Log In') }}">
+  <a href="{{ url_for('main.login') }}" class="btn" aria-label="{{ gettext('Log In Again Using A Previous Codename') }}">
     {{ gettext('LOG IN') }}</a>
 </nav>
 <section>

--- a/securedrop/source_templates/logout.html
+++ b/securedrop/source_templates/logout.html
@@ -4,7 +4,7 @@
 
 {% block body %}
 <nav>
-  <a href="{{ url_for('main.login') }}" class="btn" aria-label="{{ gettext('Log In Again Using A Previous Codename') }}">
+  <a href="{{ url_for('main.login') }}" class="btn" aria-label="{{ gettext('Log Back In' }}">
     {{ gettext('LOG IN') }}</a>
 </nav>
 <section>

--- a/securedrop/source_templates/logout.html
+++ b/securedrop/source_templates/logout.html
@@ -4,7 +4,7 @@
 
 {% block body %}
 <nav>
-  <a href="{{ url_for('main.login') }}" class="btn" aria-label="{{ gettext('Log Back In' }}">
+  <a href="{{ url_for('main.login') }}" class="btn" aria-label="{{ gettext('Log Back In') }}">
     {{ gettext('LOG IN') }}</a>
 </nav>
 <section>

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -65,7 +65,7 @@
         aria-label="{{ gettext('Cancel and Clear Uploaded Content') }}">
         {{ gettext('CANCEL') }}
       </a>
-      <button type="submit" aria-label="{{ gettext('Submit Uploaded Content to the SecureDrop') }}">
+      <button type="submit" aria-label="{{ gettext('Submit Uploaded Content') }}">
         {{ gettext('SUBMIT') }}
       </button>
     </div>

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -62,10 +62,10 @@
 
     <div class="form-controls">
       <a href="{{ url_for('main.lookup') }}" class="btn secondary" role="button"
-        aria-label="{{ gettext('Cancel') }}">
+        aria-label="{{ gettext('Cancel and Clear Uploaded Content') }}">
         {{ gettext('CANCEL') }}
       </a>
-      <button type="submit" aria-label="{{ gettext('Submit') }}">
+      <button type="submit" aria-label="{{ gettext('Submit Uploaded Content to the SecureDrop') }}">
         {{ gettext('SUBMIT') }}
       </button>
     </div>
@@ -96,7 +96,7 @@
               {{ gettext('Delete reply from {timestamp}?').format(timestamp=timestamp) }}</h4>
             <div class="form-controls">
               <button type="submit" class="danger" role="button"
-                aria-label="{{ gettext('Delete') }}">{{ gettext('DELETE') }}</button>
+                aria-label="{{ gettext('Delete Reply') }}">{{ gettext('DELETE') }}</button>
               <a href="#reply-{{ reply.filename }}" class="btn danger secondary" role="button"
                  aria-label="{{ gettext('Cancel') }}">{{ gettext('CANCEL') }}</a>
             </div>

--- a/securedrop/source_templates/utils.html
+++ b/securedrop/source_templates/utils.html
@@ -13,7 +13,7 @@
 {% endif %}
 
   <input id="codename-show-checkbox" type="checkbox" role="button"{% if not new %} checked {% endif -%}
-    aria-label="{{ gettext('Make Codename Visible on the Display') }}" aria-controls="codename">
+    aria-label="{{ gettext('Reveal Codename') }}" aria-controls="codename">
 
   <mark id="codename" lang="en-US" dir="ltr"{% if not new %}
     aria-describedby="codename-instructions codename-explanation"{% endif %}><span>{{ codename }}</span></mark>

--- a/securedrop/source_templates/utils.html
+++ b/securedrop/source_templates/utils.html
@@ -13,7 +13,7 @@
 {% endif %}
 
   <input id="codename-show-checkbox" type="checkbox" role="button"{% if not new %} checked {% endif -%}
-    aria-label="{{ gettext('Show Codename') }}" aria-controls="codename">
+    aria-label="{{ gettext('Make Codename Visible on the Display') }}" aria-controls="codename">
 
   <mark id="codename" lang="en-US" dir="ltr"{% if not new %}
     aria-describedby="codename-instructions codename-explanation"{% endif %}><span>{{ codename }}</span></mark>

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -368,7 +368,7 @@ msgstr ""
 msgid "No users to display"
 msgstr ""
 
-msgid "Update instance config"
+msgid "Update instance configuration"
 msgstr ""
 
 msgid "INSTANCE CONFIG"
@@ -431,6 +431,9 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
+msgid "Return to All Sources"
+msgstr ""
+
 msgid "Powered by <b>SecureDrop {version}</b>."
 msgstr ""
 
@@ -443,7 +446,13 @@ msgstr ""
 msgid "All messages, files, and replies from sources are stored as encrypted files for security. To read them, you will need to decrypt them on your Secure Viewing Station."
 msgstr ""
 
+msgid "Download Selected Files"
+msgstr ""
+
 msgid "Download Selected"
+msgstr ""
+
+msgid "Delete Selected Files"
 msgstr ""
 
 msgid "Delete Selected"
@@ -663,13 +672,25 @@ msgstr ""
 msgid "Reset Security Key Credentials"
 msgstr ""
 
+msgid "Download Selected Unread Submissions"
+msgstr ""
+
 msgid "Download Unread"
+msgstr ""
+
+msgid "Download Selected Submissions"
 msgstr ""
 
 msgid "Download"
 msgstr ""
 
+msgid "Star Selected Submissions"
+msgstr ""
+
 msgid "Star"
+msgstr ""
+
+msgid "Un-star Selected Submissions"
 msgstr ""
 
 msgid "Un-star"
@@ -723,7 +744,7 @@ msgstr ""
 msgid "Show password"
 msgstr ""
 
-msgid "Log In"
+msgid "Log In to Journalist Interface"
 msgstr ""
 
 msgid "LOG IN"
@@ -809,6 +830,12 @@ msgstr ""
 msgid "Skip to notification"
 msgstr ""
 
+msgid "Return to Submission Page"
+msgstr ""
+
+msgid "Return to Home Page"
+msgstr ""
+
 msgid "We're sorry, our SecureDrop is currently offline."
 msgstr ""
 
@@ -851,7 +878,7 @@ msgstr ""
 msgid "<strong>Keep it safe.</strong> There is no account recovery option."
 msgstr ""
 
-msgid "Continue"
+msgid "Continue to Submission Page"
 msgstr ""
 
 msgid "Welcome"
@@ -878,7 +905,7 @@ msgstr ""
 msgid "<strong>It is recommended to use Tor Browser to access SecureDrop:</strong> <a class=\"recommend-tor\" href=\"{tor_browser_url}\">Learn how to install it</a>, or ignore this warning to continue."
 msgstr ""
 
-msgid "<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Orfox does not provide the same level of security and anonymity as the desktop version.</strong> <a class=\"recommend-tor\" href=\"{tor_browser_url}\">Learn how to install it</a>, or ignore this warning to continue."
+msgid "<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Orfox does not provide the same level of security and anonymity as the desktop version.</strong> <a class=\"recommend-tor\" aria-label=\"Learn how to install Tor Browser\" href=\"{tor_browser_url}\" >Learn how to install it</a>, or ignore this warning to continue."
 msgstr ""
 
 msgid "{} logo"
@@ -890,7 +917,7 @@ msgstr ""
 msgid "First time submitting to our SecureDrop? Start here."
 msgstr ""
 
-msgid "Get Started"
+msgid "Get Started With Your First Submission"
 msgstr ""
 
 msgid "GET STARTED"
@@ -902,6 +929,9 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
+msgid "Log In Using Your Codename"
+msgstr ""
+
 msgid "Log in"
 msgstr ""
 
@@ -911,10 +941,16 @@ msgstr ""
 msgid "Enter your codename"
 msgstr ""
 
+msgid "Cancel and Return to Previous Page"
+msgstr ""
+
 msgid "CANCEL"
 msgstr ""
 
 msgid "Additional Action Required"
+msgstr ""
+
+msgid "Log Back In"
 msgstr ""
 
 msgid "One more thing..."
@@ -950,7 +986,10 @@ msgstr ""
 msgid "Anti-spam check. Do not fill this in!"
 msgstr ""
 
-msgid "Submit"
+msgid "Cancel and Clear Uploaded Content"
+msgstr ""
+
+msgid "Submit Uploaded Content"
 msgstr ""
 
 msgid "Read Replies"
@@ -963,6 +1002,9 @@ msgid "Delete this reply"
 msgstr ""
 
 msgid "Delete reply from {timestamp}?"
+msgstr ""
+
+msgid "Delete Reply"
 msgstr ""
 
 msgid "Delete All Replies"
@@ -1026,6 +1068,9 @@ msgid "Remember, your codename is:"
 msgstr ""
 
 msgid "Codename"
+msgstr ""
+
+msgid "Reveal Codename"
 msgstr ""
 
 msgid "Show Codename"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6404

Changes proposed in this pull request:

* This PR adds and expands labels to improve accessibility in areas where existing descriptions were either missing, or lacking context for visually impaired users to be able to understand where they are in the system and where they will be navigating next.
* ~This PR also includes updated translation files, as new translations will be needed.~

## Testing

How should the reviewer test this PR?

* Build the dev environment using the usual steps, then verify everything is working as expected.
* Optionally, enable a screen reader to verify these changes and see (or rather, hear) the differences first-hand.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

This will require new translations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container*
 \* There are three failures with make test, but it appears to be unrelated to changes in this branch, and I still see those when I run `make test` for the `develop` branch as well. 653 tests pass.

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
