### PR TITLE
README: add make venv to developer quickstart section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,27 @@ See our [contribution page](CONTRIBUTING.md).
 
 ## Developer Quickstart
 
-Ensure you have Docker installed and:
+To run SecureDrop locally, ensure you have Docker installed and:
 
 ```
 make dev
 ```
 
 This will start the source interface on `127.0.0.1:8080` and the journalist interface on `127.0.0.1:8081`. The credentials to login are printed in the Terminal. To login to the journalist interface, you must also [generate a two-factor code](https://developers.securedrop.org/en/latest/setup_development.html#using-the-docker-environment).
+
++To run SecureDrop locally, ensure you have Docker installed and:
+ 
+ ```
+ make dev
+ ```
+ 
+ This will start the source interface on `127.0.0.1:8080` and the journalist interface on `127.0.0.1:8081`. The credentials to login are printed in the Terminal. To login to the journalist interface, you must also [generate a two-factor code](https://developers.securedrop.org/en/latest/setup_development.html#using-the-docker-environment).
+ 
+To provision a Python 3 virtual environment for development:
+
+```
+make venv && source ./venv/bin/activate
+```
 
 ## License
 


### PR DESCRIPTION
Adds instructions to run `make venv` in developer quickstart