### PR TITLE
Recommend people start on good first issues directly in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 See the [introduction for contributors](https://developers.securedrop.org/en/latest/contributing.html) and [Contributing Guidelines](https://developers.securedrop.org/en/latest/contributor_guidelines.html).
 
+If you're just starting, we have labeled some issues as a [*good first issue*](https://github.com/freedomofpress/securedrop/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22). If no one else has
+indicated they're working on it, please leave a comment saying you're interested, and feel free to get started right away!
+
 Check out our [Development Roadmap](https://github.com/freedomofpress/securedrop/wiki-Roadmap) to see our plans and priorities for upcoming releases.
 
 For translators, see the [Translator Guide](https://developers.securedrop.org/en/latest/translations.html) to learn how to get started with SecureDrop translations


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Advertise the list of "good first issue"s in CONTRIBUTING, and recommend that after leaving a comment, people get started right away instead of waiting for a maintainer to assign the task to them.

## Testing

* [ ] Visual review

