### PR TITLE
build(`lint`): run ruff first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,10 @@ yamllint:  ## Lint YAML files (does not validate syntax!).
 	@yamllint --strict .
 	@echo
 
+# While the order mostly doesn't matter here, keep "check-ruff" first, since it
+# gives the broadest coverage and runs (and therefore fails) fastest.
 .PHONY: lint
-lint: ansible-config-lint app-lint check-black check-desktop-files check-strings check-ruff check-supported-locales html-lint shellcheck typelint yamllint ## Runs all lint checks
+lint: check-ruff ansible-config-lint app-lint check-black check-desktop-files check-strings check-supported-locales html-lint shellcheck typelint yamllint ## Runs all lint checks
 
 .PHONY: safety
 safety:  ## Run `safety check` to check python dependencies for vulnerabilities.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Addresses @legoktm's feedback in <https://github.com/freedomofpress/securedrop/pull/6954#discussion_r1356053185> by running ruff first, for the greatest coverage as soon as possible.

## Testing

Nothing special apart from CI.

## Deployment

CI-only; no deployment considerations.