### PR TITLE
Do fully automated upgrade of 20% of app servers

### DIFF
--- a/securedrop/debian/config/usr/share/securedrop/noble-upgrade.json
+++ b/securedrop/debian/config/usr/share/securedrop/noble-upgrade.json
@@ -1,7 +1,7 @@
 {
     "app": {
-        "enabled": false,
-        "bucket": 0
+        "enabled": true,
+        "bucket": 1
     },
     "mon": {
         "enabled": false,


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes

Kick off the first stage of the full automated noble migration, by upgrading all instances in bucket 1, which should be ~20% of app servers.

## Testing

How should the reviewer test this PR?

* [ ] edit `/etc/securedrop-noble-migration-state.json` on app to be in bucket 5.
* [ ] upgrade to packages with this PR; see the fully automated migration doesn't begin
* [ ] edit the state file to be in bucket 1
* [ ] wait for the timer to run again, migration should begin.

## Deployment

Any special considerations for deployment? n/a
