### PR TITLE
[2.5.0] Backport builder image update

### DIFF
--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_07_28
-f3b5ea1ce8948f931c28e2080d229e0123b20ded033d47e081ec76aff7d7a02e
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_10_18
+5fbcb1cfc38eb02376f70b3e78c5c7415ac5d337e42c603be7c5dfbd50218af9


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Backports #6649, updating builder image to latest.



## Testing

- [x] CI is passing
- [x] base is `release/2.5.0`
- [x] contains only changes from #6649