### PR TITLE
Ensure /etc/iptables exists before writing to it

### DIFF
--- a/install_files/ansible-base/roles/restrict-direct-access/tasks/iptables.yml
+++ b/install_files/ansible-base/roles/restrict-direct-access/tasks/iptables.yml
@@ -41,6 +41,19 @@
     admin_net_cidr: "{{ '/'.join([admin_net_info.network, admin_net_info.netmask])|ipaddr('cidr') }}"
   delegate_to: localhost
 
+- name: Check iptables-persistent was installed
+  stat:
+    path: /etc/iptables/
+  register: etc_iptables_check
+
+- name: Install iptables-persistent if needed
+  apt:
+    name: iptables-persistent
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+  when: not etc_iptables_check.stat.exists
+
 - name: Copy IPv4 iptables rules.
   template:
     src: rules_v4


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes

In the specific case of installing a fresh mon server when the app server is already configured AND you're using ssh over the local network, we'll try to write to /etc/iptables before the iptables-persistent package is installed.

This is because we end up running the restrict-direct-access role before the common role, which installs the base packages.

The easy fix is to install iptables-persistent ahead of time if we see that it's necessary.

Fixes #7119.

## Testing

How should the reviewer test this PR?

* [x] setup a 2.11.1 prod install that uses ssh over localhost
* [x] on the admin workstation, cherry-pick this patch 
* [x] reinstall ubuntu fresh on just the mon server, and then run `./securedrop-admin install` (i.e. with the cherry-pick)
* [x] the install should complete successfully with no errors about /etc/iptables being missing.

## Deployment

Any special considerations for deployment? n/a, bug only affects fresh installs

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
