### PR TITLE
Added ignore for safety alert 62044

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
                 --ignore 60350 \
 		--ignore 60789 \
 		--ignore 60841 \
+		--ignore 62044 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION


## Status

Ready for review 

## Description of Changes

This alert affects pip >23.3 and involves a possible exploit when downloading packages from a mercurial repo. We don't do that, so it's safe to ignore this in development requirements files. 

(This is not yet failing in `make safety`, but will once the public db is updated. Centralised check is failing already.)

## Testing

- [ ] CI is passing
- [ ] `make safety` passes locally
- [ ] logic for adding the ignore looks sound
