### PR TITLE
Do not include config.py in built packages

### DIFF
--- a/securedrop/debian/rules
+++ b/securedrop/debian/rules
@@ -49,6 +49,8 @@ override_dh_install:
 	rm upload-screenshots.py
 	# If a custom logo exists in the tree, delete it
 	rm -f static/i/custom_logo.png
+	# Same with any config.py
+	rm -f config.py
 	dh_install
 
 override_dh_strip_nondeterminism:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Just like the custom_logo.png, we don't want to package config.py if it exists.

The absence of config.py is already verified by
test_securedrop_deb_package.py, but now you won't have to rebuild your packages since it won't be included at all.

Fixes #6973.

## Testing

* [ ] Run `make securedrop/config.py`
* [ ] Run `make build-debs`
* [ ] Post-package build tests pass, i.e. no config.py included in the package

## Deployment

Any special considerations for deployment? No

## Checklist

- [ ] I have written a test plan and validated it for this PR
