### PR TITLE
Filter sources without last_updated from API response

### DIFF
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -120,7 +120,11 @@ def make_blueprint() -> Blueprint:
 
     @api.route("/sources", methods=["GET"])
     def get_all_sources() -> Tuple[flask.Response, int]:
-        sources = Source.query.filter_by(pending=False, deleted_at=None).all()
+        sources = (
+            Source.query.filter_by(pending=False, deleted_at=None)
+            .filter(Source.last_updated.isnot(None))
+            .all()
+        )
         return jsonify({"sources": [source.to_api_v1() for source in sources]}), 200
 
     @api.route("/sources/<source_uuid>", methods=["GET", "DELETE"])


### PR DESCRIPTION
Fixes #6667

The Journalist API's `/sources` endpoint was returning sources that the Journalist Interface filters out. Specifically, sources with `last_updated=None` were included in API responses but excluded from the JI.

This adds the missing `.filter(Source.last_updated.isnot(None))` to align the API with the Journalist Interface behavior.

## Test plan

1. Start the dev environment and create a source that has not yet submitted anything (so `last_updated` is null)
2. Query `/api/v1/sources` - verify the incomplete source is not returned
3. Submit something as that source
4. Query `/api/v1/sources` again - verify the source now appears

## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)