### PR TITLE
Clarify Developer Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Ensure you have Docker installed and:
 make dev
 ```
 
-This will start the source interface on `127.0.0.1:8080` and the journalist interface on `127.0.0.1:8081`. The credentials to login are printed in the Terminal.
+This will start the source interface on `127.0.0.1:8080` and the journalist interface on `127.0.0.1:8081`. The credentials to login are printed in the Terminal. To login to the journalist interface, you must also [generate a two-factor code](https://developers.securedrop.org/en/latest/setup_development.html#using-the-docker-environment).
 
 ## License
 


### PR DESCRIPTION
Added a link to instructions for generating a two-factor code.

## Status

Ready for review.

## Description of Changes

Previously, the instructions implied that all the information needed to login to the journalist interface was present in the Terminal. Now, the instructions clarify that the otp_secret must be used to generate 2FA codes. 

## Testing

N/A

## Deployment

N/A

## Checklist

N/A