### PR TITLE
feat(index): let client request arbitrary metadata shards, hinted at login

### DIFF
--- a/API2.md
+++ b/API2.md
@@ -107,34 +107,33 @@ end
 #### Sharding metadata
 
 On login, the server returns _hints_ to help the client choose whether and how
-to shard metadata for sources, items, and journalists:
+to shard metadata for sources and their items:
 
 ```json
 {
   "version": "abcdef",
   "sources": 100,
-  "items": 200,
-  "journalists": 3
+  "items": 200
 }
 ```
 
 A _shard_ is specified by a comma-separated list of UUID prefixes, so that the
 client can choose both the breadth and the depth of the shard:
 
-| Shard | Matches                                                                  |
-| ----- | ------------------------------------------------------------------------ |
-| `a`   | All sources, items, and journalists with UUIDs beginning with `a`        |
-| `ab`  | All sources, items, and journalists with UUIDs beginning with `ab`       |
-| `a,b` | All sources, items, and journalists with UUIDs beginning with `a` or `b` |
+| Shard | Matches                                                            |
+| ----- | ------------------------------------------------------------------ |
+| `a`   | All sources (and their items) with UUIDs beginning with `a`        |
+| `ab`  | All sources (and their items) with UUIDs beginning with `ab`       |
+| `a,b` | All sources (and their items) with UUIDs beginning with `a` or `b` |
 
 Putting it all together, the client MAY make sharding decisions such as:
 
-| Client's version | `version` | `sources` | `items` | `journalists` | Client's next step                                                                | Records synced     |
-| ---------------- | --------- | --------- | ------- | ------------- | --------------------------------------------------------------------------------- | ------------------ |
-| `abcdef`         | `abcdef`  | 100       | 200     | 3             | None; already in sync                                                             | 0                  |
-| `ghijkl`         | `abcdef`  | 100       | 200     | 3             | Global sync; no sharding necessary                                                | 303                |
-| `ghijkl`         | `abcdef`  | 100       | 1000    | 3             | Sync over 4 shards:<br>`["0,1,2,3", "4,5,6,7", "8,9,a,b", "c,d,e,f"]`             | ~275 records/shard |
-| `ghijkl`         | `abcdef`  | 100       | 2000    | 3             | Sync over 8 shards:<br>`["0,1", "2,3", "4,5", "6,7", "8,9", "a,b", "c,d", "e,f"]` | ~262 records/shard |
+| Client's version | `version` | `sources` | `items` | Client's next step                                                                | Records synced     |
+| ---------------- | --------- | --------- | ------- | --------------------------------------------------------------------------------- | ------------------ |
+| `abcdef`         | `abcdef`  | 100       | 200     | None; already in sync                                                             | 0                  |
+| `ghijkl`         | `abcdef`  | 100       | 200     | Global sync; no sharding necessary                                                | 300                |
+| `ghijkl`         | `abcdef`  | 100       | 1000    | Sync over 4 shards:<br>`["0,1,2,3", "4,5,6,7", "8,9,a,b", "c,d,e,f"]`             | ~275 records/shard |
+| `ghijkl`         | `abcdef`  | 100       | 2000    | Sync over 8 shards:<br>`["0,1", "2,3", "4,5", "6,7", "8,9", "a,b", "c,d", "e,f"]` | ~262 records/shard |
 
 The client SHOULD ensure that the set of shards it requests covers either (a)
 the entire UUID namespace or (b) the portion of the UUID namespace of interest.

--- a/API2.md
+++ b/API2.md
@@ -141,7 +141,11 @@ the entire UUID namespace or (b) the portion of the UUID namespace of interest.
 
 #### Batching data
 
