### PR TITLE
docs: distinguish build-time and runtime allow-lists

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,13 @@ Any special considerations for deployment? Consider both:
 
 - [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
 
-### If you added or removed a file deployed with the application:
+### If you added or removed a file
+
+#### ...used to build the application:
+
+- [ ] I have updated `securedrop/.rsync-filter` to include the change
+
+#### ...deployed with the application:
 
 - [ ] I have updated AppArmor rules to include the change
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Learns a lesson from #6566 by asking contributors to distinguish between two different allow-lists and the impact their proposed changes may have on them:
1. The `.rsync-filter` list governs what files are available in the build environment.
2. AppArmor rules govern what files can be accessed at runtime.

## Testing

Filing for the record and for the purpose of debate:

- [ ] This change is worthwhile documentation, even if it's soon obsoleted by #6544, which will eliminate (1) but not (2) above.

Otherwise, feel free to close this in favor of waiting for #6544! 

## Deployment

Developer-only change to GitHub template; no deployment considerations.