### PR TITLE
Copy backup to Admin Workstation before manual noble migration

### DIFF
--- a/install_files/ansible-base/roles/noble-migration/tasks/main.yml
+++ b/install_files/ansible-base/roles/noble-migration/tasks/main.yml
@@ -13,6 +13,16 @@
 - name: Perform migration
   when: not already_finished
   block:
+    - debug:
+        msg: "Taking a backup before the upgrade begins"
+
+    - name: Backup
+      include_role: backup
+      when: ossec_is_client
+
+    - debug:
+        msg: "Backup finished; starting the upgrade"
+
     - name: Instruct upgrade to begin
       ansible.builtin.copy:
         # It's okay to enable both app and mon here to simplify the logic,
@@ -90,3 +100,11 @@
         search_regex: '"finished":"Done"'
         sleep: 5
         timeout: 300
+
+    # Delete the backup file
+    - name: Delete backup
+      when: ossec_is_client
+      delegate_to: localhost
+      file:
+        path: "./{{ backup_filename }}"
+        state: absent


### PR DESCRIPTION

## Status

Work in progress

## Description of Changes

If the admin has manually initiated a backup, let's copy a backup to the Admin Workstation so it's easier to use. The backup is automatically deleted at the end of a successful playbook run.

Especially for instances using SSH-over-Tor, this step may take a while, but if something does go wrong, it'll be nice.

A backup is still taken on the server that stays on the server, there's no adverse effect except for a slight delay in waiting for the extraneous backup.

## Testing

How should the reviewer test this PR?

* [ ] Start manual migration of the app server
* [ ] See debug message that the backup finished
* [ ] Verify there's a backup in your securedrop directory
* [ ] Wait for migration to finish
* [ ] See that backup was deleted

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container
- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
