### PR TITLE
Use shellcheck-py, update to 0.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
           command: |
             fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" securedrop/bin/dev-shell \
-                  bash -c "sudo apt install shellcheck && /opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/develop-requirements.txt && make -C .. lint"
+                  bash -c "/opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/develop-requirements.txt && make -C .. lint"
 
   app-tests:
     machine:

--- a/Makefile
+++ b/Makefile
@@ -141,10 +141,6 @@ shellcheck:  ## Lint shell scripts.
 	@$(SDROOT)/devops/scripts/shellcheck.sh
 	@echo
 
-.PHONY: shellcheckclean
-shellcheckclean:  ## Clean up temporary container associated with shellcheck target.
-	@docker rm -f $(SDROOT)/shellcheck-targets
-
 .PHONY: typelint
 typelint:  ## Run mypy type linting.
 	@echo "███ Running mypy type checking..."

--- a/admin/bin/validate-gpg-key.sh
+++ b/admin/bin/validate-gpg-key.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2317
 # Verifies a key at at given path matches a fingerprint
 # Does so by importing the key into gpg2 and checking output
 #

--- a/devops/scripts/shellcheck.sh
+++ b/devops/scripts/shellcheck.sh
@@ -2,25 +2,7 @@
 
 set -e
 
-USE_PODMAN="${USE_PODMAN:-}"
-
-# Allow opting into using podman with USE_PODMAN=1
-if  [[ -n "${USE_PODMAN}" ]]; then
-    DOCKER_BIN="podman"
-else
-    DOCKER_BIN="docker"
-fi
-
-function run_native_or_in_docker () {
-    EXCLUDE_RULES="SC1090,SC1091,SC2001,SC2064,SC2181,SC1117"
-    if [ "$(command -v shellcheck)" ]; then
-        shellcheck -x --exclude="$EXCLUDE_RULES" "$@"
-    else
-        $DOCKER_BIN run --rm -v "$(pwd):/sd:Z" -w /sd \
-            -t docker.io/koalaman/shellcheck:v0.4.7 \
-            -x --exclude=$EXCLUDE_RULES "$@"
-    fi
-}
+EXCLUDE_RULES="SC1090,SC1091,SC2001,SC2064,SC2181,SC1117"
 
 # Omitting:
 # - the `.git/` directory since its hooks won't pass # validation, and
@@ -57,6 +39,7 @@ FILES=$(find "." \
 # Turn the multiline find output into a single space-separated line
 FILES=$(echo "$FILES" | tr '\n' ' ')
 
-# Intentionally unquoted so each file is passed as its own argument
+shellcheck --version
+# $FILES intentionally unquoted so each file is passed as its own argument
 # shellcheck disable=SC2086
-run_native_or_in_docker $FILES
+shellcheck -x --exclude="$EXCLUDE_RULES" $FILES

--- a/install_files/ansible-base/roles/ossec/templates/send_encrypted_alarm.sh
+++ b/install_files/ansible-base/roles/ossec/templates/send_encrypted_alarm.sh
@@ -44,6 +44,7 @@ function send_encrypted_alert() {
     # Try to encrypt the alert message. We'll inspect the exit status of the
     # pipeline to decide whether to send the alert text, or the default
     # failure message.
+    # shellcheck disable=SC2086
     encrypted_alert_text="$(printf "%s" "${ossec_alert_text}" | \
         /usr/bin/formail -I '' | \
         /usr/bin/gpg $compression --homedir /var/ossec/.gnupg --trust-model always -ear "$gpg_fpr")"

--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -38,6 +38,7 @@ ruamel.yaml>=0.16.10
 safety>2.2.0
 semgrep>=0.98.0
 setuptools>=56.0.0
+shellcheck-py
 testinfra>=5.3.1
 urllib3>=1.26.5
 yamllint

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -845,6 +845,12 @@ sh==1.12.14 \
     # via
     #   molecule
     #   python-gilt
+shellcheck-py==0.9.0.2 \
+    --hash=sha256:1c29aa5864cc937f037b84b8e6b13b7016d25a45f7a07a1f1f16d38e387c76b4 \
+    --hash=sha256:6a1be188d0a7183fc4bfcf52087512d879519bb6beb67d76927e0331edb45eb1 \
+    --hash=sha256:bbaaba3044d266e793964e391c8caad4fcccafcd64e63de24e9b87a31a0c7aff \
+    --hash=sha256:ddb9b9fd4750d726b9ac24df8b63599dc742c8749477bcdfd4ed639b22de21ae
+    # via -r requirements/python3/develop-requirements.in
 shellingham==1.3.2 \
     --hash=sha256:576c1982bea0ba82fb46c36feb951319d7f42214a82634233f58b40d858a751e \
     --hash=sha256:7f6206ae169dc1a03af8a138681b3f962ae61cc93ade84d0585cca3aaf770044


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

shellcheck-py is the same shellcheck binary, just packaged into a Python wheel so it can be pip installed. This makes it much easier to integrate into our existing Python tooling, letting us skip the need for a system package or container.

This lets us update to the latest shellcheck, 0.9.0, because we're no longer limited by what focal has packaged. Two new failures are suppressed as a result.

While we're at it, clean up the obsolete "shellcheckclean" make target.

Fixes #6715.

## Testing

* [x] CI passes
* [x] `make shellcheck` works
* [x] `make lint` works

## Deployment

Any special considerations for deployment? No, dev only

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
