### PR TITLE
Actually use source flask config for Source Interface

### DIFF
--- a/securedrop/sdconfig.py
+++ b/securedrop/sdconfig.py
@@ -191,12 +191,12 @@ def _parse_config_from_file(config_module_name: str) -> SecureDropConfig:
     source_flask_config = config_from_local_file.SourceInterfaceFlaskConfig
     parsed_source_flask_config = SourceInterfaceConfig(
         SECRET_KEY=source_flask_config.SECRET_KEY,
-        SESSION_COOKIE_NAME=getattr(journ_flask_config, "SESSION_COOKIE_NAME", "ss"),
-        DEBUG=getattr(journ_flask_config, "DEBUG", False),
-        TESTING=getattr(journ_flask_config, "TESTING", False),
-        WTF_CSRF_ENABLED=getattr(journ_flask_config, "WTF_CSRF_ENABLED", True),
-        MAX_CONTENT_LENGTH=getattr(journ_flask_config, "MAX_CONTENT_LENGTH", 524288000),
-        USE_X_SENDFILE=getattr(journ_flask_config, "USE_X_SENDFILE", False),
+        SESSION_COOKIE_NAME=getattr(source_flask_config, "SESSION_COOKIE_NAME", "ss"),
+        DEBUG=getattr(source_flask_config, "DEBUG", False),
+        TESTING=getattr(source_flask_config, "TESTING", False),
+        WTF_CSRF_ENABLED=getattr(source_flask_config, "WTF_CSRF_ENABLED", True),
+        MAX_CONTENT_LENGTH=getattr(source_flask_config, "MAX_CONTENT_LENGTH", 524288000),
+        USE_X_SENDFILE=getattr(source_flask_config, "USE_X_SENDFILE", False),
     )
 
     return SecureDropConfig(


### PR DESCRIPTION
The main impact of this was that the SI used a "js" cookie name instead of "ss".

Notably this did not affect the secret key, which was correctly using the source config.

Fixes #7553.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] On develop, log into the SI and notice that the cookie is "js"
* [x] Check out this change, log into the SI and notice that the cookie is correctly "ss"

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)