### PR TITLE
Updated SI security slider instructions

### DIFF
--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -32,11 +32,12 @@
       <li>
         {{ gettext('Click the <img src="{icon}" alt="&quot;Security Level&quot; button"> in the toolbar above').format(icon=url_for("static", filename="i/font-awesome/black/guard.svg"))  }}
       </li>
-      <li>{{ gettext('Click <b>Change</b> to open Security Level preferences') }}</li>
-      <li>{{ gettext('Select <b>Safest</b> and close the preferences tab') }}</li>
+      <li>{{ gettext('Click <b>Settings</b> to open Security Level preferences') }}</li>
+      <li>{{ gettext('Click <b>Change...</b> and select <b>Safest</b>') }}</li>
+      <li>{{ gettext('Click <b>Save and restart.</b>') }}</li>
     </ol>
     <p>
-      {{ gettext('<a href="/" aria-label="Follow these instructions, then refresh this page">Refresh this page</a>, and you\'re done!') }}
+    {{ gettext('Tor Browser will restart, with its security level set to <b>Safest</b>. After the restart, come back to this site.') }}
     </p>
   </dialog>
   <div id="browser-tb" class="warning" role="alert">

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -902,13 +902,16 @@ msgstr ""
 msgid "Click the <img src=\"{icon}\" alt=\"&quot;Security Level&quot; button\"> in the toolbar above"
 msgstr ""
 
-msgid "Click <b>Change</b> to open Security Level preferences"
+msgid "Click <b>Settings</b> to open Security Level preferences"
 msgstr ""
 
-msgid "Select <b>Safest</b> and close the preferences tab"
+msgid "Click <b>Change...</b> and select <b>Safest</b>"
 msgstr ""
 
-msgid "<a href=\"/\" aria-label=\"Follow these instructions, then refresh this page\">Refresh this page</a>, and you're done!"
+msgid "Click <b>Save and restart.</b>"
+msgstr ""
+
+msgid "Tor Browser will restart, with its security level set to <b>Safest</b>. After the restart, come back to this site."
 msgstr ""
 
 msgid "<strong>It is recommended to use Tor Browser to access SecureDrop:</strong> <a class=\"recommend-tor\" href=\"{tor_browser_url}\">Learn how to install it</a>, or ignore this warning to continue."


### PR DESCRIPTION
Fixes #7585

## Test plan
- [x] CI is good
- [x] When SI is viewed in Tor Browser on a security level other than Safest, the Javascript warning banner is displayed and its popup text reflects new TBB UX changes
- [x] When SI is viewed in Tor Browser on the Safest security level  the Javascript warning banner is not displayed.

