### PR TITLE
l10n: update strings to be translated for v2.5.0

### DIFF
--- a/securedrop/translations/ar/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ar/LC_MESSAGES/messages.po
@@ -46,9 +46,6 @@ msgstr "{time} مضت"
 msgid "You have been logged out due to inactivity."
 msgstr "تم الخروج من الحساب بسبب انعدام النشاط."
 
-msgid "You have been logged out due to password change"
-msgstr "تم الخروج من الحساب بسبب تغيير كلمة السر"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -516,7 +513,9 @@ msgstr "غير مقروءة"
 msgid "Read"
 msgstr "قراءة"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "تم رفع المستند"
 
 msgid "Reply"
@@ -551,6 +550,19 @@ msgstr "حذف حساب المصدر"
 
 msgid "Are you sure?"
 msgstr "هل أنت متأكد؟"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "نعم، احذف حساب المصدر"
@@ -591,7 +603,9 @@ msgstr "تغيير الشعار"
 msgid "Submission Preferences"
 msgstr "تفضيلات الإرسال"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "منع المصادر من رفع وثائق. سوف تظل المصادر قادرة على توجيه رسائل."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -714,8 +728,10 @@ msgstr "إزالة النجمة"
 msgid "Designation"
 msgstr "تعيين رمز"
 
-msgid "Documents"
-msgstr "المستندات"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "اسم الملف"
 
 msgid "Messages"
 msgstr "الرسائل"
@@ -723,8 +739,8 @@ msgstr "الرسائل"
 msgid "Date"
 msgstr "التاريخ"
 
-msgid "No documents have been submitted!"
-msgstr "لا توجد مستندات مودعة!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "الترشيح بالاسم الرمزي"
@@ -816,11 +832,15 @@ msgstr "شكرا لإرسالك هذه المعلومات إلينا. تَرَق
 msgid "Thanks! We received your message."
 msgstr "شكرا! لقد تلقينا الرسالة."
 
-msgid "Thanks! We received your document."
-msgstr "شكرا! لقد تلقينا المستند."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "شكرا! لقد تلقينا الرسالة."
 
-msgid "Thanks! We received your message and document."
-msgstr "شكرا! لقد تلقينا الرسالة و&nbsp;المستند."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "شكرا! لقد تلقينا الرسالة."
 
 msgid "Reply deleted"
 msgstr "حُذِفَ الرد"
@@ -864,7 +884,9 @@ msgstr "البحث عن اسم رمزي..."
 msgid "Powered by"
 msgstr "تشغّله"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "يرجى الانتباه: قد تعرّضك مشاركة وثائق حساسة للخطر وإن لجأت لتور Tor و سيكيور دروب SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1092,6 +1114,21 @@ msgstr "<strong>هام:</strong> إذا كنت ترغب في البقاء مجه
 
 msgid "Back to submission page"
 msgstr "الرجوع إلى صفحة الإيداع"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "تم الخروج من الحساب بسبب تغيير كلمة السر"
+
+#~ msgid "Documents"
+#~ msgstr "المستندات"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "لا توجد مستندات مودعة!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "شكرا! لقد تلقينا المستند."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "شكرا! لقد تلقينا الرسالة و&nbsp;المستند."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "هل نسيت اسمك الرمزي بك؟"

--- a/securedrop/translations/ca/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ca/LC_MESSAGES/messages.po
@@ -41,9 +41,6 @@ msgstr "fa {time}"
 msgid "You have been logged out due to inactivity."
 msgstr "S'ha desconnectat la sessió per inactivitat."
 
-msgid "You have been logged out due to password change"
-msgstr "S'ha desconnectat la sessió per un canvi de la contrasenya"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -475,7 +472,9 @@ msgstr "Per llegir"
 msgid "Read"
 msgstr "Llegit"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Document penjat"
 
 msgid "Reply"
@@ -510,6 +509,19 @@ msgstr "Suprimeix el compte font"
 
 msgid "Are you sure?"
 msgstr "N'esteu segur?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Sí, suprimeix el compte font"
@@ -550,7 +562,9 @@ msgstr "ACTUALITZA EL LOGOTIP"
 msgid "Submission Preferences"
 msgstr "Preferències de l'enviament"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Evita que les fonts puguin pujar documents. Les fonts encara podran enviar missatges."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -673,8 +687,10 @@ msgstr "Desmarca"
 msgid "Designation"
 msgstr "Designació"
 
-msgid "Documents"
-msgstr "Documents"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Nom del fitxer"
 
 msgid "Messages"
 msgstr "Missatges"
@@ -682,8 +698,8 @@ msgstr "Missatges"
 msgid "Date"
 msgstr "Data"
 
-msgid "No documents have been submitted!"
-msgstr "No s'ha enviat cap document!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Filtra per nom en clau"
@@ -775,11 +791,15 @@ msgstr "Gràcies per enviar-nos aquesta informació. Comproveu més endavant si 
 msgid "Thanks! We received your message."
 msgstr "Gràcies! Hem rebut el missatge."
 
-msgid "Thanks! We received your document."
-msgstr "Gràcies! Hem rebut el document."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Gràcies! Hem rebut el missatge."
 
-msgid "Thanks! We received your message and document."
-msgstr "Gràcies! Hem rebut el missatge i el document."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Gràcies! Hem rebut el missatge."
 
 msgid "Reply deleted"
 msgstr "S'ha suprimit la resposta"
@@ -823,7 +843,9 @@ msgstr "Cerca un nom en clau..."
 msgid "Powered by"
 msgstr "Funciona amb"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Atenció: Si compartiu documents sensibles, podríeu posar-vos en risc, fins i tot utilitzant el Tor i el SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1051,6 +1073,21 @@ msgstr "<strong>Important:</strong> si voleu romandre en l'anonimat, <strong>no<
 
 msgid "Back to submission page"
 msgstr "Torna a la pàgina d'enviaments"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "S'ha desconnectat la sessió per un canvi de la contrasenya"
+
+#~ msgid "Documents"
+#~ msgstr "Documents"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "No s'ha enviat cap document!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Gràcies! Hem rebut el document."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Gràcies! Hem rebut el missatge i el document."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Heu oblidat el vostre nom en clau?"

--- a/securedrop/translations/cs/LC_MESSAGES/messages.po
+++ b/securedrop/translations/cs/LC_MESSAGES/messages.po
@@ -42,9 +42,6 @@ msgstr "před {time}"
 msgid "You have been logged out due to inactivity."
 msgstr "Z důvodu neaktivity jste byli odhlášeni."
 
-msgid "You have been logged out due to password change"
-msgstr "Z důvodu změny hesla jste byl/a odhlášen/a"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -485,7 +482,9 @@ msgstr "Nepřečteno"
 msgid "Read"
 msgstr "Přečteno"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Nahraný dokument"
 
 msgid "Reply"
@@ -520,6 +519,19 @@ msgstr "Smazat účet zdroje"
 
 msgid "Are you sure?"
 msgstr "Jste si jisti?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Ano, smazat účet zdroje"
@@ -560,7 +572,9 @@ msgstr "AKTUALIZOVAT LOGO"
 msgid "Submission Preferences"
 msgstr "Preference podání"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Zabraňte zdrojům nahrávat dokumenty. Zdroje budou stále moci posílat zprávy."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -683,8 +697,10 @@ msgstr "Odznačit"
 msgid "Designation"
 msgstr "Označení"
 
-msgid "Documents"
-msgstr "Dokumenty"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Jméno souboru"
 
 msgid "Messages"
 msgstr "Zprávy"
@@ -692,8 +708,8 @@ msgstr "Zprávy"
 msgid "Date"
 msgstr "Datum"
 
-msgid "No documents have been submitted!"
-msgstr "Žádné dokumenty nebyly podány!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Filtrovat podle krycího jména"
@@ -785,11 +801,15 @@ msgstr "Děkujeme za zaslání těchto informací. Přihlaste se prosím za něj
 msgid "Thanks! We received your message."
 msgstr "Děkujeme! Obdrželi jsme vaši zprávu."
 
-msgid "Thanks! We received your document."
-msgstr "Děkujeme! Obdrželi jsme váš dokument."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Děkujeme! Obdrželi jsme vaši zprávu."
 
-msgid "Thanks! We received your message and document."
-msgstr "Děkujeme! Obdrželi jsme vaši zprávu a dokument."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Děkujeme! Obdrželi jsme vaši zprávu."
 
 msgid "Reply deleted"
 msgstr "Odpověď smazána"
@@ -833,7 +853,9 @@ msgstr "Vyhledat krycí jméno..."
 msgid "Powered by"
 msgstr "Používá systém"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Uvědomte si prosím, že sdílení citlivých dokumentů Vás může ohrozit i při používání Tor a SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1061,6 +1083,21 @@ msgstr "<strong>Důležité:</strong> Chcete-li zůstat v anonymitě, <strong>ne
 
 msgid "Back to submission page"
 msgstr "Zpátky na stránku podání"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Z důvodu změny hesla jste byl/a odhlášen/a"
