### PR TITLE
Switch Ubuntu APT sources to use HTTPS

### DIFF
--- a/install_files/ansible-base/roles/common/templates/sources.list.j2
+++ b/install_files/ansible-base/roles/common/templates/sources.list.j2
@@ -1,13 +1,13 @@
 ## newer versions of the distribution.
-deb http://archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }} main
+deb https://archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }} main
 
 ## newer versions of the distribution.
-deb http://archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }} universe
+deb https://archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }} universe
 
 ## Major bug fix updates produced after the final release of the
 ## distribution.
-deb http://archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }}-updates main
+deb https://archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }}-updates main
 
 ### Security fixes for distribution packages
-deb http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security main
-deb http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security universe
+deb https://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security main
+deb https://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security universe

--- a/install_files/ansible-base/roles/common/templates/ubuntu.sources.j2
+++ b/install_files/ansible-base/roles/common/templates/ubuntu.sources.j2
@@ -1,11 +1,11 @@
 Types: deb
-URIs: http://archive.ubuntu.com/ubuntu/
+URIs: https://archive.ubuntu.com/ubuntu/
 Suites: {{ ansible_distribution_release }} {{ ansible_distribution_release }}-updates
 Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
 Types: deb
-URIs: http://security.ubuntu.com/ubuntu/
+URIs: https://security.ubuntu.com/ubuntu/
 Suites: {{ ansible_distribution_release }}-security
 Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg

--- a/molecule/testinfra/common/test_automatic_updates.py
+++ b/molecule/testinfra/common/test_automatic_updates.py
@@ -39,10 +39,10 @@ def test_cron_apt_config(host):
 @pytest.mark.parametrize(
     "repo",
     [
-        "deb http://security.ubuntu.com/ubuntu {securedrop_target_platform}-security main",
-        "deb http://security.ubuntu.com/ubuntu {securedrop_target_platform}-security universe",
-        "deb http://archive.ubuntu.com/ubuntu/ {securedrop_target_platform}-updates main",
-        "deb http://archive.ubuntu.com/ubuntu/ {securedrop_target_platform} main",
+        "deb https://security.ubuntu.com/ubuntu {securedrop_target_platform}-security main",
+        "deb https://security.ubuntu.com/ubuntu {securedrop_target_platform}-security universe",
+        "deb https://archive.ubuntu.com/ubuntu/ {securedrop_target_platform}-updates main",
+        "deb https://archive.ubuntu.com/ubuntu/ {securedrop_target_platform} main",
     ],
 )
 def test_sources_list(host, repo):
@@ -74,13 +74,13 @@ def test_ubuntu_sources(host):
     assert f.user == "root"
     assert f.mode == 0o644
     expected = f"""\
-URIs: http://archive.ubuntu.com/ubuntu/
+URIs: https://archive.ubuntu.com/ubuntu/
 Suites: {distro} {distro}-updates
 Components: main universe restricted multiverse
 """
     assert f.contains(expected)
     expected_security = f"""\
-URIs: http://security.ubuntu.com/ubuntu/
+URIs: https://security.ubuntu.com/ubuntu/
 Suites: {distro}-security
 Components: main universe restricted multiverse
 """

--- a/noble-migration/files/sources.list
+++ b/noble-migration/files/sources.list
@@ -1,13 +1,13 @@
 ## newer versions of the distribution.
-deb http://archive.ubuntu.com/ubuntu/ noble main
+deb https://archive.ubuntu.com/ubuntu/ noble main
 
 ## newer versions of the distribution.
-deb http://archive.ubuntu.com/ubuntu/ noble universe
+deb https://archive.ubuntu.com/ubuntu/ noble universe
 
 ## Major bug fix updates produced after the final release of the
 ## distribution.
-deb http://archive.ubuntu.com/ubuntu/ noble-updates main
+deb https://archive.ubuntu.com/ubuntu/ noble-updates main
 
 ### Security fixes for distribution packages
-deb http://security.ubuntu.com/ubuntu noble-security main
-deb http://security.ubuntu.com/ubuntu noble-security universe
+deb https://security.ubuntu.com/ubuntu noble-security main
+deb https://security.ubuntu.com/ubuntu noble-security universe

--- a/noble-migration/files/ubuntu.sources
+++ b/noble-migration/files/ubuntu.sources
@@ -1,11 +1,11 @@
 Types: deb
-URIs: http://archive.ubuntu.com/ubuntu/
+URIs: https://archive.ubuntu.com/ubuntu/
 Suites: noble noble-updates
 Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
 Types: deb
-URIs: http://security.ubuntu.com/ubuntu/
+URIs: https://security.ubuntu.com/ubuntu/
 Suites: noble-security
 Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Ubuntu now supports HTTPS on their primary mirrors, including archive.ubuntu.com and security.ubuntu.com.

While APT verifies integrity using PGP signatures, there have been a few vulnerabilities in APT that would've been prevented by also layering TLS on top.

No attempt is made to update the configuration on existing instances; instead this change will be made during the noble migration.

Fixes #3286.

## Testing

How should the reviewer test this PR?

* [x] staging CI passes

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing production instances. -> taken care of during noble migration
3. New installs. -> handled in this PR via ansible

## Checklist

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
