### PR TITLE
feat: enable Tor's proof-of-work defense on the Source Interface

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -376,6 +376,15 @@ class SiteConfig:
                 lambda config: True,
             ),
             (
+                "securedrop_app_pow_on_source_interface",
+                True,
+                bool,
+                "Whether Tor proof of work should be enabled on Source Interface",
+                SiteConfig.ValidateYesNo(),
+                lambda x: x.lower() == "yes",
+                lambda config: True,
+            ),
+            (
                 "securedrop_app_https_on_source_interface",
                 False,
                 bool,

--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -379,7 +379,8 @@ class SiteConfig:
                 "securedrop_app_pow_on_source_interface",
                 True,
                 bool,
-                "Whether Tor proof of work should be enabled on Source Interface",
+                "Enable Tor's proof-of-work defense against denial-of-service attacks for the "
+                "Source Interface?",
                 SiteConfig.ValidateYesNo(),
                 lambda x: x.lower() == "yes",
                 lambda config: True,
@@ -388,7 +389,7 @@ class SiteConfig:
                 "securedrop_app_https_on_source_interface",
                 False,
                 bool,
-                "Whether HTTPS should be enabled on " + "Source Interface (requires EV cert)",
+                "Enable HTTPS for the Source Interface (requires EV certificate)?",
                 SiteConfig.ValidateYesNo(),
                 lambda x: x.lower() == "yes",
                 lambda config: True,

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -916,6 +916,7 @@ class TestSiteConfig:
     verify_prompt_monitor_hostname = verify_desc_consistency
     verify_prompt_dns_server = verify_desc_consistency
 
+    verify_prompt_securedrop_app_pow_on_source_interface = verify_prompt_boolean
     verify_prompt_securedrop_app_https_on_source_interface = verify_prompt_boolean
     verify_prompt_enable_ssh_over_tor = verify_prompt_boolean
 

--- a/install_files/ansible-base/roles/tor-hidden-services/templates/torrc
+++ b/install_files/ansible-base/roles/tor-hidden-services/templates/torrc
@@ -6,6 +6,10 @@ RunAsDaemon 1
 HiddenServiceDir /var/lib/tor/services/sourcev3
 HiddenServicePort 80 127.0.0.1:80
 
+{% if securedrop_app_pow_on_source_interface|default(True) %}
+HiddenServicePoWDefensesEnabled 1
+{% endif %}
+
 {% if securedrop_app_https_on_source_interface|default(False) %}
 HiddenServicePort 443 127.0.0.1:443
 {% endif %}

--- a/install_files/ansible-base/roles/tor-hidden-services/templates/torrc
+++ b/install_files/ansible-base/roles/tor-hidden-services/templates/torrc
@@ -6,7 +6,7 @@ RunAsDaemon 1
 HiddenServiceDir /var/lib/tor/services/sourcev3
 HiddenServicePort 80 127.0.0.1:80
 
-{% if securedrop_app_pow_on_source_interface|default(True) %}
+{% if securedrop_app_pow_on_source_interface|default(False) %}
 HiddenServicePoWDefensesEnabled 1
 {% endif %}
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #6933 by:
1. adding a `securedrop-admin sdconfig` prompt for enabling Tor's proof-of-work defense on the Source Interface (i.e., the only unauthenticated onion service a SecureDrop installation hosts); and
2. making it so.

## Testing

On this branch:

1. `securedrop-admin sdconfig`, accepting the new default:

    ```sh-session
    On the Source Interface, enable Tor's proof-of-work defense against denial-of-service attacks?: yes
    ```
2. `securedrop-admin install`
3. [x] `ssh app sudo cat /etc/tor/torrc` shows `HiddenServicePoWDefensesEnabled 1`
4. [x] [`onionprobe -e <your Source Interface>.onion`](https://tpo.pages.torproject.net/onion-services/ecosystem/apps/web/onionprobe/usage/) includes[^1] output like:

    ```sh-session
    2024-06-11 22:07:39,747 INFO: Proof of Work (PoW) params found in the descriptor
    2024-06-11 22:07:39,747 INFO: PoW v1 set with effort 0, expiration 2024-06-12T05:54:47 and seed Avq2iMON/49Vevxb+q479hUReRYKGAyw1fLScS/uKdE=
    ```
5. `securedrop-admin sdconfig` again, but turn the proof-of-work defense off
6. `securedrop-admin install` again
7. [x] `ssh app sudo cat /etc/tor/torrc` does NOT show `HiddenServicePoWDefensesEnabled 1`
8. [x] [`onionprobe -e <your Source Interface>.onion`](https://tpo.pages.torproject.net/onion-services/ecosystem/apps/web/onionprobe/usage/) ~~does NOT include `PoW` output~~ includes `Proof of Work (PoW) params not found`[^2]

[^1]: You'll need [onionprobe v1.2.0](https://gitlab.torproject.org/tpo/onion-services/onionprobe/-/blob/main/docs/changelog.md?ref_type=heads#v120---2024-04-24) [directly from Tor](https://community.torproject.org/onion-services/ecosystem/apps/web/onionprobe/installation/), not from the Debian bookworm package.
[^2]: https://github.com/freedomofpress/securedrop/pull/7175#issuecomment-2163949743

## Deployment

See discussion in this thread on half-opt-out:  This change will default to enabled on subsequent `securedrop-admin {sdconfig,install}` runs, but it won't be applied automatically on server-side update.

## Checklist

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

https://github.com/freedomofpress/securedrop/pull/7175#issuecomment-2164114278

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [x] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- I would appreciate help with the documentation
- These changes do not require documentation

Deferred to freedomofpress/securedrop-docs#568.