### PR TITLE
Add `make dev-arti` as an alternative to C-Tor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,13 @@ dev-tor:  ## Run the development server with onion services in a Docker containe
 	@OFFSET_PORTS='false' DOCKER_BUILD_VERBOSE='true' USE_TOR='true' SLIM_BUILD=1 $(DEVSHELL) $(SDBIN)/run
 	@echo
 
+.PHONY: dev-arti
+dev-arti:  ## Same as `dev-tor`, but using Arti instead of C-Tor
+	@echo "███ Starting development server with onion services..."
+	@echo "███ WARNING: Arti support is experimental. Good luck!"
+	@USE_ARTI='true' $(MAKE) dev
+	@echo
+
 .PHONY: demo-landing-page
 demo-landing-page: ## Serve the landing page for the SecureDrop demo
 	@echo "███ Building Docker image..."

--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -85,23 +85,69 @@ function maybe_use_tor() {
         openssl pkey -in /tmp/k1.prv.pem -pubout | grep -v " PUBLIC KEY" | base64pem -d | tail --bytes=32 | base32 | sed 's/=//g' > /tmp/k1.pub.key
         echo "descriptor:x25519:$(cat /tmp/k1.pub.key)" | sudo -u debian-tor tee /var/lib/tor/services/journalist/authorized_clients/client.auth
         # shellcheck disable=SC2024
-        sudo -u debian-tor cat /var/lib/tor/services/source/hostname > /var/lib/securedrop/source_v3_url
         # kill and restart Tor to pick up authorized_clients change
         # (restart a little flaky hence the kill)
         sudo kill "$(cat /run/tor/tor.pid)"; sudo service tor restart
-        # print out the addresses and the JI client auth key
 
         si_address="$(sudo -u debian-tor cat /var/lib/tor/services/source/hostname)"
         ji_address="$(sudo -u debian-tor cat /var/lib/tor/services/journalist/hostname)"
-        ji_authkey="$(sudo -u debian-tor cat /tmp/k1.prv.key)"
-        sdkey_fpr="$(gpg --with-fingerprint --with-colons ./tests/files/test_journalist_key.pub | grep -e '^fpr' | tr -d 'fpr:')"
+        ji_auth_private="$(sudo -u debian-tor cat /tmp/k1.prv.key)"
+    fi
+    if [[ -n "${USE_ARTI:-}" ]]; then
+        echo "Setting up Arti..."
 
+        mkdir -p /var/lib/arti
+        if [ ! -f "/var/lib/arti/config.toml" ]; then
+            # create config.toml for SI and JI
+            openssl genpkey -algorithm x25519 -out /var/lib/arti/ji_priv.key
+            ji_auth_public=$(openssl pkey -in /var/lib/arti/ji_priv.key -pubout | grep -v " PUBLIC KEY" | base64pem -d | tail --bytes=32 | base32 | sed 's/=//g')
+            cat > /var/lib/arti/config.toml << TOML
+[proxy]
+socks_listen = 9152
+
+[storage]
+# store temporarily
+cache_dir = "/tmp/arti-cache"
+# store persistently
+state_dir = "/var/lib/arti/data"
+
+[onion_services."source"]
+proxy_ports = [
+    ["80", "127.0.0.1:8080"]
+]
+
+[onion_services."journalist"]
+proxy_ports = [
+    ["80", "127.0.0.1:8081"]
+]
+[onion_services."journalist".restricted_discovery]
+enabled = true
+[onion_services."journalist".restricted_discovery.static_keys]
+journalist = "descriptor:x25519:${ji_auth_public}"
+
+TOML
+        fi
+        # Install the latest version of Arti, if not already present.
+        PATH="$PATH:/opt/cargo/bin/" CARGO_HOME="${REPOROOT}/target/cargo-dev" \
+            cargo install --locked arti --features onion-service-service,restricted-discovery
+        ARTI="${REPOROOT}/target/cargo-dev/bin/arti"
+
+        si_address="$($ARTI -c /var/lib/arti/config.toml hss --nickname source onion-name -l none --generate=if-needed)"
+        ji_address="$($ARTI -c /var/lib/arti/config.toml hss --nickname journalist onion-name -l none --generate=if-needed)"
+        ji_auth_private=$(grep -v " PRIVATE KEY" /var/lib/arti/ji_priv.key | base64pem -d | tail --bytes=32 | base32 | sed 's/=//g')
+        # Start Arti!
+        $ARTI -c /var/lib/arti/config.toml proxy &
+    fi
+    if [ -n "${USE_TOR:-}" ] || [ -n "${USE_ARTI:-}" ]; then
+        # print out the addresses and the JI client auth key
+        sdkey_fpr="$(gpg --with-fingerprint --with-colons ./tests/files/test_journalist_key.pub | grep -e '^fpr' | tr -d 'fpr:')"
+        echo "$si_address" > /var/lib/securedrop/source_v3_url
         cat > /tmp/qubes-config.json <<EOF
 {
   "submission_key_fpr": "${sdkey_fpr}",
   "hidserv": {
     "hostname": "${ji_address}",
-    "key": "${ji_authkey}"
+    "key": "${ji_auth_private}"
   },
   "environment": "prod",
   "vmsizes": {
@@ -115,7 +161,7 @@ EOF
         echo "--------"
         echo "Source Interface:     http://${si_address}"
         echo "Journalist Interface: http://${ji_address}"
-        echo "Journalist Auth Key:  ${ji_authkey}"
+        echo "Journalist Auth Key:  ${ji_auth_private}"
         echo "--------"
         echo
         echo "SecureDrop Workstation config.json:"

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -10,6 +10,7 @@ export PATH="/opt/venvs/securedrop-app-code/bin:$PATH"
 
 TOPLEVEL=$(git rev-parse --show-toplevel)
 USE_TOR="${USE_TOR:-}"
+USE_ARTI="${USE_ARTI:-}"
 USE_PODMAN="${USE_PODMAN:-}"
 SLIM_BUILD="${SLIM_BUILD:-}"
 DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS:-}"
@@ -116,10 +117,19 @@ function docker_run() {
         DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} -it"
     fi
 
+    if [ -n "${USE_TOR:-}" ] && [ -n "${USE_ARTI:-}" ]; then
+        echo "Cannot set both USE_TOR and USE_ARTI; pick one"
+        exit 1
+    fi
     if [ -n "${USE_TOR:-}" ]; then
         # Mount persistent onion services
         $DOCKER_BIN volume inspect sd-onion-services -f " " || $DOCKER_BIN volume create sd-onion-services
         DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} --volume sd-onion-services:/var/lib/tor/services"
+    fi
+    if [ -n "${USE_ARTI:-}" ]; then
+        # Mount persistent onion services
+        $DOCKER_BIN volume inspect sd-arti -f " " || $DOCKER_BIN volume create sd-arti
+        DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} --volume sd-arti:/var/lib/arti"
     fi
 
     # The --shm-size argument sets up dedicated shared memory for the
