### PR TITLE
fix(test_empty_crontabs): s/parameterize/parametrize/

### DIFF
--- a/molecule/testinfra/app/test_appenv.py
+++ b/molecule/testinfra/app/test_appenv.py
@@ -105,7 +105,7 @@ def test_ensure_logo(host):
         assert f.group == "root"
 
 
-@pytest.mark.parameterize("user", ("root", "www-data"))
+@pytest.mark.parametrize("user", ("root", "www-data"))
 def test_empty_crontabs(host, user):
     """Ensure root + www-data crontabs are empty"""
     with host.sudo():


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #6824 by correcting the invocation to pytest's `parametrize` mark.

## Testing

- [x] Confirm `staging-test-with-rebase` has run and passed on this `stg-`-prefixed branch.

## Deployment

No deployment considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
