### PR TITLE
feat(`api2`): support conversation truncation via `source_conversation_truncated` event

### DIFF
--- a/API2.md
+++ b/API2.md
@@ -155,7 +155,7 @@ direction TB
 [*] --> CacheLookup : process(event)
 CacheLookup: status = redis.get(event.id)
 
-CacheLookup --> IdempotentBranch : status in {102 Processing, 200 OK}
+CacheLookup --> IdempotentBranch : status in {102 Processing, 200 OK, 207 MultiStatus}
 CacheLookup --> StartBranch : status == None
 
 state "Enforce idempotency" as IdempotentBranch {
@@ -176,10 +176,13 @@ state "handle_&lt;event.type&gt;()" as Handler {
 Handler --> OK
 state "Cache and report success" as SuccessBranch {
     OK : 200 OK
-    OK --> UpdateCache
+    MultiStatus : 207 MultiStatus
 
-    UpdateCache : redis.set(event.id, OK, ttl)
-    UpdateCache --> [*] : return (OK, delta)
+    OK --> UpdateCache
+    MultiStatus --> UpdateCache
+
+    UpdateCache : redis.set(event.id, status, ttl)
+    UpdateCache --> [*] : return (status, delta)
 }
 
 Handler --> BadRequest

--- a/API2.md
+++ b/API2.md
@@ -155,7 +155,7 @@ direction TB
 [*] --> CacheLookup : process(event)
 CacheLookup: status = redis.get(event.id)
 
-CacheLookup --> IdempotentBranch : status in {102 Processing, 200 OK, 207 MultiStatus}
+CacheLookup --> IdempotentBranch : status in {102 Processing, 200 OK}
 CacheLookup --> StartBranch : status == None
 
 state "Enforce idempotency" as IdempotentBranch {
@@ -176,12 +176,9 @@ state "handle_&lt;event.type&gt;()" as Handler {
 Handler --> OK
 state "Cache and report success" as SuccessBranch {
     OK : 200 OK
-    MultiStatus : 207 MultiStatus
-
     OK --> UpdateCache
-    MultiStatus --> UpdateCache
 
-    UpdateCache : redis.set(event.id, status, ttl)
+    UpdateCache : redis.set(event.id, OK, ttl)
     UpdateCache --> [*] : return (status, delta)
 }
 

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+from typing import Any, Dict
 
 from db import db
 from journalist_app import utils
@@ -69,6 +70,7 @@ class EventHandler:
                 EventType.SOURCE_CONVERSATION_DELETED: self.handle_source_conversation_deleted,
                 EventType.SOURCE_STARRED: self.handle_source_starred,
                 EventType.SOURCE_UNSTARRED: self.handle_source_unstarred,
+                EventType.SOURCE_CONVERSATION_TRUNCATED: self.handle_source_conversation_truncated,
             }[event.type]
         except KeyError:
             return EventResult(
@@ -216,6 +218,50 @@ class EventHandler:
             status=(EventStatusCode.OK, None),
             sources={source.uuid: source},
             items=deleted_items,
+        )
+
+    @staticmethod
+    def handle_source_conversation_truncated(event: Event, minor: int) -> EventResult:
+        """
+        A `source_conversation_truncated` event involves deleting all the items
+        in the source's collection with interaction counts less than or equal to
+        the specified upper bound, assumed to be the last item known to the
+        client.  This achieves the same consistency as a
+        `source_conversation_deleted` event without requiring its strict
+        versioning.
+        """
+
+        try:
+            source = Source.query.filter(Source.uuid == event.target.source_uuid).one()
+        except NoResultFound:
+            return EventResult(
+                event_id=event.id,
+                status=(
+                    EventStatusCode.Gone,
+                    None,
+                ),
+            )
+
+        deleted: Dict[ItemUUID, Any] = {}
+        for item in source.collection:
+            if item.interaction_count <= event.data.upper_bound:
+                try:
+                    utils.delete_file_object(item)
+                    deleted[item.uuid] = None
+                except ValueError:
+                    deleted[item.uuid] = item
+
+        if any(deleted.values()):
+            status = EventStatusCode.MultiStatus
+        else:
+            status = EventStatusCode.OK
+
+        db.session.refresh(source)
+        return EventResult(
+            event_id=event.id,
+            status=(status, None),
+            sources={source.uuid: source},
+            items=deleted,
         )
 
     @staticmethod

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict
-from typing import Any, Dict
+from typing import List
 
 from db import db
 from journalist_app import utils
@@ -255,26 +255,27 @@ class EventHandler:
                 ),
             )
 
-        deleted: Dict[ItemUUID, Any] = {}
+        deleted: List[ItemUUID] = []
         for item in source.collection:
             if item.interaction_count <= event.data.upper_bound:
                 try:
                     utils.delete_file_object(item)
-                    deleted[item.uuid] = None
                 except ValueError:
-                    deleted[item.uuid] = item
+                    # `utils.delete_file_object()` is non-atomic: it guarantees
+                    # database deletion but not filesystem deletion.  The former
+                    # is all we need for consistency with the client, and the
+                    # latter will be caught by monitoring for "disconnected"
+                    # submissions.
+                    pass
 
-        if any(deleted.values()):
-            status = EventStatusCode.MultiStatus
-        else:
-            status = EventStatusCode.OK
+                deleted.append(item.uuid)
 
         db.session.refresh(source)
         return EventResult(
             event_id=event.id,
-            status=(status, None),
+            status=(EventStatusCode.OK, None),
             sources={source.uuid: source},
-            items=deleted,
+            items={item_uuid: None for item_uuid in deleted},
         )
 
     @staticmethod

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -120,12 +120,18 @@ class EventHandler:
                 status=(EventStatusCode.Gone, None),
             )
 
