### PR TITLE
ci(`reproducible-debs`): don't catch `$PKG-dbgsym` in glob for `$PKG`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,5 +64,5 @@ jobs:
           for pkg in ossec-agent ossec-server securedrop-config securedrop-keyring securedrop-ossec-agent securedrop-ossec-server
           do
               echo "Checking ${pkg}..."
-              diffoscope ${{ matrix.ubuntu_version }}-one/${pkg}*.deb ${{ matrix.ubuntu_version }}-two/${pkg}*.deb
+              diffoscope ${{ matrix.ubuntu_version }}-one/${pkg}_*.deb ${{ matrix.ubuntu_version }}-two/${pkg}_*.deb
           done


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #7364 by narrowing the glob to diffoscope to exclude `$PKG-dbgsym*.deb` for `$PKG*.deb`.

## Testing

- [ ] Visual review.
- [ ] Pick one of the `reproducible-debs` jobs that's run on this pull request and confirm that it still diffoscopes all of:
    https://github.com/freedomofpress/securedrop/blob/6ad1fa95330c4f36c3144cb871620c64d8bc1f94/.github/workflows/build.yml#L64

## Deployment

CI-only; no deployment considerations.