### PR TITLE
Display a banner in the JI regarding the noble migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ fix: ruff ## Apply automatic fixes.
 .PHONY: html-lint
 html-lint:  ## Validate HTML in web application template files.
 	@echo "███ Linting application templates..."
-	@html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation,names,quotation \
+	@html_lint.py --printfilename --disable=optional_tag,extra_whitespace,indentation,names,quotation,protocol \
 		securedrop/source_templates/*.html securedrop/journalist_templates/*.html
 	@echo
 

--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any, Optional, Tuple, Union
 
 import i18n
+import server_os
 import template_filters
 import version
 from db import db
@@ -54,6 +55,11 @@ def create_app(config: SecureDropConfig) -> Flask:
 
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     app.config["SQLALCHEMY_DATABASE_URI"] = config.DATABASE_URI
+
+    # Check if the server OS is past EOL; if so, we'll display banners
+    app.config["OS_PAST_EOL"] = server_os.is_os_past_eol()
+    app.config["OS_NEEDS_MIGRATION_FIXES"] = server_os.needs_migration_fixes()
+
     db.init_app(app)
 
     class JSONEncoder(json.JSONEncoder):
@@ -109,6 +115,8 @@ def create_app(config: SecureDropConfig) -> Flask:
         """Store commonly used values in Flask's special g object"""
 
         i18n.set_locale(config)
+        g.show_os_past_eol_warning = app.config["OS_PAST_EOL"]
+        g.show_os_needs_migration_fixes = app.config["OS_NEEDS_MIGRATION_FIXES"]
 
         if InstanceConfig.get_default().organization_name:
             g.organization_name = (  # pylint: disable=assigning-non-slot

--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -18,6 +18,15 @@
 <body>
 
   {% if session.logged_in() %}
+  {% if g.show_os_past_eol_warning %}
+  <div id="os-past-eol" class="alert-banner">
+    {{ gettext('<strong>Critical:</strong>&nbsp;&nbsp;The operating system used by your SecureDrop servers has reached its end-of-life. A manual update is required to re-enable the Source Interface and remain safe. Please contact your administrator. <a href="https://securedrop.org/focal-eol" rel="noreferrer">Learn More</a>') }}
+  </div>
+  {% elif g.show_os_needs_migration_fixes %}
+  <div id="os-near-eol" class="alert-banner">
+    {{ gettext('<strong>Important:</strong>&nbsp;&nbsp;Your SecureDrop server needs manual attention to resolve issues blocking automatic upgrade to the next operating system. Please contact your adminstrator. <a href="https://securedrop.org/focal-eol" rel="noreferrer">Learn More</a>') }}
+  </div>
+  {% endif %}
   <nav aria-label="{{ gettext('Navigation') }}">
     <a href="#main" class="visually-hidden until-focus">{{ gettext('Skip to main content') }}</a>
     {{ gettext('Logged on as') }}

--- a/securedrop/server_os.py
+++ b/securedrop/server_os.py
@@ -1,6 +1,12 @@
 import functools
+import json
+from datetime import date
+from pathlib import Path
 
 FOCAL_VERSION = "20.04"
+NOBLE_VERSION = "24.04"
+
+FOCAL_ENDOFLIFE = date(2025, 4, 2)
 
 
 @functools.lru_cache
@@ -12,3 +18,33 @@ def get_os_release() -> str:
                 version_id = line.split("=")[1].strip().strip('"')
                 break
     return version_id
+
+
+def is_os_past_eol() -> bool:
+    """
+    Check if it's focal and if today is past the official EOL date
+    """
+    return get_os_release() == FOCAL_VERSION and date.today() >= FOCAL_ENDOFLIFE
+
+
+def needs_migration_fixes() -> bool:
+    """
+    See if the check script has flagged any issues
+    """
+    if get_os_release() != FOCAL_VERSION:
+        return False
+    state_path = Path("/etc/securedrop-noble-migration.json")
+    if not state_path.exists():
+        # Script hasn't run yet
+        return False
+    try:
+        contents = json.loads(state_path.read_text())
+    except json.JSONDecodeError:
+        # Invalid output from the script is an error
+        return True
+    if "error" in contents:
+        # Something went wrong with the script itself,
+        # it needs manual fixes.
+        return True
+    # True if any of the checks failed
+    return not all(contents.values())

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -419,6 +419,12 @@ msgstr ""
 msgid "Can't scan the barcode? You can manually pair FreeOTP with this account by entering the following two-factor secret into the app:"
 msgstr ""
 
+msgid "<strong>Critical:</strong>&nbsp;&nbsp;The operating system used by your SecureDrop servers has reached its end-of-life. A manual update is required to re-enable the Source Interface and remain safe. Please contact your administrator. <a href=\"https://securedrop.org/focal-eol\" rel=\"noreferrer\">Learn More</a>"
+msgstr ""
+
+msgid "<strong>Important:</strong>&nbsp;&nbsp;Your SecureDrop server needs manual attention to resolve issues blocking automatic upgrade to the next operating system. Please contact your adminstrator. <a href=\"https://securedrop.org/focal-eol\" rel=\"noreferrer\">Learn More</a>"
+msgstr ""
+
 msgid "Navigation"
 msgstr ""
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

#### Display a banner in the JI regarding the noble migration

This is largely copied from the same functionality that was implemented during the focal migration (ecfecea).

There are two banners that can be seen:
    
OS_PAST_EOL is in effect after April 2, 2025 if the system is still
running on focal. The Source Interface automatically disables itself and
the Journalist Interface will display a banner informing journalists to
contact their administrator.

OS_NEEDS_MIGRATION_FIXES will display a notice in the Journalist
Interface if the check script has run and found issues that need
resolution. It doesn't affect the Source Interface.

The banners point at <https://securedrop.org/focal-eol>, which will be
set up as a redirect to the relevant documentation.

Both checks are done during startup, which means if the state changes
(e.g. disk space is freed up or a systemd unit fails), the banner state
will only change after the nightly reboot.

#### Disable "protocol" check from html_lint.py

This actively dissuades from using HTTPS URLs, favoring
protocol-relative ones. Even ignoring HTTPS-only URLs as a best
practice, given most onion services are hosted as HTTP sites,
they'd become HTTP links instead of HTTPS.

So let's just suppress this rule and link to the correct protocol.

Refs #7322

## Testing

How should the reviewer test this PR?

* [ ] visual review
* [ ] CI passes 
* [ ] if you create `/etc/securedrop-noble-migration.json` in the dev container with a false value, the migration banner will be triggered
   * [ ] the way this file is interpreted is consistent with https://github.com/freedomofpress/securedrop/pull/7334
* [ ] if you change the `FOCAL_ENDOFLIFE` date in server_os.py  to 2024 or some other past date, the EOL banner will be triggered.

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
- [ ] I have updated AppArmor rules to include the change
- [ ] I have written a test plan and validated it for this PR
- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
