### PR TITLE
noble-migration: Run migration check first

### DIFF
--- a/install_files/ansible-base/roles/noble-migration/tasks/main.yml
+++ b/install_files/ansible-base/roles/noble-migration/tasks/main.yml
@@ -5,8 +5,8 @@
     # Keep in sync with upgrade.rs
     stages:
       - 'None'
-      - 'PendingUpdates'
       - 'MigrationCheck'
+      - 'PendingUpdates'
       - 'DisableApache2'
       - 'Backup'
       - 'BackupIptables'
@@ -103,8 +103,8 @@
     # the block is in a `when` that we just made false by updating `finished_state_index`.
 
 - name: Phase 2 of migration
-  # After PendingUpdates (index 1) but before Reboot (index 15)
-  when: finished_state_index|int >= 1 and finished_state_index|int < 15
+  # After PendingUpdates (index 2) but before Reboot (index 15)
+  when: finished_state_index|int >= 2 and finished_state_index|int < 15
   block:
     # Start the systemd service manually to avoid waiting for the timer to pick it up
     - name: Resume upgrade systemd service
@@ -154,8 +154,8 @@
     # the block is in a `when` that we just made false by updating `finished_state_index`.
 
 - name: Phase 2.5 of migration (for SSH-over-Tor users)
-  # After PendingUpdates (index 1) but before Reboot (index 15)
-  when: enable_ssh_over_tor and finished_state_index|int >= 1 and finished_state_index|int < 15
+  # After PendingUpdates (index 2) but before Reboot (index 15)
+  when: enable_ssh_over_tor and finished_state_index|int >= 2 and finished_state_index|int < 15
   block:
     # Same as above, this will most likely fail as unreachable when the server
     # actually reboots.

--- a/noble-migration/src/bin/upgrade.rs
+++ b/noble-migration/src/bin/upgrade.rs
@@ -35,8 +35,8 @@ const EXTRA_APT_SOURCE: &str = "EXTRA_APT_SOURCE";
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 enum Stage {
     None,
-    PendingUpdates,
     MigrationCheck,
+    PendingUpdates,
     DisableApache2,
     Backup,
     BackupIptables,
@@ -118,14 +118,14 @@ impl State {
 fn run_next_stage(state: &mut State) -> Result<()> {
     match state.finished {
         Stage::None => {
-            pending_updates(state)?;
-            unreachable!("script should have already exited/rebooted");
-        }
-        Stage::PendingUpdates => {
             migration_check()?;
             state.set(Stage::MigrationCheck)?;
         }
         Stage::MigrationCheck => {
+            pending_updates(state)?;
+            unreachable!("script should have already exited/rebooted");
+        }
+        Stage::PendingUpdates => {
             disable_apache2()?;
             state.set(Stage::DisableApache2)?;
         }
@@ -273,27 +273,7 @@ fn is_mon_server() -> bool {
     Path::new("/usr/share/doc/securedrop-ossec-server/copyright").exists()
 }
 
-/// Step 1: Apply any pending updates
-///
-/// Explicitly run unattended-upgrade, then disable it and reboot
-fn pending_updates(state: &mut State) -> Result<()> {
-    info!("Applying any pending updates...");
-    check_call("apt-get", &["update"])?;
-    check_call_nokill("unattended-upgrade", &[])?;
-    // Disable all background updates pre-reboot so we know it's fully
-    // disabled when we come back.
-    info!("Temporarily disabling background updates...");
-    check_call("systemctl", &["mask", "unattended-upgrades"])?;
-    check_call("systemctl", &["mask", "apt-daily"])?;
-    check_call("systemctl", &["mask", "apt-daily-upgrade"])?;
-    state.set(Stage::PendingUpdates)?;
-    check_call("systemctl", &["reboot"])?;
-    // Because we've initiated the reboot, do a hard stop here to ensure that
-    // we don't keep moving forward if the reboot doesn't happen instantly
-    process::exit(0);
-}
-
-/// Step 2: Run the migration check
+/// Step 1: Run the migration check
 ///
 /// Run the same migration check as a final verification step before
 /// we begin
@@ -316,6 +296,26 @@ fn migration_check() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Step 2: Apply any pending updates
+///
+/// Explicitly run unattended-upgrade, then disable it and reboot
+fn pending_updates(state: &mut State) -> Result<()> {
+    info!("Applying any pending updates...");
+    check_call("apt-get", &["update"])?;
+    check_call_nokill("unattended-upgrade", &[])?;
+    // Disable all background updates pre-reboot so we know it's fully
+    // disabled when we come back.
+    info!("Temporarily disabling background updates...");
+    check_call("systemctl", &["mask", "unattended-upgrades"])?;
+    check_call("systemctl", &["mask", "apt-daily"])?;
+    check_call("systemctl", &["mask", "apt-daily-upgrade"])?;
+    state.set(Stage::PendingUpdates)?;
+    check_call("systemctl", &["reboot"])?;
+    // Because we've initiated the reboot, do a hard stop here to ensure that
+    // we don't keep moving forward if the reboot doesn't happen instantly
+    process::exit(0);
 }
 
 /// Step 3: Disable apache2


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

We currently run `pending_updates()` and then run `migration_check()`, and the initial thinking was that we should update everything to latest before checking stuff, which is reasonable, except at some point I refactored it to also disable unattended-updates during `pending_updates()` to take advantage of the fact that `pending_updates()` does a reboot.

The only problem is that we expect the `migration_check()` to somewhat be fallible. But we shouldn't end up in a state where it fails and then now updates are fully stopped, needing manual intervention.

So the fix is to simply reorder them, which is relatively trivial, though the manual index in the semiautomated playbook also needs updating.

It's theoretically possible that `pending_updates()` brings in something that would have caused `migration_check()` to fail, but at this point I think it's pretty unlikely given that the fully automated migration is only going to be kicked off immediately after pending updates are applied.

Fixes #7514.
## Testing

How should the reviewer test this PR?

Part 1:
* [ ] Set up a focal system, and then on the app server:
* [x] Cause the migration check to fail by e.g. `sudo apt install ufw -y`
   * note: there's an hourly systemd timer that removes this, so you probably want to temporarily stop that timer `systemctl stop securedrop-remove-packages.timer` 
* [x] Move your app server into bucket 1, and then `sudo systemctl start securedrop-noble-migration-upgrade` (or wait for the timer)
* [x] Observe that 1) the state file still shows you in "None" and 2) the systemd unit unattended-upgrades is not masked
* [x] Then fix the migration check thing (uninstall ufw). Then `sudo systemctl start securedrop-noble-migration-upgrade` (or wait for the timer) and the upgrade should proceed and complete like normal.

Part 2:
* [x] verify semiautomated upgrade still works (i.e. the index changes are correct)

## Deployment

Any special considerations for deployment? n/a

