### PR TITLE
chore: ignore Safety 73711 in `cryptography`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 71681 \
 		--ignore 71684 \
 		--ignore 73302 \
+		--ignore 73711 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Ignores Safety alert no. 73711 in `cryptography` per freedomofpress/fpf-misc-resources#52.

## Testing

Visual review.