### PR TITLE
refactor: generalize `/index` and `/metadata` to flat collections

### DIFF
--- a/securedrop/journalist_app/api2/README.md
+++ b/securedrop/journalist_app/api2/README.md
@@ -31,9 +31,9 @@ else Sharded by UUID prefix
 end
 
 Server ->> Client: ETag: abcdef<br>Index
-Note over Client: New sources → "full sources" for which we want all metadata.
-Client -->> Server: POST /api/v2/sources<br>SourceDelta
-Server ->> Client: SourceMetadata
+Note over Client: We want metadata for all new sources and items.
+Client -->> Server: POST /api/v2/metadata<br>MetadataRequest
+Server ->> Client: MetadataResponse
 ```
 
 ### Incremental synchronization
@@ -56,8 +56,8 @@ alt Up to date
     Server ->> Client: HTTP 304
 else Out of date
     Server ->> Client: ETag: abcdef<br>Index
-    Note over Client: New/changed sources → "full sources" for which we want all metadata.<br>New/changed items → "partial sources",  we want metadata only for the specified items.
-    Client -->> Server: POST /api/v2/sources<br>SourceDelta
-    Server ->> Client: SourceMetadata
+    Note over Client: We want metadata for all new/changed sources and items.
+    Client -->> Server: POST /api/v2/metadata<br>MetadataRequest
+    Server ->> Client: MetadataResponse
 end
 ```

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -122,18 +122,24 @@ def metadata() -> Response:
 
     response = MetadataResponse()
 
-    for source in all_sources().filter(Source.uuid.in_(str(uuid) for uuid in requested.sources)):
-        response.sources[source.uuid] = source.to_api_v2()
+    if requested.sources:
+        for source in all_sources().filter(
+            Source.uuid.in_(str(uuid) for uuid in requested.sources)
+        ):
+            response.sources[source.uuid] = source.to_api_v2()
 
-    for item in Submission.query.filter(Submission.uuid.in_(str(uuid) for uuid in requested.items)):
-        response.items[item.uuid] = item.to_api_v2()
+    if requested.items:
+        for item in Submission.query.filter(
+            Submission.uuid.in_(str(uuid) for uuid in requested.items)
+        ):
+            response.items[item.uuid] = item.to_api_v2()
 
-    for item in Reply.query.filter(Reply.uuid.in_(str(uuid) for uuid in requested.items)):
-        if item.uuid in response.items:
-            # Fail if we get unlucky and hit a UUID collision between the
-            # `Submission` and `Reply` tables.  This is vanishingly unlikely,
-            # but SQLite can't enforce uniqueness between them.
-            raise MultipleResultsFound(f"found {item.uuid} in both submissions and replies")
-        response.items[item.uuid] = item.to_api_v2()
+        for item in Reply.query.filter(Reply.uuid.in_(str(uuid) for uuid in requested.items)):
+            if item.uuid in response.items:
+                # Fail if we get unlucky and hit a UUID collision between the
+                # `Submission` and `Reply` tables.  This is vanishingly unlikely,
+                # but SQLite can't enforce uniqueness between them.
+                raise MultipleResultsFound(f"found {item.uuid} in both submissions and replies")
+            response.items[item.uuid] = item.to_api_v2()
 
     return jsonify(asdict(response))

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -1,9 +1,9 @@
 import hashlib
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List, Mapping, NewType, Optional
+from typing import Any, Dict, Mapping, NewType, Optional, Set
 
 from flask import Blueprint, abort, json, jsonify, request
-from models import Source
+from models import Reply, Source, Submission
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import Query, joinedload
 from werkzeug.wrappers.response import Response
@@ -48,29 +48,23 @@ ItemUUID = NewType("ItemUUID", str)
 
 
 @dataclass
-class IndexSourceEntry:
-    version: Version
-    collection: Dict[ItemUUID, Version] = field(default_factory=dict)
-
-
-@dataclass
 class Index:
