### PR TITLE
Add ignores for safety alerts 70612, 71064

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,8 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 66710 \
 		--ignore 67895 \
 		--ignore 67599 \
+		--ignore 70612 \
+		--ignore 71064 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Mirrors changes in 
https://github.com/freedomofpress/fpf-misc-resources/pull/46
https://github.com/freedomofpress/fpf-misc-resources/pull/47

Adds safety ignores for #s 70612 (bogus jinja2), 71064 (not relevant requests)

## Testing

- [ ] CI is passing.
- [ ] visual review.