### PR TITLE
refactor: `eager_query()` wraps SQLAlchemy queries for consistent eager loading

### DIFF
--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -1,11 +1,12 @@
 import hashlib
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Mapping, NewType, Optional, Set
+from typing import Any, Dict, Mapping, NewType, Optional, Set, Tuple
 
+from db import db
 from flask import Blueprint, abort, json, jsonify, request
-from models import Journalist, Reply, Source, Submission
+from models import Journalist, Reply, SeenFile, SeenMessage, SeenReply, Source, Submission
 from sqlalchemy.inspection import inspect
-from sqlalchemy.orm import Query, joinedload
+from sqlalchemy.orm import Load, Query, configure_mappers, joinedload
 from sqlalchemy.orm.exc import MultipleResultsFound
 from werkzeug.wrappers.response import Response
 
@@ -14,16 +15,55 @@ blp = Blueprint("api2", __name__, url_prefix="/api/v2")
 PREFIX_MAX_LEN = inspect(Source).columns["uuid"].type.length
 
 
-def all_sources() -> Query:
-    """
-    Return a base query for all ``Sources`` with eager loading of their metadata
-    and collections.
-    """
+# Used by `{Submission,Reply}_query_options()` when called directly rather than
+# via `Source_query_options()`.
+LOADER_BASE = {
+    Submission: Load(Submission),
+    Reply: Load(Reply),
+}
+
+
+def Submission_query_options(base: Load = LOADER_BASE[Submission]) -> Tuple:
+    configure_mappers()
     return (
-        Source.query.options(joinedload(Source.star))
-        .options(joinedload(Source.submissions))
-        .options(joinedload(Source.replies))
+        base.joinedload(Submission.source),
+        base.joinedload(Submission.seen_files).joinedload(SeenFile.journalist),
+        base.joinedload(Submission.seen_messages).joinedload(SeenMessage.journalist),
     )
+
+
+def Reply_query_options(base: Load = LOADER_BASE[Reply]) -> Tuple:
+    configure_mappers()
+    return (
+        base.joinedload(Reply.source),
+        base.joinedload(Reply.journalist),
+        base.joinedload(Reply.seen_replies).joinedload(SeenReply.journalist),
+    )
+
+
+def Source_query_options() -> Tuple:
+    configure_mappers()
+    return (
+        joinedload(Source.star),
+        *Submission_query_options(joinedload(Source.submissions)),
+        *Reply_query_options(joinedload(Source.replies)),
+    )
+
+
+EAGER_BUNDLES = {
+    Source: lambda: Source_query_options(),
+    Submission: lambda: Submission_query_options(),
+    Reply: lambda: Reply_query_options(),
+}
+
+
+def eager_query(model: db.Model) -> Query:
+    """
+    Return ``model.query`` with the appropriate eager-loading options applied.
+    Falls back to plain ``model.query`` if no bundle is registered.
+    """
+    options = EAGER_BUNDLES.get(model)
+    return model.query.options(*options()) if options else model.query
 
 
 Version = NewType("Version", str)
