### PR TITLE
Fix OS check ansible task in staging.

### DIFF
--- a/install_files/ansible-base/securedrop-staging.yml
+++ b/install_files/ansible-base/securedrop-staging.yml
@@ -27,7 +27,7 @@
   hosts: staging
   environment:
     LC_ALL: C
-  gather_facts: no
+  gather_facts: yes
   max_fail_percentage: 0
   any_errors_fatal: yes
   become: yes


### PR DESCRIPTION
Adds the necessary facts toggle in the staging playbook for the `prepare-servers` role, so that the OS check for Noble will work there too.

## Test plan
- [ ] CI is passing, in particular the staging job.
