### PR TITLE
[2.11.1] Backport "Don't use the word failed in a success message; triggers OSSEC"

### DIFF
--- a/molecule/testinfra/common/test_release_upgrades.py
+++ b/molecule/testinfra/common/test_release_upgrades.py
@@ -62,9 +62,5 @@ def test_migration_check(host):
             print(cmd.stdout)
             # We'll fail in the next line after this
         assert "error" not in contents
-        # staging CI jobs don't have enough free space, so just check
-        # that it returned a value for it
-        assert "free_space" in contents
-        del contents["free_space"]
         # All the values should be True
         assert all(contents.values())

--- a/molecule/testinfra/mon/test_ossec_ruleset.py
+++ b/molecule/testinfra/mon/test_ossec_ruleset.py
@@ -25,3 +25,19 @@ def test_ossec_expected_alerts_are_present(host, log_event):
         assert alert_level == log_event["level"]
         rule_id = rule_id_regex.findall(c.stderr)[0]
         assert rule_id == log_event["rule_id"]
+
+
+def test_noble_migration_check(host):
+    """
+    Verify the noble migration check does not generate OSSEC notifications
+
+    Regression check for <https://github.com/freedomofpress/securedrop/issues/7393>;
+    we are assuming that no checks will fail; otherwise
+    test_release_upgrades.py::test_migration_check would've already failed
+    """
+    if host.system_info.codename != "focal":
+        pytest.skip("only applicable/testable on focal")
+
+    with host.sudo():
+        cmd = host.run("securedrop-noble-migration-check | /var/ossec/bin/ossec-logtest")
+        assert "Alert to be generated" not in cmd.stderr

--- a/noble-migration/src/bin/check.rs
+++ b/noble-migration/src/bin/check.rs
@@ -264,7 +264,7 @@ fn check_systemd() -> Result<bool> {
         println!("systemd ERROR: some units are failed");
         Ok(false)
     } else {
-        println!("systemd OK: no failed units");
+        println!("systemd OK: all units are happy");
         Ok(true)
     }
 }


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7394.

## Testing

* [x] CI is passing
* [x] base is `release/2.11.1`
* [x] Only contains changes from #7394 
