### PR TITLE
refactor: wrap `sqlalchemy.orm.{backref,relationship}()` to enforce eager loading

### DIFF
--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -5,25 +5,12 @@ from typing import Any, Dict, Mapping, NewType, Optional, Set
 from flask import Blueprint, abort, json, jsonify, request
 from models import Journalist, Reply, Source, Submission
 from sqlalchemy.inspection import inspect
-from sqlalchemy.orm import Query, joinedload
 from sqlalchemy.orm.exc import MultipleResultsFound
 from werkzeug.wrappers.response import Response
 
 blp = Blueprint("api2", __name__, url_prefix="/api/v2")
 
 PREFIX_MAX_LEN = inspect(Source).columns["uuid"].type.length
-
-
-def all_sources() -> Query:
-    """
-    Return a base query for all ``Sources`` with eager loading of their metadata
-    and collections.
-    """
-    return (
-        Source.query.options(joinedload(Source.star))
-        .options(joinedload(Source.submissions))
-        .options(joinedload(Source.replies))
-    )
 
 
 Version = NewType("Version", str)
@@ -76,7 +63,7 @@ def index(source_prefix: Optional[str] = None) -> Response:
     """
     index = Index()
 
-    source_query = all_sources()
+    source_query = Source.query
     if source_prefix is not None:
         if len(source_prefix) >= PREFIX_MAX_LEN:
             abort(
@@ -85,7 +72,7 @@ def index(source_prefix: Optional[str] = None) -> Response:
                 f"characters",
             )
 
-        source_query = source_query.filter(Source.uuid.startswith(source_prefix))
+        source_query = Source.query.filter(Source.uuid.startswith(source_prefix))
 
     for source in source_query.all():
         index.sources[source.uuid] = json_version(source.to_api_v2())
@@ -130,10 +117,6 @@ def metadata() -> Response:
     Return the ``MetadataResponse`` requested in the ``MetadataRequest``.  The
     client MAY choose an arbitrary list of objects with each request, e.g. from
     a shard retrieved from ``/index/<source_prefix>``.
-
-    NB.  Returning sources is O(1) from the eagerly-loaded ``all_sources()``.
-    Returning items is O(2), since we have to search both the ``Submission`` and
-    the ``Reply`` tables for the set of all item UUIDs.
     """
     try:
         requested = MetadataRequest(**request.json)  # type: ignore
@@ -143,9 +126,7 @@ def metadata() -> Response:
     response = MetadataResponse()
 
     if requested.sources:
-        for source in all_sources().filter(
-            Source.uuid.in_(str(uuid) for uuid in requested.sources)
-        ):
+        for source in Source.query.filter(Source.uuid.in_(str(uuid) for uuid in requested.sources)):
             response.sources[source.uuid] = source.to_api_v2()
 
     if requested.items:

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -820,10 +820,7 @@ class Journalist(db.Model):
         return deleted
 
     def delete(self) -> None:
-        """delete a journalist, migrating some data over to the "deleted" journalist
-
-        Callers must commit the session themselves
-        """
+        """delete a journalist, migrating some data over to the "deleted" journalist"""
         deleted = self.get_deleted()
         # All replies should be reassociated with the "deleted" journalist
         for reply in Reply.query.filter_by(journalist_id=self.id).all():
@@ -863,8 +860,12 @@ class Journalist(db.Model):
                 reply.journalist_id = deleted.id
                 db.session.add(reply)
 
-        # For the rest of the associated data we rely on cascading deletions
+        # Commit these reassignments first...
+        db.session.commit()
+
+        # ...and then rely on cascading deletions.
         db.session.delete(self)
+        db.session.commit()
 
 
 class SeenFile(db.Model):

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -20,13 +20,34 @@ from flask_babel import gettext, ngettext
 from passphrases import PassphraseGenerator
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, LargeBinary, String, Text
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Query, backref, relationship
+from sqlalchemy.orm import (
+    Query,
+    RelationshipProperty,
+)
+from sqlalchemy.orm import (
+    backref as _backref,
+)
+from sqlalchemy.orm import (
+    relationship as _relationship,
+)
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from store import Storage
 
 _default_instance_config: Optional["InstanceConfig"] = None
 
 ARGON2_PARAMS = {"memory_cost": 2**16, "time_cost": 4, "parallelism": 2, "type": argon2.Type.ID}
