### PR TITLE
Do not escape org name twice

### DIFF
--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -2,7 +2,6 @@
 
 import binascii
 import os
-from html import escape
 from typing import Optional, Union
 
 import werkzeug
@@ -132,7 +131,7 @@ def make_blueprint(config: SDConfig) -> Blueprint:
         if form.validate_on_submit():
             try:
                 value = request.form["organization_name"]
-                InstanceConfig.set_organization_name(escape(value, quote=True))
+                InstanceConfig.set_organization_name(value)
                 flash(gettext("Preferences saved."), "org-name-success")
             except Exception:
                 flash(gettext("Failed to update organization name."), "org-name-error")

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -7,7 +7,6 @@ import os
 import random
 import zipfile
 from base64 import b64decode
-from html import escape as htmlescape
 from io import BytesIO
 from pathlib import Path
 
@@ -2001,25 +2000,6 @@ def test_orgname_oversized_fails(config, journalist_app, test_admin, locale):
                 InstanceConfig.MAX_ORG_NAME_LEN,
             ).format(num=InstanceConfig.MAX_ORG_NAME_LEN) in resp.data.decode("utf-8")
         assert InstanceConfig.get_current().organization_name == "SecureDrop"
-
-
-@flaky(rerun_filter=utils.flaky_filter_xfail)
-@pytest.mark.parametrize("locale", get_test_locales())
-def test_orgname_html_escaped(config, journalist_app, test_admin, locale):
-    t_name = '"> <a href=foo>'
-    with journalist_app.test_client() as app:
-        _login_user(app, test_admin["username"], test_admin["password"], test_admin["otp_secret"])
-        form = journalist_app_module.forms.OrgNameForm(organization_name=t_name)
-        assert InstanceConfig.get_current().organization_name == "SecureDrop"
-        with InstrumentedApp(journalist_app) as ins:
-            resp = app.post(
-                url_for("admin.update_org_name", l=locale), data=form.data, follow_redirects=True
-            )
-            assert page_language(resp.data) == language_tag(locale)
-            msgids = ["Preferences saved."]
-            with xfail_untranslated_messages(config, locale, msgids):
-                ins.assert_message_flashed(gettext(msgids[0]), "org-name-success")
-            assert InstanceConfig.get_current().organization_name == htmlescape(t_name, quote=True)
 
 
 def test_logo_default_available(journalist_app):


### PR DESCRIPTION
## Description of Changes

If `InstanceConfig.organization_name` is escaped before writing it to the database, we'd need to mark every use of it in the templates as `| safe`, which is more dubious than not escaping the database entry in the first place.

Fixes #6357

## Testing

* Log into JI with an admin user
* Navigate to the _Instance Configuration_ interface
- [ ] Change the instance name to something that would be escaped (for example `&`s or ümläüts) and click _Set Organization Name_
- [ ] When you get the _Preferences saved._ notification, none of the characters of the name you submitted are double-escaped
- [ ] Navigate to the SI and verify the correct name is shown in the title

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
