### PR TITLE
[2.12.0] Backport "fix: allow Apache to read `i18n.json`"

### DIFF
--- a/securedrop/debian/app-code/etc/apparmor.d/usr.sbin.apache2
+++ b/securedrop/debian/app-code/etc/apparmor.d/usr.sbin.apache2
@@ -173,6 +173,7 @@
   /var/www/securedrop/dictionaries/nouns.txt r,
   /var/www/securedrop/encryption.py r,
   /var/www/securedrop/execution.py r,
+  /var/www/securedrop/i18n.json r,
   /var/www/securedrop/i18n.py r,
   /var/www/securedrop/journalist.py r,
   /var/www/securedrop/journalist_app/ r,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7451.

## Testing

* [x] CI is passing
* [x] base is `release/2.12.0`
* [x] Only contains changes from #7451 
