### PR TITLE
Update hint on login failure to cover all invalid credential cases

### DIFF
--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -107,16 +107,11 @@ def validate_user(
                 "Your 2FA details are invalid" " - please contact an administrator to reset them."
             )
         else:
-            try:
-                user = Journalist.query.filter_by(username=username).one()
-                if user.is_totp:
-                    login_flashed_msg += " "
-                    login_flashed_msg += gettext(
-                        "Please wait for a new code from your two-factor mobile"
-                        " app or security key before trying again."
-                    )
-            except Exception:
-                pass
+            login_flashed_msg += " "
+            login_flashed_msg += gettext(
+                "Please check your credentials. If you are using a two-factor mobile"
+                " app or security key, wait for a new code before trying again."
+            )
 
         flash(login_flashed_msg, "error")
         return None

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -1708,8 +1708,8 @@ def test_deleted_user_cannot_login(config, journalist_app, locale):
             msgids = [
                 "Login failed.",
                 (
-                    "Please wait for a new code from your two-factor mobile"
-                    " app or security key before trying again."
+                    "Please check your credentials. If you are using a two-factor mobile"
+                    " app or security key, wait for a new code before trying again."
                 ),
             ]
             with xfail_untranslated_messages(config, locale, msgids):
@@ -2689,8 +2689,8 @@ def test_incorrect_current_password_change(config, journalist_app, test_journo, 
             msgids = [
                 "Incorrect password or two-factor code.",
                 (
-                    "Please wait for a new code from your two-factor mobile"
-                    " app or security key before trying again."
+                    "Please check your credentials. If you are using a two-factor mobile"
+                    " app or security key, wait for a new code before trying again."
                 ),
             ]
             with xfail_untranslated_messages(config, locale, msgids):

--- a/securedrop/translations/messages.pot
+++ b/securedrop/translations/messages.pot
@@ -179,7 +179,7 @@ msgstr[1] ""
 msgid "Your 2FA details are invalid - please contact an administrator to reset them."
 msgstr ""
 
-msgid "Please wait for a new code from your two-factor mobile app or security key before trying again."
+msgid "Please check your credentials. If you are using a two-factor mobile app or security key, wait for a new code before trying again."
 msgstr ""
 
 msgid "The item has been deleted."


### PR DESCRIPTION
Fixes #7828 

## Test plan
- [ ] attempt to log in with permutations of invalid username, passphrase, and 2fa, and verify that in all cases the flash message is the same, starting with "Login failed. Please check your credentials..." 

## Checklist

This change accounts for:
- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)