### PR TITLE
SecureDrop 2.14.0~rc1

### DIFF
--- a/admin/debian/changelog
+++ b/admin/debian/changelog
@@ -1,8 +1,8 @@
 securedrop-admin (2.14.0~rc1) unstable; urgency=medium
 
-  * 
+  * see changelog.md
 
- -- SecureDrop Team <securedrop@freedom.press>  Fri, 05 Dec 2025 10:56:36 -0500
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 05 Feb 2026 12:44:51 -0500
 
 securedrop-admin (2.13.0) unstable; urgency=medium
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,41 @@
 
 ## 2.14.0~rc1
 
+### Web Applications and API
+
+* Update Source Interface warning banner to refer to modern mobile browsers (#7751)
+
+* v2 Journalist API:
+  * Support conversation truncation via source\_conversation\_truncated event (#7723)
+  * Document synchronization behaviour with multiple clients (#7734)
+  * Strengthen binding between Event.type and Event.target (#7744)
+
+### Operations
+
+* Ensure KeePassXC is installed with securedrop-admin (#7762)
+
+### Development
+
+* Update image build automation to drop redundant tag prep jobs (#7742)
+* Remove current year from messages.pot (#7753)
+* Have ruff lint against Python 3.12 as its baseline (#7764)
+
+* Dependency updates:
+  * Github actions/checkout from 5 to 6 (#7724)
+  * Github actions/cache from 4 to 5 (#7739)
+  * Github actions/download-artifact from 5 to 7 (#7738)
+  * Github actions/upload-artifact from 5 to 6 (#7740)
+  * urllib3 from 2.5.0 to 2.6.3 (#7736, #7754)
+  * filelock from 3.19.1 to 3.20.3 (#7743, #7765)
+  * wheel from 0.45.1 to 0.46.3 (#7760)
+  * python-multipart from 0.0.20 to 0.0.22 (#7761)
+  * virtualenv from 20.34.0 to 20.36.1 (#7765)
+  * pynacl from 1.5.* to 1.6.2 (#7765)
+  * protobuf from 6.33.0 to 6.33.5 (#7765)
+  * pip from 25.0 to 26.0 (#7766)
+
+* Ignores:
+  * CVE-2025-67897 in Sequoia-PGP (7741)
 
 
 ## 2.13.0

--- a/securedrop/debian/changelog
+++ b/securedrop/debian/changelog
@@ -1,8 +1,8 @@
 securedrop (2.14.0~rc1) unstable; urgency=medium
 
-  * 
+  * see changelog.md
 
- -- SecureDrop Team <securedrop@freedom.press>  Fri, 05 Dec 2025 10:56:53 -0500
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 05 Feb 2026 12:45:21 -0500
 
 securedrop (2.13.0) unstable; urgency=medium
 


### PR DESCRIPTION
Towards #7768

- updates version and adds changelog for 2.14.0-rc1

## Test plan
- [ ] CI is good
- [ ] changelog and version bump are consistent
