### PR TITLE
Import Markup and escape from markupsafe

### DIFF
--- a/securedrop/journalist_app/col.py
+++ b/securedrop/journalist_app/col.py
@@ -5,10 +5,8 @@ from db import db
 from encryption import GpgKeyNotFoundError
 from flask import (
     Blueprint,
-    Markup,
     abort,
     current_app,
-    escape,
     flash,
     redirect,
     render_template,
@@ -32,6 +30,7 @@ from journalist_app.utils import (
     make_star_true,
     mark_seen,
 )
+from markupsafe import Markup, escape
 from models import Reply, Submission
 from sqlalchemy.orm.exc import NoResultFound
 from store import Storage

--- a/securedrop/journalist_app/main.py
+++ b/securedrop/journalist_app/main.py
@@ -8,10 +8,8 @@ from db import db
 from encryption import EncryptionManager
 from flask import (
     Blueprint,
-    Markup,
     abort,
     current_app,
-    escape,
     flash,
     g,
     redirect,
@@ -23,6 +21,7 @@ from flask_babel import gettext
 from journalist_app.forms import ReplyForm
 from journalist_app.sessions import session
 from journalist_app.utils import bulk_delete, download, get_source, validate_user
+from markupsafe import Markup, escape
 from models import Reply, SeenReply, Source, SourceStar, Submission
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import func

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -7,9 +7,10 @@ import flask
 import werkzeug
 from db import db
 from encryption import EncryptionManager
-from flask import Markup, abort, current_app, escape, flash, redirect, send_file, url_for
+from flask import abort, current_app, flash, redirect, send_file, url_for
 from flask_babel import gettext, ngettext
 from journalist_app.sessions import session
+from markupsafe import Markup, escape
 from models import (
     FirstOrLastNameError,
     InvalidPasswordLength,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Importing from Flask was deprecated and already fixed in most of SecureDrop.

Refs #6963.

## Testing

* [ ] Visual review & CI passes

## Deployment

Any special considerations for deployment? No

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
