### PR TITLE
Adds option to create large random files as test submissions 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,8 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 66777 \
 		--ignore 66704 \
 		--ignore 66710 \
+		--ignore 67895 \
+		--ignore 67599 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Adds `--random-file-size` option to `loaddata.py`. If set to 0, default file creation behaviour is followed. If set to N > 0, files containing random data NKB will be created instead.

Adds safety ignores as per https://github.com/freedomofpress/fpf-misc-resources/pull/43
## Testing

- [x] Run `make dev` and confirm it completes successfully, creating the usual test journalists and sources
- start a shell on the running dev instance with eg `docker exec -it securedrop-dev-0 bash`
- [x] Confirm that the command `./loaddata.py --random-file-size 100` completes successfully
- [x] Confirm that 3 new sources with 100KB file submissions have been created, checking the JI and `/var/lib/securedrop/store`


## Deployment
N/A dev only.