### PR TITLE
feat: include journalist accounts in sync

### DIFF
--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -50,35 +50,42 @@ ItemUUID = NewType("ItemUUID", str)
 
 @dataclass
 class Index:
+    # Source metadata, optionally filtered by `source_prefix`:
     sources: Dict[SourceUUID, Version] = field(default_factory=dict)
     items: Dict[ItemUUID, Version] = field(default_factory=dict)
 
+    # Non-source metadata (always returned):
+
 
 @blp.get("/index")
-@blp.get("/index/<string:prefix>")
-def index(prefix: Optional[str] = None) -> Response:
+@blp.get("/index/<string:source_prefix>")
+def index(source_prefix: Optional[str] = None) -> Response:
     """
-    By default, return the ETag-versioned ``Index`` of all sources and their
-    items, unless the client provides the ETag of the current index.
+    By default, return the ETag-versioned ``Index`` of all metadata unless the
+    client provides the ETag of the current index.
 
-    Given a ``prefix``, return the sub-index of all sources whose UUIDs begin
-    with that prefix (and their items), unless the client provides the ETag of
-    the current sub-index for that prefix.  The client MAY choose an arbitrary
-    prefix with each request: e.g., a series of requests with the prefixes
-    ``{0...f}`` will effectively shard the index into 16 shards.
+    Given a ``source_prefix``, return the sub-index of source metadata for all
+    sources whose UUIDs begin with that prefix, plus all non-source metadata,
+    unless the client provides the ETag of the current sub-index for that
+    prefix.  The client MAY choose an arbitrary prefix with each request: e.g.,
+    a series of requests with the prefixes ``{0...f}`` will effectively shard
+    the source index into 16 shards.  (Non-source metadata is not filtered by
+    the prefix and is always returned.)
     """
     index = Index()
 
-    query = all_sources()
-    if prefix is not None:
-        if len(prefix) >= PREFIX_MAX_LEN:
+    source_query = all_sources()
+    if source_prefix is not None:
+        if len(source_prefix) >= PREFIX_MAX_LEN:
             abort(
-                422, f"malformed request; prefix must be shorter than {PREFIX_MAX_LEN} characters"
+                422,
+                f"malformed request; source prefix must be shorter than {PREFIX_MAX_LEN} "
+                f"characters",
             )
 
-        query = query.filter(Source.uuid.startswith(prefix))
+        source_query = source_query.filter(Source.uuid.startswith(source_prefix))
 
-    for source in query.all():
+    for source in source_query.all():
         index.sources[source.uuid] = json_version(source.to_api_v2())
         for item in source.collection:
             index.items[item.uuid] = json_version(item.to_api_v2())
@@ -94,22 +101,28 @@ def index(prefix: Optional[str] = None) -> Response:
 
 @dataclass
 class MetadataRequest:
+    # Source metadata:
     sources: Set[SourceUUID] = field(default_factory=set)
     items: Set[ItemUUID] = field(default_factory=set)
+
+    # Non-source metadata:
 
 
 @dataclass
 class MetadataResponse:
+    # Source metadata:
     sources: Dict[SourceUUID, Any] = field(default_factory=dict)
     items: Dict[ItemUUID, Any] = field(default_factory=dict)
