### PR TITLE
[2.12.9] Backport 7564: Suppress flask vulnerability CVE-2025-47278

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,8 @@ safety:  ## Run `safety check` to check python dependencies for vulnerabilities.
 		--ignore 74221 \
 		--ignore 74261 \
 		--ignore 74735 \
+		--ignore 76752 \
+		--ignore 77323 \
 		--full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \


### PR DESCRIPTION
Suppresses https://github.com/advisories/GHSA-4grg-w6v8-c28g / CVE-2025-47278 / Safety Vulnerability ID: 77323

SECRET_KEY_FALLBACKS are a 3.1+ feature, securedrop's version doesn't currently support it (or secret key rotation).

(cherry picked from commit 5bebea0f34804a19207e42b28019fa6cf3aa8a71)

Fixes #

## Test plan
- [ ] base is release/2.12.x
- [ ] only contains changes from #7564

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)