### PR TITLE
Use cargo's sparse index in Rust CI too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,9 @@ jobs:
     # Keep version in sync with rust-toolchain.toml
     docker:
       - image: rust:1.69.0
+    environment:
+      # TODO: Remove after we're on Rust 1.70
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "sparse"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Use cargo's sparse index in Rust CI too

We're using this everywhere else, should shave off a minute or two.

^ It cut runtime nearly in half, from 3:10 to 1:40.

## Testing

* [x] CI passes, and finishes faster than previous jobs.

