### PR TITLE
Use gpgv for signature verification in dev Dockerfile

### DIFF
--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -31,9 +31,11 @@ RUN curl -s https://openpgpkey.torproject.org/.well-known/openpgpkey/torproject.
 RUN TBB_VERSION=$(curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US | grep -oP 'appVersion="\K[^"]*' | head -1) && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc && \
-    gpg2 --verify tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc 2>&1 | grep "Primary key fingerprint:" | sed -e 's/Primary key fingerprint: //' -e 's/ //g' | tail -1 | grep -qE "${TOR_RELEASE_KEY_FINGERPRINT}" && \
+    gpg2 --output ./tor.keyring --export ${TOR_RELEASE_KEY_FINGERPRINT} && \
+    gpgv --keyring ./tor.keyring tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
     tar -xvJf tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz && \
-    mkdir -p /root/.local/tbb && mv tor-browser_en-US /root/.local/tbb
+    mkdir -p /root/.local/tbb && mv tor-browser_en-US /root/.local/tbb && \
+    rm -f tor.keyring tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz.asc tor-browser-linux64-${TBB_VERSION}_en-US.tar.xz 
 
 # Import Mozilla release signing key
 ENV MOZILLA_RELEASE_KEY_FINGERPRINT "14F26682D0916CDD81E37B6D61B7B526D98F0353"
@@ -42,15 +44,19 @@ RUN curl -s https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/KEY |
 # Install the version of Firefox on which Tor Browser is based
 RUN curl -LO https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/linux-x86_64/en-US/firefox-${FF_VERSION}.tar.bz2 && \
     curl -LO https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/linux-x86_64/en-US/firefox-${FF_VERSION}.tar.bz2.asc && \
-    gpg2 --verify firefox-${FF_VERSION}.tar.bz2.asc 2>&1 | grep "Primary key fingerprint:" | sed -e 's/Primary key fingerprint: //' -e 's/ //g' | tail -1 | grep -qE "${MOZILLA_RELEASE_KEY_FINGERPRINT}" && \
+    gpg2 --output ./mozilla.keyring --export ${MOZILLA_RELEASE_KEY_FINGERPRINT} && \
+    gpgv --keyring ./mozilla.keyring firefox-${FF_VERSION}.tar.bz2.asc firefox-${FF_VERSION}.tar.bz2 && \
     tar xjf firefox-*.tar.bz2 && \
-    mv firefox /usr/bin
+    mv firefox /usr/bin && \
+    rm -f firefox-${FF_VERSION}.tar.bz2.asc firefox-${FF_VERSION}.tar.bz2 
 
 # Install geckodriver
 RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz && \
     wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz.asc && \
-    gpg2 --verify geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz.asc && \
-    tar -zxvf geckodriver*tar.gz && chmod +x geckodriver && mv geckodriver /bin
+    # geckodriver uses the same key used by Mozilla
+    gpgv --keyring ./mozilla.keyring geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz.asc geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz && \
+    tar -zxvf geckodriver*tar.gz && chmod +x geckodriver && mv geckodriver /bin && \
+    rm -f mozilla.keyring geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz.asc geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
 
 COPY requirements requirements
 RUN python3 -m venv /opt/venvs/securedrop-app-code && \


### PR DESCRIPTION
update `gpg --verify` to `gpgv --keyring` for verification of signatures

## Status

Work in progress

## Description of Changes
- add `./tor.keyring`, `./firefox.keyring` and `./geckodriver.keyring` to store keys of tor, firefox and geckodriver respectively
- update `gpg --verify` to `gpgv --keyring` for tor, firefox and geckodriver
- delete the keys after verification is complete

Fixes #6526

Changes proposed in this pull request:

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [x] I would like someone else to do the diff review
