### PR TITLE
Add accessibility sniffs to pageslayout tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,13 @@ jobs:
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" \
               make validate-test-html || true
 
+      - run:
+          name: Validate accessibility (informational)
+          command: |
+            fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
+            DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" \
+              make accessibility-summary || true
+
       - store_test_results:
           path: ~/project/test-results
 

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,12 @@ validate-test-html:
 	@$(DEVSHELL) html5validator tests/functional/pageslayout/html
 	@echo
 
+.PHONY: accessibility-summary
+accessibility-summary:
+	@echo "███ Processing accessibility results..."
+	@$(DEVSHELL) $(SDBIN)/summarize-accessibility-info
+	cat securedrop/tests/functional/pageslayout/accessibility-info/summary.txt
+
 .PHONY: docker-vnc
 docker-vnc:  ## Open a VNC connection to a running Docker instance.
 	@echo "███ Opening VNC connection to dev container..."

--- a/devops/docker/CIDockerfile
+++ b/devops/docker/CIDockerfile
@@ -7,8 +7,9 @@ ENV DOCKER_SHA256_x86_64 340e0b5a009ba70e1b644136b94d13824db0aeb52e09071410f35a9
 
 RUN apt-get update && \
     apt-get install -y flake8 make virtualenv ccontrol libpython2.7-dev \
-            libffi-dev libssl-dev libyaml-dev python-pip curl git &&\
-    apt-get clean
+            libffi-dev libssl-dev libyaml-dev python-pip curl git npm &&\
+    apt-get clean && \
+    npm --global install html_codesniffer@2.5.1
 
 RUN curl -L -o /tmp/docker-${DOCKER_VER}.tgz https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VER}.tgz; \
 	echo "${DOCKER_SHA256_x86_64} /tmp/docker-${DOCKER_VER}.tgz" | sha256sum -c -; \

--- a/securedrop/bin/summarize-accessibility-info
+++ b/securedrop/bin/summarize-accessibility-info
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export PATH="/opt/venvs/securedrop-app-code/bin:$PATH"
+
+cd ..
+export REPOROOT="${REPOROOT:-$PWD}"
+git config --global --add safe.directory "$REPOROOT"
+cd "${REPOROOT}/securedrop"
+
+PYTHONPATH=".:${PYTHONPATH:-}"
+export PYTHONPATH
+
+python3 -c 'from tests.functional.pageslayout.accessibility import summarize_accessibility_results; summarize_accessibility_results()'

--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update  && apt-get install -y \
     # cached along with everything else too.
     default-jdk \
     libasound2 libdbus-glib-1-2 libgtk2.0-0 libfontconfig1 libxrender1 \
-    libcairo-gobject2 libgtk-3-0 libstartup-notification0
+    libcairo-gobject2 libgtk-3-0 libstartup-notification0 npm && \
+    npm install --global html_codesniffer@2.5.1
 
 # Current versions of the test browser software. Tor Browser is based
 # on a specific version of Firefox, noted in Help > About Tor Browser.

--- a/securedrop/tests/functional/pageslayout/.gitignore
+++ b/securedrop/tests/functional/pageslayout/.gitignore
@@ -1,2 +1,3 @@
+accessibility-info
 html
 screenshots

