### PR TITLE
Print SDW config.json when using make dev-tor

### DIFF
--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -73,13 +73,38 @@ function maybe_use_tor() {
         # (restart a little flaky hence the kill)
         sudo kill "$(cat /run/tor/tor.pid)"; sudo service tor restart
         # print out the addresses and the JI client auth key
+
+        si_address="$(sudo -u debian-tor cat /var/lib/tor/services/source/hostname)"
+        ji_address="$(sudo -u debian-tor cat /var/lib/tor/services/journalist/hostname)"
+        ji_authkey="$(sudo -u debian-tor cat /tmp/k1.prv.key)"
+        sdkey_fpr="$(gpg --with-fingerprint --with-colons ./tests/files/test_journalist_key.pub | grep -e '^fpr' | tr -d 'fpr:')"
+
+        cat > /tmp/qubes-config.json <<EOF
+{
+  "submission_key_fpr": "${sdkey_fpr}",
+  "hidserv": {
+    "hostname": "${ji_address}",
+    "key": "${ji_authkey}"
+  },
+  "environment": "prod",
+  "vmsizes": {
+     "sd_app": 10,
+     "sd_log": 5
+  }
+}
+EOF
         echo
-        echo  ##############################################################################
         echo "Tor configuration complete! details as follows:"
-        echo "Source Interface:     http://$(sudo -u debian-tor cat /var/lib/tor/services/source/hostname)"
-        echo "Journalist Interface: http://$(sudo -u debian-tor cat /var/lib/tor/services/journalist/hostname)"
-        echo "Journalist Auth Key:  $(sudo -u debian-tor cat /tmp/k1.prv.key)"
-        echo  ##############################################################################
+        echo "--------"
+        echo "Source Interface:     http://${si_address}"
+        echo "Journalist Interface: http://${ji_address}"
+        echo "Journalist Auth Key:  ${ji_authkey}"
+        echo "--------"
+        echo
+        echo "SecureDrop Workstation config.json:"
+        echo "--------"
+        cat /tmp/qubes-config.json
+        echo "--------"
     fi
 }
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

`make dev-tor` sets up a dev environment with the SI and JI available over hidden services. This PR tweaks the Docker output listing service information to also print a `config.json` file suitable for use with SecureDrop Workstation.

## Testing

- [x] CI good (especially shellcheck/lints)
- [x] `make dev-tor` runs successfully locally and Tor onion services are available
- [x] Docker output includes a valid config.json file listing the correct info for the services above

## Deployment

no issues, dev-only
