### PR TITLE
admin: Trim newlines from inputted PGP fingerprints

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -609,7 +609,7 @@ class SiteConfig:
             return value
 
     def sanitize_fingerprint(self, value: str) -> str:
-        return value.upper().replace(" ", "")
+        return value.upper().replace(" ", "").strip()
 
     def validate_gpg_keys(self) -> bool:
         keys = (

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -650,7 +650,7 @@ class TestSiteConfig:
             root=tmpdir,
         )
         site_config = securedrop_admin.SiteConfig(args)
-        assert site_config.sanitize_fingerprint("    A bc") == "ABC"
+        assert site_config.sanitize_fingerprint("    A bc\n") == "ABC"
 
     def test_validate_int(self):
         validator = securedrop_admin.SiteConfig.ValidateInt()


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes

If people copy-and-paste from GPG, there's a decent chance they'll bring in extraneous whitespace. While normal spaces were already removed, we weren't cleaning up newlines.

Extend the sanitization step to `.strip()` any remaining whitespace. The test now includes a trailing newline to verify it as well.

Fixes #7468.

## Testing

How should the reviewer test this PR?

* [ ] visual review
* [ ] admin CI passes

## Deployment

Any special considerations for deployment? only affects new installs / new config changes. If someone already has an invalid `site-specific` file, they will still need to manually fix it.

## Checklist

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container
