### PR TITLE
Fix: update functional tests to use webdriver-supplied locale

### DIFF
--- a/securedrop/bin/run-test
+++ b/securedrop/bin/run-test
@@ -26,6 +26,7 @@ urandom
 build_redwood
 maybe_create_config_py
 run_redis
+pybabel compile --directory translations/
 
 if [ -n "${CIRCLE_BRANCH:-}" ] ; then
     touch tests/log/firefox.log

--- a/securedrop/tests/functional/app_navigators/journalist_app_nav.py
+++ b/securedrop/tests/functional/app_navigators/journalist_app_nav.py
@@ -34,8 +34,7 @@ class JournalistAppNavigator:
         self.nav_helper = NavigationHelper(web_driver)
         self.driver = web_driver
 
-        # Some string-based tests check this to avoid failing on translated strings.
-        self.accept_languages = accept_languages
+        self.accept_languages = self.driver.locale  # type: ignore[attr-defined]
 
     def got_expected_language(self, locale: str) -> None:
         expected = locale.replace("_", "-")
@@ -91,7 +90,7 @@ class JournalistAppNavigator:
         collections_count = self.count_sources_on_index_page()
         assert collections_count == 1
 
-        if not self.accept_languages:
+        if self.accept_languages in [None, "en_US"]:
             # There should be a "1 unread" span in the sole collection entry
             unread_span = self.driver.find_element(By.CSS_SELECTOR, "tr.unread")
             assert "1 unread" in unread_span.text
@@ -154,7 +153,7 @@ class JournalistAppNavigator:
         self.driver.find_element(By.ID, "reply-button").click()
 
         def reply_stored() -> None:
-            if not self.accept_languages:
+            if self.accept_languages in [None, "en_US"]:
                 assert "The source will receive your reply" in self.driver.page_source
 
         self.nav_helper.wait_for(reply_stored)
@@ -244,7 +243,7 @@ class JournalistAppNavigator:
         self.nav_helper.safe_click_by_id("add-user")
         self.nav_helper.wait_for(lambda: self.driver.find_element(By.ID, "username"))
 
-        if not self.accept_languages:
+        if self.accept_languages in [None, "en_US"]:
             # The add user page has a form with an "ADD USER" button
             btns = self.driver.find_elements(By.TAG_NAME, "button")
             assert "ADD USER" in [el.text for el in btns]
@@ -304,7 +303,7 @@ class JournalistAppNavigator:
 
         # Verify the two-factor authentication
         def user_token_added():
-            if not self.accept_languages:
+            if self.accept_languages in [None, "en_US"]:
                 # Successfully verifying the code should redirect to the admin
                 # interface, and flash a message indicating success
                 flash_msg = self.driver.find_elements(By.CSS_SELECTOR, ".flash")
@@ -326,7 +325,8 @@ class JournalistAppNavigator:
 
         # Logging out should redirect back to the login page
         def login_page():
-            assert "Log in to access the journalist interface" in self.driver.page_source
+            if self.accept_languages in [None, "en_US"]:
+                assert "Log in to access the journalist interface" in self.driver.page_source
 
         self.nav_helper.wait_for(login_page)
 
@@ -351,7 +351,7 @@ class JournalistAppNavigator:
         # Ensure the admin is allowed to edit the journalist
         def can_edit_user():
             h = self.driver.find_elements(By.TAG_NAME, "h1")[0]
-            if not self.accept_languages:
+            if self.accept_languages in [None, "en_US"]:
                 assert f'Edit user "{username_of_journalist_to_edit}"' == h.text
 
         self.nav_helper.wait_for(can_edit_user)

--- a/securedrop/tests/functional/app_navigators/source_app_nav.py
+++ b/securedrop/tests/functional/app_navigators/source_app_nav.py
@@ -28,7 +28,7 @@ class SourceAppNavigator:
         self.driver = web_driver
 
         # Some string-based tests check this to avoid failing on translated strings.
-        self.accept_languages = accept_languages
+        self.accept_languages = self.driver.locale  # type: ignore[attr-defined]
 
     @classmethod
     @contextmanager
@@ -71,7 +71,7 @@ class SourceAppNavigator:
         self.nav_helper.safe_click_by_css_selector("#create-form button")
 
         def submit_page_loaded() -> None:
-            if not self.accept_languages:
+            if self.accept_languages in [None, "en_US"]:
                 headline = self.driver.find_element(By.ID, "submit-heading")
                 # Message will either be "Submit Messages" or "Submit Files or Messages" depending
                 #  on whether file uploads are allowed by the instance's config
@@ -125,7 +125,7 @@ class SourceAppNavigator:
 
         # Wait for confirmation that the message was submitted
         def message_submitted():
-            if not self.accept_languages:
+            if self.accept_languages in [None, "en_US"]:
                 notification = self.driver.find_element(By.CSS_SELECTOR, ".success")
                 assert "Thank" in notification.text
                 return notification.text
@@ -145,7 +145,7 @@ class SourceAppNavigator:
             self.nav_helper.safe_click_by_css_selector(".form-controls button")
 
             def file_submitted() -> None:
