### PR TITLE
fix: format $SCRIPT_OUTPUT_PREFIX with month, not minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,7 +375,7 @@ endif
 ###########
 
 SCRIPT_MESSAGE="You can now examine or commit the log at:"
-SCRIPT_OUTPUT_PREFIX=$(SDROOT)/build/$(shell date +%Y%M%d)
+SCRIPT_OUTPUT_PREFIX=$(SDROOT)/build/$(shell date +%Y%m%d)
 SCRIPT_OUTPUT_EXT=log
 
 .PHONY: build-debs


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6864 by correcting the date format of `$SCRIPT_OUTPUT_PREFIX`.

## Testing

1. `make build-debs-ossec-notest` (e.g.)
2. [ ] Confirm that the log file is prefixed (e.g., as of this writing) `20230620`, not `20233120`...

## Deployment

Maintainer-only change; no deployment considerations.