### PR TITLE
build: when building from a tag, verify the tag's signature and working tree

### DIFF
--- a/builder/build-debs.sh
+++ b/builder/build-debs.sh
@@ -4,7 +4,17 @@
 
 set -euxo pipefail
 
+# --- BEGIN keep this section in sync with securedrop-client, so that build logs
+# from both repositories can be verified in the same way. ---
+
 git --no-pager log -1 --oneline --show-signature --no-color
+# We intentionally want the git tag list to be word-split
+# shellcheck disable=SC2046
+git --no-pager tag -v $(git tag --points-at HEAD)
+# Record if we're building with local (i.e., post-signature) changes present.
+git status --short
+
+# --- END keep this section in sync. ---
 
 export UBUNTU_VERSION="${UBUNTU_VERSION:-focal}"
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

`securedrop-apt-prod`'s pull-request template [refers](https://github.com/freedomofpress/securedrop-apt-prod/blob/0b0d7f72264b1874fe7e2f7f1d319163c40b36ee/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L9C1-L9C52) to checking that `build-logs` demonstrates that the intended tag was built.  But that's not what we get from:

https://github.com/freedomofpress/securedrop/blob/dd90e52e473d1ac63015af0c759fca7484944062/builder/build-debs.sh#L7

1. `git log --show-signature` verifies the signature on the tag's commit, not the tag itself, which still has to be verified manually with `git tag -v`.
2. Either verification is enforced on history, not on the working tree actually being built from.

This pull request explicitly verifies both (1) and (2).

## Testing

Review along with freedomofpress/securedrop-client#2431.

- [ ] New checks are visible in CI.
- [ ] Check out `2.12.0` and run `make build-debs`, and confirm that `2.12.0` is verified by tag rather than by commit.

## Deployment

No deployment considerations.

- [x] If we adopt this change, we should check what other build scripts might need it too. 