### PR TITLE
return reply-key generation to "/lookup" (revert #6490)

### DIFF
--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Union
 import flask
 import werkzeug
 from db import db
-from encryption import EncryptionManager, GpgKeyNotFoundError
+from encryption import EncryptionManager
 from flask import Markup, abort, current_app, escape, flash, redirect, send_file, url_for
 from flask_babel import gettext, ngettext
 from journalist_app.sessions import session
@@ -397,11 +397,8 @@ def delete_collection(filesystem_id: str) -> None:
     if os.path.exists(path):
         Storage.get_default().move_to_shredder(path)
 
-    # Delete the source's reply keypair, if it exists
-    try:
-        EncryptionManager.get_default().delete_source_key_pair(filesystem_id)
-    except GpgKeyNotFoundError:
-        pass
+    # Delete the source's reply keypair
+    EncryptionManager.get_default().delete_source_key_pair(filesystem_id)
 
     # Delete their entry in the db
     source = get_source(filesystem_id, include_deleted=True)


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6489 .

This PR reverts the changes in #6490, which moved source reply key generation to after the first submission, thereby avoiding an accumulation of pending sources (and keys). Since we have an option to manually and soon automatically purge stale pending sources,  this is no longer required and can be removed to reduce scope/potential for subtle errors due to the change in key generation.

## Testing

- [ ] CI is passing
- [ ] on the SI, when a source is created, a reply key is generated before their first submission
- [ ] Replies work correctly (can be sent, read, deleted in  SI and removed in JI)

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/requirements.in`

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
