### PR TITLE
Resolve daemon warnings for threading methods

### DIFF
--- a/securedrop/pretty_bad_protocol/_meta.py
+++ b/securedrop/pretty_bad_protocol/_meta.py
@@ -388,7 +388,7 @@ class GPGBase:
         If unspecified, use $HOME/.config/python-gnupg. If specified, ensure
         that the ``directory`` does not contain various shell escape
         characters. If ``directory`` is not found, it will be automatically
-        created. Lastly, the ``direcory`` will be checked that the EUID has
+        created. Lastly, the ``directory`` will be checked that the EUID has
         read and write permissions for it.
 
         :param str directory: A relative or absolute path to the directory to
@@ -491,7 +491,7 @@ class GPGBase:
             except OSError:
                 log.error(
                     "Could neither invoke nor terminate a gpg process... "
-                    "Are you sure you specified the corrent (and full) "
+                    "Are you sure you specified the correct (and full) "
                     "path to the gpg binary?"
                 )
 
@@ -728,13 +728,13 @@ class GPGBase:
         """
         stderr = codecs.getreader(self._encoding)(process.stderr)
         rr = threading.Thread(target=self._read_response, args=(stderr, result))
-        rr.setDaemon(True)
+        rr.daemon = True
         log.debug("stderr reader: %r", rr)
         rr.start()
 
         stdout = process.stdout
         dr = threading.Thread(target=self._read_data, args=(stdout, result))
-        dr.setDaemon(True)
+        dr.daemon = True
         log.debug("stdout reader: %r", dr)
         dr.start()
 

--- a/securedrop/pretty_bad_protocol/_util.py
+++ b/securedrop/pretty_bad_protocol/_util.py
@@ -100,7 +100,7 @@ def _copy_data(instream, outstream):  # type: ignore[no-untyped-def]
         except TypeError as te:
             # XXX FIXME This appears to happen because
             # _threaded_copy_data() sometimes passes the `outstream` as an
-            # object with type <_io.BufferredWriter> and at other times
+            # object with type <_io.BufferedWriter> and at other times
             # with type <encodings.utf_8.StreamWriter>.  We hit the
             # following error when the `outstream` has type
             # <encodings.utf_8.StreamWriter>.
@@ -393,7 +393,7 @@ def _threaded_copy_data(instream, outstream):  # type: ignore[no-untyped-def]
     :param file outstream: The file descriptor of a tmpfile to write to.
     """
     copy_thread = threading.Thread(target=_copy_data, args=(instream, outstream))
-    copy_thread.setDaemon(True)
+    copy_thread.daemon = True
     log.debug("%r, %r, %r", copy_thread, instream, outstream)
     copy_thread.start()
     return copy_thread
@@ -406,7 +406,7 @@ def _which(executable, flags=os.X_OK, abspath_only=False, disallow_symlinks=Fals
 
     On newer versions of MS-Windows, the PATHEXT environment variable will be
     set to the list of file extensions for files considered executable. This
-    will normally include things like ".EXE". This fuction will also find files
+    will normally include things like ".EXE". This function will also find files
     with the given name ending with any of these extensions.
 
     On MS-Windows the only flag that has any meaning is os.F_OK. Any other


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This small PR resolves the `threading` deprecation warnings:
```python
/home/runner/work/securedrop/securedrop/securedrop/pretty_bad_protocol/_meta.py:737: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead

/home/runner/work/securedrop/securedrop/securedrop/pretty_bad_protocol/_util.py:396: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
```
It also fixes a few typos I came across along the way in the relevant files.

## Testing
run tests and check for warnings.

## Deployment

## Checklist

### If you made changes to the server application code:

- [x] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [x] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [ ] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [x] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a reference to a production code dependency:

[*Documentation*](https://developers.securedrop.org/en/latest/dependency_updates.html)

**For Rust code,** dependency review is enforced by the [cargo-vet](https://github.com/freedomofpress/securedrop/actions/workflows/cargo-vet.yml) CI job.

**For Python code,** production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/requirements.in`
- `securedrop/requirements/python3/translation.in` (used in the build
  container)

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [ ] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
- [ ] I am silencing an alert related to a production dependency, because (please explain below):