+
+#~ msgid "Documents"
+#~ msgstr "Dokumenty"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Žádné dokumenty nebyly podány!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Děkujeme! Obdrželi jsme váš dokument."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Děkujeme! Obdrželi jsme vaši zprávu a dokument."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Zapomněli jste své krycí jméno?"

--- a/securedrop/translations/de_DE/LC_MESSAGES/messages.po
+++ b/securedrop/translations/de_DE/LC_MESSAGES/messages.po
@@ -37,9 +37,6 @@ msgstr "vor {time}"
 msgid "You have been logged out due to inactivity."
 msgstr "Sie wurden wegen Inaktivität abgemeldet."
 
-msgid "You have been logged out due to password change"
-msgstr "Sie wurden wegen einer Passwortänderung abgemeldet"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -471,7 +468,9 @@ msgstr "Ungelesen"
 msgid "Read"
 msgstr "Gelesen"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Hochgeladenes Dokument"
 
 msgid "Reply"
@@ -506,6 +505,19 @@ msgstr "Quellkonto löschen"
 
 msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Ja, Quellkonto löschen"
@@ -546,7 +558,9 @@ msgstr "LOGO AKTUALISIEREN"
 msgid "Submission Preferences"
 msgstr "Einreichungseinstellungen"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Quellen am Hochladen von Dokumenten hindern. Quellen werden weiterhin Nachrichten senden können."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -669,8 +683,10 @@ msgstr "Markieren rückgängig machen"
 msgid "Designation"
 msgstr "Bestimmung"
 
-msgid "Documents"
-msgstr "Dokumente"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Dateiname"
 
 msgid "Messages"
 msgstr "Nachrichten"
@@ -678,8 +694,8 @@ msgstr "Nachrichten"
 msgid "Date"
 msgstr "Datum"
 
-msgid "No documents have been submitted!"
-msgstr "Es wurden keine Dokumente eingereicht!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Nach Deckname filtern"
@@ -771,11 +787,15 @@ msgstr "Danke, dass Sie uns diese Information gesendet haben. Bitte kommen Sie s
 msgid "Thanks! We received your message."
 msgstr "Danke! Wir haben Ihre Nachricht erhalten."
 
-msgid "Thanks! We received your document."
-msgstr "Danke! Wir haben Ihr Dokument erhalten."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Danke! Wir haben Ihre Nachricht erhalten."
 
-msgid "Thanks! We received your message and document."
-msgstr "Danke! Wir haben Ihre Nachricht und Dokument erhalten."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Danke! Wir haben Ihre Nachricht erhalten."
 
 msgid "Reply deleted"
 msgstr "Antwort gelöscht"
@@ -819,7 +839,9 @@ msgstr "Decknamen nachschlagen..."
 msgid "Powered by"
 msgstr "Ermöglicht durch"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Achtung: Das Teilen von vertraulichen Dokumenten kann Sie in Gefahr bringen, auch wenn Sie Tor und SecureDrop verwenden."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1047,6 +1069,21 @@ msgstr "<strong>Wichtig:</strong> Verwenden Sie <strong>nicht</strong> GPG, um d
 
 msgid "Back to submission page"
 msgstr "Zurück zur Einreichungsseite"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Sie wurden wegen einer Passwortänderung abgemeldet"
+
+#~ msgid "Documents"
+#~ msgstr "Dokumente"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Es wurden keine Dokumente eingereicht!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Danke! Wir haben Ihr Dokument erhalten."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Danke! Wir haben Ihre Nachricht und Dokument erhalten."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Decknamen vergessen?"

--- a/securedrop/translations/el/LC_MESSAGES/messages.po
+++ b/securedrop/translations/el/LC_MESSAGES/messages.po
@@ -41,9 +41,6 @@ msgstr "πριν από {time}"
 msgid "You have been logged out due to inactivity."
 msgstr "Αποσυνδεθήκατε λόγω αδράνειας."
 
-msgid "You have been logged out due to password change"
-msgstr "Αποσυνδεθήκατε λόγω αλλαγής κωδικού πρόσβασης"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -475,7 +472,9 @@ msgstr "Μη αναγνωσμένο"
 msgid "Read"
 msgstr "Αναγνωσμένο"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Ανεβασμένο έγγραφο"
 
 msgid "Reply"
@@ -510,6 +509,19 @@ msgstr "Διαγραφή λογαριασμού πηγής"
 
 msgid "Are you sure?"
 msgstr "Είστε σίγουρος/η;"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Ναι, Διαγραφή λογαριασμού πηγής"
@@ -550,7 +562,9 @@ msgstr "ΑΝΑΝΕΩΣΗ ΛΟΓΟΤΥΠΟΥ"
 msgid "Submission Preferences"
 msgstr "Ρυθμίσεις καταχωρήσεων"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Να μην επιτρέπεται σε πηγές να ανεβάζουν έγγραφα. Οι πηγές θα μπορούν παρ' όλα αυτά να στέλνουν μηνύματα."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -673,8 +687,10 @@ msgstr "Απο-επισήμανση"
 msgid "Designation"
 msgstr "Χαρακτηρισμός"
 
-msgid "Documents"
-msgstr "Έγγραφα"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Όνομα αρχείου"
 
 msgid "Messages"
 msgstr "Μηνύματα"
@@ -682,8 +698,8 @@ msgstr "Μηνύματα"
 msgid "Date"
 msgstr "Ημερομηνία"
 
-msgid "No documents have been submitted!"
-msgstr "Δεν έχουν καταχωρηθεί έγγραφα!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Φιλτράρισμα ανά κωδικό όνομα"
@@ -775,11 +791,15 @@ msgstr "Ευχαριστούμε που μας στείλατε αυτές τι�
 msgid "Thanks! We received your message."
 msgstr "Ευχαριστούμε! Λάβαμε το μήνυμά σας."
 
-msgid "Thanks! We received your document."
-msgstr "Ευχαριστούμε! Λάβαμε το έγγραφό σας."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Ευχαριστούμε! Λάβαμε το μήνυμά σας."
 
-msgid "Thanks! We received your message and document."
-msgstr "Ευχαριστούμε! Λάβαμε το μήνυμα και το έγγραφό σας."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Ευχαριστούμε! Λάβαμε το μήνυμά σας."
 
 msgid "Reply deleted"
 msgstr "Η απάντηση διαγράφτηκε"
@@ -823,7 +843,9 @@ msgstr "Αναζήτηση ενός κωδικού ονόματος..."
 msgid "Powered by"
 msgstr "Με την υποστήριξη του"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Σημείωση: Η κοινοποίηση ευαίσθητων αρχείων μπορεί να σας εκθέσει σε κίνδυνο, ακόμα και όταν χρησιμοποιείτε το Tor και το SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1051,6 +1073,21 @@ msgstr "<strong>Σημαντικό:</strong> Αν επιθυμείτε να δι
 
 msgid "Back to submission page"
 msgstr "Πίσω στη σελίδα υποβολών"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Αποσυνδεθήκατε λόγω αλλαγής κωδικού πρόσβασης"
+
+#~ msgid "Documents"
+#~ msgstr "Έγγραφα"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Δεν έχουν καταχωρηθεί έγγραφα!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Ευχαριστούμε! Λάβαμε το έγγραφό σας."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Ευχαριστούμε! Λάβαμε το μήνυμα και το έγγραφό σας."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Ξεχάσατε το κωδικό όνομά σας;"

--- a/securedrop/translations/es_ES/LC_MESSAGES/messages.po
+++ b/securedrop/translations/es_ES/LC_MESSAGES/messages.po
@@ -42,9 +42,6 @@ msgstr "hace {time}"
 msgid "You have been logged out due to inactivity."
 msgstr "Tu sesión ha terminado debido a inactividad."
 
-msgid "You have been logged out due to password change"
-msgstr "Tu sesión ha sido terminada debido a un cambio de contraseña"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -476,7 +473,9 @@ msgstr "No leído"
 msgid "Read"
 msgstr "Leído"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Documento Cargado"
 
 msgid "Reply"
@@ -511,6 +510,19 @@ msgstr "Eliminar Cuenta de Fuente"
 
 msgid "Are you sure?"
 msgstr "¿Estás seguro?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Sí, eliminar cuenta de fuente"
@@ -551,7 +563,9 @@ msgstr "ACTUALIZAR LOGOTIPO"
 msgid "Submission Preferences"
 msgstr "Preferencias de envío"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Impide que las fuentes suban documentos. Las fuentes todavía podrán seguir enviando mensajes."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -674,8 +688,10 @@ msgstr "Desmarcar"
 msgid "Designation"
 msgstr "Designación"
 
