### PR TITLE
fix: change `NEVER_LOCALE` to Interlingua (`ia`)

### DIFF
--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -305,7 +305,6 @@ def test_parse_locale_set():
     assert parse_locale_set([FALLBACK_LOCALE]) == {Locale.parse(FALLBACK_LOCALE)}
 
 
-@pytest.mark.xfail()  # #6873
 def test_no_usable_fallback_locale():
     """
     The apps fail if neither the default nor the fallback locale is usable.
@@ -321,7 +320,6 @@ def test_no_usable_fallback_locale():
         source_app.create_app(test_config)
 
 
-@pytest.mark.xfail()  # #6873
 def test_unusable_default_but_usable_fallback_locale(caplog):
     """
     The apps start even if the default locale is unusable, as along as the fallback locale is

--- a/securedrop/tests/test_i18n.py
+++ b/securedrop/tests/test_i18n.py
@@ -34,7 +34,9 @@ from sdconfig import DEFAULT_SECUREDROP_ROOT, FALLBACK_LOCALE, SecureDropConfig
 from tests.factories import SecureDropConfigFactory
 from werkzeug.datastructures import Headers
 
-NEVER_LOCALE = "eo"  # Esperanto
+# Interlingua, per
+# <https://developers.securedrop.org/en/latest/supported_languages.html>.
+NEVER_LOCALE = "ia"
 
 
 def create_config_for_i18n_test(


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6873 by changing `NEVER_LOCALE` to Interlingua (`ia`).  Per freedomofpress/securedrop-dev-docs#85, Esperanto (`eo`) remains usable for pseudolocale generation.

## Testing

- [x] Review freedomofpress/securedrop-dev-docs#85 first.
- [x] CI passes.

## Deployment

No special considerations.