### PR TITLE
Remove obsolete dependencies from package building

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         debhelper \
         devscripts \
         dh-python \
-        dh-systemd \
         gdb \
         git \
         gnupg2 \
@@ -27,7 +26,6 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         python3-venv \
         python3-virtualenv \
         rsync \
-        sqlite \
         sudo \
         tzdata \
         libevent-dev \

--- a/securedrop/debian/control
+++ b/securedrop/debian/control
@@ -2,7 +2,7 @@ Source: securedrop
 Section: web
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper (>= 9), dh-python, python3-all, python3-setuptools, dh-systemd
+Build-Depends: debhelper (>= 9), dh-python, python3-all, python3-setuptools
 Homepage: https://securedrop.org
 Standards-Version: 4.5.1
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

These packages aren't available in noble, but also aren't needed when building in focal:

* dh-systemd was merged into debhelper itself
* sqlite is actually sqlite2 and not sqlite3, but regardless, package building doesn't require the sqlite command-line tool

This is a no-op for the packages themselves.

## Testing

* [ ] CI passes
* [ ] If you build without this change and build with it, the diffoscope should look something like https://gist.github.com/legoktm/7f7f40327d0ff40f481df0b975db8268, which importantly shows no systemd nor sqlite related changes.

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [x] I have written a test plan and validated it for this PR
