### PR TITLE
fix `staging-test-with-rebase`, failing on stale Ubuntu mirrors

### DIFF
--- a/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
+++ b/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
@@ -3,7 +3,7 @@
 # are present
 
 - name: Install python and packages required by installer
-  raw: apt install -y python3 apt-transport-https dnsutils ubuntu-release-upgrader-core mokutil
+  raw: apt-get update && apt-get install -y python3 apt-transport-https dnsutils ubuntu-release-upgrader-core mokutil
   register: _apt_install_prereqs_results
   changed_when: "'0 upgraded, 0 newly installed, 0 to remove' not in _apt_install_prereqs_results.stdout"
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

`staging-test-with-rebase` has been failing since January 3, because an `apt-get install` had stale mirrors.  Let's `apt-get update` them.

## Testing

- [ ] CI passes, with `stg-` including `staging-test-with-rebase`.

## Deployment

The `prepare-servers` task is also run in production.  `apt-get update` at worst has no side effects and at best will also prevent this failure during a production installation.

## Checklist

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass