### PR TITLE
Add optional persistence for the dev datastore

### DIFF
--- a/devops/clean
+++ b/devops/clean
@@ -49,6 +49,11 @@ function remove_unwanted_files() {
         $DOCKER_BIN volume remove sd-onion-services
     fi
 
+    # Remove any persistent dev datastore
+    if $DOCKER_BIN volume inspect sd-store > /dev/null; then
+        $DOCKER_BIN volume remove sd-store
+    fi
+
     # Remove extraneous copies of the git repos, pulled in
     # via the Molecule upgrade testing scenario.
     rm -rf molecule/upgrade/.molecule/sd-orig \

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -122,6 +122,12 @@ function docker_run() {
         DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} --volume sd-onion-services:/var/lib/tor/services"
     fi
 
+    if [ -n "${USE_PERSISTENT_STORE:-}" ]; then
+        # Mount persistent data store
+        $DOCKER_BIN volume inspect sd-store -f " " || $DOCKER_BIN volume create sd-store
+        DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} --volume sd-store:/var/lib/securedrop"
+    fi
+
     # The --shm-size argument sets up dedicated shared memory for the
     # container. Our tests can fail with the default of 64m.
     echo "Starting ${UBUNTU_VERSION} container..."

--- a/securedrop/bin/run
+++ b/securedrop/bin/run
@@ -16,7 +16,19 @@ urandom
 build_redwood
 maybe_create_config_py
 run_redis
-reset_demo
+
+if [[ -e /var/lib/securedrop/db.sqlite ]]; then
+    echo "Using existing SecureDrop data..."
+    # Compile translated strings
+    pybabel compile --directory translations/
+    # remove previously uploaded custom logos
+    rm -f /var/www/securedrop/static/i/custom_logo.png
+else
+    echo "Creating fresh SecureDrop data..."
+    reset_demo
+fi
+
+
 maybe_use_tor
 
 # run the batch processing services normally managed by systemd


### PR DESCRIPTION
Fixes #7577

Adds the option to keep and reuse `/var/lib/securedrop` in the dev environment, by setting an env var `USE_PERSISTENT_STORE="true"`.

## Test plan
- [x] on this branch, run `make dev` and confirm the default dataset of 3 sources is generated
- [x] shut down the dev env and run `USE_PERSISTENT_STORE="true" make dev`, and confirm the default dataset is also generated.
- [x] connect to the dev env with `docker exec -it securedrop-dev-0 bash` and use `loaddata.py` to add additional sources. Record the number of sources
- [x] shut down the dev env and run `USE_PERSISTENT_STORE="true" make dev`, and confirm the default dataset is not generated.
- [x] connect to the dev env with `docker exec -it securedrop-dev-0 bash` and confirm that the source count matches the number in the loaddata step.
- [ ] shut down the dev env and run `make clean` confirming it succeeds.
- [ ] run `USE_PERSISTENT_STORE="true" make dev`, and confirm the default dataset is once again generated.
- [ ] for extra points, repeat with `make dev-tor`, tho it's not really necessary.
