### PR TITLE
Remove no longer needed CRYPTOGRAPHY_ALLOW_OPENSSL_102 environment variable

### DIFF
--- a/install_files/ansible-base/roles/app-test/files/source.wsgi.logging
+++ b/install_files/ansible-base/roles/app-test/files/source.wsgi.logging
@@ -3,7 +3,6 @@
 import os
 import sys
 
-os.environ["CRYPTOGRAPHY_ALLOW_OPENSSL_102"] = "True"
 sys.path.insert(0,"/var/www/securedrop")
 
 import logging

--- a/install_files/securedrop-app-code/var/www/journalist.wsgi
+++ b/install_files/securedrop-app-code/var/www/journalist.wsgi
@@ -3,7 +3,6 @@
 import os
 import sys
 
-os.environ["CRYPTOGRAPHY_ALLOW_OPENSSL_102"] = "True"
 sys.path.insert(0, "/var/www/securedrop")
 
 import logging

--- a/install_files/securedrop-app-code/var/www/source.wsgi
+++ b/install_files/securedrop-app-code/var/www/source.wsgi
@@ -3,7 +3,6 @@
 import os
 import sys
 
-os.environ["CRYPTOGRAPHY_ALLOW_OPENSSL_102"] = "True"
 sys.path.insert(0, "/var/www/securedrop")
 
 # import logging


### PR DESCRIPTION
SecureDrop has dropped support of Xenial in https://github.com/freedomofpress/securedrop/issues/5725

As described in the `cryptography` documentation, the `CRYPTOGRAPHY_ALLOW_OPENSSL_102` was used to force compatibility between `cryptography==3.2` and OpenSSL 1.0.2.
The current version of OpenSSL in Focal is in the 1.1 branch and also `cryptography` is now pinned to the `cryptography>=3.4.7` version.

The description of the original compatibility issue is here https://cryptography.io/en/3.2/faq/
The commit of the original change is here https://github.com/freedomofpress/securedrop/commit/4569657531f3cd2539ef0cb5ba79ccab033175d6

## Status

Ready for review

## Description of Changes
Dropping the flag should have no effect on any supported system.

## Testing
A normal test run in staging and prod, if any function that uses the cryptography module works, then everything should be working as usual.


## Checklist
My staging environment is currently undergoing other disruptive testing and thus I have not run the infra tests yet.

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

- [x] These changes do not require documentation

