### PR TITLE
Fix pagelayout tests under Firefox 128 and Tor Browser 14.0

### DIFF
--- a/securedrop/dockerfiles/focal/python3/Dockerfile
+++ b/securedrop/dockerfiles/focal/python3/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update  && apt-get install -y \
     npm install --global html_codesniffer@2.5.1
 
 # Current versions of the test browser software. Tor Browser is based
-# on a specific version of Firefox, noted in Help > About Tor Browser.
-# Ideally we'll keep those in sync.
-ENV FF_VERSION 115.3.1esr
+# on a specific version of Firefox - we download both for generic and TBB testing
+
+# We should use the version of geckodriver corresponding to the above Firefox version.
 ENV GECKODRIVER_VERSION v0.35.0
 
 # Import Tor release signing key
@@ -32,12 +32,14 @@ RUN TBB_VERSION=$(curl -s https://aus1.torproject.org/torbrowser/update_3/releas
     mkdir -p /root/.local/tbb && mv tor-browser /root/.local/tbb && \
     rm -f tor.keyring tor-browser-linux-x86_64-${TBB_VERSION}.tar.xz.asc tor-browser-linux-x86_64-${TBB_VERSION}.tar.xz
 
-# Import Mozilla release signing key
-ENV MOZILLA_RELEASE_KEY_FINGERPRINT "14F26682D0916CDD81E37B6D61B7B526D98F0353"
-RUN curl -s https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/KEY | gpg2 --import -
 
-# Install the version of Firefox on which Tor Browser is based
-RUN curl -LO https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/linux-x86_64/en-US/firefox-${FF_VERSION}.tar.bz2 && \
+# Import Mozilla release signing key and install the version of Firefox on which
+# Tor Browser is based
+ENV MOZILLA_RELEASE_KEY_FINGERPRINT "14F26682D0916CDD81E37B6D61B7B526D98F0353"
+
+RUN FF_VERSION=$(curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/ALL | grep -oP '(?<=platformVersion=")[^"]*' | head -1)esr && \
+curl -s https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/KEY | gpg2 --import - && \
+curl -LO https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/linux-x86_64/en-US/firefox-${FF_VERSION}.tar.bz2 && \
     curl -LO https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/linux-x86_64/en-US/firefox-${FF_VERSION}.tar.bz2.asc && \
     gpg2 --output ./mozilla.keyring --export ${MOZILLA_RELEASE_KEY_FINGERPRINT} && \
     gpgv --keyring ./mozilla.keyring firefox-${FF_VERSION}.tar.bz2.asc firefox-${FF_VERSION}.tar.bz2 && \

--- a/securedrop/tests/functional/pageslayout/test_source_layout_torbrowser.py
+++ b/securedrop/tests/functional/pageslayout/test_source_layout_torbrowser.py
@@ -15,10 +15,39 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import json
+from typing import Union
+
 import pytest
+import tbselenium
 from tbselenium.utils import disable_js
 from tests.functional.app_navigators.source_app_nav import SourceAppNavigator
 from tests.functional.pageslayout.utils import list_locales, save_static_data
+
+
+# Monkey  Patch set_tbb_pref until a new version of tbselenium > 0.8.1 is released
+def monkey_patch_set_tbb_pref(
+    driver: tbselenium.tbdriver.TorBrowserDriver, name: str, value: Union[bool, str, int]
+) -> None:
+    try:
+        script = "Services.prefs."
+        if isinstance(value, bool):
+            script += "setBoolPref"
+        elif isinstance(value, (str)):
+            script += "setStringPref"
+        else:
+            script += "setIntPref"
+        script += f"({json.dumps(name)}, {json.dumps(value)});"
+
+        with driver.context(driver.CONTEXT_CHROME):
+            driver.execute_script(script)
+    except Exception:
+        raise
+    finally:
+        driver.set_context(driver.CONTEXT_CONTENT)
+
+
+tbselenium.utils.set_tbb_pref = monkey_patch_set_tbb_pref
 
 
 @pytest.mark.parametrize("locale", list_locales())


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Following the release of Tor Browser 14.0 (based on FF 128.3.0esr) `pageslayout` tests involving setting Tor Browser preferences are failing. The problem is already fixed upstream (see https://github.com/webfp/tor-browser-selenium/blob/main/tbselenium/utils.py#L96) but a release with the fix isn't available yet. This PR:

- Updates the test Dockerfile to check for and use the correct Firefox version for latest stable Tor Browser
- monkeypatches `tbselenium` with the upstream fix. 

## Testing

- [ ] CI is passing - in particular pageslayouts tests.
- [ ] Visual review
