### PR TITLE
Remove /etc/apt/apt.conf.d/zzzz-temp-installer-unattended-upgrade if it exists

### DIFF
--- a/securedrop/debian/securedrop-config.postinst
+++ b/securedrop/debian/securedrop-config.postinst
@@ -31,6 +31,10 @@ case "$1" in
     # Migrate the ssh group to sdssh
     securedrop-migrate-ssh-group.py
 
+    # Should not exist but might because of an Ubuntu installer bug that is
+    # now fixed: https://bugs.launchpad.net/subiquity/+bug/2053002
+    rm -f /etc/apt/apt.conf.d/zzzz-temp-installer-unattended-upgrade
+
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

A now-fixed bug in the Ubuntu installer caused this file to be created (<https://bugs.launchpad.net/subiquity/+bug/2053002>), just remove it if we find it since it affects our unattended-upgrades config and shouldn't be there anyways.

Fixes #7379.

## Testing

How should the reviewer test this PR?

* [x] visual review

## Deployment

Any special considerations for deployment? Unclear how to reproduce the bug, will only affect existing installs.

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
