### PR TITLE
Ignore CVE-2024-8775 in ansible-core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 71680 \
 		--ignore 71681 \
 		--ignore 71684 \
+		--ignore 73302 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We don't use ansible vault functionality.

Same as <https://github.com/freedomofpress/fpf-misc-resources/pull/51>.

## Testing

* [ ] CI passes, esp. static-analysis-and-no-known-cves job

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [x] I am silencing an alert related to a production dependency, because (please explain below): see above :)
