### PR TITLE
feat(`validate_locale_configuration`): discard and warn on configured but unsupported locale

### DIFF
--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -159,7 +159,7 @@ def validate_locale_configuration(config: SecureDropConfig, babel: Babel) -> Set
 
     missing = configured - usable
     if missing:
-        babel.app.logger.error(
+        babel.app.logger.warning(
             f"Configured locales {missing} are not in the set of usable locales {usable}"
         )
 

--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import collections
+import json
 from typing import DefaultDict, List, OrderedDict, Set
 
 from babel.core import (
@@ -28,6 +29,8 @@ from babel.core import (
 from flask import Flask, current_app, g, request, session
 from flask_babel import Babel
 from sdconfig import FALLBACK_LOCALE, SecureDropConfig
+
+I18N_CONF = "i18n.json"
 
 
 class RequestLocaleInfo:
@@ -137,12 +140,17 @@ def validate_locale_configuration(config: SecureDropConfig, babel: Babel) -> Set
     available = set(babel.list_translations())
     available.add(Locale.parse(FALLBACK_LOCALE))
 
+    # These locales are supported in the current version of securedrop-app-code.
+    with open(I18N_CONF) as i18n_conf_file:
+        i18n_conf = json.load(i18n_conf_file)
+    supported = parse_locale_set(i18n_conf["supported_locales"].keys())
+
     # These locales were configured via "securedrop-admin sdconfig", meaning
     # they were present on the Admin Workstation at "securedrop-admin" runtime.
     configured = parse_locale_set(config.SUPPORTED_LOCALES)
 
     # The intersection of these sets is the set of locales usable by Babel.
-    usable = available & configured
+    usable = available & configured & supported
 
     missing = configured - usable
     if missing:

--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -17,6 +17,7 @@
 #
 import collections
 import json
+from pathlib import Path
 from typing import DefaultDict, List, OrderedDict, Set
 
 from babel.core import (
@@ -30,7 +31,7 @@ from flask import Flask, current_app, g, request, session
 from flask_babel import Babel
 from sdconfig import FALLBACK_LOCALE, SecureDropConfig
 
-I18N_CONF = "i18n.json"
+I18N_CONF = Path(__file__).parent / "i18n.json"
 
 
 class RequestLocaleInfo:
@@ -141,9 +142,13 @@ def validate_locale_configuration(config: SecureDropConfig, babel: Babel) -> Set
     available.add(Locale.parse(FALLBACK_LOCALE))
 
     # These locales are supported in the current version of securedrop-app-code.
-    with open(I18N_CONF) as i18n_conf_file:
-        i18n_conf = json.load(i18n_conf_file)
-    supported = parse_locale_set(i18n_conf["supported_locales"].keys())
+    try:
+        with open(I18N_CONF) as i18n_conf_file:
+            i18n_conf = json.load(i18n_conf_file)
+        supported = parse_locale_set(i18n_conf["supported_locales"].keys())
+    # I18N_CONF may not be available under test.
+    except FileNotFoundError:
+        supported = available
 
     # These locales were configured via "securedrop-admin sdconfig", meaning
     # they were present on the Admin Workstation at "securedrop-admin" runtime.


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Closes #7442:  If `validate_locale_configuration()` doesn't check the authoritative list of supported locales in the `i18n.json` file installed by `securedrop-app-code`, then a language for which support has been revoked won't be disabled until `config.SUPPORTED_LOCALES` is updated on the next `securedrop-admin {sdconfig,install}` run.

This isn't a bug; it was simply out of scope of #6557.  Now #7442 motivates us to at least consider: **Do we *want* an unsupported language to be disabled immediately on upgrade of `securedrop-app-code`, not just on the next `securedrop-admin {sdconfig,install}`?**  If yes, then this diff handles this case.  If not, then we can just close this pull request.


## Testing

Under `make dev` with:

```patch
--- a/securedrop/bin/dev-config
+++ b/securedrop/bin/dev-config
@@ -26,7 +26,7 @@ with open('securedrop/config.py', 'w') as f:
     text = env.get_template("securedrop/config.py.example").render(ctx)
     text += '\n'
     supported_locales = subprocess.check_output(['make', '--quiet', 'supported-locales']).decode().strip()
-    text += f'SUPPORTED_LOCALES = {supported_locales}\n'
+    text += f'SUPPORTED_LOCALES = {"de_DE", "ro", "en_US"}\n'
     f.write(text)
 
 with open('securedrop/rq_config.py', 'w') as f:
--- a/securedrop/i18n.json
+++ b/securedrop/i18n.json
@@ -63,10 +63,6 @@
       "name": "Portuguese, Portugal",
       "desktop": "pt_PT"
     },
-    "ro": {
-      "name": "Romanian",
-      "desktop": "ro"
-    },
     "ru": {
       "name": "Russian",
       "desktop": "ru"
```

- [ ] Observe on startup:
    ```
    [2025-02-19 23:51:46,846] WARNING in i18n: Configured locales {Locale('ro')} are not in the set of usable locales {Locale('de', territory='DE'), Locale('en', territory='US')}
    ```
- [ ] Romanian is not offered in the locale switcher
- [ ] `/?l=ro` defaults to en_US


## Deployment

As above:

1. Do we want an unsupported language to be disabled immediately on upgrade of `securedrop-app-code`, not just on the next `securedrop-admin {sdconfig,install}`?
2. ~~Do we want an error to be logged and an OSSEC alert to be sent in this case?~~
    - Release QA should confirm that the warning (downgraded from error) does not trigger an OSSEC alert.


## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

**NB.**  This is already covered at the implementation (as opposed to configuration) level by [`test_valid_but_unusable_locales()`](https://github.com/freedomofpress/securedrop/blob/35e4b2df2b5c3197c605884e078adc6116cffc69/securedrop/tests/test_i18n.py#L374).

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [x] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [x] I have written a test plan and validated it for this PR

Choose one of the following:

- I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- I would appreciate help with the documentation
- [x] These changes do not require documentation