### PR TITLE
chore: update to `pip` 25.0 for Safety 75180

### DIFF
--- a/admin/requirements-dev.in
+++ b/admin/requirements-dev.in
@@ -2,7 +2,6 @@ coverage>=7.0  # #6091
 flaky
 mock
 packaging==21.3
-pip>=21.1
 pip-tools>=6.1.0
 py>=1.11.0
 pylint>=3.0.0
@@ -12,3 +11,7 @@ tox==3.28.0
 pexpect
 urllib3>=1.26.5
 setuptools>=70.0.0
+
+# If this needs updating, search this repository for other references to "pip"
+# that may be missed by our tools.
+pip>=25  # Safety 75180

--- a/admin/requirements-dev.txt
+++ b/admin/requirements-dev.txt
@@ -207,9 +207,9 @@ virtualenv==20.25.0 \
     # via tox
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.1.1 \
-    --hash=sha256:11d095ed5c15265fc5c15cc40a45188675c239fb0f9913b673a33e54ff7d45f0 \
-    --hash=sha256:51ad01ddcd8de923533b01a870e7b987c2eb4d83b50b89e1bf102723ff9fed8b
+pip==25.0 \
+    --hash=sha256:8e0a97f7b4c47ae4a494560da84775e9e2f671d415d8d828e052efefb206b30b \
+    --hash=sha256:b6eb97a803356a52b2dd4bb73ba9e65b2ba16caa6bcb25a7497350a4e5859b65
     # via
     #   -r requirements-dev.in
     #   pip-tools

--- a/admin/requirements-testinfra.txt
+++ b/admin/requirements-testinfra.txt
@@ -329,6 +329,7 @@ six==1.16.0 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
     #   -r requirements.in
+    #   paramiko
     #   prompt-toolkit
 testinfra==5.3.1 \
     --hash=sha256:9d3a01fb787253df76ac4ab46d18a84d4b01be877ed1b5812e590dcf480a627e \

--- a/securedrop/debian/rules
+++ b/securedrop/debian/rules
@@ -28,7 +28,7 @@ override_dh_auto_install:
 	# Set up virtualenv and install dependencies
 	/usr/bin/python3 -m venv ./debian/securedrop-app-code/opt/venvs/securedrop-app-code
 	./debian/securedrop-app-code/opt/venvs/securedrop-app-code/bin/pip install $(PIP_ARGS) \
-		pip==24.2
+		pip==25.0
 	./debian/securedrop-app-code/opt/venvs/securedrop-app-code/bin/pip install $(PIP_ARGS) \
 		-r requirements/python3/requirements.txt
 	./debian/securedrop-app-code/opt/venvs/securedrop-app-code/bin/pip install $(PIP_ARGS) \

--- a/securedrop/debian/translations.sh
+++ b/securedrop/debian/translations.sh
@@ -6,9 +6,9 @@ set -ex
 # beyond what the system version provides, see #6317.
 python3 -m venv /tmp/securedrop-app-code-i18n-ve
 /tmp/securedrop-app-code-i18n-ve/bin/pip3 install -r \
-<(echo "pip==24.2 \
---hash=sha256:5b5e490b5e9cb275c879595064adce9ebd31b854e3e803740b72f9ccf34a45b8 \
---hash=sha256:2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2")
+<(echo "pip==25.0 \
+--hash=sha256:8e0a97f7b4c47ae4a494560da84775e9e2f671d415d8d828e052efefb206b30b \
+--hash=sha256:b6eb97a803356a52b2dd4bb73ba9e65b2ba16caa6bcb25a7497350a4e5859b65")
 
 # Install dependencies
 /tmp/securedrop-app-code-i18n-ve/bin/pip3 install --no-deps --no-binary :all: --require-hashes -r requirements/python3/translation-requirements.txt

--- a/securedrop/requirements/python3/bootstrap-requirements.in
+++ b/securedrop/requirements/python3/bootstrap-requirements.in
@@ -1,4 +1,7 @@
-pip>=24.2
 setuptools>=70.0.0
 setuptools-scm>=8.0.0
 wheel>=0.38.1
+
+# If this needs updating, search this repository for other references to "pip"
+# that may be missed by our tools.
+pip>=25  # Safety 75180

--- a/securedrop/requirements/python3/bootstrap-requirements.txt
+++ b/securedrop/requirements/python3/bootstrap-requirements.txt
@@ -4,9 +4,9 @@ packaging==24.1 \
     --hash=sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002 \
     --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
     # via setuptools-scm
-pip==24.2 \
-    --hash=sha256:2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2 \
-    --hash=sha256:5b5e490b5e9cb275c879595064adce9ebd31b854e3e803740b72f9ccf34a45b8
+pip==25.0 \
+    --hash=sha256:8e0a97f7b4c47ae4a494560da84775e9e2f671d415d8d828e052efefb206b30b \
+    --hash=sha256:b6eb97a803356a52b2dd4bb73ba9e65b2ba16caa6bcb25a7497350a4e5859b65
     # via -r requirements/python3/bootstrap-requirements.in
 setuptools==70.3.0 \
     --hash=sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5 \

--- a/securedrop/requirements/python3/develop-requirements.in
+++ b/securedrop/requirements/python3/develop-requirements.in
@@ -18,7 +18,6 @@ molecule-vagrant>=1,<2
 # Needed for ansible network filter
 # http://docs.ansible.com/ansible/latest/playbooks_filters_ipaddr.html
 netaddr
-pip>=24.2
 polib
 prompt_toolkit==2.0.9
 psutil>=5.6.6
@@ -44,3 +43,7 @@ urllib3>=1.26.5
 uv
 yamllint
 zizmor
+
+# If this needs updating, search this repository for other references to "pip"
+# that may be missed by our tools.
+pip>=25  # Safety 75180

--- a/securedrop/requirements/python3/develop-requirements.txt
+++ b/securedrop/requirements/python3/develop-requirements.txt
@@ -534,9 +534,9 @@ pathspec==0.9.0 \
 peewee==3.17.1 \
     --hash=sha256:e009ac4227c4fdc0058a56e822ad5987684f0a1fbb20fed577200785102581c3
     # via semgrep
-pip==24.2 \
-    --hash=sha256:2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2 \
-    --hash=sha256:5b5e490b5e9cb275c879595064adce9ebd31b854e3e803740b72f9ccf34a45b8
+pip==25.0 \
+    --hash=sha256:8e0a97f7b4c47ae4a494560da84775e9e2f671d415d8d828e052efefb206b30b \
+    --hash=sha256:b6eb97a803356a52b2dd4bb73ba9e65b2ba16caa6bcb25a7497350a4e5859b65
     # via -r requirements/python3/develop-requirements.in
 pkgutil-resolve-name==1.3.10 \
     --hash=sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174 \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Addresses Safety alert no. 75180.

## Testing

- [ ] CI passes.
- [ ] This does not require diff review, per <https://github.com/freedomofpress/securedrop-dev-docs/blob/4a42bbb4eb4007edcccb317da5f19998dc3175e0/docs/dependency_updates.rst?plain=1#L52-L53>.