### PR TITLE
Add `cargo audit` job in CI

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,27 +1,12 @@
 [advisories]
 ignore = [] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
-informational_warnings = ["unmaintained"] # warn for categories of informational advisories
-severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")
-
-# Advisory Database Configuration
-[database]
-path = "~/.cargo/advisory-db" # Path where advisory git repo will be cloned
-url = "https://github.com/RustSec/advisory-db.git" # URL to git repo
-fetch = true # Perform a `git fetch` before auditing (default: true)
-stale = false # Allow stale advisory DB (i.e. no commits for 90 days, default: false)
 
 # Output Configuration
 [output]
 deny = ["yanked", "unmaintained"]
-format = "terminal" # "terminal" (human readable report) or "json"
-quiet = false # Only print information on error
-show_tree = true # Show inverse dependency trees along with advisories (default: true)
+quiet = false
 
 # Target Configuration
 [target]
 arch = "x86_64" # Ignore advisories for CPU architectures other than this one
 os = "linux" # Ignore advisories for operating systems other than this one
-
-[yanked]
-enabled = true # Warn for yanked crates in Cargo.lock (default: true)
-update_index = true # Auto-update the crates.io index (default: true)

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -12,7 +12,7 @@ stale = false # Allow stale advisory DB (i.e. no commits for 90 days, default: f
 
 # Output Configuration
 [output]
-deny = ["unmaintained"] # exit on error if unmaintained dependencies are found
+deny = ["yanked", "unmaintained"]
 format = "terminal" # "terminal" (human readable report) or "json"
 quiet = false # Only print information on error
 show_tree = true # Show inverse dependency trees along with advisories (default: true)

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,27 @@
+[advisories]
+ignore = [] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
+informational_warnings = ["unmaintained"] # warn for categories of informational advisories
+severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")
+
+# Advisory Database Configuration
+[database]
+path = "~/.cargo/advisory-db" # Path where advisory git repo will be cloned
+url = "https://github.com/RustSec/advisory-db.git" # URL to git repo
+fetch = true # Perform a `git fetch` before auditing (default: true)
+stale = false # Allow stale advisory DB (i.e. no commits for 90 days, default: false)
+
+# Output Configuration
+[output]
+deny = ["unmaintained"] # exit on error if unmaintained dependencies are found
+format = "terminal" # "terminal" (human readable report) or "json"
+quiet = false # Only print information on error
+show_tree = true # Show inverse dependency trees along with advisories (default: true)
+
+# Target Configuration
+[target]
+arch = "x86_64" # Ignore advisories for CPU architectures other than this one
+os = "linux" # Ignore advisories for operating systems other than this one
+
+[yanked]
+enabled = true # Warn for yanked crates in Cargo.lock (default: true)
+update_index = true # Auto-update the crates.io index (default: true)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,17 @@ jobs:
             make rust-lint
             make rust-test
 
+  rust-security:
+    # Keep version in sync with rust-toolchain.toml
+    docker:
+      - image: rust:1.71.1
+    steps:
+      - checkout
+      - run:
+          name: Check Rust dependencies
+          command: |
+            make rust-audit
+
   app-tests:
     machine:
       image: ubuntu-2004:202010-01
@@ -421,6 +432,12 @@ workflows:
           context:
             - circleci-slack
           <<: *slack-fail-post-step
+      - rust-security:
+          requires:
+            - lint
+          context:
+            - circleci-slack
+          <<: *slack-fail-post-step
       - staging-test-with-rebase:
           filters:
             branches:
@@ -455,6 +472,7 @@ workflows:
     jobs:
       - staging-test-with-rebase
       - static-analysis-and-no-known-cves
+      - rust-security
 
   weekly:
     triggers:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,9 +317,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "idna"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "buffered-reader"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,11 +512,11 @@ checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "openssl"
-version = "0.10.53"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12df40a956736488b7b44fe79fe12d4f245bb5b3f5a1f6095e499760015be392"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -532,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
@@ -727,7 +733,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -736,7 +742,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -790,7 +796,7 @@ version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,16 @@ semgrep:
 	@semgrep --exclude "securedrop/tests/" --error --strict --metrics off --max-chars-per-line 200 --verbose --config "p/r2c-security-audit" securedrop
 	@echo
 
+
+# check dependencies in Cargo.lock
+.PHONY: rust-audit
+rust-audit:
+	@echo "███ Running Rust dependency checks..."
+	@cargo install cargo-audit
+	@cargo audit
+	@echo
+
+
 #############
 #
 # Development


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6815.

- adds a `make rust-audit` target that installs and runs cargo-audit against the project
- adds an `audit.toml` config file with defaults+fail-on-yanked
- adds a `rust-security` job running on commits and nightlies using said target
- updates openssl and hermit-abi rust dependencies to make said job pass :)

## Testing

- [x] CI is passing
- [x] `make rust-audit` passes locally.

## Deployment

n/a