-                if not self.accept_languages:
+                if self.accept_languages in [None, "en_US"]:
                     notification = self.driver.find_element(By.CSS_SELECTOR, ".success")
                     expected_notification = "Thank you for sending this information to us"
                     assert expected_notification in notification.text

--- a/securedrop/tests/functional/test_admin_interface.py
+++ b/securedrop/tests/functional/test_admin_interface.py
@@ -142,12 +142,14 @@ class TestAdminInterfaceAddUser:
         error_msg = journ_app_nav.nav_helper.wait_for(
             lambda: journ_app_nav.driver.find_element(By.CSS_SELECTOR, ".form-validation-error")
         )
+        assert len(error_msg.text) > 0
 
         # And they see the corresponding error message
-        assert (
-            "This username is invalid because it is reserved for internal use "
-            "by the software." in error_msg.text
-        )
+        if journ_app_nav.driver.locale in [None, "en_US"]:
+            assert (
+                "This username is invalid because it is reserved for internal use "
+                "by the software." in error_msg.text
+            )
 
 
 # Tests for editing a user need a second journalist user to be created
@@ -240,7 +242,8 @@ class TestAdminInterfaceEditAndDeleteUser:
         # Then it succeeds
         def user_edited():
             flash_msg = journ_app_nav.driver.find_element(By.CSS_SELECTOR, ".flash")
-            assert "Account updated." in flash_msg.text
+            if journ_app_nav.driver.locale in [None, "en_US"]:
+                assert "Account updated." in flash_msg.text
 
         journ_app_nav.nav_helper.wait_for(user_edited)
 
@@ -261,7 +264,8 @@ class TestAdminInterfaceEditAndDeleteUser:
         # Then it fails
         def user_edited():
             flash_msg = journ_app_nav.driver.find_element(By.CSS_SELECTOR, ".flash")
-            assert "Invalid username" in flash_msg.text
+            if journ_app_nav.driver.locale in [None, "en_US"]:
+                assert "Invalid username" in flash_msg.text
 
         journ_app_nav.nav_helper.wait_for(user_edited)
 
@@ -420,7 +424,8 @@ class TestAdminInterfaceEditConfig:
     def _admin_submits_instance_settings_form(journ_app_nav: JournalistAppNavigator) -> None:
         def preferences_saved():
             flash_msg = journ_app_nav.driver.find_element(By.CSS_SELECTOR, ".flash")
-            assert "Preferences saved." in flash_msg.text
+            if journ_app_nav.driver.locale in [None, "en_US"]:
+                assert "Preferences saved." in flash_msg.text
 
         journ_app_nav.nav_helper.wait_for(preferences_saved, timeout=20)
 

--- a/securedrop/tests/functional/test_journalist.py
+++ b/securedrop/tests/functional/test_journalist.py
@@ -181,7 +181,10 @@ class TestJournalist:
         # Then a message shows up to say that the collection was deleted
         def collection_deleted():
             flash_msg = journ_app_nav.driver.find_element(By.CSS_SELECTOR, ".flash")
-            assert "The account and all data for the source have been deleted." in flash_msg.text
+            if journ_app_nav.accept_languages in [None, "en_US"]:
+                assert (
+                    "The account and all data for the source have been deleted." in flash_msg.text
+                )
 
         journ_app_nav.nav_helper.wait_for(collection_deleted)
 
@@ -367,10 +370,11 @@ class TestJournalist:
         def one_source_no_files():
             assert journ_app_nav.count_sources_on_index_page() == 1
             flash_msg = journ_app_nav.driver.find_element(By.CSS_SELECTOR, ".flash")
-            assert "The files and messages have been deleted" in flash_msg.text
             counts = journ_app_nav.driver.find_elements(By.CSS_SELECTOR, ".submission-count")
-            assert "0 docs" in counts[0].text
-            assert "0 messages" in counts[1].text
+            if journ_app_nav.accept_languages in [None, "en_US"]:
+                assert "The files and messages have been deleted" in flash_msg.text
+                assert "0 docs" in counts[0].text
+                assert "0 messages" in counts[1].text
 
         journ_app_nav.nav_helper.wait_for(one_source_no_files)
 

--- a/securedrop/tests/functional/test_source.py
+++ b/securedrop/tests/functional/test_source.py
@@ -60,13 +60,15 @@ class TestSourceAppCodenameHints:
         confirmation_text_first_submission = navigator.source_submits_a_message()
 
         # And they see the expected confirmation messages for a first submission on first login
-        assert self.FIRST_SUBMISSION_TEXT in confirmation_text_first_submission
+        if navigator.accept_languages in [None, "en_US"]:
+            assert self.FIRST_SUBMISSION_TEXT in confirmation_text_first_submission
 
         # And when they submit a second message
         confirmation_text_second_submission = navigator.source_submits_a_message()
 
         # Then they don't see the messages since it's not their first submission