@@ -76,7 +116,7 @@ def index(source_prefix: Optional[str] = None) -> Response:
     """
     index = Index()
 
-    source_query = all_sources()
+    source_query = eager_query(Source)
     if source_prefix is not None:
         if len(source_prefix) >= PREFIX_MAX_LEN:
             abort(
@@ -92,7 +132,7 @@ def index(source_prefix: Optional[str] = None) -> Response:
         for item in source.collection:
             index.items[item.uuid] = json_version(item.to_api_v2())
 
-    for journalist in Journalist.query.all():
+    for journalist in eager_query(Journalist).all():
         index.journalists[journalist.uuid] = json_version(journalist.to_api_v2())
 
     version = json_version(asdict(index))
@@ -143,18 +183,20 @@ def metadata() -> Response:
     response = MetadataResponse()
 
     if requested.sources:
-        for source in all_sources().filter(
+        for source in eager_query(Source).filter(
             Source.uuid.in_(str(uuid) for uuid in requested.sources)
         ):
             response.sources[source.uuid] = source.to_api_v2()
 
     if requested.items:
-        for item in Submission.query.filter(
+        for item in eager_query(Submission).filter(
             Submission.uuid.in_(str(uuid) for uuid in requested.items)
         ):
             response.items[item.uuid] = item.to_api_v2()
 
-        for item in Reply.query.filter(Reply.uuid.in_(str(uuid) for uuid in requested.items)):
+        for item in eager_query(Reply).filter(
+            Reply.uuid.in_(str(uuid) for uuid in requested.items)
+        ):
             if item.uuid in response.items:
                 # Fail if we get unlucky and hit a UUID collision between the
                 # `Submission` and `Reply` tables.  This is vanishingly unlikely,
@@ -163,7 +205,7 @@ def metadata() -> Response:
             response.items[item.uuid] = item.to_api_v2()
 
     if requested.journalists:
-        for journalist in Journalist.query.filter(
+        for journalist in eager_query(Journalist).filter(
             Journalist.uuid.in_(str(uuid) for uuid in requested.journalists)
         ):
             response.journalists[journalist.uuid] = journalist.to_api_v2()

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -65,10 +65,11 @@ EAGER_OPTIONS: Dict[str, Callable[[], Tuple[Load, ...]]] = {
     "Source": source_query_options,
     "Submission": submission_query_options,
     "Reply": reply_query_options,
+    "Journalist": lambda: (),
 }
 
 EagerQuery = NewType("EagerQuery", Query)
-EagerModelName = Literal["Source", "Submission", "Reply"]
+EagerModelName = Literal["Source", "Submission", "Reply", "Journalist"]
 
 
 @overload

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -26,18 +26,18 @@ LOADER_BASE = {
 def Submission_query_options(base: Load = LOADER_BASE[Submission]) -> Tuple:
     configure_mappers()
     return (
-        base.joinedload(Submission.source),
-        base.joinedload(Submission.seen_files).joinedload(SeenFile.journalist),
-        base.joinedload(Submission.seen_messages).joinedload(SeenMessage.journalist),
+        base.joinedload(Submission.source),  # type: ignore[attr-defined]
+        base.joinedload(Submission.seen_files).joinedload(SeenFile.journalist),  # type: ignore[attr-defined]
+        base.joinedload(Submission.seen_messages).joinedload(SeenMessage.journalist),  # type: ignore[attr-defined]
     )
 
 
 def Reply_query_options(base: Load = LOADER_BASE[Reply]) -> Tuple:
     configure_mappers()
     return (
-        base.joinedload(Reply.source),
-        base.joinedload(Reply.journalist),
-        base.joinedload(Reply.seen_replies).joinedload(SeenReply.journalist),
+        base.joinedload(Reply.source),  # type: ignore[attr-defined]
+        base.joinedload(Reply.journalist),  # type: ignore[attr-defined]
+        base.joinedload(Reply.seen_replies).joinedload(SeenReply.journalist),  # type: ignore[attr-defined]
     )
 
 

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -2,92 +2,22 @@ import hashlib
 from dataclasses import asdict, dataclass, field
 from typing import (
     Any,
-    Callable,
     Dict,
-    Literal,
     Mapping,
     NewType,
     Optional,
     Set,
-    Tuple,
-    Union,
-    overload,
 )
 
 from flask import Blueprint, abort, json, jsonify, request
-from models import Journalist, Reply, SeenFile, SeenMessage, SeenReply, Source, Submission
+from models import EagerQuery, Journalist, Reply, Source, Submission, eager_query
 from sqlalchemy.inspection import inspect
-from sqlalchemy.orm import Load, Query, configure_mappers, joinedload
 from sqlalchemy.orm.exc import MultipleResultsFound
 from werkzeug.wrappers.response import Response
 
 blp = Blueprint("api2", __name__, url_prefix="/api/v2")
 
 PREFIX_MAX_LEN = inspect(Source).columns["uuid"].type.length
-
-
-# Used by `{submission,reply}_query_options()` when called directly rather than
-# via `source_query_options()`.
-LOADER_BASE = {
-    Submission: Load(Submission),
-    Reply: Load(Reply),
-}
-
-
-def submission_query_options(base: Load = LOADER_BASE[Submission]) -> Tuple:
-    configure_mappers()
-    return (
-        base.joinedload(Submission.source),  # type: ignore[attr-defined]
-        base.joinedload(Submission.seen_files).joinedload(SeenFile.journalist),  # type: ignore[attr-defined]
-        base.joinedload(Submission.seen_messages).joinedload(SeenMessage.journalist),  # type: ignore[attr-defined]
-    )
-
-
-def reply_query_options(base: Load = LOADER_BASE[Reply]) -> Tuple:
-    configure_mappers()
-    return (
-        base.joinedload(Reply.source),  # type: ignore[attr-defined]
-        base.joinedload(Reply.journalist),  # type: ignore[attr-defined]
-        base.joinedload(Reply.seen_replies).joinedload(SeenReply.journalist),  # type: ignore[attr-defined]
-    )
-
-
-def source_query_options() -> Tuple:
-    configure_mappers()
-    return (
-        joinedload(Source.star),
-        *submission_query_options(joinedload(Source.submissions)),
-        *reply_query_options(joinedload(Source.replies)),
-    )
-
-
-EAGER_OPTIONS: Dict[str, Callable[[], Tuple[Load, ...]]] = {
-    "Source": source_query_options,
-    "Submission": submission_query_options,
-    "Reply": reply_query_options,
-    "Journalist": lambda: (),
-}
-
-EagerQuery = NewType("EagerQuery", Query)
-EagerModelName = Literal["Source", "Submission", "Reply", "Journalist"]
-
-
-@overload
-def eager_query(model: EagerModelName) -> EagerQuery: ...
-@overload
-def eager_query(model: str) -> Query: ...
-
-
-def eager_query(model: str) -> Union[EagerQuery, Query]:
-    """
-    Return an ``EagerQuery`` with the registered eager-loading options applied.
-    Falls back to a plain ``Query`` if no options are registered.  A caller that
-    requires eager loading can annotate the return value with ``EagerQuery`` to
-    enforce it during type-checking.
-    """
-    cls = globals()[model]
-    options = EAGER_OPTIONS.get(model)
-    return cls.query.options(*options()) if options else cls.query
 
 
 Version = NewType("Version", str)

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -1,8 +1,19 @@
 import hashlib
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Mapping, NewType, Optional, Set, Tuple
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Literal,
+    Mapping,
+    NewType,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    overload,
+)
 
-from db import db
 from flask import Blueprint, abort, json, jsonify, request
 from models import Journalist, Reply, SeenFile, SeenMessage, SeenReply, Source, Submission
 from sqlalchemy.inspection import inspect
@@ -50,20 +61,32 @@ def source_query_options() -> Tuple:
     )
 
 
-EAGER_BUNDLES = {
-    Source: source_query_options,
-    Submission: submission_query_options,
-    Reply: reply_query_options,
+EAGER_OPTIONS: Dict[str, Callable[[], Tuple[Load, ...]]] = {
+    "Source": source_query_options,
+    "Submission": submission_query_options,
+    "Reply": reply_query_options,
 }
 
+EagerQuery = NewType("EagerQuery", Query)
+EagerModelName = Literal["Source", "Submission", "Reply"]
 
-def eager_query(model: db.Model) -> Query:
+
+@overload
+def eager_query(model: EagerModelName) -> EagerQuery: ...
+@overload
+def eager_query(model: str) -> Query: ...
+
+
+def eager_query(model: str) -> Union[EagerQuery, Query]:
     """
