### PR TITLE
chore: ignore urllib3 CVE-2023-43804

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
                 --ignore 60350 \
 		--ignore 60789 \
 		--ignore 60841 \
+		--ignore 61601 \
 		--ignore 62044 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes https://app.circleci.com/pipelines/github/freedomofpress/securedrop/6694/workflows/93dd8bfb-947a-430d-b003-8b9f74da02a9/jobs/74973.  See commit message for rationale.

## Testing

- [ ] Visual review; rationale is sensible.

## Deployment

- [ ] Backport to `release/2.7.0`.