-    sources: Dict[SourceUUID, IndexSourceEntry] = field(default_factory=dict)
+    sources: Dict[SourceUUID, Version] = field(default_factory=dict)
+    items: Dict[ItemUUID, Version] = field(default_factory=dict)
 
 
 @blp.get("/index")
 @blp.get("/index/<string:prefix>")
 def index(prefix: Optional[str] = None) -> Response:
     """
-    By default, return the ETag-versioned ``Index`` consisting of an
-    ``IndexSourceEntry`` for each source and its collection, unless the client
-    provides the ETag of the current index.
+    By default, return the ETag-versioned ``Index`` of all sources and their
+    items, unless the client provides the ETag of the current index.
 
     Given a ``prefix``, return the sub-index of all sources whose UUIDs begin
-    with that prefix, unless the client provides the ETag of the current
-    sub-index for that prefix.  The client MAY choose an arbitrary prefix with
-    each request: e.g., a series of requests with the prefixes ``{0...f}`` will
-    effectively shard the index into 16 shards.
+    with that prefix (and their items), unless the client provides the ETag of
+    the current sub-index for that prefix.  The client MAY choose an arbitrary
+    prefix with each request: e.g., a series of requests with the prefixes
+    ``{0...f}`` will effectively shard the index into 16 shards.
     """
     index = Index()
 
@@ -85,12 +79,9 @@ def index(prefix: Optional[str] = None) -> Response:
 
     for source in query.all():
         all_source_metadata = source.to_api_v2()
-        source_entry = IndexSourceEntry(
-            version=json_version(all_source_metadata["source"]),
-        )
+        index.sources[source.uuid] = json_version(all_source_metadata)
         for uuid, item in all_source_metadata["collection"].items():
-            source_entry.collection[uuid] = json_version(item)
-        index.sources[source.uuid] = source_entry
+            index.items[uuid] = json_version(item)
 
     version = json_version(asdict(index))
     response = jsonify(asdict(index))
@@ -102,71 +93,42 @@ def index(prefix: Optional[str] = None) -> Response:
 
 
 @dataclass
-class SourcesRequest:
-    full_sources: List[SourceUUID] = field(default_factory=list)
-    partial_sources: Mapping[SourceUUID, List[ItemUUID]] = field(default_factory=dict)
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.full_sources, list):
-            raise ValueError("full_sources must be a list of strings")
-        if not all(isinstance(item, str) for item in self.full_sources):
-            raise ValueError("full_sources must be a list of strings")
-
-        if not isinstance(self.partial_sources, Mapping):
-            raise ValueError("partial_sources must be a dict")
-        for key, value in self.partial_sources.items():
-            if not isinstance(key, str):
-                raise ValueError("partial_sources must be keyed by UUID")
-            if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-                raise ValueError("each value in partial_sources must be a list of strings")
+class MetadataRequest:
+    sources: Set[SourceUUID] = field(default_factory=set)
+    items: Set[ItemUUID] = field(default_factory=set)
 
 
 @dataclass
-class SourceEntry:
-    collection: Dict[ItemUUID, Any] = field(default_factory=dict)
+class MetadataResponse:
+    sources: Dict[SourceUUID, Any] = field(default_factory=dict)
+    items: Dict[ItemUUID, Any] = field(default_factory=dict)
 
 
-@dataclass
-class FullSourceEntry(SourceEntry):
-    info: Dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class SourcesResponse:
-    sources: Dict[SourceUUID, SourceEntry] = field(default_factory=dict)
-
-
-@blp.post("/sources")
-def sources() -> Response:
+@blp.post("/metadata")
+def metadata() -> Response:
     """
-    Return the ``SourcesResponse`` requested in the ``SourcesRequest``.  For "full"
-    sources, return all metadata.  For "partial" sources, return metadata only
-    for the specified items in their collections.
+    Return the ``MetadataResponse`` requested in the ``MetadataRequest``.  The
+    client MAY choose an arbitrary list of sources and items with each request,
+    e.g. from a shard retrieved from ``/index/<prefix>``.
 
-    The client MAY choose an arbitrary source delta with each request, e.g.
-    from a shard retrieved from ``/index/<prefix>``.
+    NB.  Returning sources is O(1) from the eagerly-loaded ``all_sources()``.
+    Returning items is O(2), since we have to search both the ``Submission`` and
+    the ``Reply`` tables for the set of all item UUIDs.
     """
     try:
-        requested = SourcesRequest(**request.json)  # type: ignore
+        requested = MetadataRequest(**request.json)  # type: ignore
     except (TypeError, ValueError) as exc:
         abort(422, f"malformed request; {exc}")
 
-    # Look up all requested sources, and return both "full" and "partial"
-    # metadata in a single pass.
-    source_lookup = set(requested.full_sources) | set(requested.partial_sources.keys())
-    response = SourcesResponse()
+    response = MetadataResponse()
 
-    for source in all_sources().filter(Source.uuid.in_(str(uuid) for uuid in source_lookup)):
-        all_source_metadata = source.to_api_v2()
-        want_full = source.uuid in requested.full_sources
-        partial = requested.partial_sources.get(source.uuid, [])
-        cls = FullSourceEntry if want_full else SourceEntry
-        source_entry = cls()
-        for uuid, item in all_source_metadata["collection"].items():
-            if want_full or uuid in partial:
-                source_entry.collection[uuid] = item
-        if want_full:
-            source_entry.info = all_source_metadata["source"]
-        response.sources[source.uuid] = source_entry
+    for source in all_sources().filter(Source.uuid.in_(str(uuid) for uuid in requested.sources)):
+        response.sources[source.uuid] = source.to_api_v2()
+
+    for item in Submission.query.filter(Submission.uuid.in_(str(uuid) for uuid in requested.items)):
+        response.items[item.uuid] = item.to_api_v2()
+
+    for item in Reply.query.filter(Reply.uuid.in_(str(uuid) for uuid in requested.items)):
+        response.items[item.uuid] = item.to_api_v2()
 
     return jsonify(asdict(response))

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -6,6 +6,7 @@ from flask import Blueprint, abort, json, jsonify, request
 from models import Reply, Source, Submission
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import Query, joinedload
+from sqlalchemy.orm.exc import MultipleResultsFound
 from werkzeug.wrappers.response import Response
 
 blp = Blueprint("api2", __name__, url_prefix="/api/v2")
@@ -129,6 +130,11 @@ def metadata() -> Response:
         response.items[item.uuid] = item.to_api_v2()
 
     for item in Reply.query.filter(Reply.uuid.in_(str(uuid) for uuid in requested.items)):
+        if item.uuid in response.items:
+            # Fail if we get unlucky and hit a UUID collision between the
+            # `Submission` and `Reply` tables.  This is vanishingly unlikely,
+            # but SQLite can't enforce uniqueness between them.
+            raise MultipleResultsFound(f"found {item.uuid} in both submissions and replies")
         response.items[item.uuid] = item.to_api_v2()
 
     return jsonify(asdict(response))

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -79,10 +79,9 @@ def index(prefix: Optional[str] = None) -> Response:
         query = query.filter(Source.uuid.startswith(prefix))
 
     for source in query.all():
-        all_source_metadata = source.to_api_v2()
-        index.sources[source.uuid] = json_version(all_source_metadata)
-        for uuid, item in all_source_metadata["collection"].items():
-            index.items[uuid] = json_version(item)
+        index.sources[source.uuid] = json_version(source.to_api_v2())
+        for item in source.collection:
+            index.items[item.uuid] = json_version(item.to_api_v2())
 
     version = json_version(asdict(index))
     response = jsonify(asdict(index))

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -152,17 +152,14 @@ class Source(db.Model):
             collection[item.uuid] = item.to_api_v2()
 
         return {
-            "source": {
-                "uuid": self.uuid,
-                "journalist_designation": self.journalist_designation,
-                "is_starred": starred,
-                "is_seen": self.is_seen,
-                "has_attachment": self.has_attachment,
-                "last_updated": last_updated,
-                "public_key": self.public_key,
-                "fingerprint": self.fingerprint,
-            },
-            "collection": collection,
+            "uuid": self.uuid,
+            "journalist_designation": self.journalist_designation,
+            "is_starred": starred,
+            "is_seen": self.is_seen,
+            "has_attachment": self.has_attachment,
+            "last_updated": last_updated,
+            "public_key": self.public_key,
+            "fingerprint": self.fingerprint,
         }
 
     def to_api_v1(self) -> "Dict[str, object]":

--- a/securedrop/tests/conftest.py
+++ b/securedrop/tests/conftest.py
@@ -268,6 +268,24 @@ def test_files(journalist_app, test_journo, app_storage):
 
 
 @pytest.fixture
