### PR TITLE
feat: update all languages in Weblate, but only offer supported ones in `securedrop-admin sdconfig`

### DIFF
--- a/admin/tests/files/securedrop/i18n.json
+++ b/admin/tests/files/securedrop/i18n.json
@@ -1,0 +1,16 @@
+{
+  "supported_locales": {
+    "de_DE": {
+      "name": "German",
+      "desktop": "de_DE"
+    },
+    "es_ES": {
+      "name": "Spanish",
+      "desktop": "es_ES"
+    },
+    "fr_FR": {
+      "name": "French",
+      "desktop": "fr"
+    }
+  }
+}

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -140,6 +140,9 @@ def setup_function(function):
     for name in ["de_DE", "es_ES", "fr_FR", "pt_BR"]:
         dircmd = "mkdir -p {0}/securedrop/translations/{1}".format(SD_DIR, name)
         subprocess.check_call(dircmd.split())
+    subprocess.check_call(
+        "cp {0}/files/securedrop/i18n.json {1}/securedrop".format(CURRENT_DIR, SD_DIR).split()
+    )
 
 
 def teardown_function(function):

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -480,13 +480,16 @@ class TestSecureDropAdmin(object):
 
 
 class TestSiteConfig(object):
-    def test_exists(self):
+    def test_exists(self, tmpdir):
         args = argparse.Namespace(
-            site_config="DOES_NOT_EXIST", ansible_path=".", app_path=dirname(__file__)
+            site_config="DOES_NOT_EXIST",
+            ansible_path=".",
+            app_path=dirname(__file__),
+            root=tmpdir,
         )
         assert not securedrop_admin.SiteConfig(args).exists()
         args = argparse.Namespace(
-            site_config=__file__, ansible_path=".", app_path=dirname(__file__)
+            site_config=__file__, ansible_path=".", app_path=dirname(__file__), root=tmpdir
         )
         assert securedrop_admin.SiteConfig(args).exists()
 
@@ -623,9 +626,12 @@ class TestSiteConfig(object):
         assert validator.validate(Document("012345678901234567890123456789ABCDEFABCD"))
         assert validator.validate(Document(""))
 
