### PR TITLE
feat: add systemd timer to run "manage.py remove-pending-sources" daily

### DIFF
--- a/securedrop/debian/app-code/lib/systemd/system/securedrop-remove-pending-sources.service
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop-remove-pending-sources.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=job to remove pending SecureDrop sources daily
+
+[Service]
+ExecStart=/var/www/securedrop/manage.py remove-pending-sources
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectSystem=full
+ReadOnlyDirectories=/
+ReadWriteDirectories=/var/lib/securedrop
+User=www-data
+WorkingDirectory=/var/www/securedrop

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop-remove-pending-sources.timer
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop-remove-pending-sources.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=remove pending SecureDrop sources daily
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/securedrop/debian/rules
+++ b/securedrop/debian/rules
@@ -62,12 +62,13 @@ override_dh_gencontrol:
 override_dh_installinit:
 	dh_installinit --noscripts
 
-# We want to enable all systemd units except the two that are run by timers,
-# so we have to mark those two as --no-enable first, then the final
-# `dh_systemd_enable` invocation will enable the rest
+# We want to enable all systemd units except those that are run by timers, so
+# we have to mark those as --no-enable first, then the final
+# `dh_systemd_enable` invocation will enable the rest.
 override_dh_systemd_enable:
 	dh_systemd_enable --no-enable securedrop-submissions-today.service
 	dh_systemd_enable --no-enable securedrop-clean-tmp.service
+	dh_systemd_enable --no-enable securedrop-remove-pending-sources.service
 	dh_systemd_enable
 
 # This is basically the same as the enable stanza above, just whether the
@@ -75,4 +76,5 @@ override_dh_systemd_enable:
 override_dh_systemd_start:
 	dh_systemd_start --no-start securedrop-submissions-today.service
 	dh_systemd_start --no-start securedrop-clean-tmp.service
+	dh_systemd_start --no-start securedrop-remove-pending-sources.service
 	dh_systemd_start


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Closes #6788.

**NB.**  Per <https://github.com/freedomofpress/securedrop/pull/6780#discussion_r1205934851>, we are trusting that well-formed systemd units will Do the Right Thing without specific test cases.


## Testing

1. Install `securedrop-app-code` built via `make build-debs` on this branch into a production or staging installation.
2. Generate more than 100 "pending" sources, e.g.: `loaddata.py --source-count 110 --files-per-source 0 --messages-per-source 0 --replies-per-source 0`
3. Wait for the nightly timers to fire.
4. [ ] Confirm that only 100 "pending" sources remain on the server.
5. ~Check that no OSSEC alert was logged when the `securedrop-remove-pending-sources` timer fired (i.e., its standard output was suppressed).~ (obsoleted by <https://github.com/freedomofpress/securedrop/pull/6826#discussion_r1218565000>)
6. **Bonus:**
    1. Mangle `manage.py remove-pending-sources` so that it will raise an exception.
    2. Repeat steps (2) and (3).
    3. Confirm that an OSSEC alert *was* logged when the `securedrop-remove-pending-sources` timer fired ~(i.e., its standard error was *not* suppressed)~, because OSSEC triggered on a log message containing the string `error`. (clarified per <https://github.com/freedomofpress/securedrop/pull/6826#discussion_r1218565000>)

## Deployment

No deployment considerations, but it's worth documenting this behavior for administrators and flagging it in release notes, as noted below.


## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [x] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- I would appreciate help with the documentation
- These changes do not require documentation