### PR TITLE
Replace reboot-flag cron job with a systemd timer

### DIFF
--- a/securedrop/debian/config/lib/systemd/system/securedrop-reboot-required.service
+++ b/securedrop/debian/config/lib/systemd/system/securedrop-reboot-required.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Touch /var/run/reboot-required file
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/touch /var/run/reboot-required
+User=root

--- a/securedrop/debian/config/lib/systemd/system/securedrop-reboot-required.timer
+++ b/securedrop/debian/config/lib/systemd/system/securedrop-reboot-required.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Touch reboot-required file every 12 hours
+
+[Timer]
+OnCalendar=*-*-* 0/12:00:00
+
+[Install]
+WantedBy=timers.target

--- a/securedrop/debian/rules
+++ b/securedrop/debian/rules
@@ -85,6 +85,7 @@ override_dh_systemd_enable:
 	dh_systemd_enable --no-enable securedrop-remove-pending-sources.service
 	dh_systemd_enable --no-enable securedrop-remove-packages.service
 	dh_systemd_enable --no-enable securedrop-cleanup-ossec.service
+	dh_systemd_enable --no-enable securedrop-reboot-required.service
 	dh_systemd_enable
 
 # This is basically the same as the enable stanza above, just whether the
@@ -95,4 +96,5 @@ override_dh_systemd_start:
 	dh_systemd_start --no-start securedrop-remove-pending-sources.service
 	dh_systemd_start --no-start securedrop-remove-packages.service
 	dh_systemd_start --no-start securedrop-cleanup-ossec.service
+	dh_systemd_start --no-start securedrop-reboot-required.service
 	dh_systemd_start

--- a/securedrop/debian/securedrop-config.postinst
+++ b/securedrop/debian/securedrop-config.postinst
@@ -18,7 +18,8 @@ case "$1" in
     # Configuration required for unattended-upgrades
     cp /opt/securedrop/20auto-upgrades /etc/apt/apt.conf.d/
     cp /opt/securedrop/50unattended-upgrades /etc/apt/apt.conf.d/
-    cp /opt/securedrop/reboot-flag /etc/cron.d/
+    # Remove old cron job if it exists (now a systemd timer)
+    rm -f /etc/cron.d/reboot-flag
     # Drop old cloud-init sshd_config if it still exists
     rm -f /etc/ssh/sshd_config.d/50-cloud-init.conf
 


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

This is our very last cron job, so let's get rid of it. On the plus side this makes it easier to disable when needed (e.g. during a system upgrade).

The testinfra check now actually verifies that the file is created when the service is run.

Fixes #7013.

## Testing

* [x] visual review
* [x] staging CI passes

## Deployment

Any special considerations for deployment? handles both

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
