### PR TITLE
ci: run all non-staging tests on `i18n-` branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - /i18n-.*/
                 - /update-builder-.*/
           requires:
             - lint
@@ -394,7 +393,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - /i18n-.*/
                 - /update-builder-.*/
           requires:
             - lint
@@ -405,7 +403,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - /i18n-.*/
                 - /update-builder-.*/
           context:
             - circleci-slack
@@ -414,7 +411,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - /i18n-.*/
                 - /update-builder-.*/
           context:
             - circleci-slack
@@ -428,8 +424,6 @@ workflows:
       - staging-test-with-rebase:
           filters:
             branches:
-              # Ignore needs to be here explicitly as only clause introduced in PR #6086 might be removed afterwards.
-              ignore: /i18n-.*/
               only: /(stg-|release\/).*/
           requires:
             - lint


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6876 by un-skipping on `i18n-` branches all the testing jobs we run normally on pull requests and `develop`.

Not implemented here:

* Running `staging-test-with-rebase` on `i18n-` branches, since [it's not run on most pull requests or `develop`](https://github.com/freedomofpress/securedrop/blob/980d6068c594c8e33039cdd169743bfec3f4d8d8/.circleci/config.yml#L424-L427).
* Running anything on `securedrop-i18n`, which after #6232 will open pull requests into this repository that will be subject to its CI anyway.

## Testing

- [ ] CI passes, including all of:
    - [ ] `app-tests`
    - [ ] `app-page-layout-tests`
    - [ ] `translation-tests`

## Deployment

CI-only; no deployment considerations.