### PR TITLE
Fix typo of securedrop-reboot-required unit in testinfra tests

### DIFF
--- a/molecule/testinfra/common/test_automatic_updates.py
+++ b/molecule/testinfra/common/test_automatic_updates.py
@@ -221,7 +221,7 @@ def test_reboot_required_timer(host):
             assert cmd.rc == 0
         cmd = host.run("systemctl start securedrop-reboot-required")
         assert cmd.rc == 0
-        while host.service("securedrop-reboot-requried").is_running:
+        while host.service("securedrop-reboot-required").is_running:
             time.sleep(1)
         assert host.file("/var/run/reboot-required").exists
 


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

This is a hard error on noble but was silently ignored on focal and just happened to pass because of how fast the systemd unit is.

## Testing

How should the reviewer test this PR?

* [ ] visual review
* [ ] CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
