### PR TITLE
Use a slimmer container for `make dev`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,13 +235,13 @@ test-config: securedrop/config.py
 .PHONY: dev
 dev:  ## Run the development server in a Docker container.
 	@echo "███ Starting development server..."
-	@OFFSET_PORTS='false' DOCKER_BUILD_VERBOSE='true' $(DEVSHELL) $(SDBIN)/run
+	@OFFSET_PORTS='false' DOCKER_BUILD_VERBOSE='true' SLIM_BUILD=1 $(DEVSHELL) $(SDBIN)/run
 	@echo
 
 .PHONY: dev-tor
 dev-tor:  ## Run the development server with onion services in a Docker container.
-	@echo "███ Starting development server..."
-	@OFFSET_PORTS='false' DOCKER_BUILD_VERBOSE='true' USE_TOR='true' $(DEVSHELL) $(SDBIN)/run
+	@echo "███ Starting development server with onion services..."
+	@OFFSET_PORTS='false' DOCKER_BUILD_VERBOSE='true' USE_TOR='true' SLIM_BUILD=1 $(DEVSHELL) $(SDBIN)/run
 	@echo
 
 .PHONY: demo-landing-page

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -9,9 +9,9 @@ set -eu
 export PATH="/opt/venvs/securedrop-app-code/bin:$PATH"
 
 TOPLEVEL=$(git rev-parse --show-toplevel)
-BASE_OS="${BASE_OS:-focal}"
 USE_TOR="${USE_TOR:-}"
 USE_PODMAN="${USE_PODMAN:-}"
+SLIM_BUILD="${SLIM_BUILD:-}"
 DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS:-}"
 
 # Allow opting into using podman with USE_PODMAN=1