-msgid "Documents"
-msgstr "Documentos"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Nombre de archivo"
 
 msgid "Messages"
 msgstr "Mensajes"
@@ -683,8 +699,8 @@ msgstr "Mensajes"
 msgid "Date"
 msgstr "Fecha"
 
-msgid "No documents have been submitted!"
-msgstr "¡No se han enviado documentos!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Filtrar por nombre clave"
@@ -778,11 +794,15 @@ msgstr "Gracias por enviarnos esta información. Por favor, verifica más tarde 
 msgid "Thanks! We received your message."
 msgstr "¡Gracias! Recibimos tu mensaje."
 
-msgid "Thanks! We received your document."
-msgstr "¡Gracias! Recibimos tu documento."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "¡Gracias! Recibimos tu mensaje."
 
-msgid "Thanks! We received your message and document."
-msgstr "¡Gracias! Recibimos tu mensaje y documento."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "¡Gracias! Recibimos tu mensaje."
 
 msgid "Reply deleted"
 msgstr "Respuesta eliminada"
@@ -826,7 +846,9 @@ msgstr "Buscar un nombre clave..."
 msgid "Powered by"
 msgstr "Con tecnología de"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Por favor ten en cuenta: compartir documentos confidenciales puede ponerte en riesgo, incluso si lo haces a través de Tor y SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1060,6 +1082,21 @@ msgstr "<strong>Importante:</strong> Si deseas permanecer anónimo, <strong>no</
 
 msgid "Back to submission page"
 msgstr "Regresar a la página de envío"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Tu sesión ha sido terminada debido a un cambio de contraseña"
+
+#~ msgid "Documents"
+#~ msgstr "Documentos"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "¡No se han enviado documentos!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "¡Gracias! Recibimos tu documento."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "¡Gracias! Recibimos tu mensaje y documento."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "¿Olvidaste tu nombre clave?"

--- a/securedrop/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/securedrop/translations/fr_FR/LC_MESSAGES/messages.po
@@ -42,9 +42,6 @@ msgstr "il y a {time}"
 msgid "You have been logged out due to inactivity."
 msgstr "Vous avez été déconnecté pour cause d’inactivité."
 
-msgid "You have been logged out due to password change"
-msgstr "Vous avez été déconnecté en raison d’un changement du mot de passe"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -476,7 +473,9 @@ msgstr "Non lu"
 msgid "Read"
 msgstr "Lu"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Le document a été téléversé"
 
 msgid "Reply"
@@ -511,6 +510,19 @@ msgstr "Supprimer le compte source"
 
 msgid "Are you sure?"
 msgstr "Confirmez-vous ?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Oui, supprimer le compte de la source"
@@ -551,7 +563,9 @@ msgstr "METTRE À JOUR LE LOGO"
 msgid "Submission Preferences"
 msgstr "Préférences des envois"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Empêcher les sources de téléverser des documents. Les sources pourront encore envoyer des messages."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -674,8 +688,10 @@ msgstr "Ôter l’étoile"
 msgid "Designation"
 msgstr "Désignation"
 
-msgid "Documents"
-msgstr "Documents"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Nom du fichier"
 
 msgid "Messages"
 msgstr "Messages"
@@ -683,8 +699,8 @@ msgstr "Messages"
 msgid "Date"
 msgstr "Date"
 
-msgid "No documents have been submitted!"
-msgstr "Aucun document n’a été envoyé !"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Filtrer par nom de code"
@@ -776,11 +792,15 @@ msgstr "Nous vous remercions de nous avoir envoyé ces renseignements. Veuillez 
 msgid "Thanks! We received your message."
 msgstr "Merci ! Nous avons reçu votre message."
 
-msgid "Thanks! We received your document."
-msgstr "Merci ! Nous avons reçu votre document."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Merci ! Nous avons reçu votre message."
 
-msgid "Thanks! We received your message and document."
-msgstr "Merci ! Nous avons reçu vos document et message."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Merci ! Nous avons reçu votre message."
 
 msgid "Reply deleted"
 msgstr "La réponse a été supprimée"
@@ -824,7 +844,9 @@ msgstr "Chercher un nom de code…"
 msgid "Powered by"
 msgstr "Propulsée par"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Veuillez noter : le partage de documents délicats pourrait vous mettre en danger, même en utilisant Tor et SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1052,6 +1074,21 @@ msgstr "<strong>Important :</strong> Si vous souhaitez rester anonyme, <strong>
 
 msgid "Back to submission page"
 msgstr "Revenir à la page d'envoi"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Vous avez été déconnecté en raison d’un changement du mot de passe"
+
+#~ msgid "Documents"
+#~ msgstr "Documents"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Aucun document n’a été envoyé !"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Merci ! Nous avons reçu votre document."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Merci ! Nous avons reçu vos document et message."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Avez-vous oublié votre nom de code ?"

--- a/securedrop/translations/hi/LC_MESSAGES/messages.po
+++ b/securedrop/translations/hi/LC_MESSAGES/messages.po
@@ -43,9 +43,6 @@ msgstr "{time} पहले"
 msgid "You have been logged out due to inactivity."
 msgstr "निष्क्रियता के कारण आपको लॉग आउट कर दिया गया है|"
 
-msgid "You have been logged out due to password change"
-msgstr "पासवर्ड बदलने के कारण आप लॉग आउट हो गये है"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -495,7 +492,9 @@ msgstr "अपठित"
 msgid "Read"
 msgstr "पठित"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "अपलोड किए गए दस्तावेज़"
 
 msgid "Reply"
@@ -534,6 +533,19 @@ msgstr "स्रोत खाता हटाएं"
 
 msgid "Are you sure?"
 msgstr "क्या आपको यकीन है?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "हाँ, स्रोत खाता हटाएं"
@@ -578,7 +590,9 @@ msgstr "अपडेट लोगो"
 msgid "Submission Preferences"
 msgstr "सबमिशन पसंदगी"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "दस्तावेज़ अपलोड करने से स्रोतों को रोकें। स्रोत अभी भी संदेश भेजने में सक्षम होंगे।"
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -708,9 +722,9 @@ msgid "Designation"
 msgstr ""
 
 #, fuzzy
-#| msgid "Uploaded Document"
-msgid "Documents"
-msgstr "अपलोड किए गए दस्तावेज़"
+#| msgid "First name"
+msgid "Files"
+msgstr "प्रथम नाम"
 
 #, fuzzy
 #| msgid "Message"
@@ -720,8 +734,8 @@ msgstr "संदेश"
 msgid "Date"
 msgstr ""
 
-msgid "No documents have been submitted!"
-msgstr "कोई दस्तावेज जमा नहीं किया गया है!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "कोडनेम द्वारा फ़िल्टर करें"
@@ -826,11 +840,15 @@ msgstr "हमें यह जानकारी भेजने के लि�
 msgid "Thanks! We received your message."
 msgstr "धन्यवाद! हमें आपका संदेशा मिला|"
 
-msgid "Thanks! We received your document."
-msgstr "धन्यवाद! हमें आपका दस्तावेज़ मिला।"
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "धन्यवाद! हमें आपका संदेशा मिला|"
 
-msgid "Thanks! We received your message and document."
-msgstr "धन्यवाद! हमें आपका संदेशा और दस्तावेज़ मिला।"
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "धन्यवाद! हमें आपका संदेशा मिला|"
 
 msgid "Reply deleted"
 msgstr "जवाब हटा दिया गया"
@@ -874,7 +892,9 @@ msgstr "एक कोडनाम खोजें..."
 msgid "Powered by"
 msgstr "द्वारा संचालित"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "कृपया ध्यान दें: Tor और SecureDrop द्वारा संवेदनशील दस्तावेज़ साझा करना आपको जोखिम में डाल सकता है।"
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1121,6 +1141,23 @@ msgstr "<strong>महत्वपूर्ण:</strong> यदि आप गु
 
 msgid "Back to submission page"
 msgstr "सबमिशन पृष्ठ पर वापस जाएं"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "पासवर्ड बदलने के कारण आप लॉग आउट हो गये है"
+
+#, fuzzy
+#~| msgid "Uploaded Document"
+#~ msgid "Documents"
+#~ msgstr "अपलोड किए गए दस्तावेज़"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "कोई दस्तावेज जमा नहीं किया गया है!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "धन्यवाद! हमें आपका दस्तावेज़ मिला।"
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "धन्यवाद! हमें आपका संदेशा और दस्तावेज़ मिला।"
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "अपना संकेत नाम भूल गए?"

--- a/securedrop/translations/is/LC_MESSAGES/messages.po
+++ b/securedrop/translations/is/LC_MESSAGES/messages.po
@@ -41,9 +41,6 @@ msgstr "Fyrir {time} síðan"
 msgid "You have been logged out due to inactivity."
 msgstr "Þú hefur verið skráð/ur út vegna aðgerðaleysis."
 
-msgid "You have been logged out due to password change"
-msgstr "Útskráning vegna breytingar á lykilorði"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -475,7 +472,9 @@ msgstr "Ólesið"
 msgid "Read"
 msgstr "Lesa"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Innsent skjal"
 
 msgid "Reply"
@@ -510,6 +509,19 @@ msgstr "Eyða notandaaðgangi heimildarmanns"
 
 msgid "Are you sure?"
 msgstr "Ertu viss?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Já, eyða notandaaðgangi heimildarmanns"
@@ -550,7 +562,9 @@ msgstr "UPPFÆRA MERKI"
 msgid "Submission Preferences"
 msgstr "Kjörstillingar fyrir innsendingu"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Koma í veg fyrir að heimildarmenn geti sent inn skjöl. Heimildamenn geta eftir sem áður sent skilaboð."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -673,8 +687,10 @@ msgstr "Fjarlægja stjörnumerkingu"
 msgid "Designation"
 msgstr "Tilnefnt"
 
-msgid "Documents"
-msgstr "Skjöl"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Skráarheiti"
 
 msgid "Messages"
 msgstr "Skilaboð"
@@ -682,8 +698,8 @@ msgstr "Skilaboð"
 msgid "Date"
 msgstr "Dagsetning"
 
-msgid "No documents have been submitted!"
-msgstr "Engin skjöl hafa verið send inn!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Sía eftir kóðanafni"
@@ -775,11 +791,15 @@ msgstr "Takk fyrir að senda þessar upplýsingar til okkar. Komdu svo aftur sí
 msgid "Thanks! We received your message."
 msgstr "Takk fyrir! Við fengum skilaboðin þín."
 
-msgid "Thanks! We received your document."
-msgstr "Takk fyrir! Við fengum skjalið þitt."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Takk fyrir! Við fengum skilaboðin þín."
 
-msgid "Thanks! We received your message and document."
-msgstr "Takk fyrir! Við fengum skilaboðin og skjalið þitt."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Takk fyrir! Við fengum skilaboðin þín."
 
 msgid "Reply deleted"
 msgstr "Svari var eytt"
@@ -823,7 +843,9 @@ msgstr "Fletta upp kóðanafni..."
 msgid "Powered by"
 msgstr "Keyrt með"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Athugaðu: Að deila viðkvæmum upplýsingum getur falið í sér áhættu, jafnvel þó notast sé við Tor og SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1051,6 +1073,21 @@ msgstr "<strong>Mikilvægt:</strong> Ef þú óskar áframhaldandi nafnleyndar, 
 
 msgid "Back to submission page"
 msgstr "Til baka á innsendingasíðuna"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Útskráning vegna breytingar á lykilorði"
+
+#~ msgid "Documents"
+#~ msgstr "Skjöl"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Engin skjöl hafa verið send inn!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Takk fyrir! Við fengum skjalið þitt."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Takk fyrir! Við fengum skilaboðin og skjalið þitt."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Gleymdirðu kóðanafninu þínu?"

--- a/securedrop/translations/it_IT/LC_MESSAGES/messages.po
+++ b/securedrop/translations/it_IT/LC_MESSAGES/messages.po
@@ -45,9 +45,6 @@ msgstr "{time} fa"
 msgid "You have been logged out due to inactivity."
 msgstr "La sessione è stata terminata per inattività."
 
-msgid "You have been logged out due to password change"
-msgstr "Sei stato disconnesso a seguito della modifica della password"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -479,7 +476,9 @@ msgstr "Non letto"
 msgid "Read"
 msgstr "Letto"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Documento caricato"
 
 msgid "Reply"
@@ -514,6 +513,19 @@ msgstr "Elimina l'account della fonte"
 
 msgid "Are you sure?"
 msgstr "Procedere veramente?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Sì, elimina l'account della fonte"
@@ -554,7 +566,9 @@ msgstr "AGGIORNA LOGO"
 msgid "Submission Preferences"
 msgstr "Preferenze di invio"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Impedire alle fonti di caricare documenti. Le stesse potranno comunque continuare a inviare messaggi."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -677,8 +691,10 @@ msgstr "Rimuovi dai preferiti"
 msgid "Designation"
 msgstr "Denominazione"
 
-msgid "Documents"
-msgstr "Documenti"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Nome file"
 
 msgid "Messages"
 msgstr "Messaggi"
@@ -686,8 +702,8 @@ msgstr "Messaggi"
 msgid "Date"
 msgstr "Data"
 
-msgid "No documents have been submitted!"
-msgstr "Non è stato inviato alcun documento!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Filtra per nome in codice"
@@ -779,11 +795,15 @@ msgstr "Grazie per aver inviato questa informazione. Verifica più tardi per ved
 msgid "Thanks! We received your message."
 msgstr "Grazie! Abbiamo ricevuto il tuo messaggio."
 
-msgid "Thanks! We received your document."
-msgstr "Grazie! Abbiamo ricevuto il tuo documento."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Grazie! Abbiamo ricevuto il tuo messaggio."
 
-msgid "Thanks! We received your message and document."
-msgstr "Grazie! Abbiamo ricevuto il tuo messaggio e il documento."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Grazie! Abbiamo ricevuto il tuo messaggio."
 
 msgid "Reply deleted"
 msgstr "Risposta eliminata"
@@ -827,7 +847,9 @@ msgstr "Ricerca un nome in codice..."
 msgid "Powered by"
 msgstr "Implementato da"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Nota: la condivisione di documenti riservati può comportare un rischio, anche quando si utilizzano Tor e SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1055,6 +1077,21 @@ msgstr "<strong>Importante:</strong> per rimanere anonimi <strong>non usare</str
 
 msgid "Back to submission page"
 msgstr "Torna alla pagina di invio documenti e messaggi"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Sei stato disconnesso a seguito della modifica della password"
+
+#~ msgid "Documents"
+#~ msgstr "Documenti"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Non è stato inviato alcun documento!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Grazie! Abbiamo ricevuto il tuo documento."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Grazie! Abbiamo ricevuto il tuo messaggio e il documento."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Nome in codice dimenticato?"

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: SecureDrop 2.4.0~rc1\n"
+"Project-Id-Version: SecureDrop 2.5.0~rc1\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
@@ -37,9 +37,6 @@ msgid "{time} ago"
 msgstr ""
 
 msgid "You have been logged out due to inactivity."
-msgstr ""
-
-msgid "You have been logged out due to password change"
 msgstr ""
 
 msgid "SecureDrop"
@@ -473,7 +470,7 @@ msgstr ""
 msgid "Read"
 msgstr ""
 
-msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr ""
 
 msgid "Reply"
@@ -507,6 +504,19 @@ msgid "Delete Source Account"
 msgstr ""
 
 msgid "Are you sure?"
+msgstr ""
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
 msgstr ""
 
 msgid "Yes, Delete Source Account"
@@ -548,7 +558,7 @@ msgstr ""
 msgid "Submission Preferences"
 msgstr ""
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr ""
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -671,7 +681,7 @@ msgstr ""
 msgid "Designation"
 msgstr ""
 
-msgid "Documents"
+msgid "Files"
 msgstr ""
 
 msgid "Messages"
@@ -680,7 +690,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-msgid "No documents have been submitted!"
+msgid "There are no submissions!"
 msgstr ""
 
 msgid "Filter by codename"
@@ -773,10 +783,10 @@ msgstr ""
 msgid "Thanks! We received your message."
 msgstr ""
 
-msgid "Thanks! We received your document."
+msgid "Thanks! We received your file."
 msgstr ""
 
-msgid "Thanks! We received your message and document."
+msgid "Thanks! We received your file and message."
 msgstr ""
 
 msgid "Reply deleted"
@@ -821,7 +831,7 @@ msgstr ""
 msgid "Powered by"
 msgstr ""
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr ""
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."

--- a/securedrop/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/securedrop/translations/nb_NO/LC_MESSAGES/messages.po
@@ -42,9 +42,6 @@ msgstr "{time} siden"
 msgid "You have been logged out due to inactivity."
 msgstr "Du har blitt utlogget som følge av inaktivitet."
 
-msgid "You have been logged out due to password change"
-msgstr "Du har blitt utlogget som følge av passordsendring"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -476,7 +473,9 @@ msgstr "Ulest"
 msgid "Read"
 msgstr "Lest"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Opplastet dokument"
 
 msgid "Reply"
@@ -511,6 +510,19 @@ msgstr "Slett kilde-konto"
 
 msgid "Are you sure?"
 msgstr "Er du sikker?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Ja, slett kildens konto"
