### PR TITLE
Switch systemd units to use Type=exec instead of Type=oneshot

### DIFF
--- a/securedrop/debian/config/lib/systemd/system/securedrop-cleanup-ossec.service
+++ b/securedrop/debian/config/lib/systemd/system/securedrop-cleanup-ossec.service
@@ -2,6 +2,6 @@
 Description=Cleanup OSSEC diff queue
 
 [Service]
-Type=oneshot
+Type=exec
 ExecStart=/usr/bin/securedrop-cleanup-ossec.py
 User=root

--- a/securedrop/debian/config/lib/systemd/system/securedrop-reboot-required.service
+++ b/securedrop/debian/config/lib/systemd/system/securedrop-reboot-required.service
@@ -2,6 +2,6 @@
 Description=Touch /var/run/reboot-required file
 
 [Service]
-Type=oneshot
+Type=exec
 ExecStart=/usr/bin/touch /var/run/reboot-required
 User=root

--- a/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.service
+++ b/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.service
@@ -4,7 +4,7 @@ ConditionPathExists|=/usr/sbin/ufw
 ConditionPathExists|=/usr/sbin/haveged
 
 [Service]
-Type=oneshot
+Type=exec
 Environment="DEBIAN_FRONTEND=noninteractive"
 ExecStart=/usr/bin/apt-get purge --yes ufw haveged
 User=root


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes

`oneshot` is designed to be used with RemainAfterExit, but we don't need that nor use it. After reviewing
<https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html>, `exec` appears to be the correct type since we want the service to be running once the binary has started, not once it's finished.

Practically this shouldn't make a big difference except that `systemctl start <name>` won't wait for the entire command to complete.

Fixes #7349.

## Testing

How should the reviewer test this PR?

* [x] staging CI passes
* [x] visual review

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
