### PR TITLE
[2.6.0] fix: `s/Login/Log in/` per translator feedback

### DIFF
--- a/securedrop/journalist_templates/login.html
+++ b/securedrop/journalist_templates/login.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block tab_title %}{{ gettext('Login to access the journalist interface') }}{% endblock %}
+{% block tab_title %}{{ gettext('Log in to access the journalist interface') }}{% endblock %}
 
 {% block body %}
 
-<h1>{{ gettext('Login to access the journalist interface') }}</h1>
+<h1>{{ gettext('Log in to access the journalist interface') }}</h1>
 
 <form method="post" action="/login" autocomplete="off" class="login-form">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">

--- a/securedrop/source_templates/login.html
+++ b/securedrop/source_templates/login.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block tab_title %}{{ gettext('Login') }}{% endblock %}
+{% block tab_title %}{{ gettext('Log in') }}{% endblock %}
 
 {% block body %}
 

--- a/securedrop/translations/ar/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ar/LC_MESSAGES/messages.po
@@ -757,8 +757,8 @@ msgstr "اللغة المختارة"
 msgid "Choose language"
 msgstr "اختيار اللغة"
 
-msgid "Login to access the journalist interface"
-msgstr "لِج إلى حسابك للنفاذ إلى واجهة الصحافيين"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "كلمة السر"
@@ -943,7 +943,7 @@ msgstr "زائر متكرر"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "هل لديك اسم رمزي؟ تحقق إن أتتك ردود أو قم بإيداع جديد."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1111,6 +1111,9 @@ msgstr "<strong>هام:</strong> إذا كنت ترغب في البقاء مجه
 
 msgid "Back to submission page"
 msgstr "الرجوع إلى صفحة الإيداع"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "لِج إلى حسابك للنفاذ إلى واجهة الصحافيين"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "OTP غير صالحة"

--- a/securedrop/translations/az/LC_MESSAGES/messages.po
+++ b/securedrop/translations/az/LC_MESSAGES/messages.po
@@ -716,7 +716,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/bn/LC_MESSAGES/messages.po
+++ b/securedrop/translations/bn/LC_MESSAGES/messages.po
@@ -716,7 +716,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/bn_BD/LC_MESSAGES/messages.po
+++ b/securedrop/translations/bn_BD/LC_MESSAGES/messages.po
@@ -716,7 +716,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/bn_IN/LC_MESSAGES/messages.po
+++ b/securedrop/translations/bn_IN/LC_MESSAGES/messages.po
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -903,7 +903,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/ca/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ca/LC_MESSAGES/messages.po
@@ -726,8 +726,8 @@ msgstr "Llengua seleccionada"
 msgid "Choose language"
 msgstr "Trieu una llengua"
 
-msgid "Login to access the journalist interface"
-msgstr "Inicieu la sessió per accedir a la interfície de periodista"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Contrasenya"
@@ -912,7 +912,7 @@ msgstr "Cap novetat?"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Si ja teniu un nom en clau, entreu i comproveu les respostes o envieu quelcom nou."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1080,6 +1080,9 @@ msgstr "<strong>Important:</strong> si voleu romandre en l'anonimat, <strong>no<
 
 msgid "Back to submission page"
 msgstr "Torna a la pàgina d'enviaments"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Inicieu la sessió per accedir a la interfície de periodista"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "El secret OTP no és vàlid"

--- a/securedrop/translations/ckb/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ckb/LC_MESSAGES/messages.po
@@ -714,7 +714,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/cs/LC_MESSAGES/messages.po
+++ b/securedrop/translations/cs/LC_MESSAGES/messages.po
@@ -726,8 +726,8 @@ msgstr "Vybraný jazyk"
 msgid "Choose language"
 msgstr "Vyberte jazyk"
 