@@ -132,6 +142,7 @@ function docker_run() {
            -p "127.0.0.1:${SD_HOSTPORT_SI}:8080" \
            -p "127.0.0.1:${SD_HOSTPORT_JI}:8081" \
            -e USE_TOR=$USE_TOR \
+           -e USE_ARTI=$USE_ARTI \
            -e NUM_JOURNALISTS \
            -e NUM_SOURCES \
            -e LOADDATA_ARGS \

--- a/securedrop/dockerfiles/focal/python3/SlimDockerfile
+++ b/securedrop/dockerfiles/focal/python3/SlimDockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
                        apache2-dev coreutils vim \
                        python3-pip python3-all python3-venv virtualenv python3-dev libssl-dev \
                        gnupg2 redis-server git curl wget jq \
-                       enchant-2 libffi-dev sqlite3 gettext sudo tor basez pkg-config
+                       enchant-2 libffi-dev libsqlite3-dev sqlite3 gettext sudo tor basez pkg-config
 
 # Install Rust using the same steps as <https://github.com/rust-lang/docker-rust>
 # 1) Download rustup-init and verify it matches hardcoded checksum


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Arti is Tor's RIIR effort, and while it is 1.x, the onion service support is still experimental.

Given that, it is to our (and Tor's) benefit for us to try using Arti in development modes to provide feedback. To that end, using Arti is now possible, in parallel, to the existing C-Tor support.

Running `make dev-arti` should give exactly the same experience as the existing `make dev-tor` endpoint, aside from the inital launch, which will be slower since it needs to compile Arti from scratch.

As an intentional choice, we don't version pin Arti since this is an experimental thing, so it's more beneficial we just automatically stay on the latest version and fix breakage instead of needing to constantly bump versions.

Note that `make dev-tor` is entirely independent from this, so the two commands will serve the dev server on different onion addresses.

As far as the Arti code itself, generating a config.toml file seems much cleaner than adding to `torrc` and generating `.auth` files.

## Testing

How should the reviewer test this PR?

* [ ] Without this PR, run `make dev-tor`, see that it's all fine
* [ ] With this PR, run `make dev-tor`, see that it uses the same onion addresses and is all fine. Basically this PR should not adversely affect the existing dev-tor in any way.
* [ ] With this PR, run `make dev-arti`, wait a bit for it to all compile, and then it works in just about the same way.
* [ ] Stop the dev server, and then run `make dev-arti` again, verify it gives you the same onion addresses as the previous run.

## Deployment

Any special considerations for deployment? n/a, dev-only

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

While this modifies the dev container, I explicitly didn't try anything in it yet because this is just for interactive use and not for like, running tests and stuff.