### PR TITLE
Add tests for empty or malformed recipient gpg key

### DIFF
--- a/redwood/src/lib.rs
+++ b/redwood/src/lib.rs
@@ -244,4 +244,34 @@ mod tests {
         // Verify message is what we put in originally
         assert_eq!("Rust is great 🦀", &plaintext);
     }
+
+    #[test]
+    fn test_encryption_missing_malformed_recipient_key() {
+        // Bad fingerprints can be: empty, empty string, or malformed
+        let bad_keys: Vec<(Vec<String>, &str)> = vec![
+            (
+                vec![],
+                "OpenPGP error: Invalid operation: \
+                Neither recipients, passwords, nor session key given",
+            ),
+            (
+                vec!["".to_string()],
+                "OpenPGP error: Malformed Cert: No data",
+            ),
+            (
+                vec!["DEADBEEF0123456".to_string()],
+                "OpenPGP error: unexpected EOF",
+            ),
+        ];
+        let tmp: NamedTempFile = NamedTempFile::new().unwrap();
+        for (key, error) in bad_keys {
+            let err = encrypt_message(
+                key, // missing or malformed recipient key
+                "Look ma, no key".to_string(),
+                tmp.path().to_path_buf(),
+            )
+            .unwrap_err();
+            assert_eq!(err.to_string(), error);
+        }
+    }
 }


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #6889.

Changes proposed in this pull request:

Add tests for cases of missing or malformed journalist key

Visual review/CI passes

## Deployment 

n/a

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container (`make rust-lint`, `make rust-test`)

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
