### PR TITLE
feat(`handle_source_deleted`): initiate asynchronous deletion

### DIFF
--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -183,11 +183,12 @@ class EventHandler:
                 ),
             )
 
-        # Mark as deleted all the items in the source's collection
-        deleted_items = {item.uuid: None for item in source.collection}
-
         try:
-            utils.delete_collection(source.filesystem_id)
+            # Deletion via `col_delete()` is asynchronous, but if it's initiated
+            # successfully we should report back to the client that all of the
+            # deleted source's items have also been deleted.
+            deleted_items = {item.uuid: None for item in source.collection}
+            utils.col_delete([source.filesystem_id])
             return EventResult(
                 event_id=event.id,
                 status=(EventStatusCode.OK, None),

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -2,7 +2,7 @@ from dataclasses import asdict
 
 from db import db
 from journalist_app import utils
-from journalist_app.api2.shared import json_version, save_reply
+from journalist_app.api2.shared import json_version, mark_source_deleted, save_reply
 from journalist_app.api2.types import (
     Event,
     EventResult,
@@ -184,11 +184,11 @@ class EventHandler:
             )
 
         try:
-            # Deletion via `col_delete()` is asynchronous, but if it's initiated
-            # successfully we should report back to the client that all of the
-            # deleted source's items have also been deleted.
+            # Deletion via `mark_source_deleted()` is asynchronous, but if it's
+            # initiated successfully we should report back to the client that
+            # all of the deleted source's items have also been deleted.
             deleted_items = {item.uuid: None for item in source.collection}
-            utils.col_delete([source.filesystem_id])
+            mark_source_deleted([source.filesystem_id])
             return EventResult(
                 event_id=event.id,
                 status=(EventStatusCode.OK, None),

--- a/securedrop/journalist_app/api2/shared.py
+++ b/securedrop/journalist_app/api2/shared.py
@@ -7,6 +7,7 @@ import hashlib
 import os
 from collections.abc import Mapping
 from dataclasses import asdict
+from datetime import UTC, datetime
 from uuid import UUID
 
 from db import db
@@ -166,3 +167,10 @@ def save_reply(source: Source, data: dict) -> Reply:
         raise e
 
     return reply
+
+
+def mark_source_deleted(cols_selected: list[str]) -> None:
+    now = datetime.now(UTC)
+    sources = Source.query.filter(Source.filesystem_id.in_(cols_selected))
+    sources.update({Source.deleted_at: now}, synchronize_session="fetch")
+    db.session.commit()

--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -10,6 +10,7 @@ from db import db
 from encryption import EncryptionManager
 from flask import abort, current_app, flash, redirect, send_file, url_for
 from flask_babel import gettext, ngettext
+from journalist_app.api2.shared import mark_source_deleted
 from journalist_app.sessions import session
 from markupsafe import Markup, escape
 from models import (
@@ -318,10 +319,7 @@ def col_delete(cols_selected: list[str]) -> werkzeug.Response:
     if len(cols_selected) < 1:
         flash(gettext("No collections selected for deletion."), "error")
     else:
-        now = datetime.now(UTC)
-        sources = Source.query.filter(Source.filesystem_id.in_(cols_selected))
-        sources.update({Source.deleted_at: now}, synchronize_session="fetch")
-        db.session.commit()
+        mark_source_deleted(cols_selected)
 
         num = len(cols_selected)
 

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -55,9 +55,17 @@ def eager_query(model: str) -> EagerQuery | Query:
     except AttributeError:
         query = cls.query
 
-    # Filter out pending and deleted sources
+    # Filter out pending and deleted sources and their items
     if model == "Source":
         query = query.filter_by(pending=False, deleted_at=None)
+    elif model in ["Reply", "Submission"]:
+        query = query.filter(
+            cls.source.has(
+                # Pending should be impossible here; kept for consistency:
+                pending=False,
+                deleted_at=None,
+            )
+        )
 
     return query
 

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -684,8 +684,35 @@ def test_api2_source_deleted(
             assert item_uuid in response.json["items"]
             assert response.json["items"][item_uuid] is None
 
-        # Verify source is deleted from database
-        assert Source.query.filter(Source.uuid == source_uuid).one_or_none() is None
+        # Verify source is either (a) deleted or (b) pending deletion:
+        source = Source.query.filter(Source.uuid == source_uuid).one_or_none()
+        assert source is None or source.deleted_at is not None
+
+        # Verify source is gone from the index:
+        index = app.get(
+            url_for("api2.index"),
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert index.status_code == 200
+        assert source_uuid not in index.json["sources"]
+
+        # Verify source can't be fetched:
+        data = app.post(
+            url_for("api2.data"),
+            json={"sources": [source_uuid]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert data.status_code == 200
+        assert source_uuid not in data.json["sources"]
+
+        # Verify source's items can't be fetched:
+        data = app.post(
+            url_for("api2.data"),
+            json={"items": [list(expected_item_uuids)[0]]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert data.status_code == 200
+        assert list(expected_item_uuids)[0] not in data.json["items"]
 
         # Try to delete a source that doesn't exist
         nonexistent_event = Event(

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -5,6 +5,7 @@ from dataclasses import asdict
 from datetime import UTC, datetime
 from uuid import uuid4
 
+import journalist_app as journalist_app_module
 import pytest
 from flask import url_for
 from flask_sqlalchemy import get_debug_queries
@@ -684,9 +685,9 @@ def test_api2_source_deleted(
             assert item_uuid in response.json["items"]
             assert response.json["items"][item_uuid] is None
 
-        # Verify source is either (a) deleted or (b) pending deletion:
+        # Verify source is pending deletion:
         source = Source.query.filter(Source.uuid == source_uuid).one_or_none()
-        assert source is None or source.deleted_at is not None
+        assert source.deleted_at is not None
 
         # Verify source is gone from the index:
         index = app.get(
@@ -713,6 +714,11 @@ def test_api2_source_deleted(
         )
         assert data.status_code == 200
         assert list(expected_item_uuids)[0] not in data.json["items"]
+
+        # Verify source pending deletion is deleted:
+        journalist_app_module.utils.purge_deleted_sources()
+        source = Source.query.filter(Source.uuid == source_uuid).one_or_none()
+        assert source is None
 
         # Try to delete a source that doesn't exist
         nonexistent_event = Event(


### PR DESCRIPTION
Closes #7807.  For consistency, we reuse the v1 API's `utils.col_delete()`, which sets the `Source.deleted_at` timestamp, and refine the `eager_query()` factory to filter out items that belong to sources with this flag set.


## Test plan

Against `make dev`:
1. Delete a source from the Inbox.
2. [ ] The source disappears immediately from the Journalist Interface.
3. Delete a source from the Journalist Interface.
4. [ ] The source disappears from the Inbox on the next sync.

Bonus, against a large dataset:
1. Delete a large number of sources from the Inbox.
2. [ ] The request goes through immediately.
3. [ ] The shredder runs in the background on the server side.