### PR TITLE
[2.8.0] Backport "Run GUI updater on wayland platform by default; fall back to xcb if it's not available"

### DIFF
--- a/install_files/ansible-base/roles/tails-config/files/65-configure-tor-for-securedrop.sh
+++ b/install_files/ansible-base/roles/tails-config/files/65-configure-tor-for-securedrop.sh
@@ -14,4 +14,4 @@ if [ "$2" != "up" ]; then
   exit 0
 fi
 
-/usr/bin/python3 /home/amnesia/Persistent/.securedrop/securedrop_init.py
+QT_QPA_PLATFORM="wayland;xcb" /usr/bin/python3 /home/amnesia/Persistent/.securedrop/securedrop_init.py


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7134.

## Testing

* [ ] CI is passing
* [x] base is `release/2.8.0`
* [x] Only contains changes from #7134.
