### PR TITLE
Remove ufw from new and existing installs

### DIFF
--- a/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
+++ b/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
@@ -23,9 +23,11 @@
       custom kernel that is not signed. Please disable SecureBoot on the
       target servers and try again.
 
-- name: Remove cloud-init
+- name: Remove cloud-init and ufw
   apt:
-    name: cloud-init
+    name:
+      - cloud-init
+      - ufw
     state: absent
     purge: yes
   tags:

--- a/molecule/testinfra/common/test_system_hardening.py
+++ b/molecule/testinfra/common/test_system_hardening.py
@@ -1,4 +1,5 @@
 import re
+import time
 
 import pytest
 import testutils
@@ -173,6 +174,29 @@ def test_iptables_packages(host):
     firewall config across reboots.
     """
     assert host.package("iptables-persistent").is_installed
+    assert not host.package("ufw").is_installed
+
+
+def test_package_removal(host):
+    """Test the securedrop-remove-packages service"""
+    if host.system_info.codename != "focal":
+        # ufw is uninstallable in noble because of the conflict
+        # with iptables-persistent
+        pytest.skip("only applicable/testable on focal")
+
+    with host.sudo():
+        if not host.package("ufw").is_installed:
+            cmd = host.run("apt-get install ufw --yes")
+            assert cmd.rc == 0
+        assert host.file("/usr/sbin/ufw").exists
+        # Trigger the service manually
+        cmd = host.run("systemctl start securedrop-remove-packages")
+        assert cmd.rc == 0
+        # Wait for the unit to run
+        while host.service("securedrop-remove-packages").is_running:
+            time.sleep(1)
+
+    assert not host.package("ufw").is_installed
 
 
 def test_snapd_absent(host):

--- a/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.service
+++ b/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Remove ufw if installed
+ConditionPathExists=/usr/sbin/ufw
+
+[Service]
+Type=oneshot
+Environment="DEBIAN_FRONTEND=noninteractive"
+ExecStart=/usr/bin/apt-get purge --yes ufw
+User=root

--- a/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.timer
+++ b/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Remove ufw if installed
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=5m
+
+[Install]
+WantedBy=timers.target

--- a/securedrop/debian/rules
+++ b/securedrop/debian/rules
@@ -78,6 +78,7 @@ override_dh_systemd_enable:
 	dh_systemd_enable --no-enable securedrop-submissions-today.service
 	dh_systemd_enable --no-enable securedrop-clean-tmp.service
 	dh_systemd_enable --no-enable securedrop-remove-pending-sources.service
+	dh_systemd_enable --no-enable securedrop-remove-packages.service
 	dh_systemd_enable
 
 # This is basically the same as the enable stanza above, just whether the
@@ -86,4 +87,5 @@ override_dh_systemd_start:
 	dh_systemd_start --no-start securedrop-submissions-today.service
 	dh_systemd_start --no-start securedrop-clean-tmp.service
 	dh_systemd_start --no-start securedrop-remove-pending-sources.service
+	dh_systemd_start --no-start securedrop-remove-packages.service
 	dh_systemd_start

--- a/securedrop/debian/securedrop-config.install
+++ b/securedrop/debian/securedrop-config.install
@@ -1,2 +1,3 @@
 debian/config/etc /
+debian/config/lib /
 debian/config/opt /


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We don't use ufw and in noble, it conflicts with iptables-persistent, which we do want to use.

Remove it during provisioning and install a systemd timer to remove it. (We can't do it during a postinst because we're already in an apt session at that time.)

Fixes #7313.

## Testing

How should the reviewer test this PR?

* [x] Visual review
* [x] staging CI passes (tests fresh install case)
* [ ] build debs and install on a focal system, wait 1 day and see that ufw was removed

## Deployment

Any special considerations for deployment? Both new installs and upgrades are handled

## Checklist

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
