### PR TITLE
Added journalist_app/sessions.py to apache2 apparmor profile

### DIFF
--- a/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
+++ b/install_files/ansible-base/roles/build-securedrop-app-code-deb-pkg/files/usr.sbin.apache2
@@ -181,6 +181,7 @@
   /var/www/securedrop/journalist_app/decorators.py r,
   /var/www/securedrop/journalist_app/forms.py r,
   /var/www/securedrop/journalist_app/main.py r,
+  /var/www/securedrop/journalist_app/sessions.py r,
   /var/www/securedrop/journalist_app/utils.py r,
   /var/www/securedrop/journalist_templates/_confirmation_modal.html r,
   /var/www/securedrop/journalist_templates/_source_row.html r,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds an entry for `/var/www/securedrop/journalist_app/sessions.py` in `/etc/apparmor.d/usr.sbin.apache2`.

## Testing

- [ ] CI is passing, including the `staging-test-with-rebase` job.

## Deployment
 
Required for new installs and upgrades.

## Checklist

### If you added or removed a file deployed with the application:

- [x] I have updated AppArmor rules to include the change
