### PR TITLE
Updated requests dependency from 2.26.0 to 2.31.0

### DIFF
--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -34,7 +34,7 @@ pytest>=7.2.0
 pytest-xdist>=3.0.2
 python-vagrant
 pyyaml>=5.4.1
-requests>=2.26.0
+requests>=2.31.0
 ruamel.yaml>=0.16.10
 safety>2.2.0
 semgrep>=0.98.0

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -789,9 +789,9 @@ pyyaml==5.4.1 \
     #   pre-commit
     #   python-gilt
     #   yamllint
-requests==2.26.0 \
-    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
-    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
+requests==2.31.0 \
+    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
+    --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
     # via
     #   -r requirements/python3/develop-requirements.in
     #   cookiecutter

--- a/securedrop/requirements/python3/test-requirements.in
+++ b/securedrop/requirements/python3/test-requirements.in
@@ -13,7 +13,7 @@ pluggy>=0.13.1
 pytest-cov
 pytest-mock
 hypothesis
-requests[socks]>=2.26.0
+requests[socks]>=2.31.0
 setuptools>=56.0.0
 selenium>=3.141.0
 tbselenium>=0.5.2

--- a/securedrop/requirements/python3/test-requirements.txt
+++ b/securedrop/requirements/python3/test-requirements.txt
@@ -291,9 +291,9 @@ pyyaml==5.4.1 \
     --hash=sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6 \
     --hash=sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0
     # via html5validator
-requests[socks]==2.26.0 \
-    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
-    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
+requests[socks]==2.31.0 \
+    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
+    --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
     # via -r requirements/python3/test-requirements.in
 selenium==3.141.0 \
     --hash=sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6820.

Updates requests from 2.26.0 to 2.31.0

## Testing

- [ ] CI is passing
- [ ] Diff review looks good

## Deployment

n/a

## Checklist

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a production code dependency:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [x] I would like someone else to do the diff review
