### PR TITLE
Fix manage.py delete-user failing on users with SeenMessage records

### DIFF
--- a/securedrop/manage.py
+++ b/securedrop/manage.py
@@ -272,7 +272,7 @@ def delete_user(args: argparse.Namespace, context: Optional[AppContext] = None) 
 
         # Try to delete user from the database
         try:
-            db.session.delete(selected_user)
+            selected_user.delete()
             db.session.commit()
         except Exception as e:
             # If the user was deleted between the user selection and


### PR DESCRIPTION
Fixes #6616

`manage.py delete-user` fails with an `IntegrityError` when deleting a user that has `SeenMessage` records. This happens because it calls `db.session.delete()` directly instead of using the `Journalist.delete()` method, which properly handles related records.

This change updates `manage.py` to use `Journalist.delete()`, matching the behavior of the Admin Interface.

## Test plan

1. Create a user via `manage.py add-journalist`
2. Log in as that user via SecureDrop Client and read some messages (creating SeenMessage records)
3. Run `manage.py delete-user` and enter the username
4. Verify the user is deleted successfully without errors

## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)