### PR TITLE
Remove bogus $GNUPG_HOME variable from securedrop-log command

### DIFF
--- a/install_files/ansible-base/securedrop-logs.yml
+++ b/install_files/ansible-base/securedrop-logs.yml
@@ -93,8 +93,6 @@
         --trust-model always
         --batch --yes
         "{{ log_tarball_filename }}"
-      environment:
-        GNUPG_HOME: /home/amnesia/.gnupg
 
     - name: Delete local unencrypted log tarballs.
       become: no


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The variable is actually named $GNUPGHOME (no underscore). Prior to a05883392b1 the path this variable pointed to was wrong, but luckily that didn't break anything because the variable name was also wrong.

Since this is unused, rather than fixing it let's just remove it entirely.

Refs #6670.

## Testing

* look at `man gpg` (https://manpages.debian.org/bullseye/gpg/gpg.1.en.html), ctrl+f "$GNUPGHOME"

## Deployment

Any special considerations for deployment? None, has historically been broken.

## Checklist

- [x] Linting and tests (`make -C admin test`) pass in the admin development container
- [x] These changes do not require documentation
