### PR TITLE
fix(i18n_tool): correctly parse Git history for translators for attribution

### DIFF
--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -389,7 +389,10 @@ class I18NTool:
 
         log_command.extend([args.target, "--", path])
 
-        log_lines = subprocess.check_output(log_command, encoding="utf-8").strip().splitlines()
+        # NB. We use an explicit str.split("\n") here because str.splitlines() splits on a
+        # set of characters that includes the \x1e "record separator" we pass to "git log
+        # --format" in log_command.  See #6648.
+        log_lines = subprocess.check_output(log_command, encoding="utf-8").strip().split("\n")
         path_changes = [c.split("\x1e") for c in log_lines]
         path_changes = [
             c

--- a/securedrop/tests/test_i18n_tool.py
+++ b/securedrop/tests/test_i18n_tool.py
@@ -392,7 +392,9 @@ class TestI18NTool(object):
         subprocess.check_call(["git", "add", str(po_file)], **k)
         subprocess.check_call(["git", "config", "user.email", "somone@else.com"], **k)
         subprocess.check_call(["git", "config", "user.name", "Someone Else"], **k)
-        subprocess.check_call(["git", "commit", "-m", "translation change", str(po_file)], **k)
+        subprocess.check_call(
+            ["git", "commit", "-m", "Translated using Weblate", str(po_file)], **k
+        )
 
         k = {"cwd": join(d, "securedrop")}
         subprocess.check_call(["git", "config", "user.email", "somone@else.com"], **k)
@@ -426,3 +428,18 @@ class TestI18NTool(object):
         )
         assert "Someone Else" in message
         assert "Loïc" not in message
+
+        # The "list-translators" command correctly reads the translator from Git history.
+        caplog.clear()
+        i18n_tool.I18NTool().main(
+            [
+                "--verbose",
+                "list-translators",
+                "--all",
+                "--root",
+                join(str(tmpdir), "securedrop"),
+                "--url",
+                join(str(tmpdir), "i18n"),
+            ]
+        )
+        assert "Someone Else" in caplog.text

--- a/securedrop/tests/test_i18n_tool.py
+++ b/securedrop/tests/test_i18n_tool.py
@@ -417,6 +417,8 @@ class TestI18NTool(object):
         )
         assert "l10n: updated Dutch (nl)" in r()
         assert "l10n: updated German (de_DE)" not in r()
+
+        # The translator is credited in Git history.
         message = subprocess.check_output(
             ["git", "--no-pager", "-C", "securedrop", "show"],
             cwd=d,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6648 by:
* reverting 21ebdc8d9a04f228d7fb0643a3e81745cc17db90's use of `str.striplines()` in place of the explicit `str.strip("\n")`, per https://github.com/freedomofpress/securedrop/issues/6648#issuecomment-1284728817; and
* adding a test stanza for the expected behavior.

## Testing

### With the test suite

```sh-session
$ git checkout 6648-one-true-newline^
$ TESTFILES=tests/test_i18n_tool.py make test
```

- `tests/test_i18n_tool.py::TestI18NTool::test_update_from_weblate` fails consistent with #6648.

```sh-session
$ git checkout 6648-one-true-newline
$ TESTFILES=tests/test_i18n_tool.py make test
```

- [x] The test suite passes.

### Manually

Do something like:

```sh-session
$ git checkout 2.4.2
$ git checkout develop securedrop/{i18n.json,i18n_tool.py}
$ securedrop/bin/dev-shell ./i18n_tool.py update-from-weblate
```

- Translations are committed with empty `contributors:` sections.

```sh-session
$ git reset --hard
$ git checkout 2.4.2
$ git checkout 6648-one-true-newline securedrop/{i18n.json,i18n_tool.py}
$ securedrop/bin/dev-shell ./i18n_tool.py update-from-weblate
```

- [x] Translations are committed listing contributors.


## Deployment

Tooling-only change; no deployment considerations.


## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container