### PR TITLE
Remove sh dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,6 @@ app-lint:  ## Test pylint compliance.
 	@echo "███ Linting application code..."
 	@cd securedrop && find . -name '*.py' | xargs pylint --reports=no --errors-only \
 	   --disable=no-name-in-module \
-	   --disable=unexpected-keyword-arg \
-	   --disable=too-many-function-args \
 	   --disable=import-error \
 	   --disable=no-member \
 	   --max-line-length=100

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -311,9 +311,7 @@ docutils==0.14 \
 dparse==0.6.2 \
     --hash=sha256:8097076f1dd26c377f30d4745e6ec18fef42f3bf493933b842ac5bafad8c345f \
     --hash=sha256:d45255bda21f998bc7ddf2afd5e62505ba6134756ba2d42a84c56b0826614dfe
-    # via
-    #   -r requirements/python3/develop-requirements.in
-    #   safety
+    # via safety
 entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451
@@ -977,9 +975,7 @@ ujson==5.5.0 \
     --hash=sha256:f5179088ef6487c475604b7898731a6ddeeada7702cfb2162155b016703a8475 \
     --hash=sha256:f63d1ae1ca17bb2c847e298c7bcf084a73d56d434b4c50509fb93a4b4300b0b2 \
     --hash=sha256:ff4928dc1e9704b567171c16787238201fdbf023665573c12c02146fe1e02eec
-    # via
-    #   -r requirements/python3/develop-requirements.in
-    #   python-lsp-jsonrpc
+    # via python-lsp-jsonrpc
 urllib3==1.26.6 \
     --hash=sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4 \
     --hash=sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.in
@@ -21,7 +21,6 @@ qrcode
 redis>=3.3.6
 rq>=1.8.1
 setuptools>=56.0.0
-sh
 SQLAlchemy>=1.3.0
 typing;python_version<"3.8"
 Werkzeug>=2.0.2

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.txt
@@ -276,10 +276,6 @@ rq==1.10.0 \
     --hash=sha256:92950a3e60863de48dd1800882939bbaf089a37497ebf9f2ecf7c9fd0a4c4a95 \
     --hash=sha256:be09ec43fae9a75a4d26ea3cd520e5fa3ea2ea8cf481be33e6ec9416f0369cac
     # via -r requirements/python3/securedrop-app-code-requirements.in
-sh==1.12.14 \
-    --hash=sha256:ae3258c5249493cebe73cb4e18253a41ed69262484bad36fdb3efcb8ad8870bb \
-    --hash=sha256:b52bf5833ed01c7b5c5fb73a7f71b3d98d48e9b9b8764236237bdc7ecae850fc
-    # via -r requirements/python3/securedrop-app-code-requirements.in
 six==1.11.0 \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import re
+import subprocess
 from pathlib import Path
 from typing import List
 
@@ -31,7 +32,6 @@ from flask import render_template, render_template_string, request, session
 from flask_babel import gettext
 from i18n import parse_locale_set
 from sdconfig import FALLBACK_LOCALE
-from sh import pybabel
 from tests.functional.factories import SecureDropConfigFactory
 from tests.functional.sd_config_v2 import DEFAULT_SECUREDROP_ROOT, SecureDropConfig
 from werkzeug.datastructures import Headers
@@ -259,7 +259,7 @@ def test_i18n():
     )
 
     pot = translation_dirs / "messages.pot"
-    pybabel("init", "-i", pot, "-d", translation_dirs, "-l", "en_US")
+    subprocess.check_call(["pybabel", "init", "-i", pot, "-d", translation_dirs, "-l", "en_US"])
 
     for (locale, translated_msg) in (
         ("fr_FR", "code bonjour"),
@@ -268,7 +268,7 @@ def test_i18n():
         ("nb_NO", "code norwegian"),
         ("es_ES", "code spanish"),
     ):
-        pybabel("init", "-i", pot, "-d", translation_dirs, "-l", locale)
+        subprocess.check_call(["pybabel", "init", "-i", pot, "-d", translation_dirs, "-l", locale])
 
         # Populate the po file with a translation
         po_file = translation_dirs / locale / "LC_MESSAGES" / "messages.po"

--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -1,3 +1,4 @@
+import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -8,7 +9,6 @@ import source_app
 import template_filters
 from db import db
 from flask import session
-from sh import pybabel
 from tests.test_i18n import create_config_for_i18n_test
 
 
@@ -104,7 +104,7 @@ def do_test(create_app):
 
     for l in ("en_US", "fr_FR"):
         pot = Path(test_config.TEMP_DIR) / "messages.pot"
-        pybabel("init", "-i", pot, "-d", test_config.TEMP_DIR, "-l", l)
+        subprocess.check_call(["pybabel", "init", "-i", pot, "-d", test_config.TEMP_DIR, "-l", l])
 
     app = create_app(test_config)
     with app.app_context():


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6547.

I removed all the `sh` dependencies with the exception of `sh.sed`, as this has been addressed in another contribution (https://github.com/freedomofpress/securedrop/issues/6547#issuecomment-1256930073).


## Testing

Small changes, limited to two files:
$ `securedrop/bin/dev-shell bin/run-test tests/test_i18n_tool.py`
$ `securedrop/bin/dev-shell bin/run-test tests/test_i18n.py`

## Deployment

Ready

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] These changes do not require documentation