-msgid "Login to access the journalist interface"
-msgstr "Přihlaste se do rozhraní pro novináře"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Heslo"
@@ -912,7 +912,7 @@ msgstr "Vracím se"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Už máte krycí jméno? Zkontrolujte odpovědi anebo pošlete něco nového."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1080,6 +1080,9 @@ msgstr "<strong>Důležité:</strong> Chcete-li zůstat v anonymitě, <strong>ne
 
 msgid "Back to submission page"
 msgstr "Zpátky na stránku podání"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Přihlaste se do rozhraní pro novináře"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Neplatný kód pro generování OTP"

--- a/securedrop/translations/da/LC_MESSAGES/messages.po
+++ b/securedrop/translations/da/LC_MESSAGES/messages.po
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -903,7 +903,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/de_DE/LC_MESSAGES/messages.po
+++ b/securedrop/translations/de_DE/LC_MESSAGES/messages.po
@@ -712,8 +712,8 @@ msgstr "Ausgewählte Sprache"
 msgid "Choose language"
 msgstr "Sprache auswählen"
 
-msgid "Login to access the journalist interface"
-msgstr "Melden Sie sich an, um auf die Journalistenoberfläche zugreifen zu können"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Passwort"
@@ -898,7 +898,7 @@ msgstr "Wiederholungsbesuch"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Haben Sie bereits einen Decknamen? Schauen Sie nach Antworten oder reichen Sie etwas Neues ein."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1066,6 +1066,9 @@ msgstr "<strong>Wichtig:</strong> Verwenden Sie <strong>nicht</strong> GPG, um d
 
 msgid "Back to submission page"
 msgstr "Zurück zur Einreichungsseite"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Melden Sie sich an, um auf die Journalistenoberfläche zugreifen zu können"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Ungültiges OTP-Geheimnis"

--- a/securedrop/translations/el/LC_MESSAGES/messages.po
+++ b/securedrop/translations/el/LC_MESSAGES/messages.po
@@ -726,8 +726,8 @@ msgstr "Επιλεγμένη γλώσσα"
 msgid "Choose language"
 msgstr "Επιλογή γλώσσας"
 
-msgid "Login to access the journalist interface"
-msgstr "Συνδεθείτε για πρόσβαση στη διεπαφή δημοσιογράφου"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Κωδικός πρόσβασης"
@@ -912,7 +912,7 @@ msgstr "Επιστροφή"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Έχετε ήδη κωδικό όνομα; Ελέγξτε για απαντήσεις ή υποβάλετε κάτι καινούριο."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1080,6 +1080,9 @@ msgstr "<strong>Σημαντικό:</strong> Αν επιθυμείτε να δι
 
 msgid "Back to submission page"
 msgstr "Πίσω στη σελίδα υποβολών"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Συνδεθείτε για πρόσβαση στη διεπαφή δημοσιογράφου"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Άκυρο μυστικό OTP"

--- a/securedrop/translations/es_ES/LC_MESSAGES/messages.po
+++ b/securedrop/translations/es_ES/LC_MESSAGES/messages.po
@@ -727,8 +727,8 @@ msgstr "Idioma selecciondo"
 msgid "Choose language"
 msgstr "Elegir idioma"
 
-msgid "Login to access the journalist interface"
-msgstr "Inicio de sesión para acceder a la interfaz de periodista"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Contraseña"
@@ -913,7 +913,7 @@ msgstr "Nueva visita"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "¿Ya tienes un nombre clave? Revisa si hay respuestas o envía algo nuevo."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1081,6 +1081,9 @@ msgstr "<strong>Importante:</strong> Si deseas permanecer anónimo, <strong>no</
 
 msgid "Back to submission page"
 msgstr "Regresar a la página de envío"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Inicio de sesión para acceder a la interfaz de periodista"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Secreto OTP inválido"

