### PR TITLE
fix: Git needs `--no-pager` under non-interactive SSH

### DIFF
--- a/builder/build-debs.sh
+++ b/builder/build-debs.sh
@@ -4,7 +4,7 @@
 
 set -euxo pipefail
 
-git log -1 --oneline --no-color --show-signature
+git --no-pager log -1 --oneline --show-signature --no-color
 
 OCI_RUN_ARGUMENTS="--user=root -v $(pwd):/src:Z"
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes <https://app.circleci.com/pipelines/github/freedomofpress/securedrop/6577/workflows/d569397a-d36b-42de-8532-3439a2889d25/jobs/73991?invite=true#step-104-720_41>, in which SSH from CircleCI stalls on `WARNING: terminal is not fully functional`.

## Testing
- [ ] `staging-test-with-rebase` passes.

## Deployment
- [ ] Backport into `release/2.7.0`.