### PR TITLE
fix: determine and add `safe.directory` entry for `$REPOROOT` directly from the filesystem

### DIFF
--- a/securedrop/bin/run
+++ b/securedrop/bin/run
@@ -3,7 +3,9 @@
 
 set -eu
 
-export REPOROOT="${REPOROOT:-$(git rev-parse --show-toplevel)}"
+cd ..
+export REPOROOT="${REPOROOT:-$PWD}"
+git config --global --add safe.directory "$REPOROOT"
 
 cd "${REPOROOT}/securedrop"
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6672 by:
* determining `$REPOROOT` directly from the filesystem passes; and
* explicitly adding a `safe.directory` entry to placate Git versions that are paranoid about heterogeneous ownership between host and containers.

Thanks to @eaon for pairing and @legoktm for good instincts.

## Testing

* [x] CI passes.
* `make dev` starts normally:
    * [x] on Linux
    * [x] ideally on macOS too

## Deployment

Development-only.