### PR TITLE
Disabled codecov uploads, as GPG key to verify the uploader is not available

### DIFF
--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -34,17 +34,18 @@ if [ -n "${CIRCLE_BRANCH:-}" ] ; then
 
         cp tests/log/firefox.log "$TEST_RESULTS"
 
-        # download and validate codecov uploader
-        echo "   Validating codecov uploader..."
-        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-        shasum -a 256 -c codecov.SHA256SUM
-        chmod +x codecov
-        echo "   Uploading coverage results to codecov..."
-        ./codecov
+        # # Codecov disabled temporarily due to GPG key not being available
+        # # download and validate codecov uploader
+        # echo "   Validating codecov uploader..."
+        # curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+        # curl -Os https://uploader.codecov.io/latest/linux/codecov
+        # curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+        # curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+        # gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+        # shasum -a 256 -c codecov.SHA256SUM
+        # chmod +x codecov
+        # echo "   Uploading coverage results to codecov..."
+        # ./codecov
     }
     trap finish EXIT
 fi


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6610 

Removes codecov uploads from `securedrop/bin/run-test`. The uploader uses a GPG key hosted on keybase.io for verification, but said site is currently down, blocking CI.

## Testing

- [x] CI is passing
