### PR TITLE
Have app-code depend on apparmor in noble

### DIFF
--- a/securedrop/debian/control
+++ b/securedrop/debian/control
@@ -10,7 +10,7 @@ Package: securedrop-app-code
 Architecture: amd64
 Conflicts: libapache2-mod-wsgi, supervisor
 Replaces: libapache2-mod-wsgi, supervisor
-Depends: ${dist:Depends}, ${misc:Depends}, ${python3:Depends}, apache2, apparmor-utils, coreutils, gnupg2, libapache2-mod-xsendfile, paxctld, python3, redis-server, securedrop-config, securedrop-keyring, sqlite3
+Depends: ${dist:Depends}, ${misc:Depends}, ${python3:Depends}, ${apparmor:Depends}, apache2, apparmor-utils, coreutils, gnupg2, libapache2-mod-xsendfile, paxctld, python3, redis-server, securedrop-config, securedrop-keyring, sqlite3
 Description: SecureDrop application code, dependencies, Apache configuration, systemd services, and AppArmor profiles. This package will put the AppArmor profiles in enforce mode.
 
 Package: securedrop-config

--- a/securedrop/debian/rules
+++ b/securedrop/debian/rules
@@ -59,6 +59,11 @@ override_dh_strip_nondeterminism:
 	dh_strip_nondeterminism $@
 
 override_dh_gencontrol:
+ifneq ($(findstring +noble,$(DEB_VERSION)),)
+	dh_gencontrol -psecuredrop-app-code -- "-Vapparmor:Depends=apparmor (>= 4.0.1really4.0.1-0ubuntu0.24.04.3)"
+else
+	dh_gencontrol -psecuredrop-app-code -- "-Vapparmor:Depends="
+endif
 	dh_gencontrol -psecuredrop-ossec-agent -- "-v3.6.0+${DEB_VERSION}"
 	dh_gencontrol -psecuredrop-ossec-server -- "-v3.6.0+${DEB_VERSION}"
 	dh_gencontrol -psecuredrop-keyring -- "-v0.2.2+${DEB_VERSION}"


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

During a system upgrade, the securedrop-app-code postinst tries to enable the apparmor profiles for apache2 and tor, except it uses newer apparmor syntax, which can fail if apparmor hasn't already been upgraded.

The easiest and correct way to ensure that securedrop-app-code is upgraded after apparmor is by setting a versioned dependency. We need to do a bit of makefile magic so it only applies to noble builds though, and a test verifies that.


## Testing

How should the reviewer test this PR?

* [x] CI passes, esp the build-debs jobs
* [ ] version of apparmor we set the dependency on matches what noble has (see https://launchpad.net/ubuntu/+source/apparmor)

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
