### PR TITLE
Add check for valid tab IDs when creating sources

### DIFF
--- a/securedrop/source_app/main.py
+++ b/securedrop/source_app/main.py
@@ -108,7 +108,19 @@ def make_blueprint(config: SecureDropConfig) -> Blueprint:
             if not date_codenames_expire or datetime.now(timezone.utc) >= date_codenames_expire:
                 return clear_session_and_redirect_to_logged_out_page(flask_session=session)
 
-            tab_id = request.form["tab_id"]
+            tab_id = request.form.get("tab_id")
+            if not tab_id or tab_id not in session.get("codenames", {}):
+                # Use generic error message text for source creation issue
+                session.clear()
+                flash_msg(
+                    "error",
+                    None,
+                    gettext(
+                        "There was a temporary problem creating your account. Please try again."
+                    ),
+                )
+                return redirect(url_for("main.index"))
+
             codename = session["codenames"][tab_id]
             del session["codenames"]
 

--- a/securedrop/tests/test_source.py
+++ b/securedrop/tests/test_source.py
@@ -145,6 +145,34 @@ def test_create_new_source(source_app):
         assert "codenames" not in session
 
 
+def test_create_no_tab_id(source_app):
+    with source_app.test_client() as app:
+        resp = app.post(url_for("main.generate"), data=GENERATE_DATA)
+        assert resp.status_code == 200
+        resp = app.post(url_for("main.create"), follow_redirects=True)
+        assert not SessionManager.is_user_logged_in(db_session=db.session)
+
+        # should be redirected to /lookup
+        text = resp.data.decode("utf-8")
+        assert "There was a temporary problem" in text
+        assert "Get Started" in text
+        assert "codenames" not in session
+
+
+def test_create_bad_tab_id(source_app):
+    with source_app.test_client() as app:
+        resp = app.post(url_for("main.generate"), data=GENERATE_DATA)
+        assert resp.status_code == 200
+        resp = app.post(url_for("main.create"), data={"tab_id": "ohno"}, follow_redirects=True)
+        assert not SessionManager.is_user_logged_in(db_session=db.session)
+
+        # should be redirected to /lookup
+        text = resp.data.decode("utf-8")
+        assert "There was a temporary problem" in text
+        assert "Get Started" in text
+        assert "codenames" not in session
+
+
 def test_generate_as_post(source_app):
     with source_app.test_client() as app:
         resp = app.post(url_for("main.generate"), data=GENERATE_DATA)


### PR DESCRIPTION
Fixes #7619 

## Test plan
- [x] CI is passing
- [ ] source account creation functionality unchanged with single or multiple tabs open
- [ ] (bonus points) send modified `/create` POST requests against a valid session and verify that:
  - [ ] when `tab_id` not set, source creation fails, session is cleared and user is redirected to index
  - [ ] when `tab_id` set to a value not present in session, source creation fails, session is cleared and user is redirected to index

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)