### PR TITLE
update builder image to version tagged 2023_02_22

### DIFF
--- a/molecule/builder-focal/dh-virtualenv.pref
+++ b/molecule/builder-focal/dh-virtualenv.pref
@@ -3,9 +3,9 @@ Pin: release a=focal
 Pin-Priority: 500
 
 Package: dh-virtualenv libjs-sphinxdoc sphinx-rtd-theme-common
-Pin: release a=impish
+Pin: release a=jammy
 Pin-Priority: 700
 
 Package: *
-Pin: release a=impish
+Pin: release a=jammy
 Pin-Priority: 1

--- a/molecule/builder-focal/image_hash
+++ b/molecule/builder-focal/image_hash
@@ -1,2 +1,2 @@
-# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2022_12_07
-0cf762a1c96b6b33d2cded24e29552933ec5be81b80a7ec94fbf4e2fda9d9b77
+# sha256 digest quay.io/freedomofpress/sd-docker-builder-focal:2023_02_22
+5c684ede91c2227f59f6f8393dcdcbec8616b13e62eaddfcdaca8c42bda7f668


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Towards #6749 .

Updates builder image to version tagged 2023_02_22.

## Testing

- [x] CI is passing
- [x] `make build-debs` passes locally.