### PR TITLE
refactor: `EventType` → `EventData` is now `EventType` → `(Target, EventData)`

### DIFF
--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -29,12 +29,16 @@ class EventHandler:
     This class is the per-request context for handling events.  To add a handler
     for a new event `thing_done`, you must:
 
-    1. define the enum value `EventType.THING_DONE` in journalist_api2.types;
+    1. define the enum value `EventType.THING_DONE` in
+       `journalist_api2.types.EventType`;
 
-    2. define the handler as a static method `handle_thing_done(event: Event)`
+    2. define its expected target and data types in
+       `journalist_api2.types.EVENT_DATA_TYPES`;
+
+    3. define the handler as a static method `handle_thing_done(event: Event)`
        in this class
 
-    3. explicitly register `{"thing_done": self.handle_thing_done}` inside
+    4. explicitly register `{"thing_done": self.handle_thing_done}` inside
       `EventHandler.process()`.
 
     This is belt-and-suspenders for ensuring that only the intended methods are

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -126,8 +126,8 @@ class ItemTarget(Target):
 @dataclass(frozen=True)
 class EventData:
     """
-    Base class for `<EventType>Data dataclasses, to make their union usable at runtime.
-    For non-empty events, subclass and add to `EVENT_DATA_TYPES`.
+    Base class for `<EventType>Data` dataclasses, to make their union usable at
+    runtime.  For non-empty events, subclass and add to `EVENT_TYPES`.
     """
 
 
@@ -157,9 +157,15 @@ class SourceConversationTruncatedData(EventData):
             raise ValueError("upper_bound must be non-negative")
 
 