+def test_files_with_uuid_collision(journalist_app, test_journo, app_storage):
+    with journalist_app.app_context():
+        source, codename = utils.db_helper.init_source(app_storage)
+        utils.db_helper.submit(app_storage, source, 1, submission_type="file")
+        utils.db_helper.reply(app_storage, test_journo["journalist"], source, 1)
+        source.replies[0].uuid = source.submissions[0].uuid
+        db.session.commit()
+        return {
+            "source": source,
+            "codename": codename,
+            "filesystem_id": source.filesystem_id,
+            "uuid": source.uuid,
+            "submissions": source.submissions,
+            "replies": source.replies,
+        }
+
+
+@pytest.fixture
 def test_files_deleted_journalist(journalist_app, test_journo, app_storage):
     with journalist_app.app_context():
         source, codename = utils.db_helper.init_source(app_storage)

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -48,7 +48,7 @@ def test_json_version():
         ("api2.index", {}),
         ("api2.index", {"prefix": "foo"}),
         # while this should be a POST request, the 403 will kick in first
-        ("api2.sources", {}),
+        ("api2.metadata", {}),
     ],
 )
 def test_auth_required(journalist_app, endpoint, kwargs):
@@ -77,7 +77,7 @@ def test_index(journalist_app, test_files, journalist_api_token):
         assert response.status_code == 200
         assert uuid in response.json["sources"]
         # test_files generates 2 submissions and 1 reply, so 3 items total
-        assert len(response.json["sources"][uuid]["collection"]) == 3
+        assert len(response.json["items"]) == 3
 
         with assert_query_count(1):
             response2 = app.get(
@@ -109,7 +109,7 @@ def test_index_with_prefix(journalist_app, test_files, journalist_api_token):
         assert response.status_code == 200
         assert uuid in response.json["sources"]
         # test_files generates 2 submissions and 1 reply, so 3 items total
-        assert len(response.json["sources"][uuid]["collection"]) == 3
+        assert len(response.json["items"]) == 3
 
         with assert_query_count(1):
             response2 = app.get(
@@ -132,6 +132,7 @@ def test_index_with_prefix(journalist_app, test_files, journalist_api_token):
         # HTTP 200, but zero sources
         assert response3.status_code == 200
         assert response3.json["sources"] == {}
+        assert response3.json["items"] == {}
 
 
 def test_index_with_invalid_prefix(journalist_app, test_files, journalist_api_token):
@@ -151,9 +152,9 @@ def test_index_with_invalid_prefix(journalist_app, test_files, journalist_api_to
         assert "malformed request; prefix must be shorter than" in response.get_data(as_text=True)
 
 
-def test_sources(journalist_app, test_files, journalist_api_token):
+def test_metadata(journalist_app, test_files, journalist_api_token):
     """
-    Verify POST /sources response
+    Verify POST /metadata response
     """
     with journalist_app.test_client() as app:
         uuid = test_files["source"].uuid
@@ -166,41 +167,32 @@ def test_sources(journalist_app, test_files, journalist_api_token):
         source_versions = index.json["sources"][uuid]
 
         # Get the full source
-        with assert_query_count(1):
+        with assert_query_count(3):
             response = app.post(
-                url_for("api2.sources"),
-                json={"full_sources": [uuid], "partial_sources": {}},
+                url_for("api2.metadata"),
+                json={"sources": [uuid]},
                 headers=get_api_headers(journalist_api_token),
             )
         assert response.status_code == 200
         assert uuid in response.json["sources"]
         source = response.json["sources"][uuid]
         # Verify the source has the same version
-        assert json_version(source["info"]) == source_versions["version"]
-        # Verify the collection has an identical set of UUIDs and the versions are the same
-        assert set(source["collection"].keys()) == set(source_versions["collection"].keys())
-        for item_uuid, item in source["collection"].items():
-            assert json_version(item) == source_versions["collection"][item_uuid]
+        assert json_version(source) == source_versions
 
-        # Get a partial source
-        item_uuid = list(source["collection"].keys())[0]
-        with assert_query_count(1):
+        # Get an item
+        item_uuid = test_files["submissions"][0].uuid
+        with assert_query_count(3):
             response = app.post(
-                url_for("api2.sources"),
-                json={"full_sources": [], "partial_sources": {uuid: [item_uuid]}},
+                url_for("api2.metadata"),
+                json={"items": [item_uuid]},
                 headers=get_api_headers(journalist_api_token),
             )
         assert response.status_code == 200
-        assert uuid in response.json["sources"]
-        source = response.json["sources"][uuid]
+        assert item_uuid in response.json["items"]
         # Verify no source metadata is returned
-        assert "info" not in source
-        # Verify the collection has an identical set of UUIDs and the versions are the same
-        assert set(source["collection"].keys()) == {item_uuid}
-        assert (
-            json_version(source["collection"][item_uuid])
-            == source_versions["collection"][item_uuid]
-        )
+        assert len(response.json["sources"]) == 0
+        # Verify the versions are the same
+        assert json_version(response.json["items"][item_uuid]) == index.json["items"][item_uuid]
 
 
 # Verify POST /sources input validation
@@ -214,11 +206,11 @@ def test_sources(journalist_app, test_files, journalist_api_token):
         None,
     ],
 )
-def test_api2_sources_validation_invalid_json(journalist_app, journalist_api_token, invalid_data):
+def test_api2_metadata_validation_invalid_json(journalist_app, journalist_api_token, invalid_data):
     """Test that Flask rejects invalid JSON."""
     with journalist_app.test_client() as app:
         response = app.post(
-            url_for("api2.sources"),
+            url_for("api2.metadata"),
             data=invalid_data,
             headers=get_api_headers(journalist_api_token),
         )
@@ -234,13 +226,13 @@ def test_api2_sources_validation_invalid_json(journalist_app, journalist_api_tok
         True,
     ],
 )
