### PR TITLE
Fix downloads for Tor Browser 13 and test against Firefox 115 ESR

### DIFF
--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update  && apt-get install -y \
 # Current versions of the test browser software. Tor Browser is based
 # on a specific version of Firefox, noted in Help > About Tor Browser.
 # Ideally we'll keep those in sync.
-ENV FF_VERSION 102.15.1esr
+ENV FF_VERSION 115.3.1esr
 ENV GECKODRIVER_VERSION v0.33.0
 
 # Import Tor release signing key
@@ -24,13 +24,13 @@ RUN curl -s https://openpgpkey.torproject.org/.well-known/openpgpkey/torproject.
 
 # Fetch latest TBB version (obtained from https://github.com/micahflee/torbrowser-launcher/blob/develop/torbrowser_launcher/common.py#L198) and install Tor Browser
 RUN TBB_VERSION=$(curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/ALL | grep -oP '(?<=appVersion=")[^"]*' | head -1) && \
-    wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_ALL.tar.xz && \
-    wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux64-${TBB_VERSION}_ALL.tar.xz.asc && \
+    wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux-x86_64-${TBB_VERSION}.tar.xz && \
+    wget https://www.torproject.org/dist/torbrowser/${TBB_VERSION}/tor-browser-linux-x86_64-${TBB_VERSION}.tar.xz.asc && \
     gpg2 --output ./tor.keyring --export ${TOR_RELEASE_KEY_FINGERPRINT} && \
-    gpgv --keyring ./tor.keyring tor-browser-linux64-${TBB_VERSION}_ALL.tar.xz.asc tor-browser-linux64-${TBB_VERSION}_ALL.tar.xz && \
-    tar -xvJf tor-browser-linux64-${TBB_VERSION}_ALL.tar.xz && \
+    gpgv --keyring ./tor.keyring tor-browser-linux-x86_64-${TBB_VERSION}.tar.xz.asc tor-browser-linux-x86_64-${TBB_VERSION}.tar.xz && \
+    tar -xvJf tor-browser-linux-x86_64-${TBB_VERSION}.tar.xz && \
     mkdir -p /root/.local/tbb && mv tor-browser /root/.local/tbb && \
-    rm -f tor.keyring tor-browser-linux64-${TBB_VERSION}_ALL.tar.xz.asc tor-browser-linux64-${TBB_VERSION}_ALL.tar.xz
+    rm -f tor.keyring tor-browser-linux-x86_64-${TBB_VERSION}.tar.xz.asc tor-browser-linux-x86_64-${TBB_VERSION}.tar.xz
 
 # Import Mozilla release signing key
 ENV MOZILLA_RELEASE_KEY_FINGERPRINT "14F26682D0916CDD81E37B6D61B7B526D98F0353"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

As explained in
<https://blog.torproject.org/new-release-tor-browser-130/>, the filename of Tor Browser 13.0 tarballs has changed so we need to update for that.

We can now update to the corresponding Firefox 115 ESR as well.

Fixes #6956.

## Testing

How should the reviewer test this PR?

* [ ] CI passes

I also browsed around the SI and it all seemed fine.

## Deployment

Any special considerations for deployment? No.

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
