### PR TITLE
Persist onion addresses with "make dev-tor"

### DIFF
--- a/devops/clean
+++ b/devops/clean
@@ -36,6 +36,11 @@ function remove_unwanted_files() {
         install_files/ansible-base/tor_v3_keys.json \
         build/*.deb
 
+    # Remove any Onion URL from make dev-tor
+    if docker volume inspect sd-onion-services > /dev/null; then
+        docker volume remove sd-onion-services
+    fi
+
     # Remove extraneous copies of the git repos, pulled in
     # via the Molecule upgrade testing scenario.
     rm -rf molecule/upgrade/.molecule/sd-orig \

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -54,16 +54,28 @@ function maybe_create_config_py() {
 function maybe_use_tor() {
     if [[ -n "${USE_TOR:-}" ]]; then
         echo "Setting up Tor..."
+        if [ ! -d "/var/lib/tor/services" ]; then
+            sudo chown -R debian-tor:debian-tor /var/lib/tor/services
+        else
+            sudo -u debian-tor mkdir -p /var/lib/tor/services
+        fi
         # append torrc lines for SI and JI
-        sudo -u debian-tor mkdir -p /var/lib/tor/services
         echo "HiddenServiceDir /var/lib/tor/services/source/" | sudo tee -a /etc/tor/torrc
         echo "HiddenServicePort 80 127.0.0.1:8080" | sudo tee -a /etc/tor/torrc
         echo "HiddenServiceDir /var/lib/tor/services/journalist/" | sudo tee -a /etc/tor/torrc
         echo "HiddenServicePort 80 127.0.0.1:8081" | sudo tee -a /etc/tor/torrc
         # start Tor to create service directories
         sudo service tor start
-        # create x25519 keypair and journalist client auth file
-        openssl genpkey -algorithm x25519 -out /tmp/k1.prv.pem
+        if sudo test -f "/var/lib/tor/services/journalist_auth_token.prv.pem"; then
+            # recover x25519 key
+            sudo cat /var/lib/tor/services/journalist_auth_token.prv.pem | tee /tmp/k1.prv.pem
+        else
+            echo "Generating new client authorization..."
+            # create x25519 keypair and journalist client auth file
+            openssl genpkey -algorithm x25519 -out /tmp/k1.prv.pem
+            # store private auth token for regeneration after restarts
+            sudo cp /tmp/k1.prv.pem /var/lib/tor/services/journalist_auth_token.prv.pem
+        fi
         grep -v " PRIVATE KEY" < /tmp/k1.prv.pem | base64pem -d | tail --bytes=32 | base32 | sed 's/=//g' > /tmp/k1.prv.key
         openssl pkey -in /tmp/k1.prv.pem -pubout | grep -v " PUBLIC KEY" | base64pem -d | tail --bytes=32 | base32 | sed 's/=//g' > /tmp/k1.pub.key
         echo "descriptor:x25519:$(cat /tmp/k1.pub.key)" | sudo -u debian-tor tee /var/lib/tor/services/journalist/authorized_clients/client.auth

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -114,6 +114,12 @@ function docker_run() {
         DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} -it"
     fi
 
+    if [ -n "${USE_TOR:-}" ]; then
+        # Mount persistent onion services
+        docker volume create sd-onion-services
+        DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} --volume sd-onion-services:/var/lib/tor/services"
+    fi
+
     # The --shm-size argument sets up dedicated shared memory for the
     # container. Our tests can fail with the default of 64m.
     $DOCKER_BIN run $ci_env \


### PR DESCRIPTION
Makes the SecureDrop Workstation dev workflow easier by removing the need to setup standalone server VMs if one wants a persistent server address and authentication token.

The solution involves creating a docker volume. This will persist as long as the user does not manually remove it or moves to another system without porting the volume. Since this a dev environment, long term persistence should not be a concern, so this solution sufices.

Fixes #7115

## Status

Ready for review 

## Description of Changes

Fixes #7115.

Changes proposed in this pull request:

## Testing
Run `make dev-tor` multiple times and ensure that the same journalist config is generated.

## Deployment

Any special considerations for deployment? no

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a reference to a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/requirements.in`
- `securedrop/requirements/python3/translation.in` (used in the build
  container)

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
- [ ] I am silencing an alert related to a production dependency, because (please explain below):
