### PR TITLE
Set noble end-of-life date

### DIFF
--- a/securedrop/journalist_templates/base.html
+++ b/securedrop/journalist_templates/base.html
@@ -20,7 +20,7 @@
   {% if session.logged_in() %}
   {% if g.show_os_past_eol_warning %}
   <div id="os-past-eol" class="alert-banner">
-    {{ gettext('<strong>Critical:</strong>&nbsp;&nbsp;The operating system used by your SecureDrop servers has reached its end-of-life. A manual update is required to re-enable the Source Interface and remain safe. Please contact your administrator. <a href="https://securedrop.org/focal-eol" rel="noreferrer">Learn More</a>') }}
+    {{ gettext('<strong>Critical:</strong>&nbsp;&nbsp;The operating system used by your SecureDrop servers has reached its end-of-life. A manual update is required to re-enable the Source Interface and remain safe. Please contact your administrator. <a href="https://securedrop.org/noble-eol" rel="noreferrer">Learn More</a>') }}
   </div>
   {% endif %}
   <nav aria-label="{{ gettext('Navigation') }}">

--- a/securedrop/server_os.py
+++ b/securedrop/server_os.py
@@ -1,10 +1,10 @@
 import functools
 from datetime import date
 
-FOCAL_VERSION = "20.04"
 NOBLE_VERSION = "24.04"
 
-FOCAL_ENDOFLIFE = date(2025, 5, 31)
+# Per <https://endoflife.date/ubuntu>
+NOBLE_ENDOFLIFE = date(2029, 4, 25)
 
 
 @functools.lru_cache
@@ -20,6 +20,6 @@ def get_os_release() -> str:
 
 def is_os_past_eol() -> bool:
     """
-    Check if it's focal and if today is past the official EOL date
+    Check if it's noble and if today is past the official EOL date
     """
-    return get_os_release() == FOCAL_VERSION and date.today() >= FOCAL_ENDOFLIFE
+    return get_os_release() == NOBLE_VERSION and date.today() >= NOBLE_ENDOFLIFE

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -419,7 +419,7 @@ msgstr ""
 msgid "Can't scan the barcode? You can manually pair FreeOTP with this account by entering the following two-factor secret into the app:"
 msgstr ""
 
-msgid "<strong>Critical:</strong>&nbsp;&nbsp;The operating system used by your SecureDrop servers has reached its end-of-life. A manual update is required to re-enable the Source Interface and remain safe. Please contact your administrator. <a href=\"https://securedrop.org/focal-eol\" rel=\"noreferrer\">Learn More</a>"
+msgid "<strong>Critical:</strong>&nbsp;&nbsp;The operating system used by your SecureDrop servers has reached its end-of-life. A manual update is required to re-enable the Source Interface and remain safe. Please contact your administrator. <a href=\"https://securedrop.org/noble-eol\" rel=\"noreferrer\">Learn More</a>"
 msgstr ""
 
 msgid "Navigation"


### PR DESCRIPTION
Historically we only did this closer to the end of life, but that left very old SecureDrops that were on an outdated version still up because they never picked up the code update that shipped the EOL check.

So let's enable it now, so that regardless of whether they continue to receive further updates, they will go down in April 2029.

Note that the https://securedrop.org/noble-eol URL doesn't exist yet, presumably we'll create it as an alias later.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] I think visual review is fine, unless tests would be beneficial?
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)