### PR TITLE
Run securedrop-remove-packages hourly instead of daily

### DIFF
--- a/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.timer
+++ b/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.timer
@@ -2,7 +2,7 @@
 Description=Remove ufw and haveged if installed
 
 [Timer]
-OnCalendar=daily
+OnCalendar=hourly
 Persistent=true
 RandomizedDelaySec=5m
 


### PR DESCRIPTION


## Status

Ready for review 

## Description of Changes

This is an incredibly quick thing so let's run it more frequently so it is taken care of sooner and reduces the risk of the check script complaining that ufw is still present.

https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Calendar%20Events indicates that "hourly" is a supported shorthand.

## Testing

How should the reviewer test this PR?

* [ ] visual review

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
