### PR TITLE
fix: strings per translator feedback

### DIFF
--- a/securedrop/source_app/forms.py
+++ b/securedrop/source_app/forms.py
@@ -19,7 +19,7 @@ class LoginForm(FlaskForm):
                 1,
                 PassphraseGenerator.MAX_PASSPHRASE_LENGTH,
                 message=ngettext(
-                    "Field must be between 1 and {max_codename_len} character long.",
+                    "Field must be 1 character long.",
                     "Field must be between 1 and {max_codename_len} characters long.",
                     PassphraseGenerator.MAX_PASSPHRASE_LENGTH,
                 ).format(max_codename_len=PassphraseGenerator.MAX_PASSPHRASE_LENGTH),

--- a/securedrop/source_templates/tor2web-warning.html
+++ b/securedrop/source_templates/tor2web-warning.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block tab_title %}{{ gettext('WARNING: Proxy Service Detected') }}{% endblock %}
+{% block tab_title %}{{ gettext('Warning: Proxy Detected') }}{% endblock %}
 
 {% block body %}
 <h2>{{ gettext('Proxy Service Detected') }}</h2>

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -729,7 +729,7 @@ msgstr ""
 msgid "LOG IN"
 msgstr ""
 
-msgid "Field must be between 1 and {max_codename_len} character long."
+msgid "Field must be 1 character long."
 msgid_plural "Field must be between 1 and {max_codename_len} characters long."
 msgstr[0] ""
 msgstr[1] ""

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -986,7 +986,7 @@ msgstr ""
 msgid "Sorry, we couldn't locate what you requested."
 msgstr ""
 
-msgid "WARNING: Proxy Service Detected"
+msgid "Warning: Proxy Detected"
 msgstr ""
 
 msgid "Proxy Service Detected"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes a few source strings per translator feedback.  See individual commits for specifics.

I don't want to add to either backport or translation churn for v2.7, but let's make these changes for v2.8.

## Testing

- [x] Changes are sensible.