### PR TITLE
Run `make update-python3-requirements` in the dev container (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ update-admin-pip-requirements:  ## Update admin requirements.
 .PHONY: update-python3-requirements
 update-python3-requirements:  ## Update Python 3 requirements with pip-compile.
 	@echo "███ Updating Python 3 requirements files..."
-	@$(SDBIN)/update-requirements
+	@SLIM_BUILD=1 $(DEVSHELL) $(SDBIN)/update-requirements
 
 .PHONY: update-pip-requirements
 update-pip-requirements: update-admin-pip-requirements update-python3-requirements ## Update all requirements with pip-compile.


### PR DESCRIPTION


## Status

Ready for review 

## Description of Changes

Some packages, especially mod-wsgi, have dependencies on system packages and cannot universally be run on the host.

Moving it back into the container will be a bit slower, but overall it should still be noticibly faster than pre-uv.

Fixes #7245.
## Testing

* [x] running `make update-python3-requirements` works

## Deployment

Any special considerations for deployment? n/a

