### PR TITLE
Install backup script on app server via Debian package

### DIFF
--- a/install_files/ansible-base/roles/backup/tasks/backup.yml
+++ b/install_files/ansible-base/roles/backup/tasks/backup.yml
@@ -1,8 +1,6 @@
 ---
 - name: Run the backup script (can take a while).
-  # Setting args inline (against project style conventions) to work around
-  # Ansible bug: https://github.com/ansible/ansible/issues/9693
-  command: /usr/bin/securedrop-app-backup.py chdir=/tmp
+  command: /usr/bin/securedrop-app-backup.py --dest /tmp
   # If there are a lot of submissions, this task could take a while.
   async: 3600
   poll: 10

--- a/install_files/ansible-base/roles/backup/tasks/backup.yml
+++ b/install_files/ansible-base/roles/backup/tasks/backup.yml
@@ -1,15 +1,8 @@
 ---
-- name: Copy the backup script to the target server.
-  copy:
-    src: backup.py
-    dest: /tmp/
-    owner: root
-    mode: "0770"
-
 - name: Run the backup script (can take a while).
   # Setting args inline (against project style conventions) to work around
   # Ansible bug: https://github.com/ansible/ansible/issues/9693
-  command: /tmp/backup.py chdir=/tmp
+  command: /usr/bin/securedrop-app-backup.py chdir=/tmp
   # If there are a lot of submissions, this task could take a while.
   async: 3600
   poll: 10

--- a/molecule/testinfra/app/test_backup.py
+++ b/molecule/testinfra/app/test_backup.py
@@ -1,0 +1,28 @@
+import pytest
+import testutils
+
+sdvars = testutils.securedrop_test_vars
+testinfra_hosts = [sdvars.app_hostname]
+
+
+@pytest.mark.skip_in_prod
+def test_backup(host):
+    """Create a backup and verify it contains expected files"""
+
+    with host.sudo():
+        result = host.run("securedrop-app-backup.py --dest /tmp")
+        assert result.rc == 0
+        tarball = result.stdout.strip()
+        # looks like a file path
+        assert tarball.endswith(".tar.gz")
+        assert host.file(f"/tmp/{tarball}").exists
+        # list files in the tarball
+        contains = host.run(f"tar -tzf /tmp/{tarball}")
+        assert contains.rc == 0
+        contains_list = contains.stdout.splitlines()
+        assert "var/www/securedrop/config.py" in contains_list
+        assert "etc/tor/torrc" in contains_list
+        assert "var/lib/tor/services/" in contains_list
+        # cleanup
+        cleanup = host.run(f"rm /tmp/{tarball}")
+        assert cleanup.rc == 0

--- a/securedrop/debian/app-code/usr/bin/securedrop-app-backup.py
+++ b/securedrop/debian/app-code/usr/bin/securedrop-app-backup.py
@@ -1,7 +1,7 @@
-#!/opt/venvs/securedrop-app-code/bin/python
+#!/usr/bin/python3
 """
-This script is copied to the App server (to /tmp) and run by the Ansible playbook,
-typically via `securedrop-admin`.
+This script is invoked by the ansible playbook, typically via
+`securedrop-admin`. It is run as root on the app server.
 
 The backup file in the format sd-backup-$TIMESTAMP.tar.gz is then copied to the
 Admin Workstation by the playbook, and removed on the server. For further

--- a/securedrop/debian/app-code/usr/bin/securedrop-app-backup.py
+++ b/securedrop/debian/app-code/usr/bin/securedrop-app-backup.py
@@ -8,12 +8,31 @@ Admin Workstation by the playbook, and removed on the server. For further
 information and limitations, see https://docs.securedrop.org/en/stable/backup_and_restore.html
 """
 
+import argparse
 import os
+import sys
 import tarfile
 from datetime import datetime
+from pathlib import Path
 
 
-def main():
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create backup")
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        default=os.getcwd(),
+        help="Destination folder for backup",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.dest.exists():
+        print(f"Error: {args.dest} does not exist")
+        sys.exit(1)
+
     backup_filename = "sd-backup-{}.tar.gz".format(datetime.utcnow().strftime("%Y-%m-%d--%H-%M-%S"))
 
     # This code assumes everything is in the default locations.
@@ -26,7 +45,7 @@ def main():
     tor_hidden_services = "/var/lib/tor/services"
     torrc = "/etc/tor/torrc"
 
-    with tarfile.open(backup_filename, "w:gz") as backup:
+    with tarfile.open(os.path.join(args.dest, backup_filename), "w:gz") as backup:
         backup.add(sd_config)
 
         # If no custom logo has been configured, the file will not exist

--- a/securedrop/debian/securedrop-app-code.install
+++ b/securedrop/debian/securedrop-app-code.install
@@ -1,6 +1,7 @@
 debian/app-code/etc /
 debian/app-code/lib /
 debian/app-code/var /
+debian/app-code/usr /
 COPYING alembic.ini babel.cfg config.py.example /var/www/securedrop
 *.py i18n.json /var/www/securedrop
 journalist_app journalist_templates /var/www/securedrop


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

#### Install backup script on app server via Debian package

This will allow the script to be invoked from the server itself.
    
Fixes #7329.

#### Give better control over where backups are stored
    
Instead of saving them in the current directory and requiring awkward workarounds to change that directory, take it as an argument so the script can be run from anywhere without requiring context changes.

#### Add testinfra check that the backup script works
    
Try creating a backup and verify it contains a few of the files we expect it to.

## Testing

How should the reviewer test this PR?

* [x] staging CI passes
* [ ] create a backup from the admin workstation, it should work just as before.

## Deployment

Consider the following scenarios:

* upgraded admin workstation + upgraded app server -> works fine
* old admin workstation + upgraded app server -> works fine (continues to rsync local backup.py)
* upgraded admin workstation + old app server -> breaks, file won't exist on app server to invoke. This is OK in my opinion because your app server should be getting updates, and if not, you can downgrade your workstation.

## Checklist

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
