### PR TITLE
Use Consistent Terminology Regarding Documents, Files, Messages, and Submissions

### DIFF
--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -74,7 +74,7 @@
 
         {% with %}
         {% if doc.filename.endswith('-doc.gz.gpg') %}
-        {% set type = gettext('Uploaded Document') %}
+        {% set type = gettext('Uploaded File') %}
         {% set icon = 'files' %}
         {% elif doc.filename.endswith('-reply.gpg') %}
         {% set type = gettext('Reply') %}

--- a/securedrop/journalist_templates/config.html
+++ b/securedrop/journalist_templates/config.html
@@ -59,7 +59,7 @@
       <div class="config_form_element">
         {{ submission_preferences_form.prevent_document_uploads() }}
         <label
-      for="prevent_document_uploads">{{ gettext('Prevent sources from uploading documents. Sources will still be able to send messages.') }}</label>
+      for="prevent_document_uploads">{{ gettext('Prevent sources from uploading files. Sources will still be able to send messages.') }}</label>
       </div>
 
       <div class="config_form_element">

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -47,7 +47,7 @@
       <thead hidden aria-hidden="false">
         <tr>
           <th scope="col">{{ gettext('Designation') }}</th>
-          <th scope="col">{{ gettext('Documents') }}</th>
+          <th scope="col">{{ gettext('Files') }}</th>
           <th scope="col">{{ gettext('Messages') }}</th>
           <th scope="col">{{ gettext('Unread') }}</th>
           <th scope="col">{{ gettext('Date') }}</th>
@@ -77,7 +77,7 @@
     </table>
   </form>
   {% else %}
-  <p>{{ gettext('No documents have been submitted!') }}</p>
+  <p>{{ gettext('There are no submissions!') }}</p>
   {% endif %}
 </div>
 {% endblock %}

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -331,7 +331,7 @@ def get_args() -> argparse.ArgumentParser:
     parser.add_argument(
         "--store-dir",
         default=config.STORE_DIR,
-        help=("directory in which the documents are stored"),
+        help=("directory in which the files are stored"),
     )
     subps = parser.add_subparsers()
     # Add/remove journalists + admins

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -294,7 +294,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             elif fh and not msg:
                 html_contents = gettext("Thanks! We received your file.")
             else:
-                html_contents = gettext("Thanks! We received your submission.")
+                html_contents = gettext("Thanks! We received your file and message.")
 
             flash_msg("success", gettext("Success!"), html_contents)
 

--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -292,9 +292,9 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             elif msg and not fh:
                 html_contents = gettext("Thanks! We received your message.")
             elif fh and not msg:
-                html_contents = gettext("Thanks! We received your document.")
+                html_contents = gettext("Thanks! We received your file.")
             else:
-                html_contents = gettext("Thanks! We received your message and document.")
+                html_contents = gettext("Thanks! We received your submission.")
 
             flash_msg("success", gettext("Success!"), html_contents)
 

--- a/securedrop/source_templates/footer.html
+++ b/securedrop/source_templates/footer.html
@@ -3,7 +3,7 @@
     {{ gettext('Powered by') }} <b>SecureDrop {{ version }}</b>.
   </p>
   <p id="footer-advisory">
-    {{ gettext('Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop.') }}
+    {{ gettext('Please note: Sharing sensitive files may put you at risk, even when using Tor and SecureDrop.') }}
   </p>
   <p id="footer-fpf">
     {{ gettext('SecureDrop is a project of Freedom of the Press Foundation.') }}

--- a/securedrop/source_templates/footer.html
+++ b/securedrop/source_templates/footer.html
@@ -3,7 +3,7 @@
     {{ gettext('Powered by') }} <b>SecureDrop {{ version }}</b>.
   </p>
   <p id="footer-advisory">
-    {{ gettext('Please note: Sharing sensitive files may put you at risk, even when using Tor and SecureDrop.') }}
+    {{ gettext('Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop.') }}
   </p>
   <p id="footer-fpf">
     {{ gettext('SecureDrop is a project of Freedom of the Press Foundation.') }}

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -462,7 +462,7 @@ def test_delete_collection(mocker, source_app, journalist_app, test_journo):
             in text
         )
 
-        assert "No documents have been submitted!" in text
+        assert "There are no submissions!" in text
 
         # Make sure the collection is deleted from the filesystem
         def assertion():

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -373,7 +373,7 @@ def test_login_valid_credentials(config, journalist_app, test_journo, locale):
             follow_redirects=True,
         )
         assert page_language(resp.data) == language_tag(locale)
-        msgids = ["All Sources", "No documents have been submitted!"]
+        msgids = ["All Sources", "There are no submissions!"]
         with xfail_untranslated_messages(config, locale, msgids):
             resp_text = resp.data.decode("utf-8")
             for msgid in msgids:

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -481,7 +481,7 @@ def test_submit_both(source_app):
         )
         assert resp.status_code == 200
         text = resp.data.decode("utf-8")
-        assert "Thanks! We received your submission" in text
+        assert "Thanks! We received your file and message" in text
 
 
 def test_submit_antispam(source_app):

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -467,7 +467,7 @@ def test_submit_file(source_app):
         )
         assert resp.status_code == 200
         text = resp.data.decode("utf-8")
-        assert "Thanks! We received your document" in text
+        assert "Thanks! We received your file" in text
 
 
 def test_submit_both(source_app):
@@ -481,7 +481,7 @@ def test_submit_both(source_app):
         )
         assert resp.status_code == 200
         text = resp.data.decode("utf-8")
-        assert "Thanks! We received your message and document" in text
+        assert "Thanks! We received your submission" in text
 
 
 def test_submit_antispam(source_app):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #2421 and fixes #6173 

Changes proposed in this pull request:

This updates the remaining user-facing references from 'Documents' to either 'Files' or 'Submissions,' depending on the given use-case. In a previous meeting we mentioned using 'Submission' for everything, but in practice I discovered that is not feasible. That's because 'Submission' includes both files and messages, but there are instances where it's necessary to specify between files and messages. This change eliminates the usage of 'Documents,' and adds consistency to the work that has already been done more recently.

## Testing

This can be tested by building according to the steps in the README.


## Deployment

This will require new translations. 

Side-note, is it necessary here to run `make translate` to update the translation files, or does that happen after the fact?

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

Just to note, normally these changes _would_ require documentation updates, but it appears that the newer terminology has already made it into the product for all the user-facing strings shown in the documentation. I have gone through the source and journalist guides, and do not see any outdated strings that would need to be replaced.
