### PR TITLE
Fix 17c559a7a685_pgp_public_keys.py migration for fresh installs

### DIFF
--- a/securedrop/alembic/versions/17c559a7a685_pgp_public_keys.py
+++ b/securedrop/alembic/versions/17c559a7a685_pgp_public_keys.py
@@ -32,7 +32,12 @@ def upgrade() -> None:
     doesn't already have key material migrated, export the key and
     save it in the database.
     """
-    config = SecureDropConfig.get_current()
+    try:
+        config = SecureDropConfig.get_current()
+    except ModuleNotFoundError:
+        # Fresh install, nothing to migrate
+        return
+
     gpg = gnupg.GPG(
         binary="gpg2",
         homedir=str(config.GPG_KEY_DIR),

--- a/securedrop/alembic/versions/b58139cfdc8c_add_checksum_columns_revoke_table.py
+++ b/securedrop/alembic/versions/b58139cfdc8c_add_checksum_columns_revoke_table.py
@@ -3,23 +3,14 @@ Revision ID: b58139cfdc8c
 Revises: f2833ac34bb6
 Create Date: 2019-04-02 10:45:05.178481
 """
-import os
 
 import sqlalchemy as sa
 from alembic import op
-
-# raise the errors if we're not in production
-raise_errors = os.environ.get("SECUREDROP_ENV", "prod") != "prod"
-
-try:
-    from journalist_app import create_app
-    from models import Reply, Submission
-    from sdconfig import SecureDropConfig
-    from store import Storage, queued_add_checksum_for_file
-    from worker import create_queue
-except:  # noqa
-    if raise_errors:
-        raise
+from journalist_app import create_app
+from models import Reply, Submission
+from sdconfig import SecureDropConfig
+from store import Storage, queued_add_checksum_for_file
+from worker import create_queue
 
 # revision identifiers, used by Alembic.
 revision = "b58139cfdc8c"
@@ -47,47 +38,48 @@ def upgrade() -> None:
 
     try:
         config = SecureDropConfig.get_current()
-        app = create_app(config)
+    except ModuleNotFoundError:
+        # Fresh install, nothing to migrate
+        return
 
-        # we need an app context for the rq worker extension to work properly
-        with app.app_context():
-            conn = op.get_bind()
-            query = sa.text(
-                """SELECT submissions.id, sources.filesystem_id, submissions.filename
-                               FROM submissions
-                               INNER JOIN sources
-                               ON submissions.source_id = sources.id
-                            """
-            )
-            for (sub_id, filesystem_id, filename) in conn.execute(query):
-                full_path = Storage.get_default().path(filesystem_id, filename)
-                create_queue(config.RQ_WORKER_NAME).enqueue(
-                    queued_add_checksum_for_file,
-                    Submission,
-                    int(sub_id),
-                    full_path,
-                    app.config["SQLALCHEMY_DATABASE_URI"],
-                )
+    app = create_app(config)
 
-            query = sa.text(
-                """SELECT replies.id, sources.filesystem_id, replies.filename
-                               FROM replies
-                               INNER JOIN sources
-                               ON replies.source_id = sources.id
-                            """
+    # we need an app context for the rq worker extension to work properly
+    with app.app_context():
+        conn = op.get_bind()
+        query = sa.text(
+            """SELECT submissions.id, sources.filesystem_id, submissions.filename
+                           FROM submissions
+                           INNER JOIN sources
+                           ON submissions.source_id = sources.id
+                        """
+        )
+        for (sub_id, filesystem_id, filename) in conn.execute(query):
+            full_path = Storage.get_default().path(filesystem_id, filename)
+            create_queue(config.RQ_WORKER_NAME).enqueue(
+                queued_add_checksum_for_file,
+                Submission,
+                int(sub_id),
+                full_path,
+                app.config["SQLALCHEMY_DATABASE_URI"],
             )
-            for (rep_id, filesystem_id, filename) in conn.execute(query):
-                full_path = Storage.get_default().path(filesystem_id, filename)
-                create_queue(config.RQ_WORKER_NAME).enqueue(
-                    queued_add_checksum_for_file,
-                    Reply,
-                    int(rep_id),
-                    full_path,
-                    app.config["SQLALCHEMY_DATABASE_URI"],
-                )
-    except:  # noqa
-        if raise_errors:
-            raise
+
+        query = sa.text(
+            """SELECT replies.id, sources.filesystem_id, replies.filename
+                           FROM replies
+                           INNER JOIN sources
+                           ON replies.source_id = sources.id
+                        """
+        )
+        for (rep_id, filesystem_id, filename) in conn.execute(query):
+            full_path = Storage.get_default().path(filesystem_id, filename)
+            create_queue(config.RQ_WORKER_NAME).enqueue(
+                queued_add_checksum_for_file,
+                Reply,
+                int(rep_id),
+                full_path,
+                app.config["SQLALCHEMY_DATABASE_URI"],
+            )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

On a fresh install, config.py doesn't exist so we can't instantiate a
SecureDropConfig. We now explicitly check this case and quietly do
nothing for fresh installs, since there's no sources needing migration.

This is similar to the `raise_errors` code in
b58139cfdc8c_add_checksum_columns_revoke_table.py and
3da3fcab826a_delete_orphaned_submissions.py but much more narrowly
scoped.

Fixes #6976.

I tacked on two more commits that fixes this in other migrations and adds a regression test - those could be dropped from this PR if we want to keep this narrow. See commit messages for full details.

* Fix other migrations to just catch SecureDropConfig usage
* Test alembic migrations when config.py doesn't exist

The third commit fixes #6977.

## Testing

How should the reviewer test this PR?

* [ ] Staging build passes (if a human wanted to test it they could do a fresh install but that's the same thing that staging does automatically...)
* [ ] Visual review & CI passes

## Deployment

Any special considerations for deployment? This error applies to fresh installs only.

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
