### PR TITLE
Upgrade wheel to 0.46.3 in dev and admin requirements

### DIFF
--- a/admin/requirements-dev.txt
+++ b/admin/requirements-dev.txt
@@ -241,6 +241,7 @@ packaging==25.0 \
     #   build
     #   pytest
     #   tox
+    #   wheel
 pexpect==4.9.0 \
     --hash=sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523 \
     --hash=sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f
@@ -309,9 +310,9 @@ virtualenv==20.34.0 \
     --hash=sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026 \
     --hash=sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a
     # via tox
-wheel==0.45.1 \
-    --hash=sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729 \
-    --hash=sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248
+wheel==0.46.3 \
+    --hash=sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d \
+    --hash=sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/securedrop/requirements/bootstrap-requirements.in
+++ b/securedrop/requirements/bootstrap-requirements.in
@@ -1,3 +1,3 @@
 packaging>=22.0  # pypa/setuptools#4483
 setuptools-scm>=8.0.0
-wheel>=0.38.1
+wheel>=0.46.2

--- a/securedrop/requirements/bootstrap-requirements.txt
+++ b/securedrop/requirements/bootstrap-requirements.txt
@@ -6,6 +6,7 @@ packaging==24.1 \
     # via
     #   -r requirements/bootstrap-requirements.in
     #   setuptools-scm
+    #   wheel
 pip==25.2 \
     --hash=sha256:578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2 \
     --hash=sha256:6d67a2b4e7f14d8b31b8b52648866fa717f45a1eb70e83002f4331d07e953717
@@ -22,7 +23,7 @@ setuptools-scm==8.1.0 \
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/bootstrap-requirements.in
-wheel==0.38.4 \
-    --hash=sha256:965f5259b566725405b05e7cf774052044b1ed30119b5d586b2703aafe8719ac \
-    --hash=sha256:b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8
+wheel==0.46.3 \
+    --hash=sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d \
+    --hash=sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803
     # via -r requirements/bootstrap-requirements.in


### PR DESCRIPTION


## Test plan
- [ ] CI is passing
- [ ] `wheel` is updated everywhere it occurs.
