### PR TITLE
Suppress safety alert for CVE-2023-30861 in flask

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
                 --ignore 54230 \
                 --ignore 54229 \
                 --ignore 54421 \
+                --ignore 55261 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes
Suppress safety alert for CVE-2023-30861 in flask

We're not affected by this. See <https://github.com/pallets/flask/security/advisories/GHSA-m2qf-hxjv-5gpq> for details.


## Testing

How should the reviewer test this PR?

* [ ] CI passes

## Deployment

Any special considerations for deployment? No

