### PR TITLE
feat(manage): add `remove-pending-sources` command

### DIFF
--- a/securedrop/loaddata.py
+++ b/securedrop/loaddata.py
@@ -250,7 +250,6 @@ def add_source() -> Tuple[Source, str]:
         source_app_storage=Storage.get_default(),
     )
     source = source_user.get_db_record()
-    source.pending = False
     db.session.commit()
 
     # Generate source key

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -29,6 +29,7 @@ if not os.environ.get("SECUREDROP_ENV"):
 from db import db  # noqa: E402
 from management import SecureDropConfig, app_context  # noqa: E402
 from management.run import run  # noqa: E402
+from management.sources import remove_pending_sources  # noqa: E402
 from management.submissions import (  # noqa: E402
     add_check_db_disconnect_parser,
     add_check_fs_disconnect_parser,
@@ -37,9 +38,6 @@ from management.submissions import (  # noqa: E402
     add_list_db_disconnect_parser,
     add_list_fs_disconnect_parser,
     add_were_there_submissions_today,
-)
-from management.sources import (
-    remove_pending_sources
 )
 from models import FirstOrLastNameError, InvalidUsernameException, Journalist  # noqa: E402
 
@@ -123,8 +121,10 @@ def reset(
 def add_admin(args: argparse.Namespace) -> int:
     return _add_user(is_admin=True)
 
+
 def add_journalist(args: argparse.Namespace) -> int:
     return _add_user()
+
 
 def _get_username() -> str:
     while True:
@@ -356,12 +356,14 @@ def get_args() -> argparse.ArgumentParser:
     delete_user_subp_a = subps.add_parser("delete_user", help="^")
     delete_user_subp_a.set_defaults(func=delete_user)
 
-    remove_pending_sources_subp = subps.add_parser("remove-pending-sources", help="Remove pending sources from the server.")
+    remove_pending_sources_subp = subps.add_parser(
+        "remove-pending-sources", help="Remove pending sources from the server."
+    )
     remove_pending_sources_subp.add_argument(
         "--keep-most-recent",
         default=100,
         type=int,
-        help="how many of the most recent pending sources to keep"
+        help="how many of the most recent pending sources to keep",
     )
     remove_pending_sources_subp.set_defaults(func=remove_pending_sources)
 

--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -38,6 +38,9 @@ from management.submissions import (  # noqa: E402
     add_list_fs_disconnect_parser,
     add_were_there_submissions_today,
 )
+from management.sources import (
+    remove_pending_sources
+)
 from models import FirstOrLastNameError, InvalidUsernameException, Journalist  # noqa: E402
 
 logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s")
@@ -120,10 +123,8 @@ def reset(
 def add_admin(args: argparse.Namespace) -> int:
     return _add_user(is_admin=True)
 
-
 def add_journalist(args: argparse.Namespace) -> int:
     return _add_user()
-
 
 def _get_username() -> str:
     while True:
@@ -354,6 +355,15 @@ def get_args() -> argparse.ArgumentParser:
     delete_user_subp.set_defaults(func=delete_user)
     delete_user_subp_a = subps.add_parser("delete_user", help="^")
     delete_user_subp_a.set_defaults(func=delete_user)
+
+    remove_pending_sources_subp = subps.add_parser("remove-pending-sources", help="Remove pending sources from the server.")
+    remove_pending_sources_subp.add_argument(
+        "--keep-most-recent",
+        default=100,
+        type=int,
+        help="how many of the most recent pending sources to keep"
+    )
+    remove_pending_sources_subp.set_defaults(func=remove_pending_sources)
 
     add_check_db_disconnect_parser(subps)
     add_check_fs_disconnect_parser(subps)

--- a/securedrop/management/sources.py
+++ b/securedrop/management/sources.py
@@ -21,12 +21,18 @@ def remove_pending_sources (args: argparse.Namespace) -> int:
     """
     n = args.keep_most_recent
     sources = find_pending_sources(n)
+    print(f"Found {len(sources)} pending sources")
+
+    deleted = []
     for source in sources:
         try:
             EncryptionManager.get_default().delete_source_key_pair(source.filesystem_id)
         except GpgKeyNotFoundError:
             pass
         delete_pending_source(source)
+        deleted.append(source)
+
+    print(f"Deleted {len(sources)} pending sources")
     return 0
 
 def find_pending_sources(keep_most_recent: int) -> List[Source]:

--- a/securedrop/management/sources.py
+++ b/securedrop/management/sources.py
@@ -1,0 +1,52 @@
+import argparse
+import datetime
+import os
+import sys
+import time
+from argparse import _SubParsersAction
+from typing import List, Optional
+
+from db import db
+from flask.ctx import AppContext
+from management import app_context
+from encryption import EncryptionManager, GpgKeyNotFoundError
+from models import Source
+from rm import secure_delete
+
+
+def remove_pending_sources (args: argparse.Namespace) -> int:
+    """
+    Removes pending source accounts, with the option of keeping
+    the n newest source accounts.
+    """
+    n = args.keep_most_recent
+    sources = find_pending_sources(n)
+    for source in sources:
+        try:
+            EncryptionManager.get_default().delete_source_key_pair(source.filesystem_id)
+        except GpgKeyNotFoundError:
+            pass
+        delete_pending_source(source)
+    return 0
+
+def find_pending_sources(keep_most_recent: int) -> List[Source]:
+    """
+    Finds all sources that are marked as pending
+    """
+    with app_context():
+    	pending_sources = Source.query.filter_by(pending=True).order_by(Source.id.desc()).offset(keep_most_recent).all()
+
+    return pending_sources
+
+def delete_pending_source(source: Source) -> None:
+    """
+    Delete a pending source from the database
+    """
+    if source.pending:
+        with app_context():
+            try:
+                db.session.delete(source)
+                db.session.commit()
+            except Exception as exc:
+                db.session.rollback()
+                print(f"ERROR: Could not remove pending source: {exc}.")

--- a/securedrop/management/sources.py
+++ b/securedrop/management/sources.py
@@ -1,20 +1,13 @@
 import argparse
-import datetime
-import os
-import sys
-import time
-from argparse import _SubParsersAction
-from typing import List, Optional
+from typing import List
 
 from db import db
-from flask.ctx import AppContext
-from management import app_context
 from encryption import EncryptionManager, GpgKeyNotFoundError
+from management import app_context
 from models import Source
-from rm import secure_delete
 
 
-def remove_pending_sources (args: argparse.Namespace) -> int:
+def remove_pending_sources(args: argparse.Namespace) -> int:
     """
     Removes pending source accounts, with the option of keeping
     the n newest source accounts.
@@ -35,14 +28,21 @@ def remove_pending_sources (args: argparse.Namespace) -> int:
     print(f"Deleted {len(sources)} pending sources")
     return 0
 
+
 def find_pending_sources(keep_most_recent: int) -> List[Source]:
     """
     Finds all sources that are marked as pending
     """
     with app_context():
-    	pending_sources = Source.query.filter_by(pending=True).order_by(Source.id.desc()).offset(keep_most_recent).all()
+        pending_sources = (
+            Source.query.filter_by(pending=True)
+            .order_by(Source.id.desc())
+            .offset(keep_most_recent)
+            .all()
+        )
 
     return pending_sources
+
 
 def delete_pending_source(source: Source) -> None:
     """

--- a/securedrop/tests/test_remove_pending_sources.py
+++ b/securedrop/tests/test_remove_pending_sources.py
@@ -1,0 +1,89 @@
+import argparse
+
+import manage
+import pytest
+from models import Source, db
+from passphrases import PassphraseGenerator
+from source_user import create_source_user
+
+
+@pytest.mark.parametrize("n,m", [(10, 5), (7, 0)])
+def test_remove_pending_sources_none_pending(n, m, source_app, config, app_storage):
+    """remove_pending_sources() is a no-op on active sources."""
+
+    # Override the configuration to point at the per-test database.
+    data_root = config.SECUREDROP_DATA_ROOT
+
+    with source_app.app_context():
+        sources = []
+        for i in range(0, n):
+            source_user = create_source_user(
+                db_session=db.session,
+                source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
+                source_app_storage=app_storage,
+            )
+            source = source_user.get_db_record()
+            source.pending = False
+            sources.append(source.id)
+        db.session.commit()
+
+        # Make sure we have n sources.
+        assert db.session.query(Source).count() == n
+
+        # If we're keeping the n most-recent sources, then remove_pending_sources()
+        # shouldn't remove any.
+        args = argparse.Namespace(data_root=data_root, verbose=True, keep_most_recent=n)
+        manage.setup_verbosity(args)
+        manage.remove_pending_sources(args)
+        assert db.session.query(Source).count() == n
+
+        # If we're keeping the m most-recent sources, then remove_pending_sources()
+        # still shouldn't do anything, because none are pending.
+        args = argparse.Namespace(data_root=data_root, verbose=True, keep_most_recent=m)
+        manage.setup_verbosity(args)
+        manage.remove_pending_sources(args)
+        assert db.session.query(Source).count() == n
+
+
+@pytest.mark.parametrize("n,m", [(10, 5), (7, 0)])
+def test_remove_pending_sources_all_pending(n, m, source_app, config, app_storage):
+    """remove_pending_sources() removes all but the most-recent m of n pending sources."""
+    # Override the configuration to point at the per-test database.
+    data_root = config.SECUREDROP_DATA_ROOT
+
+    with source_app.app_context():
+        sources = []
+        for i in range(0, n):
+            source_user = create_source_user(
+                db_session=db.session,
+                source_passphrase=PassphraseGenerator.get_default().generate_passphrase(),
+                source_app_storage=app_storage,
+            )
+            source = source_user.get_db_record()
+            sources.append(source.id)
+        db.session.commit()
+
+        # Make sure we have n sources.
+        assert db.session.query(Source).count() == n
+
+        # If we're keeping the n most-recent sources, then remove_pending_sources()
+        # shouldn't remove any.
+        args = argparse.Namespace(data_root=data_root, verbose=True, keep_most_recent=n)
+        manage.setup_verbosity(args)
+        manage.remove_pending_sources(args)
+        assert db.session.query(Source).count() == n
+
+        # If we're keeping the m most-recent sources, then remove_pending_sources()
+        # should remove n - m.
+        args = argparse.Namespace(data_root=data_root, verbose=True, keep_most_recent=m)
+        manage.setup_verbosity(args)
+        manage.remove_pending_sources(args)
+        assert db.session.query(Source).count() == m
+
+        # Specifically, the first n - m sources should be gone...
+        for source in sources[0 : n - m]:
+            assert db.session.query(Source).get(source) is None
+
+        # ...and only the last m should remain.
+        for source in sources[n - m : n]:
+            assert db.session.query(Source).get(source) is not None


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #6488 by:
1. adding a command `manage.py remove-pending-sources --keep-most-recent=n` to remove all but the most-recent `n` `Source`s (and their keys) with `pending=True`; and
2. correcting `loaddata.add_source()` so that new `Source`s are marked `pending=False` only in `loaddata.record_source_interaction()`.

Co-authored-by: @nathandyer
- who did the heavy lifting in `manage.py` and `securedrop.management.sources`

## Testing

### Against `develop`

In particular, after #6563:

- [ ] CI passes
- [ ] Interactive test cases pass as expected, e.g.:

```sh-session
$ ./loaddata.py --source-count 13  # 2 files+messages per source → pending=False
$ ./manage.py remove-pending-sources --keep-most-recent 10  # remove 0

$ ./loaddata.py --source-count 13 --files-per-source 0 --messages-per-source 0 --replies-per-source 0  # pending=True
$ ./manage.py remove-pending-sources --keep-most-recent 10  # remove 3 of 13

$ ./loaddata.py --source-count 10 --files-per-source 0 --messages-per-source 0 --replies-per-source 0  # pending=True
$ ./manage.py remove-pending-sources  # remove 0 of 10, per default "--keep-most-recent 100"
```

### Against v2.5.2

0. Visually review <https://gist.github.com/nathandyer/bb31b6c9eaed30b078230922f437c189>
    * Suggestion: diff against <https://github.com/freedomofpress/securedrop/blob/2.5.2/securedrop/manage.py
1. Upload `manage-6488.py` to `$HOME` on the Application Server
2. Patch `loaddata.py` per 2ec4613b4788b324e2dde2d35b3cf36710452c5c
4. [ ] Test cases pass as above

## Deployment

<https://gist.github.com/nathandyer/bb31b6c9eaed30b078230922f437c189> can be uploaded directly for testing purposes.  Otherwise, no deployment implications.


## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you added or removed a file deployed with the application:

- [x] I have updated AppArmor rules to include the change

Neither Apache nor Tor is permitted access to `manage.py` and its supporting modules per `securedrop/debian/app-code/etc/apparmor.d`, so the new `securedrop.management.sources` does not need to be added.

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR