### PR TITLE
test: parameterize Tor Browser by locale

### DIFF
--- a/securedrop/tests/functional/conftest.py
+++ b/securedrop/tests/functional/conftest.py
@@ -24,7 +24,7 @@ from tests.utils.i18n import get_test_locales
 # Function-scoped so that tests can be run in parallel if needed.  The fixture
 # needs to know the locale at setup time, so we do that parameterization here
 # rather than at the test level.
-@pytest.fixture(params=get_test_locales())
+@pytest.fixture(params=get_test_locales(default_locale=None))
 def firefox_web_driver(request) -> WebDriver:  # type: ignore
     locale = request.param.replace("_", "-")
     with get_web_driver(

--- a/securedrop/tests/functional/conftest.py
+++ b/securedrop/tests/functional/conftest.py
@@ -33,10 +33,15 @@ def firefox_web_driver(request) -> WebDriver:  # type: ignore
         yield web_driver
 
 
-# Function-scoped so that tests can be run in parallel if needed
-@pytest.fixture
-def tor_browser_web_driver() -> WebDriver:  # type: ignore
-    with get_web_driver(web_driver_type=WebDriverTypeEnum.TOR_BROWSER) as web_driver:
+# Function-scoped so that tests can be run in parallel if needed.  The fixture
+# needs to know the locale at setup time, so we do that parameterization here
+# rather than at the test level.
+@pytest.fixture(params=get_test_locales(default_locale=None))
+def tor_browser_web_driver(request) -> WebDriver:  # type: ignore
+    locale = request.param.replace("_", "-")
+    with get_web_driver(
+        web_driver_type=WebDriverTypeEnum.TOR_BROWSER, accept_languages=locale
+    ) as web_driver:
         yield web_driver
 
 

--- a/securedrop/tests/functional/test_source_designation_collision.py
+++ b/securedrop/tests/functional/test_source_designation_collision.py
@@ -7,7 +7,7 @@ from tests.functional.app_navigators.source_app_nav import SourceAppNavigator
 from tests.functional.conftest import spawn_sd_servers
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def sd_servers_with_designation_collisions(setup_journalist_key_and_gpg_folder, setup_rqworker):
     """Spawn source and journalist apps that can only generate a single journalist designation."""
     # Generate a config that can only generate a single journalist designation

--- a/securedrop/tests/utils/i18n.py
+++ b/securedrop/tests/utils/i18n.py
@@ -16,8 +16,9 @@ from sdconfig import SecureDropConfig
 
 @functools.lru_cache(maxsize=None)
 def get_test_locales(default_locale: str = "en_US") -> List[str]:
-    locales = set(os.environ.get("TEST_LOCALES", "ar en_US").split())
-    locales.add(default_locale)
+    locales = set(os.environ.get("TEST_LOCALES", "ar").split())
+    if default_locale:
+        locales.add(default_locale)
     return sorted(list(locales))
 
 


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Fixes #7354 by using the `tbselenium.utils.tbb_set_pref()` helper function to configure Tor Browser with the locale under test.


## Testing

- [ ] Inspect a couple of languages and confirm that screenshots are correct (modulo translations) for both the Source and Journalist Interfaces.


## Deployment

CI-only; no deployment considerations.