### PR TITLE
chore: ignore Safety 65647 in `cryptography`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 63066 \
 		--ignore 63227 \
 		--ignore 62817 \
+		--ignore 65647 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review

- Ref: freedomofpress/fpf-misc-resources#35

## Description of Changes

Silences Safety alert no. 65647 in `cryptography`, because we do not use the affected X.509 support.

## Testing

- [ ] Rationale is sensible.
- [ ] CI passes.