### PR TITLE
Remove test_securedrop_application_apt_dependencies test

### DIFF
--- a/molecule/testinfra/app-code/test_securedrop_app_code.py
+++ b/molecule/testinfra/app-code/test_securedrop_app_code.py
@@ -3,7 +3,6 @@ import testutils
 
 securedrop_test_vars = testutils.securedrop_test_vars
 testinfra_hosts = [securedrop_test_vars.app_hostname]
-python_version = securedrop_test_vars.python_version
 
 
 def test_apache_default_docroot_is_absent(host):
@@ -13,32 +12,6 @@ def test_apache_default_docroot_is_absent(host):
     leak, as it displays version information by default.
     """
     assert not host.file("/var/www/html").exists
-
-
-@pytest.mark.parametrize(
-    "package",
-    [
-        "apache2",
-        "apparmor-utils",
-        "coreutils",
-        "gnupg2",
-        "libapache2-mod-xsendfile",
-        f"libpython{python_version}",
-        "paxctld",
-        "python3",
-        "redis-server",
-        "securedrop-config",
-        "securedrop-keyring",
-        "sqlite3",
-    ],
-)
-def test_securedrop_application_apt_dependencies(host, package):
-    """
-    Ensure apt dependencies required to install `securedrop-app-code`
-    are present. These should be pulled in automatically via apt,
-    due to specification in Depends in package control file.
-    """
-    assert host.package(package).is_installed
 
 
 @pytest.mark.parametrize(

--- a/molecule/testinfra/conftest.py
+++ b/molecule/testinfra/conftest.py
@@ -31,7 +31,6 @@ def securedrop_import_testinfra_vars(hostname, with_header=False):
     hostvars["securedrop_venv_site_packages"] = hostvars["securedrop_venv_site_packages"].format(
         "3.8"
     )
-    hostvars["python_version"] = "3.8"
     hostvars["apparmor_enforce_actual"] = hostvars["apparmor_enforce"]["focal"]
 
     # If the tests are run against a production environment, check local config

--- a/molecule/testinfra/mon/test_ossec_server.py
+++ b/molecule/testinfra/mon/test_ossec_server.py
@@ -5,7 +5,6 @@ import testutils
 
 securedrop_test_vars = testutils.securedrop_test_vars
 testinfra_hosts = [securedrop_test_vars.monitor_hostname]
-python_version = securedrop_test_vars.python_version
 
 
 def test_ossec_connectivity(host):


### PR DESCRIPTION


## Status

Ready for review 

## Description of Changes

We have much more confidence in our Debian packages now, so we don't need to keep a duplicated list of dependencies and check that they're installed.

This happened to be the last use of the `python_version` variable, so remove that entirely.

## Testing

How should the reviewer test this PR?

* [ ] visual review
* [ ] staging CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
