### PR TITLE
Lint our GitHub Actions workflows with zizmor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
       artifact_id: ${{ steps.upload.outputs.artifact-id }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.8'

--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -14,6 +14,8 @@ jobs:
       CARGO_VET_VERSION: 0.10.0
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: actions/cache@v4
       id: cache-vet
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         run: |
           apt-get update && apt-get install --yes git
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install --yes --no-install-recommends \
@@ -46,6 +48,8 @@ jobs:
           - noble
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build image
         run: |
           UBUNTU_VERSION=${{ matrix.ubuntu_version }} DOCKER_BUILD_VERBOSE=true ./securedrop/bin/dev-shell true
@@ -63,6 +67,8 @@ jobs:
           - noble
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build image
         run: |
           UBUNTU_VERSION=${{ matrix.ubuntu_version }} DOCKER_BUILD_VERBOSE=true ./securedrop/bin/dev-shell true
@@ -80,6 +86,8 @@ jobs:
           - noble
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build image
         run: |
           UBUNTU_VERSION=${{ matrix.ubuntu_version }} DOCKER_BUILD_VERBOSE=true ./securedrop/bin/dev-shell true
@@ -99,6 +107,8 @@ jobs:
     container: rust:1.81.0
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           rustup component add rustfmt
@@ -116,6 +126,8 @@ jobs:
         run: |
           apt-get update && apt-get install --yes git libqt5designer5 python3-venv
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install Python dependencies
         run: |
           cd journalist_gui
@@ -131,6 +143,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run tests
         run: |
           make -C admin test

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -14,6 +14,8 @@ jobs:
       DOCKERIZE_VERSION: v0.6.1
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build container
         run: |
           podman build -t demo -f securedrop/dockerfiles/focal/python3/DemoDockerfile .

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,8 @@ jobs:
     container: rust:1.81.0
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Check Rust dependencies
         run: |
           make rust-audit
@@ -21,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.8'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -14,6 +14,8 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run staging tests on GCE
         run: |
           make ci-go

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -18,8 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       locales: ${{ steps.locales.outputs.locales }}
+    env:
+      GITHUB_ACTOR: ${{ github.actor }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Generate locale list
         id: locales
         run: |
@@ -28,7 +32,7 @@ jobs:
           # 2. A scheduled run
           # 3. A push to a `l10n-*` branch
           # Two and Three are checked above, so we just need to check One.
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.actor }}" = "weblate-fpf" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${GITHUB_ACTOR}" = "weblate-fpf" ]; then
             echo "locales=$(make supported-locales)" >> "$GITHUB_OUTPUT"
           else
             if [ "${{ github.event_name }}" != "pull_request" ]; then
@@ -48,14 +52,18 @@ jobs:
       fail-fast: false
       matrix:
         locale: ${{ fromJson(needs.locales.outputs.locales) }}
+    env:
+      LOCALES: ${{ matrix.locale }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build image
         run: |
           DOCKER_BUILD_VERBOSE=true ./securedrop/bin/dev-shell true
       - name: Run translation tests
         run: |
-          LOCALES="${{ matrix.locale }}" make translation-test
+          make translation-test
       - name: Save screenshots
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -110,10 +110,16 @@ yamllint:  ## Lint YAML files (does not validate syntax!).
 	@yamllint --strict .
 	@echo
 
+.PHONY: zizmor
+zizmor:  ## Lint GitHub Actions workflows.
+	@echo "███ Linting GitHub Actions workflows..."
+	@zizmor .
+	@echo
+
 # While the order mostly doesn't matter here, keep "check-ruff" first, since it
 # gives the broadest coverage and runs (and therefore fails) fastest.
 .PHONY: lint
-lint: check-ruff ansible-config-lint app-lint html-lint shellcheck typelint yamllint check-strings check-supported-locales check-desktop-files ## Runs all lint checks
+lint: check-ruff ansible-config-lint app-lint html-lint shellcheck typelint yamllint zizmor check-strings check-supported-locales check-desktop-files ## Runs all lint checks
 
 .PHONY: safety
 safety:  ## Run `safety check` to check python dependencies for vulnerabilities.

--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -43,3 +43,4 @@ translate-toolkit
 urllib3>=1.26.5
 uv
 yamllint
+zizmor

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -1045,3 +1045,19 @@ yamllint==1.29.0 \
     --hash=sha256:5153bf9f8205aa9dc6af6217e38bd4f5baf09d9a7c6f4ae1e23f90d9c00c49c5 \
     --hash=sha256:66a755d5fbcbb8831f1a9568676329b5bac82c37995bcc9afd048b6459f9fa48
     # via -r requirements/python3/develop-requirements.in
+zizmor==0.10.0 \
+    --hash=sha256:01743f434d8dacd3d4009999e92ddf2952c2138bfc10ab2eb1e2e592f31cb0a2 \
+    --hash=sha256:1c64fcd25149107aa6a5435fa2cf909b8fd92af2a7dfb8650aad59a1eb10f35e \
+    --hash=sha256:20eb70b037116ef29f4b90f298801f3cccb54f0a04e3454ae0ee31e70d554d77 \
+    --hash=sha256:4894141e6f0adb4821d377aad91cbcb699c88ae5c816267189926b2d40becdd3 \
+    --hash=sha256:514c5f0e104008884e4e0a2cdd1ad4cc63fc280791f43a8521f3fb96a7f264af \
+    --hash=sha256:7bbf8275ac411682200217a60a3f8ce8bf3b545ff9a1ea3c2d26436ad4ca81e1 \
+    --hash=sha256:7d74d430feb5c0a28fba3a200eac1ae6ce7e7ecbf593f386149f9c41fa02aeea \
+    --hash=sha256:85da4c1dd42b031aad3550024c6f9d2525668f04285b4280454c278153383e59 \
+    --hash=sha256:948eda1c8a33ac28946972f4672fddd09dd9ad793934b6f5d572b74acce1ec15 \
+    --hash=sha256:b88048c5b11af489ff37ff064fdd9a9cad6ea9cc34e8c25a9d2e196819859cf1 \
+    --hash=sha256:c9319af1c1806525aa18501488be2f9ba9f03b16ce8cb1c10e98b563e89aacfc \
+    --hash=sha256:d74ec6b1547f529756315238805fdfb58b59b09b6b7b85b49d38a68dc96aa706 \
+    --hash=sha256:ecac7a28aef6c7e058e0292da6f04345cfd21d36def7acff0038500544bd48c1 \
+    --hash=sha256:ffdacfddbb4eb4cbb0126e3875eb21a453414be47fe423824fdf1946fff9cc02
+    # via -r requirements/python3/develop-requirements.in


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes

zizmor is a new tool to lint GitHub Actions workflows. For the most part our workflows are pretty low risk since we don't give it a bunch of credentials, but we can avoid issues in the future by locking them down now.

Two overall issues needed to be fixed:
* setting persist-credentials: false for actions/checkout, which we do everywhere except in the workflows that need to push.
* Don't use template expansion when we can use a normal bash variable.

While zizmor is written in Rust, it is also shipped as a prebuilt binary via PyPI, so we can set it as a pip dependency and run it as part of our normal lint CI.

Refs <https://github.com/freedomofpress/securedrop-tooling/issues/18>.

## Testing

How should the reviewer test this PR?

* [ ] visual review
* [ ] CI passes

## Deployment

Any special considerations for deployment? n/a

