### PR TITLE
Support range requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       image: ubuntu-2004:current
       enabled: true
     environment:
-      DOCKER_API_VERSION: 1.23
+      DOCKER_API_VERSION: 1.24
       BASE_OS: focal
     steps:
       - checkout
@@ -106,7 +106,7 @@ jobs:
       image: ubuntu-2004:current
       enabled: true
     environment:
-      DOCKER_API_VERSION: 1.23
+      DOCKER_API_VERSION: 1.24
       BASE_OS: focal
     parallelism: 3
     steps:
@@ -142,7 +142,7 @@ jobs:
       image: ubuntu-2004:current
       enabled: true
     environment:
-      DOCKER_API_VERSION: 1.23
+      DOCKER_API_VERSION: 1.24
       BASE_OS: focal
     parallelism: 5
     steps:
@@ -194,7 +194,7 @@ jobs:
       image: ubuntu-2004:current
       enabled: true
     environment:
-      DOCKER_API_VERSION: 1.23
+      DOCKER_API_VERSION: 1.24
       BASE_OS: focal
     parallelism: 21
     steps:
@@ -247,7 +247,7 @@ jobs:
       image: ubuntu-2004:current
       enabled: true
     environment:
-      DOCKER_API_VERSION: 1.23
+      DOCKER_API_VERSION: 1.24
       BASE_OS: focal
     steps:
       - checkout
@@ -308,7 +308,7 @@ jobs:
       image: ubuntu-2004:current
       enabled: true
     environment:
-      DOCKER_API_VERSION: 1.23
+      DOCKER_API_VERSION: 1.24
       BASE_OS: focal
     steps:
       - checkout

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -371,7 +371,6 @@ def col_delete_data(cols_selected: List[str]) -> werkzeug.Response:
             "error",
         )
     else:
-
         for filesystem_id in cols_selected:
             delete_source_files(filesystem_id)
 
@@ -535,4 +534,5 @@ def serve_file_with_etag(db_obj: Union[Reply, Submission]) -> flask.Response:
 
     response.direct_passthrough = False
     response.headers["Etag"] = db_obj.checksum
+    response.headers["Accept-Ranges"] = "bytes"
     return response

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -1,3 +1,5 @@
+import binascii
+import hashlib
 import json
 import random
 from datetime import datetime
