### PR TITLE
ci: fix CircleCI conditionals for Weblate pull requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,13 @@ jobs:
       BASE_OS: focal
     parallelism: 21
     steps:
+      - run:
+          name: Only run on translation pull requests
+          command: |
+            if [ "$CIRCLE_PR_USERNAME" != "weblate-fpf" ]; then
+                circleci-agent step halt
+            fi
+
       - checkout
       - *rebaseontarget
       - *createcachedir
@@ -452,9 +459,6 @@ workflows:
       - translation-tests:
           requires:
             - lint
-          filters:
-            branches:
-              only: /weblate-.*/
           context:
             - circleci-slack
           <<: *slack-fail-post-step

--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ $(POT): securedrop
 .PHONY: check-desktop-files
 check-desktop-files: ${DESKTOP_BASE}/*.j2
 	@$(MAKE) --always-make --no-print-directory update-desktop-files
-	@git diff --quiet $^ || { echo "Desktop files are out of date. Please run \"make update-desktop-files\" and commit the changes."; exit 1; }
+	@git diff --quiet $^ || [[ "$$CIRCLE_PR_USERNAME" == "weblate-fpf" ]] || { echo "Desktop files are out of date. Please run \"make update-desktop-files\" and commit the changes."; exit 1; }
 
 .PHONY: update-desktop-files
 update-desktop-files: ${DESKTOP_BASE}/*.j2

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -95,6 +95,7 @@ function docker_run() {
                 -e CIRCLECI=true \
                 -e CIRCLE_BRANCH=${CIRCLE_BRANCH:-} \
                 -e CIRCLE_SHA1=${CIRCLE_SHA1:-} \
+                -e CIRCLE_PR_USERNAME=${CIRCLE_PR_USERNAME:-} \
                 -e CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-} \
                 -e CIRCLE_PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME:-} \
                 -e CIRCLE_REPOSITORY_URL=${CIRCLE_REPOSITORY_URL:-} \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

1. Fixes <https://app.circleci.com/pipelines/github/freedomofpress/securedrop/6416/workflows/86ef51ed-fb3d-49c1-9f87-96d59e19dd2f/jobs/72689> by exempting Weblate's pull requests from `make check-desktop-files`, since `make update-desktop-files` is still required manually *after* translations have been merged from Weblate.
2. Fixes <https://github.com/freedomofpress/securedrop/pull/6985#issuecomment-1760188206> by aborting `translation-tests` when `$CIRCLE_PR_USERNAME == "weblate-fpf"`, since `$CIRCLE_BRANCH` will be something like `pull/XXXX`.

## Testing

1. [ ] The proof here will be when this commit boomerangs back into #6984.  But you can also do:

    ```sh-session
    (.venv) user@sd-dev:~/securedrop$ head install_files/ansible-base/roles/tails-config/templates/locale/LINGUAS > install_files/ansible-base/roles/tails-config/templates/locale/LINGUAS 
    (.venv) user@sd-dev:~/securedrop$ make check-desktop-files
    make[2]: Nothing to be done for 'install_files/ansible-base/roles/tails-config/templates/ssh_config.j2'.
    Desktop files are out of date. Please run "make update-desktop-files" and commit the changes.
    make: *** [Makefile:384: check-desktop-files] Error 1
    (.venv) user@sd-dev:~/securedrop$ export CIRCLE_PR_USERNAME=weblate-fpf
    (.venv) user@sd-dev:~/securedrop$ make check-desktop-files
    make[2]: Nothing to be done for 'install_files/ansible-base/roles/tails-config/templates/ssh_config.j2'.
    ```

2. [ ] [`translation-tests`](https://app.circleci.com/pipelines/github/freedomofpress/securedrop/6420/workflows/cb820d4a-4152-4437-9daf-349cd6fc610b/jobs/72734) passed on this branch with `n=21` zero-time jobs.

## Deployment

CI-only; no deployment considerations.