### PR TITLE
Have migrate-ssh-group handle the source group not existing (fresh install)

### DIFF
--- a/securedrop/debian/config/usr/bin/securedrop-migrate-ssh-group.py
+++ b/securedrop/debian/config/usr/bin/securedrop-migrate-ssh-group.py
@@ -21,7 +21,12 @@ def main() -> None:
         print(f"Creating group {DEST_GROUP}")
         subprocess.run(["groupadd", DEST_GROUP], check=True)
 
-    source_group_info = grp.getgrnam(SOURCE_GROUP)
+    try:
+        source_group_info = grp.getgrnam(SOURCE_GROUP)
+    except KeyError:
+        # Source group doesn't exist, probably a new install.
+        print(f"Group {SOURCE_GROUP} does not exist; stopping migration")
+        return
     source_users = source_group_info.gr_mem
     print(f"Need to migrate: {source_users}")
 


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

On a fresh install, the source group doesn't exist, so it would fail with a KeyError when trying to look up the group's membership.

Since this is only possible on a new install or post-focal upgrade, we can short circuit and skip the rest of the script.


## Testing

How should the reviewer test this PR?

* [ ] try noble fresh install and not have this script fail

## Deployment

Any special considerations for deployment? This handles the fresh install case.

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
