### PR TITLE
Add Makefile helper command to return current dev OTP code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,9 @@ clean:  ## DANGER! Delete all uncommitted files, virtual machines, Onion address
 	@$(SDROOT)/devops/clean
 	@echo
 
+.PHONY: otp
+otp: ## Show (and opportunistically copy) the current development OTP (to the clipboard)
+	@$(SDROOT)/devops/scripts/otp-code.sh
 
 #########
 #

--- a/devops/scripts/otp-code.sh
+++ b/devops/scripts/otp-code.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+## Show (and opportunistically copy) the current development OTP (to the
+## clipboard)
+
+if [ -n "$(command -v oathtool)" ]; then
+    OTP=$(oathtool --totp --base32 JHCOGO7VCER3EJ4L)
+    echo "$OTP"
+
+    COPY=$(command -v wl-copy)
+    [ -z "$COPY" ] && COPY="$(command -v xclip)"
+    [ $? -eq 0 ] && [ -n "$COPY" ] && COPY="$COPY -selection clipboard"
+    [ -z "$COPY" ] && COPY=$(command -v pbcopy)
+    
+    [ -n "$COPY" ] && echo "$OTP" | $COPY
+    [ $? -eq 0 ] && echo "The one time password was copied to your clipboard"
+    exit 0
+else
+    echo "Please install \`oathtool\` to use this script!"
+fi


### PR DESCRIPTION
## Description of Changes

With this patch, `make otp` returns the current OTP code used with the test users set up by the development environment.

It also opportunistically copies the code with `wl-copy` (Wayland), `xclip` (X11) or `pbcopy` (macOS)

Fixes #6621

## Testing

- Run `make otp`
  - [x] If `oathtool` is installed/in your `$PATH`, the command returned the code
  - [x] If `oathtool` is not installed/in your `$PATH`, you're asked to installed oathtool
- Running `make otp` on a system using Wayland
  - [ ] If `wl-copy` is installed and Wayland is used, the otp code is also in your clipboard
- Running `make otp` on X11
  - [x] If `xclip` is installed and X11 is used, the otp code is also in your clipboard
- Runing `make otp` on macOS
  - [ ] The otp code is in your clipboard

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] I would appreciate help with the documentation
