### PR TITLE
fix(`create_shell_extension`): import `{app,monitor}_hostname` `site-specific` variables

### DIFF
--- a/install_files/ansible-base/roles/tails-config/tasks/install_shell_extension.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/install_shell_extension.yml
@@ -1,4 +1,7 @@
 ---
+- name: Import variables
+  include_vars: "group_vars/all/site-specific"
+
 - name: Check for v3 Source Interface file
   stat:
     path: app-sourcev3-ths
@@ -25,18 +28,6 @@
   changed_when: false
   register: journalistv3_interface_lookup_result
   when: v3_source_file.stat.exists == true
-
-- name: Look up app server hostname
-  command: "awk -v FS='app_hostname: ' 'NF>1{print $2}' group_vars/all/site-specific"
-  changed_when: false
-  register: app_server_lookup_result
-  when: site_specific_file.stat.exists == true
-
-- name: Look up mon server hostname
-  command: "awk -v FS='monitor_hostname: ' 'NF>1{print $2}' /home/amnesia/Persistent/securedrop/install_files/ansible-base/group_vars/all/site-specific"
-  changed_when: false
-  register: mon_server_lookup_result
-  when: site_specific_file.stat.exists == true
 
 - name: Create the SecureDrop GNOME Shell Extension directories
   file:
@@ -87,14 +78,6 @@
   set_fact:
     journalist_iface: "{{ journalistv3_interface_lookup_result }}"
 
-- name: Set the right variable for app server hostname
-  set_fact:
-    app_hostname: "{{ app_server_lookup_result }}"
-
-- name: Set the right variable for app server hostname
-  set_fact:
-    mon_hostname: "{{ mon_server_lookup_result }}"
-
 - name: Assemble interface information for extension
   set_fact:
     _securedrop_extension_info:
@@ -102,8 +85,6 @@
         filename: extension.js
         source_interface_address: "{{ source_iface.stdout }}"
         journalist_interface_address: "{{ journalist_iface.stdout }}"
-        app_hostname: "{{ app_hostname.stdout }}"
-        mon_hostname: "{{ mon_hostname.stdout }}"
 
 - name: Create SecureDrop extension
   become: yes

--- a/install_files/ansible-base/roles/tails-config/templates/extension.js.in
+++ b/install_files/ansible-base/roles/tails-config/templates/extension.js.in
@@ -19,8 +19,8 @@ const Domain = Gettext.domain(GETTEXT_DOMAIN)
 
 const source_interface_address = "{{ item.0.source_interface_address }}";
 const journalist_interface_address = "{{ item.0.journalist_interface_address }}";
-const app_server_hostname = "{{ item.0.app_hostname }}";
-const mon_server_hostname = "{{ item.0.mon_hostname }}";
+const app_server_hostname = "{{ app_hostname }}";
+const mon_server_hostname = "{{ monitor_hostname }}";
 
 const _ = Domain.gettext;
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6847 by importing, rather than reading and then setting new global facts for, the `app_hostname` and `monitor_hostname` `site-specific` variables.

## Testing

1. [ ] If you were involved in testing #6712, check that Admin Workstation's `/home/amnesia/.ssh/config` and observe templating as shown in <https://github.com/freedomofpress/securedrop/issues/6847#issue-1757785375>.
2. From this branch, `securedrop-admin --force tailsconfig`.
3. [ ] Check `~/.ssh/config` again and confirm that both the `{app,mon}` aliases and the servers' actual hostnames (if different than the aliases) are presented.
4. [ ] `ssh $HOSTNAME` works for each aliased hostname.
5. [ ] If the hostnames *aren't* different, bonus points for running `securedrop-admin sdconfig` with junk hostnames and repeating steps (1)‒(3).

## Deployment

After merge, backport this branch into `release/2.6.0` and add a check for #6847 in the v2.6.0 test plan.