### PR TITLE
Remove guard around opening i18n.json

### DIFF
--- a/securedrop/i18n.py
+++ b/securedrop/i18n.py
@@ -142,13 +142,9 @@ def validate_locale_configuration(config: SecureDropConfig, babel: Babel) -> Set
     available.add(Locale.parse(FALLBACK_LOCALE))
 
     # These locales are supported in the current version of securedrop-app-code.
-    try:
-        with open(I18N_CONF) as i18n_conf_file:
-            i18n_conf = json.load(i18n_conf_file)
-        supported = parse_locale_set(i18n_conf["supported_locales"].keys())
-    # I18N_CONF may not be available under test.
-    except FileNotFoundError:
-        supported = available
+    with open(I18N_CONF) as i18n_conf_file:
+        i18n_conf = json.load(i18n_conf_file)
+    supported = parse_locale_set(i18n_conf["supported_locales"].keys())
 
     # These locales were configured via "securedrop-admin sdconfig", meaning
     # they were present on the Admin Workstation at "securedrop-admin" runtime.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This operation should never fail because the i18n.json file is shipped with the package and always present.

Possibly the rationale of needing it for tests no longer applies since the path is now absolute and not relative to the current working directory.

See <https://github.com/freedomofpress/securedrop/pull/7443#discussion_r1963825620>.

## Testing

How should the reviewer test this PR?

* [x] CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
