### PR TITLE
chore(safety): ignore GitPython CVEs CVE-2023-{40590,41040}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,8 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
                 --ignore 58912 \
                 --ignore 59473 \
                 --ignore 60350 \
+		--ignore 60789 \
+		--ignore 60841 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

GitPython is a development-only dependency of Bandit, which will be obsoleted by #6961.  In the meantime:

- CVE-2023-40590 (Safety 60789) affects Windows, which we don't support.
- CVE-2023-41040 (Safety 60841) is not exploitable for our use of GitPython via Bandit.

## Testing

Assuming no objections to the above rationale:

- [x] CI passes.

## Deployment

No special considerations.