### PR TITLE
#6405 Fix wcag annotations

### DIFF
--- a/securedrop/journalist_templates/_sources_confirmation_final_modal.html
+++ b/securedrop/journalist_templates/_sources_confirmation_final_modal.html
@@ -2,19 +2,19 @@
   <a href="#close" class="external" aria-label="{{ gettext('Close') }}"></a>
   <dialog open id="delete-confirm-menu-dialog" aria-labelledby="confirm-heading">
     <h2 id="confirm-heading" class="paragraph-spacing">
-      {{ gettext('When the account for a source is deleted:') }}
+      {{ gettext('When the account for a <abr title="user">source</abr>is deleted:') }}
     </h2>
     <ul>
-      <li>{{ gettext('The source will no longer be able to log in with their codename.') }}</li>
+      <li>{{ gettext('The <abr title="user">source</abr> will no longer be able to log in with their <abbr title="user name">codename</abbr>.') }}</li>
       <li>{{ gettext('You will not be able to send them replies.') }}</li>
-      <li>{{ gettext('All files and messages from that source will also be destroyed.') }}</li>
+      <li>{{ gettext('All files and messages from that <abr title="user">source</abr> will also be destroyed.') }}</li>
     </ul>
     <p class="modal-danger-text">{{ gettext('Are you sure this is what you want?') }}</p>
     <div class="btn-row">
       <a href="#close" id="cancel-collections-deletions" title="{{ gettext('Cancel') }}"
         class="btn cancel small">{{ gettext('Cancel') }}</a>
       <button type="submit" id="delete-collections-confirm" name="action" value="delete"
-        class="btn small danger">{{ gettext('Yes, Delete Selected Source Accounts') }}</button>
+        class="btn small danger">{{ gettext('Yes, Delete Selected <abr title="user">Source</abr> Accounts') }}</button>
     </div>
   </dialog>
 </div>

--- a/securedrop/journalist_templates/account_new_two_factor_hotp.html
+++ b/securedrop/journalist_templates/account_new_two_factor_hotp.html
@@ -3,7 +3,7 @@
 {% block tab_title %}{{ gettext('Enable YubiKey (OATH-HOTP)') }}{% endblock %}
 
 {% block body %}
-<h1>{{ gettext('Enable YubiKey (OATH-HOTP)') }}</h1>
+<h1>{{ gettext('Enable YubiKey (<abbr title="HMAC-based one-time password algorithm">OATH-HOTP</abbr>)') }}</h1>
 <p>{{ gettext('Once you have configured your YubiKey, enter the 6-digit verification code below:') }}</p>
 <form id="check-token" method="post" action="{{url_for('account.new_two_factor_hotp')}}">
   <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">

--- a/securedrop/journalist_templates/admin.html
+++ b/securedrop/journalist_templates/admin.html
@@ -85,7 +85,7 @@
 
 <a href="{{ url_for('admin.manage_config') }}" class="btn icon icon-edit section-spacing-inline"
   id="update-instance-config" aria-label="{{ gettext('Update instance configuration') }}">
-  {{ gettext('INSTANCE CONFIG') }}
+  {{ gettext('INSTANCE CONFIGURATION') }}
 </a>
 
 {% endblock %}

--- a/securedrop/journalist_templates/col.html
+++ b/securedrop/journalist_templates/col.html
@@ -157,7 +157,7 @@
 Deleting the account for <b>{source}</b> will:
 </p>
 <ul>
-<li>prevent them from logging in with their codename again
+<li>prevent them from logging in with their <abr title="user name">codename</abr>again
 <li>prevent your organization from sending replies
 </ul>
 <p>

--- a/securedrop/journalist_templates/config.html
+++ b/securedrop/journalist_templates/config.html
@@ -78,7 +78,7 @@
       <div class="config_form_element">
         {{ submission_preferences_form.reject_codename_messages() }}
         <label
-      for="reject_codename_messages">{{ gettext('Prevent sources from submitting their codename as an initial message.') }}</label>
+      for="reject_codename_messages">{{ gettext('Prevent sources from submitting their <abr title="user name">codename</abr>as an initial message.') }}</label>
       </div>
     <div class="section-spacing">
       <button type="submit" id="submit-submission-preferences" class="icon icon-edit"

