### PR TITLE
ci(slack-fail-post-step): skip notifications from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,12 @@ orbs:
 
 slack-fail-post-step: &slack-fail-post-step
   post-steps:
+    - run:
+        name: Slack - Skip from Forks
+        command: |
+          if [ -z "$SLACK_ACCESS_TOKEN" ]; then
+            circleci-agent step halt
+          fi
     - slack/notify:
         channel: C01EY9C1X45
         event: fail


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6777 by making the `post-steps` provided by the Slack orb conditional on having a `$SLACK_ACCESS_TOKEN` from the CircleCI environment.

Thanks to @nabla-c0d3 (and CircleCI support) for troubleshooting in <https://github.com/freedomofpress/securedrop/pull/6764#issuecomment-1497124923>.

## Testing

- [x] CI passes:
    - [x] in `freedomofpress/securedrop`: https://app.circleci.com/pipelines/github/freedomofpress/securedrop/5664/workflows/760ce89a-bec8-4557-b09a-b5569b814b9e
    - [x] from my fork `cfm/securedrop`: https://app.circleci.com/pipelines/github/freedomofpress/securedrop/5663/workflows/e33fb989-d166-4be9-bbda-a687f937c98c
        - compare to previous: https://app.circleci.com/pipelines/github/freedomofpress/securedrop/5637/workflows/e9c890de-b5d8-4672-9608-921dc58f2237

## Deployment

CI-only.