### PR TITLE
[2.11.0] Backport "Allow apache2 to read /etc/securedrop-noble-migration.json in apparmor"

### DIFF
--- a/securedrop/debian/app-code/etc/apparmor.d/usr.sbin.apache2
+++ b/securedrop/debian/app-code/etc/apparmor.d/usr.sbin.apache2
@@ -70,6 +70,7 @@
   /etc/mime.types r,
   /etc/python3.12/sitecustomize.py r,
   /etc/python3.8/sitecustomize.py r,
+  /etc/securedrop-noble-migration.json r,
   /etc/services r,
   /etc/timezone r,
   /lib/x86_64-linux-gnu/libbz2.so.* mr,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7378.

## Testing

* [ ] CI is passing
* [ ] base is `release/2.11.0`
* [ ] Only contains changes from #7378 #
