### PR TITLE
[2.12.0] Backport "Ignore RUSTSEC-2025-0014, humantime is unmaintained, for now"

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,9 @@
 [advisories]
-ignore = [] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
+# advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
+ignore = [
+    # humantime, see #7469
+    "RUSTSEC-2025-0014"
+]
 
 # Output Configuration
 [output]


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7470.

## Testing

* [ ] CI is passing
* [ ] base is `release/2.12.0`
* [ ] Only contains changes from #7470 
