### PR TITLE
fix(`map_locale_display_names`): deduplicate supported locales

### DIFF
--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -172,13 +172,16 @@ def map_locale_display_names(
     like Chinese, we do need the additional detail.
     """
 
+    # Deduplicate before sorting.
+    supported_locales = sorted(list(set(config.SUPPORTED_LOCALES)))
+
     language_locale_counts = collections.defaultdict(int)  # type: Dict[str, int]
-    for l in sorted(config.SUPPORTED_LOCALES):
+    for l in supported_locales:
         locale = RequestLocaleInfo(l)
         language_locale_counts[locale.language] += 1
 
     locale_map = collections.OrderedDict()
-    for l in sorted(config.SUPPORTED_LOCALES):
+    for l in supported_locales:
         if Locale.parse(l) not in usable_locales:
             continue
 

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -456,3 +456,20 @@ def test_same_lang_diff_locale():
     html = resp.data.decode("utf-8")
     assert "português (Brasil)" in html
     assert "português (Portugal)" in html
+
+
+def test_duplicate_locales():
+    """
+    Verify that we don't display the full locale name for duplicate locales,
+    whether from user input or securedrop.sdconfig's enforcement of the
+    fallback locale.
+    """
+
+    # ["en_US", "en_US"] alone will not display the locale switcher, which
+    # *does* pass through set deduplication.
+    test_config = create_config_for_i18n_test(supported_locales=["en_US", "en_US", "ar"])
+
+    app = journalist_app_module.create_app(test_config).test_client()
+    resp = app.get("/", follow_redirects=True)
+    html = resp.data.decode("utf-8")
+    assert "English (United States)" not in html


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6851 by deduplicating `config.SUPPORTED_LOCALES`.  See a4384ca315e62320e2325d553260bc57bfb2132d for commentary on why this must happen in `securedrop.i18n` rather than in the originating `securedrop.sdconfig`.

## Testing

1. Check out `develop`.
2. Apply the following patch:
    ```diff
    --- a/Makefile
    +++ b/Makefile
    @@ -221,7 +221,7 @@ securedrop/config.py: ## Generate the test SecureDrop application config.
                     ctx.update(dict((k, {"stdout":v}) for k,v in os.environ.items())); \
                     ctx = open("config.py", "w").write(env.get_template("config.py.example").render(ctx))'
            @echo >> securedrop/config.py
    -       @echo "SUPPORTED_LOCALES = $$(if test -f /opt/venvs/securedrop-app-code/bin/python3; then ./securedrop/i18n_tool.py list-locales --python; else DOCKER_BUILD_VERBOSE=false $(DEVSHELL) ./i18n_tool.py list-locales --python; fi)" | sed 's/\r//' >> securedrop/config.py
    +       @echo "SUPPORTED_LOCALES = ['en_US', 'en_US', 'ar']" >> securedrop/config.py
            @echo
     
     HOOKS_DIR=.githooks
    ```
4. `make dev`
5. Load the Source or Journalist Interface.
6. Observe `English (United States)` in the locale switcher.
7. Check out this branch.
8. Repeat steps (2)‒(5).
9. Observe `English` in the locale switcher.

## Deployment

No special considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
    - Pending #6854