### PR TITLE
`/api/v2/data`: handle batched events from clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ no_implicit_optional = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 warn_unused_configs = true
-python_version = "3.8"
+python_version = "3.12"
 plugins = "sqlmypy"
 
 [[tool.mypy.overrides]]

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -12,6 +12,7 @@ from journalist_app.api2.shared import save_reply
 from journalist_app.sessions import session
 from models import (
     InvalidUsernameException,
+    InvalidUUID,
     Journalist,
     LoginThrottledException,
     Reply,
@@ -229,7 +230,7 @@ def make_blueprint() -> Blueprint:
                     abort(409, "That UUID is already in use.")
             except NotEncrypted:
                 return jsonify({"message": "You must encrypt replies client side"}), 400
-            except ValueError:
+            except InvalidUUID:
                 abort(400, "reply does not have a valid UUID")
 
             return (

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -1,29 +1,27 @@
 import collections.abc
 import json
 from datetime import datetime, timezone
-from os import path
 from typing import Set, Tuple, Union
-from uuid import UUID
 
 import flask
 import werkzeug
 from db import db
 from flask import Blueprint, abort, jsonify, request
 from journalist_app import utils
+from journalist_app.api2.shared import save_reply
 from journalist_app.sessions import session
 from models import (
     InvalidUsernameException,
     Journalist,
     LoginThrottledException,
     Reply,
-    SeenReply,
     Source,
     Submission,
     WrongPasswordException,
 )
 from sqlalchemy import Column
 from sqlalchemy.exc import IntegrityError
-from store import NotEncrypted, Storage
+from store import NotEncrypted
 from two_factor import OtpSecretInvalid, OtpTokenInvalid
 from werkzeug.exceptions import default_exceptions
 
@@ -224,43 +222,15 @@ def make_blueprint() -> Blueprint:
             if not data["reply"]:
                 abort(400, "reply should not be empty")
 
-            source.interaction_count += 1
             try:
-                filename = Storage.get_default().save_pre_encrypted_reply(
-                    source.filesystem_id,
-                    source.interaction_count,
-                    source.journalist_filename,
-                    data["reply"],
-                )
-            except NotEncrypted:
-                return jsonify({"message": "You must encrypt replies client side"}), 400
-
-            # issue #3918
-            filename = path.basename(filename)
-
-            reply = Reply(session.get_user(), source, filename, Storage.get_default())
-
-            reply_uuid = data.get("uuid", None)
-            if reply_uuid is not None:
-                # check that is is parseable
-                try:
-                    UUID(reply_uuid)
-                except ValueError:
-                    abort(400, "'uuid' was not a valid UUID")
-                reply.uuid = reply_uuid
-
-            try:
-                db.session.add(reply)
-                seen_reply = SeenReply(reply=reply, journalist=session.get_user())
-                db.session.add(seen_reply)
-                db.session.add(source)
-                db.session.commit()
+                reply = save_reply(source, data)
             except IntegrityError as e:
-                db.session.rollback()
                 if "UNIQUE constraint failed: replies.uuid" in str(e):
                     abort(409, "That UUID is already in use.")
-                else:
-                    raise e
+            except NotEncrypted:
+                return jsonify({"message": "You must encrypt replies client side"}), 400
+            except ValueError:
+                abort(400, "reply does not have a valid UUID")
 
             return (
                 jsonify(

--- a/securedrop/journalist_app/api2/README.md
+++ b/securedrop/journalist_app/api2/README.md
@@ -86,3 +86,15 @@ Server ->> Client: BatchResponse
 Note over Client: Global version uvwxyz
 end
 ```
+
+This diagram implies single-round-trip consistency. To make that expectation
+explicit:
+
+1. If the server $S$ currently has exactly one active client $C$; and
+
+2. $C$ submits a valid `BatchRequest` $BR$ with $n$ events $\{E_0, \dots,
+E_n\}$; and
+
+3. $S$ accepts $BR$ as valid and successfully processes all $E_i$; then
+
+4. $C$'s index SHOULD match $S$'s index without a subsequent synchronization.

--- a/securedrop/journalist_app/api2/README.md
+++ b/securedrop/journalist_app/api2/README.md
@@ -61,3 +61,28 @@ else Out of date
     Server ->> Client: MetadataResponse
 end
 ```
+
+### Batched events from client
+
+```mermaid
+sequenceDiagram
+participant Client
+participant Server
+
+Note over Client: Global version abcdef
+Note over Server: Global version abcdef
+
+Client ->> Client: reply_sent {id: X, uuid: Y, source: Z, ...}
+Client -->> Server: POST /api/v2/metadata<br>BatchRequest
+alt Already processed:
+Server ->> Server: look up status of event {id: X}
+Note over Server: Return status of event {id: X},<br>in addition to anything else requested.
+Server ->> Client: BatchResponse
+else
+Server ->> Server: process "reply_sent" event for reply {uuid: Y}
+Note over Server: Return new item {uuid: Y} and updated source {uuid: Z},<br>in addition to anything else requested.
+Note over Server: Global version uvwxyz
+Server ->> Client: BatchResponse
+Note over Client: Global version uvwxyz
+end
+```

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -1,15 +1,14 @@
 import hashlib
-from dataclasses import asdict, dataclass, field
-from typing import (
-    Any,
-    Dict,
-    Mapping,
-    NewType,
-    Optional,
-    Set,
-)
+from dataclasses import asdict
+from typing import Mapping, Optional
 
 from flask import Blueprint, abort, json, jsonify, request
+from journalist_app.api2.types import (
+    Index,
+    MetadataRequest,
+    MetadataResponse,
+    Version,
+)
 from models import EagerQuery, Journalist, Reply, Source, Submission, eager_query
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm.exc import MultipleResultsFound
@@ -18,9 +17,6 @@ from werkzeug.wrappers.response import Response
 blp = Blueprint("api2", __name__, url_prefix="/api/v2")
 
 PREFIX_MAX_LEN = inspect(Source).columns["uuid"].type.length
-
-
-Version = NewType("Version", str)
 
 
 def json_version(d: Mapping) -> Version:
@@ -35,22 +31,6 @@ def json_version(d: Mapping) -> Version:
     s = json.dumps(d, separators=[",", ":"], sort_keys=True)
     b = s.encode("utf-8")
     return Version(hashlib.blake2s(b).hexdigest())
-
-
-# TODO: generic UUID[T] in Python 3.12
-SourceUUID = NewType("SourceUUID", str)
-ItemUUID = NewType("ItemUUID", str)
-JournalistUUID = NewType("JournalistUUID", str)
-
-
-@dataclass
-class Index:
-    # Source metadata, optionally filtered by `source_prefix`:
-    sources: Dict[SourceUUID, Version] = field(default_factory=dict)
-    items: Dict[ItemUUID, Version] = field(default_factory=dict)
-
-    # Non-source metadata (always returned):
-    journalists: Dict[JournalistUUID, Version] = field(default_factory=dict)
 
 
 @blp.get("/index")
@@ -97,26 +77,6 @@ def index(source_prefix: Optional[str] = None) -> Response:
     # return HTTP 304 with an empty response.
     response.set_etag(version)
     return response.make_conditional(request)
-
-
-@dataclass
-class MetadataRequest:
-    # Source metadata:
-    sources: Set[SourceUUID] = field(default_factory=set)
-    items: Set[ItemUUID] = field(default_factory=set)
-
-    # Non-source metadata:
-    journalists: Set[JournalistUUID] = field(default_factory=set)
-
-
-@dataclass
-class MetadataResponse:
-    # Source metadata:
-    sources: Dict[SourceUUID, Any] = field(default_factory=dict)
-    items: Dict[ItemUUID, Any] = field(default_factory=dict)
-
-    # Non-source metadata:
-    journalists: Dict[JournalistUUID, Any] = field(default_factory=dict)
 
 
 @blp.post("/metadata")

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -7,6 +7,7 @@ from journalist_app.api2.events import EventHandler
 from journalist_app.api2.types import (
     BatchRequest,
     BatchResponse,
+    Event,
     Index,
     Version,
 )
@@ -110,6 +111,11 @@ def data() -> Response:
     response = BatchResponse()
 
     if requested.events:
+        try:
+            events = [Event(**d) for d in requested.events]
+        except TypeError:
+            abort(400, "invalid event")
+
         # Don't set up the EventHandler, connect to Redis, etc., unless we have
         # events to process.
         config = SecureDropConfig.get_current()
@@ -118,7 +124,7 @@ def data() -> Response:
         )
 
         # Process events in snowflake order.
-        for event in sorted(requested.events, key=lambda e: e.id):
+        for event in sorted(events, key=lambda e: e.id):
             result = handler.process(event)
             for uuid, source in result.sources.items():
                 response.sources[uuid] = source.to_api_v2() if source is not None else None

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -3,10 +3,11 @@ from dataclasses import asdict
 from typing import Mapping, Optional
 
 from flask import Blueprint, abort, json, jsonify, request
+from journalist_app.api2.events import EventHandler
 from journalist_app.api2.types import (
+    BatchRequest,
+    BatchResponse,
     Index,
-    MetadataRequest,
-    MetadataResponse,
     Version,
 )
 from models import EagerQuery, Journalist, Reply, Source, Submission, eager_query
@@ -79,10 +80,11 @@ def index(source_prefix: Optional[str] = None) -> Response:
     return response.make_conditional(request)
 
 
-@blp.post("/metadata")
-def metadata() -> Response:
+@blp.post("/data")  # read-write BatchRequest
+@blp.post("/metadata")  # DEPRECATED: read-only MetadataRequest
+def data() -> Response:
     """
-    Return the ``MetadataResponse`` requested in the ``MetadataRequest``.  The
+    Return the ``BatchResponse`` requested in the ``BatchRequest``.  The
     client MAY choose an arbitrary list of objects with each request, e.g. from
     a shard retrieved from ``/index/<source_prefix>``.
 
@@ -91,11 +93,27 @@ def metadata() -> Response:
     the ``Reply`` tables for the set of all item UUIDs.
     """
     try:
-        requested = MetadataRequest(**request.json)  # type: ignore
+        requested = BatchRequest(**request.json)  # type: ignore
     except (TypeError, ValueError) as exc:
         abort(422, f"malformed request; {exc}")
 
-    response = MetadataResponse()
+    response = BatchResponse()
+
+    for event in requested.events:
+        """
+        # Case 1: already processed: If event.snowflake_id is already cached in
+        # Redis, we've already processed it; just return its status.
+        status = EventStatus(event.snowflake_id, 200)  # FIXME
+        response.events.append(status)
+        """
+
+        # Case 2: needs to be processed.
+        result = EventHandler.process(event)
+        for uuid, source in result.sources.items():
+            response.sources[uuid] = source.to_api_v2()
+        for uuid, item in result.items.items():
+            response.items[uuid] = item.to_api_v2()
+        response.events[result.event_id] = result.status
 
     if requested.sources:
         source_query: EagerQuery = eager_query("Source")

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -117,8 +117,8 @@ def data() -> Response:
 
         try:
             events = [Event(**d) for d in requested.events]
-        except TypeError:
-            abort(400, "invalid event")
+        except (TypeError, ValueError) as e:
+            abort(400, f"invalid event: {e}")
 
         # Don't set up the EventHandler, connect to Redis, etc., unless we have
         # events to process.

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -11,6 +11,8 @@ from journalist_app.api2.types import (
     Version,
 )
 from models import EagerQuery, Journalist, Reply, Source, Submission, eager_query
+from redis import Redis
+from sdconfig import SecureDropConfig
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm.exc import MultipleResultsFound
 from werkzeug.wrappers.response import Response
@@ -88,9 +90,10 @@ def data() -> Response:
     client MAY choose an arbitrary list of objects with each request, e.g. from
     a shard retrieved from ``/index/<source_prefix>``.
 
-    NB.  Returning sources is O(1) from the eagerly-loaded ``all_sources()``.
-    Returning items is O(2), since we have to search both the ``Submission`` and
-    the ``Reply`` tables for the set of all item UUIDs.
+    NB.  Reading sources (without any side effects from processing events) is
+    O(1) from the eagerly-loaded ``all_sources()``.  Reading items is O(2),
+    since we have to search both the ``Submission`` and the ``Reply`` tables for
+    the set of all item UUIDs.
     """
     try:
         requested = BatchRequest(**request.json)  # type: ignore
@@ -99,21 +102,19 @@ def data() -> Response:
 
     response = BatchResponse()
 
-    for event in requested.events:
-        """
-        # Case 1: already processed: If event.snowflake_id is already cached in
-        # Redis, we've already processed it; just return its status.
-        status = EventStatus(event.snowflake_id, 200)  # FIXME
-        response.events.append(status)
-        """
+    if requested.events:
+        # Don't set up the EventHandler, connect to Redis, etc., unless we have
+        # events to process.
+        config = SecureDropConfig.get_current()
+        handler = EventHandler(redis=Redis(decode_responses=True, **config.REDIS_KWARGS))
 
-        # Case 2: needs to be processed.
-        result = EventHandler.process(event)
-        for uuid, source in result.sources.items():
-            response.sources[uuid] = source.to_api_v2() if source is not None else None
-        for uuid, item in result.items.items():
-            response.items[uuid] = item.to_api_v2() if item is not None else None
-        response.events[result.event_id] = result.status
+        for event in requested.events:
+            result = handler.process(event)
+            for uuid, source in result.sources.items():
+                response.sources[uuid] = source.to_api_v2() if source is not None else None
+            for uuid, item in result.items.items():
+                response.items[uuid] = item.to_api_v2() if item is not None else None
+            response.events[result.event_id] = result.status
 
     if requested.sources:
         source_query: EagerQuery = eager_query("Source")

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -90,6 +90,12 @@ def data() -> Response:
     client MAY choose an arbitrary list of objects with each request, e.g. from
     a shard retrieved from ``/index/<source_prefix>``.
 
+    The client MAY include a list of ``Event``s for the server to process over
+    arbitrary sources and items.  Ordering is guaranteed within a given
+    ``BatchRequest``.  Sources and items changed by one or more events will be
+    returned in their most-recent state in the ``BatchResponse`` whether or not
+    they were explicitly requested in the ``BatchRequest``.
+
     NB.  Reading sources (without any side effects from processing events) is
     O(1) from the eagerly-loaded ``all_sources()``.  Reading items is O(2),
     since we have to search both the ``Submission`` and the ``Reply`` tables for
@@ -108,7 +114,8 @@ def data() -> Response:
         config = SecureDropConfig.get_current()
         handler = EventHandler(redis=Redis(decode_responses=True, **config.REDIS_KWARGS))
 
-        for event in requested.events:
+        # Process events in snowflake order.
+        for event in sorted(requested.events, key=lambda e: e.id):
             result = handler.process(event)
             for uuid, source in result.sources.items():
                 response.sources[uuid] = source.to_api_v2() if source is not None else None

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -21,6 +21,7 @@ from werkzeug.wrappers.response import Response
 
 blp = Blueprint("api2", __name__, url_prefix="/api/v2")
 
+EVENTS_MAX = 50
 PREFIX_MAX_LEN = inspect(Source).columns["uuid"].type.length
 
 
@@ -111,6 +112,9 @@ def data() -> Response:
     response = BatchResponse()
 
     if requested.events:
+        if len(requested.events) > EVENTS_MAX:
+            abort(429, f"a BatchRequest MUST NOT include more than {EVENTS_MAX} events")
+
         try:
             events = [Event(**d) for d in requested.events]
         except TypeError:

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -10,6 +10,7 @@ from journalist_app.api2.types import (
     Index,
     Version,
 )
+from journalist_app.sessions import session
 from models import EagerQuery, Journalist, Reply, Source, Submission, eager_query
 from redis import Redis
 from sdconfig import SecureDropConfig
@@ -112,7 +113,9 @@ def data() -> Response:
         # Don't set up the EventHandler, connect to Redis, etc., unless we have
         # events to process.
         config = SecureDropConfig.get_current()
-        handler = EventHandler(redis=Redis(decode_responses=True, **config.REDIS_KWARGS))
+        handler = EventHandler(
+            session=session, redis=Redis(decode_responses=True, **config.REDIS_KWARGS)
+        )
 
         # Process events in snowflake order.
         for event in sorted(requested.events, key=lambda e: e.id):

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -110,9 +110,9 @@ def data() -> Response:
         # Case 2: needs to be processed.
         result = EventHandler.process(event)
         for uuid, source in result.sources.items():
-            response.sources[uuid] = source.to_api_v2()
+            response.sources[uuid] = source.to_api_v2() if source is not None else None
         for uuid, item in result.items.items():
-            response.items[uuid] = item.to_api_v2()
+            response.items[uuid] = item.to_api_v2() if item is not None else None
         response.events[result.event_id] = result.status
 
     if requested.sources:

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -10,28 +10,40 @@ from journalist_app.api2.types import (
     SourceTarget,
 )
 from models import Reply, Source, Submission
+from redis import Redis
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+
+# `IDEMPOTENCE_PERIOD` MUST be greater than or equal to
+# `sdconfig.SecureDropConfig.SESSION_LIFETIME`.  In practice, 24 hours is the
+# easiest period to reason about.
+IDEMPOTENCE_PERIOD = 60 * 60 * 24  # seconds * minutes * hours = 1 day
+
+REDIS_EVENT_PREFIX = "sd/events/"
 
 
 class EventHandler:
     """
-    This class is the per-event entry point for handling events.  To add a
-    handler for a new event `thing_done`, you must:
+    This class is the per-request context for handling events.  To add a handler
+    for a new event `thing_done`, you must:
 
     1. define the enum value `EventType.THING_DONE` in journalist_api2.types;
 
     2. define the handler as a static method `handle_thing_done(event: Event)`
        in this class
 
-    3. explicitly register `{"thing_done": cls.handle_thing_done}` inside
-       `EventHandler.process()`.
+    3. explicitly register `{"thing_done": self.handle_thing_done}` inside
+      `EventHandler.process()`.
 
     This is belt-and-suspenders for ensuring that only the intended methods are
     exposed as callable event handlers.
     """
 
-    @classmethod
-    def process(cls, event_dict: dict) -> EventResult:
+    def __init__(self, redis: Redis) -> None:
+        self._redis = redis
+
+    def process(self, event_dict: dict) -> EventResult:
+        """The per-event entry-point for handling a single event."""
+
         try:
             event = Event(**event_dict)
             event.type = EventType(event.type)  # strict enum
@@ -48,10 +60,16 @@ class EventHandler:
                 status=(EventStatusCode.BadRequest, str(e)),
             )
 
+        if self.has_processed(event):
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.AlreadyReported, None),
+            )
+
         try:
             handler = {
-                "item_deleted": cls.handle_item_deleted,
-                "reply_sent": cls.handle_reply_sent,
+                "item_deleted": self.handle_item_deleted,
+                "reply_sent": self.handle_reply_sent,
             }[event.type]
         except KeyError:
             return EventResult(
@@ -59,7 +77,19 @@ class EventHandler:
                 status=(EventStatusCode.NotImplemented, f"no handler for event type: {event.type}"),
             )
 
-        return handler(event)
+        result = handler(event)
+        self.mark_as_processed(event, result)
+        return result
+
+    def has_processed(self, event: Event) -> bool:
+        return self._redis.get(f"{REDIS_EVENT_PREFIX}{event.id}") is not None
+
+    def mark_as_processed(self, event: Event, result: EventResult) -> None:
+        self._redis.set(
+            f"{REDIS_EVENT_PREFIX}{event.id}",
+            result.status[0],
+            ex=IDEMPOTENCE_PERIOD,
+        )
 
     @staticmethod
     def handle_item_deleted(event: Event) -> EventResult:

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -1,4 +1,3 @@
-from db import db
 from journalist_app.api2.types import (
     Event,
     EventResult,

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -14,6 +14,22 @@ from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 
 class EventHandler:
+    """
+    This class is the per-event entry point for handling events.  To add a
+    handler for a new event `thing_done`, you must:
+
+    1. define the enum value `EventType.THING_DONE` in journalist_api2.types;
+
+    2. define the handler as a static method `handle_thing_done(event: Event)`
+       in this class
+
+    3. explicitly register `{"thing_done": cls.handle_thing_done}` inside
+       `EventHandler.process()`.
+
+    This is belt-and-suspenders for ensuring that only the intended methods are
+    exposed as callable event handlers.
+    """
+
     @classmethod
     def process(cls, event_dict: dict) -> EventResult:
         try:
@@ -33,8 +49,11 @@ class EventHandler:
             )
 
         try:
-            handler = getattr(cls, f"handle_{event.type}")
-        except AttributeError:
+            handler = {
+                "item_deleted": cls.handle_item_deleted,
+                "reply_sent": cls.handle_reply_sent,
+            }[event.type]
+        except KeyError:
             return EventResult(
                 event_id=event.id,
                 status=(EventStatusCode.NotImplemented, f"no handler for event type: {event.type}"),

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -25,10 +25,10 @@ class EventHandler:
             else:
                 raise TypeError("invalid event target")
 
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as e:
             return EventResult(
                 event_id=event_dict.get("id", 0),
-                status=EventStatusCode.BadRequest,
+                status=(EventStatusCode.BadRequest, str(e)),
             )
 
         try:
@@ -36,7 +36,7 @@ class EventHandler:
         except AttributeError:
             return EventResult(
                 event_id=event.id,
-                status=EventStatusCode.NotImplemented,
+                status=(EventStatusCode.NotImplemented, f"no handler for event type: {event.type}"),
             )
 
         return handler(event)
@@ -48,7 +48,10 @@ class EventHandler:
         except NoResultFound:
             return EventResult(
                 event_id=event.id,
-                status=EventStatusCode.NotFound,
+                status=(
+                    EventStatusCode.NotFound,
+                    f"could not find source: {event.target.source_uuid}",
+                ),
             )
 
         reply = save_reply(source, event.data)
@@ -56,7 +59,7 @@ class EventHandler:
 
         return EventResult(
             event_id=event.id,
-            status=EventStatusCode.OK,
+            status=(EventStatusCode.OK, None),
             sources={source.uuid: source},
             items={reply.uuid: reply},
         )

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -61,7 +61,7 @@ class EventHandler:
                 status=(EventStatusCode.BadRequest, str(e)),
             )
 
-        if self.has_processed(event):
+        if self.has_progress(event):
             return EventResult(
                 event_id=event.id,
                 status=(EventStatusCode.AlreadyReported, None),
@@ -78,20 +78,23 @@ class EventHandler:
                 status=(EventStatusCode.NotImplemented, f"no handler for event type: {event.type}"),
             )
 
+        self.mark_progress(event)  # prevent races
         result = handler(event)
-        self.mark_as_processed(event, result)
+        self.mark_progress(event, result.status[0])  # enforce idempotence
         return result
 
     def idempotence_key(self, event: Event) -> str:
         return f"{REDIS_EVENT_PREFIX}/{self._session.user.uuid}/{event.id}"
 
-    def has_processed(self, event: Event) -> bool:
-        return self._redis.get(self.idempotence_key(event)) is not None
+    def has_progress(self, event: Event) -> EventStatusCode:
+        return self._redis.get(self.idempotence_key(event))
 
-    def mark_as_processed(self, event: Event, result: EventResult) -> None:
+    def mark_progress(
+        self, event: Event, status: EventStatusCode = EventStatusCode.Processing
+    ) -> None:
         self._redis.set(
             self.idempotence_key(event),
-            result.status[0],
+            status,
             ex=IDEMPOTENCE_PERIOD,
         )
 

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -43,11 +43,10 @@ class EventHandler:
         self._session = session
         self._redis = redis
 
-    def process(self, event_dict: dict) -> EventResult:
+    def process(self, event: Event) -> EventResult:
         """The per-event entry-point for handling a single event."""
 
         try:
-            event = Event(**event_dict)
             event.type = EventType(event.type)  # strict enum
             if "source_uuid" in event.target:
                 event.target = SourceTarget(**event.target)
@@ -58,7 +57,7 @@ class EventHandler:
 
         except (TypeError, ValueError) as e:
             return EventResult(
-                event_id=event_dict.get("id", 0),
+                event_id=event.id,
                 status=(EventStatusCode.BadRequest, str(e)),
             )
 

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -1,3 +1,4 @@
+from db import db
 from journalist_app.api2.types import (
     Event,
     EventResult,
@@ -6,6 +7,9 @@ from journalist_app.api2.types import (
     ItemTarget,
     SourceTarget,
 )
+from journalist_app.api2.shared import save_reply
+from models import Source
+from sqlalchemy.orm.exc import NoResultFound
 
 
 class EventHandler:
@@ -36,3 +40,23 @@ class EventHandler:
             )
 
         return handler(event)
+
+    @staticmethod
+    def handle_reply_sent(event: Event) -> EventResult:
+        try:
+            source = Source.query.filter(Source.uuid == event.target.source_uuid).one()
+        except NoResultFound:
+            return EventResult(
+                event_id=event.id,
+                status=EventStatusCode.NotFound,
+            )
+
+        reply = save_reply(source, event.data)
+        db.session.refresh(source)
+
+        return EventResult(
+            event_id=event.id,
+            status=EventStatusCode.OK,
+            sources={source.uuid: source},
+            items={reply.uuid: reply},
+        )

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -9,6 +9,7 @@ from journalist_app.api2.types import (
     ItemTarget,
     SourceTarget,
 )
+from journalist_app.sessions import Session
 from models import Reply, Source, Submission
 from redis import Redis
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
@@ -18,7 +19,7 @@ from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 # easiest period to reason about.
 IDEMPOTENCE_PERIOD = 60 * 60 * 24  # seconds * minutes * hours = 1 day
 
-REDIS_EVENT_PREFIX = "sd/events/"
+REDIS_EVENT_PREFIX = "sd/events"
 
 
 class EventHandler:
@@ -38,7 +39,8 @@ class EventHandler:
     exposed as callable event handlers.
     """
 
-    def __init__(self, redis: Redis) -> None:
+    def __init__(self, session: Session, redis: Redis) -> None:
+        self._session = session
         self._redis = redis
 
     def process(self, event_dict: dict) -> EventResult:
@@ -81,12 +83,15 @@ class EventHandler:
         self.mark_as_processed(event, result)
         return result
 
+    def idempotence_key(self, event: Event) -> str:
+        return f"{REDIS_EVENT_PREFIX}/{self._session.user.uuid}/{event.id}"
+
     def has_processed(self, event: Event) -> bool:
-        return self._redis.get(f"{REDIS_EVENT_PREFIX}{event.id}") is not None
+        return self._redis.get(self.idempotence_key(event)) is not None
 
     def mark_as_processed(self, event: Event, result: EventResult) -> None:
         self._redis.set(
-            f"{REDIS_EVENT_PREFIX}{event.id}",
+            self.idempotence_key(event),
             result.status[0],
             ex=IDEMPOTENCE_PERIOD,
         )

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -1,0 +1,39 @@
+from db import db
+from journalist_app.api2.types import (
+    Event,
+    EventResult,
+    EventStatusCode,
+    EventType,
+    ItemTarget,
+    SourceTarget,
+)
+
+
+class EventHandler:
+    @classmethod
+    def process(cls, event_dict: dict) -> EventResult:
+        try:
+            event = Event(**event_dict)
+            event.type = EventType(event.type)  # strict enum
+            if "source_uuid" in event.target:
+                event.target = SourceTarget(**event.target)
+            elif "item_uuid" in event.target:
+                event.target = ItemTarget(**event.target)
+            else:
+                raise TypeError("invalid event target")
+
+        except (TypeError, ValueError):
+            return EventResult(
+                event_id=event_dict.get("id", 0),
+                status=EventStatusCode.BadRequest,
+            )
+
+        try:
+            handler = getattr(cls, f"handle_{event.type}")
+        except AttributeError:
+            return EventResult(
+                event_id=event.id,
+                status=EventStatusCode.NotImplemented,
+            )
+
+        return handler(event)

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -1,4 +1,6 @@
 from db import db
+from journalist_app import utils
+from journalist_app.api2.shared import save_reply
 from journalist_app.api2.types import (
     Event,
     EventResult,
@@ -7,9 +9,8 @@ from journalist_app.api2.types import (
     ItemTarget,
     SourceTarget,
 )
-from journalist_app.api2.shared import save_reply
-from models import Source
-from sqlalchemy.orm.exc import NoResultFound
+from models import Reply, Source, Submission
+from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 
 class EventHandler:
@@ -40,6 +41,35 @@ class EventHandler:
             )
 
         return handler(event)
+
+    @staticmethod
+    def handle_item_deleted(event: Event) -> EventResult:
+        submission = Submission.query.filter(
+            Submission.uuid == event.target.item_uuid
+        ).one_or_none()
+        reply = Reply.query.filter(Reply.uuid == event.target.item_uuid).one_or_none()
+
+        if submission and reply:
+            # Fail if we get unlucky and hit a UUID collision between the
+            # `Submission` and `Reply` tables.  This is vanishingly unlikely,
+            # but SQLite can't enforce uniqueness between them.
+            raise MultipleResultsFound(
+                f"found {event.target.item_uuid} in both submissions and replies"
+            )
+
+        item = submission or reply
+        if item is None:
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.NotFound, f"could not find item: {event.target.item_uuid}"),
+            )
+
+        utils.delete_file_object(item)
+        return EventResult(
+            event_id=event.id,
+            status=(EventStatusCode.OK, None),
+            items={event.target.item_uuid: None},
+        )
 
     @staticmethod
     def handle_reply_sent(event: Event) -> EventResult:

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -6,8 +6,6 @@ from journalist_app.api2.types import (
     EventResult,
     EventStatusCode,
     EventType,
-    ItemTarget,
-    SourceTarget,
 )
 from journalist_app.sessions import Session
 from models import Reply, Source, Submission
@@ -47,35 +45,23 @@ class EventHandler:
         """The per-event entry-point for handling a single event."""
 
         try:
-            event.type = EventType(event.type)  # strict enum
-            if "source_uuid" in event.target:
-                event.target = SourceTarget(**event.target)
-            elif "item_uuid" in event.target:
-                event.target = ItemTarget(**event.target)
-            else:
-                raise TypeError("invalid event target")
+            if self.has_progress(event):
+                return EventResult(
+                    event_id=event.id,
+                    status=(EventStatusCode.AlreadyReported, None),
+                )
 
-        except (TypeError, ValueError) as e:
-            return EventResult(
-                event_id=event.id,
-                status=(EventStatusCode.BadRequest, str(e)),
-            )
-
-        if self.has_progress(event):
-            return EventResult(
-                event_id=event.id,
-                status=(EventStatusCode.AlreadyReported, None),
-            )
-
-        try:
             handler = {
-                "item_deleted": self.handle_item_deleted,
-                "reply_sent": self.handle_reply_sent,
+                EventType.ITEM_DELETED: self.handle_item_deleted,
+                EventType.REPLY_SENT: self.handle_reply_sent,
             }[event.type]
         except KeyError:
             return EventResult(
                 event_id=event.id,
-                status=(EventStatusCode.NotImplemented, f"no handler for event type: {event.type}"),
+                status=(
+                    EventStatusCode.NotImplemented,
+                    f"no handler for event type: {event.type}",
+                ),
             )
 
         self.mark_progress(event)  # prevent races

--- a/securedrop/journalist_app/api2/shared.py
+++ b/securedrop/journalist_app/api2/shared.py
@@ -3,7 +3,7 @@ This module contains helper functions factored out of the v1 Journalist API
 (journalist_app.api) and shared with the v2 Journalist API (journalist_app.api2)
 """
 
-from os import path
+import os
 from uuid import UUID
 
 from db import db
@@ -27,7 +27,7 @@ def save_reply(source: Source, data: dict) -> Reply:
     )
 
     # We only save the stored reply's basename and not the whole storage path
-    filename = path.basename(filename)
+    filename = os.path.basename(filename)
 
     reply = Reply(session.get_user(), source, filename, Storage.get_default())
 

--- a/securedrop/journalist_app/api2/shared.py
+++ b/securedrop/journalist_app/api2/shared.py
@@ -1,0 +1,50 @@
+"""
+This module contains helper functions factored out of the v1 Journalist API
+(journalist_app.api) and shared with the v2 Journalist API (journalist_app.api2)
+"""
+
+from os import path
+from uuid import UUID
+
+from db import db
+from journalist_app.sessions import session
+from models import (
+    Reply,
+    SeenReply,
+    Source,
+)
+from sqlalchemy.exc import IntegrityError
+from store import Storage
+
+
+def save_reply(source: Source, data: dict) -> Reply:
+    source.interaction_count += 1
+    filename = Storage.get_default().save_pre_encrypted_reply(
+        source.filesystem_id,
+        source.interaction_count,
+        source.journalist_filename,
+        data["reply"],
+    )
+
+    # issue #3918
+    filename = path.basename(filename)
+
+    reply = Reply(session.get_user(), source, filename, Storage.get_default())
+
+    reply_uuid = data.get("uuid")
+    if reply_uuid is not None:
+        # check that is is parseable
+        UUID(reply_uuid)
+        reply.uuid = reply_uuid
+
+    try:
+        db.session.add(reply)
+        seen_reply = SeenReply(reply=reply, journalist=session.get_user())
+        db.session.add(seen_reply)
+        db.session.add(source)
+        db.session.commit()
+    except IntegrityError as e:
+        db.session.rollback()
+        raise e
+
+    return reply

--- a/securedrop/journalist_app/api2/shared.py
+++ b/securedrop/journalist_app/api2/shared.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from db import db
 from journalist_app.sessions import session
 from models import (
+    InvalidUUID,
     Reply,
     SeenReply,
     Source,
@@ -33,9 +34,11 @@ def save_reply(source: Source, data: dict) -> Reply:
 
     reply_uuid = data.get("uuid")
     if reply_uuid is not None:
-        # check that is is parseable
-        UUID(reply_uuid)
-        reply.uuid = reply_uuid
+        try:
+            UUID(reply_uuid)
+            reply.uuid = reply_uuid
+        except ValueError:
+            raise InvalidUUID
 
     try:
         db.session.add(reply)

--- a/securedrop/journalist_app/api2/shared.py
+++ b/securedrop/journalist_app/api2/shared.py
@@ -26,7 +26,7 @@ def save_reply(source: Source, data: dict) -> Reply:
         data["reply"],
     )
 
-    # issue #3918
+    # We only save the stored reply's basename and not the whole storage path
     filename = path.basename(filename)
 
     reply = Reply(session.get_user(), source, filename, Storage.get_default())

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -69,6 +69,18 @@ class Event:
     type: EventType
     data: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.type, EventType):
+            self.type = EventType(self.type)  # strict enum
+
+        if isinstance(self.target, dict):
+            if "source_uuid" in self.target:
+                self.target = SourceTarget(**self.target)
+            elif "item_uuid" in self.target:
+                self.target = ItemTarget(**self.target)
+            else:
+                raise TypeError(f"invalid event target: {self.target}")
+
 
 @dataclass
 class EventResult:

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -29,6 +29,7 @@ class EventType(StrEnum):
 
 
 class EventStatusCode(IntEnum):
+    Processing = 102
     OK = 200
     AlreadyReported = 208
     BadRequest = 400

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass, field
 from enum import IntEnum, StrEnum, auto
 from typing import (
     Any,
-    Dict,
     List,
     NewType,
     Optional,
@@ -11,6 +10,7 @@ from typing import (
     Union,
 )
 
+Record = NewType("Record", dict[str, Any])
 Version = NewType("Version", str)
 
 
@@ -40,11 +40,11 @@ EventStatus = Tuple[EventStatusCode, Optional[str]]
 @dataclass
 class Index:
     # Source metadata, optionally filtered by `source_prefix`:
-    sources: Dict[SourceUUID, Version] = field(default_factory=dict)
-    items: Dict[ItemUUID, Version] = field(default_factory=dict)
+    sources: dict[SourceUUID, Version] = field(default_factory=dict)
+    items: dict[ItemUUID, Version] = field(default_factory=dict)
 
     # Non-source metadata (always returned):
-    journalists: Dict[JournalistUUID, Version] = field(default_factory=dict)
+    journalists: dict[JournalistUUID, Version] = field(default_factory=dict)
 
 
 @dataclass
@@ -64,7 +64,7 @@ class Event:
     id: EventID
     target: Union[SourceTarget, ItemTarget]
     type: EventType
-    data: Any = field(default_factory=dict)
+    data: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -72,9 +72,9 @@ class EventResult:
     event_id: EventID
     status: EventStatus
 
-    # Changed:
-    sources: Dict[SourceUUID, Any] = field(default_factory=dict)
-    items: Dict[ItemUUID, Any] = field(default_factory=dict)
+    # Changed (return {<uuid>: None} to indicate deletion):
+    sources: dict[SourceUUID, Optional[Record]] = field(default_factory=dict)
+    items: dict[ItemUUID, Optional[Record]] = field(default_factory=dict)
 
 
 @dataclass
@@ -92,12 +92,16 @@ class BatchRequest:
 
 @dataclass
 class BatchResponse:
+    """
+    In dictionaries keyed by UUID, an entry {<uuid>: None} indicates deletion.
+    """
+
     # Source metadata:
-    sources: Dict[SourceUUID, Any] = field(default_factory=dict)
-    items: Dict[ItemUUID, Any] = field(default_factory=dict)
+    sources: dict[SourceUUID, Optional[Record]] = field(default_factory=dict)
+    items: dict[ItemUUID, Optional[Record]] = field(default_factory=dict)
 
     # Non-source metadata:
-    journalists: Dict[JournalistUUID, Any] = field(default_factory=dict)
+    journalists: dict[JournalistUUID, Optional[Record]] = field(default_factory=dict)
 
     # Events processed by the server:
-    events: Dict[EventID, EventStatus] = field(default_factory=dict)
+    events: dict[EventID, EventStatus] = field(default_factory=dict)

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -30,6 +30,7 @@ class EventType(StrEnum):
 
 class EventStatusCode(IntEnum):
     OK = 200
+    AlreadyReported = 208
     BadRequest = 400
     NotFound = 404
     NotImplemented = 501

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -25,6 +25,7 @@ EventID = NewType("EventID", str)  # int, but opaque on the wire
 
 class EventType(StrEnum):
     REPLY_SENT = auto()
+    ITEM_DELETED = auto()
 
 
 class EventStatusCode(IntEnum):

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass, field
+from enum import IntEnum, StrEnum, auto
 from typing import (
     Any,
     Dict,
+    List,
     NewType,
     Set,
+    Union,
 )
 
 Version = NewType("Version", str)
@@ -13,6 +16,18 @@ Version = NewType("Version", str)
 SourceUUID = NewType("SourceUUID", str)
 ItemUUID = NewType("ItemUUID", str)
 JournalistUUID = NewType("JournalistUUID", str)
+
+
+EventID = NewType("EventID", str)  # int, but opaque on the wire
+
+
+class EventType(StrEnum):
+    REPLY_SENT = auto()
+
+
+class EventStatusCode(IntEnum):
+    BadRequest = 400
+    NotImplemented = 501
 
 
 @dataclass
@@ -26,7 +41,37 @@ class Index:
 
 
 @dataclass
-class MetadataRequest:
+class SourceTarget:
+    source_uuid: SourceUUID
+    version: Version
+
+
+@dataclass
+class ItemTarget:
+    item_uuid: ItemUUID
+    version: Version
+
+
+@dataclass
+class Event:
+    id: EventID
+    target: Union[SourceTarget, ItemTarget]
+    type: EventType
+    data: Any = field(default_factory=dict)
+
+
+@dataclass
+class EventResult:
+    event_id: EventID
+    status: EventStatusCode
+
+    # Changed:
+    sources: Dict[SourceUUID, Any] = field(default_factory=dict)
+    items: Dict[ItemUUID, Any] = field(default_factory=dict)
+
+
+@dataclass
+class BatchRequest:
     # Source metadata:
     sources: Set[SourceUUID] = field(default_factory=set)
     items: Set[ItemUUID] = field(default_factory=set)
@@ -34,12 +79,18 @@ class MetadataRequest:
     # Non-source metadata:
     journalists: Set[JournalistUUID] = field(default_factory=set)
 
+    # Events submitted by the client:
+    events: List[Event] = field(default_factory=list)
+
 
 @dataclass
-class MetadataResponse:
+class BatchResponse:
     # Source metadata:
     sources: Dict[SourceUUID, Any] = field(default_factory=dict)
     items: Dict[ItemUUID, Any] = field(default_factory=dict)
 
     # Non-source metadata:
     journalists: Dict[JournalistUUID, Any] = field(default_factory=dict)
+
+    # Events processed by the server:
+    events: Dict[EventID, EventStatusCode] = field(default_factory=dict)

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -74,7 +74,7 @@ class EventResult:
     event_id: EventID
     status: EventStatus
 
-    # Changed (return {<uuid>: None} to indicate deletion):
+    # Changed sources/items, return {<uuid>: None} to indicate deletion:
     sources: dict[SourceUUID, Optional[Record]] = field(default_factory=dict)
     items: dict[ItemUUID, Optional[Record]] = field(default_factory=dict)
 

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -5,7 +5,9 @@ from typing import (
     Dict,
     List,
     NewType,
+    Optional,
     Set,
+    Tuple,
     Union,
 )
 
@@ -30,6 +32,9 @@ class EventStatusCode(IntEnum):
     BadRequest = 400
     NotFound = 404
     NotImplemented = 501
+
+
+EventStatus = Tuple[EventStatusCode, Optional[str]]
 
 
 @dataclass
@@ -65,7 +70,7 @@ class Event:
 @dataclass
 class EventResult:
     event_id: EventID
-    status: EventStatusCode
+    status: EventStatus
 
     # Changed:
     sources: Dict[SourceUUID, Any] = field(default_factory=dict)
@@ -95,4 +100,4 @@ class BatchResponse:
     journalists: Dict[JournalistUUID, Any] = field(default_factory=dict)
 
     # Events processed by the server:
-    events: Dict[EventID, EventStatusCode] = field(default_factory=dict)
+    events: Dict[EventID, EventStatus] = field(default_factory=dict)

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Dict,
+    NewType,
+    Set,
+)
+
+Version = NewType("Version", str)
+
+
+# TODO: generic UUID[T] in Python 3.12
+SourceUUID = NewType("SourceUUID", str)
+ItemUUID = NewType("ItemUUID", str)
+JournalistUUID = NewType("JournalistUUID", str)
+
+
+@dataclass
+class Index:
+    # Source metadata, optionally filtered by `source_prefix`:
+    sources: Dict[SourceUUID, Version] = field(default_factory=dict)
+    items: Dict[ItemUUID, Version] = field(default_factory=dict)
+
+    # Non-source metadata (always returned):
+    journalists: Dict[JournalistUUID, Version] = field(default_factory=dict)
+
+
+@dataclass
+class MetadataRequest:
+    # Source metadata:
+    sources: Set[SourceUUID] = field(default_factory=set)
+    items: Set[ItemUUID] = field(default_factory=set)
+
+    # Non-source metadata:
+    journalists: Set[JournalistUUID] = field(default_factory=set)
+
+
+@dataclass
+class MetadataResponse:
+    # Source metadata:
+    sources: Dict[SourceUUID, Any] = field(default_factory=dict)
+    items: Dict[ItemUUID, Any] = field(default_factory=dict)
+
+    # Non-source metadata:
+    journalists: Dict[JournalistUUID, Any] = field(default_factory=dict)

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -26,7 +26,9 @@ class EventType(StrEnum):
 
 
 class EventStatusCode(IntEnum):
+    OK = 200
     BadRequest = 400
+    NotFound = 404
     NotImplemented = 501
 
 

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -492,6 +492,13 @@ class InvalidPasswordLength(PasswordError):
         return ""  # return empty string that can be appended harmlessly
 
 
+class InvalidUUID(ValueError):
+    """
+    A caller of uuid.UUID() that catches a ValueError and wishes to pass it on
+    SHOULD raise InvalidUUID instead.
+    """
+
+
 class NonDicewarePassword(PasswordError):
     """Raised when attempting to validate a password that is not diceware-like"""
 

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -1,9 +1,11 @@
 from contextlib import contextmanager
+from dataclasses import asdict
 
 import pytest
 from flask import url_for
 from flask_sqlalchemy import get_debug_queries
 from journalist_app.api2 import json_version
+from journalist_app.api2.types import Event, EventID, EventStatusCode, EventType, SourceTarget
 from sqlalchemy.orm.exc import MultipleResultsFound
 from tests.utils.api_helper import get_api_headers
 
@@ -53,7 +55,7 @@ def test_json_version():
         ("api2.index", {}),
         ("api2.index", {"source_prefix": "foo"}),
         # while this should be a POST request, the 403 will kick in first
-        ("api2.metadata", {}),
+        ("api2.data", {}),
     ],
 )
 def test_auth_required(journalist_app, endpoint, kwargs):
@@ -176,7 +178,7 @@ def test_metadata(journalist_app, test_files, test_journo, journalist_api_token)
         # Get the full source
         with assert_query_count(1):
             response = app.post(
-                url_for("api2.metadata"),
+                url_for("api2.data"),
                 json={"sources": [uuid]},
                 headers=get_api_headers(journalist_api_token),
             )
@@ -190,7 +192,7 @@ def test_metadata(journalist_app, test_files, test_journo, journalist_api_token)
         item_uuid = test_files["submissions"][0].uuid
         with assert_query_count(2):
             response = app.post(
-                url_for("api2.metadata"),
+                url_for("api2.data"),
                 json={"items": [item_uuid]},
                 headers=get_api_headers(journalist_api_token),
             )
@@ -205,7 +207,7 @@ def test_metadata(journalist_app, test_files, test_journo, journalist_api_token)
         journalist_uuid = test_journo["uuid"]
         with assert_query_count(1, expect_login=False):
             response = app.post(
-                url_for("api2.metadata"),
+                url_for("api2.data"),
                 json={"journalists": [journalist_uuid]},
                 headers=get_api_headers(journalist_api_token),
             )
@@ -231,7 +233,7 @@ def test_item_collision(journalist_app, test_files_with_uuid_collision, journali
         item_uuid = test_files_with_uuid_collision["submissions"][0].uuid
         with pytest.raises(MultipleResultsFound):  # HTTP 500 in production
             app.post(
-                url_for("api2.metadata"),
+                url_for("api2.data"),
                 json={"items": [item_uuid]},
                 headers=get_api_headers(journalist_api_token),
             )
@@ -252,7 +254,7 @@ def test_api2_metadata_validation_invalid_json(journalist_app, journalist_api_to
     """Test that Flask rejects invalid JSON."""
     with journalist_app.test_client() as app:
         response = app.post(
-            url_for("api2.metadata"),
+            url_for("api2.data"),
             data=invalid_data,
             headers=get_api_headers(journalist_api_token),
         )
@@ -274,7 +276,7 @@ def test_api2_metadata_validation_non_dict_request(
     """Test that non-dict request body returns 400."""
     with journalist_app.test_client() as app:
         response = app.post(
-            url_for("api2.metadata"),
+            url_for("api2.data"),
             json=invalid_request,
             headers=get_api_headers(journalist_api_token),
         )
@@ -304,8 +306,55 @@ def test_api2_metadata_validation_valid_requests(
     """Test that valid requests pass validation."""
     with journalist_app.test_client() as app:
         response = app.post(
-            url_for("api2.metadata"),
+            url_for("api2.data"),
             json=valid_request,
             headers=get_api_headers(journalist_api_token),
         )
         assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "request_with_events,event_statuses",
+    [
+        (
+            {
+                "events": [
+                    {
+                        "id": "123456",
+                        "type": "foobar",
+                        "target": {"source_uuid": "abcdef", "version": "uvwxyz"},
+                    }
+                ]
+            },
+            {"123456": 400},
+        ),
+        (
+            {
+                "events": [
+                    {
+                        "id": "123456",
+                        "type": "reply_sent",
+                        "target": {"source_uuid": "abcdef", "version": "uvwxyz"},
+                    }
+                ]
+            },
+            {"123456": 501},
+        ),
+    ],
+)
+def test_api2_invalid_events(
+    journalist_app,
+    journalist_api_token,
+    request_with_events,
+    event_statuses,
+):
+    """Test that invalid events are rejected."""
+    with journalist_app.test_client() as app:
+        response = app.post(
+            url_for("api2.data"),
+            json=request_with_events,
+            headers=get_api_headers(journalist_api_token),
+        )
+        for event in request_with_events["events"]:
+            event_id = event["id"]
+            assert response.json["events"][event_id] == event_statuses[event_id]

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -6,7 +6,7 @@ import pytest
 from flask import url_for
 from flask_sqlalchemy import get_debug_queries
 from journalist_app.api2 import json_version
-from journalist_app.api2.types import Event, EventStatusCode, EventType, SourceTarget
+from journalist_app.api2.types import Event, EventType, SourceTarget
 from sqlalchemy.orm.exc import MultipleResultsFound
 from tests.utils.api_helper import get_api_headers
 
@@ -315,7 +315,7 @@ def test_api2_metadata_validation_valid_requests(
 
 
 @pytest.mark.parametrize(
-    "request_with_events,event_statuses",
+    ("request_with_events", "results"),
     [
         (
             {
@@ -327,7 +327,7 @@ def test_api2_metadata_validation_valid_requests(
                     }
                 ]
             },
-            {"123456": 400},
+            {"123456": [400, "'foobar' is not a valid EventType"]},
         ),
     ],
 )
@@ -335,7 +335,7 @@ def test_api2_invalid_events(
     journalist_app,
     journalist_api_token,
     request_with_events,
-    event_statuses,
+    results,
 ):
     """Test that invalid events are rejected."""
     with journalist_app.test_client() as app:
@@ -346,7 +346,7 @@ def test_api2_invalid_events(
         )
         for event in request_with_events["events"]:
             event_id = event["id"]
-            assert response.json["events"][event_id] == event_statuses[event_id]
+            assert response.json["events"][event_id] == results[event_id]
 
 
 # FIXME: This is
@@ -420,5 +420,5 @@ def test_api2_reply_sent_event(
             json={"events": [asdict(event)]},
             headers=get_api_headers(journalist_api_token),
         )
-        assert response.json["events"][event.id] == EventStatusCode.OK
+        assert response.json["events"][event.id] == [200, None]
         assert reply["uuid"] in response.json["items"]

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -5,6 +5,7 @@ from dataclasses import asdict
 import pytest
 from flask import url_for
 from flask_sqlalchemy import get_debug_queries
+from journalist_app import api2
 from journalist_app.api2 import json_version
 from journalist_app.api2.types import Event, EventType, ItemTarget, SourceTarget
 from sqlalchemy.orm.exc import MultipleResultsFound
@@ -423,6 +424,15 @@ def test_api2_reply_sent(
         assert response.json["events"][event.id] == [200, None]
         assert reply["uuid"] in response.json["items"]
 
+        # Duplicate reply is acknowledged but not processed again:
+        response = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(event)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.json["events"][event.id] == [208, None]
+        assert reply["uuid"] not in response.json["items"]
+
 
 def test_api2_item_deleted(
     journalist_app,
@@ -480,3 +490,13 @@ def test_api2_item_deleted(
         )
         assert response.json["events"][event.id] == [404, "could not find item: does not exist"]
         assert event.target.item_uuid not in response.json["items"]
+
+
+def test_api2_idempotence_period(journalist_app):
+    """
+    `IDEMPOTENCE_PERIOD` MUST be greater than or equal to
+    `sdconfig.SecureDropConfig.SESSION_LIFETIME`.  NB. Black/Ruff insists on
+    reversing the >= comparison to <=.
+    """
+
+    assert journalist_app.config["SESSION_LIFETIME"] <= api2.events.IDEMPOTENCE_PERIOD

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -316,41 +316,44 @@ def test_api2_metadata_validation_valid_requests(
         assert response.status_code == 200
 
 
-@pytest.mark.parametrize(
-    ("request_with_events", "results"),
-    [
-        (
-            {
-                "events": [
-                    {
-                        "id": "123456",
-                        "type": "foobar",
-                        "target": {"source_uuid": "abcdef", "version": "uvwxyz"},
-                    }
-                ]
-            },
-            {"123456": [400, "'foobar' is not a valid EventType"]},
-        ),
-    ],
-)
 def test_api2_invalid_events(
     journalist_app,
     journalist_api_token,
-    request_with_events,
-    results,
 ):
     """Test that invalid events are rejected."""
     with journalist_app.test_client() as app:
+        valid = {
+            "events": [
+                {
+                    "id": "123456",
+                    "type": "reply_sent",
+                    "target": {"source_uuid": "abcdef", "version": "uvwxyz"},
+                }
+            ]
+        }
+
+        invalid_type = deepcopy(valid)
+        invalid_type["events"][0]["type"] = "foobar"
         response = app.post(
             url_for("api2.data"),
-            json=request_with_events,
+            json=invalid_type,
             headers=get_api_headers(journalist_api_token),
         )
-        for event in request_with_events["events"]:
-            event_id = event["id"]
-            assert response.json["events"][event_id] == results[event_id]
+        assert response.status_code == 400
+        assert response.json["message"] == "invalid event: 'foobar' is not a valid EventType"
 
-        no_id = deepcopy(request_with_events)
+        invalid_target = deepcopy(valid)
+        del invalid_target["events"][0]["target"]["source_uuid"]
+
+        response = app.post(
+            url_for("api2.data"),
+            json=invalid_target,
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.status_code == 400
+        assert "invalid event target" in response.json["message"]
+
+        no_id = deepcopy(valid)
         del no_id["events"][0]["id"]
 
         response = app.post(
@@ -360,7 +363,7 @@ def test_api2_invalid_events(
         )
         assert response.status_code == 400
 
-        too_many = deepcopy(request_with_events)
+        too_many = deepcopy(invalid_type)
         too_many["events"].extend([too_many["events"][0].copy() for _ in range(api2.EVENTS_MAX)])
 
         response = app.post(
@@ -369,6 +372,7 @@ def test_api2_invalid_events(
             headers=get_api_headers(journalist_api_token),
         )
         assert response.status_code == 429
+        assert "MUST NOT include more than" in response.json["message"]
 
 
 # FIXME: This is

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -1,3 +1,4 @@
+import uuid
 from contextlib import contextmanager
 from dataclasses import asdict
 
@@ -5,7 +6,7 @@ import pytest
 from flask import url_for
 from flask_sqlalchemy import get_debug_queries
 from journalist_app.api2 import json_version
-from journalist_app.api2.types import Event, EventID, EventStatusCode, EventType, SourceTarget
+from journalist_app.api2.types import Event, EventStatusCode, EventType, SourceTarget
 from sqlalchemy.orm.exc import MultipleResultsFound
 from tests.utils.api_helper import get_api_headers
 
@@ -328,18 +329,6 @@ def test_api2_metadata_validation_valid_requests(
             },
             {"123456": 400},
         ),
-        (
-            {
-                "events": [
-                    {
-                        "id": "123456",
-                        "type": "reply_sent",
-                        "target": {"source_uuid": "abcdef", "version": "uvwxyz"},
-                    }
-                ]
-            },
-            {"123456": 501},
-        ),
     ],
 )
 def test_api2_invalid_events(
@@ -358,3 +347,78 @@ def test_api2_invalid_events(
         for event in request_with_events["events"]:
             event_id = event["id"]
             assert response.json["events"][event_id] == event_statuses[event_id]
+
+
+# FIXME: This is
+# "app/server_tests/data/items/40e13a88-5409-4201-9495-d06c335e203f.gpg" via
+# "gpg --enarmor".  Should probably pull from test_files fixture via
+# download_reply().
+REPLY = """-----BEGIN PGP MESSAGE-----
+Comment: Use "gpg --dearmor" for unpacking
+
+wcFMAwEQfVJow2WPAQ/9FAbkuKbTAu4WHk+iKNrEz21R0QeMDdKxffuQlD/36Gek
+gDqa4O8Nvkw4MfvprRuPwiXG6Jvm9++hiy1sjIlN/obIb9zUz/CfzQIrzOAipaBn
+OdwIc32s4hMtnnLdUZJa2vMKWFMyMAUrye3u0l7BgdBoDNUfDpKKLtDRtWGp0Uly
+5JkWfgVgfSEwzHkGKZvHI3EBVCt53eIyrK8B/KZ7NdMDtgzQgWb04pdWONx1SwKU
+72kIAgH7B44Btgn1MVj6Ri9IB470YZSWweIM0yTvQ/2//BPje6dCuK24vVmpz5Xd
+7tcZyqZYtIifwz0p4sfdoXMQmxMiyrCGmY7hosRjbbRFFVvI7yQ/ujEsdLqDbGok
+Ukv4gChYFMLOxqfpwF6v29A3MCHO3vwDBqQcwToQkP5BJE89jfF3+Z+n9+ahC6yX
+Gi1gYX+X0/1S9Q2kB1q+Pyqst4CtSiu9n+WJ4CoJXA27fafkUIWjxcu0GIzA+Y40
+2UzNiA4CRzj0rD9jOhDwCmrVqA/eR/nXdYK6wYnL7swGTHzD2HRf5p6fE6TnFSdt
+8K79sTDiVnH4S3AAS9vnL9HIBqhn6sSa/uojCazb7ZVcWexWLt2Mcd5ZFOpZ32qB
+Qf3Rhw4VSTJDZ4cIEDs531Pf+HZlIZRDEC64jNtTBVBJf9nn51cSxJmi4T8o4pLB
+wUwDw+fEwKIgGyoBEACLYAx2OqvbkscWu6Fp/zMM43omBiiEMQRAs87ldE1sddwk
+UE7N4H0xJE3l4x6poavY1oScEy+DiSvk6CYInEcDzGf6MSoCCBQ2cGjctfR84bE+
+mJV7M7P41AgV8Xj+NsfCcirwTrd1zir06/D3qg5JacKpscJFYJXJg0fBCFkFqiIv
+/6X1jcX9YAitLS3cLw+uV3ZuwKFUqnXLaclhvCvCTpdM+MuGvcNep+QFUeJnm+WS
+jVQPko4RiCOpTgH+g2pw1oBjVZC2UX0Iqake3Bnge89REs+zIzQ2SA+RhjVA6jR1
+rCf0ZIWckYg/WDxe2Dn4PAFhWgsjm4MM5dIE5YHvHPV8x0rIoAZQ8SwAXzTc1B1y
+pLq5Iop2AaJSQ+SFaiuFsUfc391kfsnOShQn00jLqZ7+bhWUWUS/rCH8ePa7Hp8W
+44MFOh8D3EsNN+hzuGXklHdL/dt41xmaO0o97yzusd8MJQ4fV0LBHkJEg5f21g3G
+bDpt5Fed7BWpR20cWrwuGPL46/UfjMqHJoS56ZjuZyBuUwvoC7gQlPmyPlvSWdEb
+8rF1gA4pPWURTNmClaHvPoubBig53mtXTz9esQfYu4FGmfUeFRnhdIWnrcvG3gXs
+/jY8gBIQ6N+MjkRNHS6nwzcUukStsaSvBI2uL0iclGFOCAx7p6TNQPDqwrITi9LA
+GwFbjruOwUUTjAErWxcTkGFWsUDPQV9gxamt7Agacinql4UAjSr21imTfqXkC/Kf
+6bgOb8EfLunqRg+44Zgk0JluiXYh+ss7alf/dcqeF1AMq+vhJ40F6r940IOWJ/0W
+cpZG68fwzC2YXTg4kU+OQdm4xBIeqTcgwiAnfZKKZtUCt8+JmRAzvbrLGXPe80Xc
+Dl9xuZb+mEQlOnxD3mYf6htx5CNRdp//Rl3fgbGv3vZCmE+GQ7CvgHkf+7Evinno
++eozX+auvPwAyXG4npnwjwEJ0XaTKAJwRVH26Q==
+=Eozu
+-----END PGP MESSAGE-----
+"""
+
+
+def test_api2_reply_sent_event(
+    journalist_app,
+    journalist_api_token,
+    test_files,
+    test_journo,
+):
+    """Test processing of the "reply_sent" event."""
+    with journalist_app.test_client() as app:
+        source_uuid = test_files["source"].uuid
+        index = app.get(
+            url_for("api2.index"),
+            headers=get_api_headers(journalist_api_token),
+        )
+
+        assert index.status_code == 200
+        source_version = index.json["sources"][source_uuid]
+
+        reply = {
+            "uuid": str(uuid.uuid4()),
+            "reply": REPLY,
+        }
+        event = Event(
+            id="123456",
+            target=SourceTarget(source_uuid=source_uuid, version=source_version),
+            type=EventType.REPLY_SENT,
+            data=reply,
+        )
+        response = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(event)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.json["events"][event.id] == EventStatusCode.OK
+        assert reply["uuid"] in response.json["items"]

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -360,6 +360,16 @@ def test_api2_invalid_events(
         )
         assert response.status_code == 400
 
+        too_many = deepcopy(request_with_events)
+        too_many["events"].extend([too_many["events"][0].copy() for _ in range(api2.EVENTS_MAX)])
+
+        response = app.post(
+            url_for("api2.data"),
+            json=too_many,
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.status_code == 429
+
 
 # FIXME: This is
 # "app/server_tests/data/items/40e13a88-5409-4201-9495-d06c335e203f.gpg" via

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -11,6 +11,7 @@ from journalist_app.api2 import json_version
 from journalist_app.api2.types import Event, EventType, ItemTarget, SourceTarget
 from models import Reply, Submission
 from sqlalchemy.orm.exc import MultipleResultsFound
+from tests.utils import ascii_armor, decrypt_as_journalist
 from tests.utils.api_helper import get_api_headers
 
 
@@ -376,45 +377,6 @@ def test_api2_invalid_events(
         assert "MUST NOT include more than" in response.json["message"]
 
 
-# FIXME: This is
-# "app/server_tests/data/items/40e13a88-5409-4201-9495-d06c335e203f.gpg" via
-# "gpg --enarmor".  Should probably pull from test_files fixture via
-# download_reply().
-REPLY = """-----BEGIN PGP MESSAGE-----
-Comment: Use "gpg --dearmor" for unpacking
-
-wcFMAwEQfVJow2WPAQ/9FAbkuKbTAu4WHk+iKNrEz21R0QeMDdKxffuQlD/36Gek
-gDqa4O8Nvkw4MfvprRuPwiXG6Jvm9++hiy1sjIlN/obIb9zUz/CfzQIrzOAipaBn
-OdwIc32s4hMtnnLdUZJa2vMKWFMyMAUrye3u0l7BgdBoDNUfDpKKLtDRtWGp0Uly
-5JkWfgVgfSEwzHkGKZvHI3EBVCt53eIyrK8B/KZ7NdMDtgzQgWb04pdWONx1SwKU
-72kIAgH7B44Btgn1MVj6Ri9IB470YZSWweIM0yTvQ/2//BPje6dCuK24vVmpz5Xd
-7tcZyqZYtIifwz0p4sfdoXMQmxMiyrCGmY7hosRjbbRFFVvI7yQ/ujEsdLqDbGok
-Ukv4gChYFMLOxqfpwF6v29A3MCHO3vwDBqQcwToQkP5BJE89jfF3+Z+n9+ahC6yX
-Gi1gYX+X0/1S9Q2kB1q+Pyqst4CtSiu9n+WJ4CoJXA27fafkUIWjxcu0GIzA+Y40
-2UzNiA4CRzj0rD9jOhDwCmrVqA/eR/nXdYK6wYnL7swGTHzD2HRf5p6fE6TnFSdt
-8K79sTDiVnH4S3AAS9vnL9HIBqhn6sSa/uojCazb7ZVcWexWLt2Mcd5ZFOpZ32qB
-Qf3Rhw4VSTJDZ4cIEDs531Pf+HZlIZRDEC64jNtTBVBJf9nn51cSxJmi4T8o4pLB
-wUwDw+fEwKIgGyoBEACLYAx2OqvbkscWu6Fp/zMM43omBiiEMQRAs87ldE1sddwk
-UE7N4H0xJE3l4x6poavY1oScEy+DiSvk6CYInEcDzGf6MSoCCBQ2cGjctfR84bE+
-mJV7M7P41AgV8Xj+NsfCcirwTrd1zir06/D3qg5JacKpscJFYJXJg0fBCFkFqiIv
-/6X1jcX9YAitLS3cLw+uV3ZuwKFUqnXLaclhvCvCTpdM+MuGvcNep+QFUeJnm+WS
-jVQPko4RiCOpTgH+g2pw1oBjVZC2UX0Iqake3Bnge89REs+zIzQ2SA+RhjVA6jR1
-rCf0ZIWckYg/WDxe2Dn4PAFhWgsjm4MM5dIE5YHvHPV8x0rIoAZQ8SwAXzTc1B1y
-pLq5Iop2AaJSQ+SFaiuFsUfc391kfsnOShQn00jLqZ7+bhWUWUS/rCH8ePa7Hp8W
-44MFOh8D3EsNN+hzuGXklHdL/dt41xmaO0o97yzusd8MJQ4fV0LBHkJEg5f21g3G
-bDpt5Fed7BWpR20cWrwuGPL46/UfjMqHJoS56ZjuZyBuUwvoC7gQlPmyPlvSWdEb
-8rF1gA4pPWURTNmClaHvPoubBig53mtXTz9esQfYu4FGmfUeFRnhdIWnrcvG3gXs
-/jY8gBIQ6N+MjkRNHS6nwzcUukStsaSvBI2uL0iclGFOCAx7p6TNQPDqwrITi9LA
-GwFbjruOwUUTjAErWxcTkGFWsUDPQV9gxamt7Agacinql4UAjSr21imTfqXkC/Kf
-6bgOb8EfLunqRg+44Zgk0JluiXYh+ss7alf/dcqeF1AMq+vhJ40F6r940IOWJ/0W
-cpZG68fwzC2YXTg4kU+OQdm4xBIeqTcgwiAnfZKKZtUCt8+JmRAzvbrLGXPe80Xc
-Dl9xuZb+mEQlOnxD3mYf6htx5CNRdp//Rl3fgbGv3vZCmE+GQ7CvgHkf+7Evinno
-+eozX+auvPwAyXG4npnwjwEJ0XaTKAJwRVH26Q==
-=Eozu
------END PGP MESSAGE-----
-"""
-
-
 def test_api2_reply_sent(
     journalist_app,
     journalist_api_token,
@@ -423,24 +385,34 @@ def test_api2_reply_sent(
 ):
     """Test processing of the "reply_sent" event."""
     with journalist_app.test_client() as app:
-        source_uuid = test_files["source"].uuid
+        # Fetch and decrypt the ciphertext of a reply fixture.
+        source = test_files["source"]
+        reply = test_files["replies"][0]
+        reply_res = app.get(
+            url_for("api.download_reply", source_uuid=source.uuid, reply_uuid=reply.uuid),
+            headers=get_api_headers(journalist_api_token),
+        )
+        reply_ct = reply_res.data
+        reply_pt = decrypt_as_journalist(reply_ct)
+
+        # Fetch the current index.
         index = app.get(
             url_for("api2.index"),
             headers=get_api_headers(journalist_api_token),
         )
-
         assert index.status_code == 200
-        source_version = index.json["sources"][source_uuid]
+        source_version = index.json["sources"][source.uuid]
 
-        reply = {
+        # Resubmit the reply ciphertext with a new UUID.
+        reply2 = {
             "uuid": str(uuid.uuid4()),
-            "reply": REPLY,
+            "reply": ascii_armor(reply_ct),
         }
         event = Event(
             id="123456",
-            target=SourceTarget(source_uuid=source_uuid, version=source_version),
+            target=SourceTarget(source_uuid=source.uuid, version=source_version),
             type=EventType.REPLY_SENT,
-            data=reply,
+            data=reply2,
         )
         response = app.post(
             url_for("api2.data"),
@@ -448,7 +420,16 @@ def test_api2_reply_sent(
             headers=get_api_headers(journalist_api_token),
         )
         assert response.json["events"][event.id] == [200, None]
-        assert reply["uuid"] in response.json["items"]
+        assert reply2["uuid"] in response.json["items"]
+
+        # Check that we get the same plaintext back.
+        reply2_res = app.get(
+            url_for("api.download_reply", source_uuid=source.uuid, reply_uuid=reply2["uuid"]),
+            headers=get_api_headers(journalist_api_token),
+        )
+        reply2_ct = reply2_res.data
+        reply2_pt = decrypt_as_journalist(reply2_ct)
+        assert reply2_pt == reply_pt
 
         # Duplicate reply is acknowledged but not processed again:
         response = app.post(
@@ -457,7 +438,7 @@ def test_api2_reply_sent(
             headers=get_api_headers(journalist_api_token),
         )
         assert response.json["events"][event.id] == [208, None]
-        assert reply["uuid"] not in response.json["items"]
+        assert reply2["uuid"] not in response.json["items"]
 
 
 def test_api2_item_deleted(

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -9,6 +9,7 @@ from flask_sqlalchemy import get_debug_queries
 from journalist_app import api2
 from journalist_app.api2 import json_version
 from journalist_app.api2.types import Event, EventType, ItemTarget, SourceTarget
+from models import Reply, Submission
 from sqlalchemy.orm.exc import MultipleResultsFound
 from tests.utils.api_helper import get_api_headers
 
@@ -489,6 +490,9 @@ def test_api2_item_deleted(
         )
         assert response.json["events"][event.id] == [200, None]
         assert response.json["items"][event.target.item_uuid] is None
+        assert (
+            Submission.query.filter(Submission.uuid == event.target.item_uuid).one_or_none() is None
+        )
 
         # Delete a reply:
         reply_uuid = test_files["replies"][0].uuid
@@ -505,6 +509,7 @@ def test_api2_item_deleted(
         )
         assert response.json["events"][event.id] == [200, None]
         assert response.json["items"][event.target.item_uuid] is None
+        assert Reply.query.filter(Reply.uuid == event.target.item_uuid).one_or_none() is None
 
         # Try to delete something that doesn't exist:
         event.id = "345678"

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -1,5 +1,6 @@
 import uuid
 from contextlib import contextmanager
+from copy import deepcopy
 from dataclasses import asdict
 
 import pytest
@@ -348,6 +349,16 @@ def test_api2_invalid_events(
         for event in request_with_events["events"]:
             event_id = event["id"]
             assert response.json["events"][event_id] == results[event_id]
+
+        no_id = deepcopy(request_with_events)
+        del no_id["events"][0]["id"]
+
+        response = app.post(
+            url_for("api2.data"),
+            json=no_id,
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.status_code == 400
 
 
 # FIXME: This is

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -480,7 +480,7 @@ def test_api2_item_deleted(
         reply_uuid = test_files["replies"][0].uuid
         reply_version = index.json["items"][reply_uuid]
         event = Event(
-            id="123456",
+            id="234567",
             target=ItemTarget(item_uuid=reply_uuid, version=reply_version),
             type=EventType.ITEM_DELETED,
         )
@@ -493,6 +493,7 @@ def test_api2_item_deleted(
         assert response.json["items"][event.target.item_uuid] is None
 
         # Try to delete something that doesn't exist:
+        event.id = "345678"
         event.target.item_uuid = "does not exist"
         response = app.post(
             url_for("api2.data"),

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -6,7 +6,7 @@ import pytest
 from flask import url_for
 from flask_sqlalchemy import get_debug_queries
 from journalist_app.api2 import json_version
-from journalist_app.api2.types import Event, EventType, SourceTarget
+from journalist_app.api2.types import Event, EventType, ItemTarget, SourceTarget
 from sqlalchemy.orm.exc import MultipleResultsFound
 from tests.utils.api_helper import get_api_headers
 
@@ -388,7 +388,7 @@ Dl9xuZb+mEQlOnxD3mYf6htx5CNRdp//Rl3fgbGv3vZCmE+GQ7CvgHkf+7Evinno
 """
 
 
-def test_api2_reply_sent_event(
+def test_api2_reply_sent(
     journalist_app,
     journalist_api_token,
     test_files,
@@ -422,3 +422,61 @@ def test_api2_reply_sent_event(
         )
         assert response.json["events"][event.id] == [200, None]
         assert reply["uuid"] in response.json["items"]
+
+
+def test_api2_item_deleted(
+    journalist_app,
+    journalist_api_token,
+    test_files,
+    test_journo,
+):
+    """Test processing of the "item_deleted" event."""
+    with journalist_app.test_client() as app:
+        index = app.get(
+            url_for("api2.index"),
+            headers=get_api_headers(journalist_api_token),
+        )
+
+        assert index.status_code == 200
+
+        # Delete a submission:
+        submission_uuid = test_files["submissions"][0].uuid
+        submission_version = index.json["items"][submission_uuid]
+        event = Event(
+            id="123456",
+            target=ItemTarget(item_uuid=submission_uuid, version=submission_version),
+            type=EventType.ITEM_DELETED,
+        )
+        response = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(event)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.json["events"][event.id] == [200, None]
+        assert response.json["items"][event.target.item_uuid] is None
+
+        # Delete a reply:
+        reply_uuid = test_files["replies"][0].uuid
+        reply_version = index.json["items"][reply_uuid]
+        event = Event(
+            id="123456",
+            target=ItemTarget(item_uuid=reply_uuid, version=reply_version),
+            type=EventType.ITEM_DELETED,
+        )
+        response = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(event)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.json["events"][event.id] == [200, None]
+        assert response.json["items"][event.target.item_uuid] is None
+
+        # Try to delete something that doesn't exist:
+        event.target.item_uuid = "does not exist"
+        response = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(event)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.json["events"][event.id] == [404, "could not find item: does not exist"]
+        assert event.target.item_uuid not in response.json["items"]

--- a/securedrop/tests/utils/__init__.py
+++ b/securedrop/tests/utils/__init__.py
@@ -1,5 +1,7 @@
+import base64
 import datetime
 import re
+import textwrap
 from pathlib import Path
 
 import argon2
@@ -93,6 +95,13 @@ def decrypt_as_journalist(ciphertext: bytes) -> bytes:
         secret_key=JOURNALIST_SECRET_KEY,
         passphrase="correcthorsebatterystaple",
     )
+
+
+def ascii_armor(data: bytes, header: str = "MESSAGE") -> str:
+    """Convert binary OpenPGP `data` to ASCII armored format."""
+    b64 = base64.b64encode(data).decode("ascii")
+    body = "\n".join(textwrap.wrap(b64, 64))
+    return f"-----BEGIN PGP {header}-----\n\n{body}\n-----END PGP {header}-----\n"
 
 
 def create_legacy_gpg_key(


### PR DESCRIPTION
Closes #7665 by implementing an event-handling framework and handlers for two illustrative events:

https://github.com/freedomofpress/securedrop/blob/d6dfb8775cb974f86665a7fc7b594e0455e67575/securedrop/journalist_app/api2/types.py#L26-L28

Adding the [remaining events](https://docs.google.com/document/d/1wO2MCJI5Xm_BM98JeSBIxEPne4PWNjV9cQNegAPNZp0/edit?tab=t.0#heading=h.scvzqrmhv4e9) will be follow-up work once this framework has been reviewed and can be extended.


## Test plan

Each `EventType` has a test in `test_journalist_api2.py`, including for its own conflict and idempotence properties.  I've flagged some others for follow-up work.


## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)