### PR TITLE
Migrate static-analysis-and-no-known-cves to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,37 +230,6 @@ jobs:
       - store_artifacts:
           path: ~/project/test-results
 
-  static-analysis-and-no-known-cves:
-    machine:
-      image: ubuntu-2004:current
-      enabled: true
-    environment:
-      DOCKER_API_VERSION: 1.24
-      BASE_OS: focal
-    steps:
-      - checkout
-      - *rebaseontarget
-      - *createcachedir
-      - *restorecache
-      - *loadimagelayers
-      - *dockerimagebuild
-      - *saveimagelayers
-      - *savecache
-
-      - run:
-          name: Check Python dependencies for CVEs
-          command: |
-            fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
-            DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" securedrop/bin/dev-shell \
-                  bash -c "pip3 install -U -q --upgrade safety && make -C .. safety"
-
-      - run:
-          name: Run static security testing on source code with semgrep
-          command: |
-            fromtag=$(docker images |grep securedrop-test-focal-py3 |head -n1 |awk '{print $2}')
-            DOCKER_BUILD_ARGUMENTS="--cache-from securedrop-test-focal-py3:${fromtag:-latest}" securedrop/bin/dev-shell \
-                  bash -c "pip3 install -U -q --upgrade pip && pip3 install -U -q --upgrade semgrep && make -C .. semgrep"
-
   staging-test-with-rebase:
     machine:
       image: ubuntu-2004:current
@@ -319,12 +288,6 @@ workflows:
           context:
             - circleci-slack
           <<: *slack-fail-post-step
-      - static-analysis-and-no-known-cves:
-          requires:
-            - lint
-          context:
-            - circleci-slack
-          <<: *slack-fail-post-step
       - staging-test-with-rebase:
           filters:
             branches:
@@ -351,7 +314,6 @@ workflows:
                 - develop
     jobs:
       - staging-test-with-rebase
-      - static-analysis-and-no-known-cves
 
   weekly:
     triggers:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,8 @@
-name: Security (cron)
+name: Security
 on:
+  push:
+  pull_request:
+  merge_group:
   schedule:
     - cron: '0 3 * * *'
 
@@ -13,3 +16,20 @@ jobs:
       - name: Check Rust dependencies
         run: |
           make rust-audit
+
+  static-analysis-and-no-known-cves:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+      - name: Install dependencies
+        run: |
+          pip install safety semgrep
+      - name: Check Python dependencies for CVEs
+        run: |
+          make safety
+      - name: Run static security testing on source code with semgrep
+        run: |
+          make semgrep


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This ports the same functionality but in a much simpler way since we just need the latest versions of the safety and semgrep packages.

We want this to run on each PR and every night, so move it into security.yml and configure that workflow to run on each PR as well. As a side-effect, `rust-audit` will now run on each PR, which is fine.

## Testing

How should the reviewer test this PR?

* [ ] CI passes
* [ ] visual review
* [ ] infra moves "Required" label to GHA job

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [x] I have written a test plan and validated it for this PR
- [x] These changes do not require documentation
