### PR TITLE
Only pass -it to Docker if we have a tty

### DIFF
--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -109,6 +109,11 @@ function docker_run() {
         ci_env=""
     fi
 
+    # Pass -it if we're a tty
+    if test -t 0; then
+        DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} -it"
+    fi
+
     # The --shm-size argument sets up dedicated shared memory for the
     # container. Our tests can fail with the default of 64m.
     $DOCKER_BIN run $ci_env \
@@ -130,7 +135,7 @@ function docker_run() {
            --volume "${TOPLEVEL}:${TOPLEVEL}:Z" \
            --workdir "${TOPLEVEL}/securedrop" \
            --name "${SD_CONTAINER}" \
-           -ti $DOCKER_RUN_ARGUMENTS "${1}" "${@:2}"
+           $DOCKER_RUN_ARGUMENTS "${1}" "${@:2}"
 }
 
 image="securedrop-slim-focal-py3"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Only pass `-it` to Docker if we have a tty. This is needed for https://github.com/freedomofpress/securedrop-client/pull/1746 because GitHub Actions (unlike CircleCI) doesn't have a tty.

## Testing

* [x] CI passes
* [x] https://github.com/freedomofpress/securedrop-client/pull/1746, which checks out this branch, passes

## Deployment

Any special considerations for deployment? No

