### PR TITLE
fix(ossec): run "disconnected submissions" checks from systemd timers; report on saved output

### DIFF
--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -146,6 +146,21 @@ log_events_without_ossec_alerts:
     level: "0"
     rule_id: "199996"
 
+  # OSSEC should not alert when "manage.py check-disconnected-{db,fs}-
+  # submissions" has logged that there are no disconnected submissions.
+  - name: test_no_disconnected_db_submissions_produces_alert
+    alert: >
+      ossec: output: 'cat /var/lib/securedrop/disconnected_db_submissions.txt':
+      No problems were found. All submissions' files are present.
+    level: "1"
+    rule_id: "400800"
+  - name: test_disconnected_fs_submissions_produces_alert
+    alert: >
+      ossec: output: 'cat /var/lib/securedrop/disconnected_fs_submissions.txt':
+      No unexpected files were found in the store.
+    level: "1"
+    rule_id: "400801"
+
 # Log events we expect an OSSEC alert to occur for
 log_events_with_ossec_alerts:
   # Check that a denied RWX mmaping would produce an OSSEC alert
@@ -214,6 +229,24 @@ log_events_with_ossec_alerts:
       [pid 1479:tid 4201988093696] ERROR:flask.app:This is a test OSSEC alert
     level: "7"
     rule_id: "400700"
+
+  # OSSEC should alert when "manage.py check-disconnected-{db,fs}-submissions"
+  # has logged that there are disconnected submissions.
+  - name: test_disconnected_db_submissions_produces_alert
+    alert: >
+      ossec: output: 'cat /var/lib/securedrop/disconnected_db_submissions.txt':
+      There are submissions in the database with no corresponding files. Run
+      "manage.py list-disconnected-db-submissions" for details.
+    level: "1"
+    rule_id: "400800"
+  - name: test_disconnected_fs_submissions_produces_alert
+    alert: >
+      ossec: output: 'cat /var/lib/securedrop/disconnected_fs_submissions.txt':
+      There are files in the submission area with no corresponding records in
+      the database. Run "manage.py list-disconnected-fs-submissions" for
+      details.
+    level: "1"
+    rule_id: "400801"
 
 fpf_apt_repo_url: "https://apt-test.freedom.press"
 

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop-check-disconnected-db-submissions.service
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop-check-disconnected-db-submissions.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=job to check for disconnected submissions in the database
+
+[Service]
+ExecStart=/bin/bash -c "/var/www/securedrop/manage.py check-disconnected-db-submissions > /var/lib/securedrop/disconnected_db_submissions.txt"
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectSystem=full
+ReadOnlyDirectories=/
+ReadWriteDirectories=/var/lib/securedrop
+User=www-data
+WorkingDirectory=/var/www/securedrop

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop-check-disconnected-db-submissions.timer
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop-check-disconnected-db-submissions.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=check for disconnected submissions in the database
+
+[Timer]
+# We want to run this 1 hour before reboot, or 23h after the last reboot
+OnBootSec=23h
+
+[Install]
+WantedBy=timers.target

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop-check-disconnected-fs-submissions.service
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop-check-disconnected-fs-submissions.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=job to check for disconnected submissions on the filesystem
+
+[Service]
+ExecStart=/bin/bash -c "/var/www/securedrop/manage.py check-disconnected-fs-submissions > /var/lib/securedrop/disconnected_fs_submissions.txt"
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectSystem=full
+ReadOnlyDirectories=/
+ReadWriteDirectories=/var/lib/securedrop
+User=www-data
+WorkingDirectory=/var/www/securedrop

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop-check-disconnected-fs-submissions.timer
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop-check-disconnected-fs-submissions.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=check for disconnected submissions on the filesystem
+
+[Timer]
+# We want to run this 1 hour before reboot, or 23h after the last reboot
+OnBootSec=23h
+
+[Install]
+WantedBy=timers.target

--- a/securedrop/debian/ossec-agent/var/ossec/etc/ossec.conf
+++ b/securedrop/debian/ossec-agent/var/ossec/etc/ossec.conf
@@ -52,6 +52,8 @@
     <ignore>/var/lib/securedrop/db.sqlite</ignore>
 
     <ignore>/var/lib/securedrop/submissions_today.txt</ignore>
+    <ignore>/var/lib/securedrop/disconnected_db_submissions.txt</ignore>
+    <ignore>/var/lib/securedrop/disconnected_fs_submissions.txt</ignore>
 
     <ignore type="sregex">/var/lib/securedrop/shredder/tmp</ignore>
     
@@ -128,13 +130,13 @@
 
   <localfile>
     <log_format>command</log_format>
-    <command>sudo -u www-data /opt/venvs/securedrop-app-code/bin/python3 /var/www/securedrop/manage.py check-disconnected-db-submissions</command>
+    <command>cat /var/lib/securedrop/disconnected_db_submissions.txt</command>
     <frequency>90000</frequency>
   </localfile>
 
   <localfile>
     <log_format>command</log_format>
-    <command>sudo -u www-data /opt/venvs/securedrop-app-code/bin/python3 /var/www/securedrop/manage.py check-disconnected-fs-submissions</command>
+    <command>cat /var/lib/securedrop/disconnected_fs_submissions.txt</command>
     <frequency>90000</frequency>
   </localfile>
 

--- a/securedrop/debian/ossec-server/var/ossec/rules/local_rules.xml
+++ b/securedrop/debian/ossec-server/var/ossec/rules/local_rules.xml
@@ -248,7 +248,7 @@
   <rule id="400800" level="1" >
     <if_sid>530</if_sid>
     <options>alert_by_email</options> <!-- force email to be sent -->