+
+
+def backref(*args, **kwargs):  # type: ignore
+    """Wrap ``sqlalchemy.orm.backref()`` to enforce eager loading."""
+    kwargs["lazy"] = False
+    return _backref(*args, **kwargs)
+
+
+def relationship(*args, **kwargs) -> RelationshipProperty:  # type: ignore
+    """Wrap ``sqlalchemy.orm.relationship()`` to enforce eager loading."""
+    kwargs["lazy"] = False
+    return _relationship(*args, **kwargs)
 
 
 def get_one_or_else(
@@ -49,7 +70,7 @@ class Source(db.Model):
     filesystem_id = Column(String(96), unique=True, nullable=False)
     journalist_designation = Column(String(255), nullable=False)
     last_updated = Column(DateTime)
-    star = relationship("SourceStar", uselist=False, backref="source")
+    star = relationship("SourceStar", uselist=False, backref=backref("source"))
 
     # sources are "pending" and don't get displayed to journalists until they
     # submit something
@@ -463,7 +484,7 @@ class Journalist(db.Model):
     passphrase_hash = Column(String(256))
 
     login_attempts = relationship(
-        "JournalistLoginAttempt", backref="journalist", cascade="all, delete"
+        "JournalistLoginAttempt", backref=backref("journalist"), cascade="all, delete"
     )
 
     MIN_USERNAME_LEN = 3
@@ -852,9 +873,9 @@ class SeenFile(db.Model):
     journalist_id = Column(Integer, ForeignKey("journalists.id"), nullable=False)
     file = relationship(
         "Submission",
-        backref=backref("seen_files", lazy="joined", cascade="all,delete"),
+        backref=backref("seen_files", cascade="all,delete"),
     )
-    journalist = relationship("Journalist", lazy="joined", backref=backref("seen_files"))
+    journalist = relationship("Journalist", backref=backref("seen_files"))
 
 
 class SeenMessage(db.Model):
@@ -865,9 +886,9 @@ class SeenMessage(db.Model):
     journalist_id = Column(Integer, ForeignKey("journalists.id"), nullable=False)
     message = relationship(
         "Submission",
-        backref=backref("seen_messages", lazy="joined", cascade="all,delete"),
+        backref=backref("seen_messages", cascade="all,delete"),
     )
-    journalist = relationship("Journalist", lazy="joined", backref=backref("seen_messages"))
+    journalist = relationship("Journalist", backref=backref("seen_messages"))
 
 
 class SeenReply(db.Model):
@@ -876,10 +897,8 @@ class SeenReply(db.Model):
     id = Column(Integer, primary_key=True)
     reply_id = Column(Integer, ForeignKey("replies.id"), nullable=False)
     journalist_id = Column(Integer, ForeignKey("journalists.id"), nullable=False)
-    reply = relationship(
-        "Reply", backref=backref("seen_replies", lazy="joined", cascade="all,delete")
-    )
-    journalist = relationship("Journalist", lazy="joined", backref=backref("seen_replies"))
+    reply = relationship("Reply", backref=backref("seen_replies", cascade="all,delete"))
+    journalist = relationship("Journalist", backref=backref("seen_replies"))
 
 
 class JournalistLoginAttempt(db.Model):

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -330,7 +330,9 @@ class Reply(db.Model):
     uuid = Column(String(36), unique=True, nullable=False)
 
     journalist_id = Column(Integer, ForeignKey("journalists.id"), nullable=False)
-    journalist = relationship("Journalist", backref=backref("replies", order_by=id))
+    journalist = relationship(
+        "Journalist", backref=backref("replies", order_by=id, cascade="delete")
+    )
 
     source_id = Column(Integer, ForeignKey("sources.id"))
     source = relationship("Source", backref=backref("replies", order_by=id, cascade="delete"))
@@ -875,7 +877,7 @@ class SeenFile(db.Model):
         "Submission",
         backref=backref("seen_files", cascade="all,delete"),
     )
-    journalist = relationship("Journalist", backref=backref("seen_files"))
+    journalist = relationship("Journalist", backref=backref("seen_files", cascade="all,delete"))
 
 
 class SeenMessage(db.Model):
@@ -888,7 +890,7 @@ class SeenMessage(db.Model):
         "Submission",
         backref=backref("seen_messages", cascade="all,delete"),
     )
-    journalist = relationship("Journalist", backref=backref("seen_messages"))
+    journalist = relationship("Journalist", backref=backref("seen_messages", cascade="all,delete"))
 
 
 class SeenReply(db.Model):
@@ -898,7 +900,7 @@ class SeenReply(db.Model):
     reply_id = Column(Integer, ForeignKey("replies.id"), nullable=False)
     journalist_id = Column(Integer, ForeignKey("journalists.id"), nullable=False)
     reply = relationship("Reply", backref=backref("seen_replies", cascade="all,delete"))
-    journalist = relationship("Journalist", backref=backref("seen_replies"))
+    journalist = relationship("Journalist", backref=backref("seen_replies", cascade="all,delete"))
 
 
 class JournalistLoginAttempt(db.Model):

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -188,7 +188,7 @@ def test_metadata(journalist_app, test_files, test_journo, journalist_api_token)
 
         # Get an item
         item_uuid = test_files["submissions"][0].uuid
-        with assert_query_count(3):
+        with assert_query_count(2):
             response = app.post(
                 url_for("api2.metadata"),
                 json={"items": [item_uuid]},


### PR DESCRIPTION
Closes #7628 by enforcing eager loading at the model level, obviating the need to set query-level options.
* Fixes #6616 incidentally.


## Test plan

- [ ] Visual review.


## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)


## LLM usage

ChatGPT [recommended] setting `default_load_options` like the following, but [this setting is available only from SQLAlchemy 1.4 on][sqlalchemy-1.4].  This is the compromise available in our SQLAlchemy 1.3 per `relationship` and `backref`.

```python
class Source(db.Model):
    __tablename__ = "sources"
    ...
    __mapper_args__ = {
        "eager_defaults": True,
        "default_load_options": [
            joinedload("star"),
            joinedload("submissions"),
            joinedload("replies"),
        ],
    }
```


[recommended]: https://chatgpt.com/share/689d11a0-e66c-800f-893d-bb5576db2987
[sqlalchemy-1.4]: https://docs.sqlalchemy.org/en/14/orm/internals.html#sqlalchemy.orm.QueryContext.default_load_options