### PR TITLE
Ignore some safety alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,10 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 65193 \
 		--ignore 65510 \
 		--ignore 65511 \
+		--ignore 66700 \
+		--ignore 66777 \
+		--ignore 66704 \
+		--ignore 66710 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* 66700 (CVE-2024-0690) - we only use `no_log` in tor-hidden-services where it is not in a loop
* 66777 (CVE-2023-6237) - not affected, as we build against system OpenSSL
* 66704 (CVE-2024-26130) - we should not be checking PKCS#12 keys/certs
* 66710 (CVE-2023-29483) - dev only, DoS isn't an issue

## Testing

* [x] visual review
* [x] CI passes

## Deployment

Any special considerations for deployment? n/a