--- a/securedrop/translations/fa/LC_MESSAGES/messages.po
+++ b/securedrop/translations/fa/LC_MESSAGES/messages.po
@@ -716,8 +716,8 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
-msgstr "برای دسترسی به رابط روزنامه‌نگار وارد شوید"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "رمز عبور"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1068,6 +1068,9 @@ msgstr ""
 
 msgid "Back to submission page"
 msgstr ""
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "برای دسترسی به رابط روزنامه‌نگار وارد شوید"
 
 #~ msgid "Username \"{user}\" already taken."
 #~ msgstr "نام کاربری \"{user}\" قبلا گرفته شده‌ است."

--- a/securedrop/translations/fi/LC_MESSAGES/messages.po
+++ b/securedrop/translations/fi/LC_MESSAGES/messages.po
@@ -716,8 +716,8 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
-msgstr "Kirjaudu journalistin käyttöliittymään"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Salasana"
@@ -902,7 +902,7 @@ msgstr "Paluuvierailu"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Onko sinulla jo koodinimi? Tarkista vastaukset, tai lähetä jotain uutta."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1070,6 +1070,9 @@ msgstr "<strong>Tärkeää:</strong> Jos haluat pysyä nimettömänä, <strong>�
 
 msgid "Back to submission page"
 msgstr "Takaisin lähetyssivulle"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Kirjaudu journalistin käyttöliittymään"
 
 #~ msgid "You have been logged out due to password change"
 #~ msgstr "Sinut on kirjattu ulos salasanan vaihtumisen vuoksi"

--- a/securedrop/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/securedrop/translations/fr_FR/LC_MESSAGES/messages.po
@@ -727,8 +727,8 @@ msgstr "Langue sélectionné"
 msgid "Choose language"
 msgstr "Choisir un langue"
 
-msgid "Login to access the journalist interface"
-msgstr "Connectez-vous pour accéder à l'interface des journalistes"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Mot de passe"
@@ -913,7 +913,7 @@ msgstr "Visite de suivi"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Avez-vous déjà un nom de code ? Vérifiez la présence de réponses ou envoyez quelque chose de nouveau."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1081,6 +1081,9 @@ msgstr "<strong>Important :</strong> Si vous souhaitez rester anonyme, <strong>
 
 msgid "Back to submission page"
 msgstr "Revenir à la page d'envoi"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Connectez-vous pour accéder à l'interface des journalistes"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Le secret dynamique OTP est invalide"

--- a/securedrop/translations/he/LC_MESSAGES/messages.po
+++ b/securedrop/translations/he/LC_MESSAGES/messages.po
@@ -716,7 +716,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/hi/LC_MESSAGES/messages.po
+++ b/securedrop/translations/hi/LC_MESSAGES/messages.po
@@ -716,8 +716,8 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
-msgstr "पत्रकार इंटरफेस प्रवेशने के लिए लॉगिन करें"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "पासवर्ड"
@@ -902,7 +902,7 @@ msgstr "वापसी का दौरा"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "पहले से ही एक संकेत नाम है? उत्तर के लिए जांचें या कुछ नया सबमिट करें।"
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1070,6 +1070,9 @@ msgstr "<strong>महत्वपूर्ण:</strong> यदि आप गु
 
 msgid "Back to submission page"
 msgstr "सबमिशन पृष्ठ पर वापस जाएं"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "पत्रकार इंटरफेस प्रवेशने के लिए लॉगिन करें"
 
 #~ msgid "You have been logged out due to password change"
 #~ msgstr "पासवर्ड बदलने के कारण आप लॉग आउट हो गये है"

--- a/securedrop/translations/hr/LC_MESSAGES/messages.po
+++ b/securedrop/translations/hr/LC_MESSAGES/messages.po
@@ -726,8 +726,8 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
-msgstr "Prijavite se za pristup na novinarsko sučelje"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Lozinka"
@@ -912,7 +912,7 @@ msgstr "Povratni posjet"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Već imate kodno ime? Provjerite odgovore ili predajte nešto novo."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1080,6 +1080,9 @@ msgstr "<strong>Važno:</strong> Ako želite ostati anonimni, <strong>nemojte</s
 
 msgid "Back to submission page"
 msgstr "Natrag na stranicu predaje"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Prijavite se za pristup na novinarsko sučelje"
 
 #~ msgid "You have been logged out due to password change"
 #~ msgstr "Odjavljeni ste zbog promjene lozinke"

