### PR TITLE
Use a single script to set and reset Redis password

### DIFF
--- a/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
+++ b/install_files/ansible-base/roles/app/tasks/initialize_securedrop_app.yml
@@ -126,47 +126,18 @@
   tags:
     - securedrop_config
 
-- name: Generate 32-byte value for "redis password".
-  shell: "head -c 32 /dev/urandom | base64"
+- name: Generate and set redis password in config.py, rq_config.py, and redis.conf.
+  command: /usr/bin/securedrop-set-redis-auth.py reset
   register: redis_password
   when: not config.stat.exists
   tags:
     - securedrop_config
 
-- name: Add 32-byte value for "redis password" to config.py.
-  lineinfile:
-    dest: "{{ securedrop_code }}/config.py"
-    regexp: "redis_password"
-    line: "REDIS_PASSWORD = '{{ redis_password.stdout }}'"
-  when: not config.stat.exists
-  tags:
-    - securedrop_config
-
-- name: Create rq_config.py with the redis password
-  copy:
-    content: "REDIS_PASSWORD = \"{{ redis_password.stdout }}\""
-    dest: "{{ securedrop_code }}/rq_config.py"
-    owner: "root"
-    group: "www-data"
-    mode: "0640"
-  when: not config.stat.exists
-  tags:
-    - securedrop_config
-
-- name: Add 32-byte value for "redis password" to /etc/redis/redis.conf.
-  lineinfile:
-    dest: "/etc/redis/redis.conf"
-    regexp: "^requirepass"
-    line: "requirepass {{ redis_password.stdout }}"
-    insertafter: EOF
-  when: not config.stat.exists
-  register: redis_conf
-
 - name: Restart redis
   service:
     name: redis-server
     state: restarted
-  when: redis_conf.changed
+  when: redis_password.changed
 
 - name: Declare Application GPG fingerprint in config.py.
   lineinfile:

--- a/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
+++ b/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
@@ -121,24 +121,13 @@
     exclude: "var/lib/tor,etc/tor/torrc"
   when: restore_skip_tor
 
-- name: Remove Redis password line from restored config.py, if it exists
-  lineinfile:
-    state: absent
-    path: /var/www/securedrop/config.py
-    regexp: "^REDIS_PASSWORD = .*$"
-
+# By removing rq_config.py, we'll force a reset of the Redis password in postinst
 - name: Remove /var/www/securedrop/rq_config.py if it exists
   file:
     state: absent
     path: /var/www/securedrop/rq_config.py
 
-- name: Remove Redis password line from /etc/redis/redis.conf, if it exists
-  lineinfile:
-    path: /etc/redis/redis.conf
-    state: absent
-    regexp: "^requirepass .*$"
-
-- name: Reconfigure securedrop-app-code, regenerating Redis config via postint
+- name: Reconfigure securedrop-app-code
   command: dpkg-reconfigure securedrop-app-code
 
 - name: Reconfigure securedrop-config

--- a/molecule/testinfra/app/test_redis.py
+++ b/molecule/testinfra/app/test_redis.py
@@ -4,10 +4,27 @@ Test redis is configured as desired
 
 import re
 
+import pytest
 import testutils
 
 sdvars = testutils.securedrop_test_vars
 testinfra_hosts = [sdvars.app_hostname]
+
+
+def extract_password(host) -> str:
+    f = host.file("/var/www/securedrop/rq_config.py")
+    with host.sudo():
+        contents = f.content_string
+    print(contents)
+    return re.search(r"^REDIS_PASSWORD = ['\"](.*?)['\"]$", contents).group(1)
+
+
+def assert_password_works(host, password):
+    # Run an authenticated PING
+    response = host.run(
+        f'bash -c \'echo "PING" | REDISCLI_AUTH="{password}" redis-cli\''
+    ).stdout.strip()
+    assert response == "PONG"
 
 
 def test_auth_required(host):
@@ -29,10 +46,60 @@ def test_password_works(host):
         assert f.user == "root"
         assert f.group == "www-data"
         assert f.mode == 0o640
