### PR TITLE
Run GUI updater on wayland platform by default; fall back to xcb if it's not available

### DIFF
--- a/install_files/ansible-base/roles/tails-config/files/65-configure-tor-for-securedrop.sh
+++ b/install_files/ansible-base/roles/tails-config/files/65-configure-tor-for-securedrop.sh
@@ -14,4 +14,4 @@ if [ "$2" != "up" ]; then
   exit 0
 fi
 
-/usr/bin/python3 /home/amnesia/Persistent/.securedrop/securedrop_init.py
+QT_QPA_PLATFORM="wayland;xcb" /usr/bin/python3 /home/amnesia/Persistent/.securedrop/securedrop_init.py


### PR DESCRIPTION


## Status

Ready for review 

## Description of Changes

Fixes #7133 .

Tweaks network hook to use wayland QPA platform plugin as appropriate (on Tails 6), falling back to the xcb plugin otherwise (on Tails 5)

## Testing

On an existing Tails 5 admin workstation:
- check out this branch
- run `./securedrop-admin tailsconfig` to update the network hook, and reboot the workstation
- [x] Verify that the GUI updater appears on boot
- [x] check the hook under `/live/persistent/TailsData_Unlocked/custom_nm_hooks` and verify that the code change is present 
- [x] For extra points, run `sudo journalctl -f | grep nm-dispatcher` in a terminal, bounce the network connection, and verify there are no related QT startup errors and that the updater appears

On an existing Tails 6 admin workstation:
- check out this branch
- run `./securedrop-admin tailsconfig` to update the network hook, and reboot the workstation
- [x] Verify that the GUI updater appears on boot
- [x] check the hook under `/live/persistent/TailsData_Unlocked/custom_nm_hooks` and verify that the code change is present 
- [x] For extra points, run `sudo journalctl -f | grep nm-dispatcher` in a terminal, bounce the network connection, and verify there are no related QT startup errors and that the updater appears

## Deployment

Deployed as part of regular GUI updater run.

