### PR TITLE
Remove tests checking that no apparmor profiles are complaining

### DIFF
--- a/molecule/testinfra/app/test_apparmor.py
+++ b/molecule/testinfra/app/test_apparmor.py
@@ -63,22 +63,6 @@ def test_apparmor_ensure_not_disabled(host, profile):
         assert not f.exists
 
 
-@pytest.mark.parametrize("complain_pkg", sdvars.apparmor_complain)
-def test_app_apparmor_complain(host, complain_pkg):
-    """Ensure app-armor profiles are in complain mode for staging"""
-    with host.sudo():
-        awk = "awk '/[0-9]+ profiles.*complain." "/{flag=1;next}/^[0-9]+.*/{flag=0}flag'"
-        c = host.check_output(f"aa-status | {awk}")
-        assert complain_pkg in c
-
-
-def test_app_apparmor_complain_count(host):
-    """Ensure right number of app-armor profiles are in complain mode"""
-    with host.sudo():
-        c = host.check_output("aa-status --complaining")
-        assert c == str(len(sdvars.apparmor_complain))
-
-
 @pytest.mark.parametrize("aa_enforced", sdvars.apparmor_enforce_actual)
 def test_apparmor_enforced(host, aa_enforced):
     awk = "awk '/[0-9]+ profiles.*enforce./" "{flag=1;next}/^[0-9]+.*/{flag=0}flag'"
@@ -91,7 +75,7 @@ def test_apparmor_total_profiles(host):
     """Ensure number of total profiles is sum of enforced and
     complaining profiles"""
     with host.sudo():
-        total_expected = len(sdvars.apparmor_enforce) + len(sdvars.apparmor_complain)
+        total_expected = len(sdvars.apparmor_enforce)
         assert int(host.check_output("aa-status --profiled")) >= total_expected
 
 

--- a/molecule/testinfra/vars/app-prod.yml
+++ b/molecule/testinfra/vars/app-prod.yml
@@ -18,8 +18,6 @@ apparmor_enforce:
     - "/usr/sbin/apache2//HANDLING_UNTRUSTED_INPUT"
     - "/usr/sbin/tor"
 
-apparmor_complain: []
-
 # No source-error.log allowed in prod
 allowed_apache_logfiles:
   - /var/log/apache2/access.log

--- a/molecule/testinfra/vars/app-qubes-staging.yml
+++ b/molecule/testinfra/vars/app-qubes-staging.yml
@@ -32,8 +32,6 @@ pip_deps:
   - name: 'Flask'
     version: '2.0.3'
 
-apparmor_complain: []
-
 tor_services:
   - name: journalistv3
     ports:

--- a/molecule/testinfra/vars/app-staging.yml
+++ b/molecule/testinfra/vars/app-staging.yml
@@ -31,8 +31,6 @@ pip_deps:
   - name: 'Flask'
     version: '2.0.3'
 
-apparmor_complain: []
-
 apparmor_enforce:
   focal:
     - "sbin/dhclient"

--- a/molecule/testinfra/vars/prod.yml
+++ b/molecule/testinfra/vars/prod.yml
@@ -32,8 +32,6 @@ pip_deps:
   - name: 'Flask'
     version: '2.0.3'
 
-apparmor_complain: []
-
 apparmor_enforce:
   focal:
     - "sbin/dhclient"

--- a/molecule/testinfra/vars/prodVM.yml
+++ b/molecule/testinfra/vars/prodVM.yml
@@ -31,8 +31,6 @@ pip_deps:
   - name: 'Flask'
     version: '2.0.3'
 
-apparmor_complain: []
-
 apparmor_enforce:
   focal:
     - "sbin/dhclient"

--- a/molecule/testinfra/vars/qubes-staging.yml
+++ b/molecule/testinfra/vars/qubes-staging.yml
@@ -33,8 +33,6 @@ pip_deps:
   - name: 'Flask'
     version: '2.0.3'
 
-apparmor_complain: []
-
 apparmor_enforce:
   focal:
     - "sbin/dhclient"

--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -33,8 +33,6 @@ pip_deps:
   - name: 'Flask'
     version: '2.0.3'
 
-apparmor_complain: []
-
 apparmor_enforce:
   focal:
     - "sbin/dhclient"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Ubuntu noble now has some transmission-related profiles in complain mode. We don't really care about this, so just remove the test. Ideally distros will continue to add more apparmor profiles, even if they're complain-only to start.
## Testing

How should the reviewer test this PR?

* [ ] visual review

## Deployment

Any special considerations for deployment? n/a

