### PR TITLE
Update image build automation to drop redundant tag prep jobs

### DIFF
--- a/.github/workflows/demo-landing.yml
+++ b/.github/workflows/demo-landing.yml
@@ -8,32 +8,9 @@ on:
     - devops/demo/landing-page/**
 
 jobs:
-  prepare:
-    name: Prepare
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
-    steps:
-    - name: Determine tags
-      id: tags
-      env:
-        REF: ${{ github.ref_name }}
-        SHA: ${{ github.sha }}
-      # So annoying that GHA doesn't have a builtin substring
-      # function (or expose the shortened SHA). If it did then
-      # we could drop this whole job and just set it as a statically
-      # templated value in the build job.
-      run: |
-        echo "tags=$REF;$REF-${SHA:0:7}" >>$GITHUB_OUTPUT
-    outputs:
-      tags: ${{ steps.tags.outputs.tags }}
-
   build:
     name: Build Landing Page
     uses: freedomofpress/actionslib/.github/workflows/oci-build.yaml@main
-    needs:
-    - prepare
     permissions:
       contents: read
       actions: read
@@ -41,7 +18,7 @@ jobs:
     with:
       context: "."
       containerfile: devops/demo/landing-page/Dockerfile
-      tags: ${{ needs.prepare.outputs.tags }}
       registry: ghcr.io/freedomofpress/securedrop-demo-landing-page
+      add-branch-tags: true
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/demo-publish.yml
+++ b/.github/workflows/demo-publish.yml
@@ -7,32 +7,9 @@ on:
     tags: ["**"]  # run for all tags
 
 jobs:
-  prepare:
-    name: Prepare
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
-    steps:
-    - name: Determine tags
-      id: tags
-      env:
-        REF: ${{ github.ref_name }}
-        SHA: ${{ github.sha }}
-      # So annoying that GHA doesn't have a builtin substring
-      # function (or expose the shortened SHA). If it did then
-      # we could drop this whole job and just set it as a statically
-      # templated value in the build job.
-      run: |
-        echo "tags=$REF;$REF-${SHA:0:7}" >>$GITHUB_OUTPUT
-    outputs:
-      tags: ${{ steps.tags.outputs.tags }}
-
   build:
     name: Build
     uses: freedomofpress/actionslib/.github/workflows/oci-build.yaml@main
-    needs:
-    - prepare
     strategy:
       matrix:
         debian:
@@ -44,7 +21,7 @@ jobs:
     with:
       context: "."
       containerfile: securedrop/dockerfiles/${{ matrix.debian }}/python3/DemoDockerfile
-      tags: ${{ needs.prepare.outputs.tags }}
       registry: ghcr.io/freedomofpress/securedrop-demo-${{ matrix.debian }}
+      add-branch-tags: true
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Drops the `prepare` jobs for calculating tags ahead of image builds
* Leverages the new features implemented in freedomofpress/actionslib#34