### PR TITLE
fix: allow Apache to read `i18n.json`

### DIFF
--- a/securedrop/debian/app-code/etc/apparmor.d/usr.sbin.apache2
+++ b/securedrop/debian/app-code/etc/apparmor.d/usr.sbin.apache2
@@ -173,6 +173,7 @@
   /var/www/securedrop/dictionaries/nouns.txt r,
   /var/www/securedrop/encryption.py r,
   /var/www/securedrop/execution.py r,
+  /var/www/securedrop/i18n.json r,
   /var/www/securedrop/i18n.py r,
   /var/www/securedrop/journalist.py r,
   /var/www/securedrop/journalist_app/ r,


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Fixes #7450 re: #7443.


## Testing

- [ ] Staging CI passes except for `test_all_packages_updated` per #7433.


## Checklist

### If you added or removed a file deployed with the application:

- [x] I have updated AppArmor rules to include the change

Indeed, and I will follow up in #7450 on why we didn't catch this in #7443....
