### PR TITLE
Journalist UI change 6904

### DIFF
--- a/securedrop/static/css/journalist.css
+++ b/securedrop/static/css/journalist.css
@@ -796,6 +796,16 @@ a.btn,
   font-size: .8em;
 }
 
+button[disabled], 
+button[disabled]:hover,
+a#delete-collections-link.disabled,
+a#delete-collections-link.disabled:hover {
+  background: lightgrey;
+  color: darkgrey;
+  border:none;
+  cursor: default;
+}
+
 button:not([lang=ar]),
 a.btn:not([lang=ar]),
 .btn:not([lang=ar]) {

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -34,6 +34,35 @@ function show(selector, displayStyle = "revert") {
   });
 }
 
+function disableButtons(selector) {
+  let nodelist = document.querySelectorAll(selector);
+  Array.prototype.forEach.call(nodelist, function(element) {
+    element.disabled = true;
+    element.classList.add("disabled");
+  })
+}
+
+function enableButtons(selector) {
+  let nodelist = document.querySelectorAll(selector);
+  Array.prototype.forEach.call(nodelist, function(element) {
+    element.disabled = false;
+    element.classList.remove("disabled");
+  })
+}
+
+function disableButtonsIfNoCheckedRows() {
+  let buttons = 'button[name="action"]';
+  let deletelink = 'a#delete-collections-link'
+  let checkedboxes = document.querySelectorAll(ROW_SELECTOR_PREFIX + ":not(.hidden) input[type=checkbox]:checked");
+  if (checkedboxes.length == 0) {
+    disableButtons(buttons);
+    disableButtons(deletelink);
+  } else {
+    enableButtons(buttons);
+    enableButtons(deletelink);
+  }
+}
+
 function enhance_ui() {
   // Add the "quick filter" box for the list of sources
   let filterContainer = document.getElementById("filter-container");
@@ -107,10 +136,10 @@ function ready(fn) {
 }
 
 ready(function() {
+  disableButtonsIfNoCheckedRows();
   enhance_ui();
 
   let selectAll = document.getElementById("select_all");
-
   if (selectAll) {
     selectAll.style.cursor = "pointer";
     selectAll.addEventListener("click", function() {
@@ -118,6 +147,7 @@ ready(function() {
       for (let i = 0; i < checkboxes.length; i++) {
         checkboxes[i].checked = true;
       }
+      disableButtonsIfNoCheckedRows();
     });
   }
 
@@ -129,6 +159,7 @@ ready(function() {
       for (let i = 0; i < checkboxes.length; i++) {
         checkboxes[i].checked = false;
       }
+      disableButtonsIfNoCheckedRows();
     });
   }
 
@@ -146,6 +177,11 @@ ready(function() {
       }
     });
   }
+
+  let checkboxes = document.querySelectorAll(ROW_SELECTOR_PREFIX + ":not(.hidden) input[type=checkbox]");
+  for (let i = 0; i < checkboxes.length; i++) {
+    checkboxes[i].addEventListener("click", disableButtonsIfNoCheckedRows);
+    }
 
   // When unread messages are downloaded from the source list, mark
   // the source read.
@@ -247,3 +283,5 @@ ready(function() {
     }
   }
 });
+
+

--- a/securedrop/static/js/journalist.js
+++ b/securedrop/static/js/journalist.js
@@ -5,6 +5,7 @@
 
 const COLLECTION_SELECTOR_PREFIX = "table";
 const ROW_SELECTOR_PREFIX = COLLECTION_SELECTOR_PREFIX + " tr"
+const CHECKBOX_SELECTOR = ROW_SELECTOR_PREFIX + ':not(.hidden) input[name="cols_selected"]'
 
 function closest(element, selector) {
   let parent = element.parentNode;
@@ -53,7 +54,7 @@ function enableButtons(selector) {
 function disableButtonsIfNoCheckedRows() {
   let buttons = 'button[name="action"]';
   let deletelink = 'a#delete-collections-link'
-  let checkedboxes = document.querySelectorAll(ROW_SELECTOR_PREFIX + ":not(.hidden) input[type=checkbox]:checked");
+  let checkedboxes = document.querySelectorAll(CHECKBOX_SELECTOR + ":checked");
   if (checkedboxes.length == 0) {
     disableButtons(buttons);
     disableButtons(deletelink);
@@ -143,7 +144,7 @@ ready(function() {
   if (selectAll) {
     selectAll.style.cursor = "pointer";
     selectAll.addEventListener("click", function() {
-      let checkboxes = document.querySelectorAll(ROW_SELECTOR_PREFIX + ":not(.hidden) input[type=checkbox]");
+      let checkboxes = document.querySelectorAll(CHECKBOX_SELECTOR);
       for (let i = 0; i < checkboxes.length; i++) {
         checkboxes[i].checked = true;
       }
@@ -155,7 +156,7 @@ ready(function() {
   if (selectNone) {
     selectNone.style.cursor = "pointer";
     selectNone.addEventListener("click", function() {
-      let checkboxes = document.querySelectorAll(ROW_SELECTOR_PREFIX + ":not(.hidden) input[type=checkbox]");
+      let checkboxes = document.querySelectorAll(CHECKBOX_SELECTOR);
       for (let i = 0; i < checkboxes.length; i++) {
         checkboxes[i].checked = false;
       }
@@ -167,7 +168,7 @@ ready(function() {
   if (selectUnread) {
     selectUnread.style.cursor = "pointer";
     selectUnread.addEventListener("click", function() {
-      let checkboxes = document.querySelectorAll(ROW_SELECTOR_PREFIX + " input[type='checkbox']:not(.hidden)");
+      let checkboxes = document.querySelectorAll(CHECKBOX_SELECTOR);
       for (let i = 0; i < checkboxes.length; i++) {
         if (checkboxes[i].classList.contains("unread-cb")) {
           checkboxes[i].checked = true;
@@ -178,7 +179,7 @@ ready(function() {
     });
   }
 
-  let checkboxes = document.querySelectorAll(ROW_SELECTOR_PREFIX + ":not(.hidden) input[type=checkbox]");
+  let checkboxes = document.querySelectorAll(CHECKBOX_SELECTOR);
   for (let i = 0; i < checkboxes.length; i++) {
     checkboxes[i].addEventListener("click", disableButtonsIfNoCheckedRows);
     }


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #6904.

Changes proposed in this pull request:
- The journalist Scripting has changed to disable buttons above the source rows as long as none of the rows are selected
- The journalist css has been changed to grey out disabled buttons, 

## Testing

I've not added unit tests for this change. Testing plan
- [ ] Build using `make dev`
- [ ] Log in as "journalist"
- [ ] The buttons above the source list (except for Select All and Select None) should be disabled, as no rows are selected
- [ ] Selecting any row will enable the buttons
- [ ] Buttons should always be enabled while any row is selected
- [ ] Using the Select All or Select None buttons should also affect the availability of the buttons


## Checklist
- [x] These changes do not require documentation