### PR TITLE
i18n_tool: Suppress pybabel output in translate_messages step

### DIFF
--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -119,7 +119,14 @@ class I18NTool:
                 log.warning("messages translations are already up to date")
 
         if args.compile and len(os.listdir(args.translations_dir)) > 1:
-            subprocess.check_call(["pybabel", "compile", "--directory", args.translations_dir])
+            # Suppress all pybabel to hide warnings (e.g.
+            # https://github.com/python-babel/babel/issues/566) and verbose "compiling..." messages
+            subprocess.run(
+                ["pybabel", "compile", "--directory", args.translations_dir],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
 
     def translate_desktop(self, args: argparse.Namespace) -> None:
         messages_file = Path(args.translations_dir).absolute() / "desktop.pot"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

i18n_tool: Suppress pybabel output in translate_messages step

In the conversion to use subprocess (21ebdc8d9a04f2), we unintentionally
started printing pybabel's output. We need to capture both stdout
(warnings because of an upstream limitation/bug) and stderr ("compiling...").

Fixes #6628.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

* [ ] Run `make dev`, observe no output related to compiling or po files
* [ ] Open up the SI/JI, switch language, see that it still shows up in other languages

## Deployment

Any special considerations for deployment? No.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] These changes do not require documentation