-def test_api2_sources_validation_non_dict_request(
+def test_api2_metadata_validation_non_dict_request(
     journalist_app, journalist_api_token, invalid_request
 ):
     """Test that non-dict request body returns 400."""
     with journalist_app.test_client() as app:
         response = app.post(
-            url_for("api2.sources"),
+            url_for("api2.metadata"),
             json=invalid_request,
             headers=get_api_headers(journalist_api_token),
         )
@@ -249,93 +241,28 @@ def test_api2_sources_validation_non_dict_request(
 
 
 @pytest.mark.parametrize(
-    ("request_body", "expected_error"),
-    [
-        # full_sources not a list
-        (
-            {"full_sources": "not a list", "partial_sources": {}},
-            "full_sources must be a list of strings",
-        ),
-        # full_sources with non-string items
-        (
-            {"full_sources": ["valid", 123, "another"], "partial_sources": {}},
-            "full_sources must be a list of strings",
-        ),
-    ],
-)
-def test_api2_sources_validation_full_sources_errors(
-    journalist_app, journalist_api_token, request_body, expected_error
-):
-    """Test various full_sources validation errors."""
-    with journalist_app.test_client() as app:
-        response = app.post(
-            url_for("api2.sources"),
-            json=request_body,
-            headers=get_api_headers(journalist_api_token),
-        )
-        assert response.status_code == 422
-        assert expected_error in response.get_data(as_text=True)
-
-
-@pytest.mark.parametrize(
-    ("request_body", "expected_error"),
-    [
-        # partial_sources not a dict
-        ({"full_sources": [], "partial_sources": "not a dict"}, "partial_sources must be a dict"),
-        # partial_sources values not lists
-        (
-            {"full_sources": [], "partial_sources": {"key1": "not a list"}},
-            "each value in partial_sources must be a list of strings",
-        ),
-        # partial_sources values with non-string items
-        (
-            {"full_sources": [], "partial_sources": {"key1": ["valid", 123]}},
-            "each value in partial_sources must be a list of strings",
-        ),
-        # Multiple keys, one invalid
-        (
-            {"full_sources": [], "partial_sources": {"key1": ["valid"], "key2": "not a list"}},
-            "each value in partial_sources must be a list of strings",
-        ),
-    ],
-)
-def test_api2_sources_validation_partial_sources_errors(
-    journalist_app, journalist_api_token, request_body, expected_error
-):
-    """Test various partial_sources validation errors."""
-    with journalist_app.test_client() as app:
-        response = app.post(
-            url_for("api2.sources"),
-            json=request_body,
-            headers=get_api_headers(journalist_api_token),
-        )
-        assert response.status_code == 422
-        assert expected_error in response.get_data(as_text=True)
-
-
-@pytest.mark.parametrize(
     "valid_request",
     [
         # Empty but valid
-        {"full_sources": [], "partial_sources": {}},
-        # Only full_sources
-        {"full_sources": ["uuid1", "uuid2"], "partial_sources": {}},
-        # Only partial_sources
-        {"full_sources": [], "partial_sources": {"key1": ["item1", "item2"]}},
+        {"sources": [], "items": []},
+        # Only sources
+        {"sources": ["uuid1", "uuid2"], "items": ["uuid1", "uuid2"]},
+        # Only items
+        {"sources": [], "items": ["item1", "item2"]},
         # Both with data
         {
-            "full_sources": ["uuid1", "uuid2"],
-            "partial_sources": {"key1": ["item1", "item2"], "key2": ["item3"]},
+            "sources": ["uuid1", "uuid2"],
+            "items": ["item1", "item2"],
         },
     ],
 )
-def test_api2_sources_validation_valid_requests(
+def test_api2_metadata_validation_valid_requests(
     journalist_app, journalist_api_token, valid_request
 ):
     """Test that valid requests pass validation."""
     with journalist_app.test_client() as app:
         response = app.post(
-            url_for("api2.sources"),
+            url_for("api2.metadata"),
             json=valid_request,
             headers=get_api_headers(journalist_api_token),
         )

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -168,7 +168,7 @@ def test_metadata(journalist_app, test_files, journalist_api_token):
         source_versions = index.json["sources"][uuid]
 
         # Get the full source
-        with assert_query_count(3):
+        with assert_query_count(1):
             response = app.post(
                 url_for("api2.metadata"),
                 json={"sources": [uuid]},
@@ -182,7 +182,7 @@ def test_metadata(journalist_app, test_files, journalist_api_token):
 
         # Get an item
         item_uuid = test_files["submissions"][0].uuid
-        with assert_query_count(3):
+        with assert_query_count(2):
             response = app.post(
                 url_for("api2.metadata"),
                 json={"items": [item_uuid]},

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -4,6 +4,7 @@ import pytest
 from flask import url_for
 from flask_sqlalchemy import get_debug_queries
 from journalist_app.api2 import json_version
+from sqlalchemy.orm.exc import MultipleResultsFound
 from tests.utils.api_helper import get_api_headers
 
 
@@ -193,6 +194,22 @@ def test_metadata(journalist_app, test_files, journalist_api_token):
         assert len(response.json["sources"]) == 0
         # Verify the versions are the same
         assert json_version(response.json["items"][item_uuid]) == index.json["items"][item_uuid]
+
+
+def test_item_collision(journalist_app, test_files_with_uuid_collision, journalist_api_token):
+    """
+    Test the edge case where a ``Submission`` and a ``Reply`` have the same UUID
+    in separate tables.
+    """
+    with journalist_app.test_client() as app:
+        # Get an item:
+        item_uuid = test_files_with_uuid_collision["submissions"][0].uuid
+        with pytest.raises(MultipleResultsFound):  # HTTP 500 in production
+            app.post(
+                url_for("api2.metadata"),
+                json={"items": [item_uuid]},
+                headers=get_api_headers(journalist_api_token),
+            )
 
 
 # Verify POST /sources input validation


### PR DESCRIPTION
Closes #7620 by generalizing `/index` and `/metadata` to flat collections of sources and items.

Once the index loses the source/collection hierarchy, the client has no way to "hint" the server in what source's collection to find a given item.  There are other index structures that could provide this hint, but it's simpler just to scan the `Submission` and `Reply` tables directly (without any relationships to eager-load) for the set of item UUIDs requested by the client.

As a bonus, the dataclasses provide sufficient structural validation of incoming requests.


## Test plan

- [ ] New request/response schemas look as expected for <https://github.com/freedomofpress/securedrop-client/pull/2562#pullrequestreview-3069261968>:
    - `Index`
    - `MetadataRequest`
    - `MetadataResponse` 


## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)