### PR TITLE
[2.7.0] Backport "chore: ignore urllib3 CVE-2023-43804"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
                 --ignore 60350 \
 		--ignore 60789 \
 		--ignore 60841 \
+		--ignore 61601 \
 		--ignore 62044 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7068.

## Testing

* [x] CI is passing
* [x] base is `release/2.7.0`
* [x] Only contains changes from #7068.