-_TK_
+As described in ["Incremental Synchronization"](#incremental-synchronization),
+the client MAY request arbitrary batches of data at any time. During initial
+synchronization, the client MAY choose (for example) to send a separate
+`BatchRequest` for each metadata shard, in order to fetch only the records whose
+metadata was returned in that shard.
 
 ### Incremental synchronization
 

--- a/API2.md
+++ b/API2.md
@@ -75,14 +75,14 @@ participant Client
 participant Server
 
 alt Global
-    Client -->> Server: GET /api/v2/index
+    Client ->> Server: GET /api/v2/index
 else Sharded by UUID prefix
-    Client -->> Server: GET /api/v2/index/<prefix>
+    Client ->> Server: GET /api/v2/index/<prefix>
 end
 
 Server ->> Client: ETag: abcdef<br>Index
 Note over Client: We want metadata for all new sources and items.
-Client -->> Server: POST /api/v2/data<br>BatchRequest
+Client ->> Server: POST /api/v2/data<br>BatchRequest
 Server ->> Client: BatchResponse
 ```
 
@@ -99,9 +99,9 @@ Note over Client: Global version abcdef
 Note over Client: Shard <prefix> version uvwxyz
 
 alt Global
-    Client -->> Server: GET /api/v2/index<br>If-None-Match: abcdef
+    Client ->> Server: GET /api/v2/index<br>If-None-Match: abcdef
 else Sharded by UUID prefix
-    Client -->> Server: GET /api/v2/index/<prefix><br>If-None-Match: uvwxyz
+    Client ->> Server: GET /api/v2/index/<prefix><br>If-None-Match: uvwxyz
 end
 
 alt Up to date
@@ -109,7 +109,7 @@ alt Up to date
 else Out of date
     Server ->> Client: ETag: abcdef<br>Index
     Note over Client: We want metadata for all new/changed sources and items.
-    Client -->> Server: POST /api/v2/data<br>BatchRequest
+    Client ->> Server: POST /api/v2/data<br>BatchRequest
     Server ->> Client: BatchResponse
 end
 ```
@@ -127,7 +127,7 @@ Note over Client: Global version abcdef
 Note over Server: Global version abcdef
 
 Client ->> Client: reply_sent {id: X, uuid: Y, source: Z, ...}
-Client -->> Server: POST /api/v2/data<br>BatchRequest
+Client ->> Server: POST /api/v2/data<br>BatchRequest
 alt Already processed:
 Server ->> Server: look up status of event {id: X}
 Note over Server: Return status of event {id: X},<br>in addition to anything else requested.

--- a/API2.md
+++ b/API2.md
@@ -82,8 +82,8 @@ end
 
 Server ->> Client: ETag: abcdef<br>Index
 Note over Client: We want metadata for all new sources and items.
-Client -->> Server: POST /api/v2/metadata<br>MetadataRequest
-Server ->> Client: MetadataResponse
+Client -->> Server: POST /api/v2/data<br>BatchRequest
+Server ->> Client: BatchResponse
 ```
 
 ### Incremental synchronization
@@ -109,8 +109,8 @@ alt Up to date
 else Out of date
     Server ->> Client: ETag: abcdef<br>Index
     Note over Client: We want metadata for all new/changed sources and items.
-    Client -->> Server: POST /api/v2/metadata<br>MetadataRequest
-    Server ->> Client: MetadataResponse
+    Client -->> Server: POST /api/v2/data<br>BatchRequest
+    Server ->> Client: BatchResponse
 end
 ```
 
@@ -127,7 +127,7 @@ Note over Client: Global version abcdef
 Note over Server: Global version abcdef
 
 Client ->> Client: reply_sent {id: X, uuid: Y, source: Z, ...}
-Client -->> Server: POST /api/v2/metadata<br>BatchRequest
+Client -->> Server: POST /api/v2/data<br>BatchRequest
 alt Already processed:
 Server ->> Server: look up status of event {id: X}
 Note over Server: Return status of event {id: X},<br>in addition to anything else requested.

--- a/API2.md
+++ b/API2.md
@@ -90,8 +90,8 @@ alt Global
     Server ->> Client: ETag: abcdef<br>Index
 else Sharded by sets of UUID prefixes
     loop for shard in shards:
-        Note over Server: Shard <shard> @ version uvwxyz
-        Client ->> Server: GET /api/v2/index/<shard>
+        Note over Server: Shard <shard_spec> @ version uvwxyz
+        Client ->> Server: GET /api/v2/index/<shard_spec>
         Server ->> Client: ETag: uvwxyz<br>Index
     end
 end
@@ -117,8 +117,9 @@ to shard metadata for sources and their items:
 }
 ```
 
-A _shard_ is specified by a comma-separated list of UUID prefixes, so that the
-client can choose both the breadth and the depth of the shard:
+A _shard_ is specified by _shard spec_ consisting of a comma-separated list of
+UUID _prefixes_, so that the client can choose both the breadth and the depth of
+the shard:
 
 | Shard | Matches                                                            |
 | ----- | ------------------------------------------------------------------ |
@@ -156,12 +157,12 @@ participant Client
 participant Server
 
 Note over Client: Global version abcdef
-Note over Client: Shard <shard> @ version uvwxyz
+Note over Client: Shard <shard_spec> @ version uvwxyz
 
 alt Global
     Client ->> Server: GET /api/v2/index<br>If-None-Match: abcdef
 else Sharded by sets of UUID prefixes
-    Client ->> Server: GET /api/v2/index/<shard><br>If-None-Match: uvwxyz
+    Client ->> Server: GET /api/v2/index/<shard_spec><br>If-None-Match: uvwxyz
 end
 
 alt Up to date

--- a/API2.md
+++ b/API2.md
@@ -52,6 +52,11 @@ storage in order to:
 
 ## Overview
 
+> [!NOTE]
+> The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT,
+> RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as
+> described in [RFC 2119].
+
 The request/response schemas referred to in these sequence diagrams are defined
 as mypy types in `securedrop.journalist_app.api2.types`.
 
@@ -74,17 +79,69 @@ sequenceDiagram
 participant Client
 participant Server
 
+Client ->> Server: POST /api/v1/token
+Server ->> Client: token, hints
+
+Note over Client: Calculate shards based on hints.
+
 alt Global
+    Note over Server: Global version abcdef
     Client ->> Server: GET /api/v2/index
-else Sharded by UUID prefix
-    Client ->> Server: GET /api/v2/index/<prefix>
+    Server ->> Client: ETag: abcdef<br>Index
+else Sharded by sets of UUID prefixes
+    loop for shard in shards:
+        Note over Server: Shard <shard> @ version uvwxyz
+        Client ->> Server: GET /api/v2/index/<shard>
+        Server ->> Client: ETag: uvwxyz<br>Index
+    end
 end
 
-Server ->> Client: ETag: abcdef<br>Index
-Note over Client: We want metadata for all new sources and items.
-Client ->> Server: POST /api/v2/data<br>BatchRequest
-Server ->> Client: BatchResponse
+Note over Client: We want metadata for all new sources and items.<br>Calculate batches based on total size.
+
+loop for batch in batches:
+    Client ->> Server: POST /api/v2/data<br>BatchRequest
+    Server ->> Client: BatchResponse
+end
 ```
+
+#### Sharding metadata
+
+On login, the server returns _hints_ to help the client choose whether and how
+to shard metadata for sources, items, and journalists:
+
+```json
+{
+  "version": "abcdef",
+  "sources": 100,
+  "items": 200,
+  "journalists": 3
+}
+```
+
+A _shard_ is specified by a comma-separated list of UUID prefixes, so that the
+client can choose both the breadth and the depth of the shard:
+
+| Shard | Matches                                                                  |
+| ----- | ------------------------------------------------------------------------ |
+| `a`   | All sources, items, and journalists with UUIDs beginning with `a`        |
+| `ab`  | All sources, items, and journalists with UUIDs beginning with `ab`       |
+| `a,b` | All sources, items, and journalists with UUIDs beginning with `a` or `b` |
+
+Putting it all together, the client MAY make sharding decisions such as:
+
+| Client's version | `version` | `sources` | `items` | `journalists` | Client's next step                                                                | Records synced     |
+| ---------------- | --------- | --------- | ------- | ------------- | --------------------------------------------------------------------------------- | ------------------ |
+| `abcdef`         | `abcdef`  | 100       | 200     | 3             | None; already in sync                                                             | 0                  |
+| `ghijkl`         | `abcdef`  | 100       | 200     | 3             | Global sync; no sharding necessary                                                | 303                |
+| `ghijkl`         | `abcdef`  | 100       | 1000    | 3             | Sync over 4 shards:<br>`["0,1,2,3", "4,5,6,7", "8,9,a,b", "c,d,e,f"]`             | ~275 records/shard |
+| `ghijkl`         | `abcdef`  | 100       | 2000    | 3             | Sync over 8 shards:<br>`["0,1", "2,3", "4,5", "6,7", "8,9", "a,b", "c,d", "e,f"]` | ~262 records/shard |
+
+The client SHOULD ensure that the set of shards it requests covers either (a)
+the entire UUID namespace or (b) the portion of the UUID namespace of interest.
+
+#### Batching data
+
+_TK_
 
 ### Incremental synchronization
 
@@ -96,12 +153,12 @@ participant Client
 participant Server
 
 Note over Client: Global version abcdef
