### PR TITLE
Replace Orfox references with Tor Browser for Android

### DIFF
--- a/securedrop/source_templates/index.html
+++ b/securedrop/source_templates/index.html
@@ -45,7 +45,7 @@
     <span id="browser-tb-close" aria-label="{{ gettext('Close') }}">×</span></p>
   </div>
   <div id="browser-android" class="warning" role="alert">
-    <p>{{ gettext('<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Orfox does not provide the same level of security and anonymity as the desktop version.</strong> <a class="recommend-tor" aria-label="Learn how to install Tor Browser" href="{tor_browser_url}" >Learn how to install it</a>, or ignore this warning to continue.').format(tor_browser_url=url_for('info.recommend_tor_browser')) }}
+    <p>{{ gettext('<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Tor Browser for Android does not provide the same level of security and anonymity as the desktop version.</strong> <a class="recommend-tor" aria-label="Learn how to install Tor Browser" href="{tor_browser_url}" >Learn how to install it</a>, or ignore this warning to continue.').format(tor_browser_url=url_for('info.recommend_tor_browser')) }}
     <span id="browser-android-close" aria-label="{{ gettext('Close') }}">×</span></p>
   </div>
 

--- a/securedrop/static/js/source.js
+++ b/securedrop/static/js/source.js
@@ -1,5 +1,5 @@
 const TBB_UA_REGEX = /Mozilla\/5\.0 \((Windows NT 10\.0|X11; Linux x86_64|Macintosh; Intel Mac OS X 10\.[0-9]{2}|Windows NT 10\.0; Win64; x64); rv:[0-9]{2,3}\.0\) Gecko\/20100101 Firefox\/([0-9]{2,3})\.0/
-const TB4A_UA_REGEX = /Mozilla\/5\.0 \(Android( [0-9]{2})?; Mobile; rv:[0-9]{2,3}\.0\) Gecko\/(20100101|[0-9]{2}\.0) Firefox\/([0-9]{2,3})\.0/;
+const TB4A_UA_REGEX = /Mozilla\/5\.0 \(Android( [0-9]{2})?; Mobile; rv:[0-9]{2,3}\.0\) Gecko\/(20100101|[0-9]{2,3}\.0) Firefox\/([0-9]{2,3})\.0/;
 
 /**
    Helper function to change display CSS property using CSS selectors

--- a/securedrop/tests/functional/test_source_warnings.py
+++ b/securedrop/tests/functional/test_source_warnings.py
@@ -9,19 +9,19 @@ from tests.functional.web_drivers import _FIREFOX_PATH
 
 
 @pytest.fixture
-def orbot_web_driver(sd_servers):
-    # Create new profile and driver with the orbot user agent
-    orbot_user_agent = "Mozilla/5.0 (Android; Mobile; rv:52.0) Gecko/20100101 Firefox/52.0"
+def tor_browser_android_web_driver(sd_servers):
+    # Create new profile and driver with the Tor Browser for Android user agent
+    tba_user_agent = "Mozilla/5.0 (Android 10; Mobile; rv:115.0) Gecko/115.0 Firefox/115.0"
     f_profile_path2 = "/tmp/testprofile2"
     if os.path.exists(f_profile_path2):
         shutil.rmtree(f_profile_path2)
     os.mkdir(f_profile_path2)
     profile = webdriver.FirefoxProfile(f_profile_path2)
-    profile.set_preference("general.useragent.override", orbot_user_agent)
+    profile.set_preference("general.useragent.override", tba_user_agent)
 
-    orbot_options = webdriver.FirefoxOptions()
-    orbot_options.binary_location = _FIREFOX_PATH
-    orbot_options.profile = profile
+    tba_options = webdriver.FirefoxOptions()
+    tba_options.binary_location = _FIREFOX_PATH
+    tba_options.profile = profile
 
     if sd_servers.journalist_app_base_url.find(".onion") != -1:
         # set FF preference to socks proxy in Tor Browser
@@ -32,17 +32,17 @@ def orbot_web_driver(sd_servers):
         profile.set_preference("network.proxy.socks_remote_dns", True)
         profile.set_preference("network.dns.blockDotOnion", False)
     profile.update_preferences()
-    orbot_web_driver = webdriver.Firefox(options=orbot_options)
+    tba_web_driver = webdriver.Firefox(options=tba_options)
 
     # Set a null locale so this driver behaves the same as the others
-    orbot_web_driver.locale = None  # type: ignore[attr-defined]
+    tba_web_driver.locale = None  # type: ignore[attr-defined]
 
     try:
-        driver_user_agent = orbot_web_driver.execute_script("return navigator.userAgent")
-        assert driver_user_agent == orbot_user_agent
-        yield orbot_web_driver
+        driver_user_agent = tba_web_driver.execute_script("return navigator.userAgent")
+        assert driver_user_agent == tba_user_agent
+        yield tba_web_driver
     finally:
-        orbot_web_driver.quit()
+        tba_web_driver.quit()
 
 
 class TestSourceAppBrowserWarnings:
@@ -72,12 +72,14 @@ class TestSourceAppBrowserWarnings:
 
         navigator.nav_helper.wait_for(warning_banner_is_hidden)
 
-    def test_warning_appears_if_orbot_is_used(self, sd_servers, orbot_web_driver):
+    def test_warning_appears_if_tor_browser_android_is_used(
+        self, sd_servers, tor_browser_android_web_driver
+    ):
         # Given a user
         navigator = SourceAppNavigator(
             source_app_base_url=sd_servers.source_app_base_url,
-            # Who is using Orbot instead of the (desktop) Tor browser
-            web_driver=orbot_web_driver,
+            # Who is using Tor Browser for Android instead of the desktop Tor Browser
+            web_driver=tor_browser_android_web_driver,
         )
 
         # When they access the source app's home page

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -912,7 +912,7 @@ msgstr ""
 msgid "<strong>It is recommended to use Tor Browser to access SecureDrop:</strong> <a class=\"recommend-tor\" href=\"{tor_browser_url}\">Learn how to install it</a>, or ignore this warning to continue."
 msgstr ""
 
-msgid "<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Orfox does not provide the same level of security and anonymity as the desktop version.</strong> <a class=\"recommend-tor\" aria-label=\"Learn how to install Tor Browser\" href=\"{tor_browser_url}\" >Learn how to install it</a>, or ignore this warning to continue."
+msgid "<strong>It is recommended you use the desktop version of Tor Browser to access SecureDrop, as Tor Browser for Android does not provide the same level of security and anonymity as the desktop version.</strong> <a class=\"recommend-tor\" aria-label=\"Learn how to install Tor Browser\" href=\"{tor_browser_url}\" >Learn how to install it</a>, or ignore this warning to continue."
 msgstr ""
 
 msgid "{} logo"


### PR DESCRIPTION
Fixes #6318

## Description

Orfox was discontinued in 2019 and replaced by Tor Browser for Android. This updates the mobile browser warning and related code:

- Update warning text to reference "Tor Browser for Android" instead of "Orfox"
- Fix the `TB4A_UA_REGEX` to match modern Tor Browser for Android user agents (which use 3-digit Gecko versions like `Gecko/115.0`)
- Update test fixture and test names to reflect the change

## Test plan

- Verify warning displays correctly when accessing Source Interface with Tor Browser for Android
- Existing functional test `test_warning_appears_if_tor_browser_android_is_used` covers this behavior

## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)