### PR TITLE
[2.6.0] Backport "fix(ossec): ignore NameError on builtin hasattr()"

### DIFF
--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -139,6 +139,13 @@ log_events_without_ossec_alerts:
     level: "0"
     rule_id: "100114"
 
+  # #6866
+  - name: NameError_hasattr_does_not_produce_alert
+    alert: >
+      NameError: name 'hasattr' is not defined
+    level: "0"
+    rule_id: "199996"
+
 # Log events we expect an OSSEC alert to occur for
 log_events_with_ossec_alerts:
   # Check that a denied RWX mmaping would produce an OSSEC alert

--- a/securedrop/debian/ossec-server/var/ossec/rules/local_rules.xml
+++ b/securedrop/debian/ossec-server/var/ossec/rules/local_rules.xml
@@ -117,12 +117,18 @@
   </rule>
 </group>
 
+<group name="do not alert">
+  <rule id="199996" level="0">
+    <match>NameError: name 'hasattr' is not defined</match>
+    <description>ignore NameError on builtin hasattr() at mod_wsgi teardown (https://github.com/freedomofpress/securedrop/issues/6866)</description>
+    <options>no_email_alert</options>
+   </rule>
+
 <!--
   The python gnupg library that securedrop uses includes an obsolete option
   WARNING:gnupg no-use-agent is an obsolete option - it has no effect
   Do not send an alert for this event.
 -->
-<group name="do not alert">
   <rule id="199997" level="0">
     <decoded_as>gpg warning</decoded_as>
     <match>--no-use-agent" is an obsolete option - it has no effect</match>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #6867.

## Testing

* [ ] CI is passing
* [ ] base is `release/2.6.0`
* [ ] Only contains changes from #6867.
