### PR TITLE
build: print current Git ref at the top of the build transcript

### DIFF
--- a/builder/build-debs.sh
+++ b/builder/build-debs.sh
@@ -4,6 +4,8 @@
 
 set -euxo pipefail
 
+git log -1 --oneline --no-color --show-signature
+
 OCI_RUN_ARGUMENTS="--user=root -v $(pwd):/src:Z"
 
 # Default to podman if available


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #6792 by prefacing the `script` transcript logged by `make-build-debs.sh` with the output of `git log -1 --oneline`, e.g.:

```sh-session
user@sd-dev:~/securedrop$ head build/20231019-securedrop.log
Script started on 2023-10-19 18:19:19-07:00 [TERM="xterm-256color" TTY="/dev/pts/4" COLUMNS="104" LINES="54"]
+ git log -1 --oneline
53f8dea23 (HEAD -> 6792-print-git-ref, origin/develop, origin/HEAD, develop) gpg: Signature made Thu 19 Oct 2023 01:24:00 PM PDT
gpg:                using RSA key 4AEE18F83AFDEB23
gpg: Can't check signature: No public key
Merge pull request #6830 from freedomofpress/ansible-major-bump
++ pwd
+ OCI_RUN_ARGUMENTS='--user=root -v /home/user/securedrop:/src:Z'
+ which podman
+ OCI_BIN=podman
```

## Testing

- [ ] Visual review.

## Deployment

Tooling-only; no deployment considerations.  May be worth backporting into `release/2.7.0` to increase the usefulness of our build logs.