### PR TITLE
build: add `dev-get-id`, `dev-enter`, and `dev-load-data` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ STABLE_VER := $(shell cat molecule/shared/stable.ver)
 SDBIN := $(SDROOT)/securedrop/bin
 DEVSHELL := $(SDBIN)/dev-shell
 
+ifdef USE_PODMAN
+OCI_BIN=podman
+else
+OCI_BIN=docker
+endif
 
 ######################################
 #
@@ -250,18 +255,18 @@ dev-tor:  ## Run the development server with onion services in a Docker containe
 	@echo
 
 .PHONY:
-dev-get-id:  ## (DOCKER ONLY) Get the ID of the running "make dev" or "make dev-tor" container.
-	@docker ps --format json --filter "name=securedrop-dev" | jq -r ".ID"
+dev-get-id:  ## Get the ID of the running "make dev" or "make dev-tor" container.
+	@$(OCI_BIN) ps --format json --filter "name=securedrop-dev" | jq -r ".ID"
 
 .PHONY:
-dev-enter:  ## (DOCKER ONLY) Start a shell directly in the running "make dev" or "make dev-tor" container.
-	@docker exec -it \
+dev-enter:  ## Start a shell directly in the running "make dev" or "make dev-tor" container.
+	@$(OCI_BIN) exec -it \
 		$(shell make -s dev-get-id) \
 		bash
 
 .PHONY: dev-load-data
-dev-load-data:  ## (DOCKER ONLY) Run "loaddata.py" in the running "make dev" or "make dev-tor" container. Set $NUM_JOURNALISTS and/or $NUM_SOURCES on the command line as needed.
-	@docker exec -it \
+dev-load-data:  ## Run "loaddata.py" in the running "make dev" or "make dev-tor" container. Set $NUM_JOURNALISTS and/or $NUM_SOURCES on the command line as needed.
+	@$(OCI_BIN) exec -it \
 		-e NUM_JOURNALISTS \
 		-e NUM_SOURCES \
 		$(shell make -s dev-get-id) \

--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,24 @@ dev-tor:  ## Run the development server with onion services in a Docker containe
 	@OFFSET_PORTS='false' DOCKER_BUILD_VERBOSE='true' USE_TOR='true' SLIM_BUILD=1 $(DEVSHELL) $(SDBIN)/run
 	@echo
 
+.PHONY:
+dev-get-id:  ## (DOCKER ONLY) Get the ID of the running "make dev" or "make dev-tor" container.
+	@docker ps --format json --filter "name=securedrop-dev" | jq -r ".ID"
+
+.PHONY:
+dev-enter:  ## (DOCKER ONLY) Start a shell directly in the running "make dev" or "make dev-tor" container.
+	@docker exec -it \
+		$(shell make -s dev-get-id) \
+		bash
+
+.PHONY: dev-load-data
+dev-load-data:  ## (DOCKER ONLY) Run "loaddata.py" in the running "make dev" or "make dev-tor" container. Set $NUM_JOURNALISTS and/or $NUM_SOURCES on the command line as needed.
+	@docker exec -it \
+		-e NUM_JOURNALISTS \
+		-e NUM_SOURCES \
+		$(shell make -s dev-get-id) \
+		./loaddata.py $(SD_LOADDATA_ARGS)
+
 .PHONY: demo-landing-page
 demo-landing-page: ## Serve the landing page for the SecureDrop demo
 	@echo "███ Building Docker image..."

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ dev-tor:  ## Run the development server with onion services in a Docker containe
 
 .PHONY:
 dev-get-id:  ## Get the ID of the running "make dev" or "make dev-tor" container.
-	@$(OCI_BIN) ps --format json --filter "name=securedrop-dev" | jq -r ".ID"
+	@$(OCI_BIN) ps --format json --filter "name=securedrop-dev" --format '{{.ID}}'
 
 .PHONY:
 dev-enter:  ## Start a shell directly in the running "make dev" or "make dev-tor" container.


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Adds some helper Make targets working with a running `make dev[-tor]` container:
1. `dev-get-id` looks up the container ID
2. `dev-enter` starts a shell in the running container
3. `dev-load-data` runs `loaddata.py` in the running container


## Testing

With or without `export USE_PODMAN=1`, start `make dev` or `make dev-tor`, then try each of the following and confirm that they work as expected:

```sh-session
$ make dev-get-id
$ make dev-enter
$ make dev-load-data
```

## Deployment

Development-only.