### PR TITLE
loaddata: default to NUM_SOURCES=ALL to load with all test strings

### DIFF
--- a/securedrop/loaddata.py
+++ b/securedrop/loaddata.py
@@ -106,7 +106,7 @@ def default_journalist_count() -> str:
 
 
 def default_source_count() -> str:
-    return os.environ.get("NUM_SOURCES", "3")
+    return os.environ.get("NUM_SOURCES", "ALL")
 
 
 def set_source_count(s: str) -> int:


### PR DESCRIPTION
Changes the default number of sources in `loaddata.py` script to use the special string `ALL`, which 

> a number of sources that can demonstrate all of the special strings we want to test, if each source uses two of the strings.

Means that we will load all special strings by default, including long strings, which can be useful for the development workflow.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)