### PR TITLE
Update Rust toolchain from 1.74.1 to 1.78.0

### DIFF
--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -9,7 +9,7 @@ jobs:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.74.1
+    container: rust:1.78.0
     env:
       CARGO_VET_VERSION: 0.9.0
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.74.1
+    container: rust:1.78.0
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,7 +7,7 @@ jobs:
   rust-audit:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.74.1
+    container: rust:1.78.0
     steps:
       - uses: actions/checkout@v4
       - name: Check Rust dependencies

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         unzip \
         zlib1g-dev
 
-ENV RUST_VERSION 1.74.1
+ENV RUST_VERSION 1.78.0
 ENV RUSTUP_VERSION 1.24.3
 ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
 ENV RUSTUP_HOME /opt/rustup

--- a/redwood/src/lib.rs
+++ b/redwood/src/lib.rs
@@ -334,7 +334,7 @@ mod tests {
             .checked_add(Duration::from_secs(KEY_CREATION_SECONDS_FROM_EPOCH))
             // unwrap: Safe because the value is fixed and we know it won't overflow
             .unwrap();
-        let signature = cert.primary_key().self_signatures().nth(0).unwrap();
+        let signature = cert.primary_key().self_signatures().next().unwrap();
 
         assert_eq!(
             signature.signature_creation_time(),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.74.1"
+channel = "1.78.0"

--- a/securedrop/dockerfiles/focal/python3/DemoDockerfile
+++ b/securedrop/dockerfiles/focal/python3/DemoDockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
 # 1) Download rustup-init and verify it matches hardcoded checksum
 # 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
 # 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
-ENV RUST_VERSION 1.74.1
+ENV RUST_VERSION 1.78.0
 ENV RUSTUP_VERSION 1.24.3
 ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
 ENV RUSTUP_HOME /opt/rustup

--- a/securedrop/dockerfiles/focal/python3/SlimDockerfile
+++ b/securedrop/dockerfiles/focal/python3/SlimDockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
 # 1) Download rustup-init and verify it matches hardcoded checksum
 # 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
 # 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
-ENV RUST_VERSION 1.74.1
+ENV RUST_VERSION 1.78.0
 ENV RUSTUP_VERSION 1.24.3
 ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
 ENV RUSTUP_HOME /opt/rustup


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Also fix a clippy warning about not using `.nth(0)`.

Fixes #7146.

## Testing

- [ ] CI is passing
- [ ] visual inspection