### PR TITLE
Try GitHub Actions by migrating updater-gui-tests and rust jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,25 +247,6 @@ jobs:
           command: |
             cd admin; make test
 
-  updater-gui-tests:
-    docker:
-      - image: debian:bullseye
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: |
-            apt update && apt-get install -y libqt5designer5 python3-venv
-            cd journalist_gui
-            python3 -m venv .venv/ && source .venv/bin/activate
-            pip install --require-hashes -r dev-requirements.txt
-      - run:
-          name: Run tests
-          command: |
-            cd journalist_gui
-            source .venv/bin/activate
-            QT_QPA_PLATFORM=offscreen python3 test_gui.py -v
-
   static-analysis-and-no-known-cves:
     machine:
       image: ubuntu-2004:202010-01
@@ -405,15 +386,6 @@ workflows:
             - circleci-slack
           <<: *slack-fail-post-step
       - admin-tests:
-          filters:
-            branches:
-              ignore:
-                - /i18n-.*/
-                - /update-builder-.*/
-          context:
-            - circleci-slack
-          <<: *slack-fail-post-step
-      - updater-gui-tests:
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,27 +94,6 @@ jobs:
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" securedrop/bin/dev-shell \
                   bash -c "/opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/develop-requirements.txt && make -C .. lint"
 
-  rust:
-    # Keep version in sync with rust-toolchain.toml
-    docker:
-      - image: rust:1.69.0
-    environment:
-      # TODO: Remove after we're on Rust 1.70
-      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "sparse"
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: |
-            apt-get update && apt-get install make --yes
-            rustup component add rustfmt
-            rustup component add clippy
-      - run:
-          name: Lint and test Rust code
-          command: |
-            make rust-lint
-            make rust-test
-
   app-tests:
     machine:
       image: ubuntu-2004:202010-01
@@ -356,10 +335,6 @@ workflows:
   securedrop_ci:
     jobs:
       - lint:
-          context:
-            - circleci-slack
-          <<: *slack-fail-post-step
-      - rust:
           context:
             - circleci-slack
           <<: *slack-fail-post-step

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+name: CI
+on: [push, pull_request]
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  updater-gui-tests:
+    runs-on: ubuntu-latest
+    container: debian:bullseye
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          apt-get update && apt-get install -y libqt5designer5 python3-venv
+          cd journalist_gui
+          python3 -m venv .venv/ && source .venv/bin/activate
+          pip install --require-hashes -r dev-requirements.txt
+      - name: Run tests
+        run: |
+          cd journalist_gui
+          source .venv/bin/activate
+          QT_QPA_PLATFORM=offscreen python3 test_gui.py -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,25 @@ defaults:
     shell: bash
 
 jobs:
+  rust:
+    runs-on: ubuntu-latest
+    # Keep version in sync with rust-toolchain.toml
+    container: rust:1.69.0
+    env:
+      # TODO: Remove after we're on Rust 1.70
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "sparse"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          apt-get update && apt-get install make --yes
+          rustup component add rustfmt
+          rustup component add clippy
+      - name: Lint and test Rust code
+        run: |
+          make rust-lint
+          make rust-test
+
   updater-gui-tests:
     runs-on: ubuntu-latest
     container: debian:bullseye


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Try GitHub Actions by migrating updater-gui-tests and rust jobs

The syntax is fairly close, so no actual changes were needed to the commands that are run.

I did switch usage of `apt` to `apt-get` since the former isn't supposed to be used in scripts.

I intentionally chose to not migrate the branch filter over to reduce complexity given how fast and light this job is.


## Testing

* [ ] CI passes

## Deployment

Any special considerations for deployment? No.

## Checklist

n/a