-        contents = f.content_string
-    password = re.search('"(.*?)"', contents).group(1)
-    # Now run an authenticated PING
-    response = host.run(
-        f'bash -c \'echo "PING" | REDISCLI_AUTH="{password}" redis-cli\''
-    ).stdout.strip()
-    assert response == "PONG"
+    # Get the password
+    password = extract_password(host)
+    assert_password_works(host, password)
+
+
+def test_check(host):
+    """All the redis passwords should be in sync"""
+    with host.sudo():
+        assert host.run("securedrop-set-redis-auth.py check").rc == 0
+
+
+@pytest.mark.skip_in_prod
+def test_check_fail(host):
+    with host.sudo():
+        old = extract_password(host)
+        try:
+            cmd = host.run("echo 'REDIS_PASSWORD = \"wrong\"' > /var/www/securedrop/rq_config.py")
+            assert cmd.rc == 0
+            assert host.run("securedrop-set-redis-auth.py check").rc == 1
+            # Verify reset-if-needed will fix it
+            assert host.run("securedrop-set-redis-auth.py reset-if-needed").rc == 0
+            assert host.run("systemctl restart redis-server").rc == 0
+            assert host.run("systemctl restart apache2").rc == 0
+            new = extract_password(host)
+            assert old != new, "password changed"
+            assert_password_works(host, new)
+            with pytest.raises(AssertionError):
+                # Old password no longer works
+                assert_password_works(host, old)
+        finally:
+            # Reset to cleanup
+            assert host.run("securedrop-set-redis-auth.py reset").rc == 0
+            assert host.run("systemctl restart redis-server").rc == 0
+            assert host.run("systemctl restart apache2").rc == 0
+
+
+@pytest.mark.skip_in_prod
+def test_reset(host):
+    original = extract_password(host)
+    with host.sudo():
+        assert host.run("securedrop-set-redis-auth.py reset").rc == 0
+        assert host.run("systemctl restart redis-server").rc == 0
+        assert host.run("systemctl restart apache2").rc == 0
+
+    new = extract_password(host)
+    assert new != original, "password changed"
+
+    assert_password_works(host, new)
+    with pytest.raises(AssertionError):
+        # Old password no longer works
+        assert_password_works(host, original)
+
+    # Now verify that reset-if-needed does nothing
+    with host.sudo():
+        assert host.run("securedrop-set-redis-auth.py reset-if-needed").rc == 0
+    current = extract_password(host)
+    assert current == new, "password not changed since it wasn't needed"

