### PR TITLE
Resize SD CI GCE machine type to c2-standard-8

### DIFF
--- a/devops/gce-nested/ci-env.sh
+++ b/devops/gce-nested/ci-env.sh
@@ -16,7 +16,7 @@ export GCE_CREDS_FILE
 export BUILD_NUM="${CIRCLE_BUILD_NUM}"
 export PROJECT_ID="securedrop-ci"
 export JOB_NAME="sd-ci-nested"
-export GCLOUD_MACHINE_TYPE="n1-highcpu-4"
+export GCLOUD_MACHINE_TYPE="c2-standard-8"
 GCLOUD_CONTAINER_VER="$(cat "${TOPLEVEL}/devops/gce-nested/gcloud-container.ver")"
 export GCLOUD_CONTAINER_VER
 export CLOUDSDK_COMPUTE_ZONE="us-west1-c"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Resize SD CI GCE machine type to c2-standard-8

Speeds up SD CI by using a newer GCE machine type (with doubled vCPU).

## Testing

- [x] CI passing (which is also now faster)

## Checklist

Choose one of the following:

- [x] These changes do not require documentation