### PR TITLE
Simplify i18n tests and remove sh.sed usage

### DIFF
--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -16,9 +16,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-import os
 import re
 from pathlib import Path
+from typing import List
 
 import i18n
 import i18n_tool
@@ -30,11 +30,57 @@ from db import db
 from flask import render_template, render_template_string, request, session
 from flask_babel import gettext
 from i18n import parse_locale_set
-from sdconfig import FALLBACK_LOCALE, SDConfig
-from sh import pybabel, sed
+from sdconfig import FALLBACK_LOCALE
+from sh import pybabel
+from tests.functional.factories import SecureDropConfigFactory
+from tests.functional.sd_config_v2 import DEFAULT_SECUREDROP_ROOT, SecureDropConfig
 from werkzeug.datastructures import Headers
 
 NEVER_LOCALE = "eo"  # Esperanto
+
+
+def create_config_for_i18n_test(
+    supported_locales: List[str],
+    default_locale: str = "en_US",
+    translation_dirs: Path = DEFAULT_SECUREDROP_ROOT / "translations",
+) -> SecureDropConfig:
+    tmp_root_for_test = Path(f"/tmp/sd-tests/test_i18n")
+    tmp_root_for_test.mkdir(exist_ok=True, parents=True)
+
+    i18n_config = SecureDropConfigFactory.create(
+        SECUREDROP_DATA_ROOT=tmp_root_for_test,
+        DEFAULT_LOCALE=default_locale,
+        SUPPORTED_LOCALES=supported_locales,
+        TRANSLATION_DIRS=translation_dirs,
+        # For the tests in these files, the following argument / config fields are not used so
+        # we set them to invalid values
+        RQ_WORKER_NAME="",
+        GPG_KEY_DIR=tmp_root_for_test,
+        JOURNALIST_KEY="",
+    )
+
+    # Create an empty key file just to pass the sanity checks when starting the source or
+    # journalist app; the encryption code is not exercised as part of these tests
+    gpg_key_path = tmp_root_for_test / "private-keys-v1.d"
+    gpg_key_path.mkdir(exist_ok=True)
+
+    return i18n_config
+
+
+def set_msg_translation_in_po_file(po_file: Path, msgid_to_translate: str, msgstr: str) -> None:
+    po_content = po_file.read_text()
+    content_to_update = f"""
+msgid "{msgid_to_translate}"
+msgstr ""
+"""
+    assert content_to_update in po_content
+
+    content_with_translation = f"""
+msgid "{msgid_to_translate}"
+msgstr "{msgstr}"
+"""
+    po_content_with_translation = po_content.replace(content_to_update, content_with_translation)
+    po_file.write_text(po_content_with_translation)
 
 
 def verify_i18n(app):
@@ -188,10 +234,13 @@ def verify_i18n(app):
         assert 'dir="rtl"' in base
 
 
-# Grab the journalist_app fixture to trigger creation of resources
-def test_i18n(journalist_app, config):
-    # Then delete it because using it won't test what we want
-    del journalist_app
+def test_i18n():
+    translation_dirs = Path(f"/tmp/sd-tests/test_i18n/translations")
+    translation_dirs.mkdir(exist_ok=True, parents=True)
+    test_config = create_config_for_i18n_test(
+        supported_locales=["ar", "en_US", "fr_FR", "nb_NO", "zh_Hans"],
+        translation_dirs=translation_dirs,
+    )
 
     i18n_dir = Path(__file__).absolute().parent / "i18n"
     sources = [str(i18n_dir / "code.py"), str(i18n_dir / "template.html")]
@@ -202,47 +251,52 @@ def test_i18n(journalist_app, config):
             "--mapping",
             str(i18n_dir / "babel.cfg"),
             "--translations-dir",
-            config.TEMP_DIR,
+            str(translation_dirs),
             "--sources",
             ",".join(sources),
             "--extract-update",
         ]
     )
 
-    pot = os.path.join(config.TEMP_DIR, "messages.pot")
-    pybabel("init", "-i", pot, "-d", config.TEMP_DIR, "-l", "en_US")
+    pot = translation_dirs / "messages.pot"
+    pybabel("init", "-i", pot, "-d", translation_dirs, "-l", "en_US")
 
