### PR TITLE
Add title blocks.

### DIFF
--- a/securedrop/journalist_templates/account_edit_hotp_secret.html
+++ b/securedrop/journalist_templates/account_edit_hotp_secret.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('Change Secret') }}{% endblock %}
+
 {% block body %}
 <h1>{{ gettext('Change Secret') }}</h1>
 <form method="post">

--- a/securedrop/journalist_templates/account_new_two_factor.html
+++ b/securedrop/journalist_templates/account_new_two_factor.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('Enable FreeOTP') }}{% endblock %}
+
 {% block body %}
 {% if user.is_totp %}
 <h1>{{ gettext('Enable FreeOTP') }}</h1>

--- a/securedrop/journalist_templates/admin.html
+++ b/securedrop/journalist_templates/admin.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('Admin Interface') }}{% endblock %}
+
 {% block body %}
 <h1>{{ gettext('Admin Interface') }}</h1>
 

--- a/securedrop/journalist_templates/admin_add_user.html
+++ b/securedrop/journalist_templates/admin_add_user.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('Add User') }}{% endblock %}
+
 {% block body %}
 <nav class="back" aria-labelledby="back-link">
   <a id="back-link" href="/admin">{{ gettext('Back to admin interface') }}</a>

--- a/securedrop/journalist_templates/admin_edit_hotp_secret.html
+++ b/securedrop/journalist_templates/admin_edit_hotp_secret.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('Change HOTP Secret')}}{% endblock %}
+
 {% block body %}
 <h1>{{ gettext('Change HOTP Secret')}}</h1>
 <p>{{ gettext("Enter a new HOTP secret formatted as a 40-digit hexadecimal string. Spaces will be ignored:") }}</p>

--- a/securedrop/journalist_templates/admin_new_user_two_factor.html
+++ b/securedrop/journalist_templates/admin_new_user_two_factor.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block tab_title %}{{ gettext('Enable FreeOTP') }}{% endblock %}
+
 {% block body %}
 {% if user.is_totp %}
 <h1>{{ gettext('Enable FreeOTP') }}</h1>

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ g.organization_name }}</title>
+  <title>{% block tab_title required %}{% endblock %} | {{ g.organization_name }}</title>
 
   <link rel="stylesheet" href="/static/css/journalist.css">
 

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ source.journalist_designation }}{% endblock %}
+
 {% block body %}
 <div id="content" class="journalist-view-single">
 

--- a/securedrop/journalist_templates/config.html
+++ b/securedrop/journalist_templates/config.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('Instance Configuration') }}{% endblock %}
+
 {% block body %}
 <nav class="back" aria-labelledby="back-link">
   <a id="back-link" href="/admin">{{ gettext('Back to admin interface') }}</a>

--- a/securedrop/journalist_templates/edit_account.html
+++ b/securedrop/journalist_templates/edit_account.html
@@ -1,4 +1,13 @@
 {% extends "base.html" %}
+
+{% block tab_title %}
+{% if user %}
+{{ gettext('Edit user "{user}"').format(user=user.username) }}
+{% else %}
+{{ gettext('Edit your account') }}
+{% endif %}
+{% endblock %}
+
 {% block body %}
 
 {% if user %}

--- a/securedrop/journalist_templates/error.html
+++ b/securedrop/journalist_templates/error.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ error.name }}{% endblock %}
+
 {% block body %}
 <h1>{{ error.code }}: {{ error.name }}</h1>
 {% if error.description %}

--- a/securedrop/journalist_templates/index.html
+++ b/securedrop/journalist_templates/index.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('All Sources') }}{% endblock %}
+
 {% block body %}
 <div id="content" class="journalist-view-all">
   <h1 id="all-sources-heading" class="headline">{{ gettext('All Sources') }}</h1>

--- a/securedrop/journalist_templates/login.html
+++ b/securedrop/journalist_templates/login.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('Login to access the journalist interface') }}{% endblock %}
+
 {% block body %}
 
 <h1>{{ gettext('Login to access the journalist interface') }}</h1>

--- a/securedrop/source_templates/base.html
+++ b/securedrop/source_templates/base.html
@@ -6,9 +6,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex,nofollow">
   {% if g.organization_name == "SecureDrop" %}
