### PR TITLE
Don't begin noble migration on noble

### DIFF
--- a/noble-migration/src/bin/upgrade.rs
+++ b/noble-migration/src/bin/upgrade.rs
@@ -299,6 +299,7 @@ fn pending_updates(state: &mut State) -> Result<()> {
 /// we begin
 fn migration_check() -> Result<()> {
     info!("Checking pre-migration steps...");
+    // This should've been caught in should_upgrade() but let's double check
     if noble_migration::os_codename()? != "focal" {
         bail!("not a focal system");
     }
@@ -616,6 +617,13 @@ fn should_upgrade(state: &State) -> Result<bool> {
     if state.finished != Stage::None {
         info!("Upgrade has already started; will keep going");
         return Ok(true);
+    }
+    // Check if we're already on a noble system and we're not mid-upgrade
+    if state.finished == Stage::None
+        && noble_migration::os_codename()? == "noble"
+    {
+        info!("Already on a noble system; no need to upgrade.");
+        return Ok(false);
     }
     let (for_host, host_name) = if is_mon_server() {
         (&config.mon, "mon")


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes

Now that we're enabling fully automated upgrades, we need to explicitly check that we're not already noble before starting the migration.

The existing check in the MigrationCheck stage is too late, since by then we'll have already disabled unattended-upgrades.

Fixes #7501.

## Testing

How should the reviewer test this PR?

* [ ] visual review of logic
* [x] build packages, install on a fresh install noble system and see that it does not begin the upgrade

## Deployment

Any special considerations for deployment? n/a

