### PR TITLE
Publish dbgsym packages

### DIFF
--- a/builder/build-debs-securedrop.sh
+++ b/builder/build-debs-securedrop.sh
@@ -30,6 +30,10 @@ dpkg-buildpackage -us -uc
 # Copy the built artifacts back and print checksums
 source /etc/os-release
 mkdir -p "/src/build/${VERSION_CODENAME}"
-mv -v ../*.{buildinfo,changes,deb,tar.gz} "/src/build/${VERSION_CODENAME}"
+mv -v ../*.{buildinfo,changes,deb,ddeb,tar.gz} "/src/build/${VERSION_CODENAME}"
 cd "/src/build/${VERSION_CODENAME}"
+# Rename "ddeb" packages to just "deb"
+for file in *.ddeb; do
+    mv "$file" "${file%.ddeb}.deb";
+done
 sha256sum ./*


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes

For various reasons, Ubuntu names these with a `ddeb` file extension so our wildcard for `*.deb` wasn't catching them. So let's collect them but also rename them to use the standard `deb` extension.

## Testing

How should the reviewer test this PR?

* [ ] Run `make build-debs` and see that you (now) get a securedrop-app-code dbgsym package.

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [x] I have written a test plan and validated it for this PR