-  <title>{{ g.organization_name }} | {{ gettext('Protecting Journalists and Sources') }}</title>
+  <title>{% block tab_title required %}{% endblock %} | {{ g.organization_name }} | {{ gettext('Protecting Journalists and Sources') }}</title>
   {% else %}
-  <title>{{ g.organization_name }} | {{ gettext('SecureDrop') }}</title>
+  <title>{{ self.tab_title() }} | {{ g.organization_name }} | {{ gettext('SecureDrop') }}</title>
   {% endif %}
 
   <link rel="stylesheet" href="/static/css/source.css">

--- a/securedrop/source_templates/error.html
+++ b/securedrop/source_templates/error.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('Server error') }}{% endblock %}
+
 {% block body %}
 <h2>{{ gettext('Server error') }}</h2>
 

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('Get Your Codename') }}{% endblock %}
+
 {% import 'utils.html' as utils %}
 
 {% block body %}

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -3,9 +3,9 @@
 
 <head>
   {% if g.organization_name == "SecureDrop" %}
-  <title>{{ g.organization_name }} | {{ gettext('Protecting Journalists and Sources') }}</title>
+  <title>{{ gettext('Welcome') }} | {{ g.organization_name }} | {{ gettext('Protecting Journalists and Sources') }}</title>
   {% else %}
-  <title>{{ g.organization_name }} | {{ gettext('SecureDrop') }}</title>
+  <title>{{ gettext('Welcome') }} | {{ g.organization_name }} | {{ gettext('SecureDrop') }}</title>
   {% endif %}
 
   <link rel="stylesheet" href="/static/css/source.css">

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('Login') }}{% endblock %}
+
 {% block body %}
 
 {% include 'flashed.html' %}

--- a/securedrop/source_templates/logout.html
+++ b/securedrop/source_templates/logout.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('Additional Action Required') }}{% endblock %}
+
 {% block body %}
 <nav>
   <a href="{{ url_for('main.login') }}" class="btn" aria-label="{{ gettext('Log In') }}">

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -1,6 +1,14 @@
 {% extends "base.html" %}
 {% import 'utils.html' as utils %}
 
+{% block tab_title %}
+{% if allow_document_uploads %}
+{{ gettext('Submit Files or Messages') }}
+{% else %}
+{{ gettext('Submit Messages') }}
+{% endif %}
+{% endblock %}
+
 {% block body %}
 {% include 'flashed.html' %}
 

--- a/securedrop/source_templates/notfound.html
+++ b/securedrop/source_templates/notfound.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('Page not found') }}{% endblock %}
+
 {% block body %}
 <h2>{{ gettext('Page not found') }}</h2>
 

--- a/securedrop/source_templates/tor2web-warning.html
+++ b/securedrop/source_templates/tor2web-warning.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('WARNING: Proxy Service Detected') }}{% endblock %}
+
 {% block body %}
 <h2>{{ gettext('Proxy Service Detected') }}</h2>
 <div class="center">

--- a/securedrop/source_templates/use-tor-browser.html
+++ b/securedrop/source_templates/use-tor-browser.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext('You Should Use Tor Browser') }}{% endblock %}
+
 {% block body %}
 <h2>{{ gettext('You Should Use Tor Browser') }}</h2>
 <p>{{ gettext('If you are not using Tor Browser, you <strong>may not be anonymous</strong>.') }}</p>

--- a/securedrop/source_templates/why-public-key.html
+++ b/securedrop/source_templates/why-public-key.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block tab_title %}{{ gettext("Why download the team's public key?") }}{% endblock %}
+
 {% block body %}
 <h2>{{ gettext("Why download the team's public key?") }}</h2>
 <p>{{ gettext("SecureDrop encrypts files and messages after they are submitted. Encrypting messages and files before submission can provide an extra layer of security before your data reaches the SecureDrop server.") }}

--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -487,7 +487,7 @@ class TestAdminInterfaceEditConfig:
         journ_app_nav.admin_visits_system_config_page()
 
         # When they update the organization's name
