### PR TITLE
Fix demo build

### DIFF
--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -158,13 +158,17 @@ function reset_demo() {
 }
 
 function build_redwood() {
-    # Create a debug build of redwood and install it in the app-code virtualenv
-    # TODO: add live reload support
-    # We tell cargo to put its registry/crate cache and build cache in the target/ folder so
-    # it persists instead of being recreated from scratch each time the container starts.
-    # n.b. we can't re-use the host's caches because of permission differences
-    PATH="$PATH:/opt/cargo/bin/" \
-    CARGO_HOME="${REPOROOT}/target/cargo-dev" \
-        python3 "${REPOROOT}/redwood/build-wheel.py" --redwood "${REPOROOT}/redwood" --target "${REPOROOT}/target/dev"
-    /opt/venvs/securedrop-app-code/bin/pip install "${REPOROOT}"/redwood/redwood-*.whl
+    # For the demo, we build the wheel at container build time instead of
+    # during launch, so skip this part
+    if [[ -z "${SKIP_REDWOOD_BUILD:-}" ]]; then
+        # Create a debug build of redwood and install it in the app-code virtualenv
+        # TODO: add live reload support
+        # We tell cargo to put its registry/crate cache and build cache in the target/ folder so
+        # it persists instead of being recreated from scratch each time the container starts.
+        # n.b. we can't re-use the host's caches because of permission differences
+        PATH="$PATH:/opt/cargo/bin/" \
+        CARGO_HOME="${REPOROOT}/target/cargo-dev" \
+            python3 "${REPOROOT}/redwood/build-wheel.py" --redwood "${REPOROOT}/redwood" --target "${REPOROOT}/target/dev"
+        /opt/venvs/securedrop-app-code/bin/pip install "${REPOROOT}"/redwood/redwood-*.whl
+    fi
 }

--- a/securedrop/dockerfiles/focal/python3/DemoDockerfile
+++ b/securedrop/dockerfiles/focal/python3/DemoDockerfile
@@ -1,5 +1,5 @@
-# ubuntu 20.04 image from 2021-09-21
-FROM ubuntu@sha256:3555f4996aea6be945ae1532fa377c88f4b3b9e6d93531f47af5d78a7d5e3761
+# ubuntu 20.04 image from 2022-10-19
+FROM ubuntu@sha256:450e066588f42ebe1551f3b1a535034b6aa46cd936fe7f2c6b0d72997ec61dbd
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata && \
@@ -8,23 +8,47 @@ RUN apt-get update && \
                        gnupg2 redis-server git \
                        enchant libffi-dev sqlite3 gettext sudo \
                        libasound2 libdbus-glib-1-2 libgtk2.0-0 libfontconfig1 libxrender1 \
-                       libcairo-gobject2 libgtk-3-0 libstartup-notification0 basez
+                       libcairo-gobject2 libgtk-3-0 libstartup-notification0 basez pkg-config
+
+# Install Rust using the same steps as <https://github.com/rust-lang/docker-rust>
+# 1) Download rustup-init and verify it matches hardcoded checksum
+# 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
+# 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
+ENV RUST_VERSION 1.71.1
+ENV RUSTUP_VERSION 1.24.3
+ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
+ENV RUSTUP_HOME /opt/rustup
+ENV CARGO_HOME /opt/cargo
+
+RUN TMPDIR=`mktemp -d` && cd ${TMPDIR} \
+        && curl --proto '=https' --tlsv1.2 -OO -sSf https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init \
+        && echo "${RUSTUP_INIT_SHA256} *rustup-init" | sha256sum -c - \
+        && chmod +x rustup-init \
+        && ./rustup-init --default-toolchain=${RUST_VERSION} --profile minimal -y \
+        && cd && rm -rf ${TMPDIR}
 
 COPY . /opt/securedrop
 RUN python3 -m venv /opt/venvs/securedrop-app-code && \
     /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r /opt/securedrop/securedrop/requirements/python3/bootstrap-requirements.txt && \
     /opt/venvs/securedrop-app-code/bin/pip3 install --no-deps --require-hashes -r /opt/securedrop/securedrop/requirements/python3/requirements.txt
+RUN PATH="$PATH:/opt/cargo/bin/" \
+    python3 "/opt/securedrop/redwood/build-wheel.py" \
+        --release \
+        --redwood "/opt/securedrop/redwood" \
+        --target "/opt/securedrop/redwood/target/" \
+    && /opt/venvs/securedrop-app-code/bin/pip install /opt/securedrop/redwood/redwood-*.whl
 
 RUN sed -i 's/"localhost"\];/"localhost", "demo-source.securedrop.org"];/' /opt/securedrop/securedrop/static/js/source.js
 
 RUN useradd --no-create-home --home-dir /tmp --uid 1000 demo && echo "demo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-    chown -R demo:demo /opt/securedrop /opt/venvs/securedrop-app-code
+    chown -R demo:demo /opt/securedrop /opt/venvs/
 
 STOPSIGNAL SIGKILL
 
 EXPOSE 8080 8081
 
 ENV REPOROOT=/opt/securedrop
+ENV SKIP_REDWOOD_BUILD=1
 
 USER demo
 WORKDIR /opt/securedrop/securedrop


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Build the redwood wheel during the container build instead of when launching the container. Copy some of the rustup logic into the DemoDockerfile and use the same base image version as the current dev environment.

This is hopefully good enough for now, long-term we should switch to server nightlies that are just installed into the image.

## Testing

* [ ] `podman build -f securedrop/dockerfiles/focal/python3/DemoDockerfile . -t sd-demo`
* [ ] `podman run --rm -it -p 8080:8080 sd-demo`
* [ ] Visit localhost:8080 in your browser, create a new source and send a message (invoking redwood encryption with no errors)

## Deployment

Any special considerations for deployment? Affects demo instance.
