### PR TITLE
Updated mod-wsgi from 4.6.7 to 4.9.4

### DIFF
--- a/securedrop/requirements/python3/requirements.in
+++ b/securedrop/requirements/python3/requirements.in
@@ -12,7 +12,7 @@ Flask-WTF>=1.0.0
 Flask>=2.0.3,<2.1.0
 Jinja2>=3.0.0
 markupsafe>=2.0
-mod_wsgi
+mod_wsgi>=4.9.3
 pretty-bad-protocol>=3.1.1
 psutil>=5.6.6
 qrcode

--- a/securedrop/requirements/python3/requirements.txt
+++ b/securedrop/requirements/python3/requirements.txt
@@ -208,8 +208,8 @@ markupsafe==2.1.2 \
     #   mako
     #   werkzeug
     #   wtforms
-mod-wsgi==4.6.7 \
-    --hash=sha256:b788abaf0b903a64a7bb8dae609f2e4790c87e6f3d716aa6bc97936410fcbfcc
+mod-wsgi==4.9.4 \
+    --hash=sha256:8e762662ea5b01afc386bbcfbaa079748eb6203ab1d6d3a3dac9237f5666cfc9
     # via -r requirements/python3/requirements.in
 pretty-bad-protocol==3.1.1 \
     --hash=sha256:fb73797eb6344e3680c919e2af367f9a019ee7c189d3ed7f5d843edde911f73b


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updates `mod_wsgi` from 4.6.7 to 4.9.4, addressing the X-Client-IP issue  described in https://modwsgi.readthedocs.io/en/latest/release-notes/version-4.9.3.html. 



## Testing

- [ ] CI is passing
- [ ] `make safety` is passing locally.

## Deployment

 n/a

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/requirements.in`

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [x] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki): https://github.com/freedomofpress/securedrop-builder/wiki/mod_wsgi-4.6.7-to-4.9.4
- [ ] I would like someone else to do the diff review
