### PR TITLE
Fix `make dev` on Macs with Apple Silicon

### DIFF
--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -30,6 +30,7 @@ fi
 # from Docker API 1.32 onward, while at the time of writing CI still on API 1.23
 if [[ "$(uname -sm)" != "Linux x86_64" ]]; then
     DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} --platform linux/amd64"
+    DOCKER_BUILD_ARGUMENTS="${DOCKER_BUILD_ARGUMENTS:-} --platform linux/amd64"
 fi
 
 ## Get an integer offset for exposed ports, to support multiple containers


### PR DESCRIPTION
## Description of Changes

Fixes #6478 (extending the fix in #6675)
On an M1 Mac, running `make dev` gives the following error after `docker build` has succeeded:
```
Unable to find image 'securedrop-slim-focal-py3:latest' locally
docker: Error response from daemon: pull access denied for securedrop-slim-focal-py3, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'
```
The image is presumably not found because `docker run` is looking for a `linux/amd64` image but the one that's just been built was on the default platform, `Darwin arm64`.

Changes proposed in this pull request:
On machines that aren't running Linux x86_64, add the argument `--platform linux/amd64` to `docker build` as well as to `docker run`.

## Testing

How should the reviewer test this PR?
- [ ] Run `make dev` on a non-linux machine 

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation