### PR TITLE
Disable Ubuntu Pro's `ua-timer.timer` job; causing OSSEC alerts

### DIFF
--- a/molecule/testinfra/common/test_system_hardening.py
+++ b/molecule/testinfra/common/test_system_hardening.py
@@ -180,3 +180,11 @@ def test_snapd_absent(host):
     assert not host.file("/etc/apparmor.d/usr.lib.snapd.snap-confine.real").exists
     assert not host.file("/usr/bin/snap").exists
     assert not host.file("/var/lib/snapd/snaps").exists
+
+
+def test_ubuntu_pro_disabled(host):
+    with host.sudo():
+        cmd = host.run("systemctl status esm-cache")
+        assert "Loaded: masked" in cmd.stdout
+        cmd = host.run("systemctl is-enabled ua-timer.timer")
+        assert cmd.stdout.strip() == "disabled"

--- a/securedrop/debian/securedrop-config.postinst
+++ b/securedrop/debian/securedrop-config.postinst
@@ -22,6 +22,9 @@ case "$1" in
 
     # Disable fwupd-refresh (#6204)
     systemctl is-enabled fwupd-refresh.timer && systemctl disable fwupd-refresh.timer
+    # And disable Ubuntu Pro's ua-timer and esm-cache (#6773)
+    systemctl is-enabled ua-timer.timer && systemctl disable ua-timer.timer
+    systemctl mask esm-cache
 
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Ubuntu Pro's "uaclient" expects the Linux kernel package to be versioned in a specific format that we are not currently compliant with. This error message is triggering spurious OSSEC alerts.

While we do plan to fix our kernel versioning scheme, we really don't need this Ubuntu Pro stuff, so let's disable it the same way we do with fwupd.

Fixes #6773.

## Testing

* [x] Manually run `sudo systemctl disable ua-timer.timer && sudo systemctl mask esm-cache`
* [x] Manually reboot your server or wait for the nightly reboot
* [x] Wait another 24h, observe that you get no OSSEC notifications related to `failed to process /proc/version_signature`

Note that I did not include the extensive testing plan regarding packages that #6401 had as I think we can trust that the postinst and bash conditional logic is correct since it's the same, just that disabling the timer produces the effect we want.

## Deployment

Any special considerations for deployment? Not really.

## Checklist

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
- [x] I have written a test plan and validated it for this PR
- [ ] These changes do not require documentation
