### PR TITLE
Have ruff apply to securedrop/scripts/ too

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2086
 
-PY_FILES=$(git diff --name-only --cached --diff-filter=ACMR | grep ".py$")
+PY_FILES=$(git diff --name-only --cached --diff-filter=ACMR | grep "\.py$")
 
 set -eo pipefail
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ ignore = [
     # nested if and with statements, too many violations for now
     "SIM102", "SIM117",
 ]
+extend-include = ["securedrop/scripts/*"]
 
 [tool.ruff.isort]
 # ruff's isort is smart enough to know these are first party, but let's treat

--- a/securedrop/bin/run-mypy
+++ b/securedrop/bin/run-mypy
@@ -7,9 +7,8 @@ REPOROOT=$(git rev-parse --show-toplevel)
 cd "${REPOROOT}"
 
 if [ "$(command -v mypy)" ]; then
-    source "${BASH_SOURCE%/*}/dev-deps"
+    source "securedrop/bin/dev-deps"
     build_redwood
-
     mypy ./securedrop ./admin --namespace-packages --explicit-package-bases "$@"
 elif [ -d "/opt/venvs/securedrop-app-code/" ]; then
     # Inside the dev container, but no mypy

--- a/securedrop/scripts/rqrequeue
+++ b/securedrop/scripts/rqrequeue
@@ -6,10 +6,10 @@ import logging
 import sys
 import time
 
-sys.path.insert(0, "/var/www/securedrop")  # noqa: E402
+sys.path.insert(0, "/var/www/securedrop")
 
-from sdconfig import SecureDropConfig
-from worker import requeue_interrupted_jobs
+from sdconfig import SecureDropConfig  # noqa: E402
+from worker import requeue_interrupted_jobs  # noqa: E402
 
 
 def parse_args():

--- a/securedrop/scripts/shredder
+++ b/securedrop/scripts/shredder
@@ -9,11 +9,11 @@ import logging
 import sys
 import time
 
-sys.path.insert(0, "/var/www/securedrop")  # noqa: E402
+sys.path.insert(0, "/var/www/securedrop")
 
-import journalist_app
-from sdconfig import SecureDropConfig
-from store import Storage
+import journalist_app  # noqa: E402
+from sdconfig import SecureDropConfig  # noqa: E402
+from store import Storage  # noqa: E402
 
 
 def parse_args():
@@ -32,7 +32,7 @@ def clear_shredder():
     try:
         Storage.get_default().clear_shredder()
     except Exception as e:
-        logging.info("Error clearing shredder: {}".format(e))
+        logging.info(f"Error clearing shredder: {e}")
 
 
 def main():
@@ -41,7 +41,7 @@ def main():
         format="%(asctime)s %(levelname)s %(message)s", level=logging.INFO
     )
     if args.interval:
-        logging.info("Clearing shredder every {} seconds.".format(args.interval))
+        logging.info(f"Clearing shredder every {args.interval} seconds.")
         while 1:
             clear_shredder()
             time.sleep(args.interval)

--- a/securedrop/scripts/source_deleter
+++ b/securedrop/scripts/source_deleter
@@ -9,10 +9,10 @@ import logging
 import sys
 import time
 
-sys.path.insert(0, "/var/www/securedrop")  # noqa: E402
+sys.path.insert(0, "/var/www/securedrop")
 
-import journalist_app
-from sdconfig import SecureDropConfig
+import journalist_app  # noqa: E402
+from sdconfig import SecureDropConfig  # noqa: E402
 
 
 def parse_args():
@@ -31,7 +31,7 @@ def purge_deleted_sources():
     try:
         journalist_app.utils.purge_deleted_sources()
     except Exception as e:
-        logging.info("Error purging deleted sources: {}".format(e))
+        logging.info(f"Error purging deleted sources: {e}")
 
 
 def main():
@@ -40,7 +40,7 @@ def main():
         format="%(asctime)s %(levelname)s %(message)s", level=logging.INFO
     )
     if args.interval:
-        logging.info("Purging deleted sources every {} seconds.".format(args.interval))
+        logging.info(f"Purging deleted sources every {args.interval} seconds.")
         while 1:
             purge_deleted_sources()
             time.sleep(args.interval)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

These need explicit mentioning since they don't have a `.py` extension.

The E402 error now applies to the imports following the sys.path.append() call, so move them around.

KOG Update: 
  - added a fix for #6930 as `make lint` was failing locally
  - updated the precommit hook to stay limited to `.py` files, as ruff got indigestion trying to lint a bash script.
  - recusing myself from review as a result :(

## Testing

* [ ] Visual review
* [ ] CI passes

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
