### PR TITLE
fix: various data races

### DIFF
--- a/securedrop/alembic/versions/88bb7f366038_unique_constraint_on_source_stars_source_id.py
+++ b/securedrop/alembic/versions/88bb7f366038_unique_constraint_on_source_stars_source_id.py
@@ -1,0 +1,33 @@
+"""unique constraint on source_stars.source_id
+
+Revision ID: 88bb7f366038
+Revises: 17c559a7a685
+Create Date: 2026-05-15
+
+"""
+
+from alembic import op
+
+revision = "88bb7f366038"
+down_revision = "17c559a7a685"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Delete duplicate rows, keeping the one with the highest id (most recent).
+    op.execute(
+        """
+        DELETE FROM source_stars
+        WHERE id NOT IN (
+            SELECT MAX(id) FROM source_stars GROUP BY source_id
+        )
+        """
+    )
+    with op.batch_alter_table("source_stars") as batch_op:
+        batch_op.create_unique_constraint("uq_source_stars_source_id", ["source_id"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("source_stars") as batch_op:
+        batch_op.drop_constraint("uq_source_stars_source_id", type_="unique")

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -1,6 +1,7 @@
 from dataclasses import asdict
 
 from db import db
+from flask import current_app
 from journalist_app import utils
 from journalist_app.api2.shared import json_version, mark_source_deleted, save_reply
 from journalist_app.api2.types import (
@@ -59,7 +60,7 @@ class EventHandler:
         """The per-event entry-point for handling a single event."""
 
         try:
-            if self.has_progress(event):
+            if self.is_duplicate(event):
                 return EventResult(
                     event_id=event.id,
                     status=(EventStatusCode.AlreadyReported, None),
@@ -83,35 +84,40 @@ class EventHandler:
                 ),
             )
 
-        self.mark_progress(event)  # prevent races
-        result = handler(event, minor)
-        self.mark_progress(event, result.status[0])  # enforce idempotence
+        try:
+            result = handler(event, minor)
+
+        # Catch anything not handled by the handler:
+        except Exception:
+            current_app.logger.error(f"unhandled exception in handler for {event}", exc_info=True)
+            result = EventResult(
+                event.id, (EventStatusCode.InternalServerError, "failed to process event")
+            )
+
+        self.record_status(event, result.status[0])
         return result
 
     def idempotence_key(self, event: Event) -> str:
         return f"{REDIS_EVENT_PREFIX}/{self._session.user.uuid}/{event.id}"
 
-    def has_progress(self, event: Event) -> EventStatusCode:
-        return self._redis.get(self.idempotence_key(event))
+    def is_duplicate(self, event: Event) -> bool:
+        """Returns `True` if this event is already registered (i.e., a replay)."""
+        return (
+            self._redis.set(
+                self.idempotence_key(event),
+                EventStatusCode.Processing,
+                ex=IDEMPOTENCE_PERIOD,
+                nx=True,
+            )
+            is None
+        )
 
-    def mark_progress(
-        self, event: Event, status: EventStatusCode = EventStatusCode.Processing
-    ) -> None:
-        """
-        If `status` is a non-error code, mark it as the progress of `event`, to
-        be returned later as "Already Reported".
-
-        If `status` is an error code, clear it, since `event` MAY be resubmitted
-        later.
-        """
+    def record_status(self, event: Event, status: EventStatusCode) -> None:
+        """Record the event's final status for idempotence, or clear on error to permit retry."""
         if status >= EventStatusCode.BadRequest:
             self._redis.delete(self.idempotence_key(event))
         else:
-            self._redis.set(
-                self.idempotence_key(event),
-                status,
-                ex=IDEMPOTENCE_PERIOD,
-            )
+            self._redis.set(self.idempotence_key(event), status, ex=IDEMPOTENCE_PERIOD)
 
     @staticmethod
     def handle_item_deleted(event: Event, minor: int) -> EventResult:

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -38,13 +38,17 @@ class EventHandler:
        `journalist_api2.types.EVENT_DATA_TYPES`;
 
     3. define the handler as a static method `handle_thing_done(event: Event)`
-       in this class
+       in this class; and
 
     4. explicitly register `{"thing_done": self.handle_thing_done}` inside
       `EventHandler.process()`.
 
     This is belt-and-suspenders for ensuring that only the intended methods are
     exposed as callable event handlers.
+
+    To preserve transaction separation between events, handlers MUST return with
+    a clean SQLAlchemy session: in other words, having either successfully
+    committed or rolled back all of their changes.
     """
 
     def __init__(self, session: Session, redis: Redis) -> None:
@@ -89,9 +93,15 @@ class EventHandler:
         try:
             result = handler(event, minor)
 
+            # Enforce "handlers MUST return with a clean SQLAlchemy session" above:
+            assert not db.session.dirty  # noqa: S101
+            assert not db.session.new  # noqa: S101
+            assert not db.session.deleted  # noqa: S101
+
         # Catch anything not handled by the handler:
         except Exception:
             current_app.logger.error(f"unhandled exception in handler for {event}", exc_info=True)
+            db.session.rollback()
             result = EventResult(
                 event.id, (EventStatusCode.InternalServerError, "failed to process event")
             )

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -214,23 +214,17 @@ class EventHandler:
                 ),
             )
 
-        try:
-            # Deletion via `mark_source_deleted()` is asynchronous, but if it's
-            # initiated successfully we should report back to the client that
-            # all of the deleted source's items have also been deleted.
-            deleted_items = {item.uuid: None for item in source.collection}
-            mark_source_deleted([source.filesystem_id])
-            return EventResult(
-                event_id=event.id,
-                status=(EventStatusCode.OK, None),
-                sources={event.target.source_uuid: None},
-                items=deleted_items,
-            )
-        except ValueError as exc:
-            return EventResult(
-                event_id=event.id,
-                status=(EventStatusCode.InternalServerError, str(exc)),
-            )
+        # Deletion via `mark_source_deleted()` is asynchronous, but if it's
+        # initiated successfully we should report back to the client that
+        # all of the deleted source's items have also been deleted.
+        deleted_items = {item.uuid: None for item in source.collection}
+        mark_source_deleted([source.filesystem_id])
+        return EventResult(
+            event_id=event.id,
+            status=(EventStatusCode.OK, None),
+            sources={event.target.source_uuid: None},
+            items=deleted_items,
+        )
 
     @staticmethod
     def handle_source_conversation_truncated(event: Event, minor: int) -> EventResult:

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -14,7 +14,8 @@ from journalist_app.api2.types import (
 from journalist_app.sessions import Session, session
 from models import Reply, Source, Submission
 from redis import Redis
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound, StaleDataError
 from store import NotEncrypted
 
 # `IDEMPOTENCE_PERIOD` MUST be greater than or equal to
@@ -131,16 +132,18 @@ class EventHandler:
 
         try:
             utils.delete_file_object(item)
-            return EventResult(
-                event_id=event.id,
-                status=(EventStatusCode.OK, None),
-                items={event.target.item_uuid: None},
-            )
-        except ValueError as exc:
-            return EventResult(
-                event_id=event.id,
-                status=(EventStatusCode.InternalServerError, str(exc)),
-            )
+        except (StaleDataError, ValueError):
+            # `utils.delete_file_object()` is non-atomic: it guarantees database
+            # deletion but not filesystem deletion.  The former is all we need
+            # for consistency with the client, and the latter will be caught by
+            # monitoring for "disconnected" submissions.
+            pass
+
+        return EventResult(
+            event_id=event.id,
+            status=(EventStatusCode.OK, None),
+            items={event.target.item_uuid: None},
+        )
 
     @staticmethod
     def handle_reply_sent(event: Event, minor: int) -> EventResult:
@@ -254,7 +257,7 @@ class EventHandler:
             if item.interaction_count <= event.data.upper_bound:
                 try:
                     utils.delete_file_object(item)
-                except ValueError:
+                except (StaleDataError, ValueError):
                     # `utils.delete_file_object()` is non-atomic: it guarantees
                     # database deletion but not filesystem deletion.  The former
                     # is all we need for consistency with the client, and the

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -324,15 +324,21 @@ class EventHandler:
                 ),
             )
 
-        utils.make_star_true(source.filesystem_id)
-        db.session.commit()
-        db.session.refresh(source)
+        try:
+            utils.make_star_true(source.filesystem_id)
+            db.session.commit()
+            db.session.refresh(source)
 
-        return EventResult(
-            event_id=event.id,
-            status=(EventStatusCode.OK, None),
-            sources={source.uuid: source},
-        )
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.OK, None),
+                sources={source.uuid: source},
+            )
+        except IntegrityError:
+            db.session.rollback()
+            return EventResult(
+                event_id=event.id, status=(EventStatusCode.Conflict, "duplicate star; please retry")
+            )
 
     @staticmethod
     def handle_source_unstarred(event: Event, minor: int) -> EventResult:
@@ -347,15 +353,21 @@ class EventHandler:
                 ),
             )
 
-        utils.make_star_false(source.filesystem_id)
-        db.session.commit()
-        db.session.refresh(source)
+        try:
+            utils.make_star_false(source.filesystem_id)
+            db.session.commit()
+            db.session.refresh(source)
 
-        return EventResult(
-            event_id=event.id,
-            status=(EventStatusCode.OK, None),
-            sources={source.uuid: source},
-        )
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.OK, None),
+                sources={source.uuid: source},
+            )
+        except IntegrityError:
+            db.session.rollback()
+            return EventResult(
+                event_id=event.id, status=(EventStatusCode.Conflict, "duplicate star; please retry")
+            )
 
 
 def find_item(item_uuid: ItemUUID) -> Submission | Reply | None:

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -15,6 +15,7 @@ from journalist_app.sessions import Session, session
 from models import Reply, Source, Submission
 from redis import Redis
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from store import NotEncrypted
 
 # `IDEMPOTENCE_PERIOD` MUST be greater than or equal to
 # `sdconfig.SecureDropConfig.SESSION_LIFETIME`.  In practice, 24 hours is the
@@ -154,14 +155,37 @@ class EventHandler:
                 ),
             )
 
-        reply = save_reply(source, asdict(event.data))
-        db.session.refresh(source)
+        # SQLite will enforce uniqueness within Reply.uuid, but we need
+        # uniqueness within the combined set of Reply.uuid and Submission.uuid.
+        if find_item(event.data.uuid) is not None:
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.Conflict, "duplicate UUID"),
+            )
+
+        try:
+            reply = save_reply(source, asdict(event.data))
+            db.session.refresh(source)
+
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.OK, None),
+                sources={source.uuid: source},
+                items={reply.uuid: reply},
+            )
+        except NotEncrypted:
+            db.session.rollback()
+            status = (EventStatusCode.BadRequest, "reply is not encrypted")
+        except IntegrityError:
+            db.session.rollback()
+            status = (EventStatusCode.Conflict, "duplicate UUID")
+        # `save_reply()` can also raise `InvalidUUID`, but this will have been
+        # caught by validation of the `ReplySentData` type before this handler
+        # is ever invoked.
 
         return EventResult(
             event_id=event.id,
-            status=(EventStatusCode.OK, None),
-            sources={source.uuid: source},
-            items={reply.uuid: reply},
+            status=status,
         )
 
     @staticmethod

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -46,7 +46,7 @@ class EventStatusCode(IntEnum):
     BadRequest = 400
     # The target UUID doesn't exist (non-deletion requests)
     NotFound = 404
-    # Provided version is out of date and it was a deletion request
+    # Version is out of date or the target UUID is already in use
     Conflict = 409
     # The target UUID doesn't exist and it was a deletion request
     Gone = 410

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -41,15 +41,23 @@ class EventType(StrEnum):
 class EventStatusCode(IntEnum):
     Processing = 102
     OK = 200
+
     # We already saw and processed this event
     AlreadyReported = 208
+
     BadRequest = 400
+
     # The target UUID doesn't exist (non-deletion requests)
     NotFound = 404
-    # Version is out of date or there is a database conflict
+
+    # REPLY_SENT: duplicate UUID
+    # SOURCE_DELETED: version conflict
+    # SOURCE_{STARRED,UNSTARRED}: duplicate SourceStar for Source
     Conflict = 409
+
     # The target UUID doesn't exist and it was a deletion request
     Gone = 410
+
     InternalServerError = 500
     NotImplemented = 501
 

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -46,7 +46,7 @@ class EventStatusCode(IntEnum):
     BadRequest = 400
     # The target UUID doesn't exist (non-deletion requests)
     NotFound = 404
-    # Version is out of date or the target UUID is already in use
+    # Version is out of date or there is a database conflict
     Conflict = 409
     # The target UUID doesn't exist and it was a deletion request
     Gone = 410

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -464,6 +464,7 @@ class Reply(db.Model):
 
 class SourceStar(db.Model):
     __tablename__ = "source_stars"
+    __table_args__ = (db.UniqueConstraint("source_id", name="uq_source_stars_source_id"),)
     id = Column("id", Integer, primary_key=True)
     source_id = Column("source_id", Integer, ForeignKey("sources.id"))
     starred = Column("starred", Boolean, default=True)

--- a/securedrop/tests/migrations/migration_88bb7f366038.py
+++ b/securedrop/tests/migrations/migration_88bb7f366038.py
@@ -1,0 +1,119 @@
+import uuid
+
+from db import db
+from journalist_app import create_app
+from sqlalchemy import exc, text
+
+
+def _insert_source(app, designation):
+    with app.app_context():
+        db.engine.execute(
+            text(
+                "INSERT INTO sources (uuid, filesystem_id, journalist_designation,"
+                " interaction_count) VALUES (:uuid, :filesystem_id, :designation, :count)"
+            ),
+            uuid=str(uuid.uuid4()),
+            filesystem_id=str(uuid.uuid4()),
+            designation=designation,
+            count=0,
+        )
+        return db.engine.execute("SELECT MAX(id) FROM sources").scalar()
+
+
+class UpgradeTester:
+    """The upgrade deletes duplicate source_stars rows (keeping the one with the
+    highest id per source_id), then enforces uniqueness on source_id."""
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+        self.source_ids = []
+
+    def load_data(self):
+        self.source_ids = [
+            _insert_source(self.app, "brave marmot"),
+            _insert_source(self.app, "quiet badger"),
+        ]
+        with self.app.app_context():
+            # Two duplicate stars for source 0; older starred=True, newer starred=False.
+            # The migration should keep the newer one (highest id).
+            for starred in (True, False):
+                db.engine.execute(
+                    text(
+                        "INSERT INTO source_stars (source_id, starred)" " VALUES (:sid, :starred)"
+                    ),
+                    sid=self.source_ids[0],
+                    starred=starred,
+                )
+            # One star for source 1 — should survive untouched.
+            db.engine.execute(
+                text("INSERT INTO source_stars (source_id, starred)" " VALUES (:sid, :starred)"),
+                sid=self.source_ids[1],
+                starred=True,
+            )
+
+    def check_upgrade(self):
+        with self.app.app_context():
+            rows = db.engine.execute(
+                "SELECT source_id, starred FROM source_stars ORDER BY id"
+            ).fetchall()
+            # Only one row per source_id remains.
+            assert len(rows) == 2
+            # The duplicate for source 0 was culled, keeping the newer row (starred=False).
+            assert rows[0] == (self.source_ids[0], False)
+            assert rows[1] == (self.source_ids[1], True)
+
+            # Unique constraint is now enforced.
+            try:
+                db.engine.execute(
+                    text(
+                        "INSERT INTO source_stars (source_id, starred)" " VALUES (:sid, :starred)"
+                    ),
+                    sid=self.source_ids[0],
+                    starred=True,
+                )
+                raise AssertionError("Expected a unique constraint violation")
+            except exc.IntegrityError:
+                pass
+
+
+class DowngradeTester:
+    """Downgrading drops the unique constraint but leaves existing data intact."""
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+        self.source_ids = []
+
+    def load_data(self):
+        self.source_ids = [
+            _insert_source(self.app, "bold sparrow"),
+            _insert_source(self.app, "dim walrus"),
+        ]
+        with self.app.app_context():
+            for sid in self.source_ids:
+                db.engine.execute(
+                    text(
+                        "INSERT INTO source_stars (source_id, starred)" " VALUES (:sid, :starred)"
+                    ),
+                    sid=sid,
+                    starred=True,
+                )
+
+    def check_downgrade(self):
+        with self.app.app_context():
+            rows = db.engine.execute("SELECT source_id FROM source_stars ORDER BY id").fetchall()
+            # Existing rows are still present.
+            assert len(rows) == 2
+
+            # After downgrade, the unique constraint is gone — duplicates are allowed again.
+            db.engine.execute(
+                text("INSERT INTO source_stars (source_id, starred)" " VALUES (:sid, :starred)"),
+                sid=self.source_ids[0],
+                starred=False,
+            )
+            duplicates = db.engine.execute(
+                text("SELECT id FROM source_stars WHERE source_id = :sid"),
+                sid=self.source_ids[0],
+            ).fetchall()
+            assert len(duplicates) == 2

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -2,6 +2,7 @@ import base64
 import binascii
 import os
 import random
+import threading
 import time
 import zipfile
 from base64 import b64decode
@@ -17,7 +18,7 @@ from flaky import flaky
 from flask import g, url_for
 from flask_babel import gettext, ngettext
 from journalist_app.sessions import session
-from journalist_app.utils import mark_seen
+from journalist_app.utils import make_star_false, make_star_true, mark_seen
 from markupsafe import escape
 from models import (
     InstanceConfig,
@@ -30,6 +31,7 @@ from models import (
     SeenMessage,
     SeenReply,
     Source,
+    SourceStar,
     Submission,
 )
 from passphrases import PassphraseGenerator
@@ -3771,6 +3773,38 @@ def test_single_source_is_successfully_unstarred(journalist_app, test_journo, te
 
         source = Source.query.get(test_source["id"])
         assert not source.star.starred
+
+
+@pytest.mark.parametrize("make_star", [make_star_true, make_star_false], ids=["true", "false"])
+def test_make_star_race(journalist_app, test_source, make_star):
+    """Concurrent make_star_{true,false} calls can't insert duplicate SourceStar rows."""
+    barrier = threading.Barrier(2)
+    errors = []
+    original_init = SourceStar.__init__
+
+    def slow_init(self, source, starred=True):
+        original_init(self, source, starred)
+        barrier.wait(timeout=5)
+
+    def run():
+        with journalist_app.app_context():
+            try:
+                make_star(test_source["filesystem_id"])
+                db.session.commit()
+            except IntegrityError:
+                db.session.rollback()
+                errors.append(True)
+
+    with patch.object(SourceStar, "__init__", slow_init):
+        threads = [threading.Thread(target=run) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+    assert len(errors) == 1
+    with journalist_app.app_context():
+        assert SourceStar.query.filter_by(source_id=test_source["id"]).count() == 1
 
 
 @flaky(rerun_filter=utils.flaky_filter_xfail)

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -858,22 +858,22 @@ def test_api2_atomic_idempotence(redis):
 
     barrier = threading.Barrier(2)
     handler_call_count = [0]
-    original_get = redis.get
+    original_set = redis.set
 
-    def slow_get(key):
-        result = original_get(key)
-        if not result:
-            # Widen the possible TOCTOU window: hold both threads here until
-            # both have seen the key absent, then release together.
+    def slow_set(*args, **kwargs):
+        if kwargs.get("nx"):
+            # Widen the possible TOCTOU window: hold both threads at the SETNX
+            # gate until both are about to set the not-yet-existing key, then
+            # release together so atomicity is what enforces the invariant.
             barrier.wait(timeout=5)
-        return result
+        return original_set(*args, **kwargs)
 
     def counting_handler(ev, minor):
         handler_call_count[0] += 1
         return EventResult(event_id=ev.id, status=(EventStatusCode.OK, None))
 
     with (
-        patch.object(redis, "get", slow_get),
+        patch.object(redis, "set", slow_set),
         patch.object(EventHandler, "handle_source_starred", staticmethod(counting_handler)),
     ):
         threads = [
@@ -888,8 +888,9 @@ def test_api2_atomic_idempotence(redis):
         for t in threads:
             t.join(timeout=10)
 
-    # Should be 1: a correct implementation lets only one thread past the check.
-    # Fails with count == 2 when has_progress() uses GET (non-atomic check-then-act).
+    # Should be 1: a correct implementation relies on atomic SETNX to let only
+    # one thread past the check. Fails with count == 2 if mark_progress() drops
+    # the NX flag or claim_progress() reverts to a non-atomic check-then-act.
     assert handler_call_count[0] == 1
 
 

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -571,6 +571,85 @@ def test_api2_reply_sent(
         assert reply2["uuid"] not in response.json["items"]
 
 
+def test_api2_reply_sent_unencrypted(journalist_app, journalist_api_token, test_files):
+    """handle_reply_sent returns 400 BadRequest if the reply is not PGP-encrypted."""
+    with journalist_app.test_client() as app:
+        source = test_files["source"]
+        index = app.get(url_for("api2.index"), headers=get_api_headers(journalist_api_token))
+        source_version = index.json["sources"][source.uuid]
+
+        event = Event(
+            id="400001",
+            target=SourceTarget(source_uuid=source.uuid, version=source_version),
+            type=EventType.REPLY_SENT,
+            data={"uuid": str(uuid.uuid4()), "reply": "not a pgp message"},
+        )
+        response = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(event)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.json["events"][event.id][0] == 400
+
+
+def test_api2_reply_sent_duplicate_uuid(journalist_app, journalist_api_token, test_files):
+    """handle_reply_sent returns 409 Conflict if save_reply() would commit a duplicate UUID."""
+    with journalist_app.test_client() as app:
+        source = test_files["source"]
+        reply = test_files["replies"][0]
+
+        reply_ct = app.get(
+            url_for("api.download_reply", source_uuid=source.uuid, reply_uuid=reply.uuid),
+            headers=get_api_headers(journalist_api_token),
+        ).data
+
+        index = app.get(url_for("api2.index"), headers=get_api_headers(journalist_api_token))
+        source_version = index.json["sources"][source.uuid]
+
+        shared_uuid = str(uuid.uuid4())
+        event1 = Event(
+            id="409001",
+            target=SourceTarget(source_uuid=source.uuid, version=source_version),
+            type=EventType.REPLY_SENT,
+            data={"uuid": shared_uuid, "reply": ascii_armor(reply_ct)},
+        )
+        response1 = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(event1)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response1.json["events"]["409001"] == [200, None]
+
+        # A different event that tries to commit the same reply UUID:
+        event2 = Event(
+            id="409002",
+            target=SourceTarget(source_uuid=source.uuid, version=source_version),
+            type=EventType.REPLY_SENT,
+            data={"uuid": shared_uuid, "reply": ascii_armor(reply_ct)},
+        )
+        response2 = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(event2)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response2.json["events"]["409002"][0] == 409
+
+        # A different event that tries to use a submission's UUID as the reply UUID:
+        submission = test_files["submissions"][0]
+        event3 = Event(
+            id="409003",
+            target=SourceTarget(source_uuid=source.uuid, version=source_version),
+            type=EventType.REPLY_SENT,
+            data={"uuid": submission.uuid, "reply": ascii_armor(reply_ct)},
+        )
+        response3 = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(event3)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response3.json["events"]["409003"][0] == 409
+
+
 def test_api2_item_deleted(
     journalist_app,
     journalist_api_token,

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -701,7 +701,7 @@ def test_api2_item_deleted(
         assert response.json["items"][event.target.item_uuid] is None
         assert Reply.query.filter(Reply.uuid == event.target.item_uuid).one_or_none() is None
 
-        # Try to delete something that doesn't exist:
+        # Try to delete something that doesn't exist (database-level idempotence):
         nonexistent_event = Event(
             id="345678",
             target=ItemTarget(item_uuid=str(uuid.uuid4()), version=reply_version),
@@ -714,6 +714,22 @@ def test_api2_item_deleted(
         )
         assert response.json["events"][nonexistent_event.id] == [410, None]
         assert nonexistent_event.target.item_uuid not in response.json["items"]
+
+        # File already gone from disk but DB record still present (filesystem-level idempotence):
+        stale_submission_uuid = test_files["submissions"][1].uuid
+        stale_submission_version = index.json["items"][stale_submission_uuid]
+        stale_event = Event(
+            id="410001",
+            target=ItemTarget(item_uuid=stale_submission_uuid, version=stale_submission_version),
+            type=EventType.ITEM_DELETED,
+        )
+        with patch("journalist_app.utils.delete_file_object", side_effect=FileNotFoundError):
+            response = app.post(
+                url_for("api2.data"),
+                json={"events": [asdict(stale_event)]},
+                headers=get_api_headers(journalist_api_token),
+            )
+        assert response.json["events"][stale_event.id] == [410, None]
 
 
 def test_api2_source_deleted(

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -1,3 +1,4 @@
+import os
 import threading
 import uuid
 from contextlib import contextmanager
@@ -655,6 +656,7 @@ def test_api2_item_deleted(
     journalist_api_token,
     test_files,
     test_journo,
+    app_storage,
 ):
     """Test processing of the "item_deleted" event."""
     with journalist_app.test_client() as app:
@@ -716,20 +718,21 @@ def test_api2_item_deleted(
         assert nonexistent_event.target.item_uuid not in response.json["items"]
 
         # File already gone from disk but DB record still present (filesystem-level idempotence):
-        stale_submission_uuid = test_files["submissions"][1].uuid
+        stale_submission = test_files["submissions"][1]
+        stale_submission_uuid = stale_submission.uuid
         stale_submission_version = index.json["items"][stale_submission_uuid]
+        os.remove(app_storage.path(test_files["filesystem_id"], stale_submission.filename))
         stale_event = Event(
             id="410001",
             target=ItemTarget(item_uuid=stale_submission_uuid, version=stale_submission_version),
             type=EventType.ITEM_DELETED,
         )
-        with patch("journalist_app.utils.delete_file_object", side_effect=FileNotFoundError):
-            response = app.post(
-                url_for("api2.data"),
-                json={"events": [asdict(stale_event)]},
-                headers=get_api_headers(journalist_api_token),
-            )
-        assert response.json["events"][stale_event.id] == [410, None]
+        response = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(stale_event)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.json["events"][stale_event.id] == [200, None]
 
 
 def test_api2_source_deleted(

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -1,8 +1,10 @@
+import threading
 import uuid
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import asdict
 from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import journalist_app as journalist_app_module
@@ -10,19 +12,28 @@ import pytest
 from flask import url_for
 from flask_sqlalchemy import get_debug_queries
 from journalist_app import api2
+from journalist_app.api2.events import EventHandler
 from journalist_app.api2.shared import json_version
 from journalist_app.api2.types import (
     VERSION_LEN,
     Event,
+    EventResult,
+    EventStatusCode,
     EventType,
     ItemTarget,
     SourceTarget,
 )
 from models import Reply, Source, SourceStar, Submission, db
+from redis import Redis
 from sqlalchemy.orm.exc import MultipleResultsFound
 from tests.utils import ascii_armor, decrypt_as_journalist
 from tests.utils.api_helper import get_api_headers
 from tests.utils.db_helper import init_source, submit
+
+
+@pytest.fixture
+def redis(config):
+    return Redis(decode_responses=True, **config.REDIS_KWARGS)
 
 
 def filtered_queries():
@@ -830,6 +841,56 @@ def test_api2_idempotence_period(journalist_app):
     """
 
     assert journalist_app.config["SESSION_LIFETIME"] <= api2.events.IDEMPOTENCE_PERIOD
+
+
+def test_api2_atomic_idempotence(redis):
+    """
+    Check that identical events received simultaneously are still only accepted
+    once.
+    """
+
+    session = MagicMock()
+    session.user.uuid = str(uuid4())
+
+    event = MagicMock()
+    event.id = str(uuid4())
+    event.type = EventType.SOURCE_STARRED
+
+    barrier = threading.Barrier(2)
+    handler_call_count = [0]
+    original_get = redis.get
+
+    def slow_get(key):
+        result = original_get(key)
+        if not result:
+            # Widen the possible TOCTOU window: hold both threads here until
+            # both have seen the key absent, then release together.
+            barrier.wait(timeout=5)
+        return result
+
+    def counting_handler(ev, minor):
+        handler_call_count[0] += 1
+        return EventResult(event_id=ev.id, status=(EventStatusCode.OK, None))
+
+    with (
+        patch.object(redis, "get", slow_get),
+        patch.object(EventHandler, "handle_source_starred", staticmethod(counting_handler)),
+    ):
+        threads = [
+            threading.Thread(
+                target=EventHandler(session=session, redis=redis).process,
+                args=(event, 1),
+            )
+            for _ in range(2)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+    # Should be 1: a correct implementation lets only one thread past the check.
+    # Fails with count == 2 when has_progress() uses GET (non-atomic check-then-act).
+    assert handler_call_count[0] == 1
 
 
 def test_api2_event_ordering(journalist_app, journalist_api_token, test_files):


### PR DESCRIPTION
This pull request proposes fixes for a number of data races and related logic errors in and around the v2 Journalist API.  Each of the following bug reports is reproduced in a `test` commit and fixed in a `fix` commit:

1. Fixes #7832
2. Fixes #7833
3. Fixes #7835

In addition:

4. Fixes #7834 via two `fix` commits, one of which includes a change to the `SourceStar` model and an Alembic migration to apply it.  I can split these changes out into a separate pull request if we want to evaluate them separately.

In fact, any of these changes should be easy to factor out into a separate pull request if that's easier to review, but I've found it helpful to build them up together.


## Test plan

I recommend reviewing by stepping through commit by commit rather than looking at the net diff.

- [ ] CI is passing here.
- [ ] Staging CI is passing on [`stg-fewer-data-races`].
- [ ] The Journalist Interface works normally in smoke-testing.
- [ ] The Inbox works normally in smoke-testing.


[`stg-fewer-data-races`]: https://github.com/freedomofpress/securedrop/tree/stg-fewer-data-races