### PR TITLE
Update focal EOL date to 2025-05-31

### DIFF
--- a/securedrop/server_os.py
+++ b/securedrop/server_os.py
@@ -6,7 +6,7 @@ from pathlib import Path
 FOCAL_VERSION = "20.04"
 NOBLE_VERSION = "24.04"
 
-FOCAL_ENDOFLIFE = date(2025, 4, 2)
+FOCAL_ENDOFLIFE = date(2025, 5, 31)
 
 
 @functools.lru_cache


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Ubuntu has extended the EOL to the end of May per
<https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare> and other sources.

Fixes #7455.

## Testing

How should the reviewer test this PR?

* [ ] visual review

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container
