### PR TITLE
Fix PYTHONPATH for scripts in dev environment

### DIFF
--- a/securedrop/bin/run
+++ b/securedrop/bin/run
@@ -19,7 +19,7 @@ maybe_use_tor
 # run the batch processing services normally managed by systemd
 /opt/venvs/securedrop-app-code/bin/rqworker &
 PYTHONPATH="${REPOROOT}/securedrop" /opt/venvs/securedrop-app-code/bin/python "${REPOROOT}/securedrop/scripts/rqrequeue" --interval 60 &
-/opt/venvs/securedrop-app-code/bin/python "${REPOROOT}/securedrop/scripts/shredder" --interval 60 &
-/opt/venvs/securedrop-app-code/bin/python "${REPOROOT}/securedrop/scripts/source_deleter" --interval 10 &
+PYTHONPATH="${REPOROOT}/securedrop" /opt/venvs/securedrop-app-code/bin/python "${REPOROOT}/securedrop/scripts/shredder" --interval 60 &
+PYTHONPATH="${REPOROOT}/securedrop" /opt/venvs/securedrop-app-code/bin/python "${REPOROOT}/securedrop/scripts/source_deleter" --interval 10 &
 
 ./manage.py run


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

`shredder` and `source_deleter` need to be able to import `journalist_app`, and should have the securedrop/ folder added to PYTHONPATH, just like is already done for rqrequeue. (rqworker doesn't need it since that's not our script, it's installed into the venv.)

This better matches how the systemd services are run in production since the unit has `PYTHONPATH="/var/www/securedrop:..."` (and also the sys.path addition).

Refs #6588.

## Testing

* [x] Without this patch, run `make dev`. See the errors pasted in https://github.com/freedomofpress/securedrop/issues/6588#issuecomment-1301006264
* [x] With this patch, run `make dev`. See the following output:
  * 2022-11-02 18:03:29,196 INFO Purging deleted sources every 10 seconds.
  * 2022-11-02 18:03:29,244 INFO Clearing shredder every 60 seconds.

## Deployment

Any special considerations for deployment? No, dev-only.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
