### PR TITLE
Don't return in test_swap_disabled, use skip instead

### DIFF
--- a/molecule/testinfra/common/test_system_hardening.py
+++ b/molecule/testinfra/common/test_system_hardening.py
@@ -75,9 +75,8 @@ def test_swap_disabled(host):
     """
     hostname = host.check_output("hostname")
 
-    # Mon doesn't have swap disabled yet
     if hostname.startswith("mon"):
-        return True
+        pytest.skip("mon doesn't have swap disabled yet")
 
     c = host.check_output("swapon --summary")
     # A leading slash will indicate full path to a swapfile.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Returning triggers a warning:
```
 PytestReturnNotNoneWarning: Expected None, but
 testinfra/common/test_system_hardening.py::test_swap_disabled[ansible://mon-staging]
 returned True, which will be an error in a future version of pytest.
 Did you mean to use `assert` instead of `return`?
```

## Testing

How should the reviewer test this PR?

* [ ] staging CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
