### PR TITLE
[2.6.0] Backport "fix: format $SCRIPT_OUTPUT_PREFIX with month, not minutes"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,7 +375,7 @@ endif
 ###########
 
 SCRIPT_MESSAGE="You can now examine or commit the log at:"
-SCRIPT_OUTPUT_PREFIX=$(SDROOT)/build/$(shell date +%Y%M%d)
+SCRIPT_OUTPUT_PREFIX=$(SDROOT)/build/$(shell date +%Y%m%d)
 SCRIPT_OUTPUT_EXT=log
 
 .PHONY: build-debs


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #6865.

## Testing

* [ ] CI is passing
* [ ] base is `release/2.6.0`
* [ ] Only contains changes from #6865.
