### PR TITLE
Set dependabot cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
See https://github.com/freedomofpress/securedrop-dev-docs/pull/291.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)