### PR TITLE
api2: define unimplemented event types

### DIFF
--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -26,6 +26,11 @@ EventID = NewType("EventID", str)  # int, but opaque on the wire
 class EventType(StrEnum):
     REPLY_SENT = auto()
     ITEM_DELETED = auto()
+    SOURCE_DELETED = auto()
+    SOURCE_CONVERSATION_DELETED = auto()
+    STARRED = auto()
+    UNSTARRED = auto()
+    SEEN = auto()
 
 
 class EventStatusCode(IntEnum):


### PR DESCRIPTION
Defines all the event types, even if they are not implemented yet, so the server doesn't 500 on batch requests from the client. Allows us to test the batch endpoint flow from the client with the handlers that are currently implemented!

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)