### PR TITLE
Pull descriptive titles from headings

### DIFF
--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -14,6 +14,7 @@ from journalist_app.sessions import Session, session
 from journalist_app.utils import get_source
 from models import InstanceConfig
 from sdconfig import SecureDropConfig
+from utils import create_get_descriptive_title_function
 from werkzeug import Response
 from werkzeug.exceptions import HTTPException, default_exceptions
 
@@ -94,6 +95,9 @@ def create_app(config: SecureDropConfig) -> Flask:
     app.jinja_env.trim_blocks = True
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.globals["version"] = version.__version__
+    app.jinja_env.globals["get_descriptive_title"] = create_get_descriptive_title_function(
+        app.logger
+    )
     app.jinja_env.filters["rel_datetime_format"] = template_filters.rel_datetime_format
     app.jinja_env.filters["filesizeformat"] = template_filters.filesizeformat
     app.jinja_env.filters["html_datetime_format"] = template_filters.html_datetime_format

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ g.organization_name }}</title>
+  <title>{{ get_descriptive_title() }} | {{ g.organization_name }}</title>
 
   <link rel="stylesheet" href="/static/css/journalist.css">
 

--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -17,6 +17,7 @@ from sdconfig import SecureDropConfig
 from source_app import api, info, main
 from source_app.decorators import ignore_static
 from source_app.utils import clear_session_and_redirect_to_logged_out_page
+from utils import create_get_descriptive_title_function
 
 
 def get_logo_url(app: Flask) -> str:
@@ -70,6 +71,9 @@ def create_app(config: SecureDropConfig) -> Flask:
     app.jinja_env.globals["version"] = version.__version__
     # Exported to source templates for being included in instructions
     app.jinja_env.globals["submission_key_fpr"] = config.JOURNALIST_KEY
+    app.jinja_env.globals["get_descriptive_title"] = create_get_descriptive_title_function(
+        app.logger
+    )
     app.jinja_env.filters["rel_datetime_format"] = template_filters.rel_datetime_format
     app.jinja_env.filters["nl2br"] = template_filters.nl2br
     app.jinja_env.filters["filesizeformat"] = template_filters.filesizeformat

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -6,9 +6,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex,nofollow">
   {% if g.organization_name == "SecureDrop" %}
-  <title>{{ g.organization_name }} | {{ gettext('Protecting Journalists and Sources') }}</title>
+  <title>{{ get_descriptive_title() }} | {{ g.organization_name }} | {{ gettext('Protecting Journalists and Sources') }}</title>
   {% else %}
-  <title>{{ g.organization_name }} | {{ gettext('SecureDrop') }}</title>
+  <title>{{ get_descriptive_title() }} | {{ g.organization_name }} | {{ gettext('SecureDrop') }}</title>
   {% endif %}
 
   <link rel="stylesheet" href="/static/css/source.css">

--- a/securedrop/source_templates/error.html
+++ b/securedrop/source_templates/error.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body %}
-<h2>{{ gettext('Server error') }}</h2>
+<h1>{{ gettext('Server error') }}</h1>
 
 <p>{{ gettext('Sorry, the website encountered an error and was unable to complete your request.') }}</p>
 

--- a/securedrop/source_templates/flash_message.html
+++ b/securedrop/source_templates/flash_message.html
@@ -1,4 +1,4 @@
 {%- if declarative %}
-<h2>{{ declarative }}</h2>
+<h1>{{ declarative }}</h1>
 {% endif -%}
 <p {% if not declarative %} class="icon"{% endif %}>{{ msg_contents }}</p>

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -2,7 +2,7 @@
 {% import 'utils.html' as utils %}
 
 {% block body %}
-<h2>{{ gettext('Get Your Codename') }}</h2>
+<h1>{{ gettext('Get Your Codename') }}</h1>
 
 <p id="codename-explanation" class="explanation">
   {{ gettext('A <em>codename</em> in SecureDrop functions as both your username and your password.') }}

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -3,9 +3,9 @@
 
 <head>
   {% if g.organization_name == "SecureDrop" %}
-  <title>{{ g.organization_name }} | {{ gettext('Protecting Journalists and Sources') }}</title>
+  <title>{{ gettext('Portal') }} | {{ g.organization_name }} | {{ gettext('Protecting Journalists and Sources') }}</title>
   {% else %}
