### PR TITLE
[2.15.1] Backport "Use the correct path for checking local file checksum in restore task with `--no-transfer` option set"

### DIFF
--- a/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
+++ b/install_files/ansible-base/roles/restore/tasks/perform_restore.yml
@@ -59,7 +59,7 @@
   connection: local
   become: no
   stat:
-    path: "{{ restore_file }}"
+    path: "{{ config_path }}/{{ restore_file }}"
     checksum_algorithm: sha256
   register: local_backup_file
   when: restore_manual_transfer


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #7802.

## Testing

* [x] CI is passing
* [x] base is `release/2.15.1`
* [x] Only contains changes from #7802 
