### PR TITLE
Add ignore for safety alert #59473

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
                 --ignore 54421 \
                 --ignore 55261 \
                 --ignore 58912 \
+                --ignore 59473 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
-  [a bug (not actually a security vulnerability)](https://github.com/pyca/cryptography/issues/9207#issuecomment-1656500067) in cryptography's handling of ssh certs

## Status

Ready for review 
## Description of Changes

Fixes #.

Add ignore for the alert raised by https://github.com/pyca/cryptography/issues/9207 

## Testing

- [x] CI is passing.
