### PR TITLE
Don't enable apt-daily services, just the timers

### DIFF
--- a/install_files/ansible-base/roles/common/tasks/unattended_upgrades.yml
+++ b/install_files/ansible-base/roles/common/tasks/unattended_upgrades.yml
@@ -20,11 +20,11 @@
   # Ensure daemon-reload has happened before starting/enabling
 - meta: flush_handlers
 
-- name: Ensure apt-daily and apt-daily-upgrade services are unmasked, started and enabled.
+- name: Ensure apt-daily and apt-daily-upgrade services are unmasked
   systemd:
     name: "{{ item }}"
-    state: started
-    enabled: yes
+    # We disable the service unit and enable the timer
+    enabled: no
     masked: no
   with_items:
     - 'apt-daily'
@@ -33,10 +33,9 @@
     - apt
     - unattended-upgrades
 
-- name: Ensure apt-daily and apt-daily-upgrade timers are started, and enabled.
+- name: Ensure apt-daily and apt-daily-upgrade timers are enabled.
   systemd:
     name: "{{ item }}"
-    state: started
     enabled: yes
   with_items:
     - 'apt-daily.timer'

--- a/molecule/testinfra/common/test_automatic_updates.py
+++ b/molecule/testinfra/common/test_automatic_updates.py
@@ -163,23 +163,37 @@ def test_unattended_upgrades_functional(host):
 
 
 @pytest.mark.parametrize(
-    "service",
+    "timer",
     [
-        "apt-daily",
         "apt-daily.timer",
-        "apt-daily-upgrade",
         "apt-daily-upgrade.timer",
     ],
 )
-def test_apt_daily_services_and_timers_enabled(host, service):
+def test_apt_daily_timers_enabled(host, timer):
     """
-    Ensure the services and timers used for unattended upgrades are enabled
-    in Ubuntu 20.04 Focal.
+    Ensure the timers used for unattended upgrades are enabled
     """
     with host.sudo():
-        # The services are started only when the upgrades are being performed.
-        s = host.service(service)
+        s = host.service(timer)
         assert s.is_enabled
+
+
+@pytest.mark.parametrize(
+    "service",
+    [
+        "apt-daily.service",
+        "apt-daily-upgrade.service",
+    ],
+)
+def test_apt_daily_services_disabled(host, service):
+    """
+    Ensure the corresponding services are disabled
+    """
+    with host.sudo():
+        print(host.run("systemctl list-units").stdout)
+        print(host.run("systemctl list-timers").stdout)
+        s = host.service(service)
+        assert not s.is_enabled
 
 
 def test_apt_daily_timer_schedule(host):

--- a/securedrop/debian/securedrop-config.postinst
+++ b/securedrop/debian/securedrop-config.postinst
@@ -28,6 +28,9 @@ case "$1" in
     # And disable Ubuntu Pro's ua-timer and esm-cache (#6773)
     systemctl is-enabled ua-timer.timer && systemctl disable ua-timer.timer
     systemctl mask esm-cache
+    # Disable the apt-daily services but not the timers (#7298)
+    systemctl is-enabled apt-daily.service && systemctl disable apt-daily.service
+    systemctl is-enabled apt-daily-upgrade.service && systemctl disable apt-daily-upgrade.service
     # Migrate the ssh group to sdssh
     securedrop-migrate-ssh-group.py
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

By enabling the services, it means it runs every time the machine boots, defeating the point of the timer.

Similarly, starting the service/timer means that it starts running while the playbook is still going, which might also explain the dpkg lock contention (#7258).

Ansible will now just ensure the units are unmasked and the securedrop-config postinst will disable the services if enabled.

Fixes #7298.

## Testing

How should the reviewer test this PR?

* [ ] visual review
* [ ] staging CI passes

## Deployment

1. Upgrading existing production instances - handled by securedrop-config postinst
2. New installs - handled by ansible logic

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
