### PR TITLE
Upgrade pip to 26.1.1

### DIFF
--- a/admin/debian/rules
+++ b/admin/debian/rules
@@ -12,7 +12,7 @@ override_dh_auto_install:
 # Set up virtualenv and install dependencies
 	/usr/bin/python3 -m venv ./debian/securedrop-admin/usr/share/securedrop-admin/venv
 	./debian/securedrop-admin/usr/share/securedrop-admin/venv/bin/pip install \
-		$(PIP_BOOTSTRAP_ARGS)  pip==26.0
+		$(PIP_BOOTSTRAP_ARGS)  pip==26.1
 
 	./debian/securedrop-admin/usr/share/securedrop-admin/venv/bin/pip install $(PIP_ARGS) \
 		-r ./requirements.txt

--- a/admin/requirements-dev.in
+++ b/admin/requirements-dev.in
@@ -13,4 +13,4 @@ uv
 
 # If this needs updating, search this repository for other references to "pip"
 # that may be missed by our tools.
-pip>=26  # Safety 75180
+pip>=26.1  # Safety 75180

--- a/admin/requirements-dev.txt
+++ b/admin/requirements-dev.txt
@@ -232,9 +232,9 @@ pexpect==4.9.0 \
     --hash=sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523 \
     --hash=sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f
     # via -r requirements-dev.in
-pip==26.0 \
-    --hash=sha256:3ce220a0a17915972fbf1ab451baae1521c4539e778b28127efa79b974aff0fa \
-    --hash=sha256:98436feffb9e31bc9339cf369fd55d3331b1580b6a6f1173bacacddcf9c34754
+pip==26.1.1 \
+    --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb \
+    --hash=sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78
     # via -r requirements-dev.in
 platformdirs==4.3.8 \
     --hash=sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc \

--- a/securedrop/debian/rules
+++ b/securedrop/debian/rules
@@ -24,7 +24,7 @@ override_dh_auto_install:
 	# Set up virtualenv and install dependencies
 	/usr/bin/python3 -m venv ./debian/securedrop-app-code/opt/venvs/securedrop-app-code
 	./debian/securedrop-app-code/opt/venvs/securedrop-app-code/bin/pip install $(PIP_ARGS) \
-		pip==26.0
+		pip==26.1.1
 	./debian/securedrop-app-code/opt/venvs/securedrop-app-code/bin/pip install $(PIP_ARGS) \
 		-r requirements/requirements.txt
 	./debian/securedrop-app-code/opt/venvs/securedrop-app-code/bin/pip install $(PIP_ARGS) \

--- a/securedrop/debian/translations.sh
+++ b/securedrop/debian/translations.sh
@@ -6,9 +6,9 @@ set -ex
 # beyond what the system version provides, see #6317.
 python3 -m venv /tmp/securedrop-app-code-i18n-ve
 /tmp/securedrop-app-code-i18n-ve/bin/pip3 install -r \
-<(echo "pip==26.0 \
---hash=sha256:3ce220a0a17915972fbf1ab451baae1521c4539e778b28127efa79b974aff0fa \
---hash=sha256:98436feffb9e31bc9339cf369fd55d3331b1580b6a6f1173bacacddcf9c34754")
+<(echo "pip==26.1.1 \
+    --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb \
+    --hash=sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78")
 
 source /etc/os-release
 

--- a/securedrop/requirements/base-requirements.in
+++ b/securedrop/requirements/base-requirements.in
@@ -3,4 +3,4 @@ setuptools>=70.0.0
 
 # If this needs updating, search this repository for other references to "pip"
 # that may be missed by our tools.
-pip>=26  # Safety 75180
+pip>=26.1  # Safety 75180

--- a/securedrop/requirements/bootstrap-requirements.txt
+++ b/securedrop/requirements/bootstrap-requirements.txt
@@ -7,9 +7,9 @@ packaging==24.1 \
     #   -r requirements/bootstrap-requirements.in
     #   setuptools-scm
     #   wheel
