### PR TITLE
Add integration tests for nl2br jinja2 filter

### DIFF
--- a/securedrop/tests/test_template_filters.py
+++ b/securedrop/tests/test_template_filters.py
@@ -10,6 +10,24 @@ from flask import session
 from tests.test_i18n import create_config_for_i18n_test
 
 
+def test_nl2br(source_app):
+    """Test the filter integrated with a Jinja2 environment."""
+    template = source_app.jinja_env.from_string("{{ text|nl2br }}")
+    result = template.render(text="Line1\nLine2")
+
+    assert result == "Line1<br>\nLine2"
+
+
+def test_nl2br_escaping(source_app):
+    """Test the filter with unsafe HTML in a Jinja2 environment."""
+    template = source_app.jinja_env.from_string("{{ text|nl2br }}")
+    result = template.render(text="<script>alert('xss')</script>\n<b>Bold</b>")
+
+    assert (
+        result == "&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;<br>\n&lt;b&gt;Bold&lt;/b&gt;"
+    )
+
+
 def verify_rel_datetime_format(app):
     with app.test_client() as c:
         c.get("/")


### PR DESCRIPTION


## Status

Ready for review 

## Description of Changes

Explicitly verify the basic behavior of turning `\n` into `<br>` and then the escaping of HTML elements, so XSS isn't possible through it.

The test cases were originally written by Claude ([transcript](https://gist.github.com/legoktm/950509e3216460f6c8d453cfe9832985)), I adjusted them to reuse our existing environment to make it more of a true integration test.

## Testing

How should the reviewer test this PR?

* [ ] CI passes

## Deployment

Any special considerations for deployment? n/a

