### PR TITLE
admin: Upgrade paramiko to 2.9.2 for SHA-2 RSA algorithms

### DIFF
--- a/admin/requirements-testinfra.in
+++ b/admin/requirements-testinfra.in
@@ -2,4 +2,4 @@ pytest==7.2.0
 testinfra==5.3.1
 py>=1.10.0
 pytest-xdist==2.1.0
-paramiko==2.7.2
+paramiko==2.9.2

--- a/admin/requirements-testinfra.txt
+++ b/admin/requirements-testinfra.txt
@@ -210,9 +210,9 @@ packaging==21.3 \
     #   -r requirements-ansible.in
     #   ansible-core
     #   pytest
-paramiko==2.7.2 \
-    --hash=sha256:4f3e316fef2ac628b05097a637af35685183111d4bc1b5979bd397c2ab7b5898 \
-    --hash=sha256:7f36f4ba2c0d81d219f4595e35f70d56cc94f9ac40a6acdf51d6ca210ce65035
+paramiko==2.9.2 \
+    --hash=sha256:04097dbd96871691cdb34c13db1883066b8a13a0df2afd4cb0a92221f51c2603 \
+    --hash=sha256:944a9e5dbdd413ab6c7951ea46b0ab40713235a9c4c5ca81cfe45c6f14fa677b
     # via -r requirements-testinfra.in
 pluggy==1.4.0 \
     --hash=sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981 \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The legacy and SHA-1 based `ssh-rsa` algorithm is disabled in newer OpenSSH (including what Ubuntu noble ships), so we need to upgrade paramiko so we can use `rsa-sha2-512` and `rsa-sha2-256`.

Fixes #7279.

## Testing

How should the reviewer test this PR?

* [ ] CI passes, esp. staging job
* [ ] I have already tested this against a noble instance (not trivial to set up yet)
* [ ] no diff review needed for testinfra dependencies

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
- [ ] These changes do not require documentation
