### PR TITLE
build: as of Tor Browser 15 / Firefox 140, expect Firefox to be an xz rather than a bzip2 archive

### DIFF
--- a/securedrop/dockerfiles/noble/python3/Dockerfile
+++ b/securedrop/dockerfiles/noble/python3/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update  && apt-get install -y \
 # Current versions of the test browser software. Tor Browser is based
 # on a specific version of Firefox - we download both for generic and TBB testing
 
-# We should use the version of geckodriver corresponding to the above Firefox version.
-ENV GECKODRIVER_VERSION v0.35.0
+# We should use the version of geckodriver corresponding to the correct Firefox version.
+ENV GECKODRIVER_VERSION v0.36.0
 
 # Import Tor release signing key
 ENV TOR_RELEASE_KEY_FINGERPRINT "EF6E286DDA85EA2A4BA7DE684E2C6E8793298290"

--- a/securedrop/dockerfiles/noble/python3/Dockerfile
+++ b/securedrop/dockerfiles/noble/python3/Dockerfile
@@ -39,13 +39,13 @@ ENV MOZILLA_RELEASE_KEY_FINGERPRINT "14F26682D0916CDD81E37B6D61B7B526D98F0353"
 
 RUN FF_VERSION=$(curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/ALL | grep -oP '(?<=platformVersion=")[^"]*' | head -1)esr && \
 curl -s https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/KEY | gpg2 --import - && \
-curl -LO https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/linux-x86_64/en-US/firefox-${FF_VERSION}.tar.bz2 && \
-    curl -LO https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/linux-x86_64/en-US/firefox-${FF_VERSION}.tar.bz2.asc && \
+curl -LO https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/linux-x86_64/en-US/firefox-${FF_VERSION}.tar.xz && \
+    curl -LO https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/linux-x86_64/en-US/firefox-${FF_VERSION}.tar.xz.asc && \
     gpg2 --output ./mozilla.keyring --export ${MOZILLA_RELEASE_KEY_FINGERPRINT} && \
-    gpgv --keyring ./mozilla.keyring firefox-${FF_VERSION}.tar.bz2.asc firefox-${FF_VERSION}.tar.bz2 && \
-    tar xjf firefox-*.tar.bz2 && \
+    gpgv --keyring ./mozilla.keyring firefox-${FF_VERSION}.tar.xz.asc firefox-${FF_VERSION}.tar.xz && \
+    tar -xvJf firefox-*.tar.xz && \
     mv firefox /usr/bin && \
-    rm -f firefox-${FF_VERSION}.tar.bz2.asc firefox-${FF_VERSION}.tar.bz2
+    rm -f firefox-${FF_VERSION}.tar.xz.asc firefox-${FF_VERSION}.tar.xz
 
 # Install geckodriver
 RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz && \

--- a/securedrop/tests/functional/web_drivers.py
+++ b/securedrop/tests/functional/web_drivers.py
@@ -67,6 +67,7 @@ def _create_driver(
         pref_dict = {
             "network.proxy.no_proxies_on": "127.0.0.1",
             "browser.privatebrowsing.autostart": False,
+            "remote.system-access-check.enabled": False,
         }
 
         Path(_TBB_PATH).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Without this change, on `develop` building `securedrop/dockerfiles/noble/python3/Dockerfile` now fails with:

```sh-session
 => ERROR [5/7] RUN FF_VERSION=$(curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/A  0.9s 
------                                                                                                                       
 > [5/7] RUN FF_VERSION=$(curl -s https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/ALL | grep -oP '(?<=platformVersion=")[^"]*' | head -1)esr && curl -s https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/KEY | gpg2 --import - && curl -LO https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/linux-x86_64/en-US/firefox-${FF_VERSION}.tar.bz2 &&     curl -LO https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/linux-x86_64/en-US/firefox-${FF_VERSION}.tar.bz2.asc &&     gpg2 --output ./mozilla.keyring --export 14F26682D0916CDD81E37B6D61B7B526D98F0353 &&     gpgv --keyring ./mozilla.keyring firefox-${FF_VERSION}.tar.bz2.asc firefox-${FF_VERSION}.tar.bz2 &&     tar xjf firefox-*.tar.bz2 &&     mv firefox /usr/bin &&     rm -f firefox-${FF_VERSION}.tar.bz2.asc firefox-${FF_VERSION}.tar.bz2:
0.609 gpg: key 61B7B526D98F0353: 24 signatures not checked due to missing keys
0.622 gpg: key 61B7B526D98F0353: public key "Mozilla Software Releases <release@mozilla.com>" imported
0.631 gpg: Total number processed: 1
0.631 gpg:               imported: 1
0.632 gpg: no ultimately trusted keys found
0.640   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
0.640                                  Dload  Upload   Total   Spent    Left  Speed
100   146  100   146    0     0   1390      0 --:--:-- --:--:-- --:--:--  1403
0.762   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
0.762                                  Dload  Upload   Total   Spent    Left  Speed
100   146  100   146    0     0   1766      0 --:--:-- --:--:-- --:--:--  1780
0.854 gpgv: no valid OpenPGP data found.
0.854 gpgv: the signature could not be verified.
0.854 Please remember that the signature file (.sig or .asc)
0.854 should be the first file given on the command line.
```

With this change, the container builds and runs normally using the latest Tor Browser and its Firefox version following:
* https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/ALL
* https://archive.mozilla.org/pub/firefox/releases/140.4.0esr/linux-x86_64/en-US/

Refs #7698.