### PR TITLE
docs(`EventType`): link to the Inbox's `PendingEventType` enum

### DIFF
--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -25,6 +25,10 @@ EventID = NewType("EventID", str)  # int, but opaque on the wire
 
 
 class EventType(StrEnum):
+    """
+    This enum MUST be kept in sync with the Inbox's `PendingEventType` enum.
+    """
+
     REPLY_SENT = auto()
     ITEM_DELETED = auto()
     SOURCE_DELETED = auto()


### PR DESCRIPTION
Trivial counterpart to freedomofpress/securedrop-client#3341.