### PR TITLE
 Update safety excludes, stale development dependency hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,9 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 49337 \
 		--ignore 51668 \
 		--ignore 52322 \
+                --ignore 52495 \
+                --ignore 52510 \
+                --ignore 52518 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -324,9 +324,9 @@ execnet==1.4.1 \
     --hash=sha256:d2b909c7945832e1c19cfacd96e78da68bdadc656440cfc7dfe59b766744eb8c \
     --hash=sha256:f66dd4a7519725a1b7e14ad9ae7d3df8e09b2da88062386e08e941cafc0ef3e6
     # via pytest-xdist
-face==20.1.1 \
-    --hash=sha256:3790311a7329e4b0d90baee346eecad54b337629576edf3a246683a5f0d24446 \
-    --hash=sha256:7d59ca5ba341316e58cf72c6aff85cca2541cf5056c4af45cb63af9a814bed3e
+face==22.0.0 \
+    --hash=sha256:344fe31562d0f6f444a45982418f3793d4b14f9abb98ccca1509d22e0a3e7e35 \
+    --hash=sha256:d5d692f90bc8f5987b636e47e36384b9bbda499aaf0a77aa0b0bbe834c76923d
     # via glom
 fasteners==0.14.1 \
     --hash=sha256:427c76773fe036ddfa41e57d89086ea03111bbac57c55fc55f3006d027107e18 \


### PR DESCRIPTION
## Status

Ready for review /

## Description of Changes

- Updates Makefile safety target, adding excludes from #6728 
-  Updates `face` hash in dev requirements. See https://github.com/mahmoud/face/issues/16#issuecomment-1397070933 for reason :)

## Testing

- [ ] CI is passing
- [ ] `make venv` and `make safety` pass locally
