### PR TITLE
Prepare 2.11.0-rc1 version and changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,77 @@
 
 ## 2.11.0~rc1
 
+The main focus for this release was to prepare SecureDrop servers for upgrading
+to Ubuntu 24.04 (Noble) next year. Other maintenance changes are also included.
+
+### Ubuntu 24.04 (Noble) upgrade
+
+* Support building packages on noble (#7273, #7247, #7319)
+* Add a noble migration check script (#7334, #7363)
+* Use Type=exec instead of Type=oneshot for systemd units (#7350)
+* Make Ansible variables distro-agnostic (#7356)
+* Apply grsec_lock once only (#7353)
+* Stop setting vm.heap_stack_gap and net.ipv4 sysctl flags via Ansible (#7324)
+* Use "sdssh" group instead of internal-only "ssh" group for access control (#7317, #7355)
+* Add timed job to clean out old OSSEC diff and state files (#7327)
+* Remove ufw from new and existing installs (#7315)
+* Update apache config templates to be distro-agnostic (#7301)
+* Install backup script on app server via Debian package (#7331)
+* Ensure sources.list is absent on noble (#7342)
+* Overwrite sources.list.d/ubuntu.sources on noble (#7307)
+
+### Web applications
+
+* Add a banner in the Journalist Interface, in preparation for the noble migration (#7348)
+* Use sqlalchemy.LargeBinary instead of deprecated Binary (#7264)
+* Upgrade sequoia-openpgp from 1.21.1 to 1.21.2 (#7248)
+* Import escape from markupsafe, not flask (#7252)
+* Ignore safety alerts:
+  * ignore Safety 73711 in cryptography (#7339)
+  * ignore Safety 73889, 73969 in werkzeug (#7361)
+
+### Operations
+
+* Regenerate Redis password on restoring from server backup (#7328)
+* Replace reboot-flag cron job with a systemd timer (#7337)
+* Remove haveged package, if installed (#7335, 7341)
+* Don't install apt-transport-https transitional package (#7303)
+* Remove unused Ansible restrict_direct_access_{app,mon} roles (#7302)
+* Remove unused Ansible sysctl_flags_ipv6 variables (#7300)
+* Prompt "sdadmin" for the default SSH username (#7309)
+* Remove unused load_iptables script (#7282)
+* Remove unused SSHd config from cloud-init (#7318)
+
+### Development and CI
+
+* Publish versions of packages with debug symbols (#7347, #7365)
+* Preserve screenshots from translation test CI job (#7240)
+* Make backport.py more flexible for complex pull requests (#7260)
+* Install xz-utils in diffoscope CI job (#7344)
+* Don't return True from test_swap_disabled for monitor server, skip test instead (#7320)
+* Run admin CI tests on bookworm (#7212)
+* Use a single pass in ansible to install local packages (#7261)
+* Upgrade tbselenium from 0.8.1 to 0.9.0 (#7274, #7271)
+* Update geckodriver from 0.33.0 to 0.35.0 (#7268)
+* Standardize git message formats in version updater (#7263)
+* Speed up update-python3-dependencies using uv (#7234)
+* Upgrade ruff, remove black, add ruff formatting fixes (#7233, #7246)
+* Remove unused devops/scripts/aws-jenkins-venv.sh (#7238)
+* Ignore safety alerts:
+  * Ignore CVE-2024-8775 in ansible-core (#7269)
+* Update dependencies:
+  * Upgrade cargo-vet from 0.9.0 to 0.10.0 (#7343)
+  * Upgrade Rust toolchain from 1.78.0 to 1.81.0 (#7232)
+
+#### In support of Ubuntu 24.04 (Noble) upgrade
+
+* Support noble dev environment (#7249)
+* Run basic lint CI against Ubuntu noble and Python 3.12 (#7242)
+* Remove tests checking that no apparmor profiles are complaining (#7308)
+* Remove test_securedrop_application_apt_dependencies test (#7305)
+* Inspect grsec_lock as root in testinfra (#7304)
+* Upgrade paramiko from 2.7.2 to 2.10.6 (#7280, #7321)
+
 ## 2.10.1
 
 * Update translations (#7143, #7259)
@@ -586,7 +657,7 @@ our [blog post](https://securedrop.org/news/securedrop-2_10_0-released/) for mor
 
 * Provide end-of-life messaging and disable source interface after Xenial End-of-life (#5789)
 * Adds safe deletion functionality to the Journalist Interface (#5770, #5827)
-* source\_app.utils.normalizer\_timestamps will no longer create an empty file (#5724)
+* source_app.utils.normalizer_timestamps will no longer create an empty file (#5724)
 
 ### Operations
 
@@ -1035,7 +1106,7 @@ our [blog post](https://securedrop.org/news/securedrop-2_10_0-released/) for mor
 * Added support for asynchronous jobs in dev container (#4392)
 * Updated Qubes staging environment to use Xenial by default (#4344, #4228)
 * Updated dev environment to use Xenial by default (#4213)
-* Fixed Dockerfile apt caching error, fixed error in create\_dev\_data.py (#4353)
+* Fixed Dockerfile apt caching error, fixed error in create_dev_data.py (#4353)
 * Added support for use of VNC during functional tests (#4288, #4324)
 * Added support for staging-specific data to create-dev-data.py (#4298)
 * Removed firefox and other packages from app-test Ansible role (#4277)

--- a/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
+++ b/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
@@ -138,7 +138,7 @@
     state: absent
     regexp: "^requirepass .*$"
 
-- name: Reconfigure securedrop-app-code, regenerating Redis config vi postint
+- name: Reconfigure securedrop-app-code, regenerating Redis config via postint
   command: dpkg-reconfigure securedrop-app-code
 
 - name: Reconfigure securedrop-config

--- a/securedrop/debian/changelog
+++ b/securedrop/debian/changelog
@@ -2,7 +2,7 @@ securedrop (2.11.0~rc1) unstable; urgency=medium
 
   * see changelog.md
 
- -- SecureDrop Team <securedrop@freedom.press>  Tue, 22 Oct 2024 16:50:19 -0400
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 09 Dec 2024 17:38:39 -0500
 
 securedrop (2.10.1+focal) focal; urgency=medium
 
@@ -16,35 +16,11 @@ securedrop (2.10.0+focal) focal; urgency=medium
 
  -- SecureDrop Team <securedrop@freedom.press>  Tue, 17 Sep 2024 16:05:58 -0400
 
-securedrop (2.10.0~rc1+focal) focal; urgency=medium
-
-  * see changelog.md
-
- -- SecureDrop Team <securedrop@freedom.press>  Thu, 29 Aug 2024 14:42:38 -0700
-
 securedrop (2.9.0+focal) focal; urgency=medium
 
   * see changelog.md 
 
  -- SecureDrop Team <securedrop@freedom.press>  Thu, 27 Jun 2024 13:42:10 -0400
-
-securedrop (2.9.0~rc3+focal) focal; urgency=medium
-
-  * see changelog.md 
-
- -- SecureDrop Team <securedrop@freedom.press>  Tue, 25 Jun 2024 17:27:17 -0400
-
-securedrop (2.9.0~rc2+focal) focal; urgency=medium
-
-  * see changelog.md
-
- -- SecureDrop Team <securedrop@freedom.press>  Thu, 13 Jun 2024 17:42:18 -0400
-
-securedrop (2.9.0~rc1+focal) focal; urgency=medium
-
-  * see changelog.md
-
- -- SecureDrop Team <securedrop@freedom.press>  Wed, 29 May 2024 11:32:58 -0400
 
 securedrop (2.8.0+focal) focal; urgency=medium
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Towards #7372 .

Changes proposed in this pull request:

- Updates version to 2.11.0-rc1 and updates changelog
- Fixes a typo in a recently-added Ansible task name
- adds a merge commit omitted in error when `release/2.11.0` was created.

Note that a noble-specific section has been added in the changelog, tracking work in support of the noble migration that does not immediately impact focal systems.

## Testing

- [ ] CI is green
- [ ] base is `release/2.11.0`
- [ ] Version updated correctly
- [ ] Changelog looks consistent

