### PR TITLE
Fix two builder bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ build-debs: ## Build and test SecureDrop Debian packages
 	@echo "Building SecureDrop Debian packages..."
 	@export TERM=dumb
 	@script \
-		--command $(SDROOT)/builder/build-debs.sh \
+		--command $(SDROOT)/builder/build-debs.sh --return \
 		$(OUT)
 	@echo
 	@echo "$(SCRIPT_MESSAGE)"
@@ -396,7 +396,7 @@ build-debs-notest: ## Build SecureDrop Debian packages without running tests.
 	@echo "Building SecureDrop Debian packages, skipping tests..."
 	@export TERM=dumb
 	@NOTEST=1 script \
-		--command $(SDROOT)/builder/build-debs.sh \
+		--command $(SDROOT)/builder/build-debs.sh --return \
 		$(OUT)
 	@echo
 	@echo "$(SCRIPT_MESSAGE)"
@@ -408,7 +408,7 @@ build-debs-ossec: ## Build OSSEC Debian packages
 	@echo "Building OSSEC Debian packages"
 	@export TERM=dumb
 	@WHAT=ossec script \
-		--command $(SDROOT)/builder/build-debs.sh \
+		--command $(SDROOT)/builder/build-debs.sh --return \
 		$(OUT)
 	@echo
 	@echo "$(SCRIPT_MESSAGE)"
@@ -420,7 +420,7 @@ build-debs-ossec-notest: ## Build OSSEC Debian packages without running tests
 	@echo "Building OSSEC Debian packages, skipping tests..."
 	@export TERM=dumb
 	@NOTEST=1 WHAT=ossec script \
-	       --command $(SDROOT)/builder/build-debs.sh \
+	       --command $(SDROOT)/builder/build-debs.sh --return \
 	       $(OUT)
 	@echo
 	@echo "$(SCRIPT_MESSAGE)"

--- a/builder/image_prep.sh
+++ b/builder/image_prep.sh
@@ -26,6 +26,8 @@ if [[ $status == 42 ]]; then
     echo "Rebuilding container to update dependencies"
     $OCI_BIN rmi fpf.local/sd-server-builder
     $OCI_BIN build -t fpf.local/sd-server-builder builder/ --no-cache
+    # Reset $status and re-run the dependency check
+    status=0
     $OCI_BIN run --rm $OCI_RUN_ARGUMENTS \
         --entrypoint "/dep-check" fpf.local/sd-server-builder || status=$?
 fi


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Two fixes:

1. Don't have `script` swallow the exit code by passing `--return`.
2. If the builder is out of date, reset the status code before re-running the dependency check.

Fixes #6858.

## Testing

* [ ] Edit `builder/build-debs-securedrop.sh` to contain `exit 1`
* [ ] `podman rmi fpf.local/sd-server-builder` (if needed)
* [ ] Run `make build-debs`, then `echo $?` and see a non-zero exit code

The second part is harder to test since you need an out of date dependency to trigger it, so hopefully visual review is sufficient.

## Deployment

Any special considerations for deployment? No
