### PR TITLE
Enforce GCE lifespan during instantiation

### DIFF
--- a/devops/gce-nested/gce-start.sh
+++ b/devops/gce-nested/gce-start.sh
@@ -43,7 +43,9 @@ function create_sd_ci_gce_instance() {
           --subnet ci-subnet \
           --boot-disk-type=pd-ssd \
           --machine-type="${GCLOUD_MACHINE_TYPE}" \
-          --metadata "ssh-keys=${SSH_USER_NAME}:$(cat $SSH_PUBKEY)"
+          --metadata "ssh-keys=${SSH_USER_NAME}:$(cat $SSH_PUBKEY)" \
+          --instance-termination-action=DELETE \
+          --max-run-duration=3h
 
       # Give box a few more seconds for SSH to become available
       echo "Sleeping for 20s to wait for SSH to become available"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

FPF used to have a GCE instance culler tool:
 https://github.com/freedomofpress/container-gce-instance-culler
which was packed into a container and run as a cronjob every other hour on Codefresh. Instead of trying to maintain said tool and Codefresh pipeline, define a lifespan during VM creation that GCP will enforce.

Changes proposed in this pull request:

## Testing

- [ ] Visual review