### PR TITLE
Have scripts/validate-pgp-key use redwood.is_valid_public_key()

### DIFF
--- a/securedrop/scripts/validate-pgp-key
+++ b/securedrop/scripts/validate-pgp-key
@@ -12,12 +12,9 @@ that only the specified fingerprint was imported
 
 import argparse
 import sys
-import tempfile
 from pathlib import Path
 
-sys.path.insert(0, "/var/www/securedrop")
-
-import pretty_bad_protocol as gnupg  # noqa: E402
+import redwood
 
 parser = argparse.ArgumentParser(description="Verify PGP key file")
 parser.add_argument("pubkey", type=Path, help="Public key file")
@@ -26,17 +23,10 @@ args = parser.parse_args()
 
 pubkey = args.pubkey.read_text()
 
-with tempfile.TemporaryDirectory() as tmpdir:
-    # FIXME: we should be using redwood/Sequoia for this!!
-    gpg = gnupg.GPG(
-        binary="gpg2",
-        homedir=tmpdir,
-        options=["--pinentry-mode loopback", "--trust-model direct"],
-    )
-    result = gpg.import_keys(pubkey)
-    if result.fingerprints == [args.fingerprint]:
-        print("Success! Specified fingerprint matches pubkey file.")
-        sys.exit(0)
-    else:
-        print(f"Failed! Key contains {result.fingerprints}, not {args.fingerprint}")
-        sys.exit(1)
+fingerprint = redwood.is_valid_public_key(pubkey)
+if fingerprint == args.fingerprint:
+    print("Success! Specified fingerprint matches pubkey file.")
+    sys.exit(0)
+else:
+    print(f"Failed! Key contains {fingerprint}, not {args.fingerprint}")
+    sys.exit(1)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We can drop our (temporary) usage of pretty_bad_protocol here by using the new redwood.is_valid_public_key() function that verifies it's a valid public key, and returns the extracted fingerprint.

## Testing

How should the reviewer test this PR?

We can keep the test plan short since we already reviewed is_valid_public_key in detail.

* [x] Run `make dev` and then open up a shell into the container (e.g. `podman exec --user=root -it $(podman ps --filter name=securedrop --format '{{.ID}}') bash`)
* [x] Run `./scripts/validate-pgp-key -h` and see help output (not an import error, etc.)
* [x] Run `./scripts/validate-pgp-key tests/files/test_journalist_key.pub foo`, get an error (non-zero exit code) with "Failed! Key contains 65A1B5FF195B56353CC63DFFCC40EF1228271441, not foo"
* [x] Run `./scripts/validate-pgp-key tests/files/test_journalist_key.pub 65A1B5FF195B56353CC63DFFCC40EF1228271441`, it should succeed with 0 exit code
* [ ] Run `./scripts/validate-pgp-key tests/files/test_journalist_key.sec 65A1B5FF195B56353CC63DFFCC40EF1228271441`, it should fail with an exception ("redwood.RedwoodError: HasSecretKeyMaterial") and a non-zero exit code

## Deployment

Any special considerations for deployment? Not particularly, this script is used in the postinst though.

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
