### PR TITLE
redwood: Intern string and improve Stream test coverage

### DIFF
--- a/redwood/src/stream.rs
+++ b/redwood/src/stream.rs
@@ -1,5 +1,5 @@
 use pyo3::types::PyBytes;
-use pyo3::{PyAny, PyResult};
+use pyo3::{intern, PyAny, PyResult};
 use std::io::{self, ErrorKind, Read, Write};
 
 /// Wrapper to implement the `Read` trait around a Python
@@ -11,7 +11,7 @@ pub(crate) struct Stream<'a> {
 impl Stream<'_> {
     /// Read the specified number of bytes out of the object
     fn read_bytes(&self, len: usize) -> PyResult<&PyBytes> {
-        let func = self.reader.getattr("read")?;
+        let func = self.reader.getattr(intern!(self.reader.py(), "read"))?;
         // In Python this is effectively calling `reader.read(len)`
         let bytes = func.call1((len,))?;
         let bytes = bytes.downcast::<PyBytes>()?;


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

To prevent pyo3 from converting `"read"` into a PyString over and over, we can intern it once to avoid repeatedly creating new PyStrings (which I learned while auditing pyo3).

While we're at it, improve test coverage of the Stream::read_bytes() function with more integration tests that verify more error handling behavior: if read() raises an exception or returns the wrong type.

## Testing

* [x] CI passes

## Deployment

Any special considerations for deployment? No

## Checklist

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container
