### PR TITLE
Fix version script, add exclude for git-url-parse dev dependency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
                 --ignore 54229 \
                 --ignore 54421 \
                 --ignore 55261 \
+                --ignore 58912 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \

--- a/update_version.sh
+++ b/update_version.sh
@@ -49,9 +49,6 @@ sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" securedrop
 # Update the version in the Debian packages
 sed -E -i "s/^(securedrop_version: \").*/\1$NEW_VERSION\"/" install_files/ansible-base/group_vars/all/securedrop
 
-# Update the version in molecule testinfra vars
-sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" molecule/builder-focal/tests/vars.yml
-
 # If version doesn't have an rc designator, it's considered stable.
 # The upgrade testing logic relies on this variable.
 if [[ ! $NEW_VERSION == *~rc* ]]; then


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

- removes reference to a vars config file used in old molecule-based builder
- adds an exclude for giturlparse vuln with ID 58912, as dev-only and no fix yet.


## Testing

- [x] CI is passing.