-        assert self.FIRST_SUBMISSION_TEXT not in confirmation_text_second_submission
+        if navigator.accept_languages in [None, "en_US"]:
+            assert self.FIRST_SUBMISSION_TEXT not in confirmation_text_second_submission
 
     def test_submission_notifications_on_second_login(self, sd_servers, tor_browser_web_driver):
         navigator = SourceAppNavigator(
@@ -91,13 +93,15 @@ class TestSourceAppCodenameHints:
         confirmation_text_first_submission = navigator.source_submits_a_message()
 
         # And they see the expected confirmation messages for a first submission on second login
-        assert self.FIRST_SUBMISSION_TEXT in confirmation_text_first_submission
+        if navigator.accept_languages in [None, "en_US"]:
+            assert self.FIRST_SUBMISSION_TEXT in confirmation_text_first_submission
 
         # And when they submit a second message
         confirmation_text_second_submission = navigator.source_submits_a_message()
 
         # Then they don't see the messages since it's not their first submission
-        assert self.FIRST_SUBMISSION_TEXT not in confirmation_text_second_submission
+        if navigator.accept_languages in [None, "en_US"]:
+            assert self.FIRST_SUBMISSION_TEXT not in confirmation_text_second_submission
 
 
 class TestSourceAppDownloadJournalistKey:
@@ -167,7 +171,7 @@ class TestSourceAppCodenamesInMultipleTabs:
         # Then the submission fails and the user sees the corresponding flash message in Tab B
         self._assert_is_on_lookup_page(navigator)
         notification = self._extract_flash_message_content(navigator)
-        if not navigator.accept_languages:
+        if navigator.driver.locale in [None, "en_US"]:
             assert "You are already logged in." in notification
 
         # And the user's actual codename is the one initially generated in Tab A
@@ -220,7 +224,7 @@ class TestSourceAppCodenamesInMultipleTabs:
         # Then they get redirected to /lookup with the corresponding flash message
         self._assert_is_on_lookup_page(navigator)
         notification = self._extract_flash_message_content(navigator)
-        if not navigator.accept_languages:
+        if navigator.driver.locale in [None, "en_US"]:
             assert "You were redirected because you are already logged in." in notification
 
         # And the user's actual codename is the expected one

--- a/securedrop/tests/functional/test_source_cancels.py
+++ b/securedrop/tests/functional/test_source_cancels.py
@@ -32,4 +32,5 @@ class TestSourceUserCancels:
 
         # And the right message is displayed
         heading = source_app_nav.driver.find_element(By.ID, "submit-heading")
-        assert heading.text == "Submit Files or Messages"
+        if source_app_nav.accept_languages in [None, "en_US"]:
+            assert heading.text == "Submit Files or Messages"

--- a/securedrop/tests/functional/test_source_warnings.py
+++ b/securedrop/tests/functional/test_source_warnings.py
@@ -34,6 +34,9 @@ def orbot_web_driver(sd_servers):
     profile.update_preferences()
     orbot_web_driver = webdriver.Firefox(options=orbot_options)
 
+    # Set a null locale so this driver behaves the same as the others
+    orbot_web_driver.locale = None  # type: ignore[attr-defined]
+
     try:
         driver_user_agent = orbot_web_driver.execute_script("return navigator.userAgent")
         assert driver_user_agent == orbot_user_agent
@@ -57,7 +60,8 @@ class TestSourceAppBrowserWarnings:
         # Then they see a warning
         warning_banner = navigator.driver.find_element(By.ID, "browser-tb")
         assert warning_banner.is_displayed()
-        assert "It is recommended to use Tor Browser" in warning_banner.text
+        if navigator.accept_languages in [None, "en_US"]:
+            assert "It is recommended to use Tor Browser" in warning_banner.text
 
         # And they are able to dismiss the warning
         warning_dismiss_button = navigator.driver.find_element(By.ID, "browser-tb-close")
@@ -82,7 +86,8 @@ class TestSourceAppBrowserWarnings:
         # Then they see a warning
         warning_banner = navigator.driver.find_element(By.ID, "browser-android")
         assert warning_banner.is_displayed()
-        assert "use the desktop version of Tor Browser" in warning_banner.text
+        if navigator.accept_languages in [None, "en_US"]:
+            assert "use the desktop version of Tor Browser" in warning_banner.text
 
         # And they are able to dismiss the warning
         warning_dismiss_button = navigator.driver.find_element(By.ID, "browser-android-close")
@@ -107,4 +112,5 @@ class TestSourceAppBrowserWarnings:
         # Then they see a warning
         banner = navigator.driver.find_element(By.ID, "browser-security-level")
         assert banner.is_displayed()
-        assert "Security Level is too low" in banner.text
+        if navigator.accept_languages in [None, "en_US"]:
+            assert "Security Level is too low" in banner.text


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #7547 
-

## Testing

- [x] CI is passing
- [x] When functional tests are run locally via `make test-functional` against a clean repo (eg. `git clean -dfx` first), the correct localized strings are shown in the application for tested locales (check via `make docker-vnc`)


## Deployment
Test-only.
