### PR TITLE
Configure hooks when running `make venv`

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,7 +8,7 @@ set -eo pipefail
 if [[ -n "$PY_FILES" ]]; then
     # set up the virtualenv if it's not already available
     if [[ ! -v VIRTUAL_ENV ]]; then
-        make venv && source .venv/bin/activate
+        source .venv/bin/activate
     fi
     echo "Checking:"
     echo "$PY_FILES"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DEVSHELL := $(SDBIN)/dev-shell
 ######################################
 
 .PHONY: venv
-venv:  ## Provision a Python 3 virtualenv for development.
+venv: hooks  ## Provision a Python 3 virtualenv for development.
 	@echo "███ Preparing Python 3 virtual environment..."
 	@$(SDROOT)/devops/scripts/boot-strap-venv.sh
 	@echo
@@ -220,14 +220,11 @@ securedrop/config.py: ## Generate the test SecureDrop application config.
 	@echo "SUPPORTED_LOCALES = $$(if test -f /opt/venvs/securedrop-app-code/bin/python3; then ./securedrop/i18n_tool.py list-locales --python; else DOCKER_BUILD_VERBOSE=false $(DEVSHELL) ./i18n_tool.py list-locales --python; fi)" | sed 's/\r//' >> securedrop/config.py
 	@echo
 
-.PHONY: setup-dev-env
-setup-dev-env: venv add-hooks ## Set up tools and hooks for local development
+HOOKS_DIR=.githooks
 
-.PHONY: add-hooks
-add-hooks:  ## copy precommit hooks into place
-	@echo "███ copying git hooks..."
-	@mkdir -p .git/hooks
-	@cp .githooks/* .git/hooks
+.PHONY: hooks
+hooks:  ## Configure Git to use the hooks provided by this repository
+	git config core.hooksPath "$(HOOKS_DIR)"
 
 .PHONY: test-config
 test-config: securedrop/config.py


### PR DESCRIPTION
## Description of Changes

Instead of copying files to the `.git` directory, it configures git to use a hook directory. Creates [parity with `securedrop-client`](https://github.com/freedomofpress/securedrop-client/blob/f0e63dd264c7152446cd7cbc842b4bdfb5c64e95/Makefile#L34-L38). Also assumes that if developers haven't added a `venv`, they probably didn't add hooks either (implying that `make venv` in the hooks would just add unnecessary on every commit)

## Testing

Wipe away your `.venv` folder and run:

- [ ] `make venv` creates a virtual environment
- [ ] `git config core.hooksPath` returns `.githooks`
- [ ] `pre-commit` is run on every subsequent attempt to commit

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation