### PR TITLE
[2.12.x] Backport "Bump h11 from 0.14.0 to 0.16.0 in /securedrop/requirements/python3"

### DIFF
--- a/securedrop/requirements/noble/test-requirements.txt
+++ b/securedrop/requirements/noble/test-requirements.txt
@@ -75,9 +75,9 @@ flaky==3.6.0 \
     --hash=sha256:36fa125bceebfe869739b62e203db4653488dff09615e5a4f3d7607d48363c6a \
     --hash=sha256:c24e321b3b4b4a2d323b646acff6738e7601849832f4280864d69f00a6a9869d
     # via -r requirements/test-requirements.in
-h11==0.14.0 \
-    --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
-    --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
+h11==0.16.0 \
+    --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
+    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
     # via wsproto
 html5validator==0.4.0 \
     --hash=sha256:3ce6e3e736c9c7b37e5e26eb173ba0777ae00776549bd608933fa14955260d49


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7535.

## Testing

* [ ] CI is passing
* [ ] base is `release/2.12.x`
* [ ] Only contains changes from #7535 
