### PR TITLE
testinfra: Improve printing of apparmor denials

### DIFF
--- a/molecule/testinfra/app/test_apparmor.py
+++ b/molecule/testinfra/app/test_apparmor.py
@@ -114,4 +114,10 @@ def test_aa_no_denies_in_syslog(host):
     """Ensure that there are no apparmor denials in syslog"""
     with host.sudo():
         f = host.file("/var/log/syslog")
-        assert 'apparmor="DENIED"' not in f.content_string
+        lines = f.content_string.splitlines()
+    # syslog is very big, just print the denial lines
+    found = []
+    for line in lines:
+        if 'apparmor="DENIED"' in line:
+            found.append(line)
+    assert found == []


### PR DESCRIPTION


## Status

Ready for review
## Description of Changes

Dumping all of syslog is huge and often what you're looking for will get truncated by pytest. Instead, look for individual lines with the DENIED substring and assert those don't exist. This will print just those lines, giving us a better chance at seeing the relevant lines.

## Testing

How should the reviewer test this PR?

I think just visual review is fine? I used this when developing #6836 to get staging-via-CI to print out the right apparmor denial line.

## Deployment

Any special considerations for deployment? No