-  <title>{{ g.organization_name }} | {{ gettext('SecureDrop') }}</title>
+  <title>{{ gettext('Portal') }} | {{ g.organization_name }} | {{ gettext('SecureDrop') }}</title>
   {% endif %}
 
   <link rel="stylesheet" href="/static/css/source.css">

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -3,7 +3,7 @@
 
 {% include 'flashed.html' %}
 
-<h2>{{ gettext('Enter Codename') }}</h2>
+<h1>{{ gettext('Enter Codename') }}</h1>
 
 <form method="post" action="{{ url_for('main.login') }}" autocomplete="off">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">

--- a/securedrop/source_templates/logout.html
+++ b/securedrop/source_templates/logout.html
@@ -5,7 +5,7 @@
     {{ gettext('LOG IN') }}</a>
 </nav>
 <section>
-  <h2>{{ gettext('One more thing...') }}</h2>
+  <h1>{{ gettext('Logout - Additional Action Needed') }}</h1>
   <p>
     {{ gettext('Click the <img src={icon} alt="" width="16" height="16">&nbsp;<b>New Identity</b> button in your Tor Browser\'s toolbar. This will clear your Tor Browser activity data on this device.').format(icon=url_for('static', filename='i/torbroom.png'))  }}
   </p>

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -10,10 +10,10 @@
 
 <section aria-labelledby="submit-heading">
   {% if allow_document_uploads %}
-  <h2 id="submit-heading">{{ gettext('Submit Files or Messages') }}</h2>
+  <h1 id="submit-heading">{{ gettext('Submit Files or Messages') }}</h1>
   <p>{{ gettext('You can submit any kind of file, a message, or both.') }}</p>
   {% else %}
-  <h2 id="submit-heading">{{ gettext('Submit Messages') }}</h2>
+  <h1 id="submit-heading">{{ gettext('Submit Messages') }}</h1>
   {% endif %}
 
   <p>

--- a/securedrop/source_templates/notfound.html
+++ b/securedrop/source_templates/notfound.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body %}
-<h2>{{ gettext('Page not found') }}</h2>
+<h1>{{ gettext('Page not found') }}</h1>
 
 <p id="page-not-found">{{ gettext("Sorry, we couldn't locate what you requested.") }}</p>
 

--- a/securedrop/source_templates/tor2web-warning.html
+++ b/securedrop/source_templates/tor2web-warning.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body %}
-<h2>{{ gettext('Proxy Service Detected') }}</h2>
+<h1>{{ gettext('Warning! Proxy Service Detected') }}</h1>
 <div class="center">
   {% include 'flashed.html' %}
 </div>

--- a/securedrop/source_templates/use-tor-browser.html
+++ b/securedrop/source_templates/use-tor-browser.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body %}
-<h2>{{ gettext('You Should Use Tor Browser') }}</h2>
+<h1>{{ gettext('You Should Use Tor Browser') }}</h1>
 <p>{{ gettext('If you are not using Tor Browser, you <strong>may not be anonymous</strong>.') }}</p>
 <p>{{ gettext('If you want to submit information to SecureDrop, we <strong>strongly advise you</strong> to install Tor Browser and use it to access our site safely and anonymously.') }}
 </p>

--- a/securedrop/source_templates/why-public-key.html
+++ b/securedrop/source_templates/why-public-key.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body %}
-<h2>{{ gettext("Why download the team's public key?") }}</h2>
+<h1>{{ gettext("Why download the team's public key?") }}</h1>
 <p>{{ gettext("SecureDrop encrypts files and messages after they are submitted. Encrypting messages and files before submission can provide an extra layer of security before your data reaches the SecureDrop server.") }}
 </p>
 <p>{{ gettext("If you are already familiar with the GPG encryption software, you may wish to encrypt your submissions yourself. To do so:") }}

--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -487,7 +487,7 @@ class TestAdminInterfaceEditConfig:
         journ_app_nav.admin_visits_system_config_page()
 
         # When they update the organization's name
-        assert "SecureDrop" == journ_app_nav.driver.title
+        assert "Instance Configuration | SecureDrop" == journ_app_nav.driver.title
         journ_app_nav.driver.find_element_by_id("organization_name").clear()
         new_org_name = "Walden Inquirer"
         journ_app_nav.nav_helper.safe_send_keys_by_id("organization_name", new_org_name)
@@ -495,7 +495,7 @@ class TestAdminInterfaceEditConfig:
         self._admin_submits_instance_settings_form(journ_app_nav)
 
         # Then it succeeds
