### PR TITLE
API: Add source-level `is_seen` and `has_attachment` properties

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -111,6 +111,18 @@ class Source(db.Model):
         return collection
 
     @property
+    def is_seen(self) -> bool:
+        """Return True if all submissions in this source's collection are marked as seen."""
+        if not self.submissions:
+            return True
+        return all(submission.seen for submission in self.submissions)
+
+    @property
+    def has_attachment(self) -> bool:
+        """Return True if any submission in this source's collection is a file attachment."""
+        return any(submission.is_file for submission in self.submissions)
+
+    @property
     def fingerprint(self) -> Optional[str]:
         if self.pgp_fingerprint is not None:
             return self.pgp_fingerprint
@@ -144,6 +156,8 @@ class Source(db.Model):
                 "uuid": self.uuid,
                 "journalist_designation": self.journalist_designation,
                 "is_starred": starred,
+                "is_seen": self.is_seen,
+                "has_attachment": self.has_attachment,
                 "last_updated": last_updated,
                 "public_key": self.public_key,
                 "fingerprint": self.fingerprint,
@@ -170,6 +184,8 @@ class Source(db.Model):
             "journalist_designation": self.journalist_designation,
             "is_flagged": False,
             "is_starred": starred,
+            "is_seen": self.is_seen,
+            "has_attachment": self.has_attachment,
             "last_updated": last_updated,
             "interaction_count": self.interaction_count,
             "key": {

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -1078,3 +1078,41 @@ def test_robots_txt(source_app):
         assert resp.status_code == 200
         text = resp.data.decode("utf-8")
         assert "Disallow: /" in text
+
+
+def test_source_is_seen_property(source_app, app_storage):
+    """Test Source.is_seen property with various submission states."""
+    with source_app.app_context():
+        from tests.utils.db_helper import init_source, submit
+
+        source, _ = init_source(app_storage)
+
+        # Empty source is considered read
+        assert source.is_seen is True
+
+        # Add unseen message submission
+        submissions = submit(app_storage, source, 1, "message")
+        assert source.is_seen is False
+
+        # Mark as seen
+        submissions[0].downloaded = True
+        assert source.is_seen is True
+
+
+def test_source_has_attachment_property(source_app, app_storage):
+    """Test Source.has_attachment property with various submission types."""
+    with source_app.app_context():
+        from tests.utils.db_helper import init_source, submit
+
+        source, _ = init_source(app_storage)
+
+        # Empty source has no attachments
+        assert source.has_attachment is False
+
+        # Add message submission
+        submit(app_storage, source, 1, "message")
+        assert source.has_attachment is False
+
+        # Add file submission
+        submit(app_storage, source, 1, "file")
+        assert source.has_attachment is True


### PR DESCRIPTION
- is_seen: indicates whether all submissions in source are marked as seen
- has_attachment: indicates whether source contains any file attachments

While the client can calculate these, let's have the server do it for efficiency, and leave to the client only things that it can do (i.e. operate on decrypted submissions).

This trivial to add to both API v1 and v2, so we'll do both.

Fixes #7621.

## Test plan
n.b. see LLM usage below

<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] Review the tests and check behavior is accurate. 


## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)

## LLM usage

I generated this entirely using Claude Code, here's the transcript: https://gist.github.com/legoktm/7b7071708073185a06ed94a77d47d7f1

It wrote too many tests, so I had it cut down and consolidate; I also rewrote the commit message because I didn't like the one it generated. This is probably a better implementation than what I had proposed in https://github.com/freedomofpress/securedrop/issues/7552#issuecomment-3050198384 as it makes it far easier to port to API v1 IMO.

~~I have not finished comprehensively reviewing this, hence why it's in draft mode, but I wanted to publish on the record what Claude generated in case there were flaws/bugs a human needed to manually fix.~~