--- a/securedrop/tests/functional/pageslayout/accessibility.py
+++ b/securedrop/tests/functional/pageslayout/accessibility.py
@@ -1,0 +1,191 @@
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Union
+
+from selenium.webdriver.firefox.webdriver import WebDriver
+
+_ACCESSIBILITY_DIR = (Path(__file__).parent / "accessibility-info").absolute()
+
+_HTMLCS_RUNNER_CODE = """
+var all_messages = [];
+console.log = msg => {
+    all_messages.push(msg);
+};
+
+HTMLCS_RUNNER.run('WCAG2AAA');
+return all_messages;
+"""
+
+
+class MessageType(Enum):
+    ERROR = 1
+    WARNING = 2
+    NOTICE = 3
+
+
+@dataclass
+class Message:
+    """Contains all of the information in a message emitted by HTML CodeSniffer."""
+
+    principle_id: str
+    message: str
+    message_type: MessageType
+    responsible_html: str
+    selector: str
+    element_type: str
+
+    @staticmethod
+    def from_output(output: str) -> "Message":
+        """Parses the output of htmlcs and returns an instance containing all data.
+
+        No processing is performed for flexibility.
+
+        Example message, post-split (note: contents of index 4 contains no newlines, but I had to
+        split it to keep the linter happy):
+
+        0: [HTMLCS] Error
+        1: WCAG2AAA.Principle1.Guideline1_3.1_3_1_AAA.G141
+        2: h2
+        3: #security-level-heading
+        4: The heading structure is not logically nested. This h2 element appears to be the
+           primary document heading, so should be an h1 element.
+        5: <h2 id="security-level-heading" hidden="">...</h2>
+        """
+
+        fields = output.split("|")
+
+        if "Error" in fields[0]:
+            message_type = MessageType.ERROR
+        elif "Warning" in fields[0]:
+            message_type = MessageType.WARNING
+        elif "Notice" in fields[0]:
+            message_type = MessageType.NOTICE
+
+        return Message(
+            message_type=message_type,
+            principle_id=fields[1],
+            element_type=fields[2],
+            selector=fields[3],
+            message=fields[4],
+            responsible_html=fields[5],
+        )
+
+    def __format__(self, _spec: str) -> str:
+        newline = "\n"
+        return f"""
+{self.message_type}: {self.principle_id}
+    {self.message}
+
+    html:
+        {self.responsible_html.replace(newline, f"{newline}        ")}
+        """
+
+
+def sniff_accessibility_issues(driver: WebDriver, locale: str, test_name: str) -> None:
+    """Runs accessibility sniffs on the driver's current page.
+
+    This function is responsible for injecting HTML CodeSniffer into the current page and writing
+    the results to a file. This way, test functions can focus on the setup required to navigate to
+    a particular URL (for example, logging in to get to the messages page).
+    """
+
+    # 1. Retrieve/compute required data
+    with open(f"/usr/local/lib/node_modules/html_codesniffer/build/HTMLCS.js") as htmlcs:
+        html_codesniffer = htmlcs.read()
+
+    errors_dir = _ACCESSIBILITY_DIR / locale / "errors"
+    errors_dir.mkdir(parents=True, exist_ok=True)
+
+    reviews_dir = _ACCESSIBILITY_DIR / locale / "reviews"
+    reviews_dir.mkdir(parents=True, exist_ok=True)
+
+    # 2. Do the thing
+    raw_messages = driver.execute_script(html_codesniffer + _HTMLCS_RUNNER_CODE)
+
+    # 3. Organize the data
+    messages: Dict[str, List[Message]] = {
+        "machine-verified": [],
+        "human-reviewed": [],
+    }
+
+    for message in map(Message.from_output, raw_messages[:-1]):  # last message is effectievly EOF
+        if message.message_type == MessageType.ERROR:
+            messages["machine-verified"].append(message)
+        else:
+            messages["human-reviewed"].append(message)
+
+    # 4. Report the data
+    # Note: it is useful to create empty files when there are no results to simplify the logic for
+    #       summarizing the results, implemented in `summarize_accessibility_results`.
+    with open(errors_dir / f"{test_name}.txt", "w") as error_file:
+        for message in messages["machine-verified"]:
+            error_file.write(f"{message}")
+
+    with open(reviews_dir / f"{test_name}.txt", "w") as review_file:
+        for message in messages["human-reviewed"]:
+            review_file.write(f"{message}")
+
+
+def summarize_accessibility_results() -> None:
+    """Creates a file containing summary information about the result of accessiblity sniffing
+
+    Note: This does not automatically run as part of the test suite, use
+          `make accessibility-summary` instead.
+    """
+
+    try:
+        summary: Dict[str, Dict[str, Dict[str, Union[int, bool]]]] = {}
+
+        # since `sniff_accessibility_issues` creates empty files, all locale/type combinations will
+        # contain the same set of files; getting filenames from en_US/reviews instead of, say,
+        # ar/errors is arbitrary and sufficient
+        for out_filename in os.listdir(_ACCESSIBILITY_DIR / "en_US" / "reviews"):
+            summary[out_filename] = {
+                "reviews": {"count": 0, "locale_differs": False},
+                "errors": {"count": 0, "locale_differs": False},
+            }
+
+            # collect all of the relevant data
+            for message_type in ["reviews", "errors"]:
+                outputs: Dict[str, Dict[str, List[str]]] = {}
+
+                for locale in ["en_US", "ar"]:
+                    outputs[locale] = {}
+                    with open(
+                        _ACCESSIBILITY_DIR / locale / message_type / out_filename
+                    ) as out_file:
+                        # Only look at lines specifying the message (including the exact WCAG error
+                        # code); this is exactly correct for the count, and approximately correct
+                        # for comparing locales. If the order of the errors differs, or if there
+                        # are a different number of any kind of error, this approximation will catch
+                        # it.
+                        outputs[locale][message_type] = [
+                            line for line in out_file.readlines() if "MessageType." in line
+                        ]
+
+                summary[out_filename][message_type]["count"] = len(outputs["en_US"][message_type])
+                summary[out_filename][message_type]["locale_differs"] = (
+                    outputs["en_US"][message_type] != outputs["ar"][message_type]
+                )
+
+        # save the data to a convenient file
+        with open(_ACCESSIBILITY_DIR / "summary.txt", "w") as summary_file:
+            for name in sorted(summary.keys()):
+                summary_file.write(name + ":\n")
+                for message_type in ["errors", "reviews"]:
+                    summary_file.write(
+                        f"\t{message_type}: {summary[name][message_type]['count']}\n"
+                    )
+                    if summary[name][message_type]["locale_differs"]:
+                        summary_file.write(f"\t        NOTE: {message_type} differ by locale\n")
+
+                summary_file.write("\n")
+
+    # this should only happen if the pageslayout tests have not created the raw output files
+    except FileNotFoundError:
+        print(
+            f"ERROR: Run `make test TESTFILES={os.path.dirname(_ACCESSIBILITY_DIR)}` before "
+            "running `make accessibility-summary`"
+        )

