### PR TITLE
Try increasing functional test startup timeout to help with Ubuntu Noble

### DIFF
--- a/securedrop/tests/functional/conftest.py
+++ b/securedrop/tests/functional/conftest.py
@@ -158,8 +158,8 @@ def spawn_sd_servers(
         journalist_app_base_url = f"http://127.0.0.1:{journalist_port}"
 
         # Sleep until the source and journalist web apps are up and running
-        attempts_count = 30
-        seconds_between_attempts = 0.25
+        attempts_count = 60
+        seconds_between_attempts = 0.5
         response_source_status_code = None
         for _ in range(attempts_count):
             try:
@@ -168,7 +168,9 @@ def spawn_sd_servers(
                 break
             except (requests.ConnectionError, requests.Timeout):
                 time.sleep(seconds_between_attempts)
-        assert response_source_status_code == 200
+        assert (
+            response_source_status_code == 200
+        ), f"Source app failed to start at {source_app_base_url}"
 
         response_journalist_status_code = None
         for _ in range(attempts_count):
@@ -178,7 +180,9 @@ def spawn_sd_servers(
                 break
             except (requests.ConnectionError, requests.Timeout):
                 time.sleep(seconds_between_attempts)
-        assert response_journalist_status_code == 200
+        assert (
+            response_journalist_status_code == 200
+        ), f"Journalist app failed to start at {journalist_app_base_url}"
 
         # Ready for the tests
         yield SdServersFixtureResult(


### PR DESCRIPTION
Address #7537 by increasing the timeout for functional test app startup from 7.5 seconds to 30 seconds (60 attempts × 0.5 seconds), and add better error messages when apps fail to start.

Refs #7537.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

I think we can just merge it and see if it stops happening.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)

## LLM usage

All generated with Claude Code (see https://gist.github.com/legoktm/08a96e8e7959b2c784eb39aaf600f202) but it kind of did the wrong thing so I told it to do something else.