### PR TITLE
ci(translation): save screenshots as workflow artifacts

### DIFF
--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -56,3 +56,8 @@ jobs:
       - name: Run translation tests
         run: |
           LOCALES="${{ matrix.locale }}" make translation-test
+      - name: Save screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots-${{ matrix.locale }}
+          path: securedrop/tests/functional/pageslayout/screenshots/

--- a/Makefile
+++ b/Makefile
@@ -427,9 +427,10 @@ $(DESKTOP_POT): ${DESKTOP_BASE}/*.in
 		--output-file $@
 	@rm ${DESKTOP_LOCALE_DIR}/*.po
 
-# Render desktop list from "i18n.json".
+# Render the list of desktop locales from those in entries "i18n.json" that
+# include a "desktop" key.
 $(DESKTOP_I18N_CONF):
-	@jq --raw-output '.supported_locales[].desktop' ${I18N_CONF} > $@
+	@jq --raw-output '.supported_locales[].desktop | values' ${I18N_CONF} > $@
 
 ## Supported locales
 

--- a/securedrop/bin/dev-config
+++ b/securedrop/bin/dev-config
@@ -27,7 +27,6 @@ with open('securedrop/config.py', 'w') as f:
     text += '\n'
     supported_locales = subprocess.check_output(['make', '--quiet', 'supported-locales']).decode().strip()
     text += f'SUPPORTED_LOCALES = {supported_locales}\n'
-    text += 'SUPPORTED_LOCALES.append("en_US")\n'
     f.write(text)
 
 with open('securedrop/rq_config.py', 'w') as f:

--- a/securedrop/i18n.json
+++ b/securedrop/i18n.json
@@ -20,6 +20,9 @@
       "name": "Greek",
       "desktop": "el"
     },
+    "en_US": {
+      "name": "English"
+    },
     "es_ES": {
       "name": "Spanish",
       "desktop": "es_ES"

--- a/securedrop/i18n.rst
+++ b/securedrop/i18n.rst
@@ -4,6 +4,7 @@
 * Czech (``cs``)
 * German (``de_DE``)
 * Greek (``el``)
+* English (``en_US``)
 * Spanish (``es_ES``)
 * French (``fr_FR``)
 * Hindi (``hi``)

--- a/securedrop/tests/functional/app_navigators/journalist_app_nav.py
+++ b/securedrop/tests/functional/app_navigators/journalist_app_nav.py
@@ -35,6 +35,14 @@ class JournalistAppNavigator:
         self.driver = web_driver
         self.accept_languages = accept_languages
 
+    def got_expected_language(self, locale: str) -> None:
+        expected = locale.replace("_", "-")
+
+        html = self.nav_helper.wait_for(lambda: self.driver.find_element(By.TAG_NAME, "html"))
+        actual = html.get_attribute("lang")
+
+        assert actual == expected
+
     def is_on_journalist_homepage(self) -> WebElement:
         return self.nav_helper.wait_for(
             lambda: self.driver.find_element(By.CSS_SELECTOR, "div.journalist-view-all")

--- a/securedrop/tests/functional/app_navigators/journalist_app_nav.py
+++ b/securedrop/tests/functional/app_navigators/journalist_app_nav.py
@@ -33,6 +33,8 @@ class JournalistAppNavigator:
         self._journalist_app_base_url = journalist_app_base_url
         self.nav_helper = NavigationHelper(web_driver)
         self.driver = web_driver
+
+        # Some string-based tests check this to avoid failing on translated strings.
         self.accept_languages = accept_languages
 
     def got_expected_language(self, locale: str) -> None:

--- a/securedrop/tests/functional/app_navigators/journalist_app_nav.py
+++ b/securedrop/tests/functional/app_navigators/journalist_app_nav.py
@@ -351,6 +351,7 @@ class JournalistAppNavigator:
         # Ensure the admin is allowed to edit the journalist
         def can_edit_user():
             h = self.driver.find_elements(By.TAG_NAME, "h1")[0]
-            assert f'Edit user "{username_of_journalist_to_edit}"' == h.text
+            if not self.accept_languages:
+                assert f'Edit user "{username_of_journalist_to_edit}"' == h.text
 
         self.nav_helper.wait_for(can_edit_user)

--- a/securedrop/tests/functional/app_navigators/source_app_nav.py
+++ b/securedrop/tests/functional/app_navigators/source_app_nav.py
@@ -26,6 +26,8 @@ class SourceAppNavigator:
         self._source_app_base_url = source_app_base_url
         self.nav_helper = NavigationHelper(web_driver)
         self.driver = web_driver
+
+        # Some string-based tests check this to avoid failing on translated strings.
         self.accept_languages = accept_languages
 
     @classmethod

--- a/securedrop/tests/functional/conftest.py
+++ b/securedrop/tests/functional/conftest.py
@@ -23,8 +23,11 @@ from tests.utils.i18n import get_test_locales
 
 # Function-scoped so that tests can be run in parallel if needed
 @pytest.fixture
-def firefox_web_driver() -> WebDriver:  # type: ignore
-    with get_web_driver(web_driver_type=WebDriverTypeEnum.FIREFOX) as web_driver:
+def firefox_web_driver(locale: str = "en_US") -> WebDriver:  # type: ignore
+    with get_web_driver(
+        web_driver_type=WebDriverTypeEnum.FIREFOX,
+        accept_languages=locale.replace("_", "-"),
+    ) as web_driver:
         yield web_driver
 
 

--- a/securedrop/tests/functional/conftest.py
+++ b/securedrop/tests/functional/conftest.py
@@ -18,6 +18,7 @@ from source_user import SourceUser
 from tests.factories import SecureDropConfigFactory
 from tests.functional.db_session import get_database_session
 from tests.functional.web_drivers import WebDriverTypeEnum, get_web_driver
+from tests.utils.i18n import get_test_locales
 
 
 # Function-scoped so that tests can be run in parallel if needed
@@ -209,6 +210,7 @@ def sd_servers(
         GPG_KEY_DIR=gpg_key_dir,
         JOURNALIST_KEY=journalist_key_fingerprint,
         RQ_WORKER_NAME=worker_name,
+        SUPPORTED_LOCALES=get_test_locales(),
     )
 
     # Spawn the apps in separate processes
@@ -232,6 +234,7 @@ def sd_servers_with_clean_state(
         GPG_KEY_DIR=gpg_key_dir,
         JOURNALIST_KEY=journalist_key_fingerprint,
         RQ_WORKER_NAME=worker_name,
+        SUPPORTED_LOCALES=get_test_locales(),
     )
 
     # Spawn the apps in separate processes
@@ -255,6 +258,8 @@ def sd_servers_with_submitted_file(
         GPG_KEY_DIR=gpg_key_dir,
         JOURNALIST_KEY=journalist_key_fingerprint,
         RQ_WORKER_NAME=worker_name,
+        SUPPORTED_LOCALES=get_test_locales(),
+
     )
 
     # Spawn the apps in separate processes with a callback to create a submission

--- a/securedrop/tests/functional/conftest.py
+++ b/securedrop/tests/functional/conftest.py
@@ -21,12 +21,14 @@ from tests.functional.web_drivers import WebDriverTypeEnum, get_web_driver
 from tests.utils.i18n import get_test_locales
 
 
-# Function-scoped so that tests can be run in parallel if needed
-@pytest.fixture
-def firefox_web_driver(locale: str = "en_US") -> WebDriver:  # type: ignore
+# Function-scoped so that tests can be run in parallel if needed.  The fixture
+# needs to know the locale at setup time, so we do that parameterization here
+# rather than at the test level.
+@pytest.fixture(params=get_test_locales())
+def firefox_web_driver(request) -> WebDriver:  # type: ignore
+    locale = request.param.replace("_", "-")
     with get_web_driver(
-        web_driver_type=WebDriverTypeEnum.FIREFOX,
-        accept_languages=locale.replace("_", "-"),
+        web_driver_type=WebDriverTypeEnum.FIREFOX, accept_languages=locale
     ) as web_driver:
         yield web_driver
 
@@ -262,7 +264,6 @@ def sd_servers_with_submitted_file(
         JOURNALIST_KEY=journalist_key_fingerprint,
         RQ_WORKER_NAME=worker_name,
         SUPPORTED_LOCALES=get_test_locales(),
-
     )
 
     # Spawn the apps in separate processes with a callback to create a submission

--- a/securedrop/tests/functional/pageslayout/test_journalist.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist.py
@@ -33,6 +33,7 @@ class TestJournalistLayout:
             accept_languages=locale_with_commas,
         )
         journ_app_nav.driver.get(f"{sd_servers.journalist_app_base_url}/login")
+        journ_app_nav.got_expected_language(locale)
         save_static_data(journ_app_nav.driver, locale, "journalist-login")
 
         # And they log into the app and are an admin

--- a/securedrop/tests/functional/pageslayout/test_journalist.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist.py
@@ -17,20 +17,19 @@
 #
 import pytest
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
-from tests.functional.pageslayout.utils import list_locales, save_static_data
+from tests.functional.pageslayout.utils import save_static_data
 
 
-@pytest.mark.parametrize("locale", list_locales())
 @pytest.mark.pagelayout
 class TestJournalistLayout:
-    def test_login_index_and_edit(self, locale, sd_servers, firefox_web_driver):
+    def test_login_index_and_edit(self, sd_servers, firefox_web_driver, request):
+        locale = firefox_web_driver.locale
         # Given an SD server
         # And a journalist accessing the journalist interface
-        locale_with_commas = locale.replace("_", "-")
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.driver.get(f"{sd_servers.journalist_app_base_url}/login")
         journ_app_nav.got_expected_language(locale)
@@ -55,14 +54,14 @@ class TestJournalistLayout:
         journ_app_nav.journalist_visits_edit_account()
         save_static_data(journ_app_nav.driver, locale, "journalist-edit_account_user")
 
-    def test_index_entered_text(self, locale, sd_servers, firefox_web_driver):
+    def test_index_entered_text(self, sd_servers, firefox_web_driver):
         # Given an SD server
         # And a journalist accessing the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
 
         # Take a screenshot of the login page with the form completed
@@ -75,15 +74,15 @@ class TestJournalistLayout:
         save_static_data(journ_app_nav.driver, locale, "journalist-index_with_text")
 
     def test_index_with_submission_and_select_documents(
-        self, locale, sd_servers_with_submitted_file, firefox_web_driver
+        self, sd_servers_with_submitted_file, firefox_web_driver
     ):
         # Given an SD server with an already-submitted file
         # And a journalist logging into the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_submitted_file.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
 
         # Take a screenshot of the index page when there is a source and submission
@@ -116,27 +115,27 @@ class TestJournalistLayout:
         )
         save_static_data(journ_app_nav.driver, locale, "journalist-composes_reply")
 
-    def test_fail_to_visit_admin(self, locale, sd_servers, firefox_web_driver):
+    def test_fail_to_visit_admin(self, sd_servers, firefox_web_driver):
         # Given an SD server
         # And someone accessing the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         # Take a screenshot of them trying to force-browse to the admin interface
         journ_app_nav.driver.get(f"{sd_servers.journalist_app_base_url}/admin")
         save_static_data(journ_app_nav.driver, locale, "journalist-code-fail_to_visit_admin")
 
-    def test_fail_login(self, locale, sd_servers, firefox_web_driver):
+    def test_fail_login(self, sd_servers, firefox_web_driver):
         # Given an SD server
         # And someone accessing the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
 
         # Take a screenshot of trying to log in using invalid credentials

--- a/securedrop/tests/functional/pageslayout/test_journalist_account.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_account.py
@@ -21,22 +21,21 @@ import pytest
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
-from tests.functional.pageslayout.utils import list_locales, save_static_data
+from tests.functional.pageslayout.utils import save_static_data
 
 
-@pytest.mark.parametrize("locale", list_locales())
 @pytest.mark.pagelayout
 class TestJournalistLayoutAccount:
     def test_account_edit_and_set_hotp_secret(
-        self, locale, sd_servers_with_clean_state, firefox_web_driver
+        self, sd_servers_with_clean_state, firefox_web_driver
     ):
         # Given an SD server
         # And a journalist logging into the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_clean_state.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_clean_state.journalist_username,
@@ -97,16 +96,14 @@ class TestJournalistLayoutAccount:
         alert = journ_app_nav.driver.switch_to.alert
         alert.accept()
 
-    def test_account_new_two_factor_totp(
-        self, locale, sd_servers_with_clean_state, firefox_web_driver
-    ):
+    def test_account_new_two_factor_totp(self, sd_servers_with_clean_state, firefox_web_driver):
         # Given an SD server
         # And a journalist logging into the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_clean_state.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_clean_state.journalist_username,

--- a/securedrop/tests/functional/pageslayout/test_journalist_account.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_account.py
@@ -86,7 +86,7 @@ class TestJournalistLayoutAccount:
             explanatory_tooltip_opacity = explanatory_tooltip.value_of_css_property("opacity")
             assert explanatory_tooltip_opacity == "1"
 
-            if assert_tooltip_text_is:
+            if assert_tooltip_text_is and not journ_app_nav.accept_languages:
                 assert explanatory_tooltip.text == assert_tooltip_text_is
 
         journ_app_nav.nav_helper.wait_for(explanatory_tooltip_is_correct)

--- a/securedrop/tests/functional/pageslayout/test_journalist_admin.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_admin.py
@@ -25,23 +25,22 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
-from tests.functional.pageslayout.utils import list_locales, save_static_data
+from tests.functional.pageslayout.utils import save_static_data
 
 
-@pytest.mark.parametrize("locale", list_locales())
 @pytest.mark.pagelayout
 class TestAdminLayoutAddAndEditUser:
     def test_admin_adds_user_hotp_and_edits_hotp(
-        self, locale, sd_servers_with_clean_state, firefox_web_driver
+        self, sd_servers_with_clean_state, firefox_web_driver
     ):
         # Given an SD server
         # And a journalist logging into the journalist interface as an admin
         assert sd_servers_with_clean_state.journalist_is_admin
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_clean_state.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_clean_state.journalist_username,
@@ -118,16 +117,16 @@ class TestAdminLayoutAddAndEditUser:
         )
 
     def test_admin_adds_user_totp_and_edits_totp(
-        self, locale, sd_servers_with_clean_state, firefox_web_driver
+        self, sd_servers_with_clean_state, firefox_web_driver
     ):
         # Given an SD server
         # And a journalist logging into the journalist interface as an admin
         assert sd_servers_with_clean_state.journalist_is_admin
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_clean_state.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_clean_state.journalist_username,
@@ -223,18 +222,17 @@ class TestAdminLayoutAddAndEditUser:
                 logging.info("Selenium has failed to click; retrying.")
 
 
-@pytest.mark.parametrize("locale", list_locales())
 @pytest.mark.pagelayout
 class TestAdminLayoutEditConfig:
-    def test_admin_changes_logo(self, locale, sd_servers_with_clean_state, firefox_web_driver):
+    def test_admin_changes_logo(self, sd_servers_with_clean_state, firefox_web_driver):
         # Given an SD server
         # And a journalist logging into the journalist interface as an admin
         assert sd_servers_with_clean_state.journalist_is_admin
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_clean_state.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_clean_state.journalist_username,
@@ -264,15 +262,15 @@ class TestAdminLayoutEditConfig:
         # Take a screenshot
         save_static_data(journ_app_nav.driver, locale, "journalist-admin_changes_logo_image")
 
-    def test_ossec_alert_button(self, locale, sd_servers, firefox_web_driver):
+    def test_ossec_alert_button(self, sd_servers, firefox_web_driver):
         # Given an SD server
         # And a journalist logging into the journalist interface as an admin
         assert sd_servers.journalist_is_admin
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers.journalist_username,

--- a/securedrop/tests/functional/pageslayout/test_journalist_admin.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_admin.py
@@ -255,7 +255,8 @@ class TestAdminLayoutEditConfig:
         # Then it succeeds
         def updated_image() -> None:
             flash_msg = journ_app_nav.driver.find_element(By.CSS_SELECTOR, ".flash")
-            assert "Image updated." in flash_msg.text
+            if not journ_app_nav.accept_languages:
+                assert "Image updated." in flash_msg.text
 
         journ_app_nav.nav_helper.wait_for(updated_image, timeout=20)
 
@@ -288,7 +289,8 @@ class TestAdminLayoutEditConfig:
         # Then it succeeds
         def test_alert_sent():
             flash_msg = journ_app_nav.driver.find_element(By.CSS_SELECTOR, ".flash")
-            assert "Test alert sent. Please check your email." in flash_msg.text
+            if not journ_app_nav.accept_languages:
+                assert "Test alert sent. Please check your email." in flash_msg.text
 
         journ_app_nav.nav_helper.wait_for(test_alert_sent)
 

--- a/securedrop/tests/functional/pageslayout/test_journalist_col.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_col.py
@@ -24,7 +24,7 @@ from sdconfig import SecureDropConfig
 from tests.factories import SecureDropConfigFactory
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
 from tests.functional.conftest import SdServersFixtureResult, spawn_sd_servers
-from tests.functional.pageslayout.utils import list_locales, save_static_data
+from tests.functional.pageslayout.utils import save_static_data
 
 
 def _create_source_and_submission_and_delete_source_key(config_in_use: SecureDropConfig) -> None:
@@ -63,19 +63,18 @@ def sd_servers_with_deleted_source_key(
         yield sd_servers_result
 
 
-@pytest.mark.parametrize("locale", list_locales())
 @pytest.mark.pagelayout
 class TestJournalistLayoutCol:
     def test_col_with_and_without_documents(
-        self, locale, sd_servers_with_submitted_file, firefox_web_driver
+        self, sd_servers_with_submitted_file, firefox_web_driver
     ):
         # Given an SD server with an already-submitted file
         # And a journalist logging into the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_submitted_file.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_submitted_file.journalist_username,
@@ -105,14 +104,14 @@ class TestJournalistLayoutCol:
         journ_app_nav.nav_helper.wait_for(submission_deleted)
         save_static_data(journ_app_nav.driver, locale, "journalist-col_no_document")
 
-    def test_col_has_no_key(self, locale, sd_servers_with_deleted_source_key, firefox_web_driver):
+    def test_col_has_no_key(self, sd_servers_with_deleted_source_key, firefox_web_driver):
         # Given an SD server with an already-submitted file, but the source's key was deleted
         # And a journalist logging into the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_deleted_source_key.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_deleted_source_key.journalist_username,

--- a/securedrop/tests/functional/pageslayout/test_journalist_delete.py
+++ b/securedrop/tests/functional/pageslayout/test_journalist_delete.py
@@ -17,20 +17,19 @@
 #
 import pytest
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
-from tests.functional.pageslayout.utils import list_locales, save_static_data
+from tests.functional.pageslayout.utils import save_static_data
 
 
-@pytest.mark.parametrize("locale", list_locales())
 @pytest.mark.pagelayout
 class TestJournalistLayoutDelete:
-    def test_delete_none(self, locale, sd_servers_with_submitted_file, firefox_web_driver):
+    def test_delete_none(self, sd_servers_with_submitted_file, firefox_web_driver):
         # Given an SD server with a file submitted by a source
         # And a journalist logged into the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_submitted_file.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_submitted_file.journalist_username,
@@ -46,16 +45,14 @@ class TestJournalistLayoutDelete:
         journ_app_nav.journalist_confirm_delete_selected()
         save_static_data(journ_app_nav.driver, locale, "journalist-delete_none")
 
-    def test_delete_one_confirmation(
-        self, locale, sd_servers_with_submitted_file, firefox_web_driver
-    ):
+    def test_delete_one_confirmation(self, sd_servers_with_submitted_file, firefox_web_driver):
         # Given an SD server with a file submitted by a source
         # And a journalist logged into the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_submitted_file.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_submitted_file.journalist_username,
@@ -73,16 +70,14 @@ class TestJournalistLayoutDelete:
         journ_app_nav.journalist_clicks_delete_selected_link()
         save_static_data(journ_app_nav.driver, locale, "journalist-delete_one_confirmation")
 
-    def test_delete_all_confirmation(
-        self, locale, sd_servers_with_submitted_file, firefox_web_driver
-    ):
+    def test_delete_all_confirmation(self, sd_servers_with_submitted_file, firefox_web_driver):
         # Given an SD server with a file submitted by a source
         # And a journalist logged into the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_submitted_file.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_submitted_file.journalist_username,
@@ -97,14 +92,14 @@ class TestJournalistLayoutDelete:
         journ_app_nav.journalist_clicks_delete_all_and_sees_confirmation()
         save_static_data(journ_app_nav.driver, locale, "journalist-delete_all_confirmation")
 
-    def test_delete_one(self, locale, sd_servers_with_submitted_file, firefox_web_driver):
+    def test_delete_one(self, sd_servers_with_submitted_file, firefox_web_driver):
         # Given an SD server with a file submitted by a source
         # And a journalist logged into the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_submitted_file.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_submitted_file.journalist_username,
@@ -124,14 +119,14 @@ class TestJournalistLayoutDelete:
         # Take a screenshot
         save_static_data(journ_app_nav.driver, locale, "journalist-delete_one")
 
-    def test_delete_all(self, locale, sd_servers_with_submitted_file, firefox_web_driver):
+    def test_delete_all(self, sd_servers_with_submitted_file, firefox_web_driver):
         # Given an SD server with a file submitted by a source
         # And a journalist logged into the journalist interface
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_submitted_file.journalist_app_base_url,
             web_driver=firefox_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_submitted_file.journalist_username,

--- a/securedrop/tests/functional/pageslayout/test_source.py
+++ b/securedrop/tests/functional/pageslayout/test_source.py
@@ -25,11 +25,10 @@ from tests.functional.pageslayout.utils import list_locales, save_static_data
 class TestSourceLayout:
     def test(self, locale, sd_servers_with_clean_state, tor_browser_web_driver):
         # Given a source user accessing the app from their browser
-        locale_with_commas = locale.replace("_", "-")
         source_app_nav = SourceAppNavigator(
             source_app_base_url=sd_servers_with_clean_state.source_app_base_url,
             web_driver=tor_browser_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
 
         # And they created an account

--- a/securedrop/tests/functional/pageslayout/test_source_layout_torbrowser.py
+++ b/securedrop/tests/functional/pageslayout/test_source_layout_torbrowser.py
@@ -27,10 +27,9 @@ from tests.functional.pageslayout.utils import list_locales, save_static_data
 class TestSourceLayoutTorBrowser:
     def test_index_and_logout(self, locale, sd_servers):
         # Given a source user accessing the app from their browser
-        locale_with_commas = locale.replace("_", "-")
         with SourceAppNavigator.using_tor_browser_web_driver(
             source_app_base_url=sd_servers.source_app_base_url,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         ) as navigator:
             # And they have disabled JS in their browser
             disable_js(navigator.driver)

--- a/securedrop/tests/functional/pageslayout/test_source_session_layout.py
+++ b/securedrop/tests/functional/pageslayout/test_source_session_layout.py
@@ -41,10 +41,9 @@ class TestSourceAppSessionTimeout:
     def test_source_session_timeout(self, locale, sd_servers_with_short_timeout):
         # Given an SD server with a very short session timeout
         # And a source user accessing the source app from their browser
-        locale_with_commas = locale.replace("_", "-")
         with SourceAppNavigator.using_tor_browser_web_driver(
             source_app_base_url=sd_servers_with_short_timeout.source_app_base_url,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         ) as navigator:
             # And they're logged in and are using the app
             navigator.source_visits_source_homepage()

--- a/securedrop/tests/functional/pageslayout/test_source_static_pages.py
+++ b/securedrop/tests/functional/pageslayout/test_source_static_pages.py
@@ -12,10 +12,9 @@ class TestSourceAppStaticPages:
     @pytest.mark.parametrize("locale", list_locales())
     def test_notfound(self, locale, sd_servers):
         # Given a source user accessing the app from their browser
-        locale_with_commas = locale.replace("_", "-")
         with get_web_driver(
             web_driver_type=WebDriverTypeEnum.TOR_BROWSER,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         ) as tor_browser_web_driver:
             # When they try to access a page that does not exist
             tor_browser_web_driver.get(f"{sd_servers.source_app_base_url}/does_not_exist")
@@ -29,10 +28,9 @@ class TestSourceAppStaticPages:
     @pytest.mark.parametrize("locale", list_locales())
     def test_static_pages(self, locale, sd_servers):
         # Given a source user accessing the app from their browser
-        locale_with_commas = locale.replace("_", "-")
         with get_web_driver(
             web_driver_type=WebDriverTypeEnum.TOR_BROWSER,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         ) as tor_browser_web_driver:
             # The user can browse to some of the app's static pages
             tor_browser_web_driver.get(f"{sd_servers.source_app_base_url}/use-tor")

--- a/securedrop/tests/functional/pageslayout/test_submit_and_retrieve_file.py
+++ b/securedrop/tests/functional/pageslayout/test_submit_and_retrieve_file.py
@@ -3,21 +3,20 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from tests.functional.app_navigators.journalist_app_nav import JournalistAppNavigator
 from tests.functional.app_navigators.source_app_nav import SourceAppNavigator
-from tests.functional.pageslayout.utils import list_locales, save_static_data
+from tests.functional.pageslayout.utils import save_static_data
 
 
-@pytest.mark.parametrize("locale", list_locales())
 @pytest.mark.pagelayout
 class TestSubmitAndRetrieveFile:
     def test_submit_and_retrieve_happy_path(
-        self, locale, sd_servers_with_clean_state, tor_browser_web_driver, firefox_web_driver
+        self, sd_servers_with_clean_state, tor_browser_web_driver, firefox_web_driver
     ):
         # Given a source user accessing the app from their browser
-        locale_with_commas = locale.replace("_", "-")
+        locale = firefox_web_driver.locale
         source_app_nav = SourceAppNavigator(
             source_app_base_url=sd_servers_with_clean_state.source_app_base_url,
             web_driver=tor_browser_web_driver,
-            accept_languages=locale_with_commas,
+            accept_languages=locale,
         )
 
         # And they created an account

--- a/securedrop/tests/functional/pageslayout/test_submit_and_retrieve_file.py
+++ b/securedrop/tests/functional/pageslayout/test_submit_and_retrieve_file.py
@@ -8,14 +8,12 @@ from tests.functional.pageslayout.utils import save_static_data
 
 @pytest.mark.pagelayout
 class TestSubmitAndRetrieveFile:
-    def test_submit_and_retrieve_happy_path(
-        self, sd_servers_with_clean_state, tor_browser_web_driver, firefox_web_driver
-    ):
+    def test_submit_and_retrieve_happy_path(self, sd_servers_with_clean_state, firefox_web_driver):
         # Given a source user accessing the app from their browser
         locale = firefox_web_driver.locale
         source_app_nav = SourceAppNavigator(
             source_app_base_url=sd_servers_with_clean_state.source_app_base_url,
-            web_driver=tor_browser_web_driver,
+            web_driver=firefox_web_driver,
             accept_languages=locale,
         )
 
@@ -34,6 +32,7 @@ class TestSubmitAndRetrieveFile:
         journ_app_nav = JournalistAppNavigator(
             journalist_app_base_url=sd_servers_with_clean_state.journalist_app_base_url,
             web_driver=firefox_web_driver,
+            accept_languages=locale,
         )
         journ_app_nav.journalist_logs_in(
             username=sd_servers_with_clean_state.journalist_username,

--- a/securedrop/tests/functional/web_drivers.py
+++ b/securedrop/tests/functional/web_drivers.py
@@ -112,6 +112,10 @@ def _create_firefox_driver(
     if not firefox_driver:
         raise Exception("Could not create Firefox web driver")
 
+    # Add this attribute to the returned driver object so that tests using this
+    # fixture can know what locale it's parameterized with.
+    firefox_driver.locale = accept_languages or "en_US"  # type: ignore[attr-defined]
+
     return firefox_driver
 
 

--- a/securedrop/tests/functional/web_drivers.py
+++ b/securedrop/tests/functional/web_drivers.py
@@ -110,7 +110,7 @@ def _create_firefox_driver(
 
     # Add this attribute to the returned driver object so that tests using this
     # fixture can know what locale it's parameterized with.
-    firefox_driver.locale = accept_languages or "en_US"  # type: ignore[attr-defined]
+    firefox_driver.locale = accept_languages  # type: ignore[attr-defined]
 
     return firefox_driver
 

--- a/securedrop/tests/functional/web_drivers.py
+++ b/securedrop/tests/functional/web_drivers.py
@@ -87,14 +87,10 @@ def _create_firefox_driver(
 ) -> webdriver.Firefox:
     logging.info("Creating Firefox web driver")
 
-    profile = webdriver.FirefoxProfile()
-    if accept_languages is not None:
-        profile.set_preference("intl.accept_languages", accept_languages)
-        profile.update_preferences()
-
     firefox_options = webdriver.FirefoxOptions()
     firefox_options.binary_location = _FIREFOX_PATH
-    firefox_options.profile = profile
+    if accept_languages is not None:
+        firefox_options.set_preference("intl.accept_languages", accept_languages)
 
     firefox_driver = None
     for i in range(_DRIVER_RETRY_COUNT):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #7237 by saving the screenshots generated by `make translation-test` as CI artifacts for 24 hours, for the following reasons:
1. `make translation-test` generates them no matter what, so we might as well make them inspectable.
2. #7237 occurs only locally, where this code path is rarely used; let's take advantage of CI exercising it.
3. This points towards perhaps even updating Weblate's copy of screenshots directly from these tests run nightly on `develop`.

Fixes #7241 by correcting the parameterization of tests and fixtures for page-layout tests.  See individual commits for details.

## Testing

- [x] Visual review.
- [x] Inspect a couple of languages and confirm that their ~~screenshots~~ Journalist Interface screenshots are correct.
    - The Source Interface is deferred to #7354.
- ~24 hours is a reasonable retention period for 100 MB of screenshots per run.~

## Deployment

CI-only; no deployment considerations.