--- a/securedrop/tests/functional/pageslayout/test_journalist.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist.py
@@ -17,7 +17,7 @@
 #
 import pytest
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
-from tests.functional.pageslayout.utils import list_locales, save_screenshot_and_html
+from tests.functional.pageslayout.utils import list_locales, save_static_data
 
 
 @pytest.mark.parametrize("locale", list_locales())
@@ -33,7 +33,7 @@ class TestJournalistLayout:
             accept_languages=locale_with_commas,
         )
         journ_app_nav.driver.get(f"{sd_servers.journalist_app_base_url}/login")
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-login")
+        save_static_data(journ_app_nav.driver, locale, "journalist-login")
 
         # And they log into the app and are an admin
         assert sd_servers.journalist_is_admin
@@ -42,19 +42,17 @@ class TestJournalistLayout:
             password=sd_servers.journalist_password,
             otp_secret=sd_servers.journalist_otp_secret,
         )
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-index_no_documents")
+        save_static_data(journ_app_nav.driver, locale, "journalist-index_no_documents")
         # The documentation uses an identical screenshot with a different name:
         # https://github.com/freedomofpress/securedrop-docs/blob/main/docs/images/manual
         # /screenshots/journalist-admin_index_no_documents.png
         # So we take the same screenshot again here
         # TODO(AD): Update the documentation to use a single screenshot
-        save_screenshot_and_html(
-            journ_app_nav.driver, locale, "journalist-admin_index_no_documents"
-        )
+        save_static_data(journ_app_nav.driver, locale, "journalist-admin_index_no_documents")
 
         # Take a screenshot of the edit account page
         journ_app_nav.journalist_visits_edit_account()
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-edit_account_user")
+        save_static_data(journ_app_nav.driver, locale, "journalist-edit_account_user")
 
     def test_index_entered_text(self, locale, sd_servers, firefox_web_driver):
         # Given an SD server
@@ -73,7 +71,7 @@ class TestJournalistLayout:
             otp_secret="2HGGVF5VPHWMCAYQ",
             should_submit_login_form=False,
         )
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-index_with_text")
+        save_static_data(journ_app_nav.driver, locale, "journalist-index_with_text")
 
     def test_index_with_submission_and_select_documents(
         self, locale, sd_servers_with_submitted_file, firefox_web_driver
@@ -93,20 +91,20 @@ class TestJournalistLayout:
             password=sd_servers_with_submitted_file.journalist_password,
             otp_secret=sd_servers_with_submitted_file.journalist_otp_secret,
         )
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-index")
+        save_static_data(journ_app_nav.driver, locale, "journalist-index")
         # The documentation uses an identical screenshot with a different name:
         # https://github.com/freedomofpress/securedrop-docs/blob/main/docs/images/manual
         # /screenshots/journalist-index_javascript.png
         # So we take the same screenshot again here
         # TODO(AD): Update the documentation to use a single screenshot
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-index_javascript")
+        save_static_data(journ_app_nav.driver, locale, "journalist-index_javascript")
 
         # Take a screenshot of the source's page
         journ_app_nav.journalist_selects_the_first_source()
         checkboxes = journ_app_nav.get_submission_checkboxes_on_current_page()
         for checkbox in checkboxes:
             checkbox.click()
-        save_screenshot_and_html(
+        save_static_data(
             journ_app_nav.driver, locale, "journalist-clicks_on_source_and_selects_documents"
         )
 
@@ -115,7 +113,7 @@ class TestJournalistLayout:
             reply_content="Thanks for the documents."
             " Can you submit more information about the main program?"
         )
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-composes_reply")
+        save_static_data(journ_app_nav.driver, locale, "journalist-composes_reply")
 
     def test_fail_to_visit_admin(self, locale, sd_servers, firefox_web_driver):
         # Given an SD server
@@ -128,9 +126,7 @@ class TestJournalistLayout:
         )
         # Take a screenshot of them trying to force-browse to the admin interface
         journ_app_nav.driver.get(f"{sd_servers.journalist_app_base_url}/admin")
-        save_screenshot_and_html(
-            journ_app_nav.driver, locale, "journalist-code-fail_to_visit_admin"
-        )
+        save_static_data(journ_app_nav.driver, locale, "journalist-code-fail_to_visit_admin")
 
     def test_fail_login(self, locale, sd_servers, firefox_web_driver):
         # Given an SD server
