### PR TITLE
Reset user 2fa only after entering verification code

### DIFF
--- a/securedrop/journalist_app/account.py
+++ b/securedrop/journalist_app/account.py
@@ -14,7 +14,6 @@ from journalist_app.utils import (
 from passphrases import PassphraseGenerator
 from two_factor import OtpTokenInvalid, random_base32
 
-
 _NEW_OTP_IS_TOTP = "new_otp_is_totp"
 _NEW_OTP_SECRET = "new_otp_secret"
 

--- a/securedrop/journalist_app/admin.py
+++ b/securedrop/journalist_app/admin.py
@@ -33,7 +33,6 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 from two_factor import OtpTokenInvalid, random_base32
 
-
 _ADMIN_NEW_OTP_IS_TOTP = "admin_new_otp_is_totp"
 _ADMIN_NEW_OTP_SECRET = "admin_new_otp_secret"
 

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -578,6 +578,10 @@ class Journalist(db.Model):
     def regenerate_totp_shared_secret(self) -> None:
         self.otp_secret = two_factor.random_base32()
 
+    def set_totp_secret(self, otp_secret: str) -> None:
+        self.is_totp = True
+        self.otp_secret = otp_secret
+
     def set_hotp_secret(self, otp_secret: str) -> None:
         self.otp_secret = base64.b32encode(binascii.unhexlify(otp_secret.replace(" ", ""))).decode(
             "ascii"

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -169,19 +169,6 @@ ready(function() {
     filter_codenames(filterInput.value);
   }
 
-  // Confirm before resetting multifactor authentication on edit user page
-  let resetTwoFactorForms = document.querySelectorAll('form.reset-two-factor');
-  for (let i = 0; i < resetTwoFactorForms.length; i++) {
-    resetTwoFactorForms[i].addEventListener('submit', function(evt) {
-      let username = this.dataset.username;
-      let confirmed = confirm(get_string("reset-user-mfa-confirm-string").supplant({ username: username }));
-      if (!confirmed) {
-        evt.preventDefault();
-      }
-      return confirmed;
-    });
-  }
-
   // make show password checkbox visible if javascript enabled
   show('.show-password-checkbox-container');
 

--- a/securedrop/tests/functional/pageslayout/test_journalist_account.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_account.py
@@ -95,9 +95,6 @@ class TestJournalistLayoutAccount:
 
         reset_form.submit()
 
-        alert = journ_app_nav.driver.switch_to_alert()
-        alert.accept()
-
     def test_account_new_two_factor_totp(
         self, locale, sd_servers_with_clean_state, firefox_web_driver
     ):

--- a/securedrop/tests/functional/pageslayout/test_journalist_admin.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_admin.py
@@ -15,13 +15,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-import logging
 import time
 from pathlib import Path
-from typing import Callable
 
 import pytest
-from selenium.common.exceptions import TimeoutException
 from selenium.webdriver import ActionChains
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
 from tests.functional.pageslayout.utils import list_locales, save_screenshot_and_html
@@ -80,34 +77,26 @@ class TestAdminLayoutAddAndEditUser:
         save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-admin_edit_hotp_secret")
 
         # Then the admin resets the new journalist's hotp
-        def _admin_visits_reset_2fa_hotp_step() -> None:
-            # 2FA reset buttons show a tooltip with explanatory text on hover.
-            # Also, confirm the text on the tooltip is the correct one.
-            hotp_reset_button = journ_app_nav.driver.find_elements_by_id("reset-two-factor-hotp")[0]
-            hotp_reset_button.location_once_scrolled_into_view
-            ActionChains(journ_app_nav.driver).move_to_element(hotp_reset_button).perform()
+        # 2FA reset buttons show a tooltip with explanatory text on hover.
+        # Also, confirm the text on the tooltip is the correct one.
+        hotp_reset_button = journ_app_nav.driver.find_elements_by_id("reset-two-factor-hotp")[0]
+        hotp_reset_button.location_once_scrolled_into_view
+        ActionChains(journ_app_nav.driver).move_to_element(hotp_reset_button).perform()
 
-            time.sleep(1)
+        time.sleep(1)
 
-            tip_opacity = journ_app_nav.driver.find_elements_by_css_selector(
-                "#button-reset-two-factor-hotp span.tooltip"
-            )[0].value_of_css_property("opacity")
-            tip_text = journ_app_nav.driver.find_elements_by_css_selector(
-                "#button-reset-two-factor-hotp span.tooltip"
-            )[0].text
-            assert tip_opacity == "1"
+        tip_opacity = journ_app_nav.driver.find_elements_by_css_selector(
+            "#button-reset-two-factor-hotp span.tooltip"
+        )[0].value_of_css_property("opacity")
+        tip_text = journ_app_nav.driver.find_elements_by_css_selector(
+            "#button-reset-two-factor-hotp span.tooltip"
+        )[0].text
+        assert tip_opacity == "1"
 
-            if not journ_app_nav.accept_languages:
-                assert (
-                    tip_text == "Reset two-factor authentication for security keys, like a YubiKey"
-                )
+        if not journ_app_nav.accept_languages:
+            assert tip_text == "Reset two-factor authentication for security keys, like a YubiKey"
 
-            journ_app_nav.nav_helper.safe_click_by_id("button-reset-two-factor-hotp")
-
-        # Run the above step in a retry loop
-        self._retry_2fa_pop_ups(
-            journ_app_nav, _admin_visits_reset_2fa_hotp_step, "reset-two-factor-hotp"
-        )
+        journ_app_nav.nav_helper.safe_click_by_id("button-reset-two-factor-hotp")
 
         # Wait for it to succeed
         journ_app_nav.nav_helper.wait_for(
@@ -151,71 +140,35 @@ class TestAdminLayoutAddAndEditUser:
         # Then the admin resets the second journalist's totp
         journ_app_nav.admin_visits_user_edit_page(username_of_journalist_to_edit=new_user_username)
 
-        def _admin_visits_reset_2fa_totp_step() -> None:
-            totp_reset_button = journ_app_nav.driver.find_elements_by_id("reset-two-factor-totp")[0]
-            assert "/admin/reset-2fa-totp" in totp_reset_button.get_attribute("action")
-            # 2FA reset buttons show a tooltip with explanatory text on hover.
-            # Also, confirm the text on the tooltip is the correct one.
-            totp_reset_button = journ_app_nav.driver.find_elements_by_css_selector(
-                "#button-reset-two-factor-totp"
-            )[0]
-            totp_reset_button.location_once_scrolled_into_view
-            ActionChains(journ_app_nav.driver).move_to_element(totp_reset_button).perform()
+        totp_reset_button = journ_app_nav.driver.find_elements_by_id("reset-two-factor-totp")[0]
+        assert "/admin/reset-2fa-totp" in totp_reset_button.get_attribute("action")
+        # 2FA reset buttons show a tooltip with explanatory text on hover.
+        # Also, confirm the text on the tooltip is the correct one.
+        totp_reset_button = journ_app_nav.driver.find_elements_by_css_selector(
+            "#button-reset-two-factor-totp"
+        )[0]
+        totp_reset_button.location_once_scrolled_into_view
+        ActionChains(journ_app_nav.driver).move_to_element(totp_reset_button).perform()
 
-            time.sleep(1)
+        time.sleep(1)
 
-            tip_opacity = journ_app_nav.driver.find_elements_by_css_selector(
-                "#button-reset-two-factor-totp span.tooltip"
-            )[0].value_of_css_property("opacity")
-            tip_text = journ_app_nav.driver.find_elements_by_css_selector(
-                "#button-reset-two-factor-totp span.tooltip"
-            )[0].text
+        tip_opacity = journ_app_nav.driver.find_elements_by_css_selector(
+            "#button-reset-two-factor-totp span.tooltip"
+        )[0].value_of_css_property("opacity")
+        tip_text = journ_app_nav.driver.find_elements_by_css_selector(
+            "#button-reset-two-factor-totp span.tooltip"
+        )[0].text
 
-            assert tip_opacity == "1"
-            if not journ_app_nav.accept_languages:
-                expected_text = "Reset two-factor authentication for mobile apps, such as FreeOTP"
-                assert tip_text == expected_text
+        assert tip_opacity == "1"
+        if not journ_app_nav.accept_languages:
+            expected_text = "Reset two-factor authentication for mobile apps, such as FreeOTP"
+            assert tip_text == expected_text
 
-            journ_app_nav.nav_helper.safe_click_by_id("button-reset-two-factor-totp")
-
-        # Run the above step in a retry loop
-        self._retry_2fa_pop_ups(
-            journ_app_nav, _admin_visits_reset_2fa_totp_step, "reset-two-factor-totp"
-        )
+        journ_app_nav.nav_helper.safe_click_by_id("button-reset-two-factor-totp")
 
         # Then it succeeds
         # Take a screenshot
         save_screenshot_and_html(journ_app_nav.driver, locale, "journalist-admin_edit_totp_secret")
-
-    @staticmethod
-    def _retry_2fa_pop_ups(
-        journ_app_nav: JournalistAppNavigator, navigation_step: Callable, button_to_click: str
-    ) -> None:
-        """Clicking on Selenium alerts can be flaky. We need to retry them if they timeout."""
-        for i in range(15):
-            try:
-                try:
-                    # This is the button we click to trigger the alert.
-                    journ_app_nav.nav_helper.wait_for(
-                        lambda: journ_app_nav.driver.find_elements_by_id(button_to_click)[0]
-                    )
-                except IndexError:
-                    # If the button isn't there, then the alert is up from the last
-                    # time we attempted to run this test. Switch to it and accept it.
-                    journ_app_nav.nav_helper.alert_wait()
-                    journ_app_nav.nav_helper.alert_accept()
-                    break
-
-                # The alert isn't up. Run the rest of the logic.
-                navigation_step()
-
-                journ_app_nav.nav_helper.alert_wait()
-                journ_app_nav.nav_helper.alert_accept()
-                break
-            except TimeoutException:
-                # Selenium has failed to click, and the confirmation
-                # alert didn't happen. We'll try again.
-                logging.info("Selenium has failed to click; retrying.")
 
 
 @pytest.mark.parametrize("locale", list_locales())


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #5237.

Changes proposed in this pull request:
* Reset user 2fa only after entering verification code

As discussed in #5237, this change stores the `otp_secret` and `is_totp` in the Flask session and only commits it to the Journalist user once a valid verification token is entered.

This is a somewhat hacky solution which stages the Journalist `otp_secret` and `is_totp` and rolls them back if the verification token entered is not valid. This is done because [many of the OTP methods](https://github.com/freedomofpress/securedrop/blob/develop/securedrop/models.py#L578-L643) are tightly coupled with the `Journalist` user model.

One way to tackle this would be to move those methods into the new [two_factor.py](https://github.com/freedomofpress/securedrop/blob/develop/securedrop/two_factor.py) file. Happy to take a look at that refactoring if it makes sense but I wanted to get your thoughts!

## Testing

### Unit tests
Unit tests have been added to cover the following cases:
* User resets own TOTP secret
  * Secret was changed successfully
  * Secret was unchanged because of invalid verification token
* User resets own HOTP secret
  * Secret was changed successfully
  * Secret was unchanged because of invalid verification token
* Admin resets user's TOTP secret
  * Secret was changed successfully
  * Secret was unchanged because of invalid verification token
* Admin resets user's HOTP secret
  * Secret was changed successfully
  * Secret was unchanged because of invalid verification token

Each of these cases can be spot tested manually by performing the following steps:
1. Log in as user/admin
2. Reset user's TOTP/HOTP
2a. If you log out at this point, you should be able to log back in using a token generated using the old secret
3. Enter correct/incorrect verification token
4. Log out
5. Log back in using a token generated using the old/new secret depending on (3)

## Deployment

No special considerations

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation (Reviewed the [documentation](https://github.com/freedomofpress/securedrop-docs/blob/5b255edf9899c43491ec8c0dc8a72da535e47f43/docs/journalist.rst#reset-passphrase-or-two-factor-authentication-credentials) for resetting 2fa and did not see any instructions that need updating)

### If you added or updated a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/requirements.in`

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