--- a/securedrop/journalist_templates/js-strings.html
+++ b/securedrop/journalist_templates/js-strings.html
@@ -1,6 +1,6 @@
 {# Hack around doing full JS translation support since JS is barely used #}
 <div id="js-strings">
-  <div id="filter-by-codename-placeholder-string" hidden>{{ gettext('Filter by codename') }}</div>
+  <div id="filter-by-codename-placeholder-string" hidden>{{ gettext('Filter by <abr title="user name">codename</abr>') }}</div>
   <div id="select-all-string" hidden>{{ gettext('Select All') }}</div>
   <div id="select-unread-string" hidden>{{ gettext('Select Unread') }}</div>
   <div id="select-none-string" hidden>{{ gettext('Select None') }}</div>

--- a/securedrop/source_templates/error.html
+++ b/securedrop/source_templates/error.html
@@ -7,5 +7,5 @@
 
 <p>{{ gettext('Sorry, the website encountered an error and was unable to complete your request.') }}</p>
 
-<p><a href="{{ url_for('main.login') }}">{{ gettext('Look up a codename...') }}</a></p>
+<p><a href="{{ url_for('main.login') }}">{{ gettext('Look up a <abr title="user name">codename</abr>...') }}</a></p>
 {% endblock %}

--- a/securedrop/source_templates/generate.html
+++ b/securedrop/source_templates/generate.html
@@ -5,13 +5,13 @@
 {% import 'utils.html' as utils %}
 
 {% block body %}
-<h2>{{ gettext('Get Your Codename') }}</h2>
+<h2>{{ gettext('Get Your <abr title="user name">codename</abr>') }}</h2>
 
 <p id="codename-explanation" class="explanation">
-  {{ gettext('A <em>codename</em> in SecureDrop functions as both your username and your password.') }}
+  {{ gettext('A <em><abr title="user name">codename</abr></em> in SecureDrop functions as both your username and your password.') }}
 </p>
 <p class="explanation">
-  {{ gettext('You will need this codename to log into our SecureDrop later:') }}
+  {{ gettext('You will need this <abr title="user name">codename</abr> to log into our SecureDrop later:') }}
 </p>
 
 {{ utils.codename(codename) }}

--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -70,7 +70,7 @@
 
       <section id="return-visit" aria-labelledby="return-visit-heading">
           <h2 id="return-visit-heading">{{ gettext('Return visit') }}</h2>
-          <p>{{ gettext('Already have a codename? Check for replies or submit something new.') }}</p>
+          <p>{{ gettext('Already have a <abr title="user name">codename</abr>? Check for replies or submit something new.') }}</p>
           <a href="{{ url_for('main.login') }}" class="btn secondary"
             aria-label="{{ gettext('Log In Using Your Codename') }}">
             {{ gettext('LOG IN') }}

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -26,9 +26,9 @@
 
   <p>
     {% if allow_document_uploads %}
-    {{ gettext('If you are already familiar with GPG, you can optionally encrypt your files and messages with our <a href="{url}" class="text-link">public key</a> before submission. Files are encrypted as they are received by SecureDrop.').format(url=url_for('info.download_public_key')) }}
+    {{ gettext('If you are already familiar with <abbr title="GNU Privacy Guard">GPG</abbr>, you can optionally encrypt your files and messages with our <a href="{url}" class="text-link">public key</a> before submission. Files are encrypted as they are received by SecureDrop.').format(url=url_for('info.download_public_key')) }}
     {% else %}
-    {{ gettext('If you are already familiar with GPG, you can optionally encrypt your messages with our <a href="{url}" class="text-link">public key</a> before submission.').format(url=url_for('info.download_public_key')) }}
+    {{ gettext('If you are already familiar with <abbr title="GNU Privacy Guard">GPG</abbr>, you can optionally encrypt your messages with our <a href="{url}" class="text-link">public key</a> before submission.').format(url=url_for('info.download_public_key')) }}
     {% endif %}
     {{ gettext('<a href="{url}" class="text-link">Learn more</a>.').format(url=url_for('info.why_download_public_key')) }}
   </p>

--- a/securedrop/source_templates/lookup.html
+++ b/securedrop/source_templates/lookup.html
@@ -78,7 +78,7 @@
   <div id="replies">
     {% if replies %}
     <p class="info">
-      {{ gettext("You have received a reply. To protect your identity in the unlikely event someone learns your codename, please delete all replies when you're done with them. This also lets us know that you are aware of our reply. You can respond by submitting new files and messages above.") }}
+      {{ gettext("You have received a reply. To protect your identity in the unlikely event someone learns your <abr title="user name">codename</abr>, please delete all replies when you're done with them. This also lets us know that you are aware of our reply. You can respond by submitting new files and messages above.") }}
     </p>
     {% for reply in replies %}
     {%- set timestamp = utils.relative_time(reply.date) -%}

--- a/securedrop/source_templates/notfound.html
+++ b/securedrop/source_templates/notfound.html
@@ -7,5 +7,5 @@
 
 <p id="page-not-found">{{ gettext("Sorry, we couldn't locate what you requested.") }}</p>
 
-<p><a href="{{ url_for('main.login') }}">{{ gettext('Look up a codename...') }}</a></p>
+<p><a href="{{ url_for('main.login') }}">{{ gettext('Look up a <abr title="user name">codename</abr>...') }}</a></p>
 {% endblock %}

--- a/securedrop/source_templates/utils.html
+++ b/securedrop/source_templates/utils.html
@@ -6,21 +6,21 @@
 {%- macro codename(codename, new=False) -%}
 {% if new %}
 <section aria-labelledby="codename-reminder">
-  <p id="codename-reminder">{{ gettext('Remember, your codename is:') }}</p>
+  <p id="codename-reminder">{{ gettext('Remember, your <abbr title="user name">codename</abbr> is:') }}</p>
 {% else %}
 <section aria-labelledby="codename-heading">
-  <h2 id="codename-heading" hidden>{{ gettext('Codename') }}</h2>
+  <h2 id="codename-heading" hidden>{{ gettext('<abbr title="user name">Codename</abbr>') }}</h2>
 {% endif %}
 
   <input id="codename-show-checkbox" type="checkbox" role="button"{% if not new %} checked {% endif -%}
     aria-label="{{ gettext('Reveal Codename') }}" aria-controls="codename">
 
   <mark id="codename" lang="en-US" dir="ltr"{% if not new %}
-    aria-describedby="codename-instructions codename-explanation"{% endif %}><span>{{ codename }}</span></mark>
+    aria-describedby="codename-instructions codename-explanation"{% endif %}><span>{{ <abbr title="user name">codename</abbr> }}</span></mark>
 
   <label for="codename-show-checkbox" id="codename-show"
     aria-hidden="true">
-      {{ gettext('Show Codename') }}
+      {{ gettext('Show <abbr title="user name">Codename</abbr>') }}
   </label>
 
 </section>

--- a/securedrop/source_templates/why-public-key.html
+++ b/securedrop/source_templates/why-public-key.html
@@ -6,12 +6,12 @@
 <h2>{{ gettext("Why download the team's public key?") }}</h2>
 <p>{{ gettext("SecureDrop encrypts files and messages after they are submitted. Encrypting messages and files before submission can provide an extra layer of security before your data reaches the SecureDrop server.") }}
 </p>
-<p>{{ gettext("If you are already familiar with the GPG encryption software, you may wish to encrypt your submissions yourself. To do so:") }}
+<p>{{ gettext("If you are already familiar with the <abbr title="GNU Privacy Guard">GPG</abbr> encryption software, you may wish to encrypt your submissions yourself. To do so:") }}
 <ol>
     <li>{{ gettext('<a href="{url}">Download</a> the public key. It will be saved to a file called:
         <p><code>{submission_key_fpr_filename}</code></p>').format(url=url_for('info.download_public_key'), submission_key_fpr_filename=submission_key_fpr + '.asc')|safe }}
     </li>
-    <li>{{ gettext('Import it into your GPG keyring.') }}
+    <li>{{ gettext('Import it into your <abbr title="GNU Privacy Guard">GPG</abbr> keyring.') }}
         <ul>
             <li>{{ gettext('If you are using <a href="{url}">Tails</a>, you can double-click the <code>.asc</code> file you just downloaded and it will be automatically imported to your keyring.').format(url='https://tails.boum.org') }}
             </li>


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Added abbreviation descriptions to the html pages.

Fixes https://github.com/freedomofpress/securedrop/issues/6405. and the closed pr: https://github.com/freedomofpress/securedrop/pull/7081

Changes proposed in this pull request:

- add abbr tag to html pages

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.
 
-when looking through the page ensure the correct words have abbreviations

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
2. New installs.

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a reference to a production code dependency:

Production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/requirements.in`
- `securedrop/requirements/python3/translation.in` (used in the build
  container)

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
- [ ] I am silencing an alert related to a production dependency, because (please explain below):
