### PR TITLE
Remove current year from messages.pot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,7 @@ $(POT): securedrop
 		--project="SecureDrop" \
 		--msgid-bugs-address=securedrop@freedom.press \
 		--copyright-holder="Freedom of the Press Foundation" \
+		--header-comment=$$'# Translations template for PROJECT.\n# This file is distributed under the same license as the PROJECT project.\n#' \
 		--add-comments="Translators:" \
 		--strip-comments \
 		--add-location=never \
@@ -363,6 +364,7 @@ $(DESKTOP_POT): ${DESKTOP_BASE}/*.in
 		--project=SecureDrop \
 		--msgid-bugs-address=securedrop@freedom.press \
 		--copyright-holder="Freedom of the Press Foundation" \
+		--header-comment=$$'# Translations template for PROJECT.\n# This file is distributed under the same license as the PROJECT project.\n#' \
 		--add-location=never \
 		--sort-output \
 		$^

--- a/install_files/ansible-base/roles/tails-config/templates/locale/messages.pot
+++ b/install_files/ansible-base/roles/tails-config/templates/locale/messages.pot
@@ -1,7 +1,5 @@
 # Translations template for SecureDrop.
-# Copyright (C) 2025 Freedom of the Press Foundation
 # This file is distributed under the same license as the SecureDrop project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -1,7 +1,5 @@
 # Translations template for SecureDrop.
-# Copyright (C) 2025 Freedom of the Press Foundation
 # This file is distributed under the same license as the SecureDrop project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""


### PR DESCRIPTION
This is pybabel boilerplate and bumping it each year is not actually how copyright works (c.f. <https://hynek.me/til/copyright-years/>), so let's just remove it entirely. No other file has a similar automated requirement it be updated after the new year.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] we're on board with the reasoning behind this
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)