### PR TITLE
[2.6.1] Backport: Ignore safety alert #59473 - a bug in cryptography's handling of ssh …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
                 --ignore 54421 \
                 --ignore 55261 \
                 --ignore 58912 \
+                --ignore 59473 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
…certs

(cherry picked from commit f628c33b673c74aec97c3ac84984cfe1bed40d7e)

## Status

Ready for review 

## Description of Changes

Backports #6920 .


## Testing

- [ ] base is `release/2.6.1`
- [ ] CI is passing
- [ ] PR contains only changes from #6920 
