### PR TITLE
ci: run flake8 for alembic migrations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,5 +9,4 @@ exclude =
     journalist_gui/journalist_gui/updaterUI.py,
     journalist_gui/journalist_gui/resources_rc.py,
     .python3,
-    securedrop/alembic/versions,
     admin/.tox/

--- a/securedrop/alembic/versions/2e24fc7536e8_make_journalist_id_non_nullable.py
+++ b/securedrop/alembic/versions/2e24fc7536e8_make_journalist_id_non_nullable.py
@@ -82,14 +82,15 @@ def migrate_nulls() -> None:
 
     deleted_id = create_deleted()
     for table in needs_migration:
-        # The seen_ tables have UNIQUE(fk_id, journalist_id), so the deleted journalist can only have
-        # seen each item once. It is possible multiple NULL journalist have seen the same thing so we
-        # do this update in two passes.
+        # The seen_ tables have UNIQUE(fk_id, journalist_id), so the deleted journalist can only
+        # have seen each item once. It is possible multiple NULL journalist have seen the same thing
+        # so we do this update in two passes.
         # First we update as many rows to point to the deleted journalist as possible, ignoring any
         # unique key violations.
         op.execute(
             sa.text(
-                f"UPDATE OR IGNORE {table} SET journalist_id=:journalist_id WHERE journalist_id IS NULL;"
+                f"UPDATE OR IGNORE {table} SET journalist_id=:journalist_id "
+                "WHERE journalist_id IS NULL;"
             ).bindparams(journalist_id=deleted_id)
         )
         # Then we delete any leftovers which had been ignored earlier.

--- a/securedrop/alembic/versions/b7f98cfd6a70_make_filesystem_id_non_nullable.py
+++ b/securedrop/alembic/versions/b7f98cfd6a70_make_filesystem_id_non_nullable.py
@@ -19,8 +19,8 @@ def upgrade() -> None:
     # Not having a filesystem_id makes the source useless, so if any of those do exist, we'll
     # delete them first, as part of this migration.
     # Because we can't rely on SQLAlchemy's cascade deletion, we have to do it manually.
-    # First we delete out of replies/seen_files/seen_messages (things that refer to things that refer
-    # to sources)
+    # First we delete out of replies/seen_files/seen_messages (things that refer to things
+    # (source_stars/submissions/replies) that refer to sources)
     op.execute(
         "DELETE FROM seen_replies WHERE reply_id IN ("
         "SELECT replies.id FROM replies "

--- a/securedrop/alembic/versions/c5a02eb52f2d_dropped_session_nonce_from_journalist_.py
+++ b/securedrop/alembic/versions/c5a02eb52f2d_dropped_session_nonce_from_journalist_.py
@@ -1,4 +1,5 @@
-"""dropped session_nonce from journalist table and revoked tokens table due to new session implementation
+"""dropped session_nonce from journalist table and revoked tokens table
+   due to new session implementation
 
 Revision ID: c5a02eb52f2d
 Revises: b7f98cfd6a70
@@ -27,7 +28,8 @@ def upgrade() -> None:
 def downgrade() -> None:
     """This would have been the easy way, however previous does not have
     default value and thus up/down assertion fails"""
-    # op.add_column('journalists', sa.Column('session_nonce', sa.Integer(), nullable=False, server_default='0'))
+    # op.add_column('journalists', sa.Column('session_nonce', sa.Integer(),
+    #               nullable=False, server_default='0'))
 
     conn = op.get_bind()
     conn.execute("PRAGMA legacy_alter_table=ON")


### PR DESCRIPTION
Signed-off-by: Rahul Sharma <rahulxsh@gmail.com>

## Status

Ready for review

## Description of Changes

Fixes #6576 

Changes proposed in this pull request: Update .flake8 file to include `securedrop/alembic/versions` and fix existing flake8 errors for alembic migrations.

## Testing

How should the reviewer test this PR?

* [x] CI passes

## Deployment

Any special considerations for deployment? None

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] These changes do not require documentation
