### PR TITLE
build(`DemoDockerfile`): install `jq`

### DIFF
--- a/securedrop/dockerfiles/focal/python3/DemoDockerfile
+++ b/securedrop/dockerfiles/focal/python3/DemoDockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata && \
     apt-get install -y paxctl apache2-dev coreutils \
                        python3-pip python3-all python3-venv virtualenv libpython3.8-dev libssl-dev \
-                       gnupg2 redis-server git \
+                       gnupg2 redis-server git jq \
                        enchant libffi-dev sqlite3 gettext sudo \
                        libasound2 libdbus-glib-1-2 libgtk2.0-0 libfontconfig1 libxrender1 \
                        libcairo-gobject2 libgtk-3-0 libstartup-notification0 basez pkg-config


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes `demo-{source,journalist}.securedrop.org` by installing `jq` to unbreak `make supported-languages`.
* `Dockerfile` inherits `jq` from `SlimDockerfile`; `DemoDockerfile` does not.
* This is another vote for #6941.

## Testing

```sh-session
user@sd-dev:~/securedrop$ docker build -t demo -f securedrop/dockerfiles/focal/python3/DemoDockerfile .
user@sd-dev:~/securedrop$ docker run -it -p 8080:8080 -p 8081:8081 --rm demo
```

* [x] The Source and Journalist Interfaces are available in all their translations at `localhost:{8080,8081}`, respectively.

## Deployment

Demo-only; no deployment considerations.