### PR TITLE
Prune obsolete test requirements

### DIFF
--- a/securedrop/requirements/test-requirements.in
+++ b/securedrop/requirements/test-requirements.in
@@ -4,7 +4,6 @@ coverage>=5.0  # #6091
 flaky
 html5validator
 mock
-pathlib2
 pillow>=10.3.0  # Safety 67136 for CVE-2024-28219
 pytest>=7.2.0
 pytest-xdist>=3.0.2

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -134,10 +134,6 @@ packaging==25.0 \
     --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484 \
     --hash=sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f
     # via pytest
-pathlib2==2.3.5 \
-    --hash=sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db \
-    --hash=sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868
-    # via -r requirements/test-requirements.in
 pbr==3.1.1 \
     --hash=sha256:05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1 \
     --hash=sha256:60c25b7dfd054ef9bb0ae327af949dd4676aa09ac3a9471cdc871d8a9213f9ac
@@ -316,9 +312,7 @@ setuptools==79.0.1 \
 six==1.11.0 \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb
-    # via
-    #   mock
-    #   pathlib2
+    # via mock
 sniffio==1.3.0 \
     --hash=sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101 \
     --hash=sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384


### PR DESCRIPTION
## Status

Ready for review.

## Description

Closes #6579.

This removes the obsolete `blinker` and `pathlib2` direct test dependencies from `securedrop/requirements/test-requirements.in` and updates `securedrop/requirements/test-requirements.txt` accordingly.

`six` remains in the generated test requirements because it is still required by `mock`; its `# via` comment was updated to reflect that remaining source.

## Testing

- `rg -n "^blinker|^pathlib2|pathlib2|blinker" securedrop/requirements/test-requirements.in securedrop/requirements/test-requirements.txt` returns no matches.
- Attempted `make update-python3-requirements`, but could not complete locally because this environment does not have `docker` installed for `securedrop/bin/dev-shell`.
