### PR TITLE
Switch systemd services to use Type=exec instead of Type=simple

### DIFF
--- a/molecule/testinfra/app-code/test_securedrop_rqrequeue.py
+++ b/molecule/testinfra/app-code/test_securedrop_rqrequeue.py
@@ -17,6 +17,7 @@ def test_securedrop_rqrequeue_service(host):
             "Wants=redis-server.service",
             "",
             "[Service]",
+            "Type=exec",
             f'Environment=PYTHONPATH="{securedrop_test_vars.securedrop_code}:{securedrop_test_vars.securedrop_venv_site_packages}"',
             f"ExecStart={securedrop_test_vars.securedrop_venv_bin}/python /var/www/securedrop/"
             "scripts/rqrequeue --interval 60",

--- a/molecule/testinfra/app-code/test_securedrop_rqworker.py
+++ b/molecule/testinfra/app-code/test_securedrop_rqworker.py
@@ -19,6 +19,7 @@ def test_securedrop_rqworker_service(host):
             "Wants=redis-server.service",
             "",
             "[Service]",
+            "Type=exec",
             f'Environment=PYTHONPATH="{securedrop_test_vars.securedrop_code}:{securedrop_test_vars.securedrop_venv_site_packages}"',
             f"ExecStart={securedrop_test_vars.securedrop_venv_bin}/rqworker -c rq_config",
             "PrivateDevices=yes",

--- a/molecule/testinfra/app-code/test_securedrop_shredder_configuration.py
+++ b/molecule/testinfra/app-code/test_securedrop_shredder_configuration.py
@@ -16,6 +16,7 @@ def test_securedrop_shredder_service(host):
             "Description=SecureDrop shredder",
             "",
             "[Service]",
+            "Type=exec",
             f'Environment=PYTHONPATH="{securedrop_test_vars.securedrop_code}:{securedrop_test_vars.securedrop_venv_site_packages}"',
             f"ExecStart={securedrop_test_vars.securedrop_venv_bin}/python /var/www/securedrop/"
             "scripts/shredder --interval 60",

--- a/molecule/testinfra/app-code/test_securedrop_source_deleter_configuration.py
+++ b/molecule/testinfra/app-code/test_securedrop_source_deleter_configuration.py
@@ -15,6 +15,7 @@ def test_securedrop_source_deleter_service(host):
             "Description=SecureDrop Source deleter",
             "",
             "[Service]",
+            "Type=exec",
             f'Environment=PYTHONPATH="{securedrop_test_vars.securedrop_code}:{securedrop_test_vars.securedrop_venv_site_packages}"',
             f"ExecStart={securedrop_test_vars.securedrop_venv_bin}/python /var/www/securedrop/"
             "scripts/source_deleter --interval 10",

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop-check-disconnected-db-submissions.service
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop-check-disconnected-db-submissions.service
@@ -2,6 +2,7 @@
 Description=job to check for disconnected submissions in the database
 
 [Service]
+Type=exec
 ExecStart=/bin/bash -c "/var/www/securedrop/manage.py check-disconnected-db-submissions > /var/lib/securedrop/disconnected_db_submissions.txt"
 PrivateDevices=yes
 PrivateTmp=yes

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop-check-disconnected-fs-submissions.service
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop-check-disconnected-fs-submissions.service
@@ -2,6 +2,7 @@
 Description=job to check for disconnected submissions on the filesystem
 
 [Service]
+Type=exec
 ExecStart=/bin/bash -c "/var/www/securedrop/manage.py check-disconnected-fs-submissions > /var/lib/securedrop/disconnected_fs_submissions.txt"
 PrivateDevices=yes
 PrivateTmp=yes

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop-clean-tmp.service
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop-clean-tmp.service
@@ -2,6 +2,7 @@
 Description=job to clean SecureDrop tmp dir daily
 
 [Service]
+Type=exec
 ExecStart=/var/www/securedrop/manage.py clean-tmp
 PrivateDevices=yes
 PrivateTmp=yes

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop-remove-pending-sources.service
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop-remove-pending-sources.service
@@ -2,6 +2,7 @@
 Description=job to remove pending SecureDrop sources daily
 
 [Service]
+Type=exec
 ExecStart=/var/www/securedrop/manage.py remove-pending-sources
 PrivateDevices=yes
 PrivateTmp=yes

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop-submissions-today.service
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop-submissions-today.service
@@ -2,6 +2,7 @@
 Description=Update the number of submissions in the past 24h
 
 [Service]
+Type=exec
 ExecStart=/var/www/securedrop/manage.py were-there-submissions-today
 PrivateDevices=yes
 PrivateTmp=yes

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop_rqrequeue.service
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop_rqrequeue.service
@@ -4,6 +4,7 @@ After=redis-server.service
 Wants=redis-server.service
 
 [Service]
+Type=exec
 Environment=PYTHONPATH="/var/www/securedrop:/opt/venvs/securedrop-app-code/lib/python3.8/site-packages"
 ExecStart=/opt/venvs/securedrop-app-code/bin/python /var/www/securedrop/scripts/rqrequeue --interval 60
 PrivateDevices=yes

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop_rqworker.service
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop_rqworker.service
@@ -4,6 +4,7 @@ After=redis-server.service
 Wants=redis-server.service
 
 [Service]
+Type=exec
 Environment=PYTHONPATH="/var/www/securedrop:/opt/venvs/securedrop-app-code/lib/python3.8/site-packages"
 ExecStart=/opt/venvs/securedrop-app-code/bin/rqworker -c rq_config
 PrivateDevices=yes

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop_shredder.service
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop_shredder.service
@@ -2,6 +2,7 @@
 Description=SecureDrop shredder
 
 [Service]
+Type=exec
 Environment=PYTHONPATH="/var/www/securedrop:/opt/venvs/securedrop-app-code/lib/python3.8/site-packages"
 ExecStart=/opt/venvs/securedrop-app-code/bin/python /var/www/securedrop/scripts/shredder --interval 60
 PrivateDevices=yes

--- a/securedrop/debian/app-code/lib/systemd/system/securedrop_source_deleter.service
+++ b/securedrop/debian/app-code/lib/systemd/system/securedrop_source_deleter.service
@@ -2,6 +2,7 @@
 Description=SecureDrop Source deleter
 
 [Service]
+Type=exec
 Environment=PYTHONPATH="/var/www/securedrop:/opt/venvs/securedrop-app-code/lib/python3.8/site-packages"
 ExecStart=/opt/venvs/securedrop-app-code/bin/python /var/www/securedrop/scripts/source_deleter --interval 10
 PrivateDevices=yes


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Per <https://github.com/freedomofpress/securedrop/pull/7350#pullrequestreview-2459744086>, exec is the ideal semantics we want, in which systemd verifies it can actually execute the command we want before marking the unit as running.

Aside from that very subtle difference, there should be no user-facing changes.

Fixes #7358.

## Testing

* [x] Visual review
* [x] CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist
- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
