### PR TITLE
Don't use the word failed in a success message; triggers OSSEC

### DIFF
--- a/molecule/testinfra/common/test_release_upgrades.py
+++ b/molecule/testinfra/common/test_release_upgrades.py
@@ -62,9 +62,5 @@ def test_migration_check(host):
             print(cmd.stdout)
             # We'll fail in the next line after this
         assert "error" not in contents
-        # staging CI jobs don't have enough free space, so just check
-        # that it returned a value for it
-        assert "free_space" in contents
-        del contents["free_space"]
         # All the values should be True
         assert all(contents.values())

--- a/molecule/testinfra/mon/test_ossec_ruleset.py
+++ b/molecule/testinfra/mon/test_ossec_ruleset.py
@@ -25,3 +25,19 @@ def test_ossec_expected_alerts_are_present(host, log_event):
         assert alert_level == log_event["level"]
         rule_id = rule_id_regex.findall(c.stderr)[0]
         assert rule_id == log_event["rule_id"]
+
+
+def test_noble_migration_check(host):
+    """
+    Verify the noble migration check does not generate OSSEC notifications
+
+    Regression check for <https://github.com/freedomofpress/securedrop/issues/7393>;
+    we are assuming that no checks will fail; otherwise
+    test_release_upgrades.py::test_migration_check would've already failed
+    """
+    if host.system_info.codename != "focal":
+        pytest.skip("only applicable/testable on focal")
+
+    with host.sudo():
+        cmd = host.run("securedrop-noble-migration-check | /var/ossec/bin/ossec-logtest")
+        assert "Alert to be generated" not in cmd.stderr

--- a/noble-migration/src/bin/check.rs
+++ b/noble-migration/src/bin/check.rs
@@ -264,7 +264,7 @@ fn check_systemd() -> Result<bool> {
         println!("systemd ERROR: some units are failed");
         Ok(false)
     } else {
-        println!("systemd OK: no failed units");
+        println!("systemd OK: all units are happy");
         Ok(true)
     }
 }


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

The line "systemd OK: no failed units" was triggering an OSSEC notification because "failed" is a bad word[1] that OSSEC alerts on.

So let's use the opportunity to focus on the positive instead of the negative and explain that in the success case, all the units are happy.

A regression test verifies that piping the output into ossec-logtest does not trigger any notifications. We already know that all the checks should be passing in a staging environment because of the test in test_release_upgrades.py. (The exemption for free space was a leftover from before 87c9af4ce23, which fixed the calcuation.)

[1] https://github.com/ossec/ossec-hids/blob/3.6.0/etc/rules/syslog_rules.xml#L21

Fixes #7393.
## Testing

How should the reviewer test this PR?

before:

* [x] install 2.11.0, you should get OSSEC notifications about this systemd OK line

after:

* [x] cherry-pick this patch onto the 2.11.0 release branch, build debs; install the new securedrop-config one on your system and run `sudo securedrop-noble-migration-check`, see the message is updated and that you get no OSSEC notifications

## Deployment

Any special considerations for deployment? n/a


