### PR TITLE
Fix pylint warning `raise-missing-from`

### DIFF
--- a/securedrop/debian/ossec-common/var/ossec/checksdconfig.py
+++ b/securedrop/debian/ossec-common/var/ossec/checksdconfig.py
@@ -57,9 +57,9 @@ def check_iptables_default_drop(rules: dict) -> None:
         for i, rule in enumerate(reversed(chain_rules), 1):
             try:
                 if rules[chain][-i] != rule:
-                    raise ValueError("The iptables default drop rules are incorrect.")
-            except (KeyError, IndexError):
-                raise ValueError("The iptables default drop rules are incorrect.")
+                    raise ValueError("The iptables default drop rules are incorrect.") from None
+            except (KeyError, IndexError) as exc:
+                raise ValueError("The iptables default drop rules are incorrect.") from exc
 
 
 def check_iptables_rules() -> None:

--- a/securedrop/encryption.py
+++ b/securedrop/encryption.py
@@ -135,10 +135,10 @@ class EncryptionManager:
         # Verify the secret key we got can be read and decrypted by redwood
         try:
             actual_fingerprint = redwood.is_valid_secret_key(secret_key, passphrase)
-        except redwood.RedwoodError:
+        except redwood.RedwoodError as exc:
             # Either Sequoia can't extract the secret key or the passphrase
             # is incorrect.
-            raise GpgKeyNotFoundError()
+            raise GpgKeyNotFoundError() from exc
         if fingerprint != actual_fingerprint:
             # Somehow we exported the wrong key?
             raise GpgKeyNotFoundError()

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -692,8 +692,8 @@ class Journalist(db.Model):
     ) -> "Journalist":
         try:
             user = Journalist.query.filter_by(username=username).one()
-        except NoResultFound:
-            raise InvalidUsernameException(gettext("Invalid username"))
+        except NoResultFound as exc:
+            raise InvalidUsernameException(gettext("Invalid username")) from exc
 
         if user.username in Journalist.INVALID_USERNAMES:
             raise InvalidUsernameException(gettext("Invalid username"))

--- a/securedrop/passphrases.py
+++ b/securedrop/passphrases.py
@@ -58,10 +58,10 @@ class PassphraseGenerator:
             # Ensure all words are ascii
             try:
                 " ".join(word_list).encode("ascii")
-            except UnicodeEncodeError:
+            except UnicodeEncodeError as exc:
                 raise InvalidWordListError(
                     "The word list for language '{}' contains non-ASCII words."
-                )
+                ) from exc
 
             # Ensure that passphrases longer than what's supported can't be generated
             longest_word = max(word_list, key=len)

--- a/securedrop/pretty_bad_protocol/_meta.py
+++ b/securedrop/pretty_bad_protocol/_meta.py
@@ -212,7 +212,7 @@ class GPGBase:
                 assert isinstance(self.options, list), "options not list"
         except (AssertionError, AttributeError) as ae:
             log.error("GPGBase.__init__(): %s" % str(ae))
-            raise RuntimeError(str(ae))
+            raise RuntimeError(str(ae)) from ae
         else:
             self._set_verbose(verbose)
             self.use_agent = use_agent
@@ -391,8 +391,8 @@ class GPGBase:
         read and write permissions for it.
 
         :param str directory: A relative or absolute path to the directory to
