### PR TITLE
Updated testinfra checks for config file ownership:

### DIFF
--- a/molecule/testinfra/app-code/test_securedrop_app_code.py
+++ b/molecule/testinfra/app-code/test_securedrop_app_code.py
@@ -89,9 +89,9 @@ def test_securedrop_application_test_journalist_key(host):
     securedrop_config = host.file("{}/config.py".format(securedrop_test_vars.securedrop_code))
     with host.sudo():
         assert securedrop_config.is_file
-        assert securedrop_config.user == securedrop_test_vars.securedrop_user
+        assert securedrop_config.user == securedrop_test_vars.securedrop_code_owner
         assert securedrop_config.group == securedrop_test_vars.securedrop_user
-        assert securedrop_config.mode == 0o600
+        assert securedrop_config.mode == 0o640
         assert securedrop_config.contains(
             "^JOURNALIST_KEY = '65A1B5FF195B56353CC63DFFCC40EF1228271441'$"
         )

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -13,6 +13,7 @@ securedrop_venv_site_packages: /opt/venvs/securedrop-app-code/lib/python{}/site-
 securedrop_code: /var/www/securedrop
 securedrop_data: /var/lib/securedrop
 securedrop_user: www-data
+securedrop_code_owner: root
 
 app_hostname: app
 monitor_hostname: mon

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -13,6 +13,7 @@ securedrop_venv_site_packages: "/opt/venvs/securedrop-app-code/lib/python3.8/sit
 securedrop_code: /var/www/securedrop
 securedrop_data: /var/lib/securedrop
 securedrop_user: www-data
+securedrop_code_owner: root
 
 app_hostname: app
 monitor_hostname: mon

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -13,6 +13,7 @@ securedrop_venv_site_packages: /opt/venvs/securedrop-app-code/lib/python{}/site-
 securedrop_code: /var/www/securedrop
 securedrop_data: /var/lib/securedrop
 securedrop_user: www-data
+securedrop_code_owner: root
 admin_user: sdadmin
 
 app_hostname: app-staging

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -13,6 +13,7 @@ securedrop_venv_site_packages: /opt/venvs/securedrop-app-code/lib/python{}/site-
 securedrop_code: /var/www/securedrop
 securedrop_data: /var/lib/securedrop
 securedrop_user: www-data
+securedrop_code_owner: root
 admin_user: vagrant
 
 app_hostname: app-staging


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6710 .
Updates tests for /var/www/securedrop/config.py:

- file should be owned by root:www-data
- perms are 640, not 600

## Testing

- [x] CI is green including `staging-test-with-rebase` job
- [ ] make testinfra passes locally
