### PR TITLE
Add redwood/build/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ securedrop/geckodriver.log
 
 # Rust build artifacts
 target/
+redwood/build/


### PR DESCRIPTION
Created during `make dev` runs.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)