### PR TITLE
Allow apache2 to read /etc/securedrop-noble-migration.json in apparmor

### DIFF
--- a/securedrop/debian/app-code/etc/apparmor.d/usr.sbin.apache2
+++ b/securedrop/debian/app-code/etc/apparmor.d/usr.sbin.apache2
@@ -70,6 +70,7 @@
   /etc/mime.types r,
   /etc/python3.12/sitecustomize.py r,
   /etc/python3.8/sitecustomize.py r,
+  /etc/securedrop-noble-migration.json r,
   /etc/services r,
   /etc/timezone r,
   /lib/x86_64-linux-gnu/libbz2.so.* mr,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Allow apache2 to read /etc/securedrop-noble-migration.json in apparmor

Needed to display the noble migration banner.

Found by @nathandyer 

## Testing

How should the reviewer test this PR?

* [ ] The JI works on a prod environment.

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
- [x] I have updated AppArmor rules to include the change

