### PR TITLE
Absent sources.list on noble

### DIFF
--- a/install_files/ansible-base/roles/common/tasks/apt_sources.yml
+++ b/install_files/ansible-base/roles/common/tasks/apt_sources.yml
@@ -20,6 +20,18 @@
   tags:
     - apt
 
+# Remove the obsolete sources.list on noble. On a fresh install,
+# this is an empty file with a comment pointing to ubuntu.sources.
+# On upgrade from focal, we're deleting this file.
+- name: Remove obsolete sources.list (noble)
+  template:
+    dest: /etc/apt/sources.list
+    state: absent
+  when: ansible_distribution_release != "focal"
+  notify: update apt cache
+  tags:
+    - apt
+
 # Ensure apt cache is updated before proceeding, otherwise
 # packages may fail to install.
 - meta: flush_handlers


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

On a fresh install, this is an empty file with a comment pointing to /etc/apt/sources.list.d/ubuntu.sources and isn't needed.

In the upgrade case it doesn't make sense for us to create the empty pointer file, so let's just ensure it's absent entirely.


## Testing

How should the reviewer test this PR?

* [x] visual review
* [x] staging CI passes (no-op on focal)
* [ ] in theory you could do a fresh install of noble ubuntu server to verify the sources.list file is useless but I've already done that a bunch

## Deployment

Any special considerations for deployment? this handles the fresh install case, upgrades will be handled by the script

## Checklist

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

