### PR TITLE
Handle undecryptable replies.

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -7,7 +7,7 @@ from typing import Union
 import store
 import werkzeug
 from db import db
-from encryption import EncryptionManager, GpgKeyNotFoundError
+from encryption import EncryptionManager, GpgDecryptError, GpgKeyNotFoundError
 from flask import (
     Blueprint,
     abort,
@@ -44,6 +44,7 @@ from source_user import (
 from store import Storage
 
 import redwood
+from redwood import RedwoodError
 
 
 def make_blueprint(config: SecureDropConfig) -> Blueprint:
@@ -171,6 +172,8 @@ def make_blueprint(config: SecureDropConfig) -> Blueprint:
                 current_app.logger.error("Could not decode reply %s" % reply.filename)
             except FileNotFoundError:
                 current_app.logger.error("Reply file missing: %s" % reply.filename)
+            except (GpgDecryptError, RedwoodError) as e:
+                current_app.logger.error(f"Could not decrypt reply {reply.filename}: {str(e)}")
             else:
                 reply.date = datetime.utcfromtimestamp(os.stat(reply_path).st_mtime)
                 replies.append(reply)


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #7025.

Previously the application failed with a 500 error when a source attempted to log in, but had replies encrypted with a missing private key (due to legacy GPG keychain corruption, partial backups, admin error etc). This PR adds error handling to catch this case, allowing the source to log.

## Testing

in `make dev`:
- in the SI, create a source and submit a message, then log out
- in the JI, submit some replies to the source
- [x] log back in as the source in the SI and confirm that the replies are readable, then log out
- start a shell in the dev container (eg. `docker exec -it securedrop-dev-0 bash`)
- find the source's entry in the database and set the pgp_fingerprint, pgp_public_key, and pgp_secret_key fields to null
- [x] in the JI, view the source's listing page and confirm that the reply box is not displayed, and a message indicating that the source has no reply key is present
- [x] in the SI, log back in as the source and confirm that login is successful
- [x] in the JI, view the source's listing page and confirm that the reply box is displayed
- [x] reply to the source, and confirm in the SI that the new reply can be read.

## Deployment
No special considerations for deployment.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR
