### PR TITLE
Import other SecureDrop Rust audits; upgrade to cargo-vet 0.9.0

### DIFF
--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -11,7 +11,7 @@ jobs:
     # Keep version in sync with rust-toolchain.toml
     container: rust:1.74.1
     env:
-      CARGO_VET_VERSION: 0.8.0
+      CARGO_VET_VERSION: 0.9.0
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache@v2

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -3,7 +3,7 @@
 default-criteria = "safe-to-run"
 
 [cargo-vet]
-version = "0.8"
+version = "0.9"
 
 [imports.bytecode-alliance]
 url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -17,6 +17,9 @@ url = "https://raw.githubusercontent.com/divviup/libprio-rs/main/supply-chain/au
 [imports.mozilla]
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
+[imports.securedrop]
+url = "https://raw.githubusercontent.com/freedomofpress/securedrop-supply-chain/main/audits.toml"
+
 [imports.zcash]
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -809,6 +809,8 @@ criteria = "safe-to-deploy"
 delta = "0.3.8 -> 0.3.13"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[audits.securedrop.audits]
+
 [[audits.zcash.audits.block-buffer]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Import other SecureDrop Rust audits. There's nothing else in this repository yet, but in the future this will contain imports from other SecureDrop repositories that can be imported.
* Upgrade to cargo-vet 0.9.0

## Testing

How should the reviewer test this PR?

* [ ] CI passes + visual review

## Deployment

Any special considerations for deployment? No