+
+    # Non-source metadata:
 
 
 @blp.post("/metadata")
 def metadata() -> Response:
     """
     Return the ``MetadataResponse`` requested in the ``MetadataRequest``.  The
-    client MAY choose an arbitrary list of sources and items with each request,
-    e.g. from a shard retrieved from ``/index/<prefix>``.
+    client MAY choose an arbitrary list of objects with each request, e.g. from
+    a shard retrieved from ``/index/<source_prefix>``.
 
     NB.  Returning sources is O(1) from the eagerly-loaded ``all_sources()``.
     Returning items is O(2), since we have to search both the ``Submission`` and

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -3,7 +3,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, Mapping, NewType, Optional, Set
 
 from flask import Blueprint, abort, json, jsonify, request
-from models import Reply, Source, Submission
+from models import Journalist, Reply, Source, Submission
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import Query, joinedload
 from sqlalchemy.orm.exc import MultipleResultsFound
@@ -46,6 +46,7 @@ def json_version(d: Mapping) -> Version:
 # TODO: generic UUID[T] in Python 3.12
 SourceUUID = NewType("SourceUUID", str)
 ItemUUID = NewType("ItemUUID", str)
+JournalistUUID = NewType("JournalistUUID", str)
 
 
 @dataclass
@@ -55,6 +56,7 @@ class Index:
     items: Dict[ItemUUID, Version] = field(default_factory=dict)
 
     # Non-source metadata (always returned):
+    journalists: Dict[JournalistUUID, Version] = field(default_factory=dict)
 
 
 @blp.get("/index")
@@ -90,6 +92,9 @@ def index(source_prefix: Optional[str] = None) -> Response:
         for item in source.collection:
             index.items[item.uuid] = json_version(item.to_api_v2())
 
+    for journalist in Journalist.query.all():
+        index.journalists[journalist.uuid] = json_version(journalist.to_api_v2())
+
     version = json_version(asdict(index))
     response = jsonify(asdict(index))
 
@@ -106,6 +111,7 @@ class MetadataRequest:
     items: Set[ItemUUID] = field(default_factory=set)
 
     # Non-source metadata:
+    journalists: Set[JournalistUUID] = field(default_factory=set)
 
 
 @dataclass
@@ -115,6 +121,7 @@ class MetadataResponse:
     items: Dict[ItemUUID, Any] = field(default_factory=dict)
 
     # Non-source metadata:
+    journalists: Dict[JournalistUUID, Any] = field(default_factory=dict)
 
 
 @blp.post("/metadata")
@@ -154,5 +161,11 @@ def metadata() -> Response:
                 # but SQLite can't enforce uniqueness between them.
                 raise MultipleResultsFound(f"found {item.uuid} in both submissions and replies")
             response.items[item.uuid] = item.to_api_v2()
+
+    if requested.journalists:
+        for journalist in Journalist.query.filter(
+            Journalist.uuid.in_(str(uuid) for uuid in requested.journalists)
+        ):
+            response.journalists[journalist.uuid] = journalist.to_api_v2()
 
     return jsonify(asdict(response))

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -763,6 +763,9 @@ class Journalist(db.Model):
 
         return json_user
 
+    def to_api_v2(self, *args, **kwargs) -> Dict[str, Any]:  # type: ignore
+        return self.to_api_v1(*args, **kwargs)
+
     def is_deleted_user(self) -> bool:
         """Is this the special "deleted" user managed by the system?"""
         return self.username == "deleted"

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -763,8 +763,13 @@ class Journalist(db.Model):
 
         return json_user
 
-    def to_api_v2(self, *args, **kwargs) -> Dict[str, Any]:  # type: ignore
-        return self.to_api_v1(*args, **kwargs)
+    def to_api_v2(self) -> Dict[str, Any]:
+        return {
+            "username": self.username,
+            "uuid": self.uuid,
+            "first_name": self.first_name,
+            "last_name": self.last_name,
+        }
 
     def is_deleted_user(self) -> bool:
         """Is this the special "deleted" user managed by the system?"""

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -47,7 +47,7 @@ def test_json_version():
     ("endpoint", "kwargs"),
     [
         ("api2.index", {}),
-        ("api2.index", {"prefix": "foo"}),
+        ("api2.index", {"source_prefix": "foo"}),
         # while this should be a POST request, the 403 will kick in first
         ("api2.metadata", {}),
     ],
@@ -94,15 +94,15 @@ def test_index(journalist_app, test_files, journalist_api_token):
         assert response2.calculate_content_length() == 0
 
 
-def test_index_with_prefix(journalist_app, test_files, journalist_api_token):
+def test_index_with_source_prefix(journalist_app, test_files, journalist_api_token):
     """
-    Verify GET /index/<prefix> response and HTTP 304 behavior
+    Verify GET /index/<source_prefix> response and HTTP 304 behavior
     """
     with journalist_app.test_client() as app:
         uuid = test_files["source"].uuid
         with assert_query_count(1):
             response = app.get(
-                url_for("api2.index", prefix=uuid[0]),
+                url_for("api2.index", source_prefix=uuid[0]),
                 headers=get_api_headers(journalist_api_token),
             )
 
@@ -114,7 +114,7 @@ def test_index_with_prefix(journalist_app, test_files, journalist_api_token):
 
         with assert_query_count(1):
             response2 = app.get(
-                url_for("api2.index", prefix=uuid[0]),
+                url_for("api2.index", source_prefix=uuid[0]),
                 headers={
                     **get_api_headers(journalist_api_token),
                     "If-None-Match": response.headers["ETag"],
@@ -125,9 +125,9 @@ def test_index_with_prefix(journalist_app, test_files, journalist_api_token):
         assert response2.status_code == 304
         assert response2.calculate_content_length() == 0
 
-        # Make a response with an invalid prefix ("x")
+        # Make a response with an invalid source_prefix ("x")
         response3 = app.get(
-            url_for("api2.index", prefix="x"),
+            url_for("api2.index", source_prefix="x"),
             headers=get_api_headers(journalist_api_token),
         )
         # HTTP 200, but zero sources
@@ -136,21 +136,23 @@ def test_index_with_prefix(journalist_app, test_files, journalist_api_token):
         assert response3.json["items"] == {}
 
 
-def test_index_with_invalid_prefix(journalist_app, test_files, journalist_api_token):
+def test_index_with_invalid_source_prefix(journalist_app, test_files, journalist_api_token):
     """
