### PR TITLE
ignore Safety 76752 in setuptools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 74221 \
 		--ignore 74261 \
 		--ignore 74735 \
+		--ignore 76752 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Suppresses vulnerability warning.

Setuptools has been bumped to the fixed version [1], but that was not possible on Ubuntu Focal due to setuptools 78.1.1 requiring Python >=3.9 and Ubuntu Focal only providing Python 3.8. In fact ealier versions of setuptools required this newer Python version but only this release justified bumping it.

Therefore, test-requirements.txt was split [2] into Ubuntu Focal and Noble and the setuptools dependency will have to be kept back on the former. This is minor given that this is a build-time dependency only and there is an ongoing migration of instances to Ubunut Noble.

The end conclusion is that this vulnerability will be silenced for the entire repository, since it has already been patched where it could be.

[1]: https://github.com/freedomofpress/securedrop/pull/7506
[2]: https://github.com/freedomofpress/securedrop/pull/7506#issuecomment-2825889614