### PR TITLE
Replace Cross-Origin-Resource-Policy: 'same-site' with 'same-origin'

### DIFF
--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/journalist.conf
@@ -29,7 +29,7 @@ Header always set Cross-Origin-Opener-Policy "same-origin"
 Header onsuccess unset Cross-Origin-Embedder-Policy
 Header always set Cross-Origin-Embedder-Policy "same-origin"
 Header onsuccess unset Cross-Origin-Resource-Policy
-Header always set Cross-Origin-Resource-Policy "same-site"
+Header always set Cross-Origin-Resource-Policy "same-origin"
 
 Header onsuccess unset X-Content-Type-Options
 Header always set X-Content-Type-Options "nosniff"

--- a/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
+++ b/install_files/ansible-base/roles/app/templates/sites-available/focal/source.conf
@@ -48,7 +48,7 @@ Header always set Cross-Origin-Opener-Policy "same-origin"
 Header onsuccess unset Cross-Origin-Embedder-Policy
 Header always set Cross-Origin-Embedder-Policy "same-origin"
 Header onsuccess unset Cross-Origin-Resource-Policy
-Header always set Cross-Origin-Resource-Policy "same-site"
+Header always set Cross-Origin-Resource-Policy "same-origin"
 
 # Set a strict CSP; "default-src 'self'" prevents 3rd party subresources from
 # loading and prevents inline script from executing.

--- a/molecule/testinfra/vars/app-qubes-staging.yml
+++ b/molecule/testinfra/vars/app-qubes-staging.yml
@@ -5,7 +5,7 @@ wanted_apache_headers:
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
   Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Embedder-Policy: "same-origin"
-  Cross-Origin-Resource-Policy: "same-site"
+  Cross-Origin-Resource-Policy: "same-origin"
 
 
 securedrop_venv: /opt/venvs/securedrop-app-code

--- a/molecule/testinfra/vars/app-staging.yml
+++ b/molecule/testinfra/vars/app-staging.yml
@@ -5,7 +5,7 @@ wanted_apache_headers:
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
   Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Embedder-Policy: "same-origin"
-  Cross-Origin-Resource-Policy: "same-site"
+  Cross-Origin-Resource-Policy: "same-origin"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: /opt/venvs/securedrop-app-code/bin

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -5,7 +5,7 @@ wanted_apache_headers:
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
   Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Embedder-Policy: "same-origin"
-  Cross-Origin-Resource-Policy: "same-site"
+  Cross-Origin-Resource-Policy: "same-origin"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -5,7 +5,7 @@ wanted_apache_headers:
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
   Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Embedder-Policy: "same-origin"
-  Cross-Origin-Resource-Policy: "same-site"
+  Cross-Origin-Resource-Policy: "same-origin"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -5,7 +5,7 @@ wanted_apache_headers:
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
   Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Embedder-Policy: "same-origin"
-  Cross-Origin-Resource-Policy: "same-site"
+  Cross-Origin-Resource-Policy: "same-origin"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: "/opt/venvs/securedrop-app-code/bin"

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -5,7 +5,7 @@ wanted_apache_headers:
   Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-ancestors 'none';"
   Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Embedder-Policy: "same-origin"
-  Cross-Origin-Resource-Policy: "same-site"
+  Cross-Origin-Resource-Policy: "same-origin"
 
 securedrop_venv: /opt/venvs/securedrop-app-code
 securedrop_venv_bin: /opt/venvs/securedrop-app-code/bin

--- a/securedrop/debian/securedrop-app-code.postinst
+++ b/securedrop/debian/securedrop-app-code.postinst
@@ -165,7 +165,7 @@ update_apache2_headers(){
             sed -i '/^Header always set Cross-Origin-Opener-Policy .*/a Header onsuccess unset Cross-Origin-Embedder-Policy\nHeader always set Cross-Origin-Embedder-Policy "same-origin"' "$1"
         fi
         if ! grep -qP '^Header onsuccess unset Cross-Origin-Resource-Policy' "$1"; then
-            sed -i '/^Header always set Cross-Origin-Embedder-Policy .*/a Header onsuccess unset Cross-Origin-Resource-Policy\nHeader always set Cross-Origin-Resource-Policy "same-site"' "$1"
+            sed -i '/^Header always set Cross-Origin-Embedder-Policy .*/a Header onsuccess unset Cross-Origin-Resource-Policy\nHeader always set Cross-Origin-Resource-Policy "same-origin"' "$1"
         fi
 }
 

--- a/securedrop/debian/securedrop-app-code.postinst
+++ b/securedrop/debian/securedrop-app-code.postinst
@@ -167,6 +167,9 @@ update_apache2_headers(){
         if ! grep -qP '^Header onsuccess unset Cross-Origin-Resource-Policy' "$1"; then
             sed -i '/^Header always set Cross-Origin-Embedder-Policy .*/a Header onsuccess unset Cross-Origin-Resource-Policy\nHeader always set Cross-Origin-Resource-Policy "same-origin"' "$1"
         fi
+
+    # Update Cross-Origin-Resource-Policy header if already present (see #6768)
+    sed -i 's/^Header always set Cross-Origin-Resource-Policy "same-site"/Header always set Cross-Origin-Resource-Policy "same-origin"/g' "$1"
 }
 
 


### PR DESCRIPTION
The configuration is recommended by the official Mozilla documentation that has a warning that inform that same-site is considered less secure than an origin. https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy

![Screenshot 2023-03-14 at 00-03-15 Cross-Origin Resource Policy (CORP) - HTTP MDN](https://user-images.githubusercontent.com/217034/224851633-3f91143c-9896-4b5c-add0-63e71c78d72d.png)

------------

## Test plan: 
- [x] CI is happy, and:

**Clean install**
- [ ] Check out this branch, `make build-debs`, `make staging`. 
- [ ] Installation completes successfully, and `/etc/apache2/sites-available/{source,journalist}.conf` are provisioned as in this PR

**Upgrade testing**
- [x] Provision staging servers (VMs OK) against tip of develop
- [x] Inspect `/etc/apache2/sites-available/{source,journalist}.conf` and notice a Cross-Origin Resource Policy of "same-site"
- [ ] Check out this branch, and run `make build-debs`. Copy the securedrop-app-code package you built to the app server (`scp $PATH_TO_YOUR_SECUREDROP_ROOT_DIR/build/focal/securedrop-app-code_2.6.0~rc1+focal_amd64.deb sdadmin@<app.server.ip.address>:`). 
- [ ] Install the .deb using dpkg, and inspect the apache2 config files again. Observe a Cross-Origin Resoure Policy of "same-origin"