-    Return ``model.query`` with the appropriate eager-loading options applied.
-    Falls back to plain ``model.query`` if no bundle is registered.
+    Return an ``EagerQuery`` with the registered eager-loading options applied.
+    Falls back to a plain ``Query`` if no options are registered.  A caller that
+    requires eager loading can annotate the return value with ``EagerQuery`` to
+    enforce it during type-checking.
     """
-    options = EAGER_BUNDLES.get(model)
-    return model.query.options(*options()) if options else model.query
+    cls = globals()[model]
+    options = EAGER_OPTIONS.get(model)
+    return cls.query.options(*options()) if options else cls.query
 
 
 Version = NewType("Version", str)
@@ -116,7 +139,7 @@ def index(source_prefix: Optional[str] = None) -> Response:
     """
     index = Index()
 
-    source_query = eager_query(Source)
+    source_query: EagerQuery = eager_query("Source")
     if source_prefix is not None:
         if len(source_prefix) >= PREFIX_MAX_LEN:
             abort(
@@ -132,7 +155,8 @@ def index(source_prefix: Optional[str] = None) -> Response:
         for item in source.collection:
             index.items[item.uuid] = json_version(item.to_api_v2())
 
-    for journalist in eager_query(Journalist).all():
+    journalist_query: EagerQuery = eager_query("Journalist")
+    for journalist in journalist_query.all():
         index.journalists[journalist.uuid] = json_version(journalist.to_api_v2())
 
     version = json_version(asdict(index))
@@ -183,20 +207,19 @@ def metadata() -> Response:
     response = MetadataResponse()
 
     if requested.sources:
-        for source in eager_query(Source).filter(
-            Source.uuid.in_(str(uuid) for uuid in requested.sources)
-        ):
+        source_query: EagerQuery = eager_query("Source")
+        for source in source_query.filter(Source.uuid.in_(str(uuid) for uuid in requested.sources)):
             response.sources[source.uuid] = source.to_api_v2()
 
     if requested.items:
-        for item in eager_query(Submission).filter(
+        submission_query: EagerQuery = eager_query("Submission")
+        for item in submission_query.filter(
             Submission.uuid.in_(str(uuid) for uuid in requested.items)
         ):
             response.items[item.uuid] = item.to_api_v2()
 
-        for item in eager_query(Reply).filter(
-            Reply.uuid.in_(str(uuid) for uuid in requested.items)
-        ):
+        reply_query: EagerQuery = eager_query("Reply")
+        for item in reply_query.filter(Reply.uuid.in_(str(uuid) for uuid in requested.items)):
             if item.uuid in response.items:
                 # Fail if we get unlucky and hit a UUID collision between the
                 # `Submission` and `Reply` tables.  This is vanishingly unlikely,
@@ -205,7 +228,8 @@ def metadata() -> Response:
             response.items[item.uuid] = item.to_api_v2()
 
     if requested.journalists:
-        for journalist in eager_query(Journalist).filter(
+        journalist_query: EagerQuery = eager_query("Journalist")
+        for journalist in journalist_query.filter(
             Journalist.uuid.in_(str(uuid) for uuid in requested.journalists)
         ):
             response.journalists[journalist.uuid] = journalist.to_api_v2()

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -15,15 +15,15 @@ blp = Blueprint("api2", __name__, url_prefix="/api/v2")
 PREFIX_MAX_LEN = inspect(Source).columns["uuid"].type.length
 
 
-# Used by `{Submission,Reply}_query_options()` when called directly rather than
-# via `Source_query_options()`.
+# Used by `{submission,reply}_query_options()` when called directly rather than
+# via `source_query_options()`.
 LOADER_BASE = {
     Submission: Load(Submission),
     Reply: Load(Reply),
 }
 
 
-def Submission_query_options(base: Load = LOADER_BASE[Submission]) -> Tuple:
+def submission_query_options(base: Load = LOADER_BASE[Submission]) -> Tuple:
     configure_mappers()
     return (
         base.joinedload(Submission.source),  # type: ignore[attr-defined]
@@ -32,7 +32,7 @@ def Submission_query_options(base: Load = LOADER_BASE[Submission]) -> Tuple:
     )
 
 
-def Reply_query_options(base: Load = LOADER_BASE[Reply]) -> Tuple:
+def reply_query_options(base: Load = LOADER_BASE[Reply]) -> Tuple:
     configure_mappers()
     return (
         base.joinedload(Reply.source),  # type: ignore[attr-defined]
@@ -41,19 +41,19 @@ def Reply_query_options(base: Load = LOADER_BASE[Reply]) -> Tuple:
     )
 
 
-def Source_query_options() -> Tuple:
+def source_query_options() -> Tuple:
     configure_mappers()
     return (
         joinedload(Source.star),
-        *Submission_query_options(joinedload(Source.submissions)),
-        *Reply_query_options(joinedload(Source.replies)),
+        *submission_query_options(joinedload(Source.submissions)),
+        *reply_query_options(joinedload(Source.replies)),
     )
 
 
 EAGER_BUNDLES = {
-    Source: lambda: Source_query_options(),
-    Submission: lambda: Submission_query_options(),
-    Reply: lambda: Reply_query_options(),
+    Source: source_query_options,
+    Submission: submission_query_options,
+    Reply: reply_query_options,
 }
 
 

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -5,7 +5,7 @@ import os
 import uuid
 from hmac import compare_digest
 from logging import Logger
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Literal, NewType, Optional, Tuple, Union, overload
 
 import argon2
 
@@ -20,13 +20,37 @@ from flask_babel import gettext, ngettext
 from passphrases import PassphraseGenerator
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, LargeBinary, String, Text
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Query, backref, relationship
+from sqlalchemy.orm import Load, Query, backref, configure_mappers, joinedload, relationship
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from store import Storage
 
 _default_instance_config: Optional["InstanceConfig"] = None
 
 ARGON2_PARAMS = {"memory_cost": 2**16, "time_cost": 4, "parallelism": 2, "type": argon2.Type.ID}
+
+
+EagerQuery = NewType("EagerQuery", Query)
+EagerModelName = Literal["Source", "Submission", "Reply", "Journalist"]
+
+
+@overload
+def eager_query(model: EagerModelName) -> EagerQuery: ...
+@overload
+def eager_query(model: str) -> Query: ...
+
+
+def eager_query(model: str) -> Union[EagerQuery, Query]:
+    """
+    Return an ``EagerQuery`` with the registered eager-loading options applied.
+    Falls back to a plain ``Query`` if no options are registered.  A caller that
+    requires eager loading can annotate the return value with ``EagerQuery`` to
+    enforce it during type-checking.
+    """
+    cls = globals()[model]
+    try:
+        return cls.query.options(*cls.query_options())
+    except AttributeError:
+        return cls.query
 
 
 def get_one_or_else(
@@ -83,6 +107,16 @@ class Source(db.Model):
 
     def __repr__(self) -> str:
         return f"<Source {self.journalist_designation!r}>"
+
+    @classmethod
+    def query_options(cls, base: Optional[Load] = None) -> Tuple[Load, ...]:
+        configure_mappers()
+        base = base or Load(cls)
+        return (
+            joinedload(cls.star),
+            *Submission.query_options(joinedload(Source.submissions)),
+            *Reply.query_options(joinedload(Source.replies)),
+        )
 
     @property
     def journalist_filename(self) -> str:
@@ -227,6 +261,16 @@ class Submission(db.Model):
     def __repr__(self) -> str:
         return f"<Submission {self.filename!r}>"
 
+    @classmethod
+    def query_options(cls, base: Optional[Load] = None) -> Tuple[Load, ...]:
+        configure_mappers()
+        base = base or Load(cls)
+        return (
+            base.joinedload(cls.source),  # type: ignore[attr-defined]
+            base.joinedload(cls.seen_files).joinedload(SeenFile.journalist),  # type: ignore[attr-defined]
+            base.joinedload(cls.seen_messages).joinedload(SeenMessage.journalist),  # type: ignore[attr-defined]
+        )
+
     @property
     def is_file(self) -> bool:
         return self.filename.endswith("doc.gz.gpg") or self.filename.endswith("doc.zip.gpg")
@@ -336,6 +380,16 @@ class Reply(db.Model):
 
     def __repr__(self) -> str:
         return f"<Reply {self.filename!r}>"
+
+    @classmethod
+    def query_options(cls, base: Optional[Load] = None) -> Tuple[Load, ...]:
+        configure_mappers()
+        base = base or Load(cls)
+        return (
+            base.joinedload(cls.source),  # type: ignore[attr-defined]
+            base.joinedload(cls.journalist),  # type: ignore[attr-defined]
+            base.joinedload(cls.seen_replies).joinedload(SeenReply.journalist),  # type: ignore[attr-defined]
+        )
 
     def to_api_v2(self) -> Dict[str, Any]:
         return {
@@ -498,6 +552,12 @@ class Journalist(db.Model):
 
     def __repr__(self) -> str:
         return "<Journalist {}{}>".format(self.username, " [admin]" if self.is_admin else "")
+
+    @classmethod
+    def query_options(cls, base: Optional[Load] = None) -> Tuple:
+        base = base or Load(cls)
+        configure_mappers()
+        return ()
 
     def _scrypt_hash(self, password: str, salt: bytes) -> bytes:
         backend = default_backend()

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -188,7 +188,7 @@ def test_metadata(journalist_app, test_files, test_journo, journalist_api_token)
 
         # Get an item
         item_uuid = test_files["submissions"][0].uuid
-        with assert_query_count(3):
+        with assert_query_count(2):
             response = app.post(
                 url_for("api2.metadata"),
                 json={"items": [item_uuid]},


### PR DESCRIPTION
- [x] Depends on #7626

Fixes #7628 by providing `eager_query(<model>)` as an extensible DRY abstraction over chaining SQLAlchemy `joinedload()` calls in `<model>.query.options()`.


## Test plan

- [ ] Visual review.
- [ ] `assert_query_count()` calls in a given test now match what you'd intuitively expect from reading through the corresponding API endpoint.


## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)


## LLM usage

[ChatGPT and I went back and forth on the DRYest way to set query options for eager loading.](https://chatgpt.com/share/68954813-10c0-800f-ace5-7de89e791de3)