### PR TITLE
Updated sequoia-openpgp to v1.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,9 +818,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sequoia-openpgp"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30efff3f9930e85b4284e76bbdad741f36412dfb1e370efd0de5866ae1a11dfc"
+checksum = "a16854c0f6297de6db4df195e28324dfbc2429802f0e48cd04007db8e3049709"
 dependencies = [
  "anyhow",
  "base64",


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #6955 .

Updates sequoia-openpgp from 1.16.0 to 1.16.1, pulling in minor bugfix described in https://lists.sequoia-pgp.org/hyperkitty/list/devel@lists.sequoia-pgp.org/thread/TTXVH5UGWAMXG2ZZO7J2BEHENC6UPMSM/

## Testing

- [ ] CI is passing
- [ ] `make rust-audit` passes locally