@@ -232,7 +234,6 @@ def test_user_without_token_cannot_del_protected_endpoints(journalist_app, test_
 def test_attacker_cannot_use_token_after_admin_deletes(
     journalist_app, test_source, journalist_api_token
 ):
-
     with journalist_app.test_client() as app:
         uuid = test_source["source"].uuid
 
@@ -893,7 +894,6 @@ def test_reply_with_valid_square_json_400(
 
 
 def test_malformed_json_400(journalist_app, journalist_api_token, test_journo, test_source):
-
     with journalist_app.app_context():
         uuid = test_source["source"].uuid
         protected_routes = [
@@ -904,7 +904,6 @@ def test_malformed_json_400(journalist_app, journalist_api_token, test_journo, t
         ]
     with journalist_app.test_client() as app:
         for protected_route in protected_routes:
-
             response = app.post(
                 protected_route,
                 data="{this is invalid {json!",
@@ -916,7 +915,6 @@ def test_malformed_json_400(journalist_app, journalist_api_token, test_journo, t
 
 
 def test_empty_json_400(journalist_app, journalist_api_token, test_journo, test_source):
-
     with journalist_app.app_context():
         uuid = test_source["source"].uuid
         protected_routes = [
@@ -925,7 +923,6 @@ def test_empty_json_400(journalist_app, journalist_api_token, test_journo, test_
         ]
     with journalist_app.test_client() as app:
         for protected_route in protected_routes:
-
             response = app.post(
                 protected_route, data="", headers=get_api_headers(journalist_api_token)
             )
@@ -935,7 +932,6 @@ def test_empty_json_400(journalist_app, journalist_api_token, test_journo, test_
 
 
 def test_empty_json_20X(journalist_app, journalist_api_token, test_journo, test_source):
-
     with journalist_app.app_context():
         uuid = test_source["source"].uuid
         protected_routes = [
@@ -944,7 +940,6 @@ def test_empty_json_20X(journalist_app, journalist_api_token, test_journo, test_
         ]
     with journalist_app.test_client() as app:
         for protected_route in protected_routes:
-
             response = app.post(
                 protected_route, data="", headers=get_api_headers(journalist_api_token)
             )
@@ -1246,3 +1241,70 @@ def test_seen_bad_requests(journalist_app, journalist_api_token):
         response = app.post(seen_url, data=json.dumps(data), headers=headers)
         assert response.status_code == 404
         assert response.json["message"] == "reply not found: not-a-reply"
+
+
+def test_download_submission_range(journalist_app, test_files, journalist_api_token):
+    with journalist_app.test_client() as app:
+        submission_uuid = test_files["submissions"][0].uuid
+        uuid = test_files["source"].uuid
+
+        # Download the full file
+        full_response = app.get(
+            url_for(
+                "api.download_submission",
+                source_uuid=uuid,
+                submission_uuid=submission_uuid,
+            ),
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert full_response.status_code == 200
+        assert full_response.mimetype == "application/pgp-encrypted"
+
+        # Verify the etag header is actually the sha256 hash
+        hasher = hashlib.sha256()
+        hasher.update(full_response.data)
+        digest = binascii.hexlify(hasher.digest()).decode("utf-8")
+        digest_str = "sha256:" + digest
+        assert full_response.headers.get("ETag") == digest_str
+
+        # Verify the Content-Length header matches the length of the content
+        assert full_response.headers.get("Content-Length") == str(len(full_response.data))
+
+        # Verify that range requests are accepted
+        assert full_response.headers.get("Accept-Ranges") == "bytes"
+
+        # Download the first 10 bytes of data
+        headers = get_api_headers(journalist_api_token)
+        headers["Range"] = "bytes=0-9"
+        partial_response = app.get(
+            url_for(
+                "api.download_submission",
+                source_uuid=uuid,
+                submission_uuid=submission_uuid,
+            ),
+            headers=headers,
+        )
+        assert partial_response.status_code == 206  # HTTP/1.1 206 Partial Content
+        assert partial_response.mimetype == "application/pgp-encrypted"
+        assert partial_response.headers.get("Content-Length") == "10"
+        assert len(partial_response.data) == 10
+        assert full_response.data[0:10] == partial_response.data
+
+        # Download the second half of the data
+        range_start = int(len(full_response.data) / 2)
+        range_end = len(full_response.data) - 1
+        headers = get_api_headers(journalist_api_token)
+        headers["Range"] = f"bytes={range_start}-{range_end}"
+        partial_response = app.get(
+            url_for(
+                "api.download_submission",
+                source_uuid=uuid,
+                submission_uuid=submission_uuid,
+            ),
+            headers=headers,
+        )
+        assert partial_response.status_code == 206  # HTTP/1.1 206 Partial Content
+        assert partial_response.mimetype == "application/pgp-encrypted"
+        assert partial_response.headers.get("Content-Length") == str(range_end - range_start)
+        assert len(partial_response.data) == range_end - range_start
+        assert full_response.data[range_start:] == partial_response.data

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -1292,7 +1292,7 @@ def test_download_submission_range(journalist_app, test_files, journalist_api_to
 
         # Download the second half of the data
         range_start = int(len(full_response.data) / 2)
-        range_end = len(full_response.data) - 1
+        range_end = len(full_response.data)
         headers = get_api_headers(journalist_api_token)
         headers["Range"] = f"bytes={range_start}-{range_end}"
         partial_response = app.get(


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #3907.

This adds a range request test, and also makes it so the two routes that we need to support range requests include the `Accept-Ranges: bytes` header. The routes are:

- `/sources/<source_uuid>/submissions/<submission_uuid>/download`
- `/sources/<source_uuid>/replies/<reply_uuid>/download`

Miraculously, implementing range requests themselves doesn't seem to be necessary because ... the test passes. It's already built-in to the version of Flask we're using, apparently.

And just for some background, here's the download submission route:

```py
@api.route("/sources/<source_uuid>/submissions/<submission_uuid>/download", methods=["GET"])
def download_submission(source_uuid: str, submission_uuid: str) -> flask.Response:
    get_or_404(Source, source_uuid, column=Source.uuid)
    submission = get_or_404(Submission, submission_uuid, column=Submission.uuid)
    return utils.serve_file_with_etag(submission)
```

This responds with the file in `utils.serve_file_with_etag`. Here's that function:

```py
def serve_file_with_etag(db_obj: Union[Reply, Submission]) -> flask.Response:
    file_path = Storage.get_default().path(db_obj.source.filesystem_id, db_obj.filename)
    response = send_file(
        file_path, mimetype="application/pgp-encrypted", as_attachment=True, etag=False
    )  # Disable Flask default ETag

    if not db_obj.checksum:
        add_checksum_for_file(db.session, db_obj, file_path)

    response.direct_passthrough = False
    response.headers["Etag"] = db_obj.checksum
    response.headers["Accept-Ranges"] = "bytes"
    return response
```

All the API is doing is using Flask's `send_file` function to load the encrypted file from disk and send it to the http client. There's no compression or anything else happening here, so range support should be easy.

## Testing

You can confirm it works by running the test and seeing it pass:

```sh
./securedrop/bin/dev-shell bin/run-test --no-cov tests/test_journalist_api.py::test_download_submission_range
```

But I didn't quite believe it, so I manually tested it too like this:

- Start a dev server with `make dev`
- Load https://localhost:8080 and create a new source
- Upload a file, such as https://raw.githubusercontent.com/freedomofpress/securedrop/develop/securedrop/static/i/logo.png

To test using curl, first authenticate to the API, of course changing `one_time_code`:

```sh
curl \
-X POST \
-H "Content-Type: application/json" \
-d '{"username": "journalist", "passphrase": "correct horse battery staple profanity oil chewy", "one_time_code": "887767"}' \
http://localhost:8081/api/v1/token
```

The response will be something like this:

```json
{
  "expiration": "2024-05-10T00:57:42.102593Z", 
  "journalist_first_name": null, 
  "journalist_last_name": null, 
  "journalist_uuid": "54688953-a6a4-407b-b916-e64a4d3cf849", 
  "token": "Im83ZGtPLWFUd3gxM1ZtOE1OMEdWcFZEeGlEQVRUWUQ1TjJ5WnNZTTA5NGci.Zj1U5Q.8zYmrlSpjzNX63SVsZZhOeJ8Sq0"
}
```

Set the token for subsequent requests, changing the token to whatever you got:

```sh
TOKEN=Im83ZGtPLWFUd3gxM1ZtOE1OMEdWcFZEeGlEQVRUWUQ1TjJ5WnNZTTA5NGci.Zj1U5Q.8zYmrlSpjzNX63SVsZZhOeJ8Sq0
```

Get the download URL for the last source's only submission (this uses `jq` so you might need to install it):

```sh
SUBMISSION_URL=$(curl -H "Authorization: Token $TOKEN" http://localhost:8081/api/v1/sources | jq -r '.sources[-1].submissions_url')
DOWNLOAD_URL=$(curl -H "Authorization: Token $TOKEN" http://localhost:8081$SUBMISSION_URL | jq -r '.submissions[0].download_url')
```

Download it:

```sh
curl -v \
-H "Authorization: Token $TOKEN" \
-o logo.png.gpg \
http://localhost:8081$DOWNLOAD_URL
```

Now download just first 100 bytes:

```sh
curl -v \
-H "Authorization: Token $TOKEN" \
-H "Range: bytes=0-99" \
-o logo.png.gpg.part-0-99 \
http://localhost:8081$DOWNLOAD_URL
```

Now grab the first 100 bytes from the full file:

```sh
dd if=logo.png.gpg of=logo.png.gpg.dd-0-99 bs=1 count=100
```

And compare:

```sh
$ ls -l logo.png.gpg.*
-rw-r--r-- 1 user user 100 May  9 16:11 logo.png.gpg.dd-0-99
-rw-r--r-- 1 user user 100 May  9 16:11 logo.png.gpg.part-0-99
$ sha256sum logo.png.gpg.*
b98d6f101320b7fbc88d2fb59c03762f847763654c136df81017ffe177173181  logo.png.gpg.dd-0-99
b98d6f101320b7fbc88d2fb59c03762f847763654c136df81017ffe177173181  logo.png.gpg.part-0-99
```