### PR TITLE
build: Fix cargo-vet binary caching

### DIFF
--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -1,4 +1,4 @@
-# Based off of https://mozilla.github.io/cargo-vet/configuring-ci.html
+# Roughly based off of https://mozilla.github.io/cargo-vet/configuring-ci.html
 
 name: cargo vet
 
@@ -15,12 +15,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache@v2
+      id: cache-vet
       with:
-        path: ${{ runner.tool_cache }}/cargo-vet
-        key: cargo-vet-bin-${{ env.CARGO_VET_VERSION }}
-    - name: Add the tool cache directory to the search path
-      run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
-    - name: Ensure that the tool cache is populated with the cargo-vet binary
-      run: cargo install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ env.CARGO_VET_VERSION }} cargo-vet
+        path: /usr/local/cargo/bin/cargo-vet
+        key: cargo-vet-${{ env.CARGO_VET_VERSION }}
+    - name: Install the cargo-vet binary, if needed
+      if: ${{ steps.cache-vet.outputs.cache-hit != 'true' }}
+      run: cargo install --version ${{ env.CARGO_VET_VERSION }} cargo-vet
     - name: Invoke cargo-vet
       run: cargo vet --locked


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The upstream cargo-vet CI manifest was a bit overcomplicated, trying to install to a different path and it just wasn't working.

Instead, install cargo-vet to the normal path, store it in the actions/cache, and skip installing on cache hits.

On a cache hit, it drops job runtime to less than a minute.

Fixes #7011.

## Testing

How should the reviewer test this PR?

* [x] Visual review
* [x] CI passes
* [ ] Review https://github.com/freedomofpress/securedrop/actions/workflows/cargo-vet.yml and see that runtime has dropped dramatically. Look at those workflows to see that the install step is being skipped since it's fetched from cache
* [x] https://github.com/freedomofpress/securedrop/actions/caches shows a new `cargo-vet-0.8.0` cache with 6.5MB stored, while the old key `cargo-vet-bin-0.8.0` had nothing stored (45 bytes).

## Deployment

Any special considerations for deployment? No, CI only
