### PR TITLE
test: import `test_grsecurity` suite and parameterize to run locally

### DIFF
--- a/molecule/testinfra/common/test_grsecurity_local.py
+++ b/molecule/testinfra/common/test_grsecurity_local.py
@@ -1,0 +1,8 @@
+"""
+Import all of the test_grsecurity suite, but clear testinfra_hosts so that
+running "py.test test_grsecurity_local.py" will run the test suite locally.
+"""
+
+from common.test_grsecurity import *  # noqa: F403
+
+testinfra_hosts = [None]


### PR DESCRIPTION
## Status

Work in progress


## Description of Changes

Towards #7527.  This is in preparation for #7534, to be able to run locally (on the kernel-testing machines) the same test suite we run to check the grsecurity kernel on VMs (in staging) and physical machines (in production).


## Testing

- [ ] `test_grsecurity_local` does not run in the staging environment.