### PR TITLE
Add an install playbook check for server OS version

### DIFF
--- a/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
+++ b/install_files/ansible-base/roles/prepare-servers/tasks/main.yml
@@ -2,6 +2,11 @@
 # Ensures that prerequisite packages for ansible and securedrop-admin install
 # are present
 
+- name: Verify server OS version
+  assert:
+    that: "ansible_distribution_release == 'noble'"
+    fail_msg: "SecureDrop must run on Ubuntu 24.04 (Noble). Please check the server OS version"
+
 - name: Install python and packages required by installer
   raw: apt-get update && apt-get install -y python3 dnsutils ubuntu-release-upgrader-core mokutil
   register: _apt_install_prereqs_results

--- a/install_files/ansible-base/securedrop-prod.yml
+++ b/install_files/ansible-base/securedrop-prod.yml
@@ -13,7 +13,7 @@
   hosts: securedrop
   environment:
     LC_ALL: C
-  gather_facts: no
+  gather_facts: yes
   max_fail_percentage: 0
   any_errors_fatal: yes
   become: yes


### PR DESCRIPTION
## Test plan

Using this branch:
- [ ] Start a fresh server install, using Focal as the base OS
- [ ] when `./securedrop-admin --force install` is run, the playbook errors out in the first `prepare_servers` task with the message "SecureDrop must run on Ubuntu 24.04 (Noble). Please check the server OS version"
- [ ] Start a fresh server install, this time using Noble.
- [ ] `./securedrop-admin --force install` completes successfully.

## Checklist