### PR TITLE
Run `make lint` and other simple jobs in GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,35 +101,6 @@ jobs:
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" securedrop/bin/dev-shell \
                   bash -c "/opt/venvs/securedrop-app-code/bin/pip3 install --require-hashes -r requirements/python3/develop-requirements.txt && make -C .. verify-mo"
 
-  rust:
-    # Keep version in sync with rust-toolchain.toml
-    docker:
-      - image: rust:1.71.1
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: |
-            apt-get update && apt-get install make --yes
-            rustup component add rustfmt
-            rustup component add clippy
-      - run:
-          name: Lint and test Rust code
-          command: |
-            make rust-lint
-            make rust-test
-
-  rust-security:
-    # Keep version in sync with rust-toolchain.toml
-    docker:
-      - image: rust:1.74.0
-    steps:
-      - checkout
-      - run:
-          name: Check Rust dependencies
-          command: |
-            make rust-audit
-
   app-tests:
     machine:
       image: ubuntu-2004:202010-01
@@ -271,25 +242,6 @@ jobs:
           command: |
             cd admin; make test
 
-  updater-gui-tests:
-    docker:
-      - image: debian:bullseye
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: |
-            apt update && apt-get install -y libqt5designer5 python3-venv
-            cd journalist_gui
-            python3 -m venv .venv/ && source .venv/bin/activate
-            pip install --require-hashes -r dev-requirements.txt
-      - run:
-          name: Run tests
-          command: |
-            cd journalist_gui
-            source .venv/bin/activate
-            QT_QPA_PLATFORM=offscreen python3 test_gui.py -v
-
   static-analysis-and-no-known-cves:
     machine:
       image: ubuntu-2004:202010-01
@@ -395,10 +347,6 @@ workflows:
           context:
             - circleci-slack
           <<: *slack-fail-post-step
-      - rust:
-          context:
-            - circleci-slack
-          <<: *slack-fail-post-step
       - app-tests:
           filters:
             branches:
@@ -427,21 +375,7 @@ workflows:
           context:
             - circleci-slack
           <<: *slack-fail-post-step
-      - updater-gui-tests:
-          filters:
-            branches:
-              ignore:
-                - /update-builder-.*/
-          context:
-            - circleci-slack
-          <<: *slack-fail-post-step
       - static-analysis-and-no-known-cves:
-          requires:
-            - lint
-          context:
-            - circleci-slack
-          <<: *slack-fail-post-step
-      - rust-security:
           requires:
             - lint
           context:
@@ -478,7 +412,6 @@ workflows:
     jobs:
       - staging-test-with-rebase
       - static-analysis-and-no-known-cves
-      - rust-security
 
   weekly:
     triggers:

--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -9,7 +9,7 @@ jobs:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.71.1
+    container: rust:1.74.0
     env:
       CARGO_VET_VERSION: 0.8.0
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container: ubuntu:focal
+    steps:
+      - name: Install Git
+        run: |
+          apt-get update && apt-get install --yes git
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install --yes --no-install-recommends \
+            build-essential python3-virtualenv python3-dev enchant file apache2-dev jq
+          virtualenv .venv
+          # TODO: this should be one step, but there are too many conflicting dependencies
+          ./.venv/bin/pip install -r securedrop/requirements/python3/test-requirements.txt
+          ./.venv/bin/pip install -r securedrop/requirements/python3/requirements.txt
+          ./.venv/bin/pip install -r securedrop/requirements/python3/develop-requirements.txt
+      - name: Run lint
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          source .venv/bin/activate
+          make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,37 @@ jobs:
           git config --global --add safe.directory $GITHUB_WORKSPACE
           source .venv/bin/activate
           make lint
+
+  rust:
+    runs-on: ubuntu-latest
+    # Keep version in sync with rust-toolchain.toml
+    container: rust:1.74.0
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          rustup component add rustfmt
+          rustup component add clippy
+      - name: Lint and test Rust code
+        run: |
+          make rust-lint
+          make rust-test
+
+  updater-gui-tests:
+    runs-on: ubuntu-latest
+    container: debian:bullseye
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update && apt-get install --yes git libqt5designer5 python3-venv
+      - uses: actions/checkout@v3
+      - name: Install Python dependencies
+        run: |
+          cd journalist_gui
+          python3 -m venv .venv/ && source .venv/bin/activate
+          pip install --require-hashes -r dev-requirements.txt
+      - name: Run tests
+        run: |
+          cd journalist_gui
+          source .venv/bin/activate
+          QT_QPA_PLATFORM=offscreen python3 test_gui.py -v

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,15 @@
+name: Security (cron)
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  rust-audit:
+    runs-on: ubuntu-latest
+    # Keep version in sync with rust-toolchain.toml
+    container: rust:1.74.0
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check Rust dependencies
+        run: |
+          make rust-audit


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

### lint
This is a ground-up rewrite of the "lint" job instead of porting it from
CircleCI. It will be much faster since it doesn't try to spin up a
Docker container and work through our various unnecessary caching
layers. It does literally the bare minimum to run lints.

The CircleCI lint job needs to remain for now because it's super
intertwined with everything else.

### part 2
Migrate rust, rust-security and updater-gui-tests since they're pretty simple.

## Testing

* [ ] Visual review & CI passes