--- a/securedrop/translations/id/LC_MESSAGES/messages.po
+++ b/securedrop/translations/id/LC_MESSAGES/messages.po
@@ -706,8 +706,8 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
-msgstr "Masuk untuk mengakses antarmuka jurnalis"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Kata Sandi"
@@ -892,7 +892,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1058,6 +1058,9 @@ msgstr ""
 
 msgid "Back to submission page"
 msgstr "Kembali ke halaman pengiriman"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Masuk untuk mengakses antarmuka jurnalis"
 
 #~ msgid "You have been logged out due to password change"
 #~ msgstr "Anda telah keluar karena perubahan kata sandi"

--- a/securedrop/translations/is/LC_MESSAGES/messages.po
+++ b/securedrop/translations/is/LC_MESSAGES/messages.po
@@ -726,8 +726,8 @@ msgstr "Valið tungumál"
 msgid "Choose language"
 msgstr "Veldu tungumál"
 
-msgid "Login to access the journalist interface"
-msgstr "Innskráning fyrir aðgang að fréttamannaviðmótinu"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Lykilorð"
@@ -912,7 +912,7 @@ msgstr "Endurkomu heimsókn"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Ertu þegar með kóðanafn? Skoðaðu  svör eða sendu inn eitthvað nýtt."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1080,6 +1080,9 @@ msgstr "<strong>Mikilvægt:</strong> Ef þú óskar áframhaldandi nafnleyndar, 
 
 msgid "Back to submission page"
 msgstr "Til baka á innsendingasíðuna"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Innskráning fyrir aðgang að fréttamannaviðmótinu"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Ógildur OTP-leynilykill"

--- a/securedrop/translations/it_IT/LC_MESSAGES/messages.po
+++ b/securedrop/translations/it_IT/LC_MESSAGES/messages.po
@@ -730,8 +730,8 @@ msgstr "Lingua selezionata"
 msgid "Choose language"
 msgstr "Scegli la lingua"
 
-msgid "Login to access the journalist interface"
-msgstr "Accedere per utilizzare l'interfaccia giornalista"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Password"
@@ -916,7 +916,7 @@ msgstr "Visitatore di ritorno"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Hai già un nome in codice? Controlla le risposte o invia qualcosa di nuovo."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1084,6 +1084,9 @@ msgstr "<strong>Importante:</strong> per rimanere anonimi <strong>non usare</str
 
 msgid "Back to submission page"
 msgstr "Torna alla pagina di invio documenti e messaggi"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Accedere per utilizzare l'interfaccia giornalista"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Segreto OTP non valido"

--- a/securedrop/translations/ja/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ja/LC_MESSAGES/messages.po
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -892,7 +892,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/km/LC_MESSAGES/messages.po
+++ b/securedrop/translations/km/LC_MESSAGES/messages.po
@@ -715,7 +715,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -901,7 +901,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/kn/LC_MESSAGES/messages.po
+++ b/securedrop/translations/kn/LC_MESSAGES/messages.po
@@ -716,7 +716,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/ko/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ko/LC_MESSAGES/messages.po
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -892,7 +892,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/lg/LC_MESSAGES/messages.po
+++ b/securedrop/translations/lg/LC_MESSAGES/messages.po
@@ -716,7 +716,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/lt/LC_MESSAGES/messages.po
+++ b/securedrop/translations/lt/LC_MESSAGES/messages.po
@@ -726,8 +726,8 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
-msgstr "Prisijunkite, kad galėtumėte pasiekti žurnalisto sąsają"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Slaptažodis"
@@ -912,7 +912,7 @@ msgstr "Grįžimas"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Jau turite kodinį pavadinimą? Patikrinkite, ar nėra atsakymų, arba pateikite ką nors naujo."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1080,6 +1080,9 @@ msgstr "<strong>Patarimas:</strong> Jeigu norite likti neatpažintas, <strong>ne
 
 msgid "Back to submission page"
 msgstr "Grįžti į pateikimo puslapį"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Prisijunkite, kad galėtumėte pasiekti žurnalisto sąsają"
 
 #~ msgid "You have been logged out due to password change"
 #~ msgstr "Buvote atjungtas dėl slaptažodžio keitimo"

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -714,7 +714,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/securedrop/translations/nb_NO/LC_MESSAGES/messages.po
@@ -727,8 +727,8 @@ msgstr "Valgt språk"
 msgid "Choose language"
 msgstr "Velg språk"
 
