### PR TITLE
Update Rust in builder to 1.69.0

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -41,7 +41,7 @@ COPY dh-virtualenv.pref /etc/apt/preferences.d/
 
 RUN apt-get update && apt-get install -y dh-virtualenv
 
-ENV RUST_VERSION 1.58.1
+ENV RUST_VERSION 1.69.0
 ENV RUSTUP_VERSION 1.24.3
 ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
 ENV RUSTUP_HOME /opt/rustup
@@ -58,10 +58,8 @@ RUN TMPDIR=`mktemp -d` && cd ${TMPDIR} \
         && ./rustup-init --default-toolchain=${RUST_VERSION} --profile minimal -y \
         && cd && rm -rf ${TMPDIR}
 ENV PATH "$PATH:/opt/cargo/bin/"
-
-# Warm the cargo index ("empty-library" is reserved by the Rust project)
-# see https://github.com/rust-lang/cargo/issues/10319 and https://github.com/rust-lang/cargo/issues/3377
-RUN cargo install empty-library ||:
+# TODO: Remove after we switch to 1.70.0 when it's enabled by default
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse
 
 # Turn the ossec key into a keyring
 COPY OSSEC-ARCHIVE-KEY.asc /tmp/OSSEC-ARCHIVE-KEY.asc

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -44,18 +44,24 @@ RUN apt-get update && apt-get install -y dh-virtualenv
 ENV RUST_VERSION 1.58.1
 ENV RUSTUP_VERSION 1.24.3
 ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
+ENV RUSTUP_HOME /opt/rustup
+ENV CARGO_HOME /opt/cargo
 
-# Install Rust for building cryptography
+# Install Rust using the same steps as <https://github.com/rust-lang/docker-rust>
+# 1) Download rustup-init and verify it matches hardcoded checksum
+# 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
+# 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
 RUN TMPDIR=`mktemp -d` && cd ${TMPDIR} \
         && curl --proto '=https' --tlsv1.2 -OO -sSf https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init \
         && echo "${RUSTUP_INIT_SHA256} *rustup-init" | sha256sum -c - \
         && chmod +x rustup-init \
         && ./rustup-init --default-toolchain=${RUST_VERSION} --profile minimal -y \
         && cd && rm -rf ${TMPDIR}
+ENV PATH "$PATH:/opt/cargo/bin/"
 
 # Warm the cargo index ("empty-library" is reserved by the Rust project)
 # see https://github.com/rust-lang/cargo/issues/10319 and https://github.com/rust-lang/cargo/issues/3377
-RUN /root/.cargo/bin/cargo install empty-library ||:
+RUN cargo install empty-library ||:
 
 # Turn the ossec key into a keyring
 COPY OSSEC-ARCHIVE-KEY.asc /tmp/OSSEC-ARCHIVE-KEY.asc

--- a/builder/build-debs-securedrop.sh
+++ b/builder/build-debs-securedrop.sh
@@ -16,10 +16,6 @@ pip3 download --no-deps --require-hashes -r requirements/python3/requirements.tx
 rm -f /usr/share/python-wheels/setuptools-*.whl
 mv /tmp/requirements-download/setuptools-*.whl /usr/share/python-wheels/
 
-# Enable Rust
-HOME="/root"
-source "$HOME"/.cargo/env
-
 # Build the package
 dpkg-buildpackage -us -uc
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

First, adjust how Rust is installed in the builder container
    
Install Rust and rustup in slightly more straightforward directories and
unconditionally add it to $PATH instead of weirdly in /root/.cargo.

This setup is partially based on <https://github.com/rust-lang/rustup/issues/1085#issuecomment-296604244>,
which is described as unsupported for multiple users but our containers
are single-user.

The plan is to copy this to the development container as well.

Second, and primarily, update Rust in builder to 1.69.0
    
For the Sequoia work, we're planning to use 1.69.0 so we need to update
the builder to match. This is being done separately since it already
affects a production component (the cryptography wheel) and should be
tested independently.

This also lets us get rid of our index-warming hack since we can use the
new fast sparse protocol instead
(<https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol>).

Refs #6817.

## Testing

How should the reviewer test this PR?

* [x] CI passes, including deb building and staging build
* [x] Build new debs, deploy on a staging/prod instance:
   * [x] Create new journalist, log in as them.

(AFAIK that's the main place we use cryptography on the server)

## Deployment

Any special considerations for deployment? No.

## Checklist

- [ ] These changes do not require documentation
