### PR TITLE
Use the correct path for checking local file checksum in restore task with `--no-transfer` option set

### DIFF
--- a/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
+++ b/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
@@ -59,7 +59,7 @@
   connection: local
   become: no
   stat:
-    path: "{{ restore_file }}"
+    path: "{{ config_path }}/{{ restore_file }}"
     checksum_algorithm: sha256
   register: local_backup_file
   when: restore_manual_transfer


### PR DESCRIPTION
Fixes #7801 

The task to check the local file checksum when doing a manual restore is currently broken, because it's looking for the local file in the same path as the Ansible task itself.

This change fixes that and looks for it at the correct location, to match the other tasks. This appears to be the only one that was missed, likely just an oversight from the packaged admin tooling changes.

## Test plan
- [ ] Create a backup file on an Admin Workstation
- [ ] Manually copy it to the `/tmp` directory on an App Server, using SCP or any method you prefer
- [ ] Run `securedrop-admin restore --no-transfer <backup_file_name>`
- [ ] Confirm the restore completes successfully
- [ ] Ensure you are still able to login after the restore operation is finished

## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)