### PR TITLE
Wipe and regenerate Redis password when restoring from backups

### DIFF
--- a/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
+++ b/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
@@ -121,7 +121,24 @@
     exclude: "var/lib/tor,etc/tor/torrc"
   when: restore_skip_tor
 
-- name: Reconfigure securedrop-app-code
+- name: Remove Redis password line from restored config.py, if it exists
+  lineinfile:
+    state: absent
+    path: /var/www/securedrop/config.py
+    regexp: "^REDIS_PASSWORD = .*$"
+
+- name: Remove /var/www/securedrop/rq_config.py if it exists
+  file:
+    state: absent
+    path: /var/www/securedrop/rq_config.py
+
+- name: Remove Redis password line from /etc/redis/redis.conf, if it exists
+  lineinfile:
+    path: /etc/redis/redis.conf
+    state: absent
+    regexp: "^requirepass .*$"
+
+- name: Reconfigure securedrop-app-code, regenerating Redis config vi postint
   command: dpkg-reconfigure securedrop-app-code
 
 - name: Reconfigure securedrop-config


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #7328 .

Updates the ansible `restore` role to remove and regenerate the Redis password.

## Testing

- set up a production SecureDrop instance (h/w or virtual) using the current release, and add journalist accounts and sources/submissions
- take a backup of the system with `./securedrop-admin backup`
- check the current redis password, eg. with `ssh app sudo cat /etc/redis/redis.conf`
- switch to this branch on the Admin workstation
- restore from the backup file with `./securedrop-admin restore <path to backup>`
  - [x] verify that the backup completes successfully and expected accounts were restored
  - [x] verify that the Redis password has changed and that the same password is listed in `/var/www/securedrop/config.py`, `/var/www/securedrop/rq_config.py`, and `/etc/redis/redis.conf`
  - [x] verify that you can create a new source account and reply to it in the journalist interface.

## Checklist


### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation
