### PR TITLE
Update rust to 1.84.0, rustup to 1.27.1

### DIFF
--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -9,7 +9,7 @@ jobs:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.81.0
+    container: rust:1.84.0
     env:
       CARGO_VET_VERSION: 0.10.0
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.81.0
+    container: rust:1.84.0
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ jobs:
   rust-audit:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.81.0
+    container: rust:1.84.0
     steps:
       - uses: actions/checkout@v4
         with:

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -29,9 +29,9 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         unzip \
         zlib1g-dev
 
-ENV RUST_VERSION 1.81.0
-ENV RUSTUP_VERSION 1.24.3
-ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
+ENV RUST_VERSION 1.84.0
+ENV RUSTUP_VERSION 1.27.1
+ENV RUSTUP_INIT_SHA256 6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d
 ENV RUSTUP_HOME /opt/rustup
 ENV CARGO_HOME /opt/cargo
 

--- a/redwood/Cargo.toml
+++ b/redwood/Cargo.toml
@@ -16,3 +16,7 @@ thiserror = "1.0.31"
 
 [dev-dependencies]
 tempfile = "3.3.0"
+
+[lints.rust]
+# can be removed once we upgrade to pyo3 >= 0.23
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(addr_of)'] }

--- a/redwood/src/decryption.rs
+++ b/redwood/src/decryption.rs
@@ -12,7 +12,7 @@ pub(crate) struct Helper<'a> {
     pub(crate) passphrase: &'a Password,
 }
 
-impl<'a> VerificationHelper for Helper<'a> {
+impl VerificationHelper for Helper<'_> {
     fn get_certs(
         &mut self,
         _ids: &[sequoia_openpgp::KeyHandle],
@@ -32,7 +32,7 @@ impl<'a> VerificationHelper for Helper<'a> {
     }
 }
 
-impl<'a> DecryptionHelper for Helper<'a> {
+impl DecryptionHelper for Helper<'_> {
     fn decrypt<D>(
         &mut self,
         pkesks: &[sequoia_openpgp::packet::PKESK],

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.84.0"

--- a/securedrop/dockerfiles/focal/python3/DemoDockerfile
+++ b/securedrop/dockerfiles/focal/python3/DemoDockerfile
@@ -14,9 +14,9 @@ RUN apt-get update && \
 # 1) Download rustup-init and verify it matches hardcoded checksum
 # 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
 # 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
-ENV RUST_VERSION 1.81.0
-ENV RUSTUP_VERSION 1.24.3
-ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
+ENV RUST_VERSION 1.84.0
+ENV RUSTUP_VERSION 1.27.1
+ENV RUSTUP_INIT_SHA256 6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d
 ENV RUSTUP_HOME /opt/rustup
 ENV CARGO_HOME /opt/cargo
 

--- a/securedrop/dockerfiles/focal/python3/SlimDockerfile
+++ b/securedrop/dockerfiles/focal/python3/SlimDockerfile
@@ -15,9 +15,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
 # 1) Download rustup-init and verify it matches hardcoded checksum
 # 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
 # 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
-ENV RUST_VERSION 1.81.0
-ENV RUSTUP_VERSION 1.24.3
-ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
+ENV RUST_VERSION 1.84.0
+ENV RUSTUP_VERSION 1.27.1
+ENV RUSTUP_INIT_SHA256 6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d
 ENV RUSTUP_HOME /opt/rustup
 ENV CARGO_HOME /opt/cargo
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #7408.

- updates Rust toolchain to 1.84.0
- updates rustup version to 1.27.1 (our version was getting long in the tooth)
- fixes some lint catches

## Testing

- [ ] version updated correctly.
- [ ] CI is passing.
- [ ] `make build-debs` passes locally