@@ -551,7 +563,9 @@ msgstr "OPPDATER LOGO"
 msgid "Submission Preferences"
 msgstr "Forsendelsesinnstillinger"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Forhindre kilder i å laste opp filer. De vil fortsatt kunne sende inn meldinger."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -674,8 +688,10 @@ msgstr "Fjern stjernemerking"
 msgid "Designation"
 msgstr "Merket"
 
-msgid "Documents"
-msgstr "Dokumenter"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Filnavn"
 
 msgid "Messages"
 msgstr "Meldinger"
@@ -683,8 +699,8 @@ msgstr "Meldinger"
 msgid "Date"
 msgstr "Dato"
 
-msgid "No documents have been submitted!"
-msgstr "Ingen dokumenter har blitt sendt!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Filtrer etter kodenavn"
@@ -776,11 +792,15 @@ msgstr "Takk for at du sendte inn informasjon. Kom gjerne tilbake for å se ette
 msgid "Thanks! We received your message."
 msgstr "Takk! Vi mottok meldingen din."
 
-msgid "Thanks! We received your document."
-msgstr "Takk! Vi har mottatt dokumentet ditt."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Takk! Vi mottok meldingen din."
 
-msgid "Thanks! We received your message and document."
-msgstr "Takk! Vi mottok meldingen og dokumentet ditt."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Takk! Vi mottok meldingen din."
 
 msgid "Reply deleted"
 msgstr "Svar slettet"
@@ -824,7 +844,9 @@ msgstr "Logg inn med kodenavn…"
 msgid "Powered by"
 msgstr "Drevet av"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Obs: Deling av sensitive dokumenter kan innebære risiko for deg, også når du bruker Tor og SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1052,6 +1074,21 @@ msgstr "<strong>Viktig:</strong> Om du ønsker å være helt anonym, <strong>ikk
 
 msgid "Back to submission page"
 msgstr "Tilbake til innsendelsesside"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Du har blitt utlogget som følge av passordsendring"
+
+#~ msgid "Documents"
+#~ msgstr "Dokumenter"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Ingen dokumenter har blitt sendt!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Takk! Vi har mottatt dokumentet ditt."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Takk! Vi mottok meldingen og dokumentet ditt."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Glemt kodenavnet ditt?"

--- a/securedrop/translations/nl/LC_MESSAGES/messages.po
+++ b/securedrop/translations/nl/LC_MESSAGES/messages.po
@@ -42,9 +42,6 @@ msgstr "{time} geleden"
 msgid "You have been logged out due to inactivity."
 msgstr "U bent wegens inactiviteit uitgelogd."
 
-msgid "You have been logged out due to password change"
-msgstr "U bent uitgelogd omdat uw wachtwoord is gewijzigd"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -476,7 +473,9 @@ msgstr "Ongelezen"
 msgid "Read"
 msgstr "Gelezen"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Geüploade document"
 
 msgid "Reply"
@@ -511,6 +510,19 @@ msgstr "Verwijder bronaccount"
 
 msgid "Are you sure?"
 msgstr "Bent u zeker?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Ja, verwijder bronaccount"
@@ -551,7 +563,9 @@ msgstr "LOGO BIJWERKEN"
 msgid "Submission Preferences"
 msgstr "Inzendingsvoorkeuren"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Voorkom dat bronnen documenten kunnen uploaden. Bronnen kunnen wel nog berichten verzenden."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -674,8 +688,10 @@ msgstr "De-markeren"
 msgid "Designation"
 msgstr "Benaming"
 
-msgid "Documents"
-msgstr "Documenten"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Bestandsnaam"
 
 msgid "Messages"
 msgstr "Bericht"
@@ -683,8 +699,8 @@ msgstr "Bericht"
 msgid "Date"
 msgstr "Datum"
 
-msgid "No documents have been submitted!"
-msgstr "Geen documenten ingezonden!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Filter op codenaam"
@@ -749,7 +765,6 @@ msgstr "Uw verbinding is op dit moment niet anoniem!"
 msgid "You were redirected because you are already logged in. If you want to create a new account, you should log out first."
 msgstr "U bent omgeleid omdat u al ingelogd bent. Indien u een nieuw account wilt aanmaken, moet u eerst uitloggen."
 
-#| msgid "You are already logged in. Please verify your codename above as it may differ from the one displayed on the previous page."
 msgid "You are already logged in. Please verify your codename as it may differ from the one displayed on the previous page."
 msgstr "U bent al ingelogd. Verifieer uw codenaam hierboven want die zou kunnen afwijken van de codenaam op de vorige pagina."
 
@@ -777,11 +792,15 @@ msgstr "Bedankt voor het inzenden van deze informatie. Kom later terug om reacti
 msgid "Thanks! We received your message."
 msgstr "Bedankt! We hebben uw bericht ontvangen."
 
-msgid "Thanks! We received your document."
-msgstr "Bedankt! We hebben uw document ontvangen."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Bedankt! We hebben uw bericht ontvangen."
 
-msgid "Thanks! We received your message and document."
-msgstr "Bedankt! We hebben uw bericht en document ontvangen."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Bedankt! We hebben uw bericht ontvangen."
 
 msgid "Reply deleted"
 msgstr "Reactie verwijderd"
@@ -825,7 +844,9 @@ msgstr "Zoek naar een codenaam..."
 msgid "Powered by"
 msgstr "Mogelijk gemaakt door"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Let op: het delen van gevoelige documenten kan u in gevaar brengen, zelfs als u Tor en SecureDrop gebruikt."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1053,6 +1074,21 @@ msgstr "<strong>Belangrijk:</strong> Als u anoniem wilt blijven, gebruik dan <st
 
 msgid "Back to submission page"
 msgstr "Terug naar inzendingenpagina"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "U bent uitgelogd omdat uw wachtwoord is gewijzigd"
+
+#~ msgid "Documents"
+#~ msgstr "Documenten"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Geen documenten ingezonden!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Bedankt! We hebben uw document ontvangen."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Bedankt! We hebben uw bericht en document ontvangen."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Uw codenaam vergeten?"

--- a/securedrop/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/securedrop/translations/pt_BR/LC_MESSAGES/messages.po
@@ -41,9 +41,6 @@ msgstr "há {time}"
 msgid "You have been logged out due to inactivity."
 msgstr "A sua sessão foi encerrada por inatividade."
 
-msgid "You have been logged out due to password change"
-msgstr "A sua sessão foi encerrada após mudança de senha"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -475,7 +472,9 @@ msgstr "Não lida"
 msgid "Read"
 msgstr "Lida"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Documento Carregado"
 
 msgid "Reply"
@@ -510,6 +509,19 @@ msgstr "Apagar a conta da fonte"
 
 msgid "Are you sure?"
 msgstr "Você tem certeza?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Sim, apagar a conta da fonte"
@@ -550,7 +562,9 @@ msgstr "ATUALIZAR LOGO"
 msgid "Submission Preferences"
 msgstr "Configurações de Envio"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Impedir que as fontes carreguem documentos. Elas continuarão a ter permissão para enviar mensagens."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -673,8 +687,10 @@ msgstr "Desmarcar"
 msgid "Designation"
 msgstr "Designação"
 
-msgid "Documents"
-msgstr "Documentos"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Nome do arquivo"
 
 msgid "Messages"
 msgstr "Mensagens"
@@ -682,8 +698,8 @@ msgstr "Mensagens"
 msgid "Date"
 msgstr "Data"
 
-msgid "No documents have been submitted!"
-msgstr "Nenhum documento foi enviado!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "filtrar por codinome"
@@ -775,11 +791,15 @@ msgstr "Agradecemos pela informação. Por favor, retorne mais tarde para ler as
 msgid "Thanks! We received your message."
 msgstr "Agradecemos a contribuição. Recebemos a sua mensagem."
 
-msgid "Thanks! We received your document."
-msgstr "Agradecemos a contribuição. Recebemos o seu documento."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Agradecemos a contribuição. Recebemos a sua mensagem."
 
-msgid "Thanks! We received your message and document."
-msgstr "Agradecemos sua contribuição. Recebemos a sua mensagem e o seu documento."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Agradecemos a contribuição. Recebemos a sua mensagem."
 
 msgid "Reply deleted"
 msgstr "Resposta apagada"
@@ -823,7 +843,9 @@ msgstr "Procurar um codinome..."
 msgid "Powered by"
 msgstr "Este site utiliza o"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Por favor, preste atenção: Ao compartilhar documentos confidenciais, você se expõe a riscos, mesmo usando Tor e SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1051,6 +1073,21 @@ msgstr "<strong>Importante:</strong> Para manter o seu anonimato, <strong>não</
 
 msgid "Back to submission page"
 msgstr "Voltar à página de envio"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "A sua sessão foi encerrada após mudança de senha"
