### PR TITLE
ignore `urllib3` CVE-2023-45803 and Werkzeug CVE-2023-46136

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,16 +156,16 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 49337 \
 		--ignore 51668 \
 		--ignore 52322 \
-                --ignore 52495 \
-                --ignore 52510 \
-                --ignore 52518 \
-                --ignore 54709 \
-                --ignore 54564 \
-                --ignore 54230 \
-                --ignore 54229 \
-                --ignore 55261 \
-                --ignore 58912 \
-                --ignore 60350 \
+		--ignore 52495 \
+		--ignore 52510 \
+		--ignore 52518 \
+		--ignore 54709 \
+		--ignore 54564 \
+		--ignore 54230 \
+		--ignore 54229 \
+		--ignore 55261 \
+		--ignore 58912 \
+		--ignore 60350 \
 		--ignore 60789 \
 		--ignore 60841 \
 		--ignore 61601 \

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 60841 \
 		--ignore 61601 \
 		--ignore 61893 \
+		--ignore 62019 \
 		--ignore 62044 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 60789 \
 		--ignore 60841 \
 		--ignore 61601 \
+		--ignore 61893 \
 		--ignore 62044 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Ignores Safety 61893 (CVE-2023-45803), which is:
* Acceptable in development and test environments.
* Not relevant when the origin is a SecureDrop instance.

Ignores Safety 62019 (CVE-2023-46136), which is:
* Not a relevant denial-of-service vector.

## Testing

- [x] Visual review.

## Checklist

### If you added or updated a reference to a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/requirements.in`
- `securedrop/requirements/python3/translation.in` (used in the build
  container)

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- I would like someone else to do the diff review
- [x] I am silencing an alert related to a production dependency, because ~(please explain below):~ (see above)