### PR TITLE
Remove now unused sysctl_flags_ipv6

### DIFF
--- a/install_files/ansible-base/roles/common/defaults/main.yml
+++ b/install_files/ansible-base/roles/common/defaults/main.yml
@@ -35,15 +35,6 @@ sysctl_flags:
   - name: "net.ipv4.conf.default.send_redirects"
     value: "0"
 
-# Store IPv6-related sysctl flags separately, for distro-specific handling
-sysctl_flags_ipv6:
-  - name: "net.ipv6.conf.all.disable_ipv6"
-    value: "1"
-  - name: "net.ipv6.conf.default.disable_ipv6"
-    value: "1"
-  - name: "net.ipv6.conf.lo.disable_ipv6"
-    value: "1"
-
 unused_packages:
   - libiw30
   - wireless-tools


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

These haven't been used since b8ef5d69ab5016, as they were only needed for xenial and older; we now disable IPv6 via the grub cmdline in securedrop-grsec.

## Testing

How should the reviewer test this PR?

* [ ] Visual review and grep for the variable

## Deployment

Any special considerations for deployment? n/a