+
+#~ msgid "Documents"
+#~ msgstr "Documentos"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Nenhum documento foi enviado!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Agradecemos a contribuição. Recebemos o seu documento."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Agradecemos sua contribuição. Recebemos a sua mensagem e o seu documento."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Esqueceu o seu codinome?"

--- a/securedrop/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/securedrop/translations/pt_PT/LC_MESSAGES/messages.po
@@ -41,9 +41,6 @@ msgstr "há {time}"
 msgid "You have been logged out due to inactivity."
 msgstr "A sua sessão terminou por inatividade."
 
-msgid "You have been logged out due to password change"
-msgstr "A sua sessão foi terminada devido à alteração da sua palavra-passe"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -475,7 +472,9 @@ msgstr "Por Ler"
 msgid "Read"
 msgstr "Lida"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Documento Carregado"
 
 msgid "Reply"
@@ -510,6 +509,19 @@ msgstr "Eliminar Conta da Fonte"
 
 msgid "Are you sure?"
 msgstr "Tem a certeza?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Sim, Eliminar Conta da Fonte"
@@ -550,7 +562,9 @@ msgstr "ALTERAR LOGÓTIPO"
 msgid "Submission Preferences"
 msgstr "Definições de Envio"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Impedir que fontes submetam documentos. As fontes continuarão a poder enviar mensagens."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -673,8 +687,10 @@ msgstr "Remover dos favoritos"
 msgid "Designation"
 msgstr "Designação"
 
-msgid "Documents"
-msgstr "Documentos"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Nome do ficheiro"
 
 msgid "Messages"
 msgstr "Mensagens"
@@ -682,8 +698,8 @@ msgstr "Mensagens"
 msgid "Date"
 msgstr "Data"
 
-msgid "No documents have been submitted!"
-msgstr "Nenhum documento foi enviado!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Filtrar por nome-código"
@@ -775,11 +791,15 @@ msgstr "Obrigado por nos enviar esta informação. Por favor, volte mais tarde p
 msgid "Thanks! We received your message."
 msgstr "Obrigado! Recebemos a sua mensagem."
 
-msgid "Thanks! We received your document."
-msgstr "Obrigado! Recebemos o seu documento."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Obrigado! Recebemos a sua mensagem."
 
-msgid "Thanks! We received your message and document."
-msgstr "Obrigado! Recebemos a sua mensagem e documento."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Obrigado! Recebemos a sua mensagem."
 
 msgid "Reply deleted"
 msgstr "Resposta eliminada"
@@ -823,7 +843,9 @@ msgstr "Procurar um nome-código..."
 msgid "Powered by"
 msgstr "Este site utiliza o"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Atenção: Partilhar documentos sensíveis pode colocá-lo em risco, mesmo usando o Tor e SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1051,6 +1073,21 @@ msgstr "<strong>Importante:</strong> para manter o seu anonimato, <strong>não</
 
 msgid "Back to submission page"
 msgstr "Voltar à página de envio"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "A sua sessão foi terminada devido à alteração da sua palavra-passe"
+
+#~ msgid "Documents"
+#~ msgstr "Documentos"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Nenhum documento foi enviado!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Obrigado! Recebemos o seu documento."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Obrigado! Recebemos a sua mensagem e documento."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Esqueceu-se do seu nome-código?"

--- a/securedrop/translations/ro/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ro/LC_MESSAGES/messages.po
@@ -44,9 +44,6 @@ msgstr "acum {time}"
 msgid "You have been logged out due to inactivity."
 msgstr "Ai fost deconectat(ă) din cauza inactivității."
 
-msgid "You have been logged out due to password change"
-msgstr "Ai fost deconectat(ă) în urma schimbării parolei"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -505,7 +502,9 @@ msgstr "Necitit"
 msgid "Read"
 msgstr "Citit"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Documentul a fost încărcat"
 
 msgid "Reply"
@@ -544,6 +543,19 @@ msgstr "Șterge contul de sursă"
 
 msgid "Are you sure?"
 msgstr "Ești sigur(ă)?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Da, șterge contul de sursă"
@@ -588,7 +600,9 @@ msgstr "ACTUALIZEAZĂ LOGO"
 msgid "Submission Preferences"
 msgstr "Preferințe de trimitere"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Împiedică sursele să încarce documente. Sursele vor putea să trimită mesaje în continuare."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -718,9 +732,9 @@ msgid "Designation"
 msgstr ""
 
 #, fuzzy
-#| msgid "Uploaded Document"
-msgid "Documents"
-msgstr "Documentul a fost încărcat"
+#| msgid "First name"
+msgid "Files"
+msgstr "Prenume"
 
 #, fuzzy
 #| msgid "Message"
@@ -730,8 +744,8 @@ msgstr "Mesaj"
 msgid "Date"
 msgstr ""
 
-msgid "No documents have been submitted!"
-msgstr "Nu a fost trimis niciun document!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Filtrează după numele de cod"
@@ -836,11 +850,15 @@ msgstr "Îți mulțumim că ne-ai trimis aceste informații. Te rugăm să revii
 msgid "Thanks! We received your message."
 msgstr "Îți mulțumim! Am primit mesajul tău."
 
-msgid "Thanks! We received your document."
-msgstr "Îți mulțumim! Am primit documentul tău."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Îți mulțumim! Am primit mesajul tău."
 
-msgid "Thanks! We received your message and document."
-msgstr "Îți mulțumim! Am primit mesajul și documentul."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Îți mulțumim! Am primit mesajul tău."
 
 msgid "Reply deleted"
 msgstr "Răspunsul a fost șters"
@@ -884,7 +902,9 @@ msgstr "Caută un nume de cod..."
 msgid "Powered by"
 msgstr "Oferit de"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Notă: Partajarea de documente sensibile te poate supune la riscuri, chiar și când folosești Tor sau SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1133,6 +1153,23 @@ msgstr "<strong>Important:</strong> Dacă vrei să rămâi anonim(ă), <strong>n
 
 msgid "Back to submission page"
 msgstr "Înapoi la pagina de trimitere"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Ai fost deconectat(ă) în urma schimbării parolei"
+
+#, fuzzy
+#~| msgid "Uploaded Document"
+#~ msgid "Documents"
+#~ msgstr "Documentul a fost încărcat"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Nu a fost trimis niciun document!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Îți mulțumim! Am primit documentul tău."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Îți mulțumim! Am primit mesajul și documentul."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Ți-ai uitat numele de cod?"

--- a/securedrop/translations/ru/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ru/LC_MESSAGES/messages.po
@@ -42,9 +42,6 @@ msgstr "{time} назад"
 msgid "You have been logged out due to inactivity."
 msgstr "Ваша сессия была завершена из-за неактивности."
 
-msgid "You have been logged out due to password change"
-msgstr "Ваша сессия была завершена из-за смены пароля"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -485,7 +482,9 @@ msgstr "Не прочитано"
 msgid "Read"
 msgstr "Прочитано"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Загруженный документ"
 
 msgid "Reply"
@@ -520,6 +519,19 @@ msgstr "Удалить учетную запись источника"
 
 msgid "Are you sure?"
 msgstr "Вы уверены?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Да, удалить учетную запись источника"
@@ -560,7 +572,9 @@ msgstr "ОБНОВИТЬ ЛОГОТИП"
 msgid "Submission Preferences"
 msgstr "Параметры публикации"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Запретить источникам загрузку документов. Источники все ещё смогут отправлять сообщения."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -683,8 +697,10 @@ msgstr "Снять отметку"
 msgid "Designation"
 msgstr "Назначение"
 
-msgid "Documents"
-msgstr "Документы"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Имя файла"
 
 msgid "Messages"
 msgstr "Сообщения"
@@ -692,8 +708,8 @@ msgstr "Сообщения"
 msgid "Date"
 msgstr "Дата"
 
-msgid "No documents have been submitted!"
-msgstr "Отправленные документы отсутствуют!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Фильтр по кодовому имени"
@@ -785,11 +801,15 @@ msgstr "Благодарим вас за отправку нам этой инф
 msgid "Thanks! We received your message."
 msgstr "Спасибо! Мы получили ваше сообщение."
 
-msgid "Thanks! We received your document."
-msgstr "Спасибо! Мы получили ваш документ."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Спасибо! Мы получили ваше сообщение."
 
-msgid "Thanks! We received your message and document."
-msgstr "Спасибо! Мы получили ваше сообщение и документ."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Спасибо! Мы получили ваше сообщение."
 
 msgid "Reply deleted"
 msgstr "Ответ удален"
@@ -833,7 +853,9 @@ msgstr "Посмотреть кодовое имя..."
 msgid "Powered by"
 msgstr "Основано на"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Пометка: выкладывать секретными документами может быть опасным, даже если используется Tor и SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1061,6 +1083,21 @@ msgstr "<strong>Внимание:</strong> Если вы хотите сохра
 
 msgid "Back to submission page"
 msgstr "Вернуться на страницу отправки"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Ваша сессия была завершена из-за смены пароля"
