### PR TITLE
Fixes uncontrolled data used in path expression on utils

### DIFF
--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -392,10 +392,17 @@ def col_delete_data(cols_selected: List[str]) -> werkzeug.Response:
 
 def delete_collection(filesystem_id: str) -> None:
     """deletes source account including files and reply key"""
+    # Define the safe root directory for storage paths
+    safe_root = Storage.get_default().root_directory()
+
     # Delete the source's collection of submissions
     path = Storage.get_default().path(filesystem_id)
-    if os.path.exists(path):
-        Storage.get_default().move_to_shredder(path)
+    normalized_path = os.path.normpath(path)
+    if not normalized_path.startswith(safe_root):
+        raise ValueError(f"Invalid filesystem_id: {filesystem_id}")
+
+    if os.path.exists(normalized_path):
+        Storage.get_default().move_to_shredder(normalized_path)
 
     # Delete the source's reply keypair
     EncryptionManager.get_default().delete_source_key_pair(filesystem_id)


### PR DESCRIPTION
https://github.com/freedomofpress/securedrop/blob/6ea4ea36820ab7e27c84c65d4b1b516baa99ab85/securedrop/journalist_app/utils.py#L397-L398


Fix the issue need to validate and sanitize the `filesystem_id` before using it to construct a file path. The best approach is to ensure that the constructed path is normalized and resides within a predefined safe root directory. This can be achieved by:
1. Normalizing the constructed path using `os.path.normpath` to remove any `..` segments.
2. Verifying that the normalized path starts with the predefined root directory.

The `Storage.get_default().path` method should be updated to include this validation, ensuring that all paths constructed using `filesystem_id` are safe. Alternatively, the validation can be performed directly in the `delete_collection` function.

---






## Checklist

### If you made changes to the server application code:

- [ ] Linting (`make lint`) and tests (`make test`) pass in the development container

### If you made changes to `securedrop-admin`:

- [ ] Linting and tests (`make -C admin test`) pass in the admin development container

### If you made changes to the system configuration:

- [x] [Configuration tests](https://docs.securedrop.org/en/latest/development/testing_configuration_tests.html) pass

### If you added or removed a file deployed with the application:

- [ ] I have updated AppArmor rules to include the change

### If you made non-trivial code changes:

- [ ] I have written a test plan and validated it for this PR

Choose one of the following:

- [x] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-docs) for these changes, or will do so later
- [x] I would appreciate help with the documentation
- [x] These changes do not require documentation

### If you added or updated a reference to a production code dependency:

[*Documentation*](https://developers.securedrop.org/en/latest/dependency_updates.html)

**For Rust code,** dependency review is enforced by the [cargo-vet](https://github.com/freedomofpress/securedrop/actions/workflows/cargo-vet.yml) CI job.

**For Python code,** production code dependencies are defined in:

- `admin/requirements.in`
- `admin/requirements-ansible.in`
- `securedrop/requirements/python3/requirements.in`
- `securedrop/requirements/python3/translation.in` (used in the build
  container)

If you changed another `requirements.in` file that applies only to development
or testing environments, then no diff review is required, and you can skip
(remove) this section.

Choose one of the following:

- [x] I have performed a diff review and pasted the contents to [the packaging wiki](https://github.com/freedomofpress/securedrop-debian-packaging/wiki)
- [ ] I would like someone else to do the diff review
- [ ] I am silencing an alert related to a production dependency, because (please explain below):
