### PR TITLE
Support podman in `make dev-tor`

### DIFF
--- a/devops/clean
+++ b/devops/clean
@@ -5,6 +5,14 @@
 set -e
 set -u
 
+USE_PODMAN="${USE_PODMAN:-}"
+
+# Allow opting into using podman with USE_PODMAN=1
+if  [[ -n "${USE_PODMAN}" ]]; then
+    DOCKER_BIN="podman"
+else
+    DOCKER_BIN="docker"
+fi
 
 function remove_unwanted_files() {
 
@@ -37,8 +45,8 @@ function remove_unwanted_files() {
         build/*.deb
 
     # Remove any Onion URL from make dev-tor
-    if docker volume inspect sd-onion-services > /dev/null; then
-        docker volume remove sd-onion-services
+    if $DOCKER_BIN volume inspect sd-onion-services > /dev/null; then
+        $DOCKER_BIN volume remove sd-onion-services
     fi
 
     # Remove extraneous copies of the git repos, pulled in

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -118,7 +118,7 @@ function docker_run() {
 
     if [ -n "${USE_TOR:-}" ]; then
         # Mount persistent onion services
-        docker volume create sd-onion-services
+        $DOCKER_BIN volume inspect sd-onion-services -f " " || $DOCKER_BIN volume create sd-onion-services
         DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} --volume sd-onion-services:/var/lib/tor/services"
     fi
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Unfortunately `podman volume` and `docker volume` are not identical, podman will (sensibly) error if you try to create a volume that already exists unless you pass `--ignore`, which docker doesn't support.

So we conditionally add the needed flag depending on which tool we're using.


## Testing

* [x] Visual review
* [ ] Run `make dev-tor` twice under docker, make sure it works
* [ ] Run `make dev-tor` twice under podman, make sure it works (I've done this laready)

## Deployment

Any special considerations for deployment? n/a, dev only

## Checklist

- [x] These changes do not require documentation