-        assert new_org_name == journ_app_nav.driver.title
+        assert f"Instance Configuration | {new_org_name}" == journ_app_nav.driver.title
 
         # And then, when a source user logs into the source app
         source_app_nav = SourceAppNavigator(

--- a/securedrop/tests/functional/test_utils.py
+++ b/securedrop/tests/functional/test_utils.py
@@ -1,0 +1,55 @@
+from typing import Any, List
+
+import pytest
+from utils import create_get_descriptive_title_function
+
+
+class FakeContext:
+    def __init__(self, h1_text: str, expected_result: Any):
+        self.blocks = {
+            "body": [
+                lambda _: [h1_text, expected_result],
+            ]
+        }
+
+        self.name = self.__class__.__name__
+
+
+class FakeLogger:
+    def __init__(self, failure_expected: bool):
+        self.failure_expected = failure_expected
+
+    def error(self, _: Any) -> None:
+        assert self.failure_expected
+
+
+def add_attribute(heading: str) -> str:
+    index = heading.find(">")
+    return heading[:index] + ' key = "value"' + heading[index:]
+
+
+def heading_examples() -> List[str]:
+    simple_heading_examples = [
+        "<h1>",  # simplest exact match
+        " <h1>",  # leading blankspace
+        "<h1> ",  # trailing blankspace
+        " <h1> ",  # leading and trailing blankspace
+    ]
+
+    attributed_heading_examples = [add_attribute(example) for example in simple_heading_examples]
+
+    return simple_heading_examples + attributed_heading_examples
+
+
+@pytest.mark.parametrize("heading_example", heading_examples())
+def test_h1_block_is_found(heading_example: str) -> None:
+    expected_result = "unique text is unique"
+    context = FakeContext(heading_example, expected_result)
+    get_descriptive_title = create_get_descriptive_title_function(FakeLogger(False))
+    assert get_descriptive_title(context) == expected_result
+
+
+def test_missing_tag_logs_error_and_returns_usable_value() -> None:
+    context = FakeContext("Not a tag", "Not actually expected")
+    get_descriptive_title = create_get_descriptive_title_function(FakeLogger(True))
+    assert isinstance(get_descriptive_title(context), str)

--- a/securedrop/utils.py
+++ b/securedrop/utils.py
@@ -1,0 +1,24 @@
+from itertools import count
+from logging import Logger
+from typing import Callable
+
+from jinja2.runtime import Context
+from jinja2.utils import pass_context
+
+
+def create_get_descriptive_title_function(logger: Logger) -> Callable[[], str]:
+    @pass_context
+    def get_descriptive_title(context: Context) -> str:
+        for block_func in context.blocks["body"]:
+            block = list(block_func(context))
+            for (possibly_h1_tag, next_index) in zip(block, count(1)):
+                if "<h1" in possibly_h1_tag:
+                    return block[next_index]
+
+        logger.error(f"No h1 block found on page {context.name}, returning empty string!")
+        return ""
+
+    # The mypy ignore is because the pass_context decorator passes in the context automatically,
+    # so the type hint is correct but mypy doesn't understand this. The noqa is because flake6
+    # throws an error when the mypy ignore specifies the error code.
+    return get_descriptive_title  # type: ignore [return-value] # noqa: F723


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

Fixes #6313.

Changes proposed in this pull request:

Adds a python function that grabs the first h1 statement in the html and uses that for the page title, then calls that function from the base templates. Also updated some HTML files so that an appropriate h1 heading exists. See the commit message for details.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

I used `make dev` and browsed pages with it, as far as the cilent is concerned the only change is what static text is sent over so I'm not overly concerned about browser compatibility, but let me know if I need to do more. I did create a new user and select YubiKey to test a page where the h1 statement was in an if/else block, and it created the correct title in the else case.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

I don't think so, this is just a normal python function added to the code.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

N/A

### If you made changes to the system configuration:

N/A

### If you added or removed a file deployed with the application:

N/A

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

Based on the state of the html files, I think that the new requirement of all pages needing a descriptive h1 block that takes into account users who depend on screen readers would be good to add to the documentation. I haven't started looking at how this is organized yet so it might make sense once I go over there, but if you have any initial advice I would be happy to hear it.

### If you added or updated a production code dependency:

N/A, all newly imported modules are already available in the project
