### PR TITLE
Set a fixed APT::Machine-ID so phased updates are consistent

### DIFF
--- a/molecule/testinfra/common/test_automatic_updates.py
+++ b/molecule/testinfra/common/test_automatic_updates.py
@@ -162,6 +162,13 @@ def test_unattended_upgrades_functional(host):
     assert expected_result in c.stdout
 
 
+def test_fixed_phasing(host):
+    """Verify APT's machine-id is set to a fixed value for consistent phasing"""
+    cmd = host.run("apt-config dump APT::Machine-ID")
+    assert cmd.rc == 0
+    assert cmd.stdout.startswith('APT::Machine-ID "1ebf')
+
+
 @pytest.mark.parametrize(
     "service",
     [

--- a/securedrop/debian/config/opt/securedrop/50unattended-upgrades
+++ b/securedrop/debian/config/opt/securedrop/50unattended-upgrades
@@ -66,3 +66,7 @@ Dpkg::Options {
     "--force-confdef";
     "--force-confold";
 }
+
+// Set a fixed machine-id to ensure phased updates are consistent across all instances
+// see <https://discourse.ubuntu.com/t/phased-updates-in-apt-in-21-04/20345>.
+APT::Machine-ID "1ebf5f15850c540b3142f1584bdd496d";


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We generally try to keep SecureDrops as homogenus as possible. APT's new phased updates can cause issues here if different instances are running different sets of packages.

As explained in <https://discourse.ubuntu.com/t/phased-updates-in-apt-in-21-04/20345>, we can override the `APT::Machine-ID` configuration setting so that all instances apply the exact same set of phased updates.

Per machine-id(5), the value is supposed to be a "hexadecimal, 32-character, lowercase ID". The hash is a random value that was selected; clever reviewers will be able to ascertain the source ;-)

Fixes #7422

## Testing

How should the reviewer test this PR?

* [ ] staging CI passes - at least the `test_fixed_phasing` test.

## Deployment

Any special considerations for deployment? Only takes effect on noble, should be a no-op for focal.

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
