### PR TITLE
Upgrade paramiko for CVE-2022-24302

### DIFF
--- a/admin/requirements-testinfra.in
+++ b/admin/requirements-testinfra.in
@@ -2,4 +2,4 @@ pytest==7.2.0
 testinfra==5.3.1
 py>=1.10.0
 pytest-xdist==2.1.0
-paramiko==2.9.2
+paramiko>=2.10.1,<2.11

--- a/admin/requirements-testinfra.txt
+++ b/admin/requirements-testinfra.txt
@@ -210,9 +210,9 @@ packaging==21.3 \
     #   -r requirements-ansible.in
     #   ansible-core
     #   pytest
-paramiko==2.9.2 \
-    --hash=sha256:04097dbd96871691cdb34c13db1883066b8a13a0df2afd4cb0a92221f51c2603 \
-    --hash=sha256:944a9e5dbdd413ab6c7951ea46b0ab40713235a9c4c5ca81cfe45c6f14fa677b
+paramiko==2.10.6 \
+    --hash=sha256:02f07596062e4a81eacef10f9608d9a05f6f2485e50a1c3865ccf7b3b04138ad \
+    --hash=sha256:faac4820a3173997c378da74b72e832b1ff075ea1a4ee3c0ba048aa30ee49cf1
     # via -r requirements-testinfra.in
 pluggy==1.4.0 \
     --hash=sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981 \


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

CVE-2022-24302 is about a race condition in `write_private_key_file`, which I don't think we use, this is a straightforward enough upgrade that we might as well do it.

## Testing

How should the reviewer test this PR?

* [ ] staging CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
