### PR TITLE
Enable deprecated docker pull functionalty to fix nightlies.

### DIFF
--- a/devops/gce-nested/ci-go.sh
+++ b/devops/gce-nested/ci-go.sh
@@ -14,6 +14,12 @@ set -o pipefail
 
 export BASE_OS="${BASE_OS:-focal}"
 
+# Temporary workaround for old gcloud-sdk image
+sudo mkdir -p /etc/systemd/system/docker.service.d
+echo -e "[Service]\nEnvironment=\"DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=true\"" | sudo tee -a /etc/systemd/system/docker.service.d/env.conf
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+
 ./devops/gce-nested/gce-start.sh
 ./devops/gce-nested/gce-runner.sh
 ./devops/gce-nested/gce-stop.sh


### PR DESCRIPTION
## Status

RfR

## Description of Changes

Fixes #7195 .

- Enables deprecated docker pull feature to fix `staging-tests-with rebase` CI job, run both nightly and for branches prefixed with `stg-`

## Testing

- [ ] CI is passing, in particular `staging-test-with-rebase`

## Deployment
n/a - CI only.
