### PR TITLE
Remove mitigation for CVE-2019-3462

### DIFF
--- a/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
+++ b/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
@@ -1,25 +1,6 @@
 ---
 # Ensures that prerequisite packages for ansible and securedrop-admin install
 # are present
-#
-# Fix for CVE-2019-3462 (see https://justi.cz/security/2019/01/22/apt-rce.html)
-# If apt < 1.4.9, it is vulnerable to CVE-2019-3462 and we must ensure no
-# redirects are followed when updating apt via apt.
-- name: Ensure apt has been updated without following redirects
-  raw: 'apt -o Acquire::http::AllowRedirect=false update &&
-    apt -o Acquire::http::AllowRedirect=false --only-upgrade -y install apt'
-  register: _apt_upgrade_command_output_results
-  changed_when: "'0 upgraded, 0 newly installed, 0 to remove' not in _apt_upgrade_command_output_results.stdout"
-
-- name: Inform user that apt traffic is being redirected
-  assert:
-    that:
-      - "'302 Found' not in _apt_upgrade_command_output_results.stdout"
-      - "'302 Found' not in _apt_upgrade_command_output_results.stderr"
-    fail_msg: >-
-      It appears your apt traffic is being redirected.
-      SecureDrop cannot be installed. For details, see
-      https://github.com/freedomofpress/securedrop/issues/4058
 
 - name: Install python and packages required by installer
   raw: apt install -y python3 apt-transport-https dnsutils ubuntu-release-upgrader-core mokutil


### PR DESCRIPTION

## Status

Ready for review 

## Description of Changes

apt in focal was never affected by CVE-2019-3462, so this mitigation isn't necessary. Per <https://ubuntu.com/security/notices/USN-3863-1>, the vulnerability was fixed in January 2019, while focal was released in April 2020.

## Testing

How should the reviewer test this PR?

* [x] Visual review

## Deployment

Any special considerations for deployment? No

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
