### PR TITLE
Ignore target/ folder from `make bandit`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 bandit: test-config ## Run bandit with medium level excluding test-related folders.
 	@command -v bandit || (echo "Please run 'pip install -U bandit'."; exit 1)
 	@echo "███ Running bandit..."
-	@bandit -ll --exclude ./admin/.tox,./admin/.venv,./admin/.eggs,./molecule,./testinfra,./securedrop/tests,./.tox,./.venv*,securedrop/config.py --recursive .
+	@bandit -ll --exclude ./admin/.tox,./admin/.venv,./admin/.eggs,./molecule,./testinfra,./securedrop/tests,./.tox,./.venv*,securedrop/config.py,./target --recursive .
 	@echo "███ Running bandit on securedrop/config.py..."
 	@bandit -ll --skip B108 securedrop/config.py
 	@echo


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

While this is nearly all Rust code, some packages do contain and ship Python code, e.g.:
 ./target/cargo-dev/registry/src/index.crates.io-6f17d22bba15001f/unicode-normalization-0.1.22/scripts/unicode.py

This follows up cc61d8344.

## Testing

* [ ] Start the development environment with `make dev`, wait for it to build the Rust/redwood wheel and then stop it
* [ ] `pip install -U bandit && make bandit`  - see: `Issue: [B310:blacklist] Audit url open for permitted schemes. Allowing use of file:/ or custom schemes is often unexpected.`
* [ ] Check out this patch
* [ ] Re-run `make bandit` - no errors.

## Deployment

Any special considerations for deployment? No

## Checklist

- [x] I have written a test plan and validated it for this PR
