### PR TITLE
Throttle login attempts for invalid usernames

### DIFF
--- a/securedrop/alembic/versions/b7f98cfd6a71_add_username_to_journalist_login_attempt.py
+++ b/securedrop/alembic/versions/b7f98cfd6a71_add_username_to_journalist_login_attempt.py
@@ -1,0 +1,81 @@
+"""add username to journalist_login_attempt
+
+Revision ID: b7f98cfd6a71
+Revises: 17c559a7a685
+Create Date: 2026-02-10 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b7f98cfd6a71"
+down_revision = "17c559a7a685"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text("PRAGMA legacy_alter_table=ON"))
+
+    # Rename old table
+    op.rename_table("journalist_login_attempt", "journalist_login_attempt_tmp")
+
+    # Create new table with username column instead of journalist_id FK
+    op.create_table(
+        "journalist_login_attempt",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("timestamp", sa.DateTime(), nullable=True),
+        sa.Column("username", sa.String(length=255), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Migrate data: join with journalists to get usernames
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO journalist_login_attempt (id, timestamp, username)
+            SELECT jla.id, jla.timestamp, j.username
+            FROM journalist_login_attempt_tmp jla
+            JOIN journalists j ON jla.journalist_id = j.id
+            """
+        )
+    )
+
+    # Drop old table
+    op.drop_table("journalist_login_attempt_tmp")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text("PRAGMA legacy_alter_table=ON"))
+
+    # Rename new table
+    op.rename_table("journalist_login_attempt", "journalist_login_attempt_tmp")
+
+    # Recreate old table with journalist_id FK
+    op.create_table(
+        "journalist_login_attempt",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("timestamp", sa.DateTime(), nullable=True),
+        sa.Column("journalist_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["journalist_id"], ["journalists.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Migrate data back: join with journalists to get IDs from usernames
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO journalist_login_attempt (id, timestamp, journalist_id)
+            SELECT jla.id, jla.timestamp, j.id
+            FROM journalist_login_attempt_tmp jla
+            JOIN journalists j ON jla.username = j.username
+            """
+        )
+    )
+
+    # Drop temp table
+    op.drop_table("journalist_login_attempt_tmp")

--- a/securedrop/loaddata.py
+++ b/securedrop/loaddata.py
@@ -152,7 +152,7 @@ def add_journalist(
         journalist.pw_hash = journalist._scrypt_hash(test_password, salt)
 
     db.session.add(journalist)
-    attempt = JournalistLoginAttempt(journalist)
+    attempt = JournalistLoginAttempt(journalist.username)
     attempt.timestamp = random_datetime(nullable=True)
     db.session.add(attempt)
     db.session.commit()

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -560,10 +560,6 @@ class Journalist(db.Model):
     last_access = Column(DateTime)
     passphrase_hash = Column(String(256))
 
-    login_attempts = relationship(
-        "JournalistLoginAttempt", backref="journalist", cascade="all, delete"
-    )
-
     MIN_USERNAME_LEN = 3
     MIN_NAME_LEN = 0
     MAX_NAME_LEN = 100
@@ -797,9 +793,10 @@ class Journalist(db.Model):
     _MAX_LOGIN_ATTEMPTS_PER_PERIOD = 5
 
     @classmethod
-    def throttle_login(cls, user: "Journalist") -> None:
+    def throttle_login(cls, username: str) -> None:
+        username = username[:255]
         # Record the login attempt...
-        login_attempt = JournalistLoginAttempt(user)
+        login_attempt = JournalistLoginAttempt(username)
         db.session.add(login_attempt)
         db.session.commit()
 
@@ -808,7 +805,7 @@ class Journalist(db.Model):
             seconds=cls._LOGIN_ATTEMPT_PERIOD
         )
         attempts_within_period = (
-            JournalistLoginAttempt.query.filter(JournalistLoginAttempt.journalist_id == user.id)
+            JournalistLoginAttempt.query.filter(JournalistLoginAttempt.username == username)
             .filter(JournalistLoginAttempt.timestamp > login_attempt_period)
             .all()
         )
@@ -825,6 +822,9 @@ class Journalist(db.Model):
         password: str | None,
         token: str | None,
     ) -> "Journalist":
+        # Login hardening measures
+        cls.throttle_login(username)
+
         try:
             user = Journalist.query.filter_by(username=username).one()
         except NoResultFound:
@@ -832,9 +832,6 @@ class Journalist(db.Model):
 
         if user.username in Journalist.INVALID_USERNAMES:
             raise InvalidUsernameException(gettext("Invalid username"))
-
-        # Login hardening measures
-        cls.throttle_login(user)
 
         sanitized_token = user.verify_2fa_token(token)
 
@@ -944,7 +941,9 @@ class Journalist(db.Model):
                 reply.journalist_id = deleted.id
                 db.session.add(reply)
 
-        # For the rest of the associated data we rely on cascading deletions
+        # Flush reassignments so relationship backrefs are in sync
+        # before the delete processes remaining cascades
+        db.session.flush()
         db.session.delete(self)
 
 
@@ -994,10 +993,10 @@ class JournalistLoginAttempt(db.Model):
     __tablename__ = "journalist_login_attempt"
     id = Column(Integer, primary_key=True)
     timestamp = Column(DateTime, default=datetime.datetime.utcnow, nullable=True)
-    journalist_id = Column(Integer, ForeignKey("journalists.id"), nullable=False)
+    username = Column(String(255), nullable=False)
 
-    def __init__(self, journalist: Journalist) -> None:
-        self.journalist = journalist
+    def __init__(self, username: str) -> None:
+        self.username = username
 
 
 class InstanceConfig(db.Model):

--- a/securedrop/tests/migrations/migration_b7f98cfd6a71.py
+++ b/securedrop/tests/migrations/migration_b7f98cfd6a71.py
@@ -1,0 +1,102 @@
+import uuid
+
+from db import db
+from journalist_app import create_app
+from sqlalchemy import text
+
+from .helpers import random_datetime
+
+
+class UpgradeTester:
+    """Verify that journalist_login_attempt rows are migrated from
+    journalist_id to username."""
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            # Create a journalist
+            db.engine.execute(
+                text(
+                    """\
+                INSERT INTO journalists (uuid, username, passphrase_hash, otp_secret)
+                VALUES (:uuid, :username, :passphrase_hash, :otp_secret)
+                """
+                ),
+                uuid=str(uuid.uuid4()),
+                username="testuser",
+                passphrase_hash="dummy",
+                otp_secret="A" * 32,
+            )
+            journalist = db.engine.execute(
+                text("SELECT id FROM journalists WHERE username='testuser'")
+            ).first()
+            # Insert a login attempt for that journalist
+            db.engine.execute(
+                text(
+                    """\
+                INSERT INTO journalist_login_attempt (timestamp, journalist_id)
+                VALUES (:timestamp, :journalist_id)
+                """
+                ),
+                timestamp=random_datetime(nullable=False),
+                journalist_id=journalist[0],
+            )
+
+    def check_upgrade(self):
+        with self.app.app_context():
+            attempts = db.engine.execute(text("SELECT * FROM journalist_login_attempt")).fetchall()
+            assert len(attempts) == 1
+            # Verify the username column is populated
+            attempt = attempts[0]
+            assert attempt.username == "testuser"
+            # Verify journalist_id column no longer exists
+            assert not hasattr(attempt, "journalist_id")
+
+
+class DowngradeTester:
+    """Verify that journalist_login_attempt rows are migrated back from
+    username to journalist_id."""
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+
+    def load_data(self):
+        with self.app.app_context():
+            # Create a journalist
+            db.engine.execute(
+                text(
+                    """\
+                INSERT INTO journalists (uuid, username, passphrase_hash, otp_secret)
+                VALUES (:uuid, :username, :passphrase_hash, :otp_secret)
+                """
+                ),
+                uuid=str(uuid.uuid4()),
+                username="testuser2",
+                passphrase_hash="dummy",
+                otp_secret="B" * 32,
+            )
+            # Insert a login attempt with username
+            db.engine.execute(
+                text(
+                    """\
+                INSERT INTO journalist_login_attempt (timestamp, username)
+                VALUES (:timestamp, :username)
+                """
+                ),
+                timestamp=random_datetime(nullable=False),
+                username="testuser2",
+            )
+
+    def check_downgrade(self):
+        with self.app.app_context():
+            attempts = db.engine.execute(text("SELECT * FROM journalist_login_attempt")).fetchall()
+            assert len(attempts) == 1
+            attempt = attempts[0]
+            # Verify journalist_id column is restored
+            assert attempt.journalist_id is not None
+            # Verify username column no longer exists
+            assert not hasattr(attempt, "username")

--- a/securedrop/tests/test_db.py
+++ b/securedrop/tests/test_db.py
@@ -64,9 +64,9 @@ def test_throttle_login(journalist_app, test_journo):
     with journalist_app.app_context():
         journalist = test_journo["journalist"]
         for _ in range(Journalist._MAX_LOGIN_ATTEMPTS_PER_PERIOD):
-            Journalist.throttle_login(journalist)
+            Journalist.throttle_login(journalist.username)
         with pytest.raises(LoginThrottledException):
-            Journalist.throttle_login(journalist)
+            Journalist.throttle_login(journalist.username)
 
 
 def test_submission_string_representation(journalist_app, test_source, app_storage):

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -264,6 +264,52 @@ def test_login_throttle(config, journalist_app, test_journo, locale):
 
 @flaky(rerun_filter=utils.flaky_filter_xfail)
 @pytest.mark.parametrize("locale", get_test_locales())
+def test_login_throttle_invalid_username(config, journalist_app, locale):
+    """Login attempts with invalid usernames should be throttled too."""
+    with journalist_app.test_client() as app:
+        with InstrumentedApp(app) as ins:
+            for _ in range(Journalist._MAX_LOGIN_ATTEMPTS_PER_PERIOD):
+                resp = app.post(
+                    url_for("main.login"),
+                    data=dict(
+                        username="invalid_username_that_does_not_exist",
+                        password="invalid",
+                        token="invalid",
+                    ),
+                )
+                assert resp.status_code == 200
+                text = resp.data.decode("utf-8")
+                assert "Login failed" in text
+
+            resp = app.post(
+                url_for("main.login", l=locale),
+                data=dict(
+                    username="invalid_username_that_does_not_exist",
+                    password="invalid",
+                    token="invalid",
+                ),
+            )
+            assert page_language(resp.data) == language_tag(locale)
+            msgids = [
+                "Login failed.",
+                "Please wait at least {num} second before logging in again.",
+            ]
+            with xfail_untranslated_messages(config, locale, msgids):
+                ins.assert_message_flashed(
+                    "{} {}".format(
+                        gettext(msgids[0]),
+                        ngettext(
+                            msgids[1],
+                            "Please wait at least {num} seconds before logging in again.",
+                            Journalist._LOGIN_ATTEMPT_PERIOD,
+                        ).format(num=Journalist._LOGIN_ATTEMPT_PERIOD),
+                    ),
+                    "error",
+                )
+
+
+@flaky(rerun_filter=utils.flaky_filter_xfail)
+@pytest.mark.parametrize("locale", get_test_locales())
 def test_login_throttle_is_not_global(config, journalist_app, test_journo, test_admin, locale):
     """The login throttling should be per-user, not global. Global login
     throttling can prevent all users logging into the application."""
@@ -4004,7 +4050,7 @@ def test_journalist_deletion(journalist_app, app_storage):
     # Create a journalist that's seen two replies and has a login attempt
     source, _ = utils.db_helper.init_source(app_storage)
     journalist, _ = utils.db_helper.init_journalist()
-    db.session.add(JournalistLoginAttempt(journalist))
+    db.session.add(JournalistLoginAttempt(journalist.username))
     replies = utils.db_helper.reply(app_storage, journalist, source, 2)
     # Create a second journalist that's seen those replies
     journalist2, _ = utils.db_helper.init_journalist()
@@ -4023,8 +4069,8 @@ def test_journalist_deletion(journalist_app, app_storage):
     deleted = Journalist.get_deleted()
     assert len(Reply.query.filter_by(journalist_id=deleted.id).all()) == 2
     assert len(SeenReply.query.filter_by(journalist_id=deleted.id).all()) == 2
-    # And there are no login attempts
-    assert JournalistLoginAttempt.query.all() == []
+    # Login attempts are tracked by username, not by FK, so they persist
+    assert len(JournalistLoginAttempt.query.all()) == 1
 
 
 def test_user_sees_os_warning_if_server_past_eol(config, journalist_app, test_journo):


### PR DESCRIPTION
Fixes #3566

Login throttling only kicked in for valid usernames because `throttle_login` was called after the username lookup in `Journalist.login()`. Invalid username attempts bypassed rate-limiting entirely.

This switches `JournalistLoginAttempt` from tracking by `journalist_id` FK to a `username` string column, and moves the throttle check before the username lookup so all attempts are rate-limited uniformly.

## Test plan
- [ ] CI passes
- [ ] Existing throttle tests still pass (`test_login_throttle`, `test_login_throttle_is_not_global`)
- [ ] New `test_login_throttle_invalid_username` verifies nonexistent usernames get throttled
- [ ] Migration up/down tests pass (`test_alembic_head_matches_db_models`, per-migration up/down tests)

## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)