### PR TITLE
Add "Copy to clipboard" to all fields on demo site

### DIFF
--- a/devops/demo/landing-page/webroot/assets/css/demo.css
+++ b/devops/demo/landing-page/webroot/assets/css/demo.css
@@ -40,3 +40,14 @@ td {
     font-weight: bold;
     margin: 2em 0;
 }
+.copy-btn {
+    cursor: pointer;
+    vertical-align: middle;
+}
+.copiedtip {
+    margin-left: 6px;
+    font-size: 0.9em;
+    font-family: sans-serif;
+    font-weight: 600;
+    color: #4caf50;
+}

--- a/devops/demo/landing-page/webroot/assets/css/demo.css
+++ b/devops/demo/landing-page/webroot/assets/css/demo.css
@@ -51,3 +51,6 @@ td {
     font-weight: 600;
     color: #4caf50;
 }
+.hidden {
+   display: none;
+}

--- a/devops/demo/landing-page/webroot/index.html
+++ b/devops/demo/landing-page/webroot/index.html
@@ -5,6 +5,14 @@
         <link rel="stylesheet" href="/assets/css/demo.css">
     </head>
     <body>
+        <!-- Apache-licensed "content copy" icon from https://material.io/resources/icons/ -->
+        <svg style="display:none">
+            <symbol id="copy-icon" viewBox="0 0 24 24">
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" fill="#ffffff"></path>
+            </symbol>
+        </svg>
+
         <img src="https://securedrop.org/static/images/_site_title.svg">
         <h1>Demo Server</h1>
         <p>This is a demonstration SecureDrop instance. It exists to:</p>
@@ -24,52 +32,70 @@
             <tbody>
                 <tr>
                     <th>Username</th>
-                    <td>journalist</td>
+                    <td><span id="usernamevalue">journalist</span>
+                        <span class="copy-btn" data-target="#usernamevalue"><svg width="18" height="18"><use href="#copy-icon"></use></svg></span>
+                    </td>
                 </tr>
 
                 <tr>
                     <th>Passphrase</th>
-                    <td>correct horse battery staple profanity oil chewy</td>
-                </tr>
-
-                <tr>
-                    <th>TOTP secret</th>
-                    <td>JHCOGO7VCER3EJ4L</td>
+                    <td><span id="passphrasevalue">correct horse battery staple profanity oil chewy</span>
+                        <span class="copy-btn" data-target="#passphrasevalue"><svg width="18" height="18"><use href="#copy-icon"></use></svg></span>
+                    </td>
                 </tr>
 
                 <tr>
                     <th>Current TOTP token</th>
                     <td id="totp">
                         <span id="totpvalue">......</span>
-                        <!-- Apache-licensed "content copy" icon from https://material.io/resources/icons/ -->
-                        <span id="totpcopy"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg></span>
+                        <span class="copy-btn" data-target="#totpvalue"><svg width="18" height="18"><use href="#copy-icon"></use></svg></span>
                         <span id="totpttl"></span>
                     </td>
                 </tr>
+
+                <tr>
+                    <th>TOTP secret</th>
+                    <td><span id="totpsecretvalue">JHCOGO7VCER3EJ4L</span>
+                        <span class="copy-btn" data-target="#totpsecretvalue"><svg width="18" height="18"><use href="#copy-icon"></use></svg></span>
+                    </td>
+                </tr>
+
             </tbody>
         </table>
         <script src="/assets/js/jsOTP.js"></script>
         <script>
-            document.getElementById("totpcopy").addEventListener(
-                "click",
-                function(e) {
-                    navigator.clipboard.writeText(
-                        document.getElementById("totpvalue").textContent
-                    );
-                }
-            )
-            function updateOTP() {
-                let totp = new jsOTP.totp();
-                let token = totp.getOtp("JHCOGO7VCER3EJ4L");
-                document.getElementById("totpvalue").textContent = token;
+            // Add "copy to clipboard" functionality to all copy buttons
+            document.querySelectorAll(".copy-btn").forEach(btn => {
+                btn.addEventListener("click", () => {
+                    const selector = btn.dataset.target;
+                    const text = document.querySelector(selector).textContent.trim();
+                    navigator.clipboard.writeText(text);
 
-                let epoch = Math.round(new Date().getTime() / 1000.0);
-                let remaining = 30 - (epoch % 30);
-                let seconds = `${remaining}`.padStart(2, "0");
+                    // Display exactly one ephemeral success message
+                    const cell = btn.parentNode;
+                    const existing = cell.querySelector(".copiedtip");
+                    if (existing) existing.remove();
+                    const tip = document.createElement("span");
+                    tip.className = "copiedtip";
+                    tip.textContent = "Copied to clipboard!";
+                    cell.appendChild(tip);
+                    setTimeout(() => tip.remove(), 2500);
+                });
+            });
+
+            // Cycle through TOTP codes
+            function updateOTP() {
+                const secret = document.getElementById("totpsecretvalue").textContent.trim();
+                const totp = new jsOTP.totp();
+                document.getElementById("totpvalue").textContent = totp.getOtp(secret);
+
+                const epoch = Math.round(new Date().getTime() / 1000.0);
+                const remaining = 30 - (epoch % 30);
+                const seconds = `${remaining}`.padStart(2, "0");
                 document.getElementById("totpttl").textContent = `(:${seconds} remaining)`;
 
-                    if (remaining < 10) {
-                        document.getElementById("totp").classList.add("expiring");
+                if (remaining < 10) {
+                    document.getElementById("totp").classList.add("expiring");
                 } else {
                     document.getElementById("totp").classList.remove("expiring");
                 }

--- a/devops/demo/landing-page/webroot/index.html
+++ b/devops/demo/landing-page/webroot/index.html
@@ -6,7 +6,7 @@
     </head>
     <body>
         <!-- Apache-licensed "content copy" icon from https://material.io/resources/icons/ -->
-        <svg style="display:none">
+        <svg class="hidden">
             <symbol id="copy-icon" viewBox="0 0 24 24">
                 <path d="M0 0h24v24H0z" fill="none"></path>
                 <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" fill="#ffffff"></path>
@@ -74,7 +74,9 @@
                     // Display exactly one ephemeral success message
                     const cell = btn.parentNode;
                     const existing = cell.querySelector(".copiedtip");
-                    if (existing) existing.remove();
+                    if (existing) {
+                        existing.remove();
+                    }
                     const tip = document.createElement("span");
                     tip.className = "copiedtip";
                     tip.textContent = "Copied to clipboard!";


### PR DESCRIPTION
This is a convenience feature for those who pull their demo or dev env creds from `demo.securedrop.org.`

## Status

Ready for review

## Testing

1. Run `python -m http.server 8000` in `webroot`
2. Load `index.html`
- [ ] Confirm that all "Copy" actions work as expected
- [ ] Confirm that repeatedly clicking "Copy" does not produce repeated success messages

## AI disclosure

[ChatGPT o3 session](https://chatgpt.com/share/682bbaf6-36f4-800b-8291-9bb87e4736c5), hand-tweaked as follows:
- moved CSS into existing CSS file
- added comments
- restored SVG credit
- restored original TOTP code (not in scope) but kept standardization towards `const` where appropriate
- moved TOTP secret to the bottom (so you can copy all required creds in sequence)