### PR TITLE
Make venv use python3.8 opportunistically, but default to python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ DEVSHELL := $(SDBIN)/dev-shell
 venv: hooks  ## Provision a Python 3 virtualenv for development.
 	@echo "███ Preparing Python 3 virtual environment..."
 	@$(SDROOT)/devops/scripts/boot-strap-venv.sh
+	@echo "Make sure to run: source .venv/bin/activate"
 	@echo
 
 .PHONY: update-admin-pip-requirements

--- a/devops/scripts/boot-strap-venv.sh
+++ b/devops/scripts/boot-strap-venv.sh
@@ -17,7 +17,7 @@ venv_instructions() {
 }
 
 function virtualenv_bootstrap() {
-    PYTHON_VERSION=3
+    PYTHON_VERSION="3.8"
     VIRTUAL_ENV="${VIRTUAL_ENV:-}"  # Just to get around all the "set -u"
     if [ -n "$VIRTUAL_ENV" ]
     then
@@ -48,12 +48,12 @@ function virtualenv_bootstrap() {
 
         if [ ! -d "$VENV" ]
         then
-            p=$(which "python${PYTHON_VERSION}")
-            echo "Creating Python ${PYTHON_VERSION} virtualenv in ${VENV}"
+            p=$(command -v "python${PYTHON_VERSION}" 2> /dev/null || command -v python3)
+            echo "Creating ${p} virtualenv in ${VENV}"
             virtualenv -p "${p}" "${VENV}"
         fi
 
-        "${VENV}/bin/pip" install -q -r "securedrop/requirements/python${PYTHON_VERSION}/develop-requirements.txt"
+        "${VENV}/bin/pip" install -q -r "securedrop/requirements/python3/develop-requirements.txt"
 
         . "${VENV}/bin/activate"
    fi


### PR DESCRIPTION
Our virtual environment generally assumes that developers use Debian stable - that's not necessarily the case though, so this commit introduces an opportunistic approach to using the same Python version.

## Testing

On a machine that defaults to a Python version higher than 3.9, but has 3.9 installed: remove your `.venv` folder:

- [ ] `make venv` creates a virtual environment with Python 3.9

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
