### PR TITLE
Switch deb-tests job to use plain Debian container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,12 +292,12 @@ jobs:
 
   deb-tests:
     docker:
-      - image: cimg/python:3.8
+      - image: debian:bullseye
     environment:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y make virtualenv enchant jq python3-dev build-essential rsync
+      - run: apt-get update && apt-get install -y git docker.io make virtualenv enchant-2 jq python3-dev build-essential rsync
       - checkout
       - setup_remote_docker
       - run:

--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_10_18
-5fbcb1cfc38eb02376f70b3e78c5c7415ac5d337e42c603be7c5dfbd50218af9
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_11_23
+ad77b4d808e9f31d4832c0a159ed0a1e75d856a2f8c5d7f33134fd8e22786cd9

--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -1,6 +1,6 @@
 FROM securedrop-slim-focal-py3
 
-RUN apt-get install -y \
+RUN apt-get update  && apt-get install -y \
     libgtk2.0 devscripts xvfb x11vnc \
     # For html5validator.  Used only in "app-page-layout-tests", but we can live
     # with its being installed along with everything else since it will be

--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -25,8 +25,9 @@ netaddr
 pip>=21.3
 pip-tools>=6.1.0
 psutil>=5.6.6
-pyenchant>=3.2.1
 pylint>=2.7.0
+# pyenchant is via pylint[spelling]
+pyenchant>=3.2.1
 pynacl>=1.4.0
 pytest>=7.2.0
 pytest-xdist>=3.0.2

--- a/securedrop/requirements/python3/docker-requirements.in
+++ b/securedrop/requirements/python3/docker-requirements.in
@@ -1,3 +1,3 @@
 pip>=21.3
 setuptools>=56.0.0
-wheel
+wheel>=0.38.1

--- a/securedrop/requirements/python3/docker-requirements.txt
+++ b/securedrop/requirements/python3/docker-requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements/python3/docker-requirements.txt requirements/python3/docker-requirements.in
 #
-wheel==0.33.6 \
-    --hash=sha256:10c9da68765315ed98850f8e048347c3eb06dd81822dc2ab1d4fde9dc9702646 \
-    --hash=sha256:f4da1763d3becf2e2cd92a14a7c920f0f00eca30fdde9ea992c836685b9faf28
+wheel==0.38.4 \
+    --hash=sha256:965f5259b566725405b05e7cf774052044b1ed30119b5d586b2703aafe8719ac \
+    --hash=sha256:b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8
     # via -r requirements/python3/docker-requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The cimg/python:3.8 container unexpectedly switched to jammy within the past week, breaking CI since it doesn't have enchant (it's now enchant-2).

We're moving away from those images anyways, so use a plain debian:bullseye image and install the correct package.

*Update:* also includes:
- a change to the full dockerfile to update the apt cache before installing packages, to clear a CI issue
- an update of the wheel dependency for the Docker-installed version to clear safety issue 51499.

Fixes #6671.

## Testing

* [x] CI `deb-tests` passes

## Deployment

Any special considerations for deployment? No, CI only

## Checklist

- [x] These changes do not require documentation
