### PR TITLE
Have GHA lint job also run `make verify-mo`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install --yes --no-install-recommends \
-            build-essential python3-virtualenv python3-dev enchant file apache2-dev jq
+            build-essential python3-virtualenv python3-dev enchant file apache2-dev jq libarchive-tools
           virtualenv .venv
           # TODO: this should be one step, but there are too many conflicting dependencies
           ./.venv/bin/pip install -r securedrop/requirements/python3/test-requirements.txt
@@ -28,6 +28,7 @@ jobs:
           git config --global --add safe.directory $GITHUB_WORKSPACE
           source .venv/bin/activate
           make lint
+          make verify-mo
 
   rust:
     runs-on: ubuntu-latest

--- a/devops/scripts/verify-mo.py
+++ b/devops/scripts/verify-mo.py
@@ -138,6 +138,8 @@ class CatalogVerifier:
         # or 1 (differences); anything else is an error.
         test = self.diffoscope_call(Path(self.mo.fpath), Path(self.mo_target), filtered=False)
         if test.returncode not in [0, 1]:
+            print(test.stdout.decode())
+            print(test.stderr.decode())
             test.check_returncode()
 
         # With filtering, since diffoscope will return 1 on differences


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This was in the CircleCI job but not GHA. We need to install libarchive for diffoscope to work; added some debugging code to make those types of diffoscope failures easier to understand and debug.
## Testing

How should the reviewer test this PR?

* [ ] CI passes
* [ ] visual review

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
