### PR TITLE
chore: factor out minimal, specialized template for changes to production dependencies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/dependencies.md
+++ b/.github/PULL_REQUEST_TEMPLATE/dependencies.md
@@ -1,0 +1,43 @@
+---
+name: Dependency change
+about: Update a production dependency or silence an alert
+---
+
+## Status
+
+Ready for review / Work in progress
+
+## Description of Changes
+
+<!-- Fill out the appropriate "###" section below and delete the others. -->
+
+### If you've added or updated a production code dependency:
+
+Production code dependencies are defined in:
+
+- `admin/requirements.in`
+- `admin/requirements-ansible.in`
+- `securedrop/requirements/python3/requirements.in`
+
+If you changed another `requirements.in` file that applies only to development
+or testing environments, then no diff review is required, and you can open
+a regular pull request.
+
+Choose one of the following:
+
+- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
+- [ ] I would like someone else to do the diff review
+
+### If you've silenced an alert about a production code dependency, explain why:
+
+## Testing
+
+How should the reviewer test this PR?
+Write out any special testing steps here.
+
+## Deployment
+
+Any special considerations for deployment? Consider both:
+
+1. Upgrading existing production instances.
+2. New installs.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,3 +1,8 @@
+---
+name: Pull request
+about: For everything else
+---
+
 ## Status
 
 Ready for review / Work in progress
@@ -47,20 +52,3 @@ Choose one of the following:
 - [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
 - [ ] I would appreciate help with the documentation
 - [ ] These changes do not require documentation
-
-### If you added or updated a production code dependency:
-
-Production code dependencies are defined in:
-
-- `admin/requirements.in`
-- `admin/requirements-ansible.in`
-- `securedrop/requirements/python3/requirements.in`
-
-If you changed another `requirements.in` file that applies only to development
-or testing environments, then no diff review is required, and you can skip
-(remove) this section.
-
-Choose one of the following:
-
-- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
-- [ ] I would like someone else to do the diff review


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We're good at filling in the diff review for meaningful updates to production dependencies, less good at leaving good breadcrumbs for why we choose to silence certain alerts for them.  Factoring out a specialized template for the latter is an experiment to try prompting specifically for the relevant information, with the bonus of simplifying the template for everything else.

## Testing

Do we want this?  Do we like this?