### PR TITLE
Ignore CVE-2023-4237 in ansible-core, we don't use the ec2_key module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 67599 \
 		--ignore 70612 \
 		--ignore 71064 \
+		--ignore 70895 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Already reviewed at <https://github.com/freedomofpress/fpf-misc-resources/pull/48>.

## Testing

How should the reviewer test this PR?

* [ ] visual review
* [ ] CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [x] I am silencing an alert related to a production dependency, because: not affected
