### PR TITLE
Have securedrop-admin emit distinct error messages

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -1066,31 +1066,24 @@ def update(args: argparse.Namespace) -> int:
             and len(good_sig_matches) == 1
             and bad_sig_text not in sig_result
         ):
-            # Finally, we check that there is no branch of the same name
-            # prior to reporting success.
+            # Check for duplicate branch name
             cmd = ["git", "show-ref", "--heads", "--verify", f"refs/heads/{latest_tag}"]
             try:
-                # We expect this to produce a non-zero exit code, which
-                # will produce a subprocess.CalledProcessError
                 subprocess.check_output(cmd, stderr=subprocess.STDOUT, cwd=args.root)
-                sdlog.info("Signature verification failed.")
+                sdlog.error("Update failed: Branch name collision detected")
                 return 1
             except subprocess.CalledProcessError as e:
                 if "not a valid ref" in e.output.decode("utf-8"):
-                    # Then there is no duplicate branch.
                     sdlog.info("Signature verification successful.")
-                else:  # If any other exception occurs, we bail.
-                    sdlog.info("Signature verification failed.")
+                else:
+                    sdlog.error("Update failed: Git command error")
                     return 1
-        else:  # If anything else happens, fail and exit 1
-            sdlog.info("Signature verification failed.")
+        else:
+            sdlog.error("Update failed: Invalid signature format")
             return 1
 
     except subprocess.CalledProcessError:
-        # If there is no signature, or if the signature does not verify,
-        # then git tag -v exits subprocess.check_output will exit 1
-        # and subprocess.check_output will throw a CalledProcessError
-        sdlog.info("Signature verification failed.")
+        sdlog.error("Update failed: Missing or invalid signature")
         return 1
 
     # Only if the proper signature verifies do we check out the latest

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -650,7 +650,7 @@ def test_update_fails_when_no_signature_present(securedrop_git_repo):
     child = pexpect.spawn(f"coverage run {cmd} --root {ansible_base} update")
     output = child.read()
     assert b"Updated to SecureDrop" not in output
-    assert b"Signature verification failed" in output
+    assert b"Update failed: Missing or invalid signature" in output
 
     child.expect(pexpect.EOF, timeout=10)  # Wait for CLI to exit
     child.close()
@@ -682,7 +682,7 @@ def test_update_with_duplicate_branch_and_tag(securedrop_git_repo):
     # Verify that we do not falsely check out a branch instead of a tag.
     assert b"Switched to branch" not in output
     assert b"Updated to SecureDrop" not in output
-    assert b"Signature verification failed" in output
+    assert b"Update failed: Branch name collision detected" in output
 
     child.expect(pexpect.EOF, timeout=10)  # Wait for CLI to exit
     child.close()

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -385,7 +385,7 @@ class TestSecureDropAdmin:
                 with mock.patch("subprocess.check_output", return_value=git_output):
                     ret_code = securedrop_admin.update(args)
                     assert "Applying SecureDrop updates..." in caplog.text
-                    assert "Signature verification failed." in caplog.text
+                    assert "Update failed: Invalid signature format" in caplog.text
                     assert "Updated to SecureDrop" not in caplog.text
                     assert ret_code != 0
 
@@ -406,7 +406,7 @@ class TestSecureDropAdmin:
                 with mock.patch("subprocess.check_output", return_value=git_output):
                     ret_code = securedrop_admin.update(args)
                     assert "Applying SecureDrop updates..." in caplog.text
-                    assert "Signature verification failed." in caplog.text
+                    assert "Update failed: Invalid signature format" in caplog.text
                     assert "Updated to SecureDrop" not in caplog.text
                     assert ret_code != 0
 
@@ -428,7 +428,7 @@ class TestSecureDropAdmin:
                 with mock.patch("subprocess.check_output", return_value=git_output):
                     ret_code = securedrop_admin.update(args)
                     assert "Applying SecureDrop updates..." in caplog.text
-                    assert "Signature verification failed." in caplog.text
+                    assert "Update failed: Invalid signature format" in caplog.text
                     assert "Updated to SecureDrop" not in caplog.text
                     assert ret_code != 0
 
@@ -451,7 +451,7 @@ class TestSecureDropAdmin:
                 with mock.patch("subprocess.check_output", return_value=git_output):
                     ret_code = securedrop_admin.update(args)
                     assert "Applying SecureDrop updates..." in caplog.text
-                    assert "Signature verification failed." in caplog.text
+                    assert "Update failed: Invalid signature format" in caplog.text
                     assert "Updated to SecureDrop" not in caplog.text
                     assert ret_code != 0
 
@@ -469,7 +469,7 @@ class TestSecureDropAdmin:
                 ):
                     ret_code = securedrop_admin.update(args)
                     assert "Applying SecureDrop updates..." in caplog.text
-                    assert "Signature verification failed." in caplog.text
+                    assert "Update failed: Missing or invalid signature" in caplog.text
                     assert "Updated to SecureDrop" not in caplog.text
                     assert ret_code != 0
 


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #7200

Changes proposed in this pull request:

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a reference to a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/requirements.in`
- `securedrop/requirements/python3/translation.in` (used in the build
  container)

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
- [ ] I am silencing an alert related to a production dependency, because (please explain below):
