### PR TITLE
Don't install apt-transport-https, it's an unnecessary transitional package

### DIFF
--- a/install_files/ansible-base/roles/common/vars/Ubuntu_focal.yml
+++ b/install_files/ansible-base/roles/common/vars/Ubuntu_focal.yml
@@ -7,7 +7,6 @@ securedrop_kernel_packages_to_remove:
 resolvconf_target_filepath: /etc/resolv.conf
 
 securedrop_common_packages:
-  - apt-transport-https
   - iptables-persistent
   - unattended-upgrades
   - tmux

--- a/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
+++ b/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
@@ -3,7 +3,7 @@
 # are present
 
 - name: Install python and packages required by installer
-  raw: apt-get update && apt-get install -y python3 apt-transport-https dnsutils ubuntu-release-upgrader-core mokutil
+  raw: apt-get update && apt-get install -y python3 dnsutils ubuntu-release-upgrader-core mokutil
   register: _apt_install_prereqs_results
   changed_when: "'0 upgraded, 0 newly installed, 0 to remove' not in _apt_install_prereqs_results.stdout"
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Don't install apt-transport-https, it's an unnecessary transitional package. On both focal and noble.

## Testing

How should the reviewer test this PR?

* [ ] visual review
* [ ] staging CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