@@ -38,13 +38,19 @@ get_port_offset() {
 }
 
 function docker_image() {
+    if [ "${DOCKER_BUILD_VERBOSE:-'false'}" = "true" ]; then
+        out="/dev/stdout"
+    else
+        out="/dev/null"
+    fi
+
     $DOCKER_BIN build \
            ${DOCKER_BUILD_ARGUMENTS:-} \
            --build-arg=USER_ID="$(id -u)" \
            --build-arg=USER_NAME="${USER:-root}" \
-           -t "securedrop-test-${1}-py3" \
-           --file "${TOPLEVEL}/securedrop/dockerfiles/${1}/python3/Dockerfile" \
-           "${TOPLEVEL}/securedrop"
+           -t "${1}" \
+           --file "${TOPLEVEL}/securedrop/dockerfiles/focal/python3/${2}" \
+           "${TOPLEVEL}/securedrop" > $out
 }
 
 function docker_run() {
@@ -64,11 +70,12 @@ function docker_run() {
     if [ "${DOCKER_BUILD_VERBOSE:-'false'}" = "true" ]
     then
         echo "************************************************************"
-        echo "Exposed Docker ports will be available on localhost with"
-        echo "Port offset: $port_offset"
-        echo "Source interface: $SD_HOSTPORT_SI"
-        echo "Journalist interface: $SD_HOSTPORT_JI"
-        echo "VNC: $SD_HOSTPORT_VNC"
+        echo "Exposed services will be available on localhost at"
+        echo "Source interface: http://127.0.0.1:$SD_HOSTPORT_SI"
+        echo "Journalist interface: http://127.0.0.1:$SD_HOSTPORT_JI"
+        if  [[ -z "${SLIM_BUILD}" ]]; then
+            echo "VNC: port $SD_HOSTPORT_VNC"
+        fi
         echo "************************************************************"
     fi
 
@@ -108,19 +115,19 @@ function docker_run() {
            -e LANG=C.UTF-8 \
            -e TEST_LOCALES \
            -e PATH \
-           -e BASE_OS=$BASE_OS \
+           -e BASE_OS="focal" \
            --user "${USER:-root}" \
            --volume "${TOPLEVEL}:${TOPLEVEL}" \
            --workdir "${TOPLEVEL}/securedrop" \
            --name "${SD_CONTAINER}" \
-           -ti $DOCKER_RUN_ARGUMENTS "securedrop-test-${1}-py3" "${@:2}"
+           -ti $DOCKER_RUN_ARGUMENTS "${1}" "${@:2}"
 }
 
-if [ "${DOCKER_BUILD_VERBOSE:-'false'}" = "true" ]
-then
-   docker_image $BASE_OS
-else
-   docker_image $BASE_OS >/dev/null
+image="securedrop-slim-focal-py3"
+docker_image "$image" "SlimDockerfile"
+if  [[ -z "${SLIM_BUILD}" ]]; then
+    image="securedrop-test-focal-py3"
+    docker_image "$image" "Dockerfile"
 fi
 
-docker_run $BASE_OS "$@"
+docker_run "$image" "$@"

--- a/securedrop/bin/run-mypy
+++ b/securedrop/bin/run-mypy
@@ -13,5 +13,5 @@ elif [ -d "/opt/venvs/securedrop-app-code/" ]; then
     echo "Could not find mypy"
     exit 1
 else
-    ./securedrop/bin/dev-shell ./bin/run-mypy
+    SLIM_BUILD=1 ./securedrop/bin/dev-shell ./bin/run-mypy
 fi

--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -1,21 +1,13 @@
-# ubuntu 20.04 image from 2022-08-01
-FROM ubuntu@sha256:a06ae92523384c2cd182dcfe7f8b2bf09075062e937d5653d7d0db0375ad2221
-ARG USER_NAME
-ENV USER_NAME ${USER_NAME:-root}
-ARG USER_ID
-ENV USER_ID ${USER_ID:-0}
+FROM securedrop-slim-focal-py3
 
-RUN apt-get update && apt-get install -y \
-                       libgtk2.0 apache2-dev coreutils devscripts vim \
-                       python3-pip python3-all python3-venv virtualenv libpython3.8-dev libssl-dev \
-                       gnupg2 redis-server git xvfb curl wget \
-                       x11vnc enchant libffi-dev sqlite3 gettext sudo \
-                       # For html5validator.  Used only in "app-page-layout-tests", but we can live
-                       # with its being installed along with everything else since it will be
-                       # cached along with everything else too.
-                       default-jdk \
-                       libasound2 libdbus-glib-1-2 libgtk2.0-0 libfontconfig1 libxrender1 \
-                       libcairo-gobject2 libgtk-3-0 libstartup-notification0 tor basez
+RUN apt-get install -y \
+    libgtk2.0 devscripts xvfb x11vnc \
+    # For html5validator.  Used only in "app-page-layout-tests", but we can live
+    # with its being installed along with everything else since it will be
+    # cached along with everything else too.
+    default-jdk \
+    libasound2 libdbus-glib-1-2 libgtk2.0-0 libfontconfig1 libxrender1 \
+    libcairo-gobject2 libgtk-3-0 libstartup-notification0
 
 # Current versions of the test browser software. Tor Browser is based
 # on a specific version of Firefox, noted in Help > About Tor Browser.
@@ -58,16 +50,8 @@ RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_
     tar -zxvf geckodriver*tar.gz && chmod +x geckodriver && mv geckodriver /bin && \
     rm -f mozilla.keyring geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz.asc geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
 
-COPY requirements requirements
-RUN python3 -m venv /opt/venvs/securedrop-app-code && \
-    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/docker-requirements.txt && \
-    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/test-requirements.txt && \
-    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/securedrop-app-code-requirements.txt 
-
-RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi && \
-    cp -r /root/.local /tmp/ && chmod +x /tmp/.local/tbb/tor-browser_en-US/Browser/firefox && chmod -R 777 /tmp/.local && \
-    chown -R $USER_NAME.$USER_NAME /tmp/.local/ && \
-    chown -R $USER_NAME.$USER_NAME /opt/venvs/securedrop-app-code/
+RUN cp -r /root/.local /tmp/ && chmod +x /tmp/.local/tbb/tor-browser_en-US/Browser/firefox && chmod -R 777 /tmp/.local && \
+    chown -R $USER_NAME.$USER_NAME /tmp/.local/
 
 STOPSIGNAL SIGKILL
 

--- a/securedrop/dockerfiles/focal/python3/SlimDockerfile
+++ b/securedrop/dockerfiles/focal/python3/SlimDockerfile
@@ -1,0 +1,25 @@
+# ubuntu 20.04 image from 2022-08-01
+FROM ubuntu@sha256:a06ae92523384c2cd182dcfe7f8b2bf09075062e937d5653d7d0db0375ad2221
+ARG USER_NAME
+ENV USER_NAME ${USER_NAME:-root}
+ARG USER_ID
+ENV USER_ID ${USER_ID:-0}
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y \
+                       apache2-dev coreutils vim \
+                       python3-pip python3-all python3-venv virtualenv python3-dev libssl-dev \
+                       gnupg2 redis-server git curl wget \
+                       enchant libffi-dev sqlite3 gettext sudo tor basez
+
+COPY requirements requirements
+RUN python3 -m venv /opt/venvs/securedrop-app-code && \
+    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/docker-requirements.txt && \
+    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/test-requirements.txt && \
+    /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r requirements/python3/securedrop-app-code-requirements.txt
+
+RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi && \
+    chown -R $USER_NAME.$USER_NAME /opt/venvs/securedrop-app-code/
+
+STOPSIGNAL SIGKILL
+
+EXPOSE 8080 8081 5909


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The current dev container is pretty heavy, it pulls in a bunch of different dependencies (X11, Java, devscripts) that are extraneous if you're just trying to run the Journalist/Source Interfaces. The new slimmer container is ~1.19GB.

The full container, used by `make dev-full`, is still the same ~2.9GB.

Refs #6620.

(explicitly not fixing the issue since I think there's still some more room for improvement...)

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

* [ ] `make dev` brings up JI+SI
* [ ] `make lint` uses only the slim container
  * Delete the full container (`podman rmi localhost/securedrop-test-focal-py3`)
  * Run `make lint`
  * Check `podman images` that the test image wasn't built
* [ ] `make dev-tor` brings up onion services
* [ ] `make dev-full` brings up JI+SI, outputs VNC port
* [ ] Other make targets work just fine

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
