### PR TITLE
[2.7.0] Backport "fix: Git needs `--no-pager` under non-interactive SSH"

### DIFF
--- a/builder/build-debs.sh
+++ b/builder/build-debs.sh
@@ -4,7 +4,7 @@
 
 set -euxo pipefail
 
-git log -1 --oneline --no-color --show-signature
+git --no-pager log -1 --oneline --show-signature --no-color
 
 OCI_RUN_ARGUMENTS="--user=root -v $(pwd):/src:Z"
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7038.

## Testing

* [x] CI is passing
* [x] base is `release/2.7.0`
* [x] Only contains changes from #7038.
