### PR TITLE
[2.9.0] backport "Ignore CVE-2023-4237 in ansible-core, we don't use the ec2_key module" (#7179)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 67599 \
 		--ignore 70612 \
 		--ignore 71064 \
+		--ignore 70895 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7179.

## Testing

* [x] CI is passing
* [x] base is `release/2.9.0`
* [x] Only contains changes from #7179.
