### PR TITLE
chore: revoke support for Hindi (`hi`)

### DIFF
--- a/install_files/ansible-base/roles/tails-config/templates/desktop-journalist-icon.j2
+++ b/install_files/ansible-base/roles/tails-config/templates/desktop-journalist-icon.j2
@@ -13,7 +13,6 @@ Name[de_DE]=Journalistenschnittstelle für SecureDrop
 Name[el]=Διεπαφή δημοσιογράφου του SecureDrop
 Name[es_ES]=Interfaz de periodista de SecureDrop
 Name[fr]=SecureDrop – Interface des journalistes
-Name[hi]=SecureDrop पत्रकार अंतराफलक
 Name[hr]=SecureDrop sučelje za novinare
 Name[is]=Blaðamannaviðmót SecureDrop
 Name[it]=Interfaccia giornalista di SecureDrop

--- a/install_files/ansible-base/roles/tails-config/templates/desktop-source-icon.j2
+++ b/install_files/ansible-base/roles/tails-config/templates/desktop-source-icon.j2
@@ -13,7 +13,6 @@ Name[de_DE]=Quellenschnittstelle für SecureDrop
 Name[el]=Διεπαφή πηγής του SecureDrop
 Name[es_ES]=Interfaz de fuente de SecureDrop
 Name[fr]=SecureDrop – Interface des sources
-Name[hi]=SecureDrop स्रोत अंतराफलक
 Name[hr]=SecureDrop sučelje za izvore
 Name[is]=Heimildarmannaviðmót SecureDrop
 Name[it]=Interfaccia fonte di SecureDrop

--- a/install_files/ansible-base/roles/tails-config/templates/locale/LINGUAS
+++ b/install_files/ansible-base/roles/tails-config/templates/locale/LINGUAS
@@ -5,7 +5,6 @@ de_DE
 el
 es_ES
 fr
-hi
 hr
 is
 it

--- a/securedrop/i18n.json
+++ b/securedrop/i18n.json
@@ -31,10 +31,6 @@
       "name": "French",
       "desktop": "fr"
     },
-    "hi": {
-      "name": "Hindi",
-      "desktop": "hi"
-    },
     "hr": {
       "name": "Croatian",
       "desktop": "hr"

--- a/securedrop/i18n.rst
+++ b/securedrop/i18n.rst
@@ -7,7 +7,6 @@
 * English (``en_US``)
 * Spanish (``es_ES``)
 * French (``fr_FR``)
-* Hindi (``hi``)
 * Croatian (``hr``)
 * Icelandic (``is``)
 * Italian (``it_IT``)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Revokes support for Hindi (`hi`), which has been on translation [probation](https://developers.securedrop.org/en/latest/supported_languages.html#revoking-support-for-a-language) [since v2.6.0](https://docs.google.com/spreadsheets/d/1IfGqf3tgcW9PoL1h8vRJG6lTqVZuNsPYIbhG947FKMk/edit?gid=0#gid=0).


## Testing

CI is adequate.


## Deployment

Per #7443.