### PR TITLE
Lazily intialize GPG code in EncryptionManager

### DIFF
--- a/securedrop/loaddata.py
+++ b/securedrop/loaddata.py
@@ -252,7 +252,7 @@ def add_source(use_gpg: bool = False) -> Tuple[Source, str]:
     source = source_user.get_db_record()
     if use_gpg:
         manager = EncryptionManager.get_default()
-        gen_key_input = manager._gpg.gen_key_input(
+        gen_key_input = manager.gpg().gen_key_input(
             passphrase=source_user.gpg_secret,
             name_email=source_user.filesystem_id,
             key_type="RSA",
@@ -263,7 +263,7 @@ def add_source(use_gpg: bool = False) -> Tuple[Source, str]:
             # to set an expiration date.
             expire_date="0",
         )
-        manager._gpg.gen_key(gen_key_input)
+        manager.gpg().gen_key(gen_key_input)
 
         # Delete the Sequoia-generated keys
         source.pgp_public_key = None

--- a/securedrop/tests/test_encryption.py
+++ b/securedrop/tests/test_encryption.py
@@ -243,7 +243,7 @@ class TestEncryptionManager:
                 )
 
         # Amd the reply can't be decrypted without providing the source1's gpg secret
-        result = encryption_mgr._gpg.decrypt(
+        result = encryption_mgr.gpg().decrypt(
             # For GPG 2.1+, a non-null passphrase _must_ be passed to decrypt()
             encrypted_reply,
             passphrase="test 123",

--- a/securedrop/tests/test_integration.py
+++ b/securedrop/tests/test_integration.py
@@ -357,6 +357,7 @@ def test_reply_normal(journalist_app, source_app, test_journo):
     gpg functions).
     """
     encryption_mgr = EncryptionManager.get_default()
+    encryption_mgr.gpg()  # lazily initialize GPG
     with mock.patch.object(encryption_mgr._gpg, "_encoding", "ansi_x3.4_1968"):
         _helper_test_reply(
             journalist_app,
@@ -376,6 +377,7 @@ def test_unicode_reply_with_ansi_env(journalist_app, source_app, test_journo):
     # environment. See
     # https://github.com/freedomofpress/securedrop/issues/1360 for context.
     encryption_mgr = EncryptionManager.get_default()
+    encryption_mgr.gpg()  # lazily initialize GPG
     with mock.patch.object(encryption_mgr._gpg, "_encoding", "ansi_x3.4_1968"):
         _helper_test_reply(
             journalist_app,

--- a/securedrop/tests/utils/__init__.py
+++ b/securedrop/tests/utils/__init__.py
@@ -84,7 +84,7 @@ def create_legacy_gpg_key(
     # Strongbox) was publicly released for the first time.
     # https://www.newyorker.com/news/news-desk/strongbox-and-aaron-swartz
     default_key_creation_date = datetime.date(2013, 5, 14)
-    gen_key_input = manager._gpg.gen_key_input(
+    gen_key_input = manager.gpg().gen_key_input(
         passphrase=source_user.gpg_secret,
         name_email=source_user.filesystem_id,
         key_type="RSA",
@@ -95,7 +95,7 @@ def create_legacy_gpg_key(
         # to set an expiration date.
         expire_date="0",
     )
-    manager._gpg.gen_key(gen_key_input)
+    manager.gpg().gen_key(gen_key_input)
 
     # Delete the Sequoia-generated keys
     source.pgp_public_key = None


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

In most cases we should no longer need GPG, so lazily initialize it only when migration code or fallbacks are invoked.

Also take the opportunity to replace a TODO that was implemented.

## Testing

* [ ] CI passes
* [ ] Visual review

## Deployment

Any special considerations for deployment? No.

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
