### PR TITLE
Fix syntax of systemd's ConditionPathExists

### DIFF
--- a/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.service
+++ b/securedrop/debian/config/lib/systemd/system/securedrop-remove-packages.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Remove ufw/haveged if installed
-ConditionPathExists|=/usr/sbin/ufw
-ConditionPathExists|=/usr/sbin/haveged
+ConditionPathExists=|/usr/sbin/ufw
+ConditionPathExists=|/usr/sbin/haveged
 
 [Service]
 Type=exec


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

systemd prefers =|, not |=.

Fixes #7412.

## Testing

How should the reviewer test this PR?

* [ ] visual review, cross-reference with systemd syntax if you want
* [ ] if you really really want, run `systemctl daemon-reload` on a staging/prod system and see that it doesn't emit warnings about the wrong syntax.

I initially held off because I wanted a regression test, and Ro is working on one in the workstation, so let's just get this in now and we can land the regression test later, as a non-release blocker.

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