-    <match>ossec: output: 'sudo -u www-data /opt/venvs/securedrop-app-code/bin/python3 /var/www/securedrop/manage.py check-disconnected-db-submissions'</match>
+    <match>ossec: output: 'cat /var/lib/securedrop/disconnected_db_submissions.txt'</match>
     <regex>There are submissions in the database with no corresponding files\.</regex>
     <description>Indicates that submissions in the database are missing their corresponding files.</description>
   </rule>
@@ -256,7 +256,7 @@
   <rule id="400801" level="1" >
     <if_sid>530</if_sid>
     <options>alert_by_email</options> <!-- force email to be sent -->
-    <match>ossec: output: 'sudo -u www-data /opt/venvs/securedrop-app-code/bin/python3 /var/www/securedrop/manage.py check-disconnected-fs-submissions'</match>
+    <match>ossec: output: 'cat /var/lib/securedrop/disconnected_fs_submissions.txt'</match>
     <regex>There are files in the submission area with no corresponding records in the database\.</regex>
     <description>Indicates that there are files in the submission area without corresponding submissions in the database.</description>
   </rule>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6982 by preventing OSSEC from having to `sudo` to run `manage.py check-disconnected-{db,fs}-submissions` directly, which adds noise to `/var/log/auth.log` and thus OSSEC's own daily "Successful Logins" report.  Instead, like `manage.py were-there-submissions-today`, these commands now:
1. are defined in systemd services,
2. are triggered by systemd timers 23 hours after boot; and
3. write their standard output to files under `/var/lib/securedrop/`;
4. which OSSEC monitors and alerts on changes.


## Testing

1. Install SecureDrop onto production VMs ([e.g.](https://github.com/cfm/terraform-metal-securedrop-staging#expert-usage-securedrop-production-vms)).
2. Set up OSSEC alerts.
3. `make build-debs` on this branch.
4. Install them:
    - **Application Server:**
        - [x] `securedrop-app-code`
        - [x] `securedrop-ossec-agent`
    - **Monitor Server:**
        - [x] `securedrop-ossec-server`
5. Submit at least two submissions.
6. SSH into the Application Server and start a `sudo -s` session.  (If you accidentally exit it between here and step the end of step 10, you'll have to factor this into your count of `authentication_success` entries.  Or you can start over from here.)
7. SSH into the Monitor Server and start a `sudo -s` session  (If you accidentally exit it between here and step the end of step 10, you'll have to factor this into your count of `authentication_success` entries.  Or you can start over from here.)
8. [x] Do the following dance, in order:

| | Server | Command | Significant output |
| --- | --- | --- | --- |
| 8.1 | Monitor | `cat /var/ossec/logs/alerts/alerts.log \| /var/ossec/bin/ossec-reportd -f group authentication_success` | Make a note of the count of `authentication_success` entries. |
| 8.2 | Application | `systemctl start securedrop-check-disconnected-db-submissions.service` | |
| 8.3 | Monitor | `cat /var/ossec/logs/alerts/alerts.log \| /var/ossec/bin/ossec-reportd -f rule 400800` | `Report completed and zero alerts post-filter.` |
| 8.4 | Application | `systemctl start securedrop-check-disconnected-fs-submissions.service` | |
| 8.5 | Monitor | `cat /var/ossec/logs/alerts/alerts.log \| /var/ossec/bin/ossec-reportd -f rule 400801` | `Report completed and zero alerts post-filter.` |
| 8.6 | Monitor | `cat /var/ossec/logs/alerts/alerts.log \| /var/ossec/bin/ossec-reportd -f group authentication_success` | You should have the same number of `authentication_success` entries as in step 8.1. |
9. On the Application Server, delete one of the submissions from the database (via `sqlite3`, leaving it on the filesystem) and another from the filesystem (via `rm`, leaving it in the database).
10. [ ] Do the following dance, in order:

| | Server | Command | Significant output |
| --- | --- | --- | --- |
| 10.1 | Monitor | `cat /var/ossec/logs/alerts/alerts.log \| /var/ossec/bin/ossec-reportd -f group authentication_success` | Make a note of the count of `authentication_success` entries. |
| 10.2 | Application | `systemctl start securedrop-check-disconnected-db-submissions.service` | |
| 10.3 | Monitor | `cat /var/ossec/logs/alerts/alerts.log \| /var/ossec/bin/ossec-reportd -f rule 400800` | 1 match for rule `400800`. |
| 10.4 | Application | `systemctl start securedrop-check-disconnected-fs-submissions.service` | |
| 10.5 | Monitor | `cat /var/ossec/logs/alerts/alerts.log \| /var/ossec/bin/ossec-reportd -f rule 400801` | 1 match for rule `400801`. |
| 10.6 | Monitor | `cat /var/ossec/logs/alerts/alerts.log \| /var/ossec/bin/ossec-reportd -f group authentication_success` | You should have the same number of `authentication_success` entries as in step 10.1. |
11. [ ] At the end of the day, you should receive level-1 reports for rules `400800` and `400801`.
12. [ ] **Bonus:**  The next day, after you have *not* logged into the servers, you should *not* receive a `Daily report: Successful logins` report.


## Deployment

After #6780, upgrades should get the new systemd units automatically when `secuerdrop-app-codes` is upgraded.  We should check that the new `ossec-agent` `ossec.conf` and `ossec-server` `local_rules.xml` are also applied on upgrade.


## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- I would appreciate help with the documentation
- [x] These changes do not require documentation