@@ -149,10 +145,10 @@ class TestJournalistLayout:
             otp_secret="2HGGVF5VPHWMCAYQ",
             should_submit_login_form=True,
         )
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-code-fail_login")
+        save_static_data(journ_app_nav.driver, locale, "journalist-code-fail_login")
         # The documentation uses an identical screenshot with a different name:
         # https://github.com/freedomofpress/securedrop-docs/blob/main/docs/images/manual
         # /screenshots/journalist-code-fail_login_many.png
         # So we take the same screenshot again here
         # TODO(AD): Update the documentation to use a single screenshot
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-code-fail_login_many")
+        save_static_data(journ_app_nav.driver, locale, "journalist-code-fail_login_many")

--- a/securedrop/tests/functional/pageslayout/test_journalist_account.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_account.py
@@ -20,7 +20,7 @@ from typing import Optional
 import pytest
 from selenium.webdriver import ActionChains
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
-from tests.functional.pageslayout.utils import list_locales, save_screenshot_and_html
+from tests.functional.pageslayout.utils import list_locales, save_static_data
 
 
 @pytest.mark.parametrize("locale", list_locales())
@@ -50,18 +50,14 @@ class TestJournalistLayoutAccount:
         self._clicks_reset_secret(
             journ_app_nav, "hotp", assert_tooltip_text_is="RESET SECURITY KEY CREDENTIALS"
         )
-        save_screenshot_and_html(
-            journ_app_nav.driver, locale, "journalist-account_edit_hotp_secret"
-        )
+        save_static_data(journ_app_nav.driver, locale, "journalist-account_edit_hotp_secret")
 
         # Update the hotp secret and take a screenshot
         journ_app_nav.nav_helper.safe_send_keys_by_css_selector(
             'input[name="otp_secret"]', "123456"
         )
         journ_app_nav.nav_helper.safe_click_by_css_selector("button[type=submit]")
