### PR TITLE
test: `s/Login/Log in/` hard-coded in tests

### DIFF
--- a/securedrop/tests/functional/app_navigators/journalist_app_nav.py
+++ b/securedrop/tests/functional/app_navigators/journalist_app_nav.py
@@ -334,7 +334,7 @@ class JournalistAppNavigator:
 
         # Logging out should redirect back to the login page
         def login_page():
-            assert "Login to access the journalist interface" in self.driver.page_source
+            assert "Log in to access the journalist interface" in self.driver.page_source
 
         self.nav_helper.wait_for(login_page)
 

--- a/securedrop/tests/i18n/securedrop/translations/de_DE/LC_MESSAGES/messages.po
+++ b/securedrop/tests/i18n/securedrop/translations/de_DE/LC_MESSAGES/messages.po
@@ -780,7 +780,7 @@ msgstr ""
 "zurücksetzen möchten?"
 
 #: journalist_templates/login.html:4
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr ""
 "Melden Sie sich an, um auf die Journalistenoberfläche zugreifen zu können"
 

--- a/securedrop/tests/i18n/securedrop/translations/nl/LC_MESSAGES/messages.po
+++ b/securedrop/tests/i18n/securedrop/translations/nl/LC_MESSAGES/messages.po
@@ -770,7 +770,7 @@ msgstr ""
 "Weet u zeker dat u de tweestapsauthenticatie voor {username} wilt herstellen?"
 
 #: journalist_templates/login.html:4
-msgid "Login to access the journalist interface"
+msgid "Log in to access the journalist interface"
 msgstr "Inloggen om de interface voor journalisten te openen"
 
 #: journalist_templates/login.html:9

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -346,7 +346,7 @@ def test_validate_redirect(config, journalist_app, locale):
     with journalist_app.test_client() as app:
         resp = app.post(url_for("main.index", l=locale), follow_redirects=True)
         assert page_language(resp.data) == language_tag(locale)
-        msgids = ["Login to access the journalist interface"]
+        msgids = ["Log in to access the journalist interface"]
         with xfail_untranslated_messages(config, locale, msgids):
             assert gettext(msgids[0]) in resp.data.decode("utf-8")
 
@@ -3551,7 +3551,7 @@ def test_journalist_session_expiration(journalist_app, test_journo, locale):
         # because the session is being cleared when it expires, the
         # response should always be in English.
         assert page_language(resp.data) == "en-US"
-        assert "Login to access the journalist interface" in resp.data.decode("utf-8")
+        assert "Log in to access the journalist interface" in resp.data.decode("utf-8")
 
         # check that the session was cleared (apart from 'expires'
         # which is always present and 'csrf_token' which leaks no info)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes `app-tests` and `app-page-layout-tests` with hard-coded references to `Login`, failing after #6846.

## Testing

- [x] CI passes.

## Deployment

Test-only; no deployment considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container