### PR TITLE
Remove haveged if installed

### DIFF
--- a/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.service
+++ b/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.service
@@ -1,9 +1,10 @@
 [Unit]
-Description=Remove ufw if installed
-ConditionPathExists=/usr/sbin/ufw
+Description=Remove ufw/haveged if installed
+ConditionPathExists|=/usr/sbin/ufw
+ConditionPathExists|=/usr/sbin/haveged
 
 [Service]
 Type=oneshot
 Environment="DEBIAN_FRONTEND=noninteractive"
-ExecStart=/usr/bin/apt-get purge --yes ufw
+ExecStart=/usr/bin/apt-get purge --yes ufw haveged
 User=root

--- a/securedrop/debian/securedrop-app-code.preinst
+++ b/securedrop/debian/securedrop-app-code.preinst
@@ -13,18 +13,6 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-function service_exists() {
-    # Test for the existence of systemctl services. Added to check for and
-    # disable haveged if present
-
-    local x=$1
-    if systemctl list-unit-files --type service | grep -F "${x}.service"; then
-        return 0
-    else
-        return 1
-    fi
-}
-
 function permanently_disable_swap() {
     # Swap usage is prohibited in the context of SecureDrop, due to risk of
     # forensic discovery recovering plaintext submissions that were written
@@ -106,12 +94,6 @@ case "$1" in
       permanently_disable_swap
       convert_document_to_journalist_interface
       migrate_custom_logo
-
-      if service_exists 'haveged'; then
-        systemctl stop haveged
-        systemctl disable haveged
-        systemctl mask haveged
-      fi
 
     ;;
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Previously we only disabled/masked haveged instead of removing the package. Now that we have the infrastructure to remove packages (created for ufw), let's remove it properly.

Note that this will remove it from both app and mon, even though it was only ever disabled on app. That should be fine since it's not expected to be running on mon.

Fixes #7326.

## Testing

How should the reviewer test this PR?

* [ ] staging CI passes
* [ ] visual review

## Deployment

Any special considerations for deployment? only applies to very old installs

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
