### PR TITLE
Require admins to authenticate if changing their own passphrases.

### DIFF
--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -366,6 +366,15 @@ def make_blueprint(config: SDConfig) -> Blueprint:
             user = Journalist.query.get(user_id)
         except NoResultFound:
             abort(404)
+
+        if user.id == session.get_uid():
+            current_app.logger.error(
+                "Admin {} tried to change their password without validation.".format(
+                    session.get_user().username
+                )
+            )
+            abort(403)
+
         password = request.form.get("password")
         if set_diceware_password(user, password, admin=True) is not False:
             current_app.session_interface.logout_user(user.id)  # type: ignore


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updates the JI admin passphrase update form to require the logged-in user to authenticate if changing their own passphrase.

## Testing
On this branch:

* log in to the JI as an admin user (`journalist` in the dev env)
* navigate to the admin section
- [x] Confirm that you can change the passphrase for another user without authenticating
- [x] Confirm that if you choose to edit your own account via the edit button on the admin page, you are presented with the authentication fields in the passphrase change form
* Navigate to the edit page for a different user (`dellsberg` in the dev env)
* Use webdev tools to modify the `new-password` form action, replacing the user's uid with your own (replacing `2` with `1` in dev env)
- [x] Click Reset Password and confirm that you receive a 403 error
- [x] Check the journalist error logs and confirm that a message was logged about the disallowed passphrase change.

## Deployment

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
