### PR TITLE
Fix lib .gitignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We now have a "lib" folder: `securedrop/debian/app-code/lib`.

I assume this was meant to be for a top-level /lib directory that building a Python package might cause, so change it to that.

## Testing

How should the reviewer test this PR?

* [ ] Visual review

## Deployment

Any special considerations for deployment? No
