### PR TITLE
Migrate secret keys from GPG to database-backed storage

### DIFF
--- a/securedrop/encryption.py
+++ b/securedrop/encryption.py
@@ -113,6 +113,12 @@ class EncryptionManager:
         self._save_key_fingerprint_to_redis(source_filesystem_id, source_key_fingerprint)
         return source_key_fingerprint
 
+    def get_source_secret_key(self, fingerprint: str, passphrase: str) -> str:
+        secret_key = self._gpg.export_keys(fingerprint, secret=True, passphrase=passphrase)
+        if not secret_key:
+            raise GpgKeyNotFoundError()
+        return secret_key
+
     def encrypt_source_message(self, message_in: str, encrypted_message_path_out: Path) -> None:
         redwood.encrypt_message(
             # A submission is only encrypted for the journalist key


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

For the final part of the GPG->Sequoia migration, we export sources' secret keys out of GPG and into database-backed storage for use with Sequoia/redwood functions. Because we don't have access to a source's GPG passphrase, we can only do this migration when they log in.

If everything has been successfully migrated, then we delete the GPG key out of the keyring as well.

Tests have been added that cover the pre-existing keypair generation code and the new secret key migration.

Fixes #6802.

## Testing

* [x] Start the dev server (`make dev`) and open a shell into the container, e.g. `podman exec --user=root -it $(podman ps --filter name=securedrop --format '{{.ID}}') bash`
* [x] Run `alembic stamp 811334d7105f` (ID of the migration before public key one added in #6946)
* [x] Run `./loaddata.py --gpg` to add some GPG sources
* [x] Run `alembic upgrade head`, completes successfully. Then run a query like `select filesystem_id, pgp_fingerprint, pgp_public_key, pgp_secret_key from sources;` to verify we now have sources that have fingerprint + public key in the database, but not secret key
* [x] Pick one of the GPG-added sources and log in as it.
* [x] Re-run the database query to see that the secret key is now populated in the database.
* [x] Obligatory visual review + CI passes


## Deployment

Any special considerations for deployment? Not really.

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
