### PR TITLE
Fix division by zero in delete-disconnected-fs-submissions

### DIFF
--- a/securedrop/management/submissions.py
+++ b/securedrop/management/submissions.py
@@ -149,7 +149,7 @@ def delete_disconnected_fs_submissions(args: argparse.Namespace) -> None:
                 remove = input(f"Enter 'y' to delete {f}: ") == "y"
             if remove:
                 filesize = os.stat(f).st_size
-                if i > 1:
+                if i > 1 and rate > 0:
                     eta = filesize / rate
                     eta_msg = f" (ETA to remove {filesize:d} bytes: {eta:.0f}s )"
                 print(f"Securely removing file {i}/{filecount} {f}{eta_msg}...")


### PR DESCRIPTION
Fixes #7201

When deleting disconnected filesystem submissions, if a file has zero bytes, `rate` becomes 0 after the first deletion. On subsequent iterations, the ETA calculation `filesize / rate` causes a `ZeroDivisionError`.

This adds a guard to skip the ETA calculation when rate is zero.

## Test plan

1. Create a disconnected empty file in the store
2. Run `manage.py delete-disconnected-fs-submissions --force`
3. Verify no ZeroDivisionError occurs

## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)