### PR TITLE
chore: add the "silencing an alert" case to the checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,7 +48,7 @@ Choose one of the following:
 - [ ] I would appreciate help with the documentation
 - [ ] These changes do not require documentation
 
-### If you added or updated a production code dependency:
+### If you added or updated a reference to a production code dependency:
 
 Production code dependencies are defined in:
 
@@ -64,3 +64,4 @@ Choose one of the following:
 
 - [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
 - [ ] I would like someone else to do the diff review
+- [ ] I am silencing an alert related to a production dependency, because (please explain below):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We're good at filling in the diff review for meaningful updates to production dependencies, less good at leaving good breadcrumbs for why we choose to silence certain alerts for them.  Let's ask for that justification in the checklist.

This is the minimized version of #6922.

## Testing

~Do we want this?~ (Yes, according to #6922.)  Do we like this?
