### PR TITLE
Upgrade Rust to 1.71.1 for CVE-2023-38497

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,10 +97,7 @@ jobs:
   rust:
     # Keep version in sync with rust-toolchain.toml
     docker:
-      - image: rust:1.69.0
-    environment:
-      # TODO: Remove after we're on Rust 1.70
-      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "sparse"
+      - image: rust:1.71.1
     steps:
       - checkout
       - run:

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         unzip \
         zlib1g-dev
 
-ENV RUST_VERSION 1.69.0
+ENV RUST_VERSION 1.71.1
 ENV RUSTUP_VERSION 1.24.3
 ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
 ENV RUSTUP_HOME /opt/rustup
@@ -51,8 +51,6 @@ RUN TMPDIR=`mktemp -d` && cd ${TMPDIR} \
         && ./rustup-init --default-toolchain=${RUST_VERSION} --profile minimal -y \
         && cd && rm -rf ${TMPDIR}
 ENV PATH "$PATH:/opt/cargo/bin/"
-# TODO: Remove after we switch to 1.70.0 when it's enabled by default
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse
 
 # Turn the ossec key into a keyring
 COPY OSSEC-ARCHIVE-KEY.asc /tmp/OSSEC-ARCHIVE-KEY.asc

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.71.1"

--- a/securedrop/dockerfiles/focal/python3/SlimDockerfile
+++ b/securedrop/dockerfiles/focal/python3/SlimDockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
 # 1) Download rustup-init and verify it matches hardcoded checksum
 # 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
 # 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
-ENV RUST_VERSION 1.69.0
+ENV RUST_VERSION 1.71.1
 ENV RUSTUP_VERSION 1.24.3
 ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
 ENV RUSTUP_HOME /opt/rustup
@@ -27,8 +27,6 @@ RUN TMPDIR=`mktemp -d` && cd ${TMPDIR} \
         && chmod +x rustup-init \
         && ./rustup-init --default-toolchain=${RUST_VERSION} --profile minimal -y \
         && cd && rm -rf ${TMPDIR}
-# TODO: Remove after we switch to 1.70.0 when it's enabled by default
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse
 
 COPY requirements requirements
 RUN python3 -m venv /opt/venvs/securedrop-app-code && \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

See <https://blog.rust-lang.org/2023/08/03/cve-2023-38497.html>.

We can also remove the overrides to enable cargo's sparse index
since it's the default now.

Fixes #6911.

## Testing

* [ ] CI passes, including deb building and staging build
* [ ] Build new debs, deploy on a staging/prod instance:
   * [ ] Create a new source, upload a file.
   * [ ] Create new journalist, log in as them.
   * [ ] As the journalist, download the file and successfully decrypt it.

## Deployment

Any special considerations for deployment? No.

