### PR TITLE
ISSUE-7274: Staging job should use pre-built deb packages

### DIFF
--- a/.github/workflows/build-debs-reusable.yml
+++ b/.github/workflows/build-debs-reusable.yml
@@ -1,0 +1,49 @@
+# Reusable: build debs and upload one artifact with build/<ubuntu_version>/ and
+# build/trixie/ (trixie admin deb is venv-ABI-required by the trixie GCE host).
+name: Build Debian packages
+
+on:
+  workflow_call:
+    inputs:
+      ubuntu_version:
+        required: true
+        type: string
+      python_version:
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+
+jobs:
+  package:
+    runs-on: ubuntu-24.04
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python_version }}
+      - name: Build SecureDrop packages
+        run: |
+          OS_VERSION=${{ inputs.ubuntu_version }} ./builder/build-debs.sh
+      - name: Build OSSEC packages
+        run: |
+          OS_VERSION=${{ inputs.ubuntu_version }} WHAT=ossec ./builder/build-debs.sh
+      - name: Build admin packages
+        run: |
+          OS_VERSION=${{ inputs.ubuntu_version }} WHAT=admin ./builder/build-debs.sh
+      - name: Build admin packages (trixie)
+        run: |
+          OS_VERSION=trixie WHAT=admin ./builder/build-debs.sh
+      - uses: actions/upload-artifact@v7
+        id: upload
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: |
+            build/${{ inputs.ubuntu_version }}
+            build/trixie
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,31 +24,11 @@ jobs:
           - ubuntu: noble
             python: "3.12"
     # TODO: change this back to ubuntu-latest once it is consistently 24.04
-    runs-on: ubuntu-24.04
-    outputs:
-      artifact_id: ${{ steps.upload.outputs.artifact-id }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.versions.python }}
-      - name: Build SecureDrop packages
-        run: |
-          OS_VERSION=${{ matrix.versions.ubuntu }} ./builder/build-debs.sh
-      - name: Build OSSEC packages
-        run: |
-          OS_VERSION=${{ matrix.versions.ubuntu }} WHAT=ossec ./builder/build-debs.sh
-      - name: Build admin packages
-        run: |
-          OS_VERSION=${{ matrix.versions.ubuntu }} WHAT=admin ./builder/build-debs.sh
-      - uses: actions/upload-artifact@v7
-        id: upload
-        with:
-          name: ${{ matrix.versions.ubuntu }}-${{ matrix.build }}
-          path: build/${{ matrix.versions.ubuntu }}
-          if-no-files-found: error
+    uses: ./.github/workflows/build-debs-reusable.yml
+    with:
+      ubuntu_version: ${{ matrix.versions.ubuntu }}
+      python_version: ${{ matrix.versions.python }}
+      artifact_name: ${{ matrix.versions.ubuntu }}-${{ matrix.build }}
 
   reproducible-debs:
     strategy:
@@ -72,6 +52,10 @@ jobs:
           # FIXME: securedrop-app-code isn't reproducible
           for pkg in ossec-agent ossec-server securedrop-config securedrop-keyring securedrop-ossec-agent securedrop-ossec-server securedrop-admin
           do
-              echo "Checking ${pkg}..."
-              diffoscope ${{ matrix.ubuntu_version }}-one/${pkg}_*.deb ${{ matrix.ubuntu_version }}-two/${pkg}_*.deb
+              echo "Checking ${pkg} (${{ matrix.ubuntu_version }})..."
+              diffoscope ${{ matrix.ubuntu_version }}-one/${{ matrix.ubuntu_version }}/${pkg}_*.deb \
+                         ${{ matrix.ubuntu_version }}-two/${{ matrix.ubuntu_version }}/${pkg}_*.deb
           done
+          echo "Checking securedrop-admin (trixie)..."
+          diffoscope ${{ matrix.ubuntu_version }}-one/trixie/securedrop-admin_*.deb \
+                     ${{ matrix.ubuntu_version }}-two/trixie/securedrop-admin_*.deb

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,3 +1,6 @@
+# Reuse the Package builds artifact for github.sha when available; otherwise
+# build via the same reusable workflow. The staging job sees one artifact
+# (staging-debs-noble) containing build/noble/* and build/trixie/*.
 name: Staging
 on:
   push:
