### PR TITLE
Fix run-test to also use git safe.directory

### DIFF
--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -5,7 +5,9 @@ set -euo pipefail
 
 export PATH="/opt/venvs/securedrop-app-code/bin:$PATH"
 
-REPOROOT=$(git rev-parse --show-toplevel)
+cd ..
+export REPOROOT="${REPOROOT:-$PWD}"
+git config --global --add safe.directory "$REPOROOT"
 cd "${REPOROOT}/securedrop"
 
 PYTHONPATH=".:${PYTHONPATH:-}"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds required git config line to run-test shell script. This makes it so that the script works properly on macOS, using the same settings as was added in #6674

## Testing

Easy to test by doing simple `make test`.

## Deployment

Any special considerations for deployment? Consider both:

None

## Checklist

- [x] These changes do not require documentation
