### PR TITLE
chore: grant support to Croatian (`hr`)

### DIFF
--- a/install_files/ansible-base/roles/tails-config/templates/desktop-journalist-icon.j2
+++ b/install_files/ansible-base/roles/tails-config/templates/desktop-journalist-icon.j2
@@ -14,6 +14,7 @@ Name[el]=Διεπαφή δημοσιογράφου του SecureDrop
 Name[es_ES]=Interfaz de periodista de SecureDrop
 Name[fr]=SecureDrop – Interface des journalistes
 Name[hi]=SecureDrop पत्रकार अंतराफलक
+Name[hr]=SecureDrop sučelje za novinare
 Name[is]=Blaðamannaviðmót SecureDrop
 Name[it]=Interfaccia giornalista di SecureDrop
 Name[nb_NO]=Journalistgrensesnitt for SecureDrop

--- a/install_files/ansible-base/roles/tails-config/templates/desktop-source-icon.j2
+++ b/install_files/ansible-base/roles/tails-config/templates/desktop-source-icon.j2
@@ -14,6 +14,7 @@ Name[el]=Διεπαφή πηγής του SecureDrop
 Name[es_ES]=Interfaz de fuente de SecureDrop
 Name[fr]=SecureDrop – Interface des sources
 Name[hi]=SecureDrop स्रोत अंतराफलक
+Name[hr]=SecureDrop sučelje za izvore
 Name[is]=Heimildarmannaviðmót SecureDrop
 Name[it]=Interfaccia fonte di SecureDrop
 Name[nb_NO]=Kildegrensesnitt for SecureDrop

--- a/install_files/ansible-base/roles/tails-config/templates/locale/LINGUAS
+++ b/install_files/ansible-base/roles/tails-config/templates/locale/LINGUAS
@@ -6,6 +6,7 @@ el
 es_ES
 fr
 hi
+hr
 is
 it
 nb_NO

--- a/securedrop/i18n.json
+++ b/securedrop/i18n.json
@@ -35,6 +35,10 @@
       "name": "Hindi",
       "desktop": "hi"
     },
+    "hr": {
+      "name": "Croatian",
+      "desktop": "hr"
+    },
     "is": {
       "name": "Icelandic",
       "desktop": "is"

--- a/securedrop/i18n.rst
+++ b/securedrop/i18n.rst
@@ -8,6 +8,7 @@
 * Spanish (``es_ES``)
 * French (``fr_FR``)
 * Hindi (``hi``)
+* Croatian (``hr``)
 * Icelandic (``is``)
 * Italian (``it_IT``)
 * Norwegian (``nb_NO``)


### PR DESCRIPTION
## Status

Ready for review; blocked on:

- #7362 


## Description of Changes

Grants support to Croatian (`hr`) per <https://developers.securedrop.org/en/latest/supported_languages.html#thresholds-for-translation-and-review-coverage>.


## Testing

- [x] Translation tests include `hr`.
- [x] Screenshots for `hr` are visibly in Croatian. 


## Deployment

This is worth calling out in release notes for interested organizations, but there's no deployment action *required*.