-    Verify that a too-long prefix is rejected.
+    Verify that a too-long source_prefix is rejected.
     """
     with journalist_app.test_client() as app:
         uuid = test_files["source"].uuid
         too_long = uuid[0] * 100
         with assert_query_count(0):
             response = app.get(
-                url_for("api2.index", prefix=too_long),
+                url_for("api2.index", source_prefix=too_long),
                 headers=get_api_headers(journalist_api_token),
             )
 
         assert response.status_code == 422
-        assert "malformed request; prefix must be shorter than" in response.get_data(as_text=True)
+        assert "malformed request; source prefix must be shorter than" in response.get_data(
+            as_text=True
+        )
 
 
 def test_metadata(journalist_app, test_files, journalist_api_token):

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -19,13 +19,17 @@ def filtered_queries():
 
 
 @contextmanager
-def assert_query_count(expected_count):
+def assert_query_count(expected_count, expect_login=True):
     """verify an API request makes the expected number of queries"""
     initial_count = len(filtered_queries())
     yield
     new_queries = filtered_queries()[initial_count:]
     # If the first API request is to look up journalists, it's part of the login flow, so skip it
-    if len(new_queries) >= 1 and new_queries[0].statement.startswith("SELECT journalists."):
+    if (
+        expect_login
+        and len(new_queries) >= 1
+        and new_queries[0].statement.startswith("SELECT journalists.")
+    ):
         new_queries = new_queries[1:]
 
     assert (
@@ -68,7 +72,7 @@ def test_index(journalist_app, test_files, journalist_api_token):
     """
     with journalist_app.test_client() as app:
         uuid = test_files["source"].uuid
-        with assert_query_count(1):
+        with assert_query_count(2):
             response = app.get(
                 url_for("api2.index"),
                 headers=get_api_headers(journalist_api_token),
@@ -80,7 +84,7 @@ def test_index(journalist_app, test_files, journalist_api_token):
         # test_files generates 2 submissions and 1 reply, so 3 items total
         assert len(response.json["items"]) == 3
 
-        with assert_query_count(1):
+        with assert_query_count(2):
             response2 = app.get(
                 url_for("api2.index"),
                 headers={
@@ -100,7 +104,7 @@ def test_index_with_source_prefix(journalist_app, test_files, journalist_api_tok
     """
     with journalist_app.test_client() as app:
         uuid = test_files["source"].uuid
-        with assert_query_count(1):
+        with assert_query_count(2):
             response = app.get(
                 url_for("api2.index", source_prefix=uuid[0]),
                 headers=get_api_headers(journalist_api_token),
@@ -112,7 +116,7 @@ def test_index_with_source_prefix(journalist_app, test_files, journalist_api_tok
         # test_files generates 2 submissions and 1 reply, so 3 items total
         assert len(response.json["items"]) == 3
 
-        with assert_query_count(1):
+        with assert_query_count(2):
             response2 = app.get(
                 url_for("api2.index", source_prefix=uuid[0]),
                 headers={
@@ -155,7 +159,7 @@ def test_index_with_invalid_source_prefix(journalist_app, test_files, journalist
         )
 
 
-def test_metadata(journalist_app, test_files, journalist_api_token):
+def test_metadata(journalist_app, test_files, test_journo, journalist_api_token):
     """
     Verify POST /metadata response
     """
@@ -184,7 +188,7 @@ def test_metadata(journalist_app, test_files, journalist_api_token):
 
         # Get an item
         item_uuid = test_files["submissions"][0].uuid
-        with assert_query_count(2):
+        with assert_query_count(3):
             response = app.post(
                 url_for("api2.metadata"),
                 json={"items": [item_uuid]},
@@ -196,6 +200,25 @@ def test_metadata(journalist_app, test_files, journalist_api_token):
         assert len(response.json["sources"]) == 0
         # Verify the versions are the same
         assert json_version(response.json["items"][item_uuid]) == index.json["items"][item_uuid]
+
+        # Get a journalist
+        journalist_uuid = test_journo["uuid"]
+        with assert_query_count(1, expect_login=False):
+            response = app.post(
+                url_for("api2.metadata"),
+                json={"journalists": [journalist_uuid]},
+                headers=get_api_headers(journalist_api_token),
+            )
+        assert response.status_code == 200
+        assert journalist_uuid in response.json["journalists"]
+        # Verify no source or item metadata is returned
+        assert len(response.json["sources"]) == 0
+        assert len(response.json["items"]) == 0
+        # Verify the versions are the same
+        assert (
+            json_version(response.json["journalists"][journalist_uuid])
+            == index.json["journalists"][journalist_uuid]
+        )
 
 
 def test_item_collision(journalist_app, test_files_with_uuid_collision, journalist_api_token):


### PR DESCRIPTION
- [x] Depends on #7624

Closes #7618 by returning `Journalist` accounts from the `/index` and `/metadata` endpoints.

Notably, after the slight refactoring in b3e42274f6ac0b2b27c31f267127335bf1fdce93, 7e6cfc21e27fb9f69a1621c9279d557abed88608 is representative of the marginal effort involved in adding new objects to the v2 sync protocol.


## Test plan

- [x] `curl localhost:8081/api/v2/index` includes a `{<uuid>: <version>}` dictionary of journalist accounts.
- [x] `curl -H "Content-Type: application/json" -d '{"journalists": ["<uuid>"]}' localhost:8081/api/v2/metadata` returns the expected metadata for that journalist account.


## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)