@@ -6,9 +9,65 @@ on:
       - 'release/*'
   schedule:
     - cron: '0 3 * * *'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
+  resolve-debs:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      reused: ${{ steps.lookup.outputs.reused }}
+    steps:
+      - name: Try to reuse Package builds artifact
+        id: lookup
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euxo pipefail
+          RUN_ID=$(gh run list --repo "${GH_REPO}" --workflow=build.yml \
+            --commit "${COMMIT_SHA}" -L 50 --json databaseId,conclusion \
+            --jq '.[] | select(.conclusion == "success") | .databaseId' | head -1)
+          if [[ -z "${RUN_ID}" ]]; then
+            echo "reused=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          mkdir -p build
+          gh run download "${RUN_ID}" --repo "${GH_REPO}" --name noble-one -D build
+          echo "reused=true" >> "${GITHUB_OUTPUT}"
+      - name: Re-upload as staging-debs-noble
+        if: steps.lookup.outputs.reused == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: staging-debs-noble
+          path: |
+            build/noble
+            build/trixie
+          if-no-files-found: error
+
+  build-debs:
+    needs: resolve-debs
+    if: needs.resolve-debs.outputs.reused != 'true'
+    uses: ./.github/workflows/build-debs-reusable.yml
+    with:
+      ubuntu_version: noble
+      python_version: "3.12"
+      artifact_name: staging-debs-noble
+
   staging:
+    needs:
+      - resolve-debs
+      - build-debs
+    if: |
+      always() &&
+      !cancelled() &&
+      (needs.resolve-debs.outputs.reused == 'true' || needs.build-debs.result == 'success')
     strategy:
       fail-fast: false
       matrix:
@@ -17,10 +76,15 @@ jobs:
     env:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
       UBUNTU_VERSION: ${{ matrix.ubuntu_version }}
+      CI_PREBUILT_DEBS: "1"
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - uses: actions/download-artifact@v8
+        with:
+          name: staging-debs-noble
+          path: build
       - name: Run staging tests on GCE
         run: |
           make ci-go

--- a/admin/bin/validate-gpg-key.sh
+++ b/admin/bin/validate-gpg-key.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC2317
+# shellcheck disable=SC2317,SC2329
 # Verifies a key at at given path matches a fingerprint
 # Does so by importing the key into gpg2 and checking output
 #

--- a/devops/gce-nested/gce-runner.sh
+++ b/devops/gce-nested/gce-runner.sh
@@ -49,21 +49,45 @@ function copy_securedrop_repo() {
       "${TOPLEVEL}/" "${SSH_TARGET}:~/securedrop-source"
 }
 
+# Sync prebuilt debs (build/${OS_VERSION}/, build/trixie/) to GCE; the repo
+# rsync above excludes *.deb.
+function copy_prebuilt_debs_to_remote() {
+  if [[ "${CI_PREBUILT_DEBS:-}" != "1" ]]; then
+    return 0
+  fi
+  local server_deb_dir="${TOPLEVEL}/build/${OS_VERSION}"
+  local admin_deb_dir="${TOPLEVEL}/build/trixie"
+  for d in "$server_deb_dir" "$admin_deb_dir"; do
+    if [[ ! -d "$d" ]] || [[ $(find "$d" -maxdepth 1 -name '*.deb' 2>/dev/null | wc -l) -eq 0 ]]; then
+      echo "ERROR: CI_PREBUILT_DEBS=1 but no .deb files found in ${d}" >&2
+      exit 1
+    fi
+  done
+  rsync -a -e "ssh ${SSH_OPTS[*]}" \
+      "${server_deb_dir}/" "${SSH_TARGET}:~/securedrop-source/build/${OS_VERSION}/"
+  rsync -a -e "ssh ${SSH_OPTS[*]}" \
+      "${admin_deb_dir}/" "${SSH_TARGET}:~/securedrop-source/build/trixie/"
+}
+
 # Main logic
 copy_securedrop_repo