-        utils.delete_file_object(item)
-        return EventResult(
-            event_id=event.id,
-            status=(EventStatusCode.OK, None),
-            items={event.target.item_uuid: None},
-        )
+        try:
+            utils.delete_file_object(item)
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.OK, None),
+                items={event.target.item_uuid: None},
+            )
+        except ValueError as exc:
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.InternalServerError, str(exc)),
+            )
 
     @staticmethod
     def handle_reply_sent(event: Event, minor: int) -> EventResult:
@@ -176,13 +182,19 @@ class EventHandler:
         # Mark as deleted all the items in the source's collection
         deleted_items = {item.uuid: None for item in source.collection}
 
-        utils.delete_collection(source.filesystem_id)
-        return EventResult(
-            event_id=event.id,
-            status=(EventStatusCode.OK, None),
-            sources={event.target.source_uuid: None},
-            items=deleted_items,
-        )
+        try:
+            utils.delete_collection(source.filesystem_id)
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.OK, None),
+                sources={event.target.source_uuid: None},
+                items=deleted_items,
+            )
+        except ValueError as exc:
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.InternalServerError, str(exc)),
+            )
 
     @staticmethod
     def handle_source_conversation_deleted(event: Event, minor: int) -> EventResult:
@@ -210,6 +222,7 @@ class EventHandler:
         # Mark as deleted all the items in the source's collection
         deleted_items = {item.uuid: None for item in source.collection}
 
+        # NB. Does not raise exceptions from `utils.delete_file_object()`.
         utils.delete_source_files(source.filesystem_id)
         db.session.refresh(source)
 

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -44,9 +44,6 @@ class EventType(StrEnum):
 class EventStatusCode(IntEnum):
     Processing = 102
     OK = 200
-    # This event decomposes into multiple actions, some of which succeeded and
-    # some of which failed.  Retries for failures must be submitted in a new event.
-    MultiStatus = 207
     # We already saw and processed this event
     AlreadyReported = 208
     BadRequest = 400

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -56,6 +56,7 @@ class EventStatusCode(IntEnum):
     Conflict = 409
     # The target UUID doesn't exist and it was a deletion request
     Gone = 410
