### PR TITLE
Add OSSEC ignores for noble-update-related red herring errors

### DIFF
--- a/molecule/testinfra/vars/staging.yml
+++ b/molecule/testinfra/vars/staging.yml
@@ -132,6 +132,20 @@ log_events_without_ossec_alerts:
     level: "0"
     rule_id: "199996"
 
+  # #7491
+  - name: Update_notifier_download_failed_text_no_alert
+    alert: >
+        Download data for packages that failed at package install time
+    level: "0"
+    rule_id: "199994"
+
+  # #7491
+  - name: apt_news_warning_text_no_alert
+    alert: >
+        Warning: W:Download is performed unsandboxed as root as file
+    level: "0"
+    rule_id: "199995"
+
   # OSSEC should not alert when "manage.py check-disconnected-{db,fs}-
   # submissions" has logged that there are no disconnected submissions.
   - name: test_no_disconnected_db_submissions_produces_alert

--- a/securedrop/debian/ossec-server/var/ossec/rules/local_rules.xml
+++ b/securedrop/debian/ossec-server/var/ossec/rules/local_rules.xml
@@ -118,6 +118,18 @@
 </group>
 
 <group name="do not alert">
+  <rule id="199994" level="0">
+    <match>Download data for packages that failed at package install time</match>
+    <description>ignore update_notifier_download.service text with "failed" string (https://github.com/freedomofpress/securedrop/issues/7491)</description>
+    <options>no_email_alert</options>
+   </rule>
+
+  <rule id="199995" level="0">
+    <match>Warning: W:Download is performed unsandboxed as root as file</match>
+    <description>ignore apt_news text with "warning" string (https://github.com/freedomofpress/securedrop/issues/7491)</description>
+    <options>no_email_alert</options>
+   </rule>
+
   <rule id="199996" level="0">
     <match>NameError: name 'hasattr' is not defined</match>
     <description>ignore NameError on builtin hasattr() at mod_wsgi teardown (https://github.com/freedomofpress/securedrop/issues/6866)</description>


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #7491.

Changes proposed in this pull request:

## Testing

- [ ] CI is passing (including staging job)
- [ ] Rule matches are consistent with strings in #7491 

## Deployment

Deployed with next securedrop-ossec-server release.