-    for (l, s) in (
+    for (locale, translated_msg) in (
         ("fr_FR", "code bonjour"),
         ("zh_Hans", "code chinese"),
         ("ar", "code arabic"),
         ("nb_NO", "code norwegian"),
         ("es_ES", "code spanish"),
     ):
-        pybabel("init", "-i", pot, "-d", config.TEMP_DIR, "-l", l)
-        po = os.path.join(config.TEMP_DIR, l, "LC_MESSAGES/messages.po")
-        sed("-i", "-e", '/code hello i18n/,+1s/msgstr ""/msgstr "{}"/'.format(s), po)
+        pybabel("init", "-i", pot, "-d", translation_dirs, "-l", locale)
+
+        # Populate the po file with a translation
+        po_file = translation_dirs / locale / "LC_MESSAGES" / "messages.po"
+        set_msg_translation_in_po_file(
+            po_file,
+            msgid_to_translate="code hello i18n",
+            msgstr=translated_msg,
+        )
 
     i18n_tool.I18NTool().main(
         [
             "--verbose",
             "translate-messages",
             "--translations-dir",
-            config.TEMP_DIR,
+            str(translation_dirs),
             "--compile",
         ]
     )
 
-    fake_config = SDConfig()
-    fake_config.SUPPORTED_LOCALES = ["ar", "en_US", "fr_FR", "nb_NO", "zh_Hans"]
-    fake_config.TRANSLATION_DIRS = Path(config.TEMP_DIR)
-
     # Use our config (and not an app fixture) because the i18n module
     # grabs values at init time and we can't inject them later.
-    for app in (journalist_app_module.create_app(fake_config), source_app.create_app(fake_config)):
+    for app in (
+        journalist_app_module.create_app(test_config),
+        source_app.create_app(test_config),
+    ):
         with app.app_context():
             db.create_all()
-        assert list(i18n.LOCALES.keys()) == fake_config.SUPPORTED_LOCALES
+        assert list(i18n.LOCALES.keys()) == test_config.SUPPORTED_LOCALES
         verify_i18n(app)
 
 
@@ -250,66 +304,60 @@ def test_parse_locale_set():
     assert parse_locale_set([FALLBACK_LOCALE]) == set([Locale.parse(FALLBACK_LOCALE)])
 
 
-def test_no_usable_fallback_locale(journalist_app, config):
+def test_no_usable_fallback_locale():
     """
     The apps fail if neither the default nor the fallback locale is usable.
     """
-    fake_config = SDConfig()
-    fake_config.DEFAULT_LOCALE = NEVER_LOCALE
-    fake_config.SUPPORTED_LOCALES = [NEVER_LOCALE]
-    fake_config.TRANSLATION_DIRS = Path(config.TEMP_DIR)
-
+    test_config = create_config_for_i18n_test(
+        default_locale=NEVER_LOCALE, supported_locales=[NEVER_LOCALE]
+    )
     i18n.USABLE_LOCALES = set()
 
     with pytest.raises(ValueError, match="in the set of usable locales"):
-        journalist_app_module.create_app(fake_config)
+        journalist_app_module.create_app(test_config)
 
     with pytest.raises(ValueError, match="in the set of usable locales"):
-        source_app.create_app(fake_config)
+        source_app.create_app(test_config)
 
 
-def test_unusable_default_but_usable_fallback_locale(config, caplog):
+def test_unusable_default_but_usable_fallback_locale(caplog):
     """
     The apps start even if the default locale is unusable, as along as the fallback locale is
     usable, but log an error for OSSEC to pick up.
     """
-    fake_config = SDConfig()
-    fake_config.DEFAULT_LOCALE = NEVER_LOCALE
-    fake_config.SUPPORTED_LOCALES = [NEVER_LOCALE, FALLBACK_LOCALE]
-    fake_config.TRANSLATION_DIRS = Path(config.TEMP_DIR)
+    test_config = create_config_for_i18n_test(
+        default_locale=NEVER_LOCALE, supported_locales=[NEVER_LOCALE, FALLBACK_LOCALE]
+    )
 
-    for app in (journalist_app_module.create_app(fake_config), source_app.create_app(fake_config)):
+    for app in (journalist_app_module.create_app(test_config), source_app.create_app(test_config)):
         with app.app_context():
             assert NEVER_LOCALE in caplog.text
             assert "not in the set of usable locales" in caplog.text
 
 
-def test_invalid_locales(config):
+def test_invalid_locales():
     """
     An invalid locale raises an error during app configuration.
     """
-    fake_config = SDConfig()
-    fake_config.SUPPORTED_LOCALES = [FALLBACK_LOCALE, "yy_ZZ"]
-    fake_config.TRANSLATION_DIRS = Path(config.TEMP_DIR)
+    test_config = create_config_for_i18n_test(supported_locales=[FALLBACK_LOCALE, "yy_ZZ"])
 
     with pytest.raises(UnknownLocaleError):
-        journalist_app_module.create_app(fake_config)
+        journalist_app_module.create_app(test_config)
 
     with pytest.raises(UnknownLocaleError):
-        source_app.create_app(fake_config)
+        source_app.create_app(test_config)
 
 
-def test_valid_but_unusable_locales(config, caplog):
+def test_valid_but_unusable_locales(caplog):
     """
     The apps start with one or more unusable, but still valid, locales, but log an error for
     OSSEC to pick up.
     """
-    fake_config = SDConfig()
+    test_config = create_config_for_i18n_test(
+        supported_locales=[FALLBACK_LOCALE, "wae_CH"],
+    )
 
-    fake_config.SUPPORTED_LOCALES = [FALLBACK_LOCALE, "wae_CH"]
-    fake_config.TRANSLATION_DIRS = Path(config.TEMP_DIR)
-
-    for app in (journalist_app_module.create_app(fake_config), source_app.create_app(fake_config)):
+    for app in (journalist_app_module.create_app(test_config), source_app.create_app(test_config)):
         with app.app_context():
             assert "wae" in caplog.text
             assert "not in the set of usable locales" in caplog.text
@@ -323,17 +371,14 @@ def test_language_tags():
     assert i18n.RequestLocaleInfo(Locale.parse("zh_Hant")).language_tag == "zh-Hant"
 
 
-# Grab the journalist_app fixture to trigger creation of resources
-def test_html_en_lang_correct(journalist_app, config):
-    # Then delete it because using it won't test what we want
-    del journalist_app
-
-    app = journalist_app_module.create_app(config).test_client()
+def test_html_en_lang_correct():
+    test_config = create_config_for_i18n_test(supported_locales=["en_US"])
+    app = journalist_app_module.create_app(test_config).test_client()
     resp = app.get("/", follow_redirects=True)
     html = resp.data.decode("utf-8")
     assert re.compile('<html lang="en-US".*>').search(html), html
 
-    app = source_app.create_app(config).test_client()
+    app = source_app.create_app(test_config).test_client()
     resp = app.get("/", follow_redirects=True)
     html = resp.data.decode("utf-8")
     assert re.compile('<html lang="en-US".*>').search(html), html
@@ -344,20 +389,16 @@ def test_html_en_lang_correct(journalist_app, config):
     assert re.compile('<html lang="en-US".*>').search(html), html
 
 
-# Grab the journalist_app fixture to trigger creation of resources
-def test_html_fr_lang_correct(journalist_app, config):
+def test_html_fr_lang_correct():
     """Check that when the locale is fr_FR the lang property is correct"""
+    test_config = create_config_for_i18n_test(supported_locales=["fr_FR", "en_US"])
 
-    # Then delete it because using it won't test what we want
-    del journalist_app
-
-    config.SUPPORTED_LOCALES = ["fr_FR", "en_US"]
-    app = journalist_app_module.create_app(config).test_client()
+    app = journalist_app_module.create_app(test_config).test_client()
     resp = app.get("/?l=fr_FR", follow_redirects=True)
     html = resp.data.decode("utf-8")
     assert re.compile('<html lang="fr-FR".*>').search(html), html
 
-    app = source_app.create_app(config).test_client()
+    app = source_app.create_app(test_config).test_client()
     resp = app.get("/?l=fr_FR", follow_redirects=True)
     html = resp.data.decode("utf-8")
     assert re.compile('<html lang="fr-FR".*>').search(html), html
@@ -370,15 +411,11 @@ def test_html_fr_lang_correct(journalist_app, config):
     assert re.compile('<html lang="fr-FR".*>').search(html), html
 
 
-# Grab the journalist_app fixture to trigger creation of resources
-def test_html_attributes(journalist_app, config):
+def test_html_attributes():
     """Check that HTML lang and dir attributes respect locale."""
+    test_config = create_config_for_i18n_test(supported_locales=["ar", "en_US"])
 
-    # Then delete it because using it won't test what we want
-    del journalist_app
-
-    config.SUPPORTED_LOCALES = ["ar", "en_US"]
-    app = journalist_app_module.create_app(config).test_client()
+    app = journalist_app_module.create_app(test_config).test_client()
     resp = app.get("/?l=ar", follow_redirects=True)
     html = resp.data.decode("utf-8")
     assert '<html lang="ar" dir="rtl">' in html
@@ -386,7 +423,7 @@ def test_html_attributes(journalist_app, config):
     html = resp.data.decode("utf-8")
     assert '<html lang="en-US" dir="ltr">' in html
 
-    app = source_app.create_app(config).test_client()
+    app = source_app.create_app(test_config).test_client()
     resp = app.get("/?l=ar", follow_redirects=True)
     html = resp.data.decode("utf-8")
     assert '<html lang="ar" dir="rtl">' in html
@@ -407,14 +444,14 @@ def test_html_attributes(journalist_app, config):
     assert '<html lang="en-US" dir="ltr">' in html
 
 
-def test_same_lang_diff_locale(journalist_app, config):
+def test_same_lang_diff_locale():
     """
     Verify that when two locales with the same lang are specified, the full locale
     name is used for both.
     """
-    del journalist_app
-    config.SUPPORTED_LOCALES = ["en_US", "pt_BR", "pt_PT"]
-    app = journalist_app_module.create_app(config).test_client()
+    test_config = create_config_for_i18n_test(supported_locales=["en_US", "pt_BR", "pt_PT"])
+
+    app = journalist_app_module.create_app(test_config).test_client()
     resp = app.get("/", follow_redirects=True)
     html = resp.data.decode("utf-8")
     assert "português (Brasil)" in html

--- a/securedrop/tests/utils/db_helper.py
+++ b/securedrop/tests/utils/db_helper.py
@@ -7,6 +7,8 @@ import io
 import math
 import os
 import random
+import subprocess
+from pathlib import Path
 from typing import Dict, List
 
 import mock
@@ -233,3 +235,9 @@ def bulk_setup_for_seen_only(journo: Journalist, storage: Storage) -> List[Dict]
         setup_collection.append(collection)
 
     return setup_collection
+
+
+def reset_database(database_file: Path) -> None:
+    database_file.unlink(missing_ok=True)  # type: ignore
+    database_file.touch()
+    subprocess.check_call(["sqlite3", database_file, ".databases"])

--- a/securedrop/tests/utils/i18n.py
+++ b/securedrop/tests/utils/i18n.py
@@ -2,6 +2,7 @@ import collections
 import contextlib
 import functools
 import os
+from pathlib import Path
 from typing import Dict, Generator, Iterable, List, Optional, Tuple
 
 import pytest
@@ -44,7 +45,7 @@ def language_tag(locale: str) -> str:
 
 
 @functools.lru_cache(maxsize=None)
-def message_catalog(config: SDConfig, locale: str) -> Catalog:
+def message_catalog(translation_dir: Path, locale: str) -> Catalog:
     """
     Returns the gettext message catalog for the given locale.
 
@@ -52,14 +53,14 @@ def message_catalog(config: SDConfig, locale: str) -> Catalog:
     an actual translation or merely the result of falling back to the
     default locale.
 
-    >>> german = message_catalog(config, 'de_DE')
+    >>> german = message_catalog(translation_dir, 'de_DE')
     >>> m = german.get("a string that has been added to the catalog but not translated")
     >>> m.string
     ''
     >>> german.get("Password").string
     'Passwort'
     """
-    return read_po(open(str(config.TRANSLATION_DIRS / locale / "LC_MESSAGES/messages.po")))
+    return read_po(open((translation_dir / locale / "LC_MESSAGES" / "messages.po")))
 
 
 def page_language(page_text: str) -> Optional[str]:
@@ -71,7 +72,9 @@ def page_language(page_text: str) -> Optional[str]:
 
 
 @contextlib.contextmanager
-def xfail_untranslated_messages(config: SDConfig, locale: str, msgids: Iterable[str]) -> Generator:
+def xfail_untranslated_messages(
+    config: SDConfig, locale: str, msgids: Iterable[str]
+) -> Generator[None, None, None]:
     """
     Trigger pytest.xfail for untranslated strings.
 
@@ -88,7 +91,7 @@ def xfail_untranslated_messages(config: SDConfig, locale: str, msgids: Iterable[
     """
     with force_locale(locale):
         if locale != "en_US":
-            catalog = message_catalog(config, locale)
+            catalog = message_catalog(config.TRANSLATION_DIRS, locale)
             for msgid in msgids:
                 m = catalog.get(msgid)
                 if not m:


### PR DESCRIPTION
## Status

Ready

## Description of Changes

* Simplify i18n-related tests:
  * De-couple the tests from the `journalist_app` and `config` fixtures, which are not actually needed by the tests.
  * Get closer to implementing an immutable SDConfig.
* Remove usage of `sh.sed` (https://github.com/freedomofpress/securedrop/issues/6547).

This PR should be reviewed and  merged after https://github.com/freedomofpress/securedrop/pull/6551.