+copy_prebuilt_debs_to_remote
 
 # The test results should be collected regardless of pass/fail,
 # so register a trap to ensure the fetch always runs.
 trap fetch_junit_test_results EXIT
 
-# build server debs
-ssh_gce "OS_VERSION=\"${OS_VERSION}\" make build-debs-notest"
-ssh_gce "OS_VERSION=\"${OS_VERSION}\" make build-debs-ossec-notest"
+# Legacy on-host build path (used when running outside CI).
+if [[ "${CI_PREBUILT_DEBS:-}" != "1" ]]; then
+  ssh_gce "OS_VERSION=\"${OS_VERSION}\" make build-debs-notest"
+  ssh_gce "OS_VERSION=\"${OS_VERSION}\" make build-debs-ossec-notest"
+  ssh_gce "OS_VERSION=\"trixie\" make build-debs-admin-notest"
+fi
 
-# build and install securedrop-admin tools and add staging config
-ssh_gce "OS_VERSION=\"trixie\" make build-debs-admin-notest"
+# GCE host is trixie; admin venv is ABI-tied to its builder Python.
+ssh_gce "sudo apt-get update && sudo apt install -y ./build/trixie/securedrop-admin_*+trixie_amd64.deb"
+
 ssh_gce "mkdir -p /home/sdci/.config/securedrop-admin"
-ssh_gce "sudo apt install -y ./build/trixie/securedrop-admin_*+trixie_amd64.deb"
 ssh_gce "cp ~/securedrop-source/install_files/ansible-base/roles/ossec/files/test_admin_key.pub /home/sdci/.config/securedrop-admin/"
 ssh_gce "cp ~/securedrop-source/install_files/ansible-base/roles/app/files/test_journalist_key.pub /home/sdci/.config/securedrop-admin/"
 


### PR DESCRIPTION
## Description

Staging no longer builds debs on the GCE host. It reuses the artifact from the
latest successful **Package builds** run for the current commit, and falls back
to building on a GitHub-hosted runner only when no run exists for that SHA.

## Implementation Details

- New `.github/workflows/build-debs-reusable.yml` builds noble debs (server,
  OSSEC, app-code, config, keyring, admin) plus a trixie-built
  `securedrop-admin`. The trixie variant is required because the GCE host is
  trixie and the staging converge invokes `securedrop-admin generate_v3_keys`
  on `localhost` (`roles/tor-hidden-services`); the admin deb's bundled venv
  is ABI-tied to its builder image's Python. Artifact ships
  `build/noble/` and `build/trixie/`.
- `.github/workflows/build.yml` now calls the reusable workflow;
  `reproducible-debs` updated for the new layout and adds the trixie admin
  deb to its diffoscope check.
- `.github/workflows/staging.yml` adds `resolve-debs` (uses `gh run list` /
  `gh run download` to grab `noble-one` for the SHA) and a fallback
  `build-debs` job; the `staging` job downloads `staging-debs-noble` into
  `build/` and exports `CI_PREBUILT_DEBS=1`. Drops the prior
  `workflow_dispatch` opt-in toggle now that strict reuse is the default.
- `devops/gce-nested/gce-runner.sh` rsyncs both deb subdirs to GCE, skips
  on-host `make build-debs-*` under `CI_PREBUILT_DEBS=1`, restores
  `apt-get update` before installing, and installs the trixie admin deb
  unconditionally.
- `admin/bin/validate-gpg-key.sh`: `SC2329` shellcheck disable for the
  trap-invoked cleanup function (false positive on newer shellcheck).

## Checklist

- documentation: CI/workflow change only; no product/dev docs updated.
- AppArmor: N/A.
- install/upgrade: no impact; same trixie admin deb installed during staging.
- [dependency policy](https://developers.securedrop.org/en/latest/dependency_updates.html):
  no new app/locked dependencies.
