### PR TITLE
Update to the CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,10 @@ workflows:
   version: 2
   securedrop_ci:
     jobs:
-      - lint
+      - lint:
+          context:
+            - circleci-slack
+          <<: *slack-fail-post-step
       - app-tests:
           filters:
             branches:
@@ -328,6 +331,9 @@ workflows:
                 - /update-builder-.*/
           requires:
             - lint
+          context:
+            - circleci-slack
+          <<: *slack-fail-post-step
       - app-page-layout-tests:
           filters:
             branches:
@@ -336,21 +342,33 @@ workflows:
                 - /update-builder-.*/
           requires:
             - lint
+          context:
+            - circleci-slack
+          <<: *slack-fail-post-step
       - admin-tests:
           filters:
             branches:
               ignore:
                 - /i18n-.*/
                 - /update-builder-.*/
+          context:
+            - circleci-slack
+          <<: *slack-fail-post-step
       - updater-gui-tests:
           filters:
             branches:
               ignore:
                 - /i18n-.*/
                 - /update-builder-.*/
+          context:
+            - circleci-slack
+          <<: *slack-fail-post-step
       - static-analysis-and-no-known-cves:
           requires:
             - lint
+          context:
+            - circleci-slack
+          <<: *slack-fail-post-step
       - staging-test-with-rebase:
           filters:
             branches:
@@ -359,12 +377,18 @@ workflows:
               only: /(stg-|release\/).*/
           requires:
             - lint
+          context:
+            - circleci-slack
+          <<: *slack-fail-post-step
       - translation-tests:
           requires:
             - lint
           filters:
             branches:
               only: /i18n-.*/
+          context:
+            - circleci-slack
+          <<: *slack-fail-post-step
       - deb-tests:
           filters:
             branches:
@@ -372,6 +396,9 @@ workflows:
                 - /update-builder-.*/
           requires:
             - lint
+          context:
+            - circleci-slack
+          <<: *slack-fail-post-step
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ common-steps:
       paths:
         - /caches/layers.tar
 
-version: 2
+version: 2.1
 jobs:
   lint:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,16 @@ common-steps:
         - /caches/layers.tar
 
 version: 2.1
+orbs:
+  slack: circleci/slack@4.4.4
+
+slack-fail-post-step: &slack-fail-post-step
+  post-steps:
+    - slack/notify:
+        channel: C01EY9C1X45
+        event: fail
+        template: basic_fail_1
+
 jobs:
   lint:
     machine:


### PR DESCRIPTION
## Status

Note: this repository will not have CircleCI Slack notifications until either this is merged, or infra-side changes are reverted. in the case the latter is needed please ping me on slack directly!

Part of https://github.com/freedomofpress/infrastructure/issues/3225

## Description of Changes

Changes proposed in this pull request: this updates the CircleCI config to the latest version, enables the Slack orb, adds a step to call Slack on a failure, and then maps that to each job in the workflow.

this repository has been using a legacy CircleCI integration that is no longer supported, and this brings it up to date with the current guidance for integrationg CircleCI and Slack.

## Testing

easiest thing to do would be to do something that would cause a CI failure and make sure the notification pops into Slack. that would have to be done in _this_ branch (or a child) unless this is otherwise merged first.

## Deployment

deploys on merge, no effect outside of circleCI

Choose one of the following:

- [x] These changes do not require documentation