### PR TITLE
Document the demo Dockerfile's UID is hardcoded by Infra

### DIFF
--- a/securedrop/dockerfiles/focal/python3/DemoDockerfile
+++ b/securedrop/dockerfiles/focal/python3/DemoDockerfile
@@ -42,6 +42,7 @@ RUN PATH="$PATH:/opt/cargo/bin/" \
 
 RUN sed -i 's/"localhost"\];/"localhost", "demo-source.securedrop.org"];/' /opt/securedrop/securedrop/static/js/source.js
 
+# Note: the 1001 UID is hardcoded in the deployment configuration; coordinate with Infra if it needs to change
 RUN useradd --no-create-home --home-dir /tmp --uid 1001 demo && echo "demo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
     chown -R demo:demo /opt/securedrop /opt/venvs/
 


### PR DESCRIPTION
So if it needs to change in the future, as it did earlier today in b546fe6181afb, to coordinate with them.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)