### PR TITLE
fix: include `i18n.json` when building packages

### DIFF
--- a/securedrop/.rsync-filter
+++ b/securedrop/.rsync-filter
@@ -88,6 +88,7 @@ include sass/global/**.sass
 include sass/modules/
 include sass/modules/**.sass
 include babel.cfg
+include i18n.json
 include translations/
 include translations/*.pot
 include translations/*/


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6566 by including `i18n.json` in the `.rsync-filter` list, so that it's available to `i18n_tool.py translate-messages --compile` at build-time step `Compile PO to MO`.

## Testing

- [ ] `make build-debs` passes, in particular #6566's failing step `Compile PO to MO`.

## Deployment

Build-time only.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container