### PR TITLE
loaddata: Fix random_datetime() edge case

### DIFF
--- a/securedrop/loaddata.py
+++ b/securedrop/loaddata.py
@@ -5,6 +5,7 @@ Loads test data into the SecureDrop database.
 """
 
 import argparse
+import calendar
 import datetime
 import io
 import math
@@ -83,10 +84,17 @@ def random_datetime(nullable: bool) -> Optional[datetime.datetime]:
         return None
 
     now = datetime.datetime.now()
+    year = random.randint(2013, now.year)
+    max_day = 366 if calendar.isleap(year) else 365
+    day = random.randint(1, max_day)
+
+    # Calculate the month/day given the year
+    date = datetime.date(year, 1, 1) + datetime.timedelta(days=day - 1)
+
     return datetime.datetime(
-        year=random.randint(2013, now.year),
-        month=random.randint(1, now.month),
-        day=random.randint(1, now.day),
+        year=year,
+        month=date.month,
+        day=date.day,
         hour=random.randint(0, 23),
         minute=random.randint(0, 59),
         second=random.randint(0, 59),


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Instead of generating month and day separately, generate them at the same time by randomly selecting a day in the year, and then calculating the month and date based on that.

This should avoid randomly generating invalid dates like February 30th.

Fixes #7155.

## Testing

* [x] Visual review
* [ ] CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] These changes do not require documentation