+    InternalServerError = 500
     NotImplemented = 501
 
 

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -36,6 +36,7 @@ class EventType(StrEnum):
     ITEM_SEEN = auto()
     SOURCE_DELETED = auto()
     SOURCE_CONVERSATION_DELETED = auto()
+    SOURCE_CONVERSATION_TRUNCATED = auto()
     SOURCE_STARRED = auto()
     SOURCE_UNSTARRED = auto()
 
@@ -43,6 +44,9 @@ class EventType(StrEnum):
 class EventStatusCode(IntEnum):
     Processing = 102
     OK = 200
+    # This event decomposes into multiple actions, some of which succeeded and
+    # some of which failed.  Retries for failures must be submitted in a new event.
+    MultiStatus = 207
     # We already saw and processed this event
     AlreadyReported = 208
     BadRequest = 400
@@ -144,7 +148,21 @@ class ReplySentData(EventData):
             raise ValueError("reply must be a non-empty string")
 
 
-EVENT_DATA_TYPES = {EventType.REPLY_SENT: ReplySentData}
+@dataclass(frozen=True)
+class SourceConversationTruncatedData(EventData):
+    # An upper bound of n means "delete items with interaction counts (sparsely)
+    # up to and including n".
+    upper_bound: int
+
+    def __post_init__(self) -> None:
+        if self.upper_bound < 0:
+            raise ValueError("upper_bound must be non-negative")
+
+
+EVENT_DATA_TYPES = {
+    EventType.REPLY_SENT: ReplySentData,
+    EventType.SOURCE_CONVERSATION_TRUNCATED: SourceConversationTruncatedData,
+}
 
 
 @dataclass(frozen=True)

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -280,6 +280,12 @@ class Submission(db.Model):
         )
 
     @property
+    def interaction_count(self) -> int:
+        # Extract interaction_count from filename
+        # (format: {interaction_count}-{journalist_filename}-*)
+        return int(self.filename.split("-")[0])
+
+    @property
     def is_file(self) -> bool:
         return self.filename.endswith("doc.gz.gpg") or self.filename.endswith("doc.zip.gpg")
 
@@ -293,10 +299,6 @@ class Submission(db.Model):
         else:  # is_message
             seen_by = [m.journalist.uuid for m in self.seen_messages if m.journalist]
 
-        # Extract interaction_count from filename
-        # (format: {interaction_count}-{journalist_filename}-*)
-        interaction_count = int(self.filename.split("-")[0])
-
         data = {
             "kind": "file" if self.is_file else "message",
             "uuid": self.uuid,
@@ -308,7 +310,7 @@ class Submission(db.Model):
         }
 
         if minor >= 2:
-            data["interaction_count"] = interaction_count
+            data["interaction_count"] = self.interaction_count
 
         return data
 
@@ -409,11 +411,13 @@ class Reply(db.Model):
             base.joinedload(cls.seen_replies).joinedload(SeenReply.journalist),  # type: ignore[attr-defined]
         )
 
-    def to_api_v2(self, minor: int) -> Dict[str, Any]:
+    @property
+    def interaction_count(self) -> int:
         # Extract interaction_count from filename
-        # (format: {interaction_count}-{journalist_filename}-reply.gpg)
-        interaction_count = int(self.filename.split("-")[0])
+        # (format: {interaction_count}-{journalist_filename}-*)
+        return int(self.filename.split("-")[0])
 
+    def to_api_v2(self, minor: int) -> Dict[str, Any]:
         data = {
             "kind": "reply",
             "uuid": self.uuid,
@@ -425,7 +429,7 @@ class Reply(db.Model):
         }
 
         if minor >= 2:
-            data["interaction_count"] = interaction_count
+            data["interaction_count"] = self.interaction_count
 
         return data
 

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -1170,10 +1170,10 @@ def test_api2_source_conversation_truncated(
 
         status_code, msg = response.json["events"][event.id]
         # Because some deletes may fail (simulated) and some succeed, the handler
-        # returns 200 if all succeed, or 207 (MultiStatus) if any fail.
+        # returns 200 if all succeed.
         # The test_files fixtures never cause delete_file_object() to raise,
         # so OK (200) is expected.
-        assert status_code in (200, 207)
+        assert status_code == 200
 
         # Verify item-wise results
         returned_items = response.json["items"]

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -1106,3 +1106,104 @@ def test_api_minor_versions(journalist_app, journalist_api_token, test_files, mi
 
         else:
             assert "events" not in resp.json
+
+
+def test_api2_source_conversation_truncated(
+    journalist_app,
+    journalist_api_token,
+    test_files,
+):
+    """
+    Test processing of the "source_conversation_truncated" event.
+    Items with interaction_count <= upper_bound must be deleted.
+    Items with interaction_count > upper_bound must remain.
+    """
+    with journalist_app.test_client() as app:
+        source = test_files["source"]
+
+        # Ensure we have submissions/replies and interaction_count fields
+        assert len(test_files["submissions"]) >= 1
+        assert len(test_files["replies"]) >= 1
+
+        # Fetch index to get current versions and interaction counts
+        index = app.get(
+            url_for("api2.index"),
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert index.status_code == 200
+
+        # Build a map of item_uuid -> interaction_count
+        item_uuids = [item.uuid for item in (test_files["submissions"] + test_files["replies"])]
+
+        batch_resp = app.post(
+            url_for("api2.data"),
+            json={"items": item_uuids},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert batch_resp.status_code == 200
+        data = batch_resp.json
+
+        initial_counts = {
+            item_uuid: item["interaction_count"] for item_uuid, item in data["items"].items()
+        }
+
+        # Choose a bound that deletes some but not all items
+        # Pick the median interaction_count so we get both outcomes
+        sorted_counts = sorted(initial_counts.values())
+        upper_bound = sorted_counts[len(sorted_counts) // 2]
+
+        source_version = index.json["sources"][source.uuid]
+
+        event = Event(
+            id="999001",
+            target=SourceTarget(source_uuid=source.uuid, version=source_version),
+            type=EventType.SOURCE_CONVERSATION_TRUNCATED,
+            data={"upper_bound": upper_bound},
+        )
+
+        response = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(event)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.status_code == 200
+
+        status_code, msg = response.json["events"][event.id]
+        # Because some deletes may fail (simulated) and some succeed, the handler
+        # returns 200 if all succeed, or 207 (MultiStatus) if any fail.
+        # The test_files fixtures never cause delete_file_object() to raise,
+        # so OK (200) is expected.
+        assert status_code in (200, 207)
+
+        # Verify item-wise results
+        returned_items = response.json["items"]
+        assert isinstance(returned_items, dict)
+
+        for item_uuid, count in initial_counts.items():
+            if count <= upper_bound:
+                # Must be returned as deleted: {uuid: None}
+                assert item_uuid in returned_items
+                assert returned_items[item_uuid] is None
+                # Also confirm removal in DB
+                assert (
+                    Submission.query.filter(Submission.uuid == item_uuid).one_or_none()
+                    or Reply.query.filter(Reply.uuid == item_uuid).one_or_none()
+                ) is None
+            else:
+                # Must not be deleted
+                assert (
+                    Submission.query.filter(Submission.uuid == item_uuid).one_or_none()
+                    or Reply.query.filter(Reply.uuid == item_uuid).one_or_none()
+                ) is not None
+
+        # Source must still exist
+        assert Source.query.filter(Source.uuid == source.uuid).one_or_none() is not None
+
+        # Resubmission must yield "Already Reported" (208)
+        res2 = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(event)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert res2.status_code == 200
+        assert res2.json["events"][event.id][0] == 208


### PR DESCRIPTION
Closes #7707 by adding a `source_conversation_truncated` event that deletes items in a source's collection up to and including the specified interaction count.

While I was here, I also added more try/catch logic around exceptions from utility functions for parity with the v1 API endpoints.


## Test plan

Does this give us everything we want for a "source conversation deleted"‒like event without requiring strict versioning?


## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)