--- a/securedrop/debian/app-code/usr/bin/securedrop-set-redis-auth.py
+++ b/securedrop/debian/app-code/usr/bin/securedrop-set-redis-auth.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import secrets
+import shutil
+import sys
+from pathlib import Path
+from typing import Optional
+
+CONFIG_PY = Path("/var/www/securedrop/config.py")
+RQ_CONFIG_PY = Path("/var/www/securedrop/rq_config.py")
+REDIS_CONF = Path("/etc/redis/redis.conf")
+
+PYTHON_RE = re.compile(r"^REDIS_PASSWORD = ['\"](.*?)['\"]$")
+REDIS_CONF_RE = re.compile(r"^requirepass (.*?)$")
+
+
+def read_python_file(path: Path) -> Optional[str]:
+    """Extract the password from a Python file"""
+    if not path.exists():
+        # rq_config.py might not exist yet
+        return None
+    contents = path.read_text()
+    # Read in reverse because we want to look for the last matching line
+    # since it'll take precedence in Python
+    for line in contents.splitlines()[::-1]:
+        match = PYTHON_RE.match(line)
+        if match:
+            return match.group(1)
+    # Nothing found
+    return None
+
+
+def write_python_file(path: Path, password: str) -> None:
+    """Set the new password in a Python file, removing any existing passwords"""
+    if path.exists():
+        lines = path.read_text().splitlines()
+    else:
+        lines = []
+    # Take the existing file, remove any matching password lines, and then add
+    # our new password at the end
+    lines = [line for line in lines if not PYTHON_RE.match(line)]
+    lines.append(f"REDIS_PASSWORD = '{password}'")
+    if path == RQ_CONFIG_PY and not path.exists():
+        # Ensure rq_config.py is created with the correct permissions
+        path.write_text("")
+        path.chmod(0o640)
+        shutil.chown(path, "root", "www-data")
+
+    path.write_text("\n".join(lines) + "\n")
+
+
+def read_redis_conf(path: Path) -> Optional[str]:
+    """Extract the password from our redis.conf file"""
+    # n.b. we assume redis.conf exists, since the package should already
+    # be installed
+    contents = path.read_text()
+    # Read in reverse because we want to look for the last matching line
+    # since redis uses the last requirepass stanza
+    for line in contents.splitlines()[::-1]:
+        match = REDIS_CONF_RE.match(line)
+        if match:
+            return match.group(1)
+    # Nothing found
+    return None
+
+
+def write_redis_conf(path: Path, password: str) -> None:
+    """Set the new password in a redis.conf file, removing any existing passwords"""
+    if not path.exists():
+        raise RuntimeError("redis.conf does not already exist")
+    lines = path.read_text().splitlines()
+    # Take the existing file, remove any matching password lines, and then add
+    # our new password at the end
+    lines = [line for line in lines if not REDIS_CONF_RE.match(line)]
+    lines.append(f"requirepass {password}")
+    path.write_text("\n".join(lines) + "\n")
+
+
+def generate_password() -> str:
+    """
+    Generate a base64-encoded, 32-byte random string
+
+    This is roughly equivalent to `head -c 32 /dev/urandom | base64`
+    """
+    return secrets.token_urlsafe(32)
+
+
+def check() -> bool:
+    config_py = read_python_file(CONFIG_PY)
+    rq_config_py = read_python_file(RQ_CONFIG_PY)
+    redis_conf = read_redis_conf(REDIS_CONF)
+    all_passwords = {config_py, rq_config_py, redis_conf}
+    # If any are None, then we don't have the password set yet
+    if None in all_passwords:
+        return False
+    # True if there's only one unique password
+    return len(all_passwords) == 1
+
+
+def reset() -> None:
+    password = generate_password()
+    write_python_file(CONFIG_PY, password)
+    write_python_file(RQ_CONFIG_PY, password)
+    write_redis_conf(REDIS_CONF, password)
+    print("Redis password has been reset; please restart redis/apache2")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=["check", "reset", "reset-if-needed"])
+    args = parser.parse_args()
+
+    if args.mode == "check":
+        if check():
+            print("Yay, all three passwords are the same!")
+        else:
+            print("Error: Passwords are not all the same!")
+            sys.exit(1)
+    elif args.mode == "reset":
+        reset()
+    elif args.mode == "reset-if-needed":
+        if not check():
+            reset()
+        else:
+            print("All three passwords are the same; nothing changed")
+    else:
+        # should be unreachable, but just in case
+        raise RuntimeError(f"unknown mode: {args.mode}")
+
+
+if __name__ == "__main__":
+    main()

--- a/securedrop/debian/securedrop-app-code.postinst
+++ b/securedrop/debian/securedrop-app-code.postinst
@@ -194,18 +194,11 @@ export_journalist_public_key() {
 
 # Password-protect access to Redis
 set_redis_password() {
-    # Only run when upgrading, which means config.py exists and rq_config.py does not.
-    if ! test -f "/var/www/securedrop/rq_config.py" && test -f "/var/www/securedrop/config.py"; then
-        password=$(head -c 32 /dev/urandom | base64)
-        echo "requirepass $password" | sudo -u redis tee -a /etc/redis/redis.conf
-        # Set in config.py for web apps
-        echo "REDIS_PASSWORD = \"$password\"" >> /var/www/securedrop/config.py
-        # Create separate rq_config for rqworker
-        touch /var/www/securedrop/rq_config.py
-        chown root:www-data /var/www/securedrop/rq_config.py
-        chmod 640 /var/www/securedrop/rq_config.py
-        echo "REDIS_PASSWORD = \"$password\"" > /var/www/securedrop/rq_config.py
+    # If we've already installed (i.e. config.py exists) then set a redis password if needed
+    if [ -f "/var/www/securedrop/config.py" ]; then
+        /usr/bin/securedrop-set-redis-auth.py reset-if-needed
         service redis-server restart
+        # Don't restart apache2, it'll be restarted at the end of the postinst
     fi
 }
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Code to set and reset Redis passwords has now proliferated into the postinst, dev environment, ansible provisioning and backup restore. Instead of maintaining separate code for this, write a single script that handles it all.

A new `securedrop-set-redis-auth.py` tool offers three operations:
* check: verify all the passwords are in sync (for testinfra checks)
* reset: forcibly change the password everywhere (for backup restore)
* reset-if-needed: change the password everywhere if needed (for postinst)

Fixes #7386.


## Testing

How should the reviewer test this PR?

* [x] Visual review
* [ ] Staging CI passes

## Deployment

Any special considerations for deployment?

Both upgrades and fresh installs are considered.

## Checklist

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container
