### PR TITLE
Run admin CI jobs in parallel, don't wait for lint success

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,16 +332,12 @@ workflows:
               ignore:
                 - /i18n-.*/
                 - /update-builder-.*/
-          requires:
-            - lint
       - updater-gui-tests:
           filters:
             branches:
               ignore:
                 - /i18n-.*/
                 - /update-builder-.*/
-          requires:
-            - lint
       - static-analysis-and-no-known-cves:
           requires:
             - lint


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We want to run all CI jobs in parallel, without waiting for lint to succeed. These two jobs are already independent, so we can parallelize them first.

Refs #6099.

## Testing

* [ ] CI passes

## Deployment

Any special considerations for deployment? No.

