### PR TITLE
Bump pyo3 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -379,6 +379,12 @@ name = "hashbrown"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -530,7 +536,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -566,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.9"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "is-terminal"
@@ -681,9 +687,9 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -762,7 +768,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -832,6 +838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "portable-atomic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,15 +869,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.18.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b1ac5b3731ba34fdaa9785f8d74d17448cd18f30cf19e0c7e7b1fdb5272109"
+checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -874,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.18.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb946f5ac61bb61a5014924910d936ebd2b23b705f7a4a3c40b05c720b079a3"
+checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -884,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.18.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c"
+checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -894,25 +907,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.18.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d39c55dab3fc5a4b25bbd1ac10a2da452c4aca13bb450f22818a002e29648d"
+checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.18.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97daff08a4c48320587b5224cc98d609e3c27b6d437315bd40b605c98eeb5918"
+checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
 dependencies = [
+ "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1116,7 +1131,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1174,17 +1189,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
@@ -1202,14 +1206,14 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.11"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -1252,7 +1256,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1294,9 +1298,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unindent"
-version = "0.1.11"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "url"
@@ -1370,7 +1374,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1392,7 +1396,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1620,7 +1624,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "synstructure",
 ]
 
@@ -1642,7 +1646,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1662,7 +1666,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "synstructure",
 ]
 
@@ -1685,5 +1689,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
+checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
+checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
+checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -907,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
+checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
+checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1211,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,9 +747,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/redwood/Cargo.toml
+++ b/redwood/Cargo.toml
@@ -10,13 +10,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0"
-pyo3 = { version = "0.18.0", features = ["extension-module"] }
+pyo3 = { version = "0.23.4", features = ["extension-module"] }
 sequoia-openpgp = { version = "1.21.1", default-features = false, features = ["crypto-openssl", "compression"]}
 thiserror = "1.0.31"
 
 [dev-dependencies]
 tempfile = "3.3.0"
-
-[lints.rust]
-# can be removed once we upgrade to pyo3 >= 0.23
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(addr_of)'] }

--- a/redwood/Cargo.toml
+++ b/redwood/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0"
-pyo3 = { version = "0.23.4", features = ["extension-module"] }
+pyo3 = { version = "0.24.1", features = ["extension-module"] }
 sequoia-openpgp = { version = "1.21.1", default-features = false, features = ["crypto-openssl", "compression"]}
 thiserror = "1.0.31"
 

--- a/redwood/src/lib.rs
+++ b/redwood/src/lib.rs
@@ -61,14 +61,14 @@ const KEY_CREATION_SECONDS_FROM_EPOCH: u64 = 1368507600;
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn redwood(py: Python, m: &PyModule) -> PyResult<()> {
+fn redwood(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(generate_source_key_pair, m)?)?;
     m.add_function(wrap_pyfunction!(is_valid_public_key, m)?)?;
     m.add_function(wrap_pyfunction!(is_valid_secret_key, m)?)?;
     m.add_function(wrap_pyfunction!(encrypt_message, m)?)?;
     m.add_function(wrap_pyfunction!(encrypt_stream, m)?)?;
     m.add_function(wrap_pyfunction!(decrypt, m)?)?;
-    m.add("RedwoodError", py.get_type::<RedwoodError>())?;
+    m.add("RedwoodError", m.py().get_type::<RedwoodError>())?;
     Ok(())
 }
 
@@ -124,7 +124,7 @@ pub fn is_valid_secret_key(input: &str, passphrase: String) -> Result<String> {
 /// Encrypt a message (text) for the specified recipients. The list of
 /// recipients is a set of PGP public keys. The encrypted message will
 /// be written to `destination`.
-#[pyfunction]
+#[pyfunction(signature = (recipients, plaintext, destination, armor=None))]
 pub fn encrypt_message(
     recipients: Vec<String>,
     plaintext: String,
@@ -141,7 +141,7 @@ pub fn encrypt_message(
 #[pyfunction]
 pub fn encrypt_stream(
     recipients: Vec<String>,
-    plaintext: &PyAny,
+    plaintext: Bound<PyAny>,
     destination: PathBuf,
 ) -> Result<()> {
     let stream = stream::Stream { reader: plaintext };

--- a/redwood/src/stream.rs
+++ b/redwood/src/stream.rs
@@ -1,21 +1,23 @@
-use pyo3::types::PyBytes;
-use pyo3::{intern, PyAny, PyResult};
+use pyo3::types::{PyAnyMethods, PyBytes, PyTuple};
+use pyo3::{intern, Bound, PyAny, PyResult};
 use std::io::{self, ErrorKind, Read, Write};
 
 /// Wrapper to implement the `Read` trait around a Python
 /// object that contains a `.read()` function.
 pub(crate) struct Stream<'a> {
-    pub(crate) reader: &'a PyAny,
+    pub(crate) reader: Bound<'a, PyAny>,
 }
 
 impl Stream<'_> {
     /// Read the specified number of bytes out of the object
-    fn read_bytes(&self, len: usize) -> PyResult<&PyBytes> {
-        let func = self.reader.getattr(intern!(self.reader.py(), "read"))?;
+    fn read_bytes(&self, len: usize) -> PyResult<Vec<u8>> {
+        let func: Bound<'_, PyAny> =
+            self.reader.getattr(intern!(self.reader.py(), "read"))?;
         // In Python this is effectively calling `reader.read(len)`
-        let bytes = func.call1((len,))?;
+        let args: Bound<PyTuple> = PyTuple::new(self.reader.py(), vec![len])?;
+        let bytes: Bound<PyAny> = func.call1(args)?;
         let bytes = bytes.downcast::<PyBytes>()?;
-        Ok(bytes)
+        bytes.extract()
     }
 }
 
@@ -27,6 +29,6 @@ impl Read for Stream<'_> {
             // all of them as "other" for simplicity.
             io::Error::new(ErrorKind::Other, err.to_string())
         })?;
-        buf.write(bytes.as_bytes())
+        buf.write(bytes.as_slice())
     }
 }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -104,6 +104,11 @@ who = "Kunal Mehta <legoktm@debian.org>"
 criteria = "safe-to-run"
 version = "0.6.5"
 
