### PR TITLE
redwood: Relax requirements for decrypting messages

### DIFF
--- a/redwood/src/decryption.rs
+++ b/redwood/src/decryption.rs
@@ -5,11 +5,9 @@ use crate::keys::secret_key_from_cert;
 use anyhow::anyhow;
 use sequoia_openpgp::crypto::{Password, SessionKey};
 use sequoia_openpgp::parse::stream::*;
-use sequoia_openpgp::policy::Policy;
 use sequoia_openpgp::types::SymmetricAlgorithm;
 
 pub(crate) struct Helper<'a> {
-    pub(crate) policy: &'a dyn Policy,
     pub(crate) secret: &'a sequoia_openpgp::Cert,
     pub(crate) passphrase: &'a Password,
 }
@@ -45,7 +43,7 @@ impl<'a> DecryptionHelper for Helper<'a> {
     where
         D: FnMut(SymmetricAlgorithm, &SessionKey) -> bool,
     {
-        let key = secret_key_from_cert(self.policy, self.secret)?;
+        let key = secret_key_from_cert(self.secret)?;
 
         for pkesk in pkesks {
             // Note: this check won't work for messages encrypted with --throw-keyids,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Even if a source key is no longer valid per policy, we still want them to be able to decrypt a previously valid message for them. We can also drop the revocation/expiry filters, which were mostly theoretical in the SecureDrop context anyways.

Fixes #6991.

## Testing

* [x] Visual review & CI passes

## Deployment

Any special considerations for deployment? No

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
