### PR TITLE
Ensure the ubuntu-advantage-tools package is not installed on servers.

### DIFF
--- a/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
+++ b/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
@@ -50,6 +50,14 @@
   tags:
     - apt
 
+- name: Remove Ubuntu Advantage
+  apt:
+    name: ubuntu-advantage-tools
+    state: absent
+    purge: yes
+  tags:
+    - apt
+
 - name: Ensure dist-upgrade before SecureDrop install
   apt:
     upgrade: dist


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6773.

Enforces the removal of the `ubuntu-advantage-tools` package, to ensure server metrics are not shared with
3rd parties

## Testing

- perform a prod install  (VMs  are fine) and verify that:
  - [ ] the install succeeds
  - [ ] the `ubuntu-advantage-tools` package is not installed
- install the `ubuntu-advantage-tools` package manually on both servers and rerun the install, verifying that:  
  - [ ] the second install run succeeds
  - [ ] the `ubuntu-advantage-tools` package is removed.