### PR TITLE
Handle unapplied phased updates in testinfra checks

### DIFF
--- a/molecule/testinfra/common/test_automatic_updates.py
+++ b/molecule/testinfra/common/test_automatic_updates.py
@@ -154,12 +154,18 @@ def test_unattended_upgrades_functional(host):
         f" origin=Ubuntu,archive={distro}, origin=Ubuntu,archive={distro}-security"
         f", origin=Ubuntu,archive={distro}-updates, origin=SecureDrop,codename={distro}"
     )
-    expected_result = (
-        "No packages found that can be upgraded unattended and no pending auto-removals"
-    )
 
+    all_good = "No packages found that can be upgraded unattended and no pending auto-removals"
     assert expected_origins in c.stdout
-    assert expected_result in c.stdout
+    if distro == "focal":
+        assert all_good in c.stdout
+    else:  # noqa: PLR5501
+        if all_good in c.stdout:
+            assert all_good in c.stdout
+        else:
+            # noble+ uses phased updates, so there may be packages that can be
+            # upgraded that won't be upgraded; look for a different message in that case
+            assert "left to upgrade set()\nAll upgrades installed" in c.stdout
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


## Status

Ready for review 

## Description of Changes

noble now has phased updates, in which the package repository will have pending updates, but they won't be applied yet. We need to look for a different message on noble to handle this change.

Fixes #7419.

## Testing

How should the reviewer test this PR?

* [x] visual review
* [x] noble staging job passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