-                            use for storing/accessing GnuPG's files, including
-                            keyrings and the trustdb.
+                             use for storing/accessing GnuPG's files, including
+                             keyrings and the trustdb.
         :raises: :exc:`~exceptions.RuntimeError` if unable to find a suitable
                  directory to use.
         """
@@ -417,10 +417,7 @@ class GPGBase:
                 msg = "Unable to set '%s' as GnuPG homedir" % directory
                 log.debug("GPGBase.homedir.setter(): %s" % msg)
                 log.debug(str(ae))
-                raise RuntimeError(str(ae))
-            else:
-                log.info("Setting homedir to '%s'" % hd)
-                self._homedir = hd
+                raise RuntimeError(str(ae)) from ae
 
     homedir = _util.InheritableProperty(_homedir_getter, _homedir_setter)
 
@@ -466,10 +463,7 @@ class GPGBase:
             msg = "Unable to set '%s' as generated keys dir" % directory
             log.debug("GPGBase._generated_keys_setter(): %s" % msg)
             log.debug(str(ae))
-            raise RuntimeError(str(ae))
-        else:
-            log.info("Setting homedir to '%s'" % hd)
-            self.__generated_keys = hd
+            raise RuntimeError(str(ae)) from ae
 
     _generated_keys = _util.InheritableProperty(_generated_keys_getter, _generated_keys_setter)
 

--- a/securedrop/pretty_bad_protocol/_parsers.py
+++ b/securedrop/pretty_bad_protocol/_parsers.py
@@ -193,11 +193,11 @@ def _is_allowed(input):  # type: ignore[no-untyped-def]
     try:
         # check that allowed is a subset of all gnupg_options
         assert allowed.issubset(gnupg_options)
-    except AssertionError:
+    except AssertionError as exc:
         raise UsageError(
             "'allowed' isn't a subset of known options, diff: %s"
             % allowed.difference(gnupg_options)
-        )
+        ) from exc
 
     # if we got a list of args, join them
     #
@@ -216,10 +216,10 @@ def _is_allowed(input):  # type: ignore[no-untyped-def]
             # xxx we probably want to use itertools.dropwhile here
             try:
                 assert hyphenated in allowed
-            except AssertionError:
+            except AssertionError as exc:
                 dropped = _fix_unsafe(hyphenated)
                 log.warn("_is_allowed(): Dropping option '%s'..." % dropped)
-                raise ProtectedOption("Option '%s' not supported." % dropped)
+                raise ProtectedOption("Option '%s' not supported." % dropped) from exc
             else:
                 return input
     return None

--- a/securedrop/source_app/session_manager.py
+++ b/securedrop/source_app/session_manager.py
@@ -73,9 +73,9 @@ class SessionManager:
         try:
             user_passphrase = session[cls._SESSION_COOKIE_KEY_FOR_CODENAME]
             date_session_expires = session[cls._SESSION_COOKIE_KEY_FOR_EXPIRATION_DATE]
-        except KeyError:
+        except KeyError as exc:
             cls.log_user_out()
-            raise UserNotLoggedIn()
+            raise UserNotLoggedIn() from exc
 
         if datetime.now(timezone.utc) >= date_session_expires:
             cls.log_user_out()
@@ -86,10 +86,10 @@ class SessionManager:
             source_user = authenticate_source_user(
                 db_session=db_session, supplied_passphrase=user_passphrase
             )
-        except InvalidPassphraseError:
+        except InvalidPassphraseError as exc:
             # The cookie contains a passphrase that is invalid: happens if the user was deleted
             cls.log_user_out()
-            raise UserHasBeenDeleted()
+            raise UserHasBeenDeleted() from exc
 
         return source_user
 

--- a/securedrop/source_user.py
+++ b/securedrop/source_user.py
@@ -117,12 +117,12 @@ def create_source_user(
     db_session.add(source_db_record)
     try:
         db_session.commit()
-    except IntegrityError:
+    except IntegrityError as exc:
         db_session.rollback()
         raise SourcePassphraseCollisionError(
             f"Passphrase already used by another Source (filesystem_id {filesystem_id})"
-        )
-
+        ) from exc
+    
     # Create the source's folder
     os.mkdir(source_app_storage.path(filesystem_id))
 

--- a/securedrop/two_factor.py
+++ b/securedrop/two_factor.py
@@ -48,8 +48,8 @@ class HOTP:
                 secret_as_base32,
                 casefold=True,
             )
-        except binascii.Error:
-            raise OtpSecretInvalid("Secret is not base32-encoded")
+        except binascii.Error as exc:
+            raise OtpSecretInvalid("Secret is not base32-encoded") from exc
 
         self._hotp = hotp.HOTP(
             key=otp_secret_as_bytes,
@@ -101,8 +101,8 @@ class TOTP:
                 secret_as_base32,
                 casefold=True,
             )
-        except binascii.Error:
-            raise OtpSecretInvalid("Secret is not base32-encoded")
+        except binascii.Error as exc:
+            raise OtpSecretInvalid("Secret is not base32-encoded") from exc
 
         self._totp = totp.TOTP(
             key=otp_secret_as_bytes,


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `raise-missing-from`.
"Python's exception chaining shows the traceback of the current exception, but also of the original exception. When you raise a new exception after another exception was caught it's likely that the second exception is a friendly re-wrapping of the first exception. In such cases `raise from` provides a better link between the two tracebacks in the final error. See [https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.