### PR TITLE
Disable werkzeug header generation for files served via mod_xsendfile

### DIFF
--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -525,8 +525,13 @@ def col_download_all(cols_selected: List[str]) -> werkzeug.Response:
 
 def serve_file_with_etag(db_obj: Union[Reply, Submission]) -> flask.Response:
     file_path = Storage.get_default().path(db_obj.source.filesystem_id, db_obj.filename)
+    add_range_headers = not current_app.config["USE_X_SENDFILE"]
     response = send_file(
-        file_path, mimetype="application/pgp-encrypted", as_attachment=True, etag=False
+        file_path,
+        mimetype="application/pgp-encrypted",
+        as_attachment=True,
+        etag=False,
+        conditional=add_range_headers,
     )  # Disable Flask default ETag
 
     if not db_obj.checksum:


### PR DESCRIPTION
## Status

Draft mode

## Description of Changes

Fixes #7186.

By default, when flask serves a file in response to a partial content request, it (or rather werkzeug) generates the necessary Content-length and Content-range headers itself. Production SD instances use mod_xsendfile to speed up downloads, but mod_xsendfile skips handling responses where said headers are already set.

This PR checks whether USE_X_SENDFILE is set, and if so, it disables extra header generation for partial content responses, allowing mod_xsendfile to handle them instead.

## Testing
### dev environment
- [ ] The range request section of the 2.9.0 test plan (https://github.com/freedomofpress/securedrop/wiki/2.9.0-Test-Plan#api-range-request-support-7160) passes against an environment configured with `make dev`

### prod environment (VMs ok)
- Set up a production environment and install the securedrop-app-code deb built from this branch on the application server
- [ ] The range request section of the 2.9.0 test plan (https://github.com/freedomofpress/securedrop/wiki/2.9.0-Test-Plan#api-range-request-support-7160) passes successfully
How should the reviewer test this PR?
Write out any special testing steps here.

## Deployment

Any special considerations for deployment? Consider both:

n/a

## Checklist

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

