### PR TITLE
Update path passed to dpkg in builder tests

### DIFF
--- a/builder/tests/test_securedrop_deb_package.py
+++ b/builder/tests/test_securedrop_deb_package.py
@@ -37,7 +37,7 @@ def test_deb_packages_appear_installable(deb: Path) -> None:
 
     # Normally this is called as root, but we can get away with simply
     # adding sbin to the path
-    path = os.getenv("PATH") + ":/usr/sbin"
+    path = os.getenv("PATH") + ":/usr/sbin:/sbin"
     subprocess.check_call(["dpkg", "--install", "--dry-run", deb], env={"PATH": path})
 
 


### PR DESCRIPTION

## Status

Ready for review 

## Description of Changes

Fixes #6822 
Since debian 11, fresh installs symlink /sbin to /usr/sbin, while installs upgraded in place have separate directories. To allow for builds on both, this PR adds /sbin to the path used by dpkg while running builder tests.



## Testing

- [x] CI is passing
- [ ] `make build-debs` is passing locally
- [ ] (optional) If on a system with separate /sbin and /usr/sbin dirs, `make build-debs` is still passing

## Deployment

N/A

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
