### PR TITLE
builder: Disable pip's progress bar

### DIFF
--- a/builder/build-debs-securedrop.sh
+++ b/builder/build-debs-securedrop.sh
@@ -3,6 +3,7 @@
 # Build SecureDrop packages. This runs *inside* the container.
 
 export PIP_DISABLE_PIP_VERSION_CHECK=1
+export PIP_PROGRESS_BAR=off
 
 set -euxo pipefail
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This gets captured in `script`'s output and causes a mess.

## Testing

* [ ] Run `make build-debs`, get to the `pip3 download --no-deps --require-hashes -r requirements/python3/requirements.txt` step, observe no progress bars. Ctrl+C, then look at the generated log file and see that it looks reasonable too.
* [ ] Basically it shouldn't look like:
![Screenshot_2023-06-12_14-01-49](https://github.com/freedomofpress/securedrop/assets/81392/7e015fca-c1a4-45f4-9802-ec6cd6b7fa14)

## Deployment

Any special considerations for deployment? No

## Checklist

- [x] I have written a test plan and validated it for this PR
