### PR TITLE
Upgrade urllib3 to 2.6.1 (dev only)

### DIFF
--- a/admin/requirements-dev.in
+++ b/admin/requirements-dev.in
@@ -9,7 +9,6 @@ pytest==7.2.0
 requests>=2.30.0
 tox==3.28.0
 pexpect
-urllib3>=2.5.0
 setuptools>=78.1.1
 
 # If this needs updating, search this repository for other references to "pip"

--- a/admin/requirements-dev.txt
+++ b/admin/requirements-dev.txt
@@ -301,12 +301,10 @@ tox==3.28.0 \
     --hash=sha256:57b5ab7e8bb3074edc3c0c0b4b192a4f3799d3723b2c5b76f1fa9f2d40316eea \
     --hash=sha256:d0d28f3fe6d6d7195c27f8b054c3e99d5451952b54abdae673b71609a581f640
     # via -r requirements-dev.in
-urllib3==2.5.0 \
-    --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
-    --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
-    # via
-    #   -r requirements-dev.in
-    #   requests
+urllib3==2.6.1 \
+    --hash=sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f \
+    --hash=sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b
+    # via requests
 virtualenv==20.34.0 \
     --hash=sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026 \
     --hash=sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a

--- a/securedrop/requirements/develop-requirements.in
+++ b/securedrop/requirements/develop-requirements.in
@@ -37,8 +37,6 @@ shellcheck-py
 six>=1.16.0
 pytest-testinfra>=5.3.1
 translate-toolkit
-urllib3>=2.5.0;python_version>="3.9"
-urllib3>=1.26.5
 uv>=0.9.6  # Safety 80896
 yamllint
 zizmor

--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -1327,11 +1327,10 @@ typing-inspection==0.4.2 \
     # via
     #   pydantic
     #   pydantic-settings
-urllib3==2.5.0 \
-    --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
-    --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
+urllib3==2.6.1 \
+    --hash=sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f \
+    --hash=sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b
     # via
-    #   -r requirements/develop-requirements.in
     #   requests
     #   semgrep
 uv==0.9.7 \

--- a/securedrop/requirements/test-requirements.in
+++ b/securedrop/requirements/test-requirements.in
@@ -13,8 +13,6 @@ pytest-mock
 requests[socks]>=2.31.0
 selenium>4.15.1
 tbselenium>=0.9
-urllib3>=2.5.0;python_version>="3.9"
-urllib3>=1.26.5
 # mypy and co.
 mypy>=1.0
 sqlalchemy-stubs==0.4

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -382,11 +382,10 @@ typing-extensions==4.1.1 \
     # via
     #   mypy
     #   sqlalchemy-stubs
-urllib3==2.5.0 \
-    --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
-    --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
+urllib3==2.6.1 \
+    --hash=sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f \
+    --hash=sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b
     # via
-    #   -r requirements/test-requirements.in
     #   requests
     #   selenium
 uv==0.9.7 \


### PR DESCRIPTION
Addresses CVE-2025-66418 and CVE-2025-66471. Also remove it from the various *.in files because it's not a direct dependency.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
CI should be sufficient.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)