### PR TITLE
Bump securedrop-keyring version to 0.2.1

### DIFF
--- a/install_files/ansible-base/group_vars/securedrop_application_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_application_server.yml
@@ -6,7 +6,7 @@ ip_info:
 
 ### Used by the install_local_deb_pkgs role ###
 local_deb_packages:
-  - "securedrop-keyring_0.2.0+{{ securedrop_version }}+{{ securedrop_target_distribution }}_all.deb"
+  - "securedrop-keyring_0.2.1+{{ securedrop_version }}+{{ securedrop_target_distribution }}_all.deb"
   - "securedrop-config_{{ securedrop_version }}+{{ securedrop_target_distribution }}_all.deb"
   - "securedrop-ossec-agent_3.6.0+{{ securedrop_version }}+{{ securedrop_target_distribution }}_all.deb"
   - "{{ securedrop_app_code_deb }}.deb"

--- a/install_files/ansible-base/group_vars/securedrop_monitor_server.yml
+++ b/install_files/ansible-base/group_vars/securedrop_monitor_server.yml
@@ -6,7 +6,7 @@ ip_info:
 
 ### Used by the install_local_deb_pkgs role ###
 local_deb_packages:
-  - "securedrop-keyring_0.2.0+{{ securedrop_version }}+{{ securedrop_target_distribution }}_all.deb"
+  - "securedrop-keyring_0.2.1+{{ securedrop_version }}+{{ securedrop_target_distribution }}_all.deb"
   - "securedrop-config_{{ securedrop_version }}+{{ securedrop_target_distribution }}_all.deb"
   - "securedrop-ossec-server_3.6.0+{{ securedrop_version }}+{{ securedrop_target_distribution }}_all.deb"
   - ossec-server_3.6.0+{{ securedrop_target_distribution }}_amd64.deb

--- a/securedrop/debian/rules
+++ b/securedrop/debian/rules
@@ -53,7 +53,7 @@ override_dh_virtualenv:
 override_dh_gencontrol:
 	dh_gencontrol -psecuredrop-ossec-agent -- "-v3.6.0+${DEB_VERSION}"
 	dh_gencontrol -psecuredrop-ossec-server -- "-v3.6.0+${DEB_VERSION}"
-	dh_gencontrol -psecuredrop-keyring -- "-v0.2.0+${DEB_VERSION}"
+	dh_gencontrol -psecuredrop-keyring -- "-v0.2.1+${DEB_VERSION}"
 	dh_gencontrol --remaining-packages
 
 #


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Refs https://github.com/freedomofpress/securedrop/issues/6804, https://github.com/freedomofpress/securedrop/commit/e6a8367972cc1d2ce1a750cd1111ae04cb6776d0
See https://github.com/freedomofpress/securedrop-builder/pull/453

Changes proposed in this pull request:

Bump securedrop-keyring package to 0.2.1. This is to account for the conffiles change #6833, also present on the workstation.

How should the reviewer test this PR? 
Visual review + CI passes

## Deployment

n/a

## Checklist

n/a