### PR TITLE
Test against Firefox 102 ESR and geckodriver to 0.33

### DIFF
--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update  && apt-get install -y \
 # Current versions of the test browser software. Tor Browser is based
 # on a specific version of Firefox, noted in Help > About Tor Browser.
 # Ideally we'll keep those in sync.
-ENV FF_VERSION 91.12.0esr
-ENV GECKODRIVER_VERSION v0.29.1
+ENV FF_VERSION 102.15.1esr
+ENV GECKODRIVER_VERSION v0.33.0
 
 # Import Tor release signing key
 ENV TOR_RELEASE_KEY_FINGERPRINT "EF6E286DDA85EA2A4BA7DE684E2C6E8793298290"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Tor Browser 12 (currently latest) is roughly based on Firefox 102 ESR, so we should be using that to test against. Note that 102 is already EOL, but Tor Browser hasn't made the switch yet (#6956).

And then upgrade to the latest version of geckodriver while we're at it.

## Testing

* [x] CI passes

## Deployment

Any special considerations for deployment? No

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
