### PR TITLE
Add safety exclude for #73889,73969 (inapplicable werkzeug CVEs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,8 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 71684 \
 		--ignore 73302 \
 		--ignore 73711 \
+		--ignore 73889 \
+		--ignore 73969 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Excludes pyup #73889 and #73969 from safety checks (already deemed inapplicable to us)