### PR TITLE
Remove systemd-resolved, explicitly install systemd-hwe-hwdb on noble

### DIFF
--- a/builder/tests/test_securedrop_deb_package.py
+++ b/builder/tests/test_securedrop_deb_package.py
@@ -130,3 +130,22 @@ def test_apparmor_conditional():
 
     print(info)
     assert found, "Depends: line wasn't found"
+
+
+def test_systemd_conditional():
+    try:
+        path = [pkg for pkg in DEB_PATHS if pkg.name.startswith("securedrop-config")][0]
+    except IndexError:
+        raise RuntimeError("Unable to find securedrop-config package in build/ folder")
+    info = subprocess.check_output(["dpkg", "--info", path]).decode()
+    found = False
+    for line in info.splitlines():
+        if line.startswith(" Depends:"):
+            found = True
+            if UBUNTU_VERSION == "focal":
+                assert "systemd-hwe-hwdb" not in line, "focal has no systemd-hwe-hwdb dependency"
+            else:
+                assert "systemd-hwe-hwdb" in line, "noble has systemd-hwe-hwdb dependency"
+
+    print(info)
+    assert found, "Depends: line wasn't found"

--- a/install_files/ansible-base/roles/common/tasks/harden_dns.yml
+++ b/install_files/ansible-base/roles/common/tasks/harden_dns.yml
@@ -7,11 +7,24 @@
     - dns
     - hardening
 
-- name: Disable systemd-resolved
+- name: Disable systemd-resolved (focal)
   systemd:
     name: systemd-resolved
     state: stopped
     enabled: no
+  when: ansible_distribution_release == "focal"
   tags:
+    - dns
+    - hardening
+
+- name: Uninstall systemd-resolved (noble)
+  apt:
+    name:
+      - systemd-resolved
+    state: absent
+    purge: yes
+  when: ansible_distribution_release != "focal"
+  tags:
+    - apt
     - dns
     - hardening

--- a/molecule/testinfra/common/test_system_hardening.py
+++ b/molecule/testinfra/common/test_system_hardening.py
@@ -49,6 +49,16 @@ def test_dns_setting(host):
     assert f.mode == 0o644
     assert f.contains(r"^nameserver 8\.8\.8\.8$")
 
+    if host.system_info.codename == "focal":
+        # On focal, systemd-resolved's unit is disabled
+        with host.sudo():
+            s = host.service("systemd-resolved")
+            assert not s.is_enabled
+            assert not s.is_running
+    else:
+        # On noble, systemd-resolved is not installed
+        assert not host.package("systemd-resolved").is_installed
+
 
 @pytest.mark.parametrize(
     "kernel_module",

--- a/securedrop/debian/control
+++ b/securedrop/debian/control
@@ -15,7 +15,7 @@ Description: SecureDrop application code, dependencies, Apache configuration, sy
 
 Package: securedrop-config
 Architecture: amd64
-Depends: ${shlibs:Depends}, unattended-upgrades, update-notifier-common
+Depends: ${shlibs:Depends}, ${systemd:Depends}, unattended-upgrades, update-notifier-common
 Description: Establishes baseline system state for running SecureDrop.
  Configures apt repositories.
 

--- a/securedrop/debian/rules
+++ b/securedrop/debian/rules
@@ -67,8 +67,10 @@ override_dh_strip_nondeterminism:
 override_dh_gencontrol:
 ifneq ($(findstring +noble,$(DEB_VERSION)),)
 	dh_gencontrol -psecuredrop-app-code -- "-Vapparmor:Depends=apparmor (>= 4.0.1really4.0.1-0ubuntu0.24.04.3)"
+	dh_gencontrol -psecuredrop-config -- "-Vsystemd:Depends=systemd-hwe-hwdb"
 else
 	dh_gencontrol -psecuredrop-app-code -- "-Vapparmor:Depends="
+	dh_gencontrol -psecuredrop-config -- "-Vsystemd:Depends="
 endif
 	dh_gencontrol -psecuredrop-ossec-agent -- "-v3.6.0+${DEB_VERSION}"
 	dh_gencontrol -psecuredrop-ossec-server -- "-v3.6.0+${DEB_VERSION}"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

These two packages are installed on fresh systems, but not on upgrades because they were split out of the systemd package. ~Set the dependency ourselves to make sure it's always pulled in.~ [see discussion below]

In the future once all SecureDrops are on noble, we can uninstall systemd-resolved entirely instead of merely stopping it.

Fixes #7464.

## Testing

* [x] CI passes (verifies conditional dependency is correctly applied)
* [x] staging CI passes, verifies fresh install is fine
* [x] do a focal to noble upgrade with these packages, verify systemd-resolved is not installed post-upgrade, `/etc/resolv.conf` points to your configured DNS, and e.g. `curl https://securedrop.org` works since DNS is working.
* [x] verify that `./securedrop-admin install` works post-upgrade.

## Deployment

Any special considerations for deployment? upgrade is more important.

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass
- [x] I have written a test plan and validated it for this PR