+
+#~ msgid "Documents"
+#~ msgstr "Документы"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Отправленные документы отсутствуют!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Спасибо! Мы получили ваш документ."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Спасибо! Мы получили ваше сообщение и документ."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Забыли ваше кодовое имя?"

--- a/securedrop/translations/sk/LC_MESSAGES/messages.po
+++ b/securedrop/translations/sk/LC_MESSAGES/messages.po
@@ -42,9 +42,6 @@ msgstr "pred {time}"
 msgid "You have been logged out due to inactivity."
 msgstr "Boli ste odhlásení z dôvodu nečinnosti."
 
-msgid "You have been logged out due to password change"
-msgstr "Kvôli zmene hesla ste boli odhlásení"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -485,7 +482,9 @@ msgstr "Neprečítané"
 msgid "Read"
 msgstr "Prečítané"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Nahratý dokument"
 
 msgid "Reply"
@@ -520,6 +519,19 @@ msgstr "Zmazať účet zdroja"
 
 msgid "Are you sure?"
 msgstr "Naozaj to chcete urobiť?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Áno, chcem zmazať účet zdroja"
@@ -560,7 +572,9 @@ msgstr "AKTUALIZOVAŤ LOGO"
 msgid "Submission Preferences"
 msgstr "Preferencie podania"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Zabráňte zdrojom v nahrávaní dokumentov. Zdroje budú môcť naďalej posielať správy."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -683,8 +697,10 @@ msgstr "Odznačiť"
 msgid "Designation"
 msgstr "Označenie"
 
-msgid "Documents"
-msgstr "Dokumenty"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Názov súboru"
 
 msgid "Messages"
 msgstr "Správy"
@@ -692,8 +708,8 @@ msgstr "Správy"
 msgid "Date"
 msgstr "Dátum"
 
-msgid "No documents have been submitted!"
-msgstr "Žiadne dokumenty neboli podané!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Filtrovať podľa krycieho mena"
@@ -794,11 +810,15 @@ msgstr "Ďakujeme za zaslanie tejto informácie. Prosím vráťte sa neskôr sko
 msgid "Thanks! We received your message."
 msgstr "Vďaka! Prijali sme vašu správu."
 
-msgid "Thanks! We received your document."
-msgstr "Vďaka! Prijali sme váš dokument."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Vďaka! Prijali sme vašu správu."
 
-msgid "Thanks! We received your message and document."
-msgstr "Vďaka! Prijali sme vašu správu a dokument."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Vďaka! Prijali sme vašu správu."
 
 msgid "Reply deleted"
 msgstr "Odpoveď zmazaná"
@@ -842,7 +862,9 @@ msgstr "Vyhľadať krycie meno..."
 msgid "Powered by"
 msgstr "Používa systém"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Nezabúdajte na to, že zdieľaním dokumentov s citlivým obsahom sa vystavujete nebezpečenstvu. A to dokonca aj vtedy, ak používate Tor alebo SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1081,6 +1103,21 @@ msgstr "<strong>Dôležité:</strong> Ak chcete zostať v anonymite, <strong>nep
 
 msgid "Back to submission page"
 msgstr "Späť na stránku podania"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Kvôli zmene hesla ste boli odhlásení"
+
+#~ msgid "Documents"
+#~ msgstr "Dokumenty"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Žiadne dokumenty neboli podané!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Vďaka! Prijali sme váš dokument."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Vďaka! Prijali sme vašu správu a dokument."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Zabudli ste svoje krycie meno?"

--- a/securedrop/translations/sv/LC_MESSAGES/messages.po
+++ b/securedrop/translations/sv/LC_MESSAGES/messages.po
@@ -41,9 +41,6 @@ msgstr "{time} sedan"
 msgid "You have been logged out due to inactivity."
 msgstr "Du har blivit utloggad på grund av inaktivitet."
 
-msgid "You have been logged out due to password change"
-msgstr "Du har blivit utloggad på grund av lösenordsbyte"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -475,7 +472,9 @@ msgstr "Olästa"
 msgid "Read"
 msgstr "Lästa"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Uppladdat dokument"
 
 msgid "Reply"
@@ -510,6 +509,19 @@ msgstr "Radera en källa"
 
 msgid "Are you sure?"
 msgstr "Är du säker?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Ja, radera källan"
@@ -550,7 +562,9 @@ msgstr "UPPDATERA LOGGA"
 msgid "Submission Preferences"
 msgstr "Inlämningsinställningar"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Förhindra källor från att ladda upp dokument. Källor kommer fortfarande kunna skicka meddelanden."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -673,8 +687,10 @@ msgstr "Ta bort stjärnmärkning"
 msgid "Designation"
 msgstr "Beteckning"
 
-msgid "Documents"
-msgstr "Dokument"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Filnamn"
 
 msgid "Messages"
 msgstr "Meddelanden"
@@ -682,8 +698,8 @@ msgstr "Meddelanden"
 msgid "Date"
 msgstr "Datum"
 
-msgid "No documents have been submitted!"
-msgstr "Inga dokument har lämnats in!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Filtrera på kodnamn"
@@ -775,11 +791,15 @@ msgstr "Tack för att du skickade denna information till oss. Kom tillbaka senar
 msgid "Thanks! We received your message."
 msgstr "Tack! Vi har tagit emot ditt meddelande."
 
-msgid "Thanks! We received your document."
-msgstr "Tack! Vi har tagit emot ditt dokument."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Tack! Vi har tagit emot ditt meddelande."
 
-msgid "Thanks! We received your message and document."
-msgstr "Tack! Vi har tagit emot ditt meddelande och dokument."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Tack! Vi har tagit emot ditt meddelande."
 
 msgid "Reply deleted"
 msgstr "Svaret har tagits bort"
@@ -823,7 +843,9 @@ msgstr "Sök ett kodnamn..."
 msgid "Powered by"
 msgstr "Körs på"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Observera: Delning av känsliga dokument kan utsätta dig för risk, även om du använder Tor och SecureDrop."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1051,6 +1073,21 @@ msgstr "<strong> Viktigt:</strong> Ifall du önskar att förbli anonym, <strong>
 
 msgid "Back to submission page"
 msgstr "Tillbaka till inlämningssidan"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Du har blivit utloggad på grund av lösenordsbyte"
+
+#~ msgid "Documents"
+#~ msgstr "Dokument"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Inga dokument har lämnats in!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Tack! Vi har tagit emot ditt dokument."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Tack! Vi har tagit emot ditt meddelande och dokument."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Har du glömt ditt kodnamn?"

--- a/securedrop/translations/tr/LC_MESSAGES/messages.po
+++ b/securedrop/translations/tr/LC_MESSAGES/messages.po
@@ -41,9 +41,6 @@ msgstr "{time} önce"
 msgid "You have been logged out due to inactivity."
 msgstr "Uzun süredir bir işlem yapmadığınız için oturumunuz kapatıldı."
 
-msgid "You have been logged out due to password change"
-msgstr "Parolanız değiştirildiği için oturumunuz kapatıldı"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -475,7 +472,9 @@ msgstr "Okunmamış"
 msgid "Read"
 msgstr "Okunmuş"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "Yüklenen Belge"
 
 msgid "Reply"
@@ -510,6 +509,19 @@ msgstr "Kaynak Hesabını Sil"
 
 msgid "Are you sure?"
 msgstr "Emin misiniz?"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "Evet, Kaynak Hesabını Sil"
@@ -550,7 +562,9 @@ msgstr "LOGOYU GÜNCELLE"
 msgid "Submission Preferences"
 msgstr "Gönderim Tercihleri"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "Kaynakların belge yüklemelerini engeller. Kaynaklar halen ileti gönderebilir."
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -673,8 +687,10 @@ msgstr "İşareti Kaldır"
 msgid "Designation"
 msgstr "Atama"
 
-msgid "Documents"
-msgstr "Belgeler"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "Dosya adı"
 
 msgid "Messages"
 msgstr "İletiler"
@@ -682,8 +698,8 @@ msgstr "İletiler"
 msgid "Date"
 msgstr "Tarih"
 
-msgid "No documents have been submitted!"
-msgstr "Herhangi bir belge gönderilmedi!"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "Kod adına göre süz"
@@ -775,11 +791,15 @@ msgstr "Bu bilgiyi bize gönderdiğiniz için teşekkür ederiz. Yanıtlar için
 msgid "Thanks! We received your message."
 msgstr "Teşekkürler! İletiniz alındı."
 
-msgid "Thanks! We received your document."
-msgstr "Teşekkürler! Belgeniz alındı."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "Teşekkürler! İletiniz alındı."
 
