### PR TITLE
Upgrade sequoia-openpgp to 1.21.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,9 +803,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sequoia-openpgp"
-version = "1.21.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b870b0275eeae174058fcf0ce5affccaaafeb7eceeabce8d6c7f51fbe6a41e2a"
+checksum = "13261ee216b44d932ef93b2d4a75d45199bef77864bcc5b77ecfc7bc0ecb02d6"
 dependencies = [
  "anyhow",
  "base64",

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -226,8 +226,8 @@ user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
 
 [[publisher.sequoia-openpgp]]
-version = "1.21.1"
-when = "2024-06-28"
+version = "1.21.2"
+when = "2024-07-10"
 user-id = 33711
 user-login = "teythoon"
 user-name = "Justus Winter"


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Pretty minor change, see <https://gitlab.com/sequoia-pgp/sequoia/-/blob/openpgp/v1.21.2/openpgp/NEWS>.
## Testing

* [ ] CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
