### PR TITLE
[2.11.0] Backport "Run securedrop-remove-packages hourly instead of daily"

### DIFF
--- a/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.timer
+++ b/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.timer
@@ -2,7 +2,7 @@
 Description=Remove ufw and haveged if installed
 
 [Timer]
-OnCalendar=daily
+OnCalendar=hourly
 Persistent=true
 RandomizedDelaySec=5m
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7377.

## Testing

* [ ] CI is passing
* [x] base is `release/2.11.0`
* [x] Only contains changes from #7377 
