### PR TITLE
Inspect grsec_lock as root in testinfra

### DIFF
--- a/molecule/testinfra/common/test_grsecurity.py
+++ b/molecule/testinfra/common/test_grsecurity.py
@@ -62,10 +62,11 @@ def test_grsecurity_lock_file(host):
     Ensure system is rerunning a grsecurity kernel by testing for the
     `grsec_lock` file, which is automatically created by grsecurity.
     """
-    f = host.file("/proc/sys/kernel/grsecurity/grsec_lock")
-    assert f.mode == 0o600
-    assert f.user == "root"
-    assert f.size == 0
+    with host.sudo():
+        f = host.file("/proc/sys/kernel/grsecurity/grsec_lock")
+        assert f.mode == 0o600
+        assert f.user == "root"
+        assert f.size == 0
 
 
 def test_grsecurity_kernel_is_running(host):


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

On Linux 6.6/noble, stat-ing this file requires being root.

## Testing

How should the reviewer test this PR?

* [ ] visual review
* [ ] staging CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
