### PR TITLE
chore(documentation): add links to setup Docker on the Dev section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,18 @@ See our [contribution page](CONTRIBUTING.md).
 
 ## Developer Quickstart
 
-To run SecureDrop locally, ensure you have Docker installed and:
+To run SecureDrop locally, ensure you have Docker installed before proceeding any further.
+
+* Follow [this](https://docs.docker.com/engine/install/) official documentation to install **Docker Engine** for Linux (CentOS/Debian/Fedora/RHEL/Ubuntu);
+* Should you be using Windows, Mac, or you prefer to have **Docker Desktop** on Linux: [here](https://docs.docker.com/get-started/get-docker/) is the documentation to set it up.
+
+Once you have Docker up and running, run:
 
 ```
 make dev
 ```
 
 This will start the source interface on `127.0.0.1:8080` and the journalist interface on `127.0.0.1:8081`. The credentials to login are printed in the Terminal. To login to the journalist interface, you must also [generate a two-factor code](https://developers.securedrop.org/en/latest/setup_development.html#credentials).
-
 
 To provision a Python 3 virtual environment for development:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ To run SecureDrop locally, ensure you have Docker installed before proceeding an
 
 * Follow the [official Docker Engine documentation](https://docs.docker.com/engine/install/) to install **Docker Engine**.
 
+> [!TIP]
 > It's also possible to use _Docker Desktop_ on Linux, if you want to. Follow the steps to install [Docker Desktop for Linux](https://docs.docker.com/desktop/setup/install/linux/) then.
 
 ### Windows/MacOS

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See our [contribution page](CONTRIBUTING.md).
 To run SecureDrop locally, ensure you have Docker installed before proceeding any further.
 
 * Follow [this](https://docs.docker.com/engine/install/) official documentation to install **Docker Engine** for Linux (CentOS/Debian/Fedora/RHEL/Ubuntu);
-* Should you be using Windows, Mac, or you prefer to have **Docker Desktop** on Linux: [here](https://docs.docker.com/get-started/get-docker/) is the documentation to set it up.
+* Should you be using Windows, Mac, or you want **Docker Desktop** on Linux: [here](https://docs.docker.com/get-started/get-docker/) is the documentation.
 
 Once you have Docker up and running, run:
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,15 @@ See our [contribution page](CONTRIBUTING.md).
 
 To run SecureDrop locally, ensure you have Docker installed before proceeding any further.
 
-* Follow [this](https://docs.docker.com/engine/install/) official documentation to install **Docker Engine** for Linux (CentOS/Debian/Fedora/RHEL/Ubuntu);
-* Should you be using Windows, Mac, or you want **Docker Desktop** on Linux: [here](https://docs.docker.com/get-started/get-docker/) is the documentation.
+### Linux (CentOS/Debian/Fedora/RHEL/Ubuntu)
+
+* Follow the [official Docker Engine documentation](https://docs.docker.com/engine/install/) to install **Docker Engine**.
+
+> It's also possible to use _Docker Desktop_ on Linux, if you want to. Follow the steps to install [Docker Desktop for Linux](https://docs.docker.com/desktop/setup/install/linux/) then.
+
+### Windows/MacOS
+
+* If you are using Windows or MacOS follow the [official Docker Desktop documentation](https://docs.docker.com/get-started/get-docker/) to install **Docker Desktop**.
 
 Once you have Docker up and running, run:
 


### PR DESCRIPTION
### Change

by merging this change, we:
  - link official Docker documentations to the Developer Quickstart section;
  - offer Docker Engine (CE) and the Docker Desktop options;
  - ensure to list the officially supported Linux distributions;
  - list the `make dev` command only after the mentions about getting Docker running.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any ~required~ additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)