### PR TITLE
Have black and isort respect .gitignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.black]
 line-length = 100
 target-version = ["py38"]
-exclude = "securedrop/config.py"
-extend-exclude = ".venv"
+# Don't use `extend`, we want the default behavior that honors .gitignore rules
 
 [tool.isort]
 line_length = 100
 profile = "black"
+skip_gitignore = true
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

For black, setting `exclude` unintentionally overrode black's default of ignoring files listed in .gitignore. isort requires setting an explicit `skip_gitignore` option.

Notably this will automatically have both tools ignore target/, which in some cases does contain Python code.

Fixes #6852.

## Testing

* [ ] Run `make dev`, stop it once the web server starts
* [ ] Run `black --check --diff . -v 2>&1 | grep config`, see `securedrop/config.py ignored: matches the .gitignore file content`
* [ ] Run `isort --check-only --diff . -v | grep target`, see `UserWarning: target was skipped as it's listed in 'skip' setting or matches a glob in 'skip_glob' setting`

## Deployment

Any special considerations for deployment? No

## Checklist

- [x] I have written a test plan and validated it for this PR
