### PR TITLE
Make noble-migration playbook smarter for SSH-over-Tor handling

### DIFF
--- a/install_files/ansible-base/roles/noble-migration/tasks/main.yml
+++ b/install_files/ansible-base/roles/noble-migration/tasks/main.yml
@@ -81,7 +81,7 @@
         connect_timeout: 20
         sleep: 5
         delay: 10
-        timeout: 300
+        timeout: 600
 
     - name: Recheck host's migration state
       ansible.builtin.slurp:
@@ -132,7 +132,7 @@
         connect_timeout: 20
         sleep: 5
         delay: 10
-        timeout: 300
+        timeout: 600
 
     - name: Recheck host's migration state
       ansible.builtin.slurp:
@@ -174,7 +174,7 @@
         connect_timeout: 20
         sleep: 5
         delay: 10
-        timeout: 300
+        timeout: 600
 
     - name: Recheck host's migration state
       ansible.builtin.slurp:

--- a/install_files/ansible-base/roles/noble-migration/tasks/main.yml
+++ b/install_files/ansible-base/roles/noble-migration/tasks/main.yml
@@ -1,17 +1,50 @@
 ---
 
+- name: Initialize
+  set_fact:
+    # Keep in sync with upgrade.rs
+    stages:
+      - 'None'
+      - 'PendingUpdates'
+      - 'MigrationCheck'
+      - 'DisableApache2'
+      - 'Backup'
+      - 'BackupIptables'
+      - 'Marker'
+      - 'SuspendOSSEC'
+      - 'ChangeAptSources'
+      - 'AptGetUpdate'
+      - 'AptGetFullUpgrade'
+      - 'AptGetAutoremove'
+      - 'RestoreIptables'
+      - 'ReenableUnattendedUpdates'
+      - 'ReenableOSSEC'
+      - 'Reboot'
+      - 'SwitchUbuntuSources'
+      - 'IntegrityCheck'
+      - 'ReenableApache2'
+      - 'RemoveBackup'
+      - 'Done'
+
 - name: Check host's migration state
   ansible.builtin.slurp:
     src: /etc/securedrop-noble-migration-state.json
   register: migration_json
-  ignore_errors: yes
 
-- name: Skip migration if already done
+# Note: the variable finished_state is only for debugging and human-readable output.
+# The finished_state_index is what must be used for logic in `when` blocks.
+
+- name: Extract current state
   set_fact:
-    already_finished: "{{ not migration_json.failed and (migration_json.content | b64decode | from_json)['finished'] == 'Done' }}"
+    # slurp base64-encodes our file
+    finished_state: "{{ (migration_json.content | b64decode | from_json)['finished'] }}"
 
-- name: Perform migration
-  when: not already_finished
+- name: Extract current state (2)
+  set_fact:
+    finished_state_index: "{{ stages.index(finished_state) }}"
+
+- name: Kick off migration
+  when: finished_state_index|int == 0
   block:
     - name: Instruct upgrade to begin
       ansible.builtin.copy:
@@ -50,6 +83,29 @@
         delay: 10
         timeout: 300
 
+    - name: Recheck host's migration state
+      ansible.builtin.slurp:
+        src: /etc/securedrop-noble-migration-state.json
+      register: migration_json
+
+    - name: Extract current state
+      set_fact:
+        # slurp base64-encodes our file
+        finished_state: "{{ (migration_json.content | b64decode | from_json)['finished'] }}"
+
+    - debug:
+        msg: "The current upgrade state is: {{ finished_state }}"
+
+    - name: Extract current state (2)
+      set_fact:
+        finished_state_index: "{{ stages.index(finished_state) }}"
+    # Note: do not add anything after this line in this block - it will not run, because
+    # the block is in a `when` that we just made false by updating `finished_state_index`.
+
+- name: Phase 2 of migration
+  # After PendingUpdates (index 1) but before Reboot (index 15)
+  when: finished_state_index|int >= 1 and finished_state_index|int < 15
+  block:
     # Start the systemd service manually to avoid waiting for the timer to pick it up
     - name: Resume upgrade systemd service
       ansible.builtin.systemd:
@@ -61,7 +117,7 @@
 
     # Same as above, this will most likely fail as unreachable when the server
     # actually reboots.
-    - name: Wait for system upgrade to noble
+    - name: Wait for system upgrade to noble (phase 2)
       ansible.builtin.wait_for:
         path: /etc/securedrop-noble-migration-state.json
         search_regex: '"finished":"Reboot"'
@@ -71,13 +127,78 @@
       ignore_unreachable: yes
       ignore_errors: yes
 
-    - name: Wait for the second reboot
+    - name: Wait for the second reboot (phase 2)
       ansible.builtin.wait_for_connection:
         connect_timeout: 20
         sleep: 5
         delay: 10
         timeout: 300
 
