### PR TITLE
Update werkzeug to 2.3.8

### DIFF
--- a/securedrop/requirements/requirements.in
+++ b/securedrop/requirements/requirements.in
@@ -19,5 +19,5 @@ redis>=4.5.4
 rq>=1.8.1
 SQLAlchemy>=1.3.0
 typing;python_version<"3.8"
-Werkzeug>=2.2.3
+Werkzeug>=2.3.8,<3.0.0
 wtforms>=3.0.0

--- a/securedrop/requirements/requirements.txt
+++ b/securedrop/requirements/requirements.txt
@@ -334,9 +334,9 @@ sqlalchemy==1.3.3 \
     #   -r requirements/requirements.in
     #   alembic
     #   flask-sqlalchemy
-werkzeug==2.2.3 \
-    --hash=sha256:2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe \
-    --hash=sha256:56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612
+werkzeug==2.3.8 \
+    --hash=sha256:554b257c74bbeb7a0d254160a4f8ffe185243f52a52035060b761ca62d977f03 \
+    --hash=sha256:bba1f19f8ec89d4d607a3bd62f1904bd2e609472d93cd85e9d4e178f472c3748
     # via
     #   -r requirements/requirements.in
     #   flask


### PR DESCRIPTION
Updates werkzeug to v2.3.8 to clear a plethora of dependabot alerts.

## Test plan
- [ ] CI is passing
- [ ] werkzeug is updated in all locations.
