### PR TITLE
test: add `libvirt-prod-noble` scenario

### DIFF
--- a/molecule/libvirt-prod-noble/molecule.yml
+++ b/molecule/libvirt-prod-noble/molecule.yml
@@ -1,0 +1,40 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+platforms:
+  - name: app-prod
+    box: bento/ubuntu-24.04
+    raw_config_args:
+      - "cpu_mode = 'host-passthrough'"
+      - "video_type = 'virtio'"
+    instance_raw_config_args:
+      - "vm.synced_folder './', '/vagrant', disabled: true"
+      - "vm.network 'private_network', ip: '10.0.1.4'"
+      - "ssh.insert_key = false"
+    memory: 1024
+    private_ip: 10.0.1.4
+    groups:
+      - securedrop_application_server
+      - securedrop
+
+  - name: mon-prod
+    box: bento/ubuntu-24.04
+    raw_config_args:
+      - "cpu_mode = 'host-passthrough'"
+      - "video_type = 'virtio'"
+    instance_raw_config_args:
+      - "vm.synced_folder './', '/vagrant', disabled: true"
+      - "vm.network 'private_network', ip: '10.0.1.5'"
+      - "ssh.insert_key = false"
+    memory: 1024
+    private_ip: 10.0.1.5
+    groups:
+      - securedrop_monitor_server
+      - securedrop
+
+scenario:
+  name: libvirt-prod-noble


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Adapts the `libvirt-prod-noble` Molecule scenario for production VM testing for Ubuntu 24.04.


## Testing


```sh-session
# molecule create -s libvirt-prod-focal  # to show no conflicts
# molecule create -s libvirt-prod-noble
# virsh list | grep "prod"
 4    libvirt-prod-focal_app-prod         running
 5    libvirt-prod-focal_mon-prod         running
 6    libvirt-prod-noble_app-prod         running
 7    libvirt-prod-noble_mon-prod         running
# curl https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant > ~/.ssh/id_rsa
# chmod 600 ~/.ssh/id_rsa
# virsh domifaddr libvirt-prod-noble_app-prod
 Name       MAC address          Protocol     Address
-------------------------------------------------------------------------------
 vnet9      52:54:00:97:ba:7b    ipv4         192.168.121.23/24
# ssh vagrant@192.168.121.23 head -n 1 /etc/os-release
PRETTY_NAME="Ubuntu 24.04.2 LTS"
```


## Deployment

Test-only.