### PR TITLE
Update redis from 3.5.3 to 4.5.4

### DIFF
--- a/securedrop/requirements/python3/requirements.in
+++ b/securedrop/requirements/python3/requirements.in
@@ -16,7 +16,7 @@ mod_wsgi>=4.9.3
 pretty-bad-protocol>=3.1.1
 psutil>=5.6.6
 qrcode
-redis>=3.3.6
+redis>=4.5.4
 rq>=1.8.1
 setuptools>=56.0.0
 SQLAlchemy>=1.3.0

--- a/securedrop/requirements/python3/requirements.txt
+++ b/securedrop/requirements/python3/requirements.txt
@@ -25,6 +25,10 @@ argon2-cffi==20.1.0 \
     --hash=sha256:d8029b2d3e4b4cea770e9e5a0104dd8fa185c1724a0f01528ae4826a6d25f97d \
     --hash=sha256:da7f0445b71db6d3a72462e04f36544b0de871289b0bc8a7cc87c0f5ec7079fa
     # via -r requirements/python3/requirements.in
+async-timeout==4.0.2 \
+    --hash=sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15 \
+    --hash=sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c
+    # via redis
 babel==2.9.1 \
     --hash=sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9 \
     --hash=sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0
@@ -250,9 +254,9 @@ qrcode==5.3 \
     --hash=sha256:4115ccee832620df16b659d4653568331015c718a754855caf5930805d76924e \
     --hash=sha256:60222a612b83231ed99e6cb36e55311227c395d0d0f62e41bb51ebbb84a9a22b
     # via -r requirements/python3/requirements.in
-redis==3.5.3 \
-    --hash=sha256:0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2 \
-    --hash=sha256:432b788c4530cfe16d8d943a09d40ca6c16149727e4afe8c2c9d5580c59d9f24
+redis==4.5.4 \
+    --hash=sha256:2c19e6767c474f2e85167909061d525ed65bea9301c0770bb151e041b7ac89a2 \
+    --hash=sha256:73ec35da4da267d6847e47f68730fdd5f62e2ca69e3ef5885c6a78a9374c3893
     # via
     #   -r requirements/python3/requirements.in
     #   rq


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updates redis from 3.5.3 to 4.5.4. Two recent CVEs were announced, CVE-2023-28859 and CVE-2023-28858. SecureDrop is not affected based on review, but since its req is laging by a major version it's as good a time as any to update.

## Testing

- [ ] CI is passing, especially safety checks
- [ ] `make safety` passes locally
- [ ] (extra credit) `make test` passes locally
- [ ] (extra extra credit) SI and JI basic functionality is unaffected when run via `make dev`

## Deployment
n/a

## Checklist

### If you added or updated a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/requirements.in`

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [x] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki) 
- [ ] I would like someone else to do the diff review