-msgid "Thanks! We received your message and document."
-msgstr "Teşekkürler! İletiniz ve belgeniz alındı."
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "Teşekkürler! İletiniz alındı."
 
 msgid "Reply deleted"
 msgstr "Yanıt silindi"
@@ -823,7 +843,9 @@ msgstr "Bir kod adı ara..."
 msgid "Powered by"
 msgstr "Destekleyen"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "Lütfen unutmayın: Tor ve SecureDrop kullanıyor olsanız bile önemli belgeleri paylaşarak risk alırsınız."
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1051,6 +1073,21 @@ msgstr "<strong>Önemli:</strong> Anonim kalmak istiyorsanız, dosyanın GPG tar
 
 msgid "Back to submission page"
 msgstr "Gönderi sayfasına geri dön"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "Parolanız değiştirildiği için oturumunuz kapatıldı"
+
+#~ msgid "Documents"
+#~ msgstr "Belgeler"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "Herhangi bir belge gönderilmedi!"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "Teşekkürler! Belgeniz alındı."
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "Teşekkürler! İletiniz ve belgeniz alındı."
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "Kod adınızı mı unuttunuz?"

--- a/securedrop/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/securedrop/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -40,9 +40,6 @@ msgstr "{time} 之前"
 msgid "You have been logged out due to inactivity."
 msgstr "您因过久未活动而被登出。"
 
-msgid "You have been logged out due to password change"
-msgstr "您因密码更改而被登出"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -465,7 +462,9 @@ msgstr "未读"
 msgid "Read"
 msgstr "读取"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "已上传的文件"
 
 msgid "Reply"
@@ -500,6 +499,19 @@ msgstr "删除线人账户"
 
 msgid "Are you sure?"
 msgstr "确定吗？"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "是的，删除线人帐号"
@@ -540,7 +552,9 @@ msgstr "更新图标"
 msgid "Submission Preferences"
 msgstr "提交设置"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "阻止线人上传文件，其将仍可发送信息。"
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -663,8 +677,10 @@ msgstr "去星"
 msgid "Designation"
 msgstr "指定"
 
-msgid "Documents"
-msgstr "文件"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "文件名"
 
 msgid "Messages"
 msgstr "消息"
@@ -672,8 +688,8 @@ msgstr "消息"
 msgid "Date"
 msgstr "日期"
 
-msgid "No documents have been submitted!"
-msgstr "无已提交的文档！"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "按代号筛选"
@@ -765,11 +781,15 @@ msgstr "感谢您向我们提供此信息。请稍后回来查看回复。"
 msgid "Thanks! We received your message."
 msgstr "万分感谢！我们收到了您的信息。"
 
-msgid "Thanks! We received your document."
-msgstr "万分感谢！我们收到了您的文档。"
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "万分感谢！我们收到了您的信息。"
 
-msgid "Thanks! We received your message and document."
-msgstr "万分感谢！我们收到了您的信息与文档。"
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "万分感谢！我们收到了您的信息。"
 
 msgid "Reply deleted"
 msgstr "回复已删除"
@@ -813,7 +833,9 @@ msgstr "查询代号···"
 msgid "Powered by"
 msgstr "技术支持"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "请注意：分享敏感文档可能会让您危在旦夕，即便您正使用 Tor 和 SecureDrop。"
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1041,6 +1063,21 @@ msgstr "<strong>重要提示：</strong>若您想保持匿名身份，<strong>�
 
 msgid "Back to submission page"
 msgstr "返回提交页面"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "您因密码更改而被登出"
+
+#~ msgid "Documents"
+#~ msgstr "文件"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "无已提交的文档！"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "万分感谢！我们收到了您的文档。"
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "万分感谢！我们收到了您的信息与文档。"
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "忘记了您的代号？"

--- a/securedrop/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/securedrop/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -41,9 +41,6 @@ msgstr "{time} 之前"
 msgid "You have been logged out due to inactivity."
 msgstr "因為閒置太久，已將您登出。"
 
-msgid "You have been logged out due to password change"
-msgstr "因密碼變更已被登出"
-
 msgid "SecureDrop"
 msgstr "SecureDrop"
 
@@ -466,7 +463,9 @@ msgstr "未讀"
 msgid "Read"
 msgstr "讀取"
 
-msgid "Uploaded Document"
+#, fuzzy
+#| msgid "Uploaded Document"
+msgid "Uploaded File"
 msgstr "已上傳的文件"
 
 msgid "Reply"
@@ -501,6 +500,19 @@ msgstr "刪除線人帳號"
 
 msgid "Are you sure?"
 msgstr "確定嗎？"
+
+msgid ""
+"<p>\n"
+"Deleting the account for <b>{source}</b> will:\n"
+"</p>\n"
+"<ul>\n"
+"<li>prevent them from logging in with their codename again\n"
+"<li>prevent your organization from sending replies\n"
+"</ul>\n"
+"<p>\n"
+"All files, messages, and replies will also be deleted when their account is deleted.\n"
+"</p>"
+msgstr ""
 
 msgid "Yes, Delete Source Account"
 msgstr "是的，請刪除線人帳號"
@@ -541,7 +553,9 @@ msgstr "更新商標"
 msgid "Submission Preferences"
 msgstr "提交偏好"
 
-msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+#, fuzzy
+#| msgid "Prevent sources from uploading documents. Sources will still be able to send messages."
+msgid "Prevent sources from uploading files. Sources will still be able to send messages."
 msgstr "防止消息來源上傳文件，但來源仍可以傳送訊息。"
 
 msgid "Prevent sources from sending initial messages shorter than the minimum required length:"
@@ -664,8 +678,10 @@ msgstr "未標星"
 msgid "Designation"
 msgstr "指定"
 
-msgid "Documents"
-msgstr "文件"
+#, fuzzy
+#| msgid "Filename"
+msgid "Files"
+msgstr "檔案名稱"
 
 msgid "Messages"
 msgstr "訊息"
@@ -673,8 +689,8 @@ msgstr "訊息"
 msgid "Date"
 msgstr "日期"
 
-msgid "No documents have been submitted!"
-msgstr "未有文件被提交！"
+msgid "There are no submissions!"
+msgstr ""
 
 msgid "Filter by codename"
 msgstr "按代號篩選"
@@ -766,11 +782,15 @@ msgstr "感谢你發送此一訊息給我們。請稍晚再來查看回覆。"
 msgid "Thanks! We received your message."
 msgstr "謝謝！我們已收到你的訊息。"
 
-msgid "Thanks! We received your document."
-msgstr "謝謝！我們已收到你的文件。"
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file."
+msgstr "謝謝！我們已收到你的訊息。"
 
-msgid "Thanks! We received your message and document."
-msgstr "謝謝！我們已收到你的訊息和文件。"
+#, fuzzy
+#| msgid "Thanks! We received your message."
+msgid "Thanks! We received your file and message."
+msgstr "謝謝！我們已收到你的訊息。"
 
 msgid "Reply deleted"
 msgstr "回覆已刪除"
@@ -814,7 +834,9 @@ msgstr "查詢代號..."
 msgid "Powered by"
 msgstr "使用版本"
 
-msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+#, fuzzy
+#| msgid "Please note: Sharing sensitive documents may put you at risk, even when using Tor and SecureDrop."
+msgid "Please note: Sharing sensitive information may put you at risk, even when using Tor and SecureDrop."
 msgstr "請注意：即便利用 Tor 或 SecureDrop，但分享敏感文件還是對您有某些風險。"
 
 msgid "SecureDrop is a project of Freedom of the Press Foundation."
@@ -1042,6 +1064,21 @@ msgstr "<strong>重要：</strong>如果您希望保持匿名，<strong>請勿</
 
 msgid "Back to submission page"
 msgstr "返回提交文件頁面"
+
+#~ msgid "You have been logged out due to password change"
+#~ msgstr "因密碼變更已被登出"
+
+#~ msgid "Documents"
+#~ msgstr "文件"
+
+#~ msgid "No documents have been submitted!"
+#~ msgstr "未有文件被提交！"
+
+#~ msgid "Thanks! We received your document."
+#~ msgstr "謝謝！我們已收到你的文件。"
+
+#~ msgid "Thanks! We received your message and document."
+#~ msgstr "謝謝！我們已收到你的訊息和文件。"
 
 #~ msgid "Forgot your codename?"
 #~ msgstr "忘記你的代號？"


### PR DESCRIPTION
## Description of Changes

This diff is the result of "make translate", per
<https://developers.securedrop.org/en/latest/i18n.html#update-strings-to-be-translated>.

## Testing

- [x] Visually sanity-check:
    - [x] the `messages.pot` template; and
    - [x] the `messages.po` catalog for the language of your choice.
