### PR TITLE
Update shell extension tasks to check for site-specific file

### DIFF
--- a/install_files/ansible-base/roles/tails-config/tasks/install_shell_extension.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/install_shell_extension.yml
@@ -1,6 +1,12 @@
 ---
+- name: Check for site specific file
+  stat:
+    path: group_vars/all/site-specific
+  register: site_specific_file
+
 - name: Import variables
   include_vars: "group_vars/all/site-specific"
+  when: site_specific_file.stat.exists
 
 - name: Check for v3 Source Interface file
   stat:
@@ -11,11 +17,6 @@
   stat:
     path: app-journalist.auth_private
   register: v3_journalist_file
-
-- name: Check for site specific file
-  stat:
-    path: group_vars/all/site-specific
-  register: site_specific_file
 
 - name: Look up v3 Source Interface URL.
   command: grep -Po '.{56}\.onion' app-sourcev3-ths

--- a/install_files/ansible-base/roles/tails-config/templates/extension.js.in
+++ b/install_files/ansible-base/roles/tails-config/templates/extension.js.in
@@ -19,8 +19,8 @@ const Domain = Gettext.domain(GETTEXT_DOMAIN)
 
 const source_interface_address = "{{ item.0.source_interface_address }}";
 const journalist_interface_address = "{{ item.0.journalist_interface_address }}";
-const app_server_hostname = "{{ app_hostname }}";
-const mon_server_hostname = "{{ monitor_hostname }}";
+const app_server_hostname = "{{ app_hostname|default('app') }}";
+const mon_server_hostname = "{{ monitor_hostname|default('mon') }}";
 
 const _ = Domain.gettext;
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6903.

During installation of the Tails shell extension:
- Ansible checks for existence of `site-specific` before attempting to load variables from it
- The extension JS script gets sensible defaults if `site-specific` is not present

## Testing
- [ ] Follow docs for creation of a Journalist workstation and verify that it succeeds, with no SSH options in the shell extension
- [ ] Follow docs for creation of an Admin Workstation and verify that it succeeds, with SSH options in the shell extension.

## Deployment
- Will be deployed and set up with next release
- a docs workaround may be necessary in the interim for fresh installs.


## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [x] I would appreciate help with the documentation
- [ ] These changes do not require documentation
