### PR TITLE
[2.9.0] Backport #7188: Disable werkzeug header generation for files served via mod_xsendfile

### DIFF
--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -525,8 +525,13 @@ def col_download_all(cols_selected: List[str]) -> werkzeug.Response:
 
 def serve_file_with_etag(db_obj: Union[Reply, Submission]) -> flask.Response:
     file_path = Storage.get_default().path(db_obj.source.filesystem_id, db_obj.filename)
+    add_range_headers = not current_app.config["USE_X_SENDFILE"]
     response = send_file(
-        file_path, mimetype="application/pgp-encrypted", as_attachment=True, etag=False
+        file_path,
+        mimetype="application/pgp-encrypted",
+        as_attachment=True,
+        etag=False,
+        conditional=add_range_headers,
     )  # Disable Flask default ETag
 
     if not db_obj.checksum:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7188.

## Testing

* [ ] CI is passing
* [ ] base is `release/2.9.0`
* [ ] Only contains changes from #7188.
