### PR TITLE
docs(test): suggest a workaround for the slow admin test suite

### DIFF
--- a/admin/Makefile
+++ b/admin/Makefile
@@ -2,6 +2,7 @@ DEFAULT_GOAL: help
 
 .PHONY: test
 test:  ## Run tox
+	@echo "NB.  This can be VERY slow.  If you find yourself running this test suite multiple times, you may prefer to \"docker run -it securedrop-admin bash\", install the editor of your choice into the container and edit there, and run \"tox\" directly as you work."
 	bin/dev-shell tox
 
 .PHONY: update-pip-requirements


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

"Fixes with documentation" the fact that the admin test suite runs in a container that's rebuilt very slowly on every change.  Given how rarely we interact with it directly (as opposed to in CI), I don't think that's worth fixing, but it is worth hinting at a quality-of-life workaround.

Refs https://github.com/freedomofpress/securedrop/issues/6897.


## Testing

- [ ] Visual review.


## Deployment

Development/test-only.