### PR TITLE
docs: Fix a few typos

### DIFF
--- a/devops/demo/landing-page/webroot/assets/js/jsOTP.js
+++ b/devops/demo/landing-page/webroot/assets/js/jsOTP.js
@@ -996,7 +996,7 @@ var SUPPORTED_ALGS = 4 | 2 | 1;
 	 * @param {Int_64} a The first 64-bit integer argument to be added
 	 * @param {Int_64} b The second 64-bit integer argument to be added
 	 * @param {Int_64} c The third 64-bit integer argument to be added
-	 * @param {Int_64} d The fouth 64-bit integer argument to be added
+	 * @param {Int_64} d The fourth 64-bit integer argument to be added
 	 * @return {Int_64} The sum of a + b + c + d
 	 */
 	function safeAdd_64_4(a, b, c, d)
@@ -1026,8 +1026,8 @@ var SUPPORTED_ALGS = 4 | 2 | 1;
 	 * @param {Int_64} a The first 64-bit integer argument to be added
 	 * @param {Int_64} b The second 64-bit integer argument to be added
 	 * @param {Int_64} c The third 64-bit integer argument to be added
-	 * @param {Int_64} d The fouth 64-bit integer argument to be added
-	 * @param {Int_64} e The fouth 64-bit integer argument to be added
+	 * @param {Int_64} d The fourth 64-bit integer argument to be added
+	 * @param {Int_64} e The fourth 64-bit integer argument to be added
 	 * @return {Int_64} The sum of a + b + c + d + e
 	 */
 	function safeAdd_64_5(a, b, c, d, e)

--- a/molecule/builder-focal/tests/test_securedrop_deb_package.py
+++ b/molecule/builder-focal/tests/test_securedrop_deb_package.py
@@ -18,7 +18,7 @@ def extract_package_name_from_filepath(filepath: str) -> str:
     E.g., given:
        securedrop-ossec-agent-2.8.2+0.3.10-amd64.deb
 
-    retuns:
+    returns:
 
        securedrop-ossec-agent
 

--- a/molecule/testinfra/app/test_tor_config.py
+++ b/molecule/testinfra/app/test_tor_config.py
@@ -63,7 +63,7 @@ def test_tor_torrc_sandbox(host):
     before we push it out to servers. See issues #944 and #1969.
     """
     f = host.file("/etc/tor/torrc")
-    # Only `Sandbox 1` will enable, but make sure there are zero occurrances
+    # Only `Sandbox 1` will enable, but make sure there are zero occurrences
     # of "Sandbox", otherwise we may have a regression somewhere.
     assert not f.contains("^.*Sandbox.*$")
 

--- a/securedrop/tests/migrations/migration_b58139cfdc8c.py
+++ b/securedrop/tests/migrations/migration_b58139cfdc8c.py
@@ -190,7 +190,7 @@ class DowngradeTester(Helper):
         """
         Verify that the checksum column is now gone.
         The dropping of the revoked_tokens table cannot be checked. If the migration completes,
-        then it wokred correctly.
+        then it worked correctly.
         """
         with self.app.app_context():
             sql = "SELECT * FROM submissions"


### PR DESCRIPTION
There are small typos in:
- devops/demo/landing-page/webroot/assets/js/jsOTP.js
- molecule/builder-focal/tests/test_securedrop_deb_package.py
- molecule/testinfra/app/test_tor_config.py
- securedrop/tests/migrations/migration_b58139cfdc8c.py

Fixes:
- Should read `fourth` rather than `fouth`.
- Should read `worked` rather than `wokred`.
- Should read `returns` rather than `retuns`.
- Should read `occurrences` rather than `occurrances`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md