### PR TITLE
chown packages to host's user after building

### DIFF
--- a/builder/build-debs-ossec.sh
+++ b/builder/build-debs-ossec.sh
@@ -30,3 +30,4 @@ source /etc/os-release
 mv -v ../*.{buildinfo,changes,deb,tar.gz} "/src/build/${VERSION_CODENAME}"
 cd "/src/build/${VERSION_CODENAME}"
 sha256sum ./*
+chown -R "$HOST_UID:$HOST_GID" "/src/build/${VERSION_CODENAME}"

--- a/builder/build-debs-securedrop.sh
+++ b/builder/build-debs-securedrop.sh
@@ -39,3 +39,4 @@ for file in *.ddeb; do
     mv "$file" "${file%.ddeb}.deb";
 done
 sha256sum ./*
+chown -R "$HOST_UID:$HOST_GID" "/src/build/${VERSION_CODENAME}"

--- a/builder/build-debs.sh
+++ b/builder/build-debs.sh
@@ -8,12 +8,12 @@ git --no-pager log -1 --oneline --show-signature --no-color
 
 export UBUNTU_VERSION="${UBUNTU_VERSION:-focal}"
 
+OCI_RUN_ARGUMENTS="--user=root -v $(pwd):/src:Z -e HOST_UID=$(id -u) -e HOST_GID=$(id -g)"
+
 # Setuptools_scm 8.3.0 breaks focal builds - so let's temporarily constrain it to 8.1.0
 TMP_CONSTRAINT="/srv/securedrop/requirements/python3/constraints.txt"
 if [[ $UBUNTU_VERSION == "focal" ]]; then
-    OCI_RUN_ARGUMENTS="-e PIP_CONSTRAINT=${TMP_CONSTRAINT} --user=root -v $(pwd):/src:Z"
-else
-    OCI_RUN_ARGUMENTS="--user=root -v $(pwd):/src:Z"
+    OCI_RUN_ARGUMENTS="-e PIP_CONSTRAINT=${TMP_CONSTRAINT} ${OCI_RUN_ARGUMENTS}"
 fi
 
 # Default to podman if available


### PR DESCRIPTION
## Status

Ready for review 

## Description

The intention was always that the host user is mapped as root in the container; but differences in the various container runtimes and versions we support make that difficult.
    
For now, let's chown the packages after building so they'll always have the correct ownership.

## Testing

How should the reviewer test this PR?

* [ ] Run `make build-debs`, verify newly built debs are owned by your host user

## Deployment

Any special considerations for deployment? n/a

