### PR TITLE
Update openssl crate for RUSTSEC-2023-0072

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,7 +3,7 @@ ignore = [] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
 
 # Output Configuration
 [output]
-deny = ["yanked", "unmaintained"]
+deny = ["warnings"]
 quiet = false
 
 # Target Configuration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,9 +533,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,5 @@
 members = [
     "redwood",
 ]
+
+resolver = "2"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -375,7 +375,7 @@ notes = "Rust Project member"
 
 [[trusted.openssl]]
 criteria = "safe-to-deploy"
-user-id = 5 # Steven Fackler (sfackler)
+user-id = 5
 start = "2019-02-22"
 end = "2024-05-02"
 notes = "Rust Project member"
@@ -389,9 +389,16 @@ notes = "Rust Project member"
 
 [[trusted.openssl-sys]]
 criteria = "safe-to-deploy"
-user-id = 5 # Steven Fackler (sfackler)
+user-id = 5
 start = "2019-03-01"
 end = "2024-05-02"
+notes = "Rust Project member"
+
+[[trusted.openssl-sys]]
+criteria = "safe-to-deploy"
+user-id = 163 # Alex Gaynor (alex)
+start = "2023-03-24"
+end = "2024-05-29"
 notes = "Rust Project member"
 
 [[trusted.parking_lot]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -135,18 +135,18 @@ user-login = "cuviper"
 user-name = "Josh Stone"
 
 [[publisher.openssl]]
-version = "0.10.57"
-when = "2023-08-27"
+version = "0.10.60"
+when = "2023-11-23"
 user-id = 163
 user-login = "alex"
 user-name = "Alex Gaynor"
 
 [[publisher.openssl-sys]]
-version = "0.9.93"
-when = "2023-09-04"
-user-id = 5
-user-login = "sfackler"
-user-name = "Steven Fackler"
+version = "0.9.96"
+when = "2023-11-23"
+user-id = 163
+user-login = "alex"
+user-name = "Alex Gaynor"
 
 [[publisher.parking_lot]]
 version = "0.12.1"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Have cargo audit error on all warnings, not just some
* Update openssl crate for RUSTSEC-2023-0072 (note that we aren't affected)
* Fix new Rust warning about wrong resolver version

## Testing

How should the reviewer test this PR?

* [x] CI passes
* [x] `make rust-audit` is clean

## Deployment

Any special considerations for deployment? No

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
