### PR TITLE
Update jinja2 in admin and dev reqs, use latest semgrep in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,7 @@ jobs:
           command: |
             fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
             DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" securedrop/bin/dev-shell \
-                  bash -c "pip3 install -U -q --upgrade pip && pip3 install -U -q semgrep==1.56.0 && make -C .. semgrep"
+                  bash -c "pip3 install -U -q --upgrade pip && pip3 install -U -q --upgrade semgrep && make -C .. semgrep"
 
   staging-test-with-rebase:
     machine:

--- a/admin/requirements-ansible.in
+++ b/admin/requirements-ansible.in
@@ -1,6 +1,6 @@
 ansible==6.7.0
 cryptography>=41.0.5  # >= OpenSSL 3.1.4 for CVE-2023-5363
-jinja2==3.0.2
+jinja2>=3.1.3
 netaddr
 markupsafe==2.1.2
 packaging~=21.0  # to reconcile with dependencies of safety, semgrep

--- a/admin/requirements-testinfra.txt
+++ b/admin/requirements-testinfra.txt
@@ -119,9 +119,9 @@ iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
     # via pytest
-jinja2==3.0.2 \
-    --hash=sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45 \
-    --hash=sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c
+jinja2==3.1.3 \
+    --hash=sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa \
+    --hash=sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90
     # via
     #   -r requirements-ansible.in
     #   ansible-core

--- a/admin/requirements.txt
+++ b/admin/requirements.txt
@@ -90,9 +90,9 @@ cryptography==41.0.7 \
     # via
     #   -r requirements-ansible.in
     #   ansible-core
-jinja2==3.0.2 \
-    --hash=sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45 \
-    --hash=sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c
+jinja2==3.1.3 \
+    --hash=sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa \
+    --hash=sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90
     # via
     #   -r requirements-ansible.in
     #   ansible-core

--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -11,6 +11,7 @@ docker
 dnspython
 html-linter
 importlib-resources
+jinja2>=3.1.3
 markupsafe>=2.0
 molecule>=3.0.1
 molecule-vagrant>=0.3

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -383,9 +383,9 @@ jinja2-time==0.2.0 \
     --hash=sha256:d14eaa4d315e7688daa4969f616f226614350c48730bfa1692d2caebd8c90d40 \
     --hash=sha256:d3eab6605e3ec8b7a0863df09cc1d23714908fa61aa6986a845c20ba488b4efa
     # via cookiecutter
-jinja2==3.0.2 \
-    --hash=sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45 \
-    --hash=sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c
+jinja2==3.1.3 \
+    --hash=sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa \
+    --hash=sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90
     # via
     #   -r ../admin/requirements-ansible.in
     #   -r requirements/python3/develop-requirements.in


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

- Updates jinja2 to 3.1.3 in admin and development requirements.
- Reverts to using latest semgrep in CI.

## Testing

- [ ] CI looks good
- [ ] prod deps not updated.