-pip==26.0 \
-    --hash=sha256:3ce220a0a17915972fbf1ab451baae1521c4539e778b28127efa79b974aff0fa \
-    --hash=sha256:98436feffb9e31bc9339cf369fd55d3331b1580b6a6f1173bacacddcf9c34754
+pip==26.1.1 \
+    --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb \
+    --hash=sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78
     # via -r requirements/base-requirements.in
 setuptools==79.0.1 \
     --hash=sha256:128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88 \

--- a/securedrop/requirements/develop-requirements.txt
+++ b/securedrop/requirements/develop-requirements.txt
@@ -720,9 +720,9 @@ pathspec==0.9.0 \
 peewee==3.18.3 \
     --hash=sha256:62c3d93315b1a909360c4b43c3a573b47557a1ec7a4583a71286df2a28d4b72e
     # via semgrep
-pip==26.0 \
-    --hash=sha256:3ce220a0a17915972fbf1ab451baae1521c4539e778b28127efa79b974aff0fa \
-    --hash=sha256:98436feffb9e31bc9339cf369fd55d3331b1580b6a6f1173bacacddcf9c34754
+pip==26.1.1 \
+    --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb \
+    --hash=sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78
     # via -r requirements/base-requirements.in
 platformdirs==4.3.6 \
     --hash=sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907 \

--- a/securedrop/requirements/requirements.txt
+++ b/securedrop/requirements/requirements.txt
@@ -270,9 +270,9 @@ markupsafe==2.1.2 \
 mod-wsgi==4.9.4 \
     --hash=sha256:8e762662ea5b01afc386bbcfbaa079748eb6203ab1d6d3a3dac9237f5666cfc9
     # via -r requirements/requirements.in
-pip==26.0 \
-    --hash=sha256:3ce220a0a17915972fbf1ab451baae1521c4539e778b28127efa79b974aff0fa \
-    --hash=sha256:98436feffb9e31bc9339cf369fd55d3331b1580b6a6f1173bacacddcf9c34754
+pip==26.1.1 \
+    --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb \
+    --hash=sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78
     # via -r requirements/base-requirements.in
 psutil==7.0.0 \
     --hash=sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25 \

--- a/securedrop/requirements/test-requirements.txt
+++ b/securedrop/requirements/test-requirements.txt
@@ -213,9 +213,9 @@ pillow==10.3.0 \
     --hash=sha256:fdcbb4068117dfd9ce0138d068ac512843c52295ed996ae6dd1faf537b6dbc27 \
     --hash=sha256:ff61bfd9253c3915e6d41c651d5f962da23eda633cf02262990094a18a55371a
     # via -r requirements/test-requirements.in
-pip==26.0 \
-    --hash=sha256:3ce220a0a17915972fbf1ab451baae1521c4539e778b28127efa79b974aff0fa \
-    --hash=sha256:98436feffb9e31bc9339cf369fd55d3331b1580b6a6f1173bacacddcf9c34754
+pip==26.1.1 \
+    --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb \
+    --hash=sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78
     # via -r requirements/base-requirements.in
 pluggy==0.13.1 \
     --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \

--- a/securedrop/requirements/translation-requirements.txt
+++ b/securedrop/requirements/translation-requirements.txt
@@ -9,9 +9,9 @@ babel==2.12.1 \
 babelgladeextractor==0.7.0 \
     --hash=sha256:bcf805e28b4bb18c8b6909a65a7cf5c7c2bcbf4ae50b164878c9682d22271798
     # via -r requirements/translation-requirements.in
-pip==26.0 \
-    --hash=sha256:3ce220a0a17915972fbf1ab451baae1521c4539e778b28127efa79b974aff0fa \
-    --hash=sha256:98436feffb9e31bc9339cf369fd55d3331b1580b6a6f1173bacacddcf9c34754
+pip==26.1.1 \
+    --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb \
+    --hash=sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78
     # via -r requirements/base-requirements.in
 setuptools==80.4.0 \
     --hash=sha256:5a78f61820bc088c8e4add52932ae6b8cf423da2aff268c23f813cfbb13b4006 \


### PR DESCRIPTION
Fixes a slew of Dependabot alerts.

## Test plan
- [ ] CI is passing
- [ ] update looks consistent and pip is updated in all locations.