### PR TITLE
Add Arabic as a supported language

### DIFF
--- a/securedrop/i18n.json
+++ b/securedrop/i18n.json
@@ -1,5 +1,9 @@
 {
   "supported_locales": {
+    "ar": {
+      "name": "Arabic",
+      "desktop": "ar"
+    },
     "ca": {
       "name": "Catalan",
       "desktop": "ca"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6605 

Adds Arabic to securedrop/i18n.json, making it available as a supported language

## Testing

- [ ] on this branch, run `./securedrop-admin sdconfig` in an admin workstation and verify the `ar` locale is valid
- [ ] complete an install with `ar` as a supported language and verify that it's available in the locale dropdown and can be selected.
