### PR TITLE
Migrate deb-tests job to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,42 +303,6 @@ jobs:
       - store_artifacts:
           path: ~/sd/junit
 
-  deb-tests:
-    machine:
-      image: ubuntu-2004:current
-      enabled: true
-    environment:
-      DOCKER_API_VERSION: 1.24
-      BASE_OS: focal
-    steps:
-      - checkout
-      - run:
-          name: Build debs
-          command: |
-            make build-debs
-      - run:
-          name: Build OSSEC debs
-          command: |
-            make build-debs-ossec
-      - run:
-          name: Second round of builds
-          command: |
-            # TODO: use reprotest in the future
-            mv build/focal build/focal-first
-            make build-debs-notest
-            make build-debs-ossec-notest
-            mv build/focal build/focal-second
-      - run:
-          name: Run diffoscope
-          command: |
-            sha256sum build/focal-*/*.deb
-            # FIXME: securedrop-app-code isn't reproducible
-            for pkg in ossec-agent ossec-server securedrop-config securedrop-keyring securedrop-ossec-agent securedrop-ossec-server
-            do
-                echo "Checking ${pkg}..."
-                ./.venv/bin/diffoscope build/focal-first/${pkg}*.deb build/focal-second/${pkg}*.deb
-            done
-
 workflows:
   version: 2
   securedrop_ci:
@@ -396,10 +360,6 @@ workflows:
           context:
             - circleci-slack
           <<: *slack-fail-post-step
-      - deb-tests:
-          context:
-            - circleci-slack
-          <<: *slack-fail-post-step
 
   nightly:
     triggers:
@@ -422,5 +382,4 @@ workflows:
               only:
                 - develop
     jobs:
-      - deb-tests
       - translation-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+name: Package builds
+on:
+  - merge_group
+  - push
+  - pull_request
+
+# Only build for latest push/PR unless it's main or release/
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith( github.ref, 'refs/heads/release/' ) }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-debs:
+    strategy:
+      matrix:
+        build: [one, two]
+    runs-on: ubuntu-latest
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+      - name: Build packages
+        run: |
+          ./builder/build-debs.sh
+          WHAT=ossec ./builder/build-debs.sh
+      - uses: actions/upload-artifact@v4
+        id: upload
+        with:
+          name: build-${{ matrix.build }}
+          path: build
+          if-no-files-found: error
+
+  reproducible-debs:
+    runs-on: ubuntu-latest
+    container: debian:bookworm
+    needs:
+      - build-debs
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update && apt-get install --yes diffoscope-minimal \
+            --no-install-recommends
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "build-*"
+      - name: diffoscope
+        run: |
+          find . -name '*.deb' -exec sha256sum {} \;
+          # FIXME: securedrop-app-code isn't reproducible
+          for pkg in ossec-agent ossec-server securedrop-config securedrop-keyring securedrop-ossec-agent securedrop-ossec-server
+          do
+              echo "Checking ${pkg}..."
+              diffoscope build-one/focal/${pkg}*.deb build-two/focal/${pkg}*.deb
+          done

--- a/devops/scripts/boot-strap-venv.sh
+++ b/devops/scripts/boot-strap-venv.sh
@@ -51,7 +51,7 @@ function virtualenv_bootstrap() {
         then
             p=$(command -v "python${PYTHON_VERSION}" 2> /dev/null || command -v python3)
             echo "Creating ${p} virtualenv in ${VENV}"
-            virtualenv -p "${p}" "${VENV}"
+            "${p}" -m venv "${VENV}"
         fi
 
         PIP_CONSTRAINT=${DEV_CONSTRAINT} "${VENV}/bin/pip" install -q -r "securedrop/requirements/python3/develop-requirements.txt"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Forked from securedrop-client job. It mostly follows the CircleCI job except it runs the two builds in parallel, and uses a separate, dependent job to run diffoscope.

There is one change needed to the virtualenv bootstrap, since actions/setup-python doesn't install `virtualenv`, we invoke it as `$python -m venv`, which should still work nearly everywhere.

I didn't re-add in nightly jobs for this since it's much more robust now that it's no longer using molecule.
## Testing

How should the reviewer test this PR?

* [ ] CI passes
* [ ] Visual review

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] I have written a test plan and validated it for this PR
- [ ] These changes do not require documentation