-msgid "Login to access the journalist interface"
-msgstr "Logg inn for å få tilgang til journalist-portalen"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Passord"
@@ -913,7 +913,7 @@ msgstr "Sendt inn før"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Har du allerede et kodenavn? Sjekk om du har fått svar, eller send inn ny informasjon."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1081,6 +1081,9 @@ msgstr "<strong>Viktig:</strong> Om du ønsker å være helt anonym, <strong>ikk
 
 msgid "Back to submission page"
 msgstr "Tilbake til innsendelsesside"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Logg inn for å få tilgang til journalist-portalen"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Ugyldig OTP nøkkel"

--- a/securedrop/translations/nl/LC_MESSAGES/messages.po
+++ b/securedrop/translations/nl/LC_MESSAGES/messages.po
@@ -727,8 +727,8 @@ msgstr "Geselecteerde taal"
 msgid "Choose language"
 msgstr "Taal kiezen"
 
-msgid "Login to access the journalist interface"
-msgstr "Inloggen om de interface voor journalisten te openen"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Wachtwoord"
@@ -913,7 +913,7 @@ msgstr "Vervolgbezoek"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Hebt u al een codenaam? Controleer of er antwoorden zijn of stuur iets nieuws in."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1081,6 +1081,9 @@ msgstr "<strong>Belangrijk:</strong> Als u anoniem wilt blijven, gebruik dan <st
 
 msgid "Back to submission page"
 msgstr "Terug naar inzendingenpagina"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Inloggen om de interface voor journalisten te openen"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Ongeldig OTP geheim"

--- a/securedrop/translations/pl/LC_MESSAGES/messages.po
+++ b/securedrop/translations/pl/LC_MESSAGES/messages.po
@@ -726,8 +726,8 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
-msgstr "Zaloguj się, aby uzyskać dostęp do interfejsu dziennikarza"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Hasło"
@@ -912,7 +912,7 @@ msgstr "Wizyta powrotna"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Masz już kryptonim? Sprawdź odpowiedzi lub prześlij coś nowego."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1080,6 +1080,9 @@ msgstr "<strong> Ważne: </strong> jeśli chcesz pozostać anonimowy, <strong> n
 
 msgid "Back to submission page"
 msgstr "Powrót do strony zgłoszenia"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Zaloguj się, aby uzyskać dostęp do interfejsu dziennikarza"
 
 #~ msgid "You have been logged out due to password change"
 #~ msgstr "Zostałeś wylogowany z powodu zmiany hasła"

--- a/securedrop/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/securedrop/translations/pt_BR/LC_MESSAGES/messages.po
@@ -716,8 +716,8 @@ msgstr "Língua selecionada"
 msgid "Choose language"
 msgstr "Escolha a língua"
 
-msgid "Login to access the journalist interface"
-msgstr "Faça login para acessar a interface para jornalistas"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Senha"
@@ -902,7 +902,7 @@ msgstr "Nova visita"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Você já criou um codinome? Verifique respostas ou envie novos documentos."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1070,6 +1070,9 @@ msgstr "<strong>Importante:</strong> Para manter o seu anonimato, <strong>não</
 
 msgid "Back to submission page"
 msgstr "Voltar à página de envio"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Faça login para acessar a interface para jornalistas"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Segredo OTP inválido"

