### PR TITLE
Return HTTP 404 instead of 500 for missing files in serve_file_with_etag

### DIFF
--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -567,13 +567,16 @@ def col_download_all(cols_selected: List[str]) -> werkzeug.Response:
 def serve_file_with_etag(db_obj: Union[Reply, Submission]) -> flask.Response:
     file_path = Storage.get_default().path(db_obj.source.filesystem_id, db_obj.filename)
     add_range_headers = not current_app.config["USE_X_SENDFILE"]
-    response = send_file(
-        file_path,
-        mimetype="application/pgp-encrypted",
-        as_attachment=True,
-        etag=False,
-        conditional=add_range_headers,
-    )  # Disable Flask default ETag
+    try:
+        response = send_file(
+            file_path,
+            mimetype="application/pgp-encrypted",
+            as_attachment=True,
+            etag=False,
+            conditional=add_range_headers,
+        )  # Disable Flask default ETag
+    except FileNotFoundError:
+        abort(404)
 
     if not db_obj.checksum:
         add_checksum_for_file(db.session, db_obj, file_path)


### PR DESCRIPTION
Fixes #7202

## Test plan

1. Create a source and submit a message/file
2. Delete the source's directory from `/var/lib/securedrop/store`
3. Attempt to download the submission via the API
4. Verify HTTP 404 is returned instead of 500

## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)