### PR TITLE
Overwrite sources.list.d/ubuntu.sources on noble

### DIFF
--- a/install_files/ansible-base/roles/common/tasks/apt_sources.yml
+++ b/install_files/ansible-base/roles/common/tasks/apt_sources.yml
@@ -1,9 +1,21 @@
-- name: Configure apt sources.
+- name: Configure apt sources.list
   template:
     src: sources.list.j2
     dest: /etc/apt/sources.list
     mode: "0644"
     owner: root
+  when: ansible_distribution_release == "focal"
+  notify: update apt cache
+  tags:
+    - apt
+
+- name: Configure apt ubuntu.sources
+  template:
+    src: ubuntu.sources.j2
+    dest: /etc/apt/sources.list.d/ubuntu.sources
+    mode: "0644"
+    owner: root
+  when: ansible_distribution_release != "focal"
   notify: update apt cache
   tags:
     - apt

--- a/install_files/ansible-base/roles/common/templates/ubuntu.sources.j2
+++ b/install_files/ansible-base/roles/common/templates/ubuntu.sources.j2
@@ -1,0 +1,11 @@
+Types: deb
+URIs: http://archive.ubuntu.com/ubuntu/
+Suites: {{ ansible_distribution_release }} {{ ansible_distribution_release }}-updates
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: http://security.ubuntu.com/ubuntu/
+Suites: {{ ansible_distribution_release }}-security
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg

--- a/molecule/testinfra/common/test_automatic_updates.py
+++ b/molecule/testinfra/common/test_automatic_updates.py
@@ -49,6 +49,8 @@ def test_sources_list(host, repo):
     Ensure the correct apt repositories are specified
     in the sources.list for apt.
     """
+    if host.system_info.codename != "focal":
+        pytest.skip("sources.list is only provisioned on focal")
     repo_config = repo.format(securedrop_target_platform=host.system_info.codename)
     f = host.file("/etc/apt/sources.list")
     assert f.is_file
@@ -56,6 +58,32 @@ def test_sources_list(host, repo):
     assert f.mode == 0o644
     repo_regex = f"^{re.escape(repo_config)}$"
     assert f.contains(repo_regex)
+
+
+def test_ubuntu_sources(host):
+    """
+    Ensure the correct apt repositories are specified
+    in the ubuntu.sources for apt.
+    """
+    distro = host.system_info.codename
+    if distro == "focal":
+        pytest.skip("sources.list is only provisioned on noble")
+    f = host.file("/etc/apt/sources.list.d/ubuntu.sources")
+    assert f.is_file
+    assert f.user == "root"
+    assert f.mode == 0o644
+    expected = f"""\
+URIs: http://archive.ubuntu.com/ubuntu/
+Suites: {distro} {distro}-updates
+Components: main universe restricted multiverse
+"""
+    assert f.contains(expected)
+    expected_security = f"""\
+URIs: http://security.ubuntu.com/ubuntu/
+Suites: {distro}-security
+Components: main universe restricted multiverse
+"""
+    assert f.contains(expected_security)
 
 
 apt_config_options = {


### PR DESCRIPTION


## Status

Ready for review 

## Description of Changes

Ubuntu noble ships an empty sources.list, instead we need to overwrite the ubuntu.sources file.

It is functionally identical to the old sources.list file, just in the newer deb822 format.

## Testing

How should the reviewer test this PR?

* [ ] Visual review
* [ ] staging CI passes

## Deployment

Any special considerations for deployment? This only handles new installs. Code for migrating will be implemented separately.

## Checklist

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

