### PR TITLE
Add exemption for gitpython safety alert #60350

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
                 --ignore 55261 \
                 --ignore 58912 \
                 --ignore 59473 \
+                --ignore 60350 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION

## Status

Ready for review 

## Description of Changes

Adds an exception for the listed safety alert. IMO Justified as:

- develop requirements only
- gitpython is a bandit dependency. A dependency fix is available in bandit's main branch. Once a release is available updating bandit will clear this alert


Changes proposed in this pull request:

## Testing

- [ ] CI is passing
- [ ] `make safety` passes locally.

## Deployment

n/a
