### PR TITLE
Update rust toolchain to 1.87.0, rustup-init to 1.28.2

### DIFF
--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -9,7 +9,7 @@ jobs:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.84.1
+    container: rust:1.87.0
     env:
       CARGO_VET_VERSION: 0.10.0
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.84.1
+    container: rust:1.87.0
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ jobs:
   rust-audit:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.84.1
+    container: rust:1.87.0
     steps:
       - uses: actions/checkout@v4
         with:

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -29,9 +29,9 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         unzip \
         zlib1g-dev
 
-ENV RUST_VERSION 1.84.1
-ENV RUSTUP_VERSION 1.27.1
-ENV RUSTUP_INIT_SHA256 6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d
+ENV RUST_VERSION 1.87.0
+ENV RUSTUP_VERSION 1.28.2
+ENV RUSTUP_INIT_SHA256 20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
 ENV RUSTUP_HOME /opt/rustup
 ENV CARGO_HOME /opt/cargo
 

--- a/redwood/src/stream.rs
+++ b/redwood/src/stream.rs
@@ -1,6 +1,6 @@
 use pyo3::types::{PyAnyMethods, PyBytes, PyTuple};
 use pyo3::{intern, Bound, PyAny, PyResult};
-use std::io::{self, ErrorKind, Read, Write};
+use std::io::{self, Read, Write};
 
 /// Wrapper to implement the `Read` trait around a Python
 /// object that contains a `.read()` function.
@@ -27,7 +27,7 @@ impl Read for Stream<'_> {
             // The PyErr could be a type error (e.g. no "read" method) or an
             // actual I/O failure if the read() call failed, let's just treat
             // all of them as "other" for simplicity.
-            io::Error::new(ErrorKind::Other, err.to_string())
+            io::Error::other(err.to_string())
         })?;
         buf.write(bytes.as_slice())
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.87.0"

--- a/securedrop/dockerfiles/focal/python3/DemoDockerfile
+++ b/securedrop/dockerfiles/focal/python3/DemoDockerfile
@@ -15,9 +15,9 @@ RUN apt-get update && \
 # 1) Download rustup-init and verify it matches hardcoded checksum
 # 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
 # 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
-ENV RUST_VERSION 1.84.1
-ENV RUSTUP_VERSION 1.27.1
-ENV RUSTUP_INIT_SHA256 6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d
+ENV RUST_VERSION 1.87.0
+ENV RUSTUP_VERSION 1.28.2
+ENV RUSTUP_INIT_SHA256 20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
 ENV RUSTUP_HOME /opt/rustup
 ENV CARGO_HOME /opt/cargo
 

--- a/securedrop/dockerfiles/focal/python3/SlimDockerfile
+++ b/securedrop/dockerfiles/focal/python3/SlimDockerfile
@@ -19,9 +19,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
 # 1) Download rustup-init and verify it matches hardcoded checksum
 # 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
 # 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
-ENV RUST_VERSION 1.84.1
-ENV RUSTUP_VERSION 1.27.1
-ENV RUSTUP_INIT_SHA256 6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d
+ENV RUST_VERSION 1.87.0
+ENV RUSTUP_VERSION 1.28.2
+ENV RUSTUP_INIT_SHA256 20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
 ENV RUSTUP_HOME /opt/rustup
 ENV CARGO_HOME /opt/cargo
 


### PR DESCRIPTION
- Update rust toolchain (Fixes #7555)
- Update rustup init script to 1.28.2 (see https://rust-lang.github.io/rustup/installation/other.html#manual-installation for hash verif)
- Satisfy clippy (https://github.com/rust-lang/rust-clippy/issues/12717)

## Test plan
 - [ ] CI passes, including staging CI (test the built redwood package)
 - [ ] Visual review

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)