### PR TITLE
Ignore Safety ID 77316

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,8 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 74261 \
 		--ignore 74735 \
 		--ignore 76752 \
-                --ignore 77323 \
+		--ignore 77323 \
+		--ignore 77316 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
Ignores safety 77316 [1] since it maps to the same CVE that the already-suppressed [2] safety 76752 [3]

[1]: https://data.safetycli.com/vulnerabilities/CVE-2025-47273/77316/
[2]: https://github.com/freedomofpress/securedrop/pull/7539/files
[3]: https://data.safetycli.com/vulnerabilities/CVE-2025-47273/76752/

(and sneakily fixes tabs-vs-spaces issue in previous ignore)

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)