--- a/securedrop/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/securedrop/translations/pt_PT/LC_MESSAGES/messages.po
@@ -726,8 +726,8 @@ msgstr "Linguagem selecionada"
 msgid "Choose language"
 msgstr "Escolher linguagem"
 
-msgid "Login to access the journalist interface"
-msgstr "Inicie sessão para aceder à interface para jornalistas"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Palavra-passe"
@@ -912,7 +912,7 @@ msgstr "Já tem conta?"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Já tem um nome-código? Veja se já lhe responderam ou envie mais documentos."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1080,6 +1080,9 @@ msgstr "<strong>Importante:</strong> para manter o seu anonimato, <strong>não</
 
 msgid "Back to submission page"
 msgstr "Voltar à página de envio"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Inicie sessão para aceder à interface para jornalistas"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Código secreto OTP inválido"

--- a/securedrop/translations/ro/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ro/LC_MESSAGES/messages.po
@@ -726,8 +726,8 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
-msgstr "Autentifică-te pentru acces la interfața jurnalistului"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Parolă"
@@ -912,7 +912,7 @@ msgstr "Am revenit"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Ai deja un nume de cod? Vezi dacă ai primit răspunsuri sau trimite ceva nou."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1080,6 +1080,9 @@ msgstr "<strong>Important:</strong> Dacă vrei să rămâi anonim(ă), <strong>n
 
 msgid "Back to submission page"
 msgstr "Înapoi la pagina de trimitere"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Autentifică-te pentru acces la interfața jurnalistului"
 
 #~ msgid "You have been logged out due to password change"
 #~ msgstr "Ai fost deconectat(ă) în urma schimbării parolei"

--- a/securedrop/translations/ru/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ru/LC_MESSAGES/messages.po
@@ -736,8 +736,8 @@ msgstr "Выбранный язык"
 msgid "Choose language"
 msgstr "Выбрать язык"
 
-msgid "Login to access the journalist interface"
-msgstr "Войдите, чтобы получить доступ к панели журналиста"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Пароль"
@@ -922,7 +922,7 @@ msgstr "Повторный визит"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Уже получали код? Введите для проверки ответов."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1090,6 +1090,9 @@ msgstr "<strong>Внимание:</strong> Если вы хотите сохра
 
 msgid "Back to submission page"
 msgstr "Вернуться на страницу отправки"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Войдите, чтобы получить доступ к панели журналиста"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Данные OTP некорректны"

--- a/securedrop/translations/si/LC_MESSAGES/messages.po
+++ b/securedrop/translations/si/LC_MESSAGES/messages.po
@@ -716,7 +716,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/sk/LC_MESSAGES/messages.po
+++ b/securedrop/translations/sk/LC_MESSAGES/messages.po
@@ -726,8 +726,8 @@ msgstr "Vybraný jazyk"
 msgid "Choose language"
 msgstr "Vyberte jazyk"
 
-msgid "Login to access the journalist interface"
-msgstr "Prihláste sa do novinárskeho rozhrania"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Heslo"
@@ -912,7 +912,7 @@ msgstr "Vraciam sa"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Už máte krycie meno? Skontrolujte odpovede alebo pošlite niečo nové."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1080,6 +1080,9 @@ msgstr "<strong>Dôležité:</strong> Ak chcete zostať v anonymite, <strong>nep
 
 msgid "Back to submission page"
 msgstr "Späť na stránku podania"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Prihláste sa do novinárskeho rozhrania"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Neplatné heslo OTP"

--- a/securedrop/translations/sv/LC_MESSAGES/messages.po
+++ b/securedrop/translations/sv/LC_MESSAGES/messages.po
@@ -726,8 +726,8 @@ msgstr "Markerat språk"
 msgid "Choose language"
 msgstr "Välj språk"
 
