### PR TITLE
pretty_bad_protocol: Support exporting encrypted secret keys

### DIFF
--- a/securedrop/pretty_bad_protocol/_parsers.py
+++ b/securedrop/pretty_bad_protocol/_parsers.py
@@ -1433,13 +1433,20 @@ class ExportResult:
 
         :raises ValueError: if the status message is unknown.
         """
-        informational_keys = ["KEY_CONSIDERED"]
-        if key in ("EXPORTED"):
+        informational_keys = ["KEY_CONSIDERED", "USERID_HINT", "INQUIRE_MAXLEN"]
+        if key in ("EXPORTED",):
             self.fingerprints.append(value)
         elif key == "EXPORT_RES":
             export_res = value.split()
             for x in self.counts:
                 self.counts[x] += int(export_res.pop(0))
+        elif key in (
+            "NEED_PASSPHRASE",
+            "BAD_PASSPHRASE",
+            "GOOD_PASSPHRASE",
+            "MISSING_PASSPHRASE",
+        ):
+            self.status = key.replace("_", " ").lower()
         elif key not in informational_keys:
             raise ValueError("Unknown status message: %r" % key)
 

--- a/securedrop/tests/test_pretty_bad_protocol.py
+++ b/securedrop/tests/test_pretty_bad_protocol.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pretty_bad_protocol as gnupg
+
+import redwood
+
+
+def test_gpg_export_keys(tmp_path):
+    gpg = gnupg.GPG(
+        binary="gpg2",
+        homedir=str(tmp_path),
+        options=["--pinentry-mode loopback", "--trust-model direct"],
+    )
+    passphrase = "correcthorsebatterystaple"
+    gen_key_input = gpg.gen_key_input(
+        passphrase=passphrase,
+        name_email="example@example.org",
+        key_type="RSA",
+        key_length=4096,
+        name_real="example",
+    )
+    fingerprint = gpg.gen_key(gen_key_input)
+    print(fingerprint)
+    public_key = gpg.export_keys(fingerprint)
+    assert public_key.startswith("-----BEGIN PGP PUBLIC KEY BLOCK-----")
+    secret_key = gpg.export_keys(fingerprint, secret=True, passphrase=passphrase)
+    assert secret_key.startswith("-----BEGIN PGP PRIVATE KEY BLOCK-----")
+
+    # Now verify the exported key pair is usable by Sequoia
+    message = "GPG to Sequoia-PGP, yippe!"
+    ciphertext = tmp_path / "encrypted.asc"
+    redwood.encrypt_message([public_key], message, ciphertext)
+    decrypted = redwood.decrypt(ciphertext.read_bytes(), secret_key, passphrase)
+    assert decrypted == message
+
+    # Test some failure cases for exporting the secret key:
+    # bad passphrase
+    assert gpg.export_keys(fingerprint, secret=True, passphrase="wrong") == ""
+    # exporting a non-existent secret key (import just the public key and try to export)
+    journalist_public_key = (
+        Path(__file__).parent / "files" / "test_journalist_key.pub"
+    ).read_text()
+    journalist_fingerprint = gpg.import_keys(journalist_public_key).fingerprints[0]
+    assert gpg.export_keys(journalist_fingerprint, secret=True, passphrase=passphrase) == ""


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

As part of the Sequoia migration, we want to export secret keys out of the GPG keyring and into our new database storage.

So, have the gpg.export_keys() function accept a passphrase to export encrypted keys that GPG wants a passphrase for. Internally we switch it to use the `_handle_io` function since that has support for taking passphrases; the one weird thing is that it requires an input file (e.g. if you were encrypting a file) but since there's no input here an empty temporary file works just fine.

For whatever reason I couldn't get a simple `p.stdin.write(passphrase)` to work, it would hang on stdout, which is probably related to the pre-existing comment about "stdout will be empty in case of failure"...

A new test generates a new GPG key pair, exports the public and secret keys from the keyring and then encrypts and decrypts a message using Sequoia to test compatibility. It also checks a few error cases
like invalid fingerprint and missing secret key.

Refs #6802.

## Testing

How should the reviewer test this PR?

* [x] Visual review
* [x] CI passes

## Deployment

Any special considerations for deployment? No

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
- [ ] I have written a test plan and validated it for this PR
