### PR TITLE
Automatically change respective SELinux contexts when running containers

### DIFF
--- a/admin/bin/dev-shell
+++ b/admin/bin/dev-shell
@@ -31,7 +31,7 @@ function docker_run() {
         docker run \
             --rm \
             --user "${USER:-root}" \
-            --volume "${TOPLEVEL}:/sd-root" \
+            --volume "${TOPLEVEL}:/sd-root:Z" \
             --workdir "/sd-root/admin" \
             -ti ${DOCKER_RUN_ARGUMENTS:-} securedrop-admin "$@"
     else

--- a/devops/scripts/shellcheck.sh
+++ b/devops/scripts/shellcheck.sh
@@ -16,7 +16,7 @@ function run_native_or_in_docker () {
     if [ "$(command -v shellcheck)" ]; then
         shellcheck -x --exclude="$EXCLUDE_RULES" "$@"
     else
-        $DOCKER_BIN run --rm -v "$(pwd):/sd" -w /sd \
+        $DOCKER_BIN run --rm -v "$(pwd):/sd:Z" -w /sd \
             -t docker.io/koalaman/shellcheck:v0.4.7 \
             -x --exclude=$EXCLUDE_RULES "$@"
     fi

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -117,7 +117,7 @@ function docker_run() {
            -e PATH \
            -e BASE_OS="focal" \
            --user "${USER:-root}" \
-           --volume "${TOPLEVEL}:${TOPLEVEL}" \
+           --volume "${TOPLEVEL}:${TOPLEVEL}:Z" \
            --workdir "${TOPLEVEL}/securedrop" \
            --name "${SD_CONTAINER}" \
            -ti $DOCKER_RUN_ARGUMENTS "${1}" "${@:2}"


### PR DESCRIPTION
## Description of Changes

This allows us to run containers without manual intervention on systems with SELinux enabled.

Fixes #6665

## Testing

This may be reviewed by multiple people that have different setups at hand.

- To ensure that previously manually changed security contexts do not impact testing this PR, always grab a fresh checkout of the respective branches
- When SELinux is installed and enabled:
  - [ ] Confirm that with the `develop` branch, `make dev` errors out
  - [ ] Confirm that with the `6665-containers-selinux-compat` branch, `make dev` works as expected
- When SELinux is not installed:
  - [ ] Confirm that with a fresh checkout of the `6665-containers-selinux-compat` branch, `make dev` works

## Checklist

- [ ] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
