### PR TITLE
feat: make `backport.py` more flexible for complex pull requests

### DIFF
--- a/utils/backport.py
+++ b/utils/backport.py
@@ -43,6 +43,9 @@ subprocess.check_call(["git", "cherry-pick", "-x"] + commit_hashes)
 if input("OK to push and create PR? [y/N]").lower() != "y":
     sys.exit()
 subprocess.check_call(["git", "push", "-u", remote, branch])
+
+skip_list = ", ".join(args.skip)
+skip_message = f", excluding {skip_list}" if len(args.skip) > 0 else ""
 body = f"""\
 ## Status
 
@@ -56,7 +59,7 @@ Backport of #{args.pr}.
 
 * [ ] CI is passing
 * [ ] base is `{base}`
-* [ ] Only contains changes from #{args.pr}.
+* [ ] Only contains changes from #{args.pr} #{skip_message}
 """
 print(body)
 

--- a/utils/backport.py
+++ b/utils/backport.py
@@ -31,9 +31,7 @@ commits = json.loads(
 # NB. It's tempting to do something like `set(commit_hashes) -= set(args.skip)`
 # here, but we must preserve the order of commits, and it's not worth pulling
 # in an ordered-set implementation just for this.
-commit_hashes = [commit["sha"] for commit in commits]
-for skip_hash in args.skip:
-    commit_hashes.remove(skip_hash)
+commit_hashes = [commit["sha"] for commit in commits if commit["sha"] not in args.skip]
 
 print(f'Backporting {len(commit_hashes)}/{len(commits)} commits from "{title}"')
 branch = f"backport-{args.pr}"

--- a/utils/backport.py
+++ b/utils/backport.py
@@ -24,7 +24,7 @@ title = json.loads(
 )["title"]
 commits = json.loads(
     subprocess.check_output(
-        ["gh", "api", f"repos/{{owner}}/{{repo}}/pulls/{args.pr}/commits"], text=True
+        ["gh", "api", "--paginate", f"repos/{{owner}}/{{repo}}/pulls/{args.pr}/commits"], text=True
     )
 )
 

--- a/utils/backport.py
+++ b/utils/backport.py
@@ -16,6 +16,7 @@ parser = argparse.ArgumentParser(description="Backport a PR")
 parser.add_argument("pr", type=int, help="the # of the PR to backport")
 parser.add_argument("version", help="the release version to target with the backport")
 parser.add_argument("remote", default="origin", help="the git remote to use (defaults to origin)")
+parser.add_argument("--skip", default=[], action="append", help="don't cherry-pick these commits")
 args = parser.parse_args()
 
 title = json.loads(
@@ -26,13 +27,21 @@ commits = json.loads(
         ["gh", "api", f"repos/{{owner}}/{{repo}}/pulls/{args.pr}/commits"], text=True
     )
 )
-print(f'Backporting {len(commits)} commits from "{title}"')
+
+# NB. It's tempting to do something like `set(commit_hashes) -= set(args.skip)`
+# here, but we must preserve the order of commits, and it's not worth pulling
+# in an ordered-set implementation just for this.
+commit_hashes = [commit["sha"] for commit in commits]
+for skip_hash in args.skip:
+    commit_hashes.remove(skip_hash)
+
+print(f'Backporting {len(commit_hashes)}/{len(commits)} commits from "{title}"')
 branch = f"backport-{args.pr}"
 base = f"release/{args.version}"
 remote = args.remote
 subprocess.check_call(["git", "fetch", remote])
 subprocess.check_call(["git", "checkout", "-b", branch, f"{remote}/{base}"])
-subprocess.check_call(["git", "cherry-pick", "-x"] + [commit["sha"] for commit in commits])
+subprocess.check_call(["git", "cherry-pick", "-x"] + commit_hashes)
 if input("OK to push and create PR? [y/N]").lower() != "y":
     sys.exit()
 subprocess.check_call(["git", "push", "-u", remote, branch])


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The much-loved `backport.py` script makes 2.5 assumptions that do not hold for complex pull requests like #7143, which we fix here:
1. There are fewer than 30 commits (the default number of results returned by `gh api`) in the pull request.
2. All commits can be merged naïvely via a mass `git cherry-pick -x` (i.e., there are no merge commits requiring `git [cherry-pick → merge] -m`).
    1. *All* of the commits in the pull request should be backported.

## Testing

Depending on the state of your local `release/2.10.1` branch, you can replicate #7257 with:

```sh-session
$ git branch -D release/2.10.1
$ git checkout -b release/2.10.1 release/2.10.0
$ utils/backport.py 7143 2.10.1 origin --skip 6e3d7bed17537fa8f69f941f21a8eec34e8da113
```


## Deployment

Development-only; no deployment considerations.