### PR TITLE
Add dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,14 @@
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v4
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,5 +10,7 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-dev/issues/14. This does not directly address the redundancy (it adds another check), but it covers the ground that our per-repo `safety` checks cover so we can remove them without regret.

If this looks good, I will prepare additional similar PRs to add the action, and to remove the per-repo `safety` checks, as appropriate.

## Test plan
- Review the description of the action itself: https://github.com/actions/dependency-review-action
- Review https://github.com/freedomofpress/securedrop/actions/runs/16791402650 as an example of a failed run (commit since dropped)

## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)