### PR TITLE
 Suppress Safety ID 77680

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 76752 \
 		--ignore 77323 \
 		--ignore 77316 \
+		--ignore 77680 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
Already managed under (private link) https://github.com/freedomofpress/securedrop/security/dependabot/307

Reason:  `.netrc` not actually used