-        assert "SecureDrop" == journ_app_nav.driver.title
+        assert "SecureDrop" in journ_app_nav.driver.title
         journ_app_nav.driver.find_element_by_id("organization_name").clear()
         new_org_name = "Walden Inquirer"
         journ_app_nav.nav_helper.safe_send_keys_by_id("organization_name", new_org_name)
@@ -495,7 +495,7 @@ class TestAdminInterfaceEditConfig:
         self._admin_submits_instance_settings_form(journ_app_nav)
 
         # Then it succeeds
-        assert new_org_name == journ_app_nav.driver.title
+        assert new_org_name in journ_app_nav.driver.title
 
         # And then, when a source user logs into the source app
         source_app_nav = SourceAppNavigator(

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -228,7 +228,10 @@ def verify_i18n(app):
             assert 'hreflang="fr-FR"' in locales
 
         c.get("/?l=ar")
-        base = render_template("base.html")
+        # We have to render a template that inherits from "base.html" so that "tab_title" will be
+        # set.  But we're just checking that when a page is rendered in an RTL language the
+        # directionality is correct, so it doesn't matter which template we render.
+        base = render_template("error.html", error={})
         assert 'dir="rtl"' in base
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Per the Web Content Accessibilty Guidelines 2.0, Success Criterion 2.4.2, all pages should have descriptive titles to help users orient themselves within the website, particularly for users who take advantage of screen readers while browsing the web.

This commit adds a new `tab_title` block to the base templates for the source and journalist, as well as the index page of the source (it does not derive from base). It is named this way so that it is clear that this block will NOT add a "title" to the *contents* of the page, eg a heading at the beginning of the content. The other files had descriptive titles added. In most cases, these titles are a copy-paste of a `gettext` call already in the page, but there are a few exceptions.

`journalist_templates/admin_add_user.html` currently does not use a `gettext` call for the heading that is appropriate for the title. `journalist_templates/error.html` also does not, although it is getting the name of an error from a variable, so I assume that translation is handled elsewhere in this case.

`journalist_templates/col.html`, `source_templates/index.html`, and `source_templates/login.html` did not have headings that were appropriate for page titles, so I invented new titles for these. I am not a translator, so these are not in `gettext` calls.

`source_templates/logout.html` and
`source_templates/tor2web-warning.html` had headings which could be used for titles, but the text was either modified or replaced to make sure that users who are relying soley on the tab title, without the ability to conveniently skim the contents to better understand the length and nature of the text, receive communication about the importance and urgency of the contents of these pages from the title itself.

Also update the `test_orgname_is_changed` test so that the assertions do
not have a dependency on the page title.

Fixes #6313.

Changes proposed in this pull request:

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

I navigated through the pages in both the source and journalist interface and made sure the titles were visible on the tab. I tested this in plain firefox, I'm not overly concerned about browser compatibility because the client is just receiving different static text due to this change, but I can go back and look at it in tor if needed.

## Deployment

I have a couple of concerns, I'm not sure if this technically qualifies as "deployment" but this seems like the best place to bring them up.

The heading that I used for the page title in `journalist_templates/admin_add_user.html` is not wrapped in a `gettext` call, while most of the others are (other exceptions are categorically different and will be explained shortly). I'm not super familiar with gettext, but IIUC this means that this text will not be translated. This doesn't seem ideal, but I don't think I'm the right person/this is the right issue within which to address that. Technically, the error page is also not in a `gettext` call, but it's referencing a variable value and I'm assuming that error messages are handled elsewhere, possibly by the browser itself since error codes are well known.

The other exceptions are all because the page did not already contain an appropriate heading, so I added a page title that seemed reasonable. These pages are `journalist_templates/col.html`, `source_templates/index.html`, `source_templates/login.html`, and `source_templates/logout.html` (see previous comments for the reason why logout has new text). Additionally, `source_templates/tor2web-warning.html` has the word "WARNING" prepended to the `gettext` call (again, see previous comments). I could dig through the `po` files to see if there is a key that seems reasonable, but I'm skeptical there will be. Assuming we want to use the new titles, is there anything I need to do to put these titles on the translations team's radar?

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

N/A

### If you made changes to the system configuration:

N/A

### If you added or removed a file deployed with the application:

N/A

### If you made non-trivial code changes:

Discussions about tests for accessibility are taking place in #6314.

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a production code dependency:

N/A