### PR TITLE
fix(`setup_i18n`): no need to guard with `@ignore_static`

### DIFF
--- a/securedrop/source_app/__init__.py
+++ b/securedrop/source_app/__init__.py
@@ -49,7 +49,6 @@ def create_app(config: SecureDropConfig) -> Flask:
     i18n.configure(config, app)
 
     @app.before_request
-    @ignore_static
     def setup_i18n() -> None:
         """Store i18n-related values in Flask's special g object"""
         i18n.set_locale(config)

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -69,6 +69,16 @@ def test_page_not_found(source_app):
             ins.assert_template_used("notfound.html")
 
 
+def test_static_asset_not_found(source_app):
+    """Verify that requesting a missing asset returns the expected template and
+    HTTP status."""
+    with InstrumentedApp(source_app) as ins:
+        with source_app.test_client() as app:
+            resp = app.get("/static/foo")
+            assert resp.status_code == 404
+            ins.assert_template_used("notfound.html")
+
+
 def test_orgname_default_set(source_app):
     class dummy_current:
         organization_name = None


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Trivially fixes #7504, and only slightly less trivially adds a regression test for it.


## Testing

- [x] `test_static_asset_not_found()` passes in CI.
- [x] If you're bored, `curl -I http://localhost:8080/static/foo` against `make dev` returns HTTP `404` rather than `500`.


## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container