### PR TITLE
build(`extract-strings`): don't version gettext templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ GCLOUD_VERSION := 222.0.0-1
 SDROOT := $(shell git rev-parse --show-toplevel)
 TAG ?= $(shell git rev-parse HEAD)
 STABLE_VER := $(shell cat molecule/shared/stable.ver)
-VERSION=$(shell python -c "import securedrop.version; print(securedrop.version.__version__)")
 
 SDBIN := $(SDROOT)/securedrop/bin
 DEVSHELL := $(SDBIN)/dev-shell
@@ -364,7 +363,6 @@ $(POT): securedrop
 		--charset=utf-8 \
 		--output=${POT} \
 		--project="SecureDrop" \
-		--version=${VERSION} \
 		--msgid-bugs-address=securedrop@freedom.press \
 		--copyright-holder="Freedom of the Press Foundation" \
 		--add-comments="Translators:" \
@@ -393,7 +391,6 @@ $(DESKTOP_POT): ${DESKTOP_BASE}/*.in
 		-F securedrop/babel.cfg \
 		--output=${DESKTOP_POT} \
 		--project=SecureDrop \
-		--version=${VERSION} \
 		--msgid-bugs-address=securedrop@freedom.press \
 		--copyright-holder="Freedom of the Press Foundation" \
 		--add-location=never \

--- a/install_files/ansible-base/roles/tails-config/templates/locale/messages.pot
+++ b/install_files/ansible-base/roles/tails-config/templates/locale/messages.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: SecureDrop 2.7.0~rc1\n"
+"Project-Id-Version: SecureDrop VERSION\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: SecureDrop 2.7.0~rc1\n"
+"Project-Id-Version: SecureDrop VERSION\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #7020 by removing the `--version` argument to `pybabel extract`.  We don't use the resulting `Project-Version-Id` header anywhere, so it's not worth updating either manually or via `update_version.sh`.

The new value `Project-Id-Version: SecureDrop VERSION` will propagate into individual `.po` catalogs on the next round trip through Weblate like any other translation or metadata change.

## Testing

- [ ] Visual review.

## Deployment

No special considerations.