### PR TITLE
test(`kernel-auto-test`): run and upload output from `test_grsecurity_local` test suite

### DIFF
--- a/install_files/ansible-base/roles/kernel-test/files/kernel-auto-test.py
+++ b/install_files/ansible-base/roles/kernel-test/files/kernel-auto-test.py
@@ -31,14 +31,17 @@ hardware = Path("/sys/devices/virtual/dmi/id/product_name").read_text().strip()
 print(f"I am beginning to test {current} on {hardware}")
 
 # paxtest
-paxtest = subprocess.run(["paxtest", "blackhat"], stderr=subprocess.STDOUT, stdout=subprocess.PIPE,
+paxtest = subprocess.run(
+    ["paxtest", "blackhat"], stderr=subprocess.STDOUT, stdout=subprocess.PIPE, check=False
+)
 
 # Spectre & Meltdown Checker
 fetch = subprocess.check_output(["curl", "-L", "https://meltdown.ovh"])
 Path("/tmp/spectre-meltdown-checker.sh").write_bytes(fetch)  # noqa: S108
 checker = subprocess.run(
     ["bash", "/tmp/spectre-meltdown-checker.sh", "--no-color"],  # noqa: S108
-    stderr=subprocess.STDOUT, stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    stdout=subprocess.PIPE,
     check=False,
 )
 
@@ -58,6 +61,7 @@ test_suite = subprocess.run(
     check=False,
 )
 
+
 def create_gist(command, result):
     headers = {
         "Authorization": f"Bearer {GIST_TOKEN}",
@@ -75,10 +79,11 @@ def create_gist(command, result):
         "https://api.github.com/gists",
         data=json.dumps(data).encode(),
         headers=headers,
-        method="POST"
+        method="POST",
     )
     with urllib.request.urlopen(req) as response:
         return json.loads(response.read().decode())["html_url"]
+
 
 paxtest_gist = create_gist("paxtest", paxtest)
 checker_gist = create_gist("spectre-meltdown-checker.sh", checker)
@@ -102,17 +107,21 @@ Your friendly kernel testing robot
 
 print(template)
 
+
 def search_issues(kernel_version):
     headers = {
         "Accept": "application/vnd.github+json",
         "Content-Type": "application/json",
     }
-    query = urllib.parse.quote(f"repo:freedomofpress/securedrop {kernel_version} in:title state:open")
+    query = urllib.parse.quote(
+        f"repo:freedomofpress/securedrop {kernel_version} in:title state:open"
+    )
     url = f"https://api.github.com/search/issues?q={query}"
     print(f"Searching via {url}")
     req = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(req) as response:
         return json.loads(response.read().decode())["items"]
+
 
 def create_issue(title, body):
     print("Creating issue")
@@ -127,6 +136,7 @@ def create_issue(title, body):
     with urllib.request.urlopen(req) as response:
         return json.loads(response.read().decode())
 
+
 def create_comment(issue_number, body):
     print("Leaving comment")
     headers = {
@@ -139,6 +149,7 @@ def create_comment(issue_number, body):
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     with urllib.request.urlopen(req) as response:
         return json.loads(response.read().decode())
+
 
 issue_body = f"""\
 Dearest SecureDrop developers,

--- a/install_files/ansible-base/roles/kernel-test/files/kernel-auto-test.py
+++ b/install_files/ansible-base/roles/kernel-test/files/kernel-auto-test.py
@@ -48,7 +48,9 @@ checker_results = subprocess.run(
 # grsecurity test suite
 CLONE = Path("/tmp/securedrop")  # noqa: S108
 subprocess.check_output(["rm", "-rf", CLONE])
-subprocess.check_output(["git", "clone", "https://github.com/freedomofpress/securedrop", CLONE])
+subprocess.check_output(
+    ["git", "clone", "https://github.com/freedomofpress/securedrop", "--depth=1", CLONE]
+)
 subprocess.check_output(["make", "venv"], cwd=CLONE)
 
 TEST_SUITE_CONTENTS = """
@@ -63,16 +65,17 @@ TEST_SUITE_PATH.write_text(TEST_SUITE_CONTENTS)
 
 test_suite_results = subprocess.run(
     [
-        # Single-shot command in the virtual environment:
-        "sh",
-        "-c",
-        f"'source .venv/bin/activate && py.test {TEST_SUITE_PATH}'",
+        ".venv/bin/pytest",
+        "-v",
+        TEST_SUITE_PATH,
     ],
     cwd=CLONE,
     stderr=subprocess.STDOUT,
     stdout=subprocess.PIPE,
     check=False,
 )
+# TODO: test_grsecurity removes paxtest for now, so we need to reinstall it
+subprocess.check_call(["apt-get", "install", "-y", "paxtest"])
 
 
 def create_gist(command, result):

--- a/install_files/ansible-base/roles/kernel-test/files/kernel-auto-test.py
+++ b/install_files/ansible-base/roles/kernel-test/files/kernel-auto-test.py
@@ -31,14 +31,14 @@ hardware = Path("/sys/devices/virtual/dmi/id/product_name").read_text().strip()
 print(f"I am beginning to test {current} on {hardware}")
 
 # paxtest
-paxtest = subprocess.run(
+paxtest_results = subprocess.run(
     ["paxtest", "blackhat"], stderr=subprocess.STDOUT, stdout=subprocess.PIPE, check=False
 )
 
 # Spectre & Meltdown Checker
 fetch = subprocess.check_output(["curl", "-L", "https://meltdown.ovh"])
 Path("/tmp/spectre-meltdown-checker.sh").write_bytes(fetch)  # noqa: S108
-checker = subprocess.run(
+checker_results = subprocess.run(
     ["bash", "/tmp/spectre-meltdown-checker.sh", "--no-color"],  # noqa: S108
     stderr=subprocess.STDOUT,
     stdout=subprocess.PIPE,
@@ -46,14 +46,27 @@ checker = subprocess.run(
 )
 
 # grsecurity test suite
-CLONE = "/tmp/securedrop"
+CLONE = Path("/tmp/securedrop")  # noqa: S108
+subprocess.check_output(["rm", "-rf", CLONE])
 subprocess.check_output(["git", "clone", "https://github.com/freedomofpress/securedrop", CLONE])
 subprocess.check_output(["make", "venv"], cwd=CLONE)
-test_suite = subprocess.run(
+
+TEST_SUITE_CONTENTS = """
+# Import all of the test_grsecurity suite, but clear testinfra_hosts so that
+# running "py.test test_grsecurity_local.py" will run the test suite locally.
+
+from common.test_grsecurity import *
+testinfra_hosts = [None]
+"""
+TEST_SUITE_PATH = CLONE / "molecule/testinfra/test_grsecurity_local.py"
+TEST_SUITE_PATH.write_text(TEST_SUITE_CONTENTS)
+
+test_suite_results = subprocess.run(
     [
+        # Single-shot command in the virtual environment:
         "sh",
         "-c",
-        "'source .venv/bin/activate && py.test molecule/testinfra/test_grsecurity_local.py'",
+        f"'source .venv/bin/activate && py.test {TEST_SUITE_PATH}'",
     ],
     cwd=CLONE,
     stderr=subprocess.STDOUT,
@@ -85,9 +98,9 @@ def create_gist(command, result):
         return json.loads(response.read().decode())["html_url"]
 
 
-paxtest_gist = create_gist("paxtest", paxtest)
-checker_gist = create_gist("spectre-meltdown-checker.sh", checker)
-test_suite_gist = create_gist("test_grsecurity_local.py", test_suite)
+paxtest_gist = create_gist("paxtest", paxtest_results)
+checker_gist = create_gist("spectre-meltdown-checker.sh", checker_results)
+test_suite_gist = create_gist("test_grsecurity_local.py", test_suite_results)
 
 template = f"""\
 Hello SecureDrop team,
@@ -97,9 +110,9 @@ Today I tested {current} on {hardware}.
 If you're seeing this comment it means it successfully booted!
 
 I ran:
-* paxtest, exit code: {paxtest.returncode} ([logs]({paxtest_gist}))
-* spectre-meltdown-checker.sh, exit code: {checker.returncode} ([logs]({checker_gist}))
-* test_grsecurity_local.py, exit code: {test_suite.returncode} ([logs]({test_suite_gist}))
+* paxtest, exit code: {paxtest_results.returncode} ([logs]({paxtest_gist}))
+* spectre-meltdown-checker.sh, exit code: {checker_results.returncode} ([logs]({checker_gist}))
+* test_grsecurity_local.py, exit code: {test_suite_results.returncode} ([logs]({test_suite_gist}))
 
 Cheers,
 Your friendly kernel testing robot

--- a/install_files/ansible-base/roles/kernel-test/files/kernel-auto-test.py
+++ b/install_files/ansible-base/roles/kernel-test/files/kernel-auto-test.py
@@ -30,13 +30,31 @@ hardware = Path("/sys/devices/virtual/dmi/id/product_name").read_text().strip()
 
 print(f"I am beginning to test {current} on {hardware}")
 
+# paxtest
 paxtest = subprocess.run(["paxtest", "blackhat"], stderr=subprocess.STDOUT, stdout=subprocess.PIPE,
-    check=False)
+
+# Spectre & Meltdown Checker
 fetch = subprocess.check_output(["curl", "-L", "https://meltdown.ovh"])
 Path("/tmp/spectre-meltdown-checker.sh").write_bytes(fetch)  # noqa: S108
 checker = subprocess.run(
     ["bash", "/tmp/spectre-meltdown-checker.sh", "--no-color"],  # noqa: S108
     stderr=subprocess.STDOUT, stdout=subprocess.PIPE,
+    check=False,
+)
+
+# grsecurity test suite
+CLONE = "/tmp/securedrop"
+subprocess.check_output(["git", "clone", "https://github.com/freedomofpress/securedrop", CLONE])
+subprocess.check_output(["make", "venv"], cwd=CLONE)
+test_suite = subprocess.run(
+    [
+        "sh",
+        "-c",
+        "'source .venv/bin/activate && py.test molecule/testinfra/test_grsecurity_local.py'",
+    ],
+    cwd=CLONE,
+    stderr=subprocess.STDOUT,
+    stdout=subprocess.PIPE,
     check=False,
 )
 
@@ -64,6 +82,7 @@ def create_gist(command, result):
 
 paxtest_gist = create_gist("paxtest", paxtest)
 checker_gist = create_gist("spectre-meltdown-checker.sh", checker)
+test_suite_gist = create_gist("test_grsecurity_local.py", test_suite)
 
 template = f"""\
 Hello SecureDrop team,
@@ -75,6 +94,7 @@ If you're seeing this comment it means it successfully booted!
 I ran:
 * paxtest, exit code: {paxtest.returncode} ([logs]({paxtest_gist}))
 * spectre-meltdown-checker.sh, exit code: {checker.returncode} ([logs]({checker_gist}))
+* test_grsecurity_local.py, exit code: {test_suite.returncode} ([logs]({test_suite_gist}))
 
 Cheers,
 Your friendly kernel testing robot

--- a/install_files/ansible-base/roles/kernel-test/tasks/main.yml
+++ b/install_files/ansible-base/roles/kernel-test/tasks/main.yml
@@ -31,14 +31,14 @@
     - fpf_repo
 
 
-- name: Install paxtest
+- name: Install required packages for kernel testing
   apt:
-    pkg: paxtest
-    state: present
-
-- name: Install readelf/strings (needed by spectre-meltdown-checker)
-  apt:
-    pkg: binutils
+    pkg:
+      - paxtest
+      - binutils
+      - build-essential
+      - python3-virtualenv
+      - python3-dev
     state: present
 
 - name: Set permissions on github-token.json


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Closes #7527 by adding a third check to the kernel-testing sequence:

1. Downloads the testinfra test suite (by cloning this repository).
2. Creates and runs the `test_grsecurity_local` override test suite.
3. Uploads the results as a third gist.


## Testing

1. [ ] Deploy to the kernel test machines.
2. [ ] `kernel-auto-test.py` creates accurate gists and tickets for a kernel (e.g. #7528) that fails the `test_grsecurity` suite.
3. [ ] `kernel-auto-test.py` creates accurate gists and tickets for a kernel (pending from #7511) that passes the `test_grsecurity` suite.