### PR TITLE
feat(`translate_messages`): filter and disable fuzzy translations

### DIFF
--- a/securedrop/i18n_tool.py
+++ b/securedrop/i18n_tool.py
@@ -104,9 +104,19 @@ class I18NTool:
                 for translation in glob.iglob(tglob):
                     subprocess.check_call(
                         [
+                            "msgattrib",
+                            "--no-fuzzy",
+                            "--output-file",
+                            translation,
+                            translation,
+                        ]
+                    )
+                    subprocess.check_call(
+                        [
                             "msgmerge",
                             "--previous",
                             "--update",
+                            "--no-fuzzy-matching",
                             "--no-wrap",
                             translation,
                             messages_file,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #6483:  `msgattrib --no-fuzzy` removes fuzzy entries from each translation catalog.  `msgmerge --no-fuzzy-matching` prevents fuzzy entries from being added back when the translation catalog is updated from the template.


## Testing

1. Check out this branch.
2. Run `make translate`.
3. [x] For some language `$LANG`, confirm that in `securedrop/translations/$LANG/LC_MESSAGES/messages.po` each `msgid` marked `fuzzy` has had its `msgstr` cleared.  For example, compare:
    - `git diff securedrop/translations/ar/LC_MESSAGES/messages.po | grep -A3 "fuzzy"`
    - https://weblate.securedrop.org/translate/securedrop/securedrop/ar/?q=state%3Aneeds-editing&offset=1  (Weblate marks `fuzzy` entries as "needs editing")

You'll see a lot of other diffs, too, from strings that have changed in `develop` since the v2.5.0 localization cycle.  You can ignore these.

## Deployment

Development-only change; no deployment considerations.