-Note over Client: Shard <prefix> version uvwxyz
+Note over Client: Shard <shard> @ version uvwxyz
 
 alt Global
     Client ->> Server: GET /api/v2/index<br>If-None-Match: abcdef
-else Sharded by UUID prefix
-    Client ->> Server: GET /api/v2/index/<prefix><br>If-None-Match: uvwxyz
+else Sharded by sets of UUID prefixes
+    Client ->> Server: GET /api/v2/index/<shard><br>If-None-Match: uvwxyz
 end
 
 alt Up to date
@@ -261,3 +318,4 @@ library like [`@sapphire/snowflake`]. To avoid precision-loss problems:
   testing equality.
 
 [`@sapphire/snowflake`]: https://www.npmjs.com/package/@sapphire/snowflake
+[RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -7,7 +7,7 @@ import werkzeug
 from db import db
 from flask import Blueprint, abort, jsonify, request
 from journalist_app import utils
-from journalist_app.api2.shared import save_reply
+from journalist_app.api2.shared import get_index_hints, save_reply
 from journalist_app.sessions import session
 from models import (
     InvalidUsernameException,
@@ -90,15 +90,18 @@ def make_blueprint() -> Blueprint:
         try:
             journalist = Journalist.login(username, passphrase, one_time_code)
 
-            response = jsonify(
-                {
-                    "token": session.get_token(),
-                    "expiration": session.get_lifetime(),
-                    "journalist_uuid": journalist.uuid,
-                    "journalist_first_name": journalist.first_name,
-                    "journalist_last_name": journalist.last_name,
-                }
-            )
+            response_dict = {
+                "token": session.get_token(),
+                "expiration": session.get_lifetime(),
+                "journalist_uuid": journalist.uuid,
+                "journalist_first_name": journalist.first_name,
+                "journalist_last_name": journalist.last_name,
+            }
+
+            if "Prefer" in request.headers:
+                response_dict["hints"] = get_index_hints()
+
+            response = jsonify(response_dict)
 
             # Update access metadata
             journalist.last_access = datetime.now(UTC)

--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -7,7 +7,7 @@ import werkzeug
 from db import db
 from flask import Blueprint, abort, jsonify, request
 from journalist_app import utils
-from journalist_app.api2.shared import get_index_hints, save_reply
+from journalist_app.api2.shared import get_index_hints, get_request_minor_version, save_reply
 from journalist_app.sessions import session
 from models import (
     InvalidUsernameException,
@@ -98,7 +98,7 @@ def make_blueprint() -> Blueprint:
                 "journalist_last_name": journalist.last_name,
             }
 
-            if "Prefer" in request.headers:
+            if get_request_minor_version(strict=True) >= 4:
                 response_dict["hints"] = get_index_hints()
 
             response = jsonify(response_dict)

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -2,48 +2,26 @@ from dataclasses import asdict
 
 from flask import Blueprint, abort, jsonify, request
 from journalist_app.api2.events import EventHandler
-from journalist_app.api2.shared import json_version
+from journalist_app.api2.shared import (
+    get_index_dict,
+    get_request_minor_version,
+    json_version,
+)
 from journalist_app.api2.types import (
     BatchRequest,
     BatchResponse,
     Event,
-    Index,
 )
 from journalist_app.sessions import session
 from models import EagerQuery, Journalist, Reply, Source, Submission, eager_query
 from redis import Redis
 from sdconfig import SecureDropConfig
-from sqlalchemy.inspection import inspect
 from sqlalchemy.orm.exc import MultipleResultsFound
 from werkzeug.wrappers.response import Response
 
 blp = Blueprint("api2", __name__, url_prefix="/api/v2")
 
 EVENTS_MAX = 50
-PREFIX_MAX_LEN = inspect(Source).columns["uuid"].type.length
-
-
-# Magic numbers to avoid having to define an `IntEnum` somewhere that can be
-# imported from `securedrop.models`:
-#
-# 0. Initial implementation
-# 1. `Index` and `BatchResponse` include `journalists`
-# 2. `Reply` and `Submission` objects include `interaction_count`
-# 3. `BatchRequest` accepts `events` to process, with results returned in
-#    `BatchResponse.events`
-API_MINOR_VERSION = 3  # 2.x
-
-
-def get_request_minor_version() -> int:
-    try:
-        prefer = request.headers.get("Prefer", f"securedrop={API_MINOR_VERSION}")
-        minor_version = int(prefer.split("=")[1])
-        if 0 <= minor_version <= API_MINOR_VERSION:
-            return minor_version
-        else:
-            return API_MINOR_VERSION
-    except (IndexError, ValueError):
-        return API_MINOR_VERSION
 
 
 @blp.get("/index")
@@ -62,35 +40,8 @@ def index(source_prefix: str | None = None) -> Response:
     the prefix and is always returned.)
     """
     minor = get_request_minor_version()
-    index = Index()
 
-    source_query: EagerQuery = eager_query("Source")
-    if source_prefix is not None:
-        if len(source_prefix) >= PREFIX_MAX_LEN:
-            abort(
-                422,
-                f"malformed request; source prefix must be shorter than {PREFIX_MAX_LEN} "
-                f"characters",
-            )
-
-        source_query = source_query.filter(Source.uuid.startswith(source_prefix))
-
-    for source in source_query.all():
-        index.sources[source.uuid] = json_version(source.to_api_v2(minor))
-        for item in source.collection:
-            index.items[item.uuid] = json_version(item.to_api_v2(minor))
-
-    journalist_query: EagerQuery = eager_query("Journalist")
-    for journalist in journalist_query.all():
-        index.journalists[journalist.uuid] = json_version(journalist.to_api_v2(minor))
-
-    # We want to enforce the *current* shape of `Index`, so we should wait until
-    # we have the dictionary representation to delete top-level keys unsupported
-    # by the current minor version.
-    index_dict = asdict(index)
-    if minor < 1:
-        del index_dict["journalists"]
-
+    index_dict = get_index_dict(minor, source_prefix)
     version = json_version(index_dict)
     response = jsonify(index_dict)
 

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -25,23 +25,27 @@ EVENTS_MAX = 50
 
 
 @blp.get("/index")
-@blp.get("/index/<string:source_prefix>")
-def index(source_prefix: str | None = None) -> Response:
+@blp.get("/index/<string:shard_spec>")
+def index(shard_spec: str | None = None) -> Response:
     """
     By default, return the ETag-versioned ``Index`` of all metadata unless the
     client provides the ETag of the current index.
 
-    Given a ``source_prefix``, return the sub-index of source metadata for all
-    sources whose UUIDs begin with that prefix, plus all non-source metadata,
-    unless the client provides the ETag of the current sub-index for that
-    prefix.  The client MAY choose an arbitrary prefix with each request: e.g.,
-    a series of requests with the prefixes ``{0...f}`` will effectively shard
-    the source index into 16 shards.  (Non-source metadata is not filtered by
-    the prefix and is always returned.)
+    Given a ``shard_spec`` of one or more comma-separated shards (UUID
+    prefixes), return the sub-index of source metadata for all sources whose
+    UUIDs begin with any of those prefixes, plus all non-source metadata, unless
+    the client provides the ETag of the current sub-index for that set of
+    shards.  The client MAY choose an arbitrary set of shards with each request:
+    e.g., a series of requests with the shards ``{0...f}`` will effectively
+    shard the source index into 16 shards.  (Non-source metadata is not filtered
+    by shard and is always returned.)
     """
     minor = get_request_minor_version()
+    shards = None
+    if shard_spec is not None:
+        shards = [shard for shard in shard_spec.split(",") if shard]
 
-    index_dict = get_index_dict(minor, source_prefix)
+    index_dict = get_index_dict(minor, shards)
     version = json_version(index_dict)
     response = jsonify(index_dict)
 
@@ -57,7 +61,7 @@ def data() -> Response:
     """
     Return the ``BatchResponse`` requested in the ``BatchRequest``.  The
     client MAY choose an arbitrary list of objects with each request, e.g. from
-    a shard retrieved from ``/index/<source_prefix>``.
+    a shard retrieved from ``/index/<shard_spec>``.
 
     The client MAY include a list of ``Event``s for the server to process over
     arbitrary sources and items.  Ordering is guaranteed within a given

--- a/securedrop/journalist_app/api2/__init__.py
+++ b/securedrop/journalist_app/api2/__init__.py
@@ -31,21 +31,21 @@ def index(shard_spec: str | None = None) -> Response:
     By default, return the ETag-versioned ``Index`` of all metadata unless the
     client provides the ETag of the current index.
 
-    Given a ``shard_spec`` of one or more comma-separated shards (UUID
-    prefixes), return the sub-index of source metadata for all sources whose
+    Given a ``shard_spec`` for a shard consisting of one or more comma-separated
+    UUID prefixes, return the sub-index of source metadata for all sources whose
     UUIDs begin with any of those prefixes, plus all non-source metadata, unless
-    the client provides the ETag of the current sub-index for that set of
-    shards.  The client MAY choose an arbitrary set of shards with each request:
-    e.g., a series of requests with the shards ``{0...f}`` will effectively
-    shard the source index into 16 shards.  (Non-source metadata is not filtered
-    by shard and is always returned.)
+    the client provides the ETag of the current sub-index for that shard.  The
+    client MAY choose an arbitrary ``shard_spec`` with each request: e.g., a
+    series of requests for the shards ``{0...f}`` will effectively shard the
+    source index into 16 shards.  (Non-source metadata is not filtered by shard
+    and is always returned.)
     """
     minor = get_request_minor_version()
-    shards = None
+    shard = None
     if shard_spec is not None:
-        shards = [shard for shard in shard_spec.split(",") if shard]
+        shard = [prefix for prefix in shard_spec.split(",") if prefix]
 
-    index_dict = get_index_dict(minor, shards)
+    index_dict = get_index_dict(minor, shard)
     version = json_version(index_dict)
     response = jsonify(index_dict)
 

--- a/securedrop/journalist_app/api2/shared.py
+++ b/securedrop/journalist_app/api2/shared.py
@@ -35,7 +35,8 @@ PREFIX_MAX_LEN = inspect(Source).columns["uuid"].type.length
 # 2. `Reply` and `Submission` objects include `interaction_count`
 # 3. `BatchRequest` accepts `events` to process, with results returned in
 #    `BatchResponse.events`
-API_MINOR_VERSION = 3  # 2.x
+# 4. `/api/v1/token` provides sync hints
+API_MINOR_VERSION = 4  # 2.x
 
 
 def get_request_minor_version() -> int:
@@ -101,15 +102,20 @@ def get_index_dict(minor: int, source_prefix: str | None = None) -> dict:
     return index_dict
 
 
-def get_index_version() -> Version:
+def get_index_hints() -> dict:
     """
-    APIv1-facing interface for getting *only* the version of the current index,
+    APIv1-facing interface for getting *only* the hints of the current index,
     without negotiation of either the minor version or the source prefix.
     """
-
     minor = get_request_minor_version()
     index_dict = get_index_dict(minor)
-    return json_version(index_dict)
+
+    return {
+        "version": json_version(index_dict),
+        "sources": len(index_dict["sources"]),
+        "items": len(index_dict["items"]),
+        "journalists": len(index_dict["journalists"]),
+    }
 
 
 def save_reply(source: Source, data: dict) -> Reply:

--- a/securedrop/journalist_app/api2/shared.py
+++ b/securedrop/journalist_app/api2/shared.py
@@ -21,6 +21,7 @@ from models import (
     Source,
     eager_query,
 )
+from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.inspection import inspect
 from store import Storage
@@ -35,7 +36,8 @@ PREFIX_MAX_LEN = inspect(Source).columns["uuid"].type.length
 # 2. `Reply` and `Submission` objects include `interaction_count`
 # 3. `BatchRequest` accepts `events` to process, with results returned in
 #    `BatchResponse.events`
-# 4. `/api/v1/token` provides sync hints
+# 4. `/api/v1/token` provides sync hints for client-specified sharding of
+#    `Index`
 API_MINOR_VERSION = 4  # 2.x
 
 
@@ -65,23 +67,26 @@ def json_version(d: Mapping) -> Version:
     return Version(hashlib.blake2s(b).hexdigest())
 
 
-def get_index_dict(minor: int, source_prefix: str | None = None) -> dict:
+def get_index_dict(minor: int, shards: list[str] | None = None) -> dict:
     """
-    APIv2-facing interface for getting the index for the specified source prefix
-    and minor version.
+    APIv2-facing interface for getting the index for the specified minor version
+    and (if specified) shards.
     """
     index = Index()
 
     source_query: EagerQuery = eager_query("Source")
-    if source_prefix is not None:
-        if len(source_prefix) >= PREFIX_MAX_LEN:
-            abort(
-                422,
-                f"malformed request; source prefix must be shorter than {PREFIX_MAX_LEN} "
-                f"characters",
-            )
+    if shards is not None:
+        for shard in shards:
+            if len(shard) >= PREFIX_MAX_LEN:
+                abort(
+                    422,
+                    f"malformed request; each shard must be shorter than {PREFIX_MAX_LEN} "
+                    f"characters",
+                )
 
-        source_query = source_query.filter(Source.uuid.startswith(source_prefix))
+        source_query = source_query.filter(
+            or_(*(Source.uuid.startswith(shard) for shard in shards))
+        )
 
     for source in source_query.all():
         index.sources[source.uuid] = json_version(source.to_api_v2(minor))
@@ -105,7 +110,7 @@ def get_index_dict(minor: int, source_prefix: str | None = None) -> dict:
 def get_index_hints() -> dict:
     """
     APIv1-facing interface for getting *only* the hints of the current index,
-    without negotiation of either the minor version or the source prefix.
+    without negotiation of either the minor version or sharding.
     """
     minor = get_request_minor_version()
     index_dict = get_index_dict(minor)

--- a/securedrop/journalist_app/api2/shared.py
+++ b/securedrop/journalist_app/api2/shared.py
@@ -78,25 +78,25 @@ def json_version(d: Mapping) -> Version:
     return Version(hashlib.blake2s(b).hexdigest())
 
 
-def get_index_dict(minor: int, shards: list[str] | None = None) -> dict:
+def get_index_dict(minor: int, prefixes: list[str] | None = None) -> dict:
     """
     APIv2-facing interface for getting the index for the specified minor version
-    and (if specified) shards.
+    and (if specified) prefixes.
     """
     index = Index()
 
     source_query: EagerQuery = eager_query("Source")
-    if shards is not None:
-        for shard in shards:
-            if len(shard) >= PREFIX_MAX_LEN:
+    if prefixes:
+        for prefix in prefixes:
+            if len(prefix) >= PREFIX_MAX_LEN:
                 abort(
                     422,
-                    f"malformed request; each shard must be shorter than {PREFIX_MAX_LEN} "
+                    f"malformed request; each prefix must be shorter than {PREFIX_MAX_LEN} "
                     f"characters",
                 )
 
         source_query = source_query.filter(
-            or_(*(Source.uuid.startswith(shard) for shard in shards))
+            or_(*(Source.uuid.startswith(prefix) for prefix in prefixes))
         )
 
     for source in source_query.all():

--- a/securedrop/journalist_app/api2/shared.py
+++ b/securedrop/journalist_app/api2/shared.py
@@ -6,20 +6,48 @@ This module contains helper functions factored out of the v1 Journalist API
 import hashlib
 import os
 from collections.abc import Mapping
+from dataclasses import asdict
 from uuid import UUID
 
 from db import db
-from flask import json
-from journalist_app.api2.types import Version
+from flask import abort, json, request
+from journalist_app.api2.types import Index, Version
 from journalist_app.sessions import session
 from models import (
+    EagerQuery,
     InvalidUUID,
     Reply,
     SeenReply,
     Source,
+    eager_query,
 )
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.inspection import inspect
 from store import Storage
+
+PREFIX_MAX_LEN = inspect(Source).columns["uuid"].type.length
+
+# Magic numbers to avoid having to define an `IntEnum` somewhere that can be
+# imported from `securedrop.models`:
+#
+# 0. Initial implementation
+# 1. `Index` and `BatchResponse` include `journalists`
+# 2. `Reply` and `Submission` objects include `interaction_count`
+# 3. `BatchRequest` accepts `events` to process, with results returned in
+#    `BatchResponse.events`
+API_MINOR_VERSION = 3  # 2.x
+
+
+def get_request_minor_version() -> int:
+    try:
+        prefer = request.headers.get("Prefer", f"securedrop={API_MINOR_VERSION}")
+        minor_version = int(prefer.split("=")[1])
+        if 0 <= minor_version <= API_MINOR_VERSION:
+            return minor_version
+        else:
+            return API_MINOR_VERSION
+    except (IndexError, ValueError):
+        return API_MINOR_VERSION
 
 
 def json_version(d: Mapping) -> Version:
@@ -34,6 +62,54 @@ def json_version(d: Mapping) -> Version:
     s = json.dumps(d, separators=[",", ":"], sort_keys=True)
     b = s.encode("utf-8")
     return Version(hashlib.blake2s(b).hexdigest())
+
+
+def get_index_dict(minor: int, source_prefix: str | None = None) -> dict:
+    """
+    APIv2-facing interface for getting the index for the specified source prefix
+    and minor version.
+    """
+    index = Index()
+
+    source_query: EagerQuery = eager_query("Source")
+    if source_prefix is not None:
+        if len(source_prefix) >= PREFIX_MAX_LEN:
+            abort(
+                422,
+                f"malformed request; source prefix must be shorter than {PREFIX_MAX_LEN} "
+                f"characters",
+            )
+
+        source_query = source_query.filter(Source.uuid.startswith(source_prefix))
+
+    for source in source_query.all():
+        index.sources[source.uuid] = json_version(source.to_api_v2(minor))
+        for item in source.collection:
+            index.items[item.uuid] = json_version(item.to_api_v2(minor))
+
+    journalist_query: EagerQuery = eager_query("Journalist")
+    for journalist in journalist_query.all():
+        index.journalists[journalist.uuid] = json_version(journalist.to_api_v2(minor))
+
+    # We want to enforce the *current* shape of `Index`, so we should wait until
+    # we have the dictionary representation to delete top-level keys unsupported
+    # by the current minor version.
+    index_dict = asdict(index)
+    if minor < 1:
+        del index_dict["journalists"]
+
+    return index_dict
+
+
+def get_index_version() -> Version:
+    """
+    APIv1-facing interface for getting *only* the version of the current index,
+    without negotiation of either the minor version or the source prefix.
+    """
+
+    minor = get_request_minor_version()
+    index_dict = get_index_dict(minor)
+    return json_version(index_dict)
 
 
 def save_reply(source: Source, data: dict) -> Reply:

--- a/securedrop/journalist_app/api2/shared.py
+++ b/securedrop/journalist_app/api2/shared.py
@@ -41,7 +41,18 @@ PREFIX_MAX_LEN = inspect(Source).columns["uuid"].type.length
 API_MINOR_VERSION = 4  # 2.x
 
 
-def get_request_minor_version() -> int:
+def get_request_minor_version(strict: bool = False) -> int:
+    """
+    By default, returns the value of x in the header ``Prefer: securedrop=x`` if
+    it is present and within the range ``[0, API_MINOR_VERSION]``; otherwise
+    returns ``API_MINOR_VERSION``.
+
+    In ``strict`` mode, returns -1 if this header is missing, indicating a
+    pre-v2 client that cannot negotiate minor-version compatibility.
+    """
+    if strict and "Prefer" not in request.headers:
+        return -1
+
     try:
         prefer = request.headers.get("Prefer", f"securedrop={API_MINOR_VERSION}")
         minor_version = int(prefer.split("=")[1])
@@ -112,7 +123,7 @@ def get_index_hints() -> dict:
     APIv1-facing interface for getting *only* the hints of the current index,
     without negotiation of either the minor version or sharding.
     """
-    minor = get_request_minor_version()
+    minor = API_MINOR_VERSION
     index_dict = get_index_dict(minor)
 
     return {

--- a/securedrop/journalist_app/api2/shared.py
+++ b/securedrop/journalist_app/api2/shared.py
@@ -119,7 +119,6 @@ def get_index_hints() -> dict:
         "version": json_version(index_dict),
         "sources": len(index_dict["sources"]),
         "items": len(index_dict["items"]),
-        "journalists": len(index_dict["journalists"]),
     }
 
 

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -56,7 +56,7 @@ EventStatus = tuple[EventStatusCode, str | None]
 
 @dataclass
 class Index:
-    # Source metadata, optionally filtered by shard:
+    # Source metadata, optionally filtered by shard spec:
     sources: dict[SourceUUID, Version] = field(default_factory=dict)
     items: dict[ItemUUID, Version] = field(default_factory=dict)
 

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -56,7 +56,7 @@ EventStatus = tuple[EventStatusCode, str | None]
 
 @dataclass
 class Index:
-    # Source metadata, optionally filtered by `source_prefix`:
+    # Source metadata, optionally filtered by shard:
     sources: dict[SourceUUID, Version] = field(default_factory=dict)
     items: dict[ItemUUID, Version] = field(default_factory=dict)
 

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -155,6 +155,157 @@ def test_user_cannot_get_an_api_token_with_no_otp_field(journalist_app, test_jou
         assert response.json["message"] == "one_time_code field is missing"
 
 
+def test_valid_user_gets_hints_with_prefer_header(journalist_app, test_journo):
+    with journalist_app.test_client() as app:
+        valid_token = TOTP(test_journo["otp_secret"]).now()
+        headers = get_api_headers()
+        headers["Prefer"] = "securedrop=4"
+        response = app.post(
+            url_for("api.get_token"),
+            data=json.dumps(
+                {
+                    "username": test_journo["username"],
+                    "passphrase": test_journo["password"],
+                    "one_time_code": valid_token,
+                }
+            ),
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        hints = response.json["hints"]
+        # version is a 64-character BLAKE2s hex digest
+        assert len(hints["version"]) == 64
+        assert isinstance(hints["sources"], int)
+        assert isinstance(hints["items"], int)
+        assert isinstance(hints["journalists"], int)
+
+
+def test_hints_version_matches_index_etag(journalist_app, test_journo):
+    with journalist_app.test_client() as app:
+        valid_token = TOTP(test_journo["otp_secret"]).now()
+        headers = get_api_headers()
+        headers["Prefer"] = "securedrop=4"
+        token_response = app.post(
+            url_for("api.get_token"),
+            data=json.dumps(
+                {
+                    "username": test_journo["username"],
+                    "passphrase": test_journo["password"],
+                    "one_time_code": valid_token,
+                }
+            ),
+            headers=headers,
+        )
+
+        assert token_response.status_code == 200
+        hint_version = token_response.json["hints"]["version"]
+
+        index_headers = get_api_headers(token_response.json["token"])
+        index_headers["Prefer"] = "securedrop=4"
+        index_response = app.get(
+            url_for("api2.index"),
+            headers=index_headers,
+        )
+
+        assert index_response.status_code == 200
+        etag = index_response.get_etag()[0]
+        assert hint_version == etag
+
+
+def test_valid_user_gets_no_hints_without_prefer_header(journalist_app, test_journo):
+    with journalist_app.test_client() as app:
+        valid_token = TOTP(test_journo["otp_secret"]).now()
+        response = app.post(
+            url_for("api.get_token"),
+            data=json.dumps(
+                {
+                    "username": test_journo["username"],
+                    "passphrase": test_journo["password"],
+                    "one_time_code": valid_token,
+                }
+            ),
+            headers=get_api_headers(),
+        )
+
+        assert response.status_code == 200
+        assert "hints" not in response.json
+
+
+def test_failed_auth_wrong_password_with_prefer_header_does_not_query_index(
+    journalist_app, test_journo, mocker
+):
+    mock_get_index_hints = mocker.patch("journalist_app.api.get_index_hints")
+
+    with journalist_app.test_client() as app:
+        valid_token = TOTP(test_journo["otp_secret"]).now()
+        headers = get_api_headers()
+        headers["Prefer"] = "securedrop=4"
+        response = app.post(
+            url_for("api.get_token"),
+            data=json.dumps(
+                {
+                    "username": test_journo["username"],
+                    "passphrase": "wrong password",
+                    "one_time_code": valid_token,
+                }
+            ),
+            headers=headers,
+        )
+
+        assert response.status_code == 403
+        assert "hints" not in response.json
+        mock_get_index_hints.assert_not_called()
+
+
+def test_failed_auth_wrong_2fa_with_prefer_header_does_not_query_index(
+    journalist_app, test_journo, mocker
+):
+    mock_get_index_hints = mocker.patch("journalist_app.api.get_index_hints")
+
+    with journalist_app.test_client() as app:
+        headers = get_api_headers()
+        headers["Prefer"] = "securedrop=4"
+        response = app.post(
+            url_for("api.get_token"),
+            data=json.dumps(
+                {
+                    "username": test_journo["username"],
+                    "passphrase": test_journo["password"],
+                    "one_time_code": "123456",
+                }
+            ),
+            headers=headers,
+        )
+
+        assert response.status_code == 403
+        assert "hints" not in response.json
+        mock_get_index_hints.assert_not_called()
+
+
+def test_failed_auth_invalid_user_with_prefer_header_does_not_query_index(journalist_app, mocker):
+    mock_get_index_hints = mocker.patch("journalist_app.api.get_index_hints")
+
+    with journalist_app.test_client() as app:
+        headers = get_api_headers()
+        headers["Prefer"] = "securedrop=4"
+        response = app.post(
+            url_for("api.get_token"),
+            data=json.dumps(
+                {
+                    "username": "nonexistent_user",
+                    "passphrase": "any passphrase",
+                    "one_time_code": "123456",
+                }
+            ),
+            headers=headers,
+        )
+
+        assert response.status_code == 403
+        assert "hints" not in response.json
+        mock_get_index_hints.assert_not_called()
+
+
 def test_authorized_user_gets_all_sources(journalist_app, test_submissions, journalist_api_token):
     with journalist_app.test_client() as app:
         response = app.get(

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -178,7 +178,6 @@ def test_valid_user_gets_hints_with_prefer_header(journalist_app, test_journo):
         assert len(hints["version"]) == 64
         assert isinstance(hints["sources"], int)
         assert isinstance(hints["items"], int)
-        assert isinstance(hints["journalists"], int)
 
 
 def test_hints_version_matches_index_etag(journalist_app, test_journo):

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -231,6 +231,27 @@ def test_valid_user_gets_no_hints_without_prefer_header(journalist_app, test_jou
         assert "hints" not in response.json
 
 
+def test_valid_user_gets_no_hints_without_compatible_prefer_header(journalist_app, test_journo):
+    with journalist_app.test_client() as app:
+        valid_token = TOTP(test_journo["otp_secret"]).now()
+        headers = get_api_headers()
+        headers["Prefer"] = "securedrop=3"
+        response = app.post(
+            url_for("api.get_token"),
+            data=json.dumps(
+                {
+                    "username": test_journo["username"],
+                    "passphrase": test_journo["password"],
+                    "one_time_code": valid_token,
+                }
+            ),
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        assert "hints" not in response.json
+
+
 def test_failed_auth_wrong_password_with_prefer_header_does_not_query_index(
     journalist_app, test_journo, mocker
 ):

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -101,7 +101,7 @@ def test_api2_not_available_when_disabled(
     ("endpoint", "kwargs"),
     [
         ("api2.index", {}),
-        ("api2.index", {"source_prefix": "foo"}),
+        ("api2.index", {"shard_spec": "foo"}),
         # while this should be a POST request, the 403 will kick in first
         ("api2.data", {}),
     ],
@@ -167,63 +167,153 @@ def test_index(journalist_app, test_files, journalist_api_token, app_storage):
         assert response2.calculate_content_length() == 0
 
 
-def test_index_with_source_prefix(journalist_app, test_files, journalist_api_token):
+def test_index_with_shard(journalist_app, test_files, journalist_api_token):
     """
-    Verify GET /index/<source_prefix> response and HTTP 304 behavior
+    Verify GET /index/<shard_spec> with a single shard prefix: matching,
+    non-matching, deeper prefixes, ETag/304, and that journalists are always
+    included.
     """
     with journalist_app.test_client() as app:
         uuid = test_files["source"].uuid
+        headers = get_api_headers(journalist_api_token)
+
+        # Single-character prefix matching the source
         with assert_query_count(2):
             response = app.get(
-                url_for("api2.index", source_prefix=uuid[0]),
-                headers=get_api_headers(journalist_api_token),
+                url_for("api2.index", shard_spec=uuid[0]),
+                headers=headers,
             )
-
-        # Verify the source is in the response
         assert response.status_code == 200
         assert uuid in response.json["sources"]
-        # test_files generates 2 submissions and 1 reply, so 3 items total
         assert len(response.json["items"]) == 3
 
+        # ETag / 304 behavior
         with assert_query_count(2):
             response2 = app.get(
-                url_for("api2.index", source_prefix=uuid[0]),
-                headers={
-                    **get_api_headers(journalist_api_token),
-                    "If-None-Match": response.headers["ETag"],
-                },
+                url_for("api2.index", shard_spec=uuid[0]),
+                headers={**headers, "If-None-Match": response.headers["ETag"]},
             )
-
-        # With the etag, verify we get an empty 304
         assert response2.status_code == 304
         assert response2.calculate_content_length() == 0
 
-        # Make a response with an invalid source_prefix ("x")
+        # Two-character prefix matching the source
         response3 = app.get(
-            url_for("api2.index", source_prefix="x"),
-            headers=get_api_headers(journalist_api_token),
+            url_for("api2.index", shard_spec=uuid[:2]),
+            headers=headers,
         )
-        # HTTP 200, but zero sources
         assert response3.status_code == 200
-        assert response3.json["sources"] == {}
-        assert response3.json["items"] == {}
+        assert uuid in response3.json["sources"]
+
+        # Two-character prefix that does NOT match
+        different_prefix = "aa" if not uuid.startswith("aa") else "bb"
+        response4 = app.get(
+            url_for("api2.index", shard_spec=different_prefix),
+            headers=headers,
+        )
+        assert response4.status_code == 200
+        assert uuid not in response4.json["sources"]
+
+        # Non-hex ("x") or empty prefix matches no sources but journalists are still present
+        response5 = app.get(
+            url_for("api2.index", shard_spec="x,,"),
+            headers=headers,
+        )
+        assert response5.status_code == 200
+        assert response5.json["sources"] == {}
+        assert response5.json["items"] == {}
+        assert len(response5.json["journalists"]) >= 1
 
 
-def test_index_with_invalid_source_prefix(journalist_app, test_files, journalist_api_token):
+def test_index_with_comma_separated_shards(
+    journalist_app, test_files, journalist_api_token, app_storage
+):
     """
-    Verify that a too-long source_prefix is rejected.
+    Verify that a comma-separated shard_spec (e.g. "a,b") matches sources whose
+    UUIDs begin with any of the listed prefixes.
+    """
+    with journalist_app.app_context():
+        source2, _ = init_source(app_storage)
+        submit(app_storage, source2, 1)
+        source2_uuid = source2.uuid
+
+    with journalist_app.test_client() as app:
+        uuid = test_files["source"].uuid
+        headers = get_api_headers(journalist_api_token)
+
+        shard_spec = f"{uuid[0]},{source2_uuid[0]}"
+        response = app.get(
+            url_for("api2.index", shard_spec=shard_spec),
+            headers=headers,
+        )
+        assert response.status_code == 200
+        assert uuid in response.json["sources"]
+        assert source2_uuid in response.json["sources"]
+        assert len(response.json["journalists"]) >= 1
+
+
+def test_index_sharding_disjoint_union(
+    journalist_app, test_files, journalist_api_token, app_storage
+):
+    """
+    Verify that two disjoint shards covering the full hex namespace combine to
+    equal the global index and share no sources between them.
+    """
+    with journalist_app.app_context():
+        for _ in range(3):
+            s, _ = init_source(app_storage)
+            submit(app_storage, s, 1)
+
+    with journalist_app.test_client() as app:
+        headers = get_api_headers(journalist_api_token)
+
+        global_response = app.get(url_for("api2.index"), headers=headers)
+        assert global_response.status_code == 200
+
+        shard_a = ",".join("01234567")
+        shard_b = ",".join("89abcdef")
+
+        resp_a = app.get(url_for("api2.index", shard_spec=shard_a), headers=headers)
+        resp_b = app.get(url_for("api2.index", shard_spec=shard_b), headers=headers)
+        assert resp_a.status_code == 200
+        assert resp_b.status_code == 200
+
+        # Union of both shards equals the global index
+        combined_sources = {**resp_a.json["sources"], **resp_b.json["sources"]}
+        assert combined_sources == global_response.json["sources"]
+
+        # Shards are disjoint
+        overlap = set(resp_a.json["sources"].keys()) & set(resp_b.json["sources"].keys())
+        assert overlap == set()
+
+
+def test_index_with_invalid_shard(journalist_app, test_files, journalist_api_token):
+    """
+    Verify that a too-long shard prefix is rejected with HTTP 422, whether it
+    appears alone or inside a comma-separated list.
     """
     with journalist_app.test_client() as app:
         uuid = test_files["source"].uuid
         too_long = uuid[0] * 100
+        headers = get_api_headers(journalist_api_token)
+
+        # Single too-long shard
         with assert_query_count(0):
             response = app.get(
-                url_for("api2.index", source_prefix=too_long),
-                headers=get_api_headers(journalist_api_token),
+                url_for("api2.index", shard_spec=too_long),
+                headers=headers,
             )
-
         assert response.status_code == 422
-        assert "malformed request; source prefix must be shorter than" in response.get_data(
+        assert "malformed request; each shard must be shorter than" in response.get_data(
+            as_text=True
+        )
+
+        # Too-long shard inside a comma-separated list
+        response2 = app.get(
+            url_for("api2.index", shard_spec=f"a,{too_long}"),
+            headers=headers,
+        )
+        assert response2.status_code == 422
+        assert "malformed request; each shard must be shorter than" in response2.get_data(
             as_text=True
         )
 

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -224,7 +224,7 @@ def test_index_with_shard(journalist_app, test_files, journalist_api_token):
         assert len(response5.json["journalists"]) >= 1
 
 
-def test_index_with_comma_separated_shards(
+def test_index_with_comma_separated_prefixes(
     journalist_app, test_files, journalist_api_token, app_storage
 ):
     """
@@ -269,11 +269,11 @@ def test_index_sharding_disjoint_union(
         global_response = app.get(url_for("api2.index"), headers=headers)
         assert global_response.status_code == 200
 
-        shard_a = ",".join("01234567")
-        shard_b = ",".join("89abcdef")
+        shard_spec_a = ",".join("01234567")
+        shard_spec_b = ",".join("89abcdef")
 
-        resp_a = app.get(url_for("api2.index", shard_spec=shard_a), headers=headers)
-        resp_b = app.get(url_for("api2.index", shard_spec=shard_b), headers=headers)
+        resp_a = app.get(url_for("api2.index", shard_spec=shard_spec_a), headers=headers)
+        resp_b = app.get(url_for("api2.index", shard_spec=shard_spec_b), headers=headers)
         assert resp_a.status_code == 200
         assert resp_b.status_code == 200
 
@@ -286,9 +286,9 @@ def test_index_sharding_disjoint_union(
         assert overlap == set()
 
 
-def test_index_with_invalid_shard(journalist_app, test_files, journalist_api_token):
+def test_index_with_invalid_prefix(journalist_app, test_files, journalist_api_token):
     """
-    Verify that a too-long shard prefix is rejected with HTTP 422, whether it
+    Verify that a too-long prefix is rejected with HTTP 422, whether it
     appears alone or inside a comma-separated list.
     """
     with journalist_app.test_client() as app:
@@ -296,24 +296,24 @@ def test_index_with_invalid_shard(journalist_app, test_files, journalist_api_tok
         too_long = uuid[0] * 100
         headers = get_api_headers(journalist_api_token)
 
-        # Single too-long shard
+        # Single too-long prefix
         with assert_query_count(0):
             response = app.get(
                 url_for("api2.index", shard_spec=too_long),
                 headers=headers,
             )
         assert response.status_code == 422
-        assert "malformed request; each shard must be shorter than" in response.get_data(
+        assert "malformed request; each prefix must be shorter than" in response.get_data(
             as_text=True
         )
 
-        # Too-long shard inside a comma-separated list
+        # Too-long prefix inside a comma-separated list
         response2 = app.get(
             url_for("api2.index", shard_spec=f"a,{too_long}"),
             headers=headers,
         )
         assert response2.status_code == 422
-        assert "malformed request; each shard must be shorter than" in response2.get_data(
+        assert "malformed request; each prefix must be shorter than" in response2.get_data(
             as_text=True
         )
 


### PR DESCRIPTION
Closes #7689 via Journalist API v2.4, which:

1. returns `hints` in the `/api/v1/token` response if a v2-capable client sends a `Prefers: securedrop=x` header with $x \geq 4$;
2. accepts a `shard_spec` parameter at `/api/v2/index` to allow a client to shard metadata arbitrarily based on these hints; and
3. provides examples of sharding strategies a client might choose for (2) and how they interact with the batching mechanism already implemented at `/api/v2/data`.

https://github.com/freedomofpress/securedrop/blob/6a27cd30b3c9557db29c4ef20fc9318eb1c5d41d/API2.md?plain=1#L109-L118


## Test plan

I recommend reviewing either (a) commit by commit or (b) in this order:
1. documentation
2. implementation
3. tests

Against `make dev`, you can do (e.g.):

```sh-session
$ curl \
    -H "Content-Type: application/json" \
    -H "Prefer: securedrop=4"
    -X POST -d "{\"username\": \"journalist\", \"passphrase\": \"correct horse battery staple profanity oil chewy\", \"one_time_code\": \"`oathtool -b --totp JHCOGO7VCER3EJ4L`\"}" \
    http://localhost:8081/api/v1/token
$ curl \
    -H "Authorization: Token <token>" \
    -H "Prefer: securedrop=4" \
    http://localhost:8081/api/v2/index/<shard_spec>  # for the <shard_spec> of your choice
```


## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)