### PR TITLE
Default to Ubuntu Noble in devops scripts and dev-shell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,6 @@ jobs:
       matrix:
         build: [one, two]
         versions:
-          - ubuntu: focal
-            python: "3.8"
           - ubuntu: noble
             python: "3.12"
     # TODO: change this back to ubuntu-latest once it is consistently 24.04
@@ -50,7 +48,7 @@ jobs:
   reproducible-debs:
     strategy:
       matrix:
-        ubuntu_version: [focal, noble]
+        ubuntu_version: [noble]
     runs-on: ubuntu-latest
     container: debian:bookworm
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_version:
-          - focal
           - noble
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_version:
-          - focal
           - noble
     steps:
       - uses: actions/checkout@v4
@@ -82,7 +80,6 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_version:
-          - focal
           - noble
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: ["focal", "noble"]
+        ubuntu_version: ["noble"]
     runs-on: ubuntu-latest
     env:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}

--- a/devops/scripts/boot-strap-venv.sh
+++ b/devops/scripts/boot-strap-venv.sh
@@ -4,7 +4,7 @@
 
 set -eo pipefail
 
-UBUNTU_VERSION="${UBUNTU_VERSION:-focal}"
+UBUNTU_VERSION="${UBUNTU_VERSION:-noble}"
 
 # https://peps.python.org/pep-0508/#environment-markers
 PYTHON_VERSION="$(python3 -c 'import platform; print(".".join(platform.python_version_tuple()[:2]))')"

--- a/devops/scripts/build-debs.sh
+++ b/devops/scripts/build-debs.sh
@@ -11,7 +11,7 @@ set -o pipefail
 virtualenv_bootstrap
 
 RUN_TESTS="${1:-test}"
-TARGET_PLATFORM="${2:-focal}"
+TARGET_PLATFORM="${2:-noble}"
 SCENARIO_NAME="builder-${TARGET_PLATFORM}"
 
 case "$RUN_TESTS" in

--- a/devops/scripts/create-staging-env
+++ b/devops/scripts/create-staging-env
@@ -14,7 +14,7 @@ set -o pipefail
 
 . ./devops/scripts/boot-strap-venv.sh
 
-export PLATFORM="${UBUNTU_VERSION:-focal}"
+export PLATFORM="${UBUNTU_VERSION:-noble}"
 
 securedrop_staging_scenario="$(./devops/scripts/select-staging-env "${PLATFORM}")"
 

--- a/devops/scripts/select-staging-env
+++ b/devops/scripts/select-staging-env
@@ -12,7 +12,7 @@ set -o pipefail
 
 
 # Support overrides for LTS version
-securedrop_platform_suffix="-${1:-focal}"
+securedrop_platform_suffix="-${1:-noble}"
 
 # Respect explicit choice of Vagrant provider if set.
 if [[ -n "${VAGRANT_DEFAULT_PROVIDER:-}" ]] ; then

--- a/devops/scripts/test-built-packages.sh
+++ b/devops/scripts/test-built-packages.sh
@@ -5,7 +5,7 @@
 
 set -e
 set -o pipefail
-TARGET_PLATFORM="${1:-focal}"
+TARGET_PLATFORM="${1:-noble}"
 . ./devops/scripts/boot-strap-venv.sh
 
 virtualenv_bootstrap

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -13,7 +13,7 @@ USE_TOR="${USE_TOR:-}"
 USE_PODMAN="${USE_PODMAN:-}"
 SLIM_BUILD="${SLIM_BUILD:-}"
 DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS:-}"
-UBUNTU_VERSION="${UBUNTU_VERSION:-focal}"
+UBUNTU_VERSION="${UBUNTU_VERSION:-noble}"
 
 # Allow opting into using podman with USE_PODMAN=1
 if  [[ -n "${USE_PODMAN}" ]]; then


### PR DESCRIPTION
Fixes #7565
Set default ubuntu version to focal in devops scripts and in securedrop/bin/dev-shell.
Note: does not change defaults in the builder/ directory (ie doesn't touch build-debs.sh or the Dockerfile), where focal is still the default. 

## Test plan
- [ ] relevant CI passes
- [ ] Visual review 

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)