### PR TITLE
Prompt "sdadmin" for the default SSH username

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -304,7 +304,7 @@ class SiteConfig:
         self.desc: List[_DescEntryType] = [
             (
                 "ssh_users",
-                "sd",
+                "sdadmin",
                 str,
                 "Username for SSH access to the servers",
                 SiteConfig.ValidateUser(),

--- a/admin/tests/files/site-specific
+++ b/admin/tests/files/site-specific
@@ -17,5 +17,5 @@ securedrop_supported_locales:
 - en_US
 smtp_relay: smtp.gmail.com
 smtp_relay_port: 587
-ssh_users: sd
+ssh_users: sdadmin
 user_defined_variable: "must not be discarded"

--- a/admin/tests/test_integration.py
+++ b/admin/tests/test_integration.py
@@ -47,7 +47,7 @@ securedrop_supported_locales:
 - es_ES
 smtp_relay: smtp.gmail.com
 smtp_relay_port: 587
-ssh_users: sd
+ssh_users: sdadmin
 """
 
 JOURNALIST_ALERT_OUTPUT = """app_hostname: app
@@ -80,7 +80,7 @@ securedrop_supported_locales:
 - es_ES
 smtp_relay: smtp.gmail.com
 smtp_relay_port: 587
-ssh_users: sd
+ssh_users: sdadmin
 """
 
 HTTPS_OUTPUT_NO_POW = """app_hostname: app
@@ -113,7 +113,7 @@ securedrop_supported_locales:
 - es_ES
 smtp_relay: smtp.gmail.com
 smtp_relay_port: 587
-ssh_users: sd
+ssh_users: sdadmin
 """
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Our documentation recommends using "sdadmin", so let's default to that in `./securedrop-admin sdconfig`.

## Testing

How should the reviewer test this PR?

* [ ] Visual review

## Deployment

Any special considerations for deployment? Not really.

## Checklist

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container
