### PR TITLE
ci(`translation-tests`): change filter prefix `s/i18n/weblate/`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,7 +461,7 @@ workflows:
             - lint
           filters:
             branches:
-              only: /i18n-.*/
+              only: /weblate-.*/
           context:
             - circleci-slack
           <<: *slack-fail-post-step


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

After #6954, runs `translation-tests` on Weblate's pull requests prefixed `weblate-` rather than our custom branches prefixed `i18n-`.

## Testing

- [ ] CI on this branch includes `translation-tests`.

## Deployment

No special considerations; CI-only.