### PR TITLE
Suppress alert for CVE-2025-67897 in Sequoia-PGP

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,6 +1,8 @@
 [advisories]
 # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
 ignore = [
+    # CVE-2025-67897 in Sequoia, we don't decrypt packets from attackers (just journalists)
+    "RUSTSEC-2025-0136"
 ]
 
 # Output Configuration


### PR DESCRIPTION
We don't decrypt messages from attackers, just journalists, and even then it's just a DoS. #7225 tracks the upgrading of Sequoia-PGP.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)