-    def test_sanitize_fingerprint(self):
+    def test_sanitize_fingerprint(self, tmpdir):
         args = argparse.Namespace(
-            site_config="DOES_NOT_EXIST", ansible_path=".", app_path=dirname(__file__)
+            site_config="DOES_NOT_EXIST",
+            ansible_path=".",
+            app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
         assert "ABC" == site_config.sanitize_fingerprint("    A bc")
@@ -643,7 +649,9 @@ class TestSiteConfig(object):
         assert "fr_FR" in translations
 
     def test_validate_locales(self):
-        validator = securedrop_admin.SiteConfig.ValidateLocales(dirname(__file__))
+        validator = securedrop_admin.SiteConfig.ValidateLocales(
+            dirname(__file__), {"en_US", "fr_FR"}
+        )
         assert validator.validate(Document("en_US  fr_FR "))
         with pytest.raises(ValidationError) as e:
             validator.validate(Document("BAD"))
@@ -652,7 +660,10 @@ class TestSiteConfig(object):
     def test_save(self, tmpdir):
         site_config_path = join(str(tmpdir), "site_config")
         args = argparse.Namespace(
-            site_config=site_config_path, ansible_path=".", app_path=dirname(__file__)
+            site_config=site_config_path,
+            ansible_path=".",
+            app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
         site_config.config = {"var1": "val1", "var2": "val2"}
@@ -665,9 +676,12 @@ class TestSiteConfig(object):
         )
         assert expected == io.open(site_config_path).read()
 
-    def test_validate_gpg_key(self, caplog):
+    def test_validate_gpg_key(self, tmpdir, caplog):
         args = argparse.Namespace(
-            site_config="INVALID", ansible_path="tests/files", app_path=dirname(__file__)
+            site_config="INVALID",
+            ansible_path="tests/files",
+            app_path=dirname(__file__),
+            root=tmpdir,
         )
         good_config = {
             "securedrop_app_gpg_public_key": "test_journalist_key.pub",
@@ -689,9 +703,12 @@ class TestSiteConfig(object):
                 site_config.validate_gpg_keys()
             assert "FAIL does not match" in str(e)
 
-    def test_journalist_alert_email(self):
+    def test_journalist_alert_email(self, tmpdir):
         args = argparse.Namespace(
-            site_config="INVALID", ansible_path="tests/files", app_path=dirname(__file__)
+            site_config="INVALID",
+            ansible_path="tests/files",
+            app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
         site_config.config = {
@@ -723,6 +740,7 @@ class TestSiteConfig(object):
             site_config="tests/files/site-specific",
             ansible_path="tests/files",
             app_path=dirname(__file__),
+            root="tests/files",
         )
         site_config = securedrop_admin.SiteConfig(args)
 
@@ -736,7 +754,10 @@ class TestSiteConfig(object):
     def test_update_config_no_site_specific(self, validate_gpg_keys, mock_validate_input, tmpdir):
         site_config_path = join(str(tmpdir), "site_config")
         args = argparse.Namespace(
-            site_config=site_config_path, ansible_path=".", app_path=dirname(__file__)
+            site_config=site_config_path,
+            ansible_path=".",
+            app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
         assert site_config.load_and_update_config()
@@ -744,11 +765,12 @@ class TestSiteConfig(object):
         validate_gpg_keys.assert_called_once()
         assert exists(site_config_path)
 
-    def test_load_and_update_config(self):
+    def test_load_and_update_config(self, tmpdir):
         args = argparse.Namespace(
             site_config="tests/files/site-specific",
             ansible_path="tests/files",
             app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
         with mock.patch("securedrop_admin.SiteConfig.update_config"):
@@ -759,6 +781,7 @@ class TestSiteConfig(object):
             site_config="tests/files/site-specific-missing-entries",
             ansible_path="tests/files",
             app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
         with mock.patch("securedrop_admin.SiteConfig.update_config"):
@@ -766,7 +789,10 @@ class TestSiteConfig(object):
             assert site_config.config != {}
 
         args = argparse.Namespace(
-            site_config="UNKNOWN", ansible_path="tests/files", app_path=dirname(__file__)
+            site_config="UNKNOWN",
+            ansible_path="tests/files",
+            app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
         with mock.patch("securedrop_admin.SiteConfig.update_config"):
@@ -797,7 +823,7 @@ class TestSiteConfig(object):
         assert site_config.user_prompt_config_one(desc, "YES") is True
         assert site_config.user_prompt_config_one(desc, "NO") is False
 
-    def test_desc_conditional(self):
+    def test_desc_conditional(self, tmpdir):
         """Ensure that conditional prompts behave correctly.
 
         Prompts which depend on another question should only be
@@ -827,6 +853,7 @@ class TestSiteConfig(object):
             site_config="tests/files/site-specific",
             ansible_path="tests/files",
             app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
         site_config.desc = questions
@@ -904,9 +931,12 @@ class TestSiteConfig(object):
         with pytest.raises(ValidationError):
             site_config.user_prompt_config_one(desc, "wrong")
 
-    def test_user_prompt_config_one(self):
+    def test_user_prompt_config_one(self, tmpdir):
         args = argparse.Namespace(
-            site_config="UNKNOWN", ansible_path="tests/files", app_path=dirname(__file__)
+            site_config="UNKNOWN",
+            ansible_path="tests/files",
+            app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
 
@@ -922,9 +952,12 @@ class TestSiteConfig(object):
                 print("checking " + method)
                 getattr(self, method)(site_config, desc)
 
-    def test_validated_input(self):
+    def test_validated_input(self, tmpdir):
         args = argparse.Namespace(
-            site_config="UNKNOWN", ansible_path="tests/files", app_path=dirname(__file__)
+            site_config="UNKNOWN",
+            ansible_path="tests/files",
+            app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
 
@@ -941,17 +974,21 @@ class TestSiteConfig(object):
             assert "a b" == site_config.validated_input("", ["a", "b"], lambda: True, None)
             assert "{}" == site_config.validated_input("", {}, lambda: True, None)
 
-    def test_load(self, caplog):
+    def test_load(self, tmpdir, caplog):
         args = argparse.Namespace(
             site_config="tests/files/site-specific",
             ansible_path="tests/files",
             app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
         assert "app_hostname" in site_config.load()
 
         args = argparse.Namespace(
-            site_config="UNKNOWN", ansible_path="tests/files", app_path=dirname(__file__)
+            site_config="UNKNOWN",
+            ansible_path="tests/files",
+            app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
         with pytest.raises(IOError) as e:
@@ -963,6 +1000,7 @@ class TestSiteConfig(object):
             site_config="tests/files/corrupted",
             ansible_path="tests/files",
             app_path=dirname(__file__),
+            root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
         with pytest.raises(yaml.YAMLError) as e:

--- a/securedrop/i18n.json
+++ b/securedrop/i18n.json
@@ -1,0 +1,84 @@
+{
+  "supported_locales": {
+    "ca": {
+      "name": "Catalan",
+      "desktop": "ca"
+    },
+    "cs": {
+      "name": "Czech",
+      "desktop": "cs"
+    },
+    "de_DE": {
+      "name": "German",
+      "desktop": "de_DE"
+    },
+    "el": {
+      "name": "Greek",
+      "desktop": "el"
+    },
+    "es_ES": {
+      "name": "Spanish",
+      "desktop": "es_ES"
+    },
+    "fr_FR": {
+      "name": "French",
+      "desktop": "fr"
+    },
+    "hi": {
+      "name": "Hindi",
+      "desktop": "hi"
+    },
+    "is": {
+      "name": "Icelandic",
+      "desktop": "is"
+    },
+    "it_IT": {
+      "name": "Italian",
+      "desktop": "it"
+    },
+    "nb_NO": {
+      "name": "Norwegian",
+      "desktop": "nb_NO"
+    },
+    "nl": {
+      "name": "Dutch",
+      "desktop": "nl"
+    },
+    "pt_BR": {
+      "name": "Portuguese, Brasil",
+      "desktop": "pt_BR"
+    },
+    "pt_PT": {
+      "name": "Portuguese, Portugal",
+      "desktop": "pt_PT"
+    },
+    "ro": {
+      "name": "Romanian",
+      "desktop": "ro"
+    },
+    "ru": {
+      "name": "Russian",
+      "desktop": "ru"
+    },
+    "sk": {
+      "name": "Slovak",
+      "desktop": "sk"
+    },
+    "sv": {
+      "name": "Swedish",
+      "desktop": "sv"
+    },
+    "tr": {
+      "name": "Turkish",
+      "desktop": "tr"
+    },
+    "zh_Hans": {
+      "name": "Chinese, Simplified",
+      "desktop": "zh_Hans"
+    },
+    "zh_Hant": {
+      "name": "Chinese, Traditional",
+      "desktop": "zh_Hant"
+    }
+  }
+}

--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -4,6 +4,7 @@
 import argparse
 import glob
 import io
+import json
 import logging
 import os
 import re
@@ -21,6 +22,8 @@ from sh import git, msgfmt, msgmerge, pybabel, sed, xgettext
 logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s")
 log = logging.getLogger(__name__)
 
+I18N_CONF = os.path.join(os.path.dirname(__file__), "i18n.json")
+
 
 class I18NTool:
     #
@@ -33,92 +36,9 @@ class I18NTool:
     #       display in the interface.
     # desktop: The language code used for dekstop icons.
     #
-    supported_languages = {
-        "ar": {
-            "name": "Arabic",
-            "desktop": "ar",
-        },
-        "ca": {
-            "name": "Catalan",
-            "desktop": "ca",
-        },
-        "cs": {
-            "name": "Czech",
-            "desktop": "cs",
-        },
-        "de_DE": {
-            "name": "German",
-            "desktop": "de_DE",
-        },
-        "el": {
-            "name": "Greek",
-            "desktop": "el",
-        },
-        "es_ES": {
-            "name": "Spanish",
-            "desktop": "es_ES",
-        },
-        "fr_FR": {
-            "name": "French",
-            "desktop": "fr",
-        },
-        "hi": {
-            "name": "Hindi",
-            "desktop": "hi",
-        },
-        "is": {
-            "name": "Icelandic",
-            "desktop": "is",
-        },
-        "it_IT": {
-            "name": "Italian",
-            "desktop": "it",
-        },
-        "nb_NO": {
-            "name": "Norwegian",
-            "desktop": "nb_NO",
-        },
-        "nl": {
-            "name": "Dutch",
-            "desktop": "nl",
-        },
-        "pt_BR": {
-            "name": "Portuguese, Brasil",
-            "desktop": "pt_BR",
-        },
-        "pt_PT": {
-            "name": "Portuguese, Portugal",
-            "desktop": "pt_PT",
-        },
-        "ro": {
-            "name": "Romanian",
-            "desktop": "ro",
-        },
-        "ru": {
-            "name": "Russian",
-            "desktop": "ru",
-        },
-        "sk": {
-            "name": "Slovak",
-            "desktop": "sk",
-        },
-        "sv": {
-            "name": "Swedish",
-            "desktop": "sv",
-        },
-        "tr": {
-            "name": "Turkish",
-            "desktop": "tr",
-        },
-        "zh_Hans": {
-            "name": "Chinese, Simplified",
-            "desktop": "zh_Hans",
-        },
-        "zh_Hant": {
-            "name": "Chinese, Traditional",
-            "desktop": "zh_Hant",
-        },
-    }
+    with open(I18N_CONF) as i18n_conf:
+        conf = json.load(i18n_conf)
+    supported_languages = conf["supported_locales"]
     release_tag_re = re.compile(r"^\d+\.\d+\.\d+$")
     translated_commit_re = re.compile("Translated using Weblate")
     updated_commit_re = re.compile(r"(?:updated from|  (?:revision|commit):) (\w+)")

--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -14,7 +14,8 @@ import sys
 import textwrap
 from argparse import _SubParsersAction
 from os.path import abspath, dirname, join, realpath
-from typing import List, Optional, Set
+from pathlib import Path
+from typing import Dict, List, Optional, Set
 
 import version
 from sh import git, msgfmt, msgmerge, pybabel, sed, xgettext
@@ -23,6 +24,13 @@ logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s")
 log = logging.getLogger(__name__)
 
 I18N_CONF = os.path.join(os.path.dirname(__file__), "i18n.json")
+
+# Map components of the "securedrop" Weblate project (keys) to their filesystem
+# paths (values) relative to the repository root.
+LOCALE_DIR = {
+    "securedrop": "securedrop/translations",
+    "desktop": "install_files/ansible-base/roles/tails-config/templates",
+}
 
 
 class I18NTool:
@@ -78,7 +86,7 @@ class I18NTool:
                 "--strip-comments",
                 "--add-location=never",
                 "--no-wrap",
-                *sources
+                *sources,
             )
 
             sed("-i", "-e", '/^"POT-Creation-Date/d', messages_file)
@@ -110,7 +118,7 @@ class I18NTool:
                 "--msgid-bugs-address=securedrop@freedom.press",
                 "--copyright-holder=Freedom of the Press Foundation",
                 *sources,
-                **k
+                **k,
             )
             sed("-i", "-e", '/^"POT-Creation-Date/d', messages_file, **k)
 
@@ -211,7 +219,8 @@ class I18NTool:
         )
         translations_dir = join(
             dirname(realpath(__file__)),
-            "../install_files/ansible-base/roles/tails-config/templates",
+            "..",
+            LOCALE_DIR["desktop"],
         )
         sources = "desktop-journalist-icon.j2.in,desktop-source-icon.j2.in"
         self.set_translate_parser(parser, translations_dir, sources)
@@ -267,56 +276,62 @@ class I18NTool:
         Pull in updated translations from the i18n repo.
         """
         self.ensure_i18n_remote(args)
-        codes = list(self.supported_languages.keys())
+
+        # Check out *all* remote changes to the LOCALE_DIRs.
+        git(
+            "-C",
+            args.root,
+            "checkout",
+            args.target,
+            "--",
+            *LOCALE_DIR.values(),
+        )
+
+        # Use the LOCALE_DIR corresponding to the "securedrop" component to
+        # determine which locales are present.
+        locale_dir = os.path.join(args.root, LOCALE_DIR["securedrop"])
+        locales = self.translated_locales(locale_dir)
         if args.supported_languages:
             codes = args.supported_languages.split(",")
-        for code in sorted(codes):
-            info = self.supported_languages[code]
+            locales = {code: locales[code] for code in locales if code in codes}
 
-            def need_update(path: str) -> bool:
-                """
-                Check if the file is different in the i18n repo.
-                """
-
-                exists = os.path.exists(join(args.root, path))
-                k = {"_cwd": args.root}
-                git.checkout(args.target, "--", path, **k)
-                git.reset("HEAD", "--", path, **k)
-                if not exists:
-                    return True
-
-                return self.file_is_modified(join(args.root, path))
+        # Then iterate over all locales present and decide which to stage and commit.
+        for code, path in locales.items():
+            paths = []
 
             def add(path: str) -> None:
                 """
                 Add the file to the git index.
                 """
                 git("-C", args.root, "add", path)
+                paths.append(path)
 
-            updated = False
-            #
-            # Add changes to web .po files
-            #
-            path = "securedrop/translations/{l}/LC_MESSAGES/messages.po".format(
-                l=code  # noqa: E741
-            )
-            if need_update(path):
-                add(path)
-                updated = True
-            #
-            # Add changes to desktop .po files
-            #
-            desktop_code = info["desktop"]
-            path = join(
-                "install_files/ansible-base/roles",
-                "tails-config/templates/{l}.po".format(l=desktop_code),  # noqa: E741
-            )
-            if need_update(path):
-                add(path)
-                updated = True
+            # Any translated locale may have changes that need to be staged from the
+            # securedrop/securedrop component.
+            add(path)
 
-            if updated:
-                self.commit_changes(args, code)
+            # Only supported locales may have changes that need to be staged from the
+            # securedrop/desktop component, because the link between the two components
+            # is defined in I18N_CONF when a language is marked supported.
+            try:
+                info = self.supported_languages[code]
+                name = info["name"]
+                desktop_code = info["desktop"]
+                path = join(
+                    LOCALE_DIR["desktop"],
+                    "{l}.po".format(l=desktop_code),  # noqa: E741
+                )
+                add(path)
+            except KeyError:
+                log.info(
+                    f"{code} has translations but is not marked as supported; "
+                    f"skipping desktop translation"
+                )
+                name = code
+
+            # Try to commit changes for this locale no matter what, even if it turns out to be a
+            # no-op.
+            self.commit_changes(args, code, name, paths)
 
     def translators(
         self, args: argparse.Namespace, path: str, since_commit: Optional[str]
@@ -358,17 +373,32 @@ class I18NTool:
             "--no-pager", "-C", root, "log", "--format=%H", path, _encoding="utf-8"
         ).splitlines()
 
-    def commit_changes(self, args: argparse.Namespace, code: str) -> None:
+    def translated_locales(self, path: str) -> Dict[str, str]:
+        """Return a dictionary of all locale directories present in `path`, where the keys
+        are the base (directory) names and the values are the full paths."""
+        p = Path(path)
+        return {x.name: str(x) for x in p.iterdir() if x.is_dir()}
+
+    def commit_changes(
+        self, args: argparse.Namespace, code: str, name: str, paths: List[str]
+    ) -> None:
+        """Check if any of the given paths have had changed staged.  If so, commit them."""
         self.require_git_email_name(args.root)
         authors = set()  # type: Set[str]
-        diffs = "{}".format(git("--no-pager", "-C", args.root, "diff", "--name-only", "--cached"))
+        diffs = "{}".format(
+            git("--no-pager", "-C", args.root, "diff", "--name-only", "--cached", *paths)
+        )
+
+        # If nothing was changed, "git commit" will return nonzero as a no-op.
+        if len(diffs) == 0:
+            return
 
         # for each modified file, find the last commit made by this
         # function, then collect all the contributors since that
         # commit, so they can be credited in this one. if no commit
         # with the right message is found, just use the most recent
         # commit that touched the file.
-        for path in sorted(diffs.strip().split("\n")):
+        for path in paths:
             path_commits = self.get_path_commits(args.root, path)
             since_commit = None
             for path_commit in path_commits:
@@ -385,7 +415,6 @@ class I18NTool:
         authors_as_str = "\n  ".join(sorted(authors))
 
         current = git("-C", args.root, "rev-parse", args.target)
-        info = self.supported_languages[code]
         message = textwrap.dedent(
             """
         l10n: updated {name} ({code})
@@ -397,10 +426,8 @@ class I18NTool:
           repo: {remote}
           commit: {current}
         """
-        ).format(
-            remote=args.url, name=info["name"], authors=authors_as_str, code=code, current=current
-        )
-        git("-C", args.root, "commit", "-m", message)
+        ).format(remote=args.url, name=name, authors=authors_as_str, code=code, current=current)
+        git("-C", args.root, "commit", "-m", message, *paths)
 
     def set_update_from_weblate_parser(self, subps: _SubParsersAction) -> None:
         parser = subps.add_parser("update-from-weblate", help=("Import translations from weblate"))
@@ -510,8 +537,8 @@ class I18NTool:
 
     def list_translators(self, args: argparse.Namespace) -> None:
         self.ensure_i18n_remote(args)
-        app_template = "securedrop/translations/{}/LC_MESSAGES/messages.po"
-        desktop_template = "install_files/ansible-base/roles/tails-config/templates/{}.po"
+        app_template = "{}/{}/LC_MESSAGES/messages.po"
+        desktop_template = LOCALE_DIR["desktop"] + "/{}.po"
         since = None
         if args.all:
             print("Listing all translators who have ever helped")
@@ -521,7 +548,7 @@ class I18NTool:
         for code, info in sorted(self.supported_languages.items()):
             translators = set([])
             paths = [
-                app_template.format(code),
+                app_template.format(LOCALE_DIR["securedrop"], code),
                 desktop_template.format(info["desktop"]),
             ]
             for path in paths:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #6156, which (with these changes) should be completed automatically as part of the v2.5.0 localization cycle.

Closes #6387 by:

1. creating a canonical list of _supported_ languages in `securedrop/i18n.json`;
2. relaxing `i18n_tool.py update-from-weblate` to pull translations for *all* locales available for translation in Weblate; thereby also
3. relaxing `i18n_tool.py translate-{messages,desktop}` to update source strings for *all* locales available for translation in Weblate; while
4. restricting `securedrop-admin sdconfig` to allow administrators to select only those languages both *present* (in the `securedrop` repository) and *supported* (in `i18n.json`).

## Testing

### `securedrop-admin sdconfig`

This is the higher priority for testing, since it is an administrator-facing change.

1. Check out `6387-supported-languages`.
2. Run `securedrop-admin sdconfig` and attempt to enable a nonexistent locale (e.g., `foo`).
    - [x] The nonexistent locale is rejected.
3. Run `securedrop-admin sdconfig` and attempt to enable any two or more supported locales (e.g., `en_US de_DE ro`).
    - [x] All locales are accepted.
4. For one of the locales you enabled in step (3), delete the corresponding directory from `securedrop/translations`.  Then run `securedrop-admin sdconfig`.
    - [x] The locale no longer suggested and is rejected, because it is no longer present.
5. For another of the locales you enabled in step (3), delete the corresponding `supported_locales` entry in `securedrop/i18n.json`.  Then run `securedrop-admin sdonfig`.
    - [x] The locale is no longer suggested and is rejected, because it is no longer supported.

### `i18n_tool.py`

This is the lower priority for testing, since it's a tooling change we can tweak in place if necessary, including during the localization cycle.

- Run `securedrop/i18n_tool.py update-from-weblate`.
- [x] An `INFO` is logged to the standard output for each _unsupported_ language like:

    https://github.com/freedomofpress/securedrop/blob/efdc952d94166cc10d0837106c0def1f2808bcad/securedrop/i18n_tool.py#L327-L328

- [x] Changes to all languages, not only supported ones, are fetched, checked out, staged, and committed.

## Deployment

These changes should be invisible to the administrators of any correctly-configured SecureDrop instance.  If (e.g.) an instance has custom translations installed, these will be unavailable after the next `securedrop-admin sdconfig`.  If in the future we drop support for a language we currently support, administrators will have to update their configured locales on their next `securedrop-admin sdconfig`.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [x] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later

Documentation will follow from me and/or @eaon as Localization Managers for the v2.5.0 release.

- I would appreciate help with the documentation
- These changes do not require documentation