### PR TITLE
Have unattended-upgrades remove unused dependencies

### DIFF
--- a/securedrop/debian/config/opt/securedrop/50unattended-upgrades
+++ b/securedrop/debian/config/opt/securedrop/50unattended-upgrades
@@ -40,7 +40,7 @@ Unattended-Upgrade::AutoFixInterruptedDpkg "true";
 
 // Do automatic removal of new unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)
-//Unattended-Upgrade::Remove-Unused-Dependencies "false";
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
 
 // Automatically reboot *WITHOUT CONFIRMATION*
 //  if the file /var/run/reboot-required is found after the upgrade


### PR DESCRIPTION
## Status

Ready for review

Towards https://github.com/freedomofpress/securedrop/issues/6762

## Description of Changes

By setting `Unattended-Upgrade::Remove-Unused-Dependencies "true";` unattended-upgrades will remove "unused" dependencies, which are packages that were pulled in as a dependency but no longer have anything depending on them and, in theory, can be safely removed.

The main motivation in the short term is to have this remove old kernel packages (#6762), but this is probably good in the long run too, since it will ensure the package set on older instances is roughly the same as fresh installs.

It's definitely possible we depend on something that is just an implicit dependency and it gets auto removed in the future, but such a bug would have already caused issues for fresh installs and should be caught by our nightly staging tests.

## Testing
On a staging/prod setup:

* [ ] Manually edit `/etc/apt/apt.conf.d/50unattended-upgrades` to set `Unattended-Upgrade::Remove-Unused-Dependencies "true";`
* [ ] Install and immediately remove a package with some dependencies, e.g. `sudo apt install -y emacs-nox && sudo apt purge -y emacs-nox`
* [ ] Run `sudo unattended-upgrades --dry-run -d`, observe that the relevant emacs packages would be removed, e.g. `marking emacs-common for removal`

## Deployment

Any special considerations for deployment? Yes! This can only be released after https://github.com/freedomofpress/securedrop/issues/6789 is released, which has now happened.

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
