### PR TITLE
Have CI verify demo container builds and runs

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,36 @@
+name: Demo
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build demo
+    runs-on: ubuntu-22.04
+    env:
+      DOCKERIZE_VERSION: v0.6.1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build container
+        run: |
+          podman build -t demo -f securedrop/dockerfiles/focal/python3/DemoDockerfile .
+      - name: Install dockerize
+        run: |
+          wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+      - name: Run container and verify it's up
+        run: |
+          function debug() {
+            # Dump container logs on failure
+            podman logs demo
+            exit 1
+          }
+          # Start the container in the background
+          podman run --name=demo -d -t -p 8080:8080 -p 8081:8081 demo
+          # And wait for both ports to be up!
+          dockerize -wait http://127.0.0.1:8080 -timeout 2m || debug
+          dockerize -wait http://127.0.0.1:8081 -timeout 2m || debug


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

CI will now build the demo container and then run it, to verify we haven't caused any regressions. If it fails to start up in 2 minutes (it normally takes a few seconds), then it'll print the container logs and exit with a failure.

Fixes #6941.

## Testing

How should the reviewer test this PR?

* [ ] CI passes
* [ ] See example failure: https://github.com/freedomofpress/securedrop/actions/runs/6699789864/job/18204567917

## Deployment

Any special considerations for deployment? No