+    - name: Recheck host's migration state
+      ansible.builtin.slurp:
+        src: /etc/securedrop-noble-migration-state.json
+      register: migration_json
+
+    - name: Extract current state
+      set_fact:
+        # slurp base64-encodes our file
+        finished_state: "{{ (migration_json.content | b64decode | from_json)['finished'] }}"
+
+    - debug:
+        msg: "The current upgrade state is: {{ finished_state }}"
+
+    - name: Extract current state (2)
+      set_fact:
+        finished_state_index: "{{ stages.index(finished_state) }}"
+    # Note: do not add anything after this line in this block - it will not run, because
+    # the block is in a `when` that we just made false by updating `finished_state_index`.
+
+- name: Phase 2.5 of migration (for SSH-over-Tor users)
+  # After PendingUpdates (index 1) but before Reboot (index 15)
+  when: enable_ssh_over_tor and finished_state_index|int >= 1 and finished_state_index|int < 15
+  block:
+    # Same as above, this will most likely fail as unreachable when the server
+    # actually reboots.
+    - name: Wait for system upgrade to noble (phase 2.5)
+      ansible.builtin.wait_for:
+        path: /etc/securedrop-noble-migration-state.json
+        search_regex: '"finished":"Reboot"'
+        sleep: 5
+        # Should finish in less than 30 minutes
+        timeout: 1800
+      ignore_unreachable: yes
+      ignore_errors: yes
+
+    - name: Wait for the second reboot (phase 2.5)
+      ansible.builtin.wait_for_connection:
+        connect_timeout: 20
+        sleep: 5
+        delay: 10
+        timeout: 300
+
+    - name: Recheck host's migration state
+      ansible.builtin.slurp:
+        src: /etc/securedrop-noble-migration-state.json
+      register: migration_json
+
+    - name: Extract current state
+      set_fact:
+        # slurp base64-encodes our file
+        finished_state: "{{ (migration_json.content | b64decode | from_json)['finished'] }}"
+
+    - debug:
+        msg: "The current upgrade state is: {{ finished_state }}"
+
+    - name: Extract current state (2)
+      set_fact:
+        finished_state_index: "{{ stages.index(finished_state) }}"
+    # Note: do not add anything after this line in this block - it will not run, because
+    # the block is in a `when` that we just made false by updating `finished_state_index`.
+
+- name: Phase 3 of migration
+  # After Reboot (index 15) but before Done (index 20)
+  when: finished_state_index|int >= 15 and finished_state_index|int < 20
+  block:
     - name: Re-resume upgrade systemd service
       ansible.builtin.systemd:
         name: securedrop-noble-migration-upgrade
@@ -90,3 +211,14 @@
         search_regex: '"finished":"Done"'
         sleep: 5
         timeout: 300
+
+    # Instead of slurping the file again, we can set the state to done
+    # because we just waited for it to reach that point.
+    - name: Extract current state
+      set_fact:
+        finished_state: "Done"
+        finished_state_index: 20
+
+- fail:
+    msg: "Upgrade did not successfully finish; please check the logs and documentation for more details."
+  when: finished_state != "Done"

--- a/noble-migration/src/bin/upgrade.rs
+++ b/noble-migration/src/bin/upgrade.rs
@@ -30,6 +30,8 @@ const EXTRA_APT_SOURCE: &str = "EXTRA_APT_SOURCE";
 ///
 /// Each stage needs to be idempotent so that it can be run multiple times
 /// in case it errors/crashes.
+///
+/// Keep this in sync with the version in noble-migration/tasks/main.yml
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 enum Stage {
     None,


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Previously, the ansible playbook didn't actually understand the sequencing - it was just a dumb, hardcoded sequence of two reboots.

We recently learned that with SSH-over-Tor there's a race condition, you might end up with 3 disconnections instead of 2 because you'll lose SSH when Tor is upgraded. In some cases if things are slow enough, you might only reconnect after the second reboot. So we need to be able to dynamically handle 2 or 3 disconnections.

The playbook is now aware of the most recently completed state, as well as the position in the overall run.

In human-readable pseudocode, the logic roughly is:

* Get current finished state
* If finished_state == None: (i.e. not started)
  * Kick off the migration.
  * Wait for a reboot (should switch to PendingUpdates here)
  * Get current finished state
* If Reboot > finished_state >= PendingUpdates: ("Phase 2")
* Wait for a reboot (should switch to Reboot here, unless SSH-over-Tor disconnects first)
  * Get current finished state
* If SSH-over-Tor and Reboot > finished_state >= PendingUpdates: ("Phase 2.5")
  * Wait for a reboot (should switch to Reboot here)
  * Get current finished state
* If Done > finished_state >= Reboot: ("Phase 3")
  * Wait for finished state to be Done
  * Set current finished state to Done
* If finished_state != Done:
  * Fail :(

Because the logic is fully aware of the migration state, if you e.g. start the playbook, the upgrade begins, you Ctrl+C, and then restart the playbook, it'll just work because it'll drop you into the correct phase's logic instead of starting from the beginning.

Fixes #7483.

## Testing

How should the reviewer test this PR?

* [ ] visual review
* [ ] CI passes
* [x] set up 2.12.0 on focal (VMs or prod is fine), check out this PR on the AW and:
   * [x] enable SSH-over-Tor, `./securedrop-admin noble_migration` completes successfully
   * [x] without SSH-over-Tor, `./securedrop-admin noble_migration` completes successfully
   * [ ] Start `./securedrop-admin noble_migration`, wait until you see "The upgrade is in progress; it may take up to 30 minutes", then Ctrl+C the playbook and restart it. It should still complete successfully even though it's one less reboot. (SSH-over-Tor doesn't matter for this scenario)

## Deployment

Any special considerations for deployment? Will be backported into a 2.12.1 AW-only release. I added a comment to upgrade.rs, which is not AW-only but it's not actually a change.

## Checklist

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container
