### PR TITLE
Have pylint run against securedrop/scripts/*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ ansible-config-lint: ## Run custom Ansible linting tasks.
 .PHONY: app-lint
 app-lint:  ## Test pylint compliance.
 	@echo "███ Linting application code..."
-	@cd securedrop && find . -name '*.py' | xargs pylint --reports=no --errors-only \
+	@cd securedrop && find . -name '*.py' -or -path './scripts/*' | xargs pylint --reports=no --errors-only \
 	   --disable=no-name-in-module \
 	   --disable=unexpected-keyword-arg \
 	   --disable=too-many-function-args \
@@ -118,7 +118,7 @@ app-lint:  ## Test pylint compliance.
 .PHONY: app-lint-full
 app-lint-full: ## Test pylint compliance, with no checks disabled.
 	@echo "███ Linting application code with no checks disabled..."
-	@cd securedrop && find . -name '*.py' | xargs pylint
+	@cd securedrop && find . -name '*.py' -or -path './scripts/*' | xargs pylint
 	@echo
 
 .PHONY: flake8


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

These files don't get matched by default because they don't end with a ".py" suffix, so add them explicitly.

I noticed this because LGTM caught an issue in #6551 that pylint did not.

Refs #6542.

## Testing

* [x] CI passes
* [x] (optional) Manually running `find . -name '*.py' -or -path './scripts/*'` spits out all Python files plus the 3 scripts.
* [x] (optional) Introducing a pylint error into one of the scripts causes it to fail.

## Deployment

Any special considerations for deployment? No

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] These changes do not require documentation
