### PR TITLE
fix(`SecureDropConfig`): pass `env` for inferring debug mode

### DIFF
--- a/securedrop/sdconfig.py
+++ b/securedrop/sdconfig.py
@@ -71,6 +71,8 @@ class SecureDropConfig:
 
     RQ_WORKER_NAME: str
 
+    env: str = "prod"
+
     @property
     def TEMP_DIR(self) -> Path:
         # We use a directory under the SECUREDROP_DATA_ROOT instead of `/tmp` because
@@ -114,6 +116,8 @@ def _parse_config_from_file(config_module_name: str) -> SecureDropConfig:
     final_scrypt_params = getattr(
         config_from_local_file, "SCRYPT_PARAMS", dict(N=2**14, r=8, p=1)
     )
+
+    env = getattr(config_from_local_file, "env", "prod")
 
     try:
         final_securedrop_root = Path(config_from_local_file.SECUREDROP_ROOT)
@@ -188,6 +192,7 @@ def _parse_config_from_file(config_module_name: str) -> SecureDropConfig:
     )
 
     return SecureDropConfig(
+        env=env,
         JOURNALIST_APP_FLASK_CONFIG_CLS=parsed_journ_flask_config,
         SOURCE_APP_FLASK_CONFIG_CLS=parsed_source_flask_config,
         GPG_KEY_DIR=final_gpg_key_dir,

--- a/securedrop/tests/test_config.py
+++ b/securedrop/tests/test_config.py
@@ -19,8 +19,12 @@ def test_parse_current_config():
     try:
         current_config_file.write_text(current_sample_config.read_text())
 
-        # When trying to parse it, it succeeds
-        assert _parse_config_from_file(f"tests.{current_config_module}")
+        # When trying to parse it, it succeeds...
+        parsed_config = _parse_config_from_file(f"tests.{current_config_module}")
+        assert parsed_config
+
+        # ...and has one of our `env` values rather than one of Flask's:
+        assert parsed_config.env in ["prod", "dev", "test"]
 
     finally:
         current_config_file.unlink(missing_ok=True)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6784.

## Testing

- Run `make dev`.
- `touch` or change a file belonging to one of the Flask apps.
- [x] The Flask apps reload.

## Deployment

Development-only; no deployment considerations.

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass