### PR TITLE
Update upgrade scenario to require 7 debs, not 8

### DIFF
--- a/molecule/upgrade/converge.yml
+++ b/molecule/upgrade/converge.yml
@@ -16,7 +16,7 @@
     - name: Ensure debs were found
       assert:
         that:
-          - "_find_debs_result.files|length >= 8"
+          - "_find_debs_result.files|length >= 7"
         msg: "No local debs found, run 'make build-debs-focal'"
 
 - name: Configure apt-server


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

The `securedrop-grsec` package was recently moved to the kernel build, so we now build 7 debs from this repo, not 8. This PR is a one-char update to the upgrade scenario `converge.yml` to reflect that.

## Testing
On this branch, on a system set up to support libvirt staging/prod VMs:

- build packages with: `make build-debs`
- set up a venv with: `make venv && source .venv/bin/activate`
- [ ] confirm that `make upgrade-start` completes successfully
- [ ] (optional) run through the upgrade scenario (prod VMs required) and confirm that you get and updated working system

