### PR TITLE
[2.11.0] Backport "Remove /etc/apt/apt.conf.d/zzzz-temp-installer-unattended-upgrade if it exists"

### DIFF
--- a/securedrop/debian/securedrop-config.postinst
+++ b/securedrop/debian/securedrop-config.postinst
@@ -31,6 +31,10 @@ case "$1" in
     # Migrate the ssh group to sdssh
     securedrop-migrate-ssh-group.py
 
+    # Should not exist but might because of an Ubuntu installer bug that is
+    # now fixed: https://bugs.launchpad.net/subiquity/+bug/2053002
+    rm -f /etc/apt/apt.conf.d/zzzz-temp-installer-unattended-upgrade
+
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7380.

## Testing

* [ ] CI is passing
* [x] base is `release/2.11.0`
* [x] Only contains changes from #7380 
