### PR TITLE
Remove Debian autogenerated conffiles from securedrop-keyring

### DIFF
--- a/securedrop/debian/rules
+++ b/securedrop/debian/rules
@@ -17,6 +17,7 @@ override_dh_installdeb:
 	dh_installdeb
 	echo "" > ${CURDIR}/debian/securedrop-app-code/DEBIAN/conffiles
 	echo "" > ${CURDIR}/debian/securedrop-config/DEBIAN/conffiles
+	echo "" > ${CURDIR}/debian/securedrop-keyring/DEBIAN/conffiles
 
 override_dh_install:
 	# Build translations


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

As we've done in the SDW package, we want the new keyring to be forcibly installed, regardless of any local modifications.

Fixes #6833.

## Testing

This was already tested in https://github.com/freedomofpress/securedrop-builder/pull/452 so not sure we need to do it again, but...

* [ ] Install older keyring package
* [ ] Modify/clobber the keyring file in some way, e.g. `head /dev/random > /etc/apt/trusted.gpg.d/securedrop-keyring.gpg`
* [ ] Run `make build-debs` and install the new keyring package
* [ ] Verify the new key is in place and no .dpkg-dist, .dpkg-old, etc.

## Deployment

Any special considerations for deployment? Not really

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