-        save_screenshot_and_html(
-            journ_app_nav.driver, locale, "journalist-account_new_two_factor_hotp"
-        )
+        save_static_data(journ_app_nav.driver, locale, "journalist-account_new_two_factor_hotp")
 
     @staticmethod
     def _clicks_reset_secret(
@@ -122,6 +118,4 @@ class TestJournalistLayoutAccount:
         self._clicks_reset_secret(
             journ_app_nav, "totp", assert_tooltip_text_is="RESET MOBILE APP CREDENTIALS"
         )
-        save_screenshot_and_html(
-            journ_app_nav.driver, locale, "journalist-account_new_two_factor_totp"
-        )
+        save_static_data(journ_app_nav.driver, locale, "journalist-account_new_two_factor_totp")

--- a/securedrop/tests/functional/pageslayout/test_journalist_admin.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_admin.py
@@ -24,7 +24,7 @@ import pytest
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver import ActionChains
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
-from tests.functional.pageslayout.utils import list_locales, save_screenshot_and_html
+from tests.functional.pageslayout.utils import list_locales, save_static_data
 
 
 @pytest.mark.parametrize("locale", list_locales())
@@ -50,14 +50,14 @@ class TestAdminLayoutAddAndEditUser:
 
         # Take a screenshot of the admin interface
         journ_app_nav.admin_visits_admin_interface()
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-admin_interface_index")
+        save_static_data(journ_app_nav.driver, locale, "journalist-admin_interface_index")
 
         # Take screenshots of the steps for creating an hotp journalist
         def screenshot_of_add_user_hotp_form() -> None:
-            save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-admin_add_user_hotp")
+            save_static_data(journ_app_nav.driver, locale, "journalist-admin_add_user_hotp")
 
         def screenshot_of_journalist_new_user_two_factor_hotp() -> None:
-            save_screenshot_and_html(
+            save_static_data(
                 journ_app_nav.driver, locale, "journalist-admin_new_user_two_factor_hotp"
             )
 
@@ -67,17 +67,17 @@ class TestAdminLayoutAddAndEditUser:
             callback_before_submitting_2fa_step=screenshot_of_journalist_new_user_two_factor_hotp,
         )
         new_user_username, new_user_pw, new_user_otp_secret = result
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-admin")
+        save_static_data(journ_app_nav.driver, locale, "journalist-admin")
 
         # Take a screenshot of the new journalist's edit page
         journ_app_nav.admin_visits_user_edit_page(username_of_journalist_to_edit=new_user_username)
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-edit_account_admin")
+        save_static_data(journ_app_nav.driver, locale, "journalist-edit_account_admin")
         # The documentation uses an identical screenshot with a different name:
         # https://github.com/freedomofpress/securedrop-docs/blob/main/docs/images/manual
         # /screenshots/journalist-admin_edit_hotp_secret.png
         # So we take the same screenshot again here
         # TODO(AD): Update the documentation to use a single screenshot
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-admin_edit_hotp_secret")
+        save_static_data(journ_app_nav.driver, locale, "journalist-admin_edit_hotp_secret")
 
         # Then the admin resets the new journalist's hotp
         def _admin_visits_reset_2fa_hotp_step() -> None:
@@ -135,10 +135,10 @@ class TestAdminLayoutAddAndEditUser:
 
         # Take screenshots of the steps for creating a totp journalist
         def screenshot_of_add_user_totp_form() -> None:
-            save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-admin_add_user_totp")
+            save_static_data(journ_app_nav.driver, locale, "journalist-admin_add_user_totp")
 
         def screenshot_of_journalist_new_user_two_factor_totp() -> None:
-            save_screenshot_and_html(
+            save_static_data(
                 journ_app_nav.driver, locale, "journalist-admin_new_user_two_factor_totp"
             )
 
@@ -185,7 +185,7 @@ class TestAdminLayoutAddAndEditUser:
 
         # Then it succeeds
         # Take a screenshot
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-admin_edit_totp_secret")
+        save_static_data(journ_app_nav.driver, locale, "journalist-admin_edit_totp_secret")
 
     @staticmethod
     def _retry_2fa_pop_ups(
@@ -240,9 +240,7 @@ class TestAdminLayoutEditConfig:
         # Take a screenshot of the system config page
         journ_app_nav.admin_visits_admin_interface()
         journ_app_nav.admin_visits_system_config_page()
-        save_screenshot_and_html(
-            journ_app_nav.driver, locale, "journalist-admin_system_config_page"
-        )
+        save_static_data(journ_app_nav.driver, locale, "journalist-admin_system_config_page")
 
         # When the admin tries to upload a new logo
         current_file_path = Path(__file__).absolute().parent
@@ -259,9 +257,7 @@ class TestAdminLayoutEditConfig:
         journ_app_nav.nav_helper.wait_for(updated_image, timeout=20)
 
         # Take a screenshot
-        save_screenshot_and_html(
-            journ_app_nav.driver, locale, "journalist-admin_changes_logo_image"
-        )
+        save_static_data(journ_app_nav.driver, locale, "journalist-admin_changes_logo_image")
 
     def test_ossec_alert_button(self, locale, sd_servers, firefox_web_driver):
         # Given an SD server
@@ -294,6 +290,4 @@ class TestAdminLayoutEditConfig:
         journ_app_nav.nav_helper.wait_for(test_alert_sent)
 
         # Take a screenshot
-        save_screenshot_and_html(
-            journ_app_nav.driver, locale, "journalist-admin_ossec_alert_button"
-        )
+        save_static_data(journ_app_nav.driver, locale, "journalist-admin_ossec_alert_button")

--- a/securedrop/tests/functional/pageslayout/test_journalist_col.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_col.py
@@ -24,7 +24,7 @@ from sdconfig import SecureDropConfig
 from tests.factories import SecureDropConfigFactory
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
 from tests.functional.conftest import SdServersFixtureResult, spawn_sd_servers
-from tests.functional.pageslayout.utils import list_locales, save_screenshot_and_html
+from tests.functional.pageslayout.utils import list_locales, save_static_data
 
 
 def _create_source_and_submission_and_delete_source_key(config_in_use: SecureDropConfig) -> None:
@@ -85,13 +85,13 @@ class TestJournalistLayoutCol:
 
         # Take a screenshot of the individual source's page when there is a document
         journ_app_nav.journalist_visits_col()
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-col")
+        save_static_data(journ_app_nav.driver, locale, "journalist-col")
         # The documentation uses an identical screenshot with a different name:
         # https://github.com/freedomofpress/securedrop-docs/blob/main/docs/images/manual
         # /screenshots/journalist-col_javascript.png
         # So we take the same screenshot again here
         # TODO(AD): Update the documentation to use a single screenshot
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-col_javascript")
+        save_static_data(journ_app_nav.driver, locale, "journalist-col_javascript")
 
         # Take a screenshot of the individual source's page when there are no documents
         journ_app_nav.journalist_clicks_delete_all_and_sees_confirmation()
@@ -103,7 +103,7 @@ class TestJournalistLayoutCol:
             assert submissions_after_confirming_count == 0
 
         journ_app_nav.nav_helper.wait_for(submission_deleted)
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-col_no_document")
+        save_static_data(journ_app_nav.driver, locale, "journalist-col_no_document")
 
     def test_col_has_no_key(self, locale, _sd_servers_with_deleted_source_key, firefox_web_driver):
         # Given an SD server with an already-submitted file, but the source's key was deleted
@@ -122,4 +122,4 @@ class TestJournalistLayoutCol:
 
         # Take a screenshot of the source's page after their key was deleted
         journ_app_nav.journalist_visits_col()
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-col_has_no_key")
+        save_static_data(journ_app_nav.driver, locale, "journalist-col_has_no_key")

--- a/securedrop/tests/functional/pageslayout/test_journalist_delete.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_delete.py
@@ -17,7 +17,7 @@
 #
 import pytest
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
-from tests.functional.pageslayout.utils import list_locales, save_screenshot_and_html
+from tests.functional.pageslayout.utils import list_locales, save_static_data
 
 
 @pytest.mark.parametrize("locale", list_locales())
@@ -44,7 +44,7 @@ class TestJournalistLayoutDelete:
         journ_app_nav.journalist_clicks_delete_selected_link()
 
         journ_app_nav.journalist_confirm_delete_selected()
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-delete_none")
+        save_static_data(journ_app_nav.driver, locale, "journalist-delete_none")
 
     def test_delete_one_confirmation(
         self, locale, sd_servers_with_submitted_file, firefox_web_driver
@@ -71,7 +71,7 @@ class TestJournalistLayoutDelete:
 
         # Take a screenshot of the confirmation prompt when the journalist clicks the delete button
         journ_app_nav.journalist_clicks_delete_selected_link()
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-delete_one_confirmation")
+        save_static_data(journ_app_nav.driver, locale, "journalist-delete_one_confirmation")
 
     def test_delete_all_confirmation(
         self, locale, sd_servers_with_submitted_file, firefox_web_driver
@@ -95,7 +95,7 @@ class TestJournalistLayoutDelete:
 
         # Take a screenshot of the prompt when the journalist clicks the delete all button
         journ_app_nav.journalist_clicks_delete_all_and_sees_confirmation()
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-delete_all_confirmation")
+        save_static_data(journ_app_nav.driver, locale, "journalist-delete_all_confirmation")
 
     def test_delete_one(self, locale, sd_servers_with_submitted_file, firefox_web_driver):
         # Given an SD server with a file submitted by a source
@@ -122,7 +122,7 @@ class TestJournalistLayoutDelete:
         journ_app_nav.nav_helper.safe_click_by_id("delete-selected")
 
         # Take a screenshot
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-delete_one")
+        save_static_data(journ_app_nav.driver, locale, "journalist-delete_one")
 
     def test_delete_all(self, locale, sd_servers_with_submitted_file, firefox_web_driver):
         # Given an SD server with a file submitted by a source
@@ -146,4 +146,4 @@ class TestJournalistLayoutDelete:
         journ_app_nav.journalist_confirms_delete_selected()
 
         # Take a screenshot
-        save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-delete_all")
+        save_static_data(journ_app_nav.driver, locale, "journalist-delete_all")

--- a/securedrop/tests/functional/pageslayout/test_source.py
+++ b/securedrop/tests/functional/pageslayout/test_source.py
@@ -17,7 +17,7 @@
 #
 import pytest
 from tests.functional.app_navigators.source_app_nav import SourceAppNavigator
-from tests.functional.pageslayout.utils import list_locales, save_screenshot_and_html
+from tests.functional.pageslayout.utils import list_locales, save_static_data
 
 
 @pytest.mark.parametrize("locale", list_locales())
@@ -37,26 +37,24 @@ class TestSourceLayout:
 
         # Take a screenshot of the "account created" page
         source_app_nav.source_clicks_submit_documents_on_homepage()
-        save_screenshot_and_html(source_app_nav.driver, locale, "source-generate")
+        save_static_data(source_app_nav.driver, locale, "source-generate")
 
         # Take a screenshot of showing the codename hint
         source_app_nav.source_continues_to_submit_page()
         source_app_nav.source_retrieves_codename_from_hint()
-        save_screenshot_and_html(source_app_nav.driver, locale, "source-lookup-shows-codename")
+        save_static_data(source_app_nav.driver, locale, "source-lookup-shows-codename")
 
         # Take a screenshot of entering text in the message field
         source_app_nav.nav_helper.safe_send_keys_by_id("msg", "Secret message éè")
-        save_screenshot_and_html(source_app_nav.driver, locale, "source-submission_entered_text")
+        save_static_data(source_app_nav.driver, locale, "source-submission_entered_text")
 
         # Take a screenshot of submitting a file
         source_app_nav.source_submits_a_file()
-        save_screenshot_and_html(source_app_nav.driver, locale, "source-lookup")
+        save_static_data(source_app_nav.driver, locale, "source-lookup")
 
         # Take a screenshot of doing a second submission
         source_app_nav.source_submits_a_message()
-        save_screenshot_and_html(
-            source_app_nav.driver, locale, "source-next_submission_flashed_message"
-        )
+        save_static_data(source_app_nav.driver, locale, "source-next_submission_flashed_message")
 
     def test_login(self, locale, sd_servers_with_clean_state, tor_browser_web_driver):
         # Given a source user accessing the app from their browser
@@ -70,10 +68,10 @@ class TestSourceLayout:
 
         # Take a screenshot of the login page
         source_app_nav.source_chooses_to_login()
-        save_screenshot_and_html(source_app_nav.driver, locale, "source-login")
+        save_static_data(source_app_nav.driver, locale, "source-login")
 
         # Take a screenshot of entering text in the login form
         source_app_nav.nav_helper.safe_send_keys_by_id(
             "codename", "ascension hypertext concert synopses"
         )
-        save_screenshot_and_html(source_app_nav.driver, locale, "source-enter-codename-in-login")
+        save_static_data(source_app_nav.driver, locale, "source-enter-codename-in-login")

--- a/securedrop/tests/functional/pageslayout/test_source_layout_torbrowser.py
+++ b/securedrop/tests/functional/pageslayout/test_source_layout_torbrowser.py
@@ -18,7 +18,7 @@
 import pytest
 from tbselenium.utils import disable_js
 from tests.functional.app_navigators.source_app_nav import SourceAppNavigator
-from tests.functional.pageslayout.utils import list_locales, save_screenshot_and_html
+from tests.functional.pageslayout.utils import list_locales, save_static_data
 
 
 @pytest.mark.parametrize("locale", list_locales())
@@ -37,11 +37,11 @@ class TestSourceLayoutTorBrowser:
 
             # When they first login, it succeeds
             navigator.source_visits_source_homepage()
-            save_screenshot_and_html(navigator.driver, locale, "source-index")
+            save_static_data(navigator.driver, locale, "source-index")
 
             navigator.source_clicks_submit_documents_on_homepage()
             navigator.source_continues_to_submit_page()
 
             # And when they logout, it succeeds
             navigator.source_logs_out()
-            save_screenshot_and_html(navigator.driver, locale, "source-logout_page")
+            save_static_data(navigator.driver, locale, "source-logout_page")

--- a/securedrop/tests/functional/pageslayout/test_source_session_layout.py
+++ b/securedrop/tests/functional/pageslayout/test_source_session_layout.py
@@ -6,7 +6,7 @@ import pytest
 from tests.factories import SecureDropConfigFactory
 from tests.functional.app_navigators.source_app_nav import SourceAppNavigator
 from tests.functional.conftest import SdServersFixtureResult, spawn_sd_servers
-from tests.functional.pageslayout.utils import list_locales, save_screenshot_and_html
+from tests.functional.pageslayout.utils import list_locales, save_static_data
 
 # Very short session expiration time
 SESSION_EXPIRATION_SECONDS = 3
@@ -64,4 +64,4 @@ class TestSourceAppSessionTimeout:
                 expected_text = "You were logged out due to inactivity."
                 assert expected_text in notification.text
 
-            save_screenshot_and_html(navigator.driver, locale, "source-session_timeout")
+            save_static_data(navigator.driver, locale, "source-session_timeout")

--- a/securedrop/tests/functional/pageslayout/test_source_static_pages.py
+++ b/securedrop/tests/functional/pageslayout/test_source_static_pages.py
@@ -1,7 +1,7 @@
 import pytest
 import requests
 from tests.functional import tor_utils
-from tests.functional.pageslayout.utils import list_locales, save_screenshot_and_html
+from tests.functional.pageslayout.utils import list_locales, save_static_data
 from tests.functional.web_drivers import WebDriverTypeEnum, get_web_driver
 from version import __version__
 
@@ -24,7 +24,7 @@ class TestSourceAppStaticPages:
             message = tor_browser_web_driver.find_element_by_id("page-not-found")
             assert message.is_displayed()
 
-            save_screenshot_and_html(tor_browser_web_driver, locale, "source-notfound")
+            save_static_data(tor_browser_web_driver, locale, "source-notfound")
 
     @pytest.mark.parametrize("locale", list_locales())
     def test_static_pages(self, locale, sd_servers):
@@ -36,13 +36,13 @@ class TestSourceAppStaticPages:
         ) as tor_browser_web_driver:
             # The user can browse to some of the app's static pages
             tor_browser_web_driver.get(f"{sd_servers.source_app_base_url}/use-tor")
-            save_screenshot_and_html(tor_browser_web_driver, locale, "source-use_tor_browser")
+            save_static_data(tor_browser_web_driver, locale, "source-use_tor_browser")
 
             tor_browser_web_driver.get(f"{sd_servers.source_app_base_url}/tor2web-warning")
-            save_screenshot_and_html(tor_browser_web_driver, locale, "source-tor2web_warning")
+            save_static_data(tor_browser_web_driver, locale, "source-tor2web_warning")
 
             tor_browser_web_driver.get(f"{sd_servers.source_app_base_url}/why-public-key")
-            save_screenshot_and_html(tor_browser_web_driver, locale, "source-why_journalist_key")
+            save_static_data(tor_browser_web_driver, locale, "source-why_journalist_key")
 
     def test_instance_metadata(self, sd_servers):
         # Given a source app, when fetching the instance's metadata

--- a/securedrop/tests/functional/pageslayout/test_submit_and_retrieve_file.py
+++ b/securedrop/tests/functional/pageslayout/test_submit_and_retrieve_file.py
@@ -3,7 +3,7 @@ from encryption import EncryptionManager
 from selenium.common.exceptions import NoSuchElementException
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
 from tests.functional.app_navigators.source_app_nav import SourceAppNavigator
-from tests.functional.pageslayout.utils import list_locales, save_screenshot_and_html
+from tests.functional.pageslayout.utils import list_locales, save_static_data
 
 
 @pytest.mark.parametrize("locale", list_locales())
@@ -64,11 +64,11 @@ class TestSubmitAndRetrieveFile:
         source_app_nav.source_visits_source_homepage()
         source_app_nav.source_chooses_to_login()
         source_app_nav.source_proceeds_to_login(codename=source_codename)
-        save_screenshot_and_html(source_app_nav.driver, locale, "source-checks_for_reply")
+        save_static_data(source_app_nav.driver, locale, "source-checks_for_reply")
 
         # When they delete the journalist's reply, it succeeds
         self._source_deletes_journalist_reply(source_app_nav)
-        save_screenshot_and_html(source_app_nav.driver, locale, "source-deletes_reply")
+        save_static_data(source_app_nav.driver, locale, "source-deletes_reply")
 
     @staticmethod
     def _source_deletes_journalist_reply(navigator: SourceAppNavigator) -> None:

--- a/securedrop/tests/functional/pageslayout/utils.py
+++ b/securedrop/tests/functional/pageslayout/utils.py
@@ -10,7 +10,8 @@ _SCREENSHOTS_DIR = (Path(__file__).parent / "screenshots").absolute()
 _HTML_DIR = (Path(__file__).parent / "html").absolute()
 
 
-def save_screenshot_and_html(driver: WebDriver, locale: str, test_name: str) -> None:
+def save_static_data(driver: WebDriver, locale: str, test_name: str) -> None:
+    """Save a screenshot and a copy of the static HTML."""
     # Save a screenshot
     locale_screenshot_dir = _SCREENSHOTS_DIR / locale
     locale_screenshot_dir.mkdir(parents=True, exist_ok=True)

--- a/securedrop/tests/functional/pageslayout/utils.py
+++ b/securedrop/tests/functional/pageslayout/utils.py
@@ -5,13 +5,14 @@ from typing import List
 
 from PIL import Image
 from selenium.webdriver.firefox.webdriver import WebDriver
+from tests.functional.pageslayout.accessibility import sniff_accessibility_issues
 
 _SCREENSHOTS_DIR = (Path(__file__).parent / "screenshots").absolute()
 _HTML_DIR = (Path(__file__).parent / "html").absolute()
 
 
 def save_static_data(driver: WebDriver, locale: str, test_name: str) -> None:
-    """Save a screenshot and a copy of the static HTML."""
+    """Save a screenshot, a copy of the static HTML, and the output of accessibility sniffs."""
     # Save a screenshot
     locale_screenshot_dir = _SCREENSHOTS_DIR / locale
     locale_screenshot_dir.mkdir(parents=True, exist_ok=True)
@@ -26,6 +27,8 @@ def save_static_data(driver: WebDriver, locale: str, test_name: str) -> None:
 
     html = driver.page_source
     (locale_html_dir / f"{test_name}.html").write_text(html)
+
+    sniff_accessibility_issues(driver, locale, test_name)
 
 
 def _autocrop_btm(img, bottom_padding=12):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This commit follows the structure of the current pageslayout tests by collecting info in the `save_screenshot_and_html` function, with the intent that it will later be consumed in the appropriate context. Presumably, a new make target similar to `validate-test-html` will be added, or this target will be updated.

- Fixes #6314.
- Closes freedomofpress/securedrop-docs#245.

### Notes for Reviewers

As previously discussed with @cfm, this commit adds code in Dockerfiles to install software from from `npm` ([context](https://github.com/freedomofpress/securedrop/issues/6314#issuecomment-1409572032)). This toolchain is new to the project.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

`make test TESTFILES=tests/functional/pageslayout` will exercise all of the changes to the test suite. A summary of the results can be seen with `make accessibility-summary`, which will process raw output into a summary file and open it in `less`. Full output can be found at `tests/functional/pageslayout/accessibility-info/`. The directory structure is similar to that of `tests/functional/pageslayout/html`, but after the locale there are 2 separate directories, `errors` and `reviews`, with the corresponding output saved to files using the `test_name` parameter.

The summary file reports when the sniff output differs by locale (this is only approximate but I believe it to be reasonably accurate, see the implementation of `summarize_accessibility_results` for details) . Currently, there are no differences by locale. I exercised this code path by manually editing the text files created in the `make test` invocation to simulate differences. Just delete any line starting with MessageType in any file to see this in action.

## Deployment

N/A

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

N/A

### If you made changes to the system configuration:

N/A

### If you added or removed a file deployed with the application:

N/A

### If you made non-trivial code changes:

Test suite question is N/A, this is a change to the test suite itself.

Choose one of the following:

Based on the link to freedomofpress/securedrop-docs#245 added by @cfm, it looks like there does need to be a doc update here?

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [x] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a production code dependency:

I previously listed this as N/A because the dependency is not "production" in the sense that it does not need to be deployed to users, is that understanding accurate?
