### PR TITLE
Suppress a few safety alerts that don't affect us

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,10 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 63227 \
 		--ignore 62817 \
 		--ignore 65647 \
+		--ignore 65278 \
+		--ignore 65212 \
+		--ignore 65401 \
+		--ignore 65193 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* 65278 (CVE-2023-50782) - we don't use crytography with TLS endpoints
* 65212 - only affects PowerPC
* 65401 - development only
* 65193 - development only

These were already all suppressed by @cfm in
<https://github.com/freedomofpress/fpf-misc-resources>.

## Testing

* [ ] visual review
* [ ] CI passes

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a reference to a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/requirements.in`
- `securedrop/requirements/python3/translation.in` (used in the build
  container)

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
- [ ] I am silencing an alert related to a production dependency, because (please explain below):
