### PR TITLE
Update demo docker file to use Noble

### DIFF
--- a/securedrop/dockerfiles/focal/python3/DemoDockerfile
+++ b/securedrop/dockerfiles/focal/python3/DemoDockerfile
@@ -1,14 +1,15 @@
-# ubuntu 20.04 image from 2022-10-19
-FROM ubuntu@sha256:450e066588f42ebe1551f3b1a535034b6aa46cd936fe7f2c6b0d72997ec61dbd
-ENV UBUNTU_VERSION=focal
+ARG UBUNTU_VERSION=noble
+FROM ubuntu:${UBUNTU_VERSION}
+ARG UBUNTU_VERSION=noble
+ENV UBUNTU_VERSION=${UBUNTU_VERSION}
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata && \
-    apt-get install -y paxctl apache2-dev coreutils \
-                       python3-pip python3-all python3-venv virtualenv libpython3.8-dev libssl-dev \
+    apt-get install -y apache2-dev coreutils \
+                       python3-pip python3-all python3-venv virtualenv libpython3-dev libssl-dev \
                        gnupg2 redis-server git jq \
-                       enchant libffi-dev sqlite3 gettext sudo \
-                       libasound2 libdbus-glib-1-2 libgtk2.0-0 libfontconfig1 libxrender1 \
+                       enchant-2 libffi-dev sqlite3 gettext sudo \
+                       libdbus-glib-1-2 libgtk2.0-0 libfontconfig1 libxrender1 \
                        libcairo-gobject2 libgtk-3-0 libstartup-notification0 basez pkg-config
 
 # Install Rust using the same steps as <https://github.com/rust-lang/docker-rust>
@@ -41,7 +42,7 @@ RUN PATH="$PATH:/opt/cargo/bin/" \
 
 RUN sed -i 's/"localhost"\];/"localhost", "demo-source.securedrop.org"];/' /opt/securedrop/securedrop/static/js/source.js
 
-RUN useradd --no-create-home --home-dir /tmp --uid 1000 demo && echo "demo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+RUN useradd --no-create-home --home-dir /tmp --uid 1001 demo && echo "demo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
     chown -R demo:demo /opt/securedrop /opt/venvs/
 
 STOPSIGNAL SIGKILL


### PR DESCRIPTION
Updates demo Dockerfile to use noble by default - if for some reason a focal build is required, specify `--build-args=UBUNTU_VERSION="focal"` in the image build command.

Fixes #7566.