### PR TITLE
Update Rust version to 1.90.0

### DIFF
--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -9,7 +9,7 @@ jobs:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.87.0
+    container: rust:1.90.0
     env:
       CARGO_VET_VERSION: 0.10.0
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.87.0
+    container: rust:1.90.0
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ jobs:
   rust-audit:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.87.0
+    container: rust:1.90.0
     steps:
       - uses: actions/checkout@v5
         with:

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         unzip \
         zlib1g-dev
 
-ENV RUST_VERSION 1.87.0
+ENV RUST_VERSION 1.90.0
 ENV RUSTUP_VERSION 1.28.2
 ENV RUSTUP_INIT_SHA256 20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
 ENV RUSTUP_HOME /opt/rustup

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.90.0"

--- a/securedrop/dockerfiles/noble/python3/DemoDockerfile
+++ b/securedrop/dockerfiles/noble/python3/DemoDockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 # 1) Download rustup-init and verify it matches hardcoded checksum
 # 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
 # 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
-ENV RUST_VERSION 1.87.0
+ENV RUST_VERSION 1.90.0
 ENV RUSTUP_VERSION 1.28.2
 ENV RUSTUP_INIT_SHA256 20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
 ENV RUSTUP_HOME /opt/rustup

--- a/securedrop/dockerfiles/noble/python3/SlimDockerfile
+++ b/securedrop/dockerfiles/noble/python3/SlimDockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
 # 1) Download rustup-init and verify it matches hardcoded checksum
 # 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
 # 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
-ENV RUST_VERSION 1.87.0
+ENV RUST_VERSION 1.90.0
 ENV RUSTUP_VERSION 1.28.2
 ENV RUSTUP_INIT_SHA256 20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
 ENV RUSTUP_HOME /opt/rustup


### PR DESCRIPTION
Fixes #7687

## Test plan

- [ ] CI is green
- [ ] Rust version updated across the board (no more 1.87.0 refs)

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)