### PR TITLE
Bump initial 2.15.0-rc1 version

### DIFF
--- a/admin/debian/changelog
+++ b/admin/debian/changelog
@@ -1,5 +1,11 @@
 securedrop-admin (2.15.0~rc1) unstable; urgency=medium
 
+  * see changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 08 Apr 2026 15:29:55 -0400
+
+securedrop-admin (2.15.0~rc1) unstable; urgency=medium
+
   *
 
  -- SecureDrop Team <securedrop@freedom.press>  Fri, 20 Feb 2026 11:43:01 -0500

--- a/admin/debian/changelog
+++ b/admin/debian/changelog
@@ -4,12 +4,6 @@ securedrop-admin (2.15.0~rc1) unstable; urgency=medium
 
  -- SecureDrop Team <securedrop@freedom.press>  Wed, 08 Apr 2026 15:29:55 -0400
 
-securedrop-admin (2.15.0~rc1) unstable; urgency=medium
-
-  *
-
- -- SecureDrop Team <securedrop@freedom.press>  Fri, 20 Feb 2026 11:43:01 -0500
-
 securedrop-admin (2.14.0) unstable; urgency=medium
 
   * see changelog.md

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,28 @@
 
 ## 2.15.0~rc1
 
+### Web Applications and API
 
+* Update terms used in English wordlist (#7785)
+
+* V2 Journalist API:
+  * Enable V2 API by default (#7789)
+  * add `source_converation_seen` event (#7784)
+  * Let client request arbitrary metadata shards (#7770)
+
+* Dependency updates:
+
+### Development
+
+* Improve V2 API documentation (#7793)
+* Use `uv` to manage admin requirements (#7773)
+* Set 7-day cooldown for dependabot alerts (#7787)
+* Update demo base container image to used fully-qualified name (#7794)
+* Dependency updates:
+  * `cffi` to 2.0.0 (#7773)
+  * `cryptography` to 46.0.6 (#7797)
+  * Github Actions `download-artifact` to 8 (#7782)
+  * Github Actions `upload-artifact` to 7 (#7782)
 
 ## 2.14.0
 

--- a/securedrop/debian/changelog
+++ b/securedrop/debian/changelog
@@ -1,8 +1,8 @@
 securedrop (2.15.0~rc1) unstable; urgency=medium
 
-  * 
+  * see changelog.md
 
- -- SecureDrop Team <securedrop@freedom.press>  Fri, 20 Feb 2026 11:43:21 -0500
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 08 Apr 2026 15:30:21 -0400
 
 securedrop (2.14.0) unstable; urgency=medium
 


### PR DESCRIPTION
Towards #7790

Adds 2.15.0-rc1 version bump and changelog.

## Test plan
- [ ] version bump and changelog are consistent.
- [ ] CI is green
- [ ] base is `release/2.15.0`
