### PR TITLE
Drop passlib, switch to argon2id hashes

### DIFF
--- a/securedrop/alembic/versions/2e24fc7536e8_make_journalist_id_non_nullable.py
+++ b/securedrop/alembic/versions/2e24fc7536e8_make_journalist_id_non_nullable.py
@@ -8,10 +8,10 @@ Create Date: 2022-01-12 19:31:06.186285
 import os
 import uuid
 
+import argon2
 import pyotp
 import sqlalchemy as sa
 from alembic import op
-from passlib.hash import argon2
 
 # raise the errors if we're not in production
 raise_errors = os.environ.get("SECUREDROP_ENV", "prod") != "prod"
@@ -33,7 +33,7 @@ depends_on = None
 
 def generate_passphrase_hash() -> str:
     passphrase = PassphraseGenerator.get_default().generate_passphrase()
-    return argon2.using(**ARGON2_PARAMS).hash(passphrase)
+    return argon2.PasswordHasher(**ARGON2_PARAMS).hash(passphrase)
 
 
 def create_deleted() -> int:

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -8,6 +8,7 @@ from io import BytesIO
 from logging import Logger
 from typing import Any, Callable, Dict, List, Optional, Union
 
+import argon2
 import pyotp
 import qrcode
 
@@ -20,7 +21,6 @@ from encryption import EncryptionManager, GpgKeyNotFoundError
 from flask import url_for
 from flask_babel import gettext, ngettext
 from markupsafe import Markup
-from passlib.hash import argon2
 from passphrases import PassphraseGenerator
 from pyotp import HOTP, TOTP
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, LargeBinary, String
@@ -35,7 +35,7 @@ LOGIN_HARDENING = True
 if os.environ.get("SECUREDROP_ENV") == "test":
     LOGIN_HARDENING = False
 
-ARGON2_PARAMS = dict(memory_cost=2**16, rounds=4, parallelism=2)
+ARGON2_PARAMS = {"memory_cost": 2**16, "time_cost": 4, "parallelism": 2, "type": argon2.Type.I}
 
 # Required length for hex-format HOTP secrets as input by users
 HOTP_SECRET_LENGTH = 40  # 160 bits == 40 hex digits (== 32 ascii-encoded chars in db)
@@ -479,10 +479,11 @@ class Journalist(db.Model):
 
         self.check_password_acceptable(passphrase)
 
+        hasher = argon2.PasswordHasher(**ARGON2_PARAMS)
         # "migrate" from the legacy case
         if not self.passphrase_hash:
-            self.passphrase_hash = argon2.using(**ARGON2_PARAMS).hash(passphrase)
-            # passlib creates one merged field that embeds randomly generated
+            self.passphrase_hash = hasher.hash(passphrase)
+            # argon2 creates one merged field that embeds randomly generated
             # salt in the output like $alg$salt$hash
             self.pw_hash = None
             self.pw_salt = None
@@ -491,7 +492,7 @@ class Journalist(db.Model):
         if self.passphrase_hash and self.valid_password(passphrase):
             return
 
-        self.passphrase_hash = argon2.using(**ARGON2_PARAMS).hash(passphrase)
+        self.passphrase_hash = hasher.hash(passphrase)
 
     def set_name(self, first_name: Optional[str], last_name: Optional[str]) -> None:
         if first_name:
@@ -550,9 +551,13 @@ class Journalist(db.Model):
         # No check on minimum password length here because some passwords
         # may have been set prior to setting the mininum password length.
 
+        hasher = argon2.PasswordHasher(**ARGON2_PARAMS)
         if self.passphrase_hash:
             # default case
-            is_valid = argon2.verify(passphrase, self.passphrase_hash)
+            try:
+                is_valid = hasher.verify(self.passphrase_hash, passphrase)
+            except argon2.exceptions.VerificationError:
+                is_valid = False
         else:
             # legacy support
             if self.pw_salt is None:
@@ -569,8 +574,8 @@ class Journalist(db.Model):
 
         # migrate new passwords
         if is_valid and not self.passphrase_hash:
-            self.passphrase_hash = argon2.using(**ARGON2_PARAMS).hash(passphrase)
-            # passlib creates one merged field that embeds randomly generated
+            self.passphrase_hash = hasher.hash(passphrase)
+            # argon2 creates one merged field that embeds randomly generated
             # salt in the output like $alg$salt$hash
             self.pw_salt = None
             self.pw_hash = None

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.in
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.in
@@ -13,7 +13,6 @@ Flask>=2.0.3,<2.1.0
 Jinja2>=3.0.0
 markupsafe>=2.0
 mod_wsgi
-passlib
 pretty-bad-protocol>=3.1.1
 psutil>=5.6.6
 pyotp>=2.6.0

--- a/securedrop/requirements/python3/securedrop-app-code-requirements.txt
+++ b/securedrop/requirements/python3/securedrop-app-code-requirements.txt
@@ -220,10 +220,6 @@ markupsafe==2.0.1 \
 mod-wsgi==4.6.7 \
     --hash=sha256:b788abaf0b903a64a7bb8dae609f2e4790c87e6f3d716aa6bc97936410fcbfcc
     # via -r requirements/python3/securedrop-app-code-requirements.in
-passlib==1.7.1 \
-    --hash=sha256:3d948f64138c25633613f303bcc471126eae67c04d5e3f6b7b8ce6242f8653e0 \
-    --hash=sha256:43526aea08fa32c6b6dbbbe9963c4c767285b78147b7437597f992812f69d280
-    # via -r requirements/python3/securedrop-app-code-requirements.in
 pretty-bad-protocol==3.1.1 \
     --hash=sha256:fb73797eb6344e3680c919e2af367f9a019ee7c189d3ed7f5d843edde911f73b
     # via -r requirements/python3/securedrop-app-code-requirements.in

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -2617,6 +2617,7 @@ def test_passphrase_migration_on_verification(journalist_app):
 
     # check that the migration happened
     assert journalist.passphrase_hash is not None
+    assert journalist.passphrase_hash.startswith("$argon2")
     assert journalist.pw_salt is None
     assert journalist.pw_hash is None
 
@@ -2639,6 +2640,7 @@ def test_passphrase_migration_on_reset(journalist_app):
 
     # check that the migration happened
     assert journalist.passphrase_hash is not None
+    assert journalist.passphrase_hash.startswith("$argon2")
     assert journalist.pw_salt is None
     assert journalist.pw_hash is None
 
@@ -3054,7 +3056,7 @@ def test_bulk_delete_works_when_files_absent(
 
 
 def test_login_with_invalid_password_doesnt_call_argon2(mocker, test_journo):
-    mock_argon2 = mocker.patch("models.argon2.verify")
+    mock_argon2 = mocker.patch("models.argon2.PasswordHasher")
     invalid_pw = "a" * (Journalist.MAX_PASSWORD_LEN + 1)
 
     with pytest.raises(InvalidPasswordLength):
@@ -3063,7 +3065,7 @@ def test_login_with_invalid_password_doesnt_call_argon2(mocker, test_journo):
 
 
 def test_valid_login_calls_argon2(mocker, test_journo):
-    mock_argon2 = mocker.patch("models.argon2.verify")
+    mock_argon2 = mocker.patch("models.argon2.PasswordHasher")
     Journalist.login(
         test_journo["username"],
         test_journo["password"],


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Use argon2-cffi directly instead of through passlib.
* Switch to argon2id passphrase hashes for journalists

The individual commit messages have more details on specifics.

Fixes #6631.
Fixes #6655.

## Testing

* [x] Spin up a dev environment using develop (probably use `HEAD~2` since develop will have moved forward since I wrote this). Log in as `journalist`. Look in the database (e.g. `SELECT username, passphrase_hash FROM journalists`) and verify the hash starts with `$argon2i$...`.
* [x] Check out this branch, see the dev environment reload models.py
* [x] Log in as `journalist` again. Look in the database and verify the hash now starts with `$argon2id$...`
* [x] Spin up a fresh dev environment, verify the passphrase_hashes start with `$argon2id$...`

Note that there's a 50% chance the generated journalist uses the even more legacy pw_hash/pw_salt scrypt mechanism if you notice that passphrase_hash is sometimes null.

## Deployment

Any special considerations for deployment?

* Newly created journalists will use the argon2id hash by default.
* Existing journalists will be migrated as they log in.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation