### PR TITLE
[2.15.1] Forcibly free memory after heavy APIv2 requests

### DIFF
--- a/securedrop/journalist_app/__init__.py
+++ b/securedrop/journalist_app/__init__.py
@@ -1,3 +1,4 @@
+import ctypes
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,8 @@ from sdconfig import SecureDropConfig
 from werkzeug import Response
 from werkzeug.exceptions import HTTPException, default_exceptions
 
+_libc = ctypes.CDLL("libc.so.6")
+_heavy_api_routes = ["api.get_token", "api2.index", "api2.data"]
 _insecure_views = ["main.login", "static"]
 _insecure_api_views = ["api.get_token", "api.get_endpoints"]
 
@@ -139,6 +142,17 @@ def create_app(config: SecureDropConfig) -> Flask:
                 g.source = get_source(filesystem_id)  # pylint: disable=assigning-non-slot
 
         return None
+
+    @app.teardown_request
+    def _malloc_trim(exception: BaseException | None) -> None:
+        # APIv2 (and APIv1 login) effectively load the entire database
+        # into memory, which ends up causing fragmentation issues in
+        # which glibc doesn't automatically release the memory back.
+        # Explicitly call the C `malloc_trim()` function to force glibc
+        # to release the memory that has been marked as freeable but not
+        # yet freed. The 0 means to free everything it can.
+        if request.endpoint in _heavy_api_routes:
+            _libc.malloc_trim(0)
 
     app.register_blueprint(main.make_blueprint())
     app.register_blueprint(account.make_blueprint(), url_prefix="/account")

--- a/securedrop/tests/test_journalist_api.py
+++ b/securedrop/tests/test_journalist_api.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from uuid import UUID, uuid4
 
+import pytest
 from db import db
 from encryption import EncryptionManager
 from flask import url_for
@@ -1476,3 +1477,60 @@ def test_download_submission_range(journalist_app, test_files, journalist_api_to
         assert partial_response.headers.get("Content-Length") == str(range_end - range_start)
         assert len(partial_response.data) == range_end - range_start
         assert full_response.data[range_start:] == partial_response.data
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "method", "should_trim"),
+    [
+        ("api2.index", "GET", True),
+        ("api2.data", "POST", True),
+        ("api.get_endpoints", "GET", False),
+        ("api.get_current_user", "GET", False),
+    ],
+)
+def test_authenticated_routes_call_malloc_trim_only_if_heavy(
+    mocker, journalist_app, journalist_api_token, endpoint, method, should_trim
+):
+    """
+    Verify the teardown_request hook invokes malloc_trim() only for the
+    heavy APIv2 routes and not for other routes.
+    """
+    mock_libc = mocker.patch("journalist_app._libc")
+
+    with journalist_app.test_client() as app:
+        app.open(
+            url_for(endpoint),
+            method=method,
+            headers=get_api_headers(journalist_api_token),
+        )
+
+    if should_trim:
+        mock_libc.malloc_trim.assert_called_once_with(0)
+    else:
+        mock_libc.malloc_trim.assert_not_called()
+
+
+def test_login_calls_malloc_trim(mocker, journalist_app, test_journo):
+    """
+    Verify the teardown_request hook invokes malloc_trim() for the
+    APIv1 login endpoint (api.get_token), which also loads the full
+    database into memory.
+    """
+    mock_libc = mocker.patch("journalist_app._libc")
+
+    with journalist_app.test_client() as app:
+        valid_token = TOTP(test_journo["otp_secret"]).now()
+        response = app.post(
+            url_for("api.get_token"),
+            data=json.dumps(
+                {
+                    "username": test_journo["username"],
+                    "passphrase": test_journo["password"],
+                    "one_time_code": valid_token,
+                }
+            ),
+            headers=get_api_headers(),
+        )
+        assert response.status_code == 200
+
+    mock_libc.malloc_trim.assert_called_once_with(0)


### PR DESCRIPTION
Explicitly invoke the C `malloc_trim()` function to force glibc to actually free memory at the end of a request instead of letting it accumulate.

This is a minimally invasive solution that only affects the specific problematic requests; long-term we should consider using a different allocator like jemalloc.

Fixes https://github.com/freedomofpress/securedrop-client/issues/3234.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] Without this commit, observe high memory usage after APIv2 requests / Inbox usage
* [x] `make build-debs` + install securedrop-app-code on prod hardware, observe constant and low memory usage.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)