+[[audits.memoffset]]
+who = "Kunal Mehta <legoktm@debian.org>"
+criteria = "safe-to-run"
+delta = "0.9.0 -> 0.9.1"
+
 [[audits.memsec]]
 who = "Kunal Mehta <legoktm@debian.org>"
 criteria = "safe-to-run"
@@ -506,12 +511,54 @@ start = "2019-05-04"
 end = "2024-04-10"
 notes = "Rust Project member"
 
+[[trusted.portable-atomic]]
+criteria = "safe-to-deploy"
+user-id = 33035 # Taiki Endo (taiki-e)
+start = "2022-02-24"
+end = "2025-10-09"
+notes = "Rust Project member"
+
 [[trusted.proc-macro2]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-04-23"
 end = "2024-04-10"
 notes = "Rust Project member"
+
+[[trusted.pyo3]]
+criteria = "safe-to-run"
+user-id = 6622 # David Hewitt (davidhewitt)
+start = "2020-09-12"
+end = "2025-10-09"
+notes = "per https://github.com/freedomofpress/securedrop-engineering/issues/112"
+
+[[trusted.pyo3-build-config]]
+criteria = "safe-to-deploy"
+user-id = 6622 # David Hewitt (davidhewitt)
+start = "2021-05-25"
+end = "2025-10-09"
+notes = "per https://github.com/freedomofpress/securedrop-engineering/issues/112"
+
+[[trusted.pyo3-ffi]]
+criteria = "safe-to-deploy"
+user-id = 6622 # David Hewitt (davidhewitt)
+start = "2022-02-27"
+end = "2025-10-09"
+notes = "per https://github.com/freedomofpress/securedrop-engineering/issues/112"
+
+[[trusted.pyo3-macros]]
+criteria = "safe-to-deploy"
+user-id = 6622 # David Hewitt (davidhewitt)
+start = "2020-12-20"
+end = "2025-10-09"
+notes = "per https://github.com/freedomofpress/securedrop-engineering/issues/112"
+
+[[trusted.pyo3-macros-backend]]
+criteria = "safe-to-deploy"
+user-id = 6622 # David Hewitt (davidhewitt)
+start = "2020-12-20"
+end = "2025-10-09"
+notes = "per https://github.com/freedomofpress/securedrop-engineering/issues/112"
 
 [[trusted.quote]]
 criteria = "safe-to-deploy"
@@ -630,6 +677,13 @@ criteria = "safe-to-deploy"
 user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2019-03-06"
 end = "2024-04-10"
+notes = "Rust Project member"
+
+[[trusted.target-lexicon]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2019-03-06"
+end = "2025-10-09"
 notes = "Rust Project member"
 
 [[trusted.thiserror]]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -476,6 +476,13 @@ start = "2023-03-24"
 end = "2025-01-22"
 notes = "Rust Project member"
 
+[[trusted.openssl]]
+criteria = "safe-to-deploy"
+user-id = 163 # Alex Gaynor (alex)
+start = "2023-03-24"
+end = "2025-10-09"
+notes = "Rust Project member"
+
 [[trusted.openssl-sys]]
 criteria = "safe-to-deploy"
 user-id = 5
@@ -495,6 +502,13 @@ criteria = "safe-to-deploy"
 user-id = 163 # Alex Gaynor (alex)
 start = "2023-03-24"
 end = "2025-01-22"
+notes = "Rust Project member"
+
+[[trusted.openssl-sys]]
+criteria = "safe-to-deploy"
+user-id = 163 # Alex Gaynor (alex)
+start = "2023-03-24"
+end = "2025-10-09"
 notes = "Rust Project member"
 
 [[trusted.parking_lot]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -121,8 +121,8 @@ user-login = "cuviper"
 user-name = "Josh Stone"
 
 [[publisher.indoc]]
-version = "1.0.9"
-when = "2023-01-29"
+version = "2.0.5"
+when = "2024-03-23"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -203,12 +203,54 @@ user-id = 2915
 user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
 
+[[publisher.portable-atomic]]
+version = "1.10.0"
+when = "2024-11-23"
+user-id = 33035
+user-login = "taiki-e"
+user-name = "Taiki Endo"
+
 [[publisher.proc-macro2]]
 version = "1.0.79"
 when = "2024-03-12"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
+
+[[publisher.pyo3]]
+version = "0.24.1"
+when = "2025-03-31"
+user-id = 6622
+user-login = "davidhewitt"
+user-name = "David Hewitt"
+
+[[publisher.pyo3-build-config]]
+version = "0.24.1"
+when = "2025-03-31"
+user-id = 6622
+user-login = "davidhewitt"
+user-name = "David Hewitt"
+
+[[publisher.pyo3-ffi]]
+version = "0.24.1"
+when = "2025-03-31"
+user-id = 6622
+user-login = "davidhewitt"
+user-name = "David Hewitt"
+
+[[publisher.pyo3-macros]]
+version = "0.24.1"
+when = "2025-03-31"
+user-id = 6622
+user-login = "davidhewitt"
+user-name = "David Hewitt"
+
+[[publisher.pyo3-macros-backend]]
+version = "0.24.1"
+when = "2025-03-31"
+user-id = 6622
+user-login = "davidhewitt"
+user-name = "David Hewitt"
 
 [[publisher.regex]]
 version = "1.10.0"
@@ -281,13 +323,6 @@ user-login = "teythoon"
 user-name = "Justus Winter"
 
 [[publisher.syn]]
-version = "1.0.109"
-when = "2023-02-24"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.syn]]
 version = "2.0.87"
 when = "2024-11-02"
 user-id = 3618
@@ -295,8 +330,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.target-lexicon]]
-version = "0.12.11"
-when = "2023-07-31"
+version = "0.13.2"
+when = "2025-02-07"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
@@ -323,8 +358,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.unindent]]
-version = "0.1.11"
-when = "2022-12-17"
+version = "0.2.3"
+when = "2023-09-16"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -408,6 +443,12 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.7.1 -> 0.8.0"
 notes = "This was a small update to the crate which has to do with Rust language features and compiler versions, no substantial changes."
+
+[[audits.bytecode-alliance.audits.memoffset]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.0 -> 0.9.0"
+notes = "No major changes in the crate, mostly updates to use new nightly Rust features."
 
 [[audits.bytecode-alliance.audits.miniz_oxide]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -539,6 +580,12 @@ notes = """
 While this crate provides crypto methods, they all defer to system or hardware
 crypto implementations. Hence, this crate does not implement crypto.
 """
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.heck]]
+who = "Ying Hsu <yinghsu@chromium.org>"
+criteria = "safe-to-run"
+version = "0.5.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.humantime]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -176,15 +176,15 @@ user-login = "cuviper"
 user-name = "Josh Stone"
 
 [[publisher.openssl]]
-version = "0.10.68"
-when = "2024-10-16"
+version = "0.10.72"
+when = "2025-04-04"
 user-id = 163
 user-login = "alex"
 user-name = "Alex Gaynor"
 
 [[publisher.openssl-sys]]
-version = "0.9.104"
-when = "2024-10-16"
+version = "0.9.107"
+when = "2025-04-04"
 user-id = 163
 user-login = "alex"
 user-name = "Alex Gaynor"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

- Fixes #7277
- Upgrades pyo3 crate in redwood/Cargo.toml from 0.18.0 to 0.23.4
- Transitions to pyo3's bound API style 
- Relevant references:  
-  [PyO3 Migration Guide](https://pyo3.rs/v0.23.4/migration.html?highlight=pybytes#to-python-conversions-changed-for-byte-collections-vec-u8-n-and-smallvec)
- https://docs.rs/pyo3/latest/pyo3/struct.Bound.html

## Testing

How should the reviewer test this PR?
_- Standard:_
```
Fastest/narrowest test of changed Rust code:
cd securedrop
cargo test --package redwood

Standard dev/docker environment:
cd securedrop
make dev                                               # run development servers
make test
```

Write out any special testing steps here.
_None required_

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances.
_I don't think so._

2. New installs.
_No._

## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

_"make test" fails on some [ar] locales. Is this to be expected? Is there anything I can do to correct the test locally? It passes all others._

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

_Not applicable. Existing tests suffice._

Choose one of the following:

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [X] I would appreciate help with the documentation
- [ ] These changes do not require documentation

### If you added or updated a reference to a production code dependency:

Production code dependencies are defined in:
- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/requirements.in`
- `securedrop/requirements/python3/translation.in` (used in the build
  container)

_I'm not sure. I changed one Rust dependency in redwood/Cargo.toml. It passes cargo vet and cargo audit._

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [X] I would like[/recommend] someone else to do the diff review [since I'm brand new here]
- [ ] I am silencing an alert related to a production dependency, because (please explain below):
