### PR TITLE
Only try to apply grsec_lock once

### DIFF
--- a/install_files/ansible-base/roles/grsecurity/tasks/apply_grsec_lock.yml
+++ b/install_files/ansible-base/roles/grsecurity/tasks/apply_grsec_lock.yml
@@ -22,7 +22,6 @@
   sysctl:
     name: "{{ item.name }}"
     value: "{{ item.value }}"
-    sysctl_set: yes
     state: present
     reload: yes
   with_items: "{{ grsec_sysctl_flags }}"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Currently we specify both `sysctl_set: yes` and `reload: yes` when setting sysctl settings, which ends up with it being applied twice, first with `sysctl -w` (sysctl_set) and then through `sysctl -p` (reload).

With noble/Linux 6.6, setting the lock twice errors out, so just enable it once with `sysctl -p`. This is also closer to what the kernel will do normally when booting in which the whole file is loaded at once.

Refs #7323.

## Testing

How should the reviewer test this PR?

* [ ] staging CI passes (this is a no-op, but tests will verify the sysctl flags are being applied)
* [ ] visual review

## Deployment

Any special considerations for deployment? only affects new installs, which is where the bug is

## Checklist

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

