### PR TITLE
build(build-debs*): log all output via `script`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,41 +357,57 @@ endif
 #
 ###########
 
+SCRIPT_MESSAGE="You can now examine or commit the log at:"
+SCRIPT_OUTPUT_PREFIX=$(SDROOT)/build/$(shell date +%Y%M%d)
+SCRIPT_OUTPUT_EXT=log
+
 .PHONY: build-debs
+build-debs: OUT:=$(SCRIPT_OUTPUT_PREFIX)-securedrop.$(SCRIPT_OUTPUT_EXT)
 build-debs: ## Build and test SecureDrop Debian packages
 	@echo "Building SecureDrop Debian packages..."
 	@export TERM=dumb
 	@script \
 		--command $(SDROOT)/builder/build-debs.sh \
-		$(SDROOT)/build/$(shell date --iso-8601=seconds)-$@.log
+		$(OUT)
 	@echo
+	@echo "$(SCRIPT_MESSAGE)"
+	@echo "$(OUT)"
 
 .PHONY: build-debs-notest
+build-debs-notest: OUT:=$(SCRIPT_OUTPUT_PREFIX)-securedrop.$(SCRIPT_OUTPUT_EXT)
 build-debs-notest: ## Build SecureDrop Debian packages without running tests.
 	@echo "Building SecureDrop Debian packages, skipping tests..."
 	@export TERM=dumb
 	@NOTEST=1 script \
 		--command $(SDROOT)/builder/build-debs.sh \
-		$(SDROOT)/build/$(shell date --iso-8601=seconds)-$@.log
+		$(OUT)
 	@echo
+	@echo "$(SCRIPT_MESSAGE)"
+	@echo "$(OUT)"
 
 .PHONY: build-debs-ossec
+build-debs-ossec: OUT:=$(SCRIPT_OUTPUT_PREFIX)-securedrop-ossec.$(SCRIPT_OUTPUT_EXT)
 build-debs-ossec: ## Build OSSEC Debian packages
 	@echo "Building OSSEC Debian packages"
 	@export TERM=dumb
 	@WHAT=ossec script \
 		--command $(SDROOT)/builder/build-debs.sh \
-		$(SDROOT)/build/$(shell date --iso-8601=seconds)-$@.log
+		$(OUT)
 	@echo
+	@echo "$(SCRIPT_MESSAGE)"
+	@echo "$(OUT)"
 
 .PHONY: build-debs-ossec-notest
+build-debs-ossec-notest: OUT:=$(SCRIPT_OUTPUT_PREFIX)-securedrop-ossec.$(SCRIPT_OUTPUT_EXT)
 build-debs-ossec-notest: ## Build OSSEC Debian packages without running tests
 	@echo "Building OSSEC Debian packages, skipping tests..."
 	@export TERM=dumb
 	@NOTEST=1 WHAT=ossec script \
 	       --command $(SDROOT)/builder/build-debs.sh \
-	       $(SDROOT)/build/$(shell date --iso-8601=seconds)-$@.log
+	       $(OUT)
 	@echo
+	@echo "$(SCRIPT_MESSAGE)"
+	@echo "$(OUT)"
 
 
 ########################

--- a/Makefile
+++ b/Makefile
@@ -360,25 +360,37 @@ endif
 .PHONY: build-debs
 build-debs: ## Build and test SecureDrop Debian packages
 	@echo "Building SecureDrop Debian packages..."
-	@$(SDROOT)/builder/build-debs.sh
+	@export TERM=dumb
+	@script \
+		--command $(SDROOT)/builder/build-debs.sh \
+		$(SDROOT)/build/$(shell date --iso-8601=seconds)-$@.log
 	@echo
 
 .PHONY: build-debs-notest
 build-debs-notest: ## Build SecureDrop Debian packages without running tests.
 	@echo "Building SecureDrop Debian packages, skipping tests..."
-	@NOTEST=1 $(SDROOT)/builder/build-debs.sh
+	@export TERM=dumb
+	@NOTEST=1 script \
+		--command $(SDROOT)/builder/build-debs.sh \
+		$(SDROOT)/build/$(shell date --iso-8601=seconds)-$@.log
 	@echo
 
 .PHONY: build-debs-ossec
 build-debs-ossec: ## Build OSSEC Debian packages
 	@echo "Building OSSEC Debian packages"
-	@WHAT=ossec $(SDROOT)/builder/build-debs.sh
+	@export TERM=dumb
+	@WHAT=ossec script \
+		--command $(SDROOT)/builder/build-debs.sh \
+		$(SDROOT)/build/$(shell date --iso-8601=seconds)-$@.log
 	@echo
 
 .PHONY: build-debs-ossec-notest
 build-debs-ossec-notest: ## Build OSSEC Debian packages without running tests
 	@echo "Building OSSEC Debian packages, skipping tests..."
-	@NOTEST=1 WHAT=ossec $(SDROOT)/builder/build-debs.sh
+	@export TERM=dumb
+	@NOTEST=1 WHAT=ossec script \
+	       --command $(SDROOT)/builder/build-debs.sh \
+	       $(SDROOT)/build/$(shell date --iso-8601=seconds)-$@.log
 	@echo
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #6774, wraps all `build-debs.sh` invocations in `script` and displays the filename of the transcript after its conclusion.

This should be easily replicable to `securedrop-builder`.

## Testing

- Run one or more of the `make build-debs*` targets
- `^C` freely
- [ ] A transcript `build/${TIMESTAMP}-${TARGET}.log` is created...
- [ ] ...and is legible

## Deployment

Developer-only; no deployment considerations.

## Checklist


### If you made non-trivial code changes:

Choose one of the following:

- I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- I would appreciate help with the documentation
- [x] These changes do not require documentation

...because they are self-documenting (-prompting), but I will probably document them anyway after merge.  :-)