-msgid "Login to access the journalist interface"
-msgstr "Logga in för att få tillgång till journalistgränssnittet"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Lösenord"
@@ -912,7 +912,7 @@ msgstr "Återkommande besök"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Har du redan ett kodnamn? Kontrollera om du fått svar eller lämna in något nytt."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1080,6 +1080,9 @@ msgstr "<strong> Viktigt:</strong> Ifall du önskar att förbli anonym, <strong>
 
 msgid "Back to submission page"
 msgstr "Tillbaka till inlämningssidan"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Logga in för att få tillgång till journalistgränssnittet"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "Inkorrekt OTP-hemlighet"

--- a/securedrop/translations/ta/LC_MESSAGES/messages.po
+++ b/securedrop/translations/ta/LC_MESSAGES/messages.po
@@ -716,8 +716,8 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
-msgstr "இதழியலாளர் இடைமுகத்தை அணுக புகுபதிக"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "கடவுச்சொல்"
@@ -902,7 +902,7 @@ msgstr "மறு வருகை"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "ஏற்கனவே ஒரு குறிப்பெயர் உள்ளதா? மறுமொழிகளைப் பார்த்திடுக அல்லது ஏதேனும் புதியதாகச் அனுப்பிடுக."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1070,6 +1070,9 @@ msgstr ""
 
 msgid "Back to submission page"
 msgstr "அனுப்புகைப் பக்கத்திற்குத் திரும்புக"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "இதழியலாளர் இடைமுகத்தை அணுக புகுபதிக"
 
 #~ msgid "You have been logged out due to password change"
 #~ msgstr "கடவுச்சொல் மாற்றத்தால் நீங்கள் விடுபதிகை செய்யப்பட்டுள்ளீர்கள்"

--- a/securedrop/translations/th/LC_MESSAGES/messages.po
+++ b/securedrop/translations/th/LC_MESSAGES/messages.po
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -892,7 +892,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/tl/LC_MESSAGES/messages.po
+++ b/securedrop/translations/tl/LC_MESSAGES/messages.po
@@ -716,7 +716,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/tr/LC_MESSAGES/messages.po
+++ b/securedrop/translations/tr/LC_MESSAGES/messages.po
@@ -726,8 +726,8 @@ msgstr "Seçilmiş dil"
 msgid "Choose language"
 msgstr "Dili seçin"
 
-msgid "Login to access the journalist interface"
-msgstr "Gazeteci arayüzüne erişmek için oturum açın"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Parola"
@@ -912,7 +912,7 @@ msgstr "Daha önce gelmiştim"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "Daha önce bir kod adı aldıysanız yanıtlara bakabilir veya yeni bir şeyler gönderebilirsiniz."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1080,6 +1080,9 @@ msgstr "<strong>Önemli:</strong> Anonim kalmak istiyorsanız, dosyanın GPG tar
 
 msgid "Back to submission page"
 msgstr "Gönderi sayfasına geri dön"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Gazeteci arayüzüne erişmek için oturum açın"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "OTP parolası geçersiz"

--- a/securedrop/translations/uz/LC_MESSAGES/messages.po
+++ b/securedrop/translations/uz/LC_MESSAGES/messages.po
@@ -714,7 +714,7 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 
 msgid "Password"
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"

--- a/securedrop/translations/vi/LC_MESSAGES/messages.po
+++ b/securedrop/translations/vi/LC_MESSAGES/messages.po
@@ -706,8 +706,8 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
-msgstr "Truy cập để sử dụng giao diện nhà báo"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Mật khẩu"
@@ -892,7 +892,7 @@ msgstr ""
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr ""
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1058,6 +1058,9 @@ msgstr ""
 
 msgid "Back to submission page"
 msgstr ""
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Truy cập để sử dụng giao diện nhà báo"
 
 #~ msgid "Username \"{user}\" already taken."
 #~ msgstr "Người dùng \"{user}\" đã được sử dụng."

--- a/securedrop/translations/yo/LC_MESSAGES/messages.po
+++ b/securedrop/translations/yo/LC_MESSAGES/messages.po
@@ -706,8 +706,8 @@ msgstr ""
 msgid "Choose language"
 msgstr ""
 
-msgid "Login to access the journalist interface"
-msgstr "Fàṣẹwọlé láti rí ìwò-ojú akọ̀ròyìn lò"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "Ọ̀rọ̀-ìfiwọlé"
@@ -892,7 +892,7 @@ msgstr "Àbẹ̀wò padà"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "O ti ní orúkọ-odù tẹ́lẹ̀? Wo èsì tàbí fi nǹkan tuntun sílẹ̀."
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1058,6 +1058,9 @@ msgstr ""
 
 msgid "Back to submission page"
 msgstr "Padà sí ojú-ìwé asàfisílẹ̀"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "Fàṣẹwọlé láti rí ìwò-ojú akọ̀ròyìn lò"
 
 #~ msgid "You have been logged out due to password change"
 #~ msgstr "O ti fàṣẹ jáde nítorí pé o pààrọ ọ̀rọ̀-ìfiwọlé"

--- a/securedrop/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/securedrop/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -716,8 +716,8 @@ msgstr "选择的语言"
 msgid "Choose language"
 msgstr "选择语言"
 
-msgid "Login to access the journalist interface"
-msgstr "登录以访问记者界面"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "密码"
@@ -902,7 +902,7 @@ msgstr "回到访问"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "已有代码？查看回复或提交新内容。"
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1070,6 +1070,9 @@ msgstr "<strong>重要提示：</strong>若您想保持匿名身份，<strong>�
 
 msgid "Back to submission page"
 msgstr "返回提交页面"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "登录以访问记者界面"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "OTP 密码无效"

--- a/securedrop/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/securedrop/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -717,8 +717,8 @@ msgstr "選取語系"
 msgid "Choose language"
 msgstr "選擇語系"
 
-msgid "Login to access the journalist interface"
-msgstr "登入記者使用介面"
+msgid "Log in to access the journalist interface"
+msgstr ""
 
 msgid "Password"
 msgstr "密碼"
@@ -903,7 +903,7 @@ msgstr "返回文件提交訪問頁"
 msgid "Already have a codename? Check for replies or submit something new."
 msgstr "已有代號名稱？檢查回應或是提交新資料。"
 
-msgid "Login"
+msgid "Log in"
 msgstr ""
 
 msgid "Enter Codename"
@@ -1071,6 +1071,9 @@ msgstr "<strong>重要：</strong>如果您希望保持匿名，<strong>請勿</
 
 msgid "Back to submission page"
 msgstr "返回提交文件頁面"
+
+#~ msgid "Login to access the journalist interface"
+#~ msgstr "登入記者使用介面"
 
 #~ msgid "Invalid OTP secret"
 #~ msgstr "OTP 密碼無效"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes:
- https://weblate.securedrop.org/translate/securedrop/securedrop/en/?checksum=7e53ab2175e6ae9b#comments
- https://weblate.securedrop.org/translate/securedrop/securedrop/en/?checksum=6ea5153a90e0b2e8#comments

## Testing

- [ ] Changed strings are correct in `make dev`.
- [ ] Changed message catalogs look good on visual review.

## Deployment

- [x] Merge this branch into `develop`
- [ ] Cherry-pick 441cb071b7c851f782832eb786273bb2d5dbaafe into `release/2.6.0`, as backport
- [x] Cherry-pick ffb831c7ff1a994f8621a4c8dd7ea867b886ac91 into `securedrop-i18n@i18n`, to make changed source strings available for translation without pulling in anything else from `develop` or `release/2.6.0`

Then then usual [release-day merge](https://developers.securedrop.org/en/latest/i18n.html#merge-weblate-to-develop) should sync everything up:
- `securedrop-i18n@i18n` → `securedrop@develop` → `securedrop@release/2.6.0` (backport), including ffb831c7ff1a994f8621a4c8dd7ea867b886ac91