-EVENT_DATA_TYPES = {
-    EventType.REPLY_SENT: ReplySentData,
-    EventType.SOURCE_CONVERSATION_TRUNCATED: SourceConversationTruncatedData,
+EVENT_TYPES = {
+    EventType.REPLY_SENT: (SourceTarget, ReplySentData),
+    EventType.ITEM_DELETED: (ItemTarget, None),
+    EventType.ITEM_SEEN: (ItemTarget, None),
+    EventType.SOURCE_DELETED: (SourceTarget, None),
+    EventType.SOURCE_CONVERSATION_DELETED: (SourceTarget, None),
+    EventType.SOURCE_CONVERSATION_TRUNCATED: (SourceTarget, SourceConversationTruncatedData),
+    EventType.SOURCE_STARRED: (SourceTarget, None),
+    EventType.SOURCE_UNSTARRED: (SourceTarget, None),
 }
 
 
@@ -180,45 +186,46 @@ class Event:
         if not isinstance(self.type, EventType):
             object.__setattr__(self, "type", EventType(self.type))
 
+        # Look up the expected types for this event type:
+        expected_target_type, expected_data_type = EVENT_TYPES[self.type]
+
         # Normalize target:
         target = self.target
-        if not isinstance(target, Target):
+        if not isinstance(target, expected_target_type):
             if not isinstance(target, Mapping):
-                raise TypeError(f"invalid event target: {target!r}")
+                raise TypeError(f"invalid event target for type {self.type}: {target!r}")
 
-            if "source_uuid" in target:
-                target = SourceTarget(**target)
-            elif "item_uuid" in target:
-                target = ItemTarget(**target)
-            else:
-                raise TypeError(f"invalid event target: {target}")
+            try:
+                target = expected_target_type(**target)
+            except (TypeError, ValueError):
+                raise TypeError(f"invalid event target for type {self.type}")
 
             object.__setattr__(self, "target", target)
 
         # Normalize data:
         data = self.data
-        if data is None:
+        if data is None and expected_data_type is None:
+            return
+        elif expected_data_type is None:
+            object.__setattr__(self, "data", None)
             return
 
-        # If it's already a `EventData` dataclass, validate it:
+        # If it's already an `EventData` dataclass, validate it:
         if isinstance(data, EventData):
-            expected = EVENT_DATA_TYPES.get(self.type)
-            if expected is not None and not isinstance(data, expected):
+            if not isinstance(data, expected_data_type):
                 raise TypeError(f"invalid event data for type {self.type}")
             return
 
-        # If it's a mapping for an event type that expects data, instantiate an
-        # `EventType` dataclass:
-        if isinstance(data, Mapping) and self.type in EVENT_DATA_TYPES:
+        # If it's a mapping, try to instantiate an `EventData` dataclass:
+        elif isinstance(data, Mapping):
             try:
-                data_obj = EVENT_DATA_TYPES[self.type](**data)
-            except TypeError:
+                data_obj = expected_data_type(**data)
+            except (TypeError, ValueError):
                 raise TypeError(f"invalid event data for type {self.type}")
             object.__setattr__(self, "data", data_obj)
 
-        # Otherwise, discard it.
         else:
-            object.__setattr__(self, "data", None)
+            raise TypeError(f"invalid event data for type {self.type}")
 
 
 @dataclass(frozen=True)

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -12,7 +12,13 @@ from flask import url_for
 from flask_sqlalchemy import get_debug_queries
 from journalist_app import api2, create_app
 from journalist_app.api2.shared import json_version
-from journalist_app.api2.types import VERSION_LEN, Event, EventType, ItemTarget, SourceTarget
+from journalist_app.api2.types import (
+    VERSION_LEN,
+    Event,
+    EventType,
+    ItemTarget,
+    SourceTarget,
+)
 from models import Reply, Source, SourceStar, Submission, db
 from sqlalchemy.orm.exc import MultipleResultsFound
 from tests.factories import SecureDropConfigFactory

--- a/securedrop/tests/test_journalist_api2_event_typing.py
+++ b/securedrop/tests/test_journalist_api2_event_typing.py
@@ -1,0 +1,179 @@
+from uuid import uuid4
+
+import pytest
+from journalist_app.api2.types import (
+    VERSION_LEN,
+    Event,
+    EventType,
+    ItemTarget,
+    ReplySentData,
+    SourceConversationTruncatedData,
+    SourceTarget,
+)
+
+VALID_VERSION = "a" * VERSION_LEN
+VALID_SOURCE_UUID = str(uuid4())
+VALID_ITEM_UUID = str(uuid4())
+VALID_REPLY_UUID = str(uuid4())
+
+
+def test_invalid_id_non_digit():
+    """Event ID must be a digit string."""
+    with pytest.raises(ValueError, match="event ID must be an integer string"):
+        Event(
+            id="abc123",
+            target=SourceTarget(source_uuid=VALID_SOURCE_UUID, version=VALID_VERSION),
+            type=EventType.SOURCE_STARRED,
+        )
+
+
+def test_wrong_target_type_item_for_source_event():
+    """Source events must have SourceTarget, not ItemTarget."""
+    with pytest.raises(TypeError, match="invalid event target for type source_starred"):
+        Event(
+            id="123456",
+            target=ItemTarget(item_uuid=VALID_ITEM_UUID, version=VALID_VERSION),
+            type=EventType.SOURCE_STARRED,
+        )
+
+
+def test_wrong_target_type_source_for_item_event():
+    """Item events must have ItemTarget, not SourceTarget."""
+    with pytest.raises(TypeError, match="invalid event target for type item_deleted"):
+        Event(
+            id="123456",
+            target=SourceTarget(source_uuid=VALID_SOURCE_UUID, version=VALID_VERSION),
+            type=EventType.ITEM_DELETED,
+        )
+
+
+def test_wrong_target_mapping_item_keys_for_source_event():
+    """Source events reject mappings with item_uuid instead of source_uuid."""
+    with pytest.raises(TypeError, match="invalid event target for type source_starred"):
+        Event(
+            id="123456",
+            target={"item_uuid": VALID_ITEM_UUID, "version": VALID_VERSION},
+            type=EventType.SOURCE_STARRED,
+        )
+
+
+def test_wrong_target_mapping_source_keys_for_item_event():
+    """Item events reject mappings with source_uuid instead of item_uuid."""
+    with pytest.raises(TypeError, match="invalid event target for type item_deleted"):
+        Event(
+            id="123456",
+            target={"source_uuid": VALID_SOURCE_UUID, "version": VALID_VERSION},
+            type=EventType.ITEM_DELETED,
+        )
+
+
+def test_target_not_mapping_wrong_type():
+    """Target must be a Target subclass or Mapping."""
+    with pytest.raises(TypeError, match="invalid event target for type source_starred"):
+        Event(
+            id="123456",
+            target="not a target",  # type: ignore[arg-type]
+            type=EventType.SOURCE_STARRED,
+        )
+
+
+def test_data_discarded_when_not_expected():
+    """Data is silently discarded for events that don't expect it."""
+    event = Event(
+        id="123456",
+        target=ItemTarget(item_uuid=VALID_ITEM_UUID, version=VALID_VERSION),
+        type=EventType.ITEM_DELETED,
+        data={"unexpected": "data"},
+    )
+    assert event.data is None
+
+
+def test_wrong_event_data_subclass():
+    """Providing wrong EventData subclass raises TypeError."""
+    wrong_data = SourceConversationTruncatedData(upper_bound=5)
+    with pytest.raises(TypeError, match="invalid event data for type reply_sent"):
+        Event(
+            id="123456",
+            target=SourceTarget(source_uuid=VALID_SOURCE_UUID, version=VALID_VERSION),
+            type=EventType.REPLY_SENT,
+            data=wrong_data,
+        )
+
+
+def test_data_mapping_missing_required_fields():
+    """Data mapping with missing required fields raises TypeError."""
+    with pytest.raises(TypeError, match="invalid event data for type reply_sent"):
+        Event(
+            id="123456",
+            target=SourceTarget(source_uuid=VALID_SOURCE_UUID, version=VALID_VERSION),
+            type=EventType.REPLY_SENT,
+            data={"wrong_field": "value"},
+        )
+
+
+def test_data_none_when_required():
+    """Missing data for events that require it raises TypeError."""
+    with pytest.raises(TypeError, match="invalid event data for type reply_sent"):
+        Event(
+            id="123456",
+            target=SourceTarget(source_uuid=VALID_SOURCE_UUID, version=VALID_VERSION),
+            type=EventType.REPLY_SENT,
+            data=None,
+        )
+
+
+def test_data_unexpected_type():
+    """Data of unexpected type raises TypeError."""
+    with pytest.raises(TypeError, match="invalid event data for type reply_sent"):
+        Event(
+            id="123456",
+            target=SourceTarget(source_uuid=VALID_SOURCE_UUID, version=VALID_VERSION),
+            type=EventType.REPLY_SENT,
+            data="not a dict or EventData",  # type: ignore[arg-type]
+        )
+
+
+def test_valid_event_with_data_mapping():
+    """Valid event with data as mapping is normalized to EventData."""
+    event = Event(
+        id="123456",
+        target=SourceTarget(source_uuid=VALID_SOURCE_UUID, version=VALID_VERSION),
+        type=EventType.REPLY_SENT,
+        data={"uuid": VALID_REPLY_UUID, "reply": "test reply content"},
+    )
+    assert isinstance(event.data, ReplySentData)
+    assert event.data.uuid == VALID_REPLY_UUID
+    assert event.data.reply == "test reply content"
+
+
+def test_valid_event_with_event_data_instance():
+    """Valid event with EventData instance is accepted."""
+    data = ReplySentData(uuid=VALID_REPLY_UUID, reply="test reply")
+    event = Event(
+        id="123456",
+        target=SourceTarget(source_uuid=VALID_SOURCE_UUID, version=VALID_VERSION),
+        type=EventType.REPLY_SENT,
+        data=data,
+    )
+    assert event.data is data
+
+
+def test_valid_event_without_data():
+    """Valid event without data when none expected."""
+    event = Event(
+        id="123456",
+        target=ItemTarget(item_uuid=VALID_ITEM_UUID, version=VALID_VERSION),
+        type=EventType.ITEM_DELETED,
+    )
+    assert event.data is None
+
+
+def test_target_normalized_from_mapping():
+    """Target mapping is normalized to correct Target subclass."""
+    event = Event(
+        id="123456",
+        target={"source_uuid": VALID_SOURCE_UUID, "version": VALID_VERSION},
+        type=EventType.SOURCE_STARRED,
+    )
+    assert isinstance(event.target, SourceTarget)
+    assert event.target.source_uuid == VALID_SOURCE_UUID


### PR DESCRIPTION
Closes #7744 by typing events as a mapping of types to both target and data.


## Test plan

CI should be sufficient.

**NB.**  Tests were generated by Claude.  Although they're more finicky than I would have written by hand, that seems like a virtue for testing validation logic, and they've already been useful in finding some rejection edge cases.  I've put them into a separate test suite `test_journalist_api2_event_typing.py` so they don't clutter up the main behavioral test suite `test_journalist_api2.py`, but let me know if they seem like overkill.


## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)