### PR TITLE
fix(`handle_item_deleted`): unify "missing file" versus "missing record" handling with `handle_source_truncated()`

### DIFF
--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -15,7 +15,7 @@ from journalist_app.sessions import Session, session
 from models import Reply, Source, Submission
 from redis import Redis
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound, StaleDataError
 from store import NotEncrypted
 
 # `IDEMPOTENCE_PERIOD` MUST be greater than or equal to
@@ -132,16 +132,18 @@ class EventHandler:
 
         try:
             utils.delete_file_object(item)
-            return EventResult(
-                event_id=event.id,
-                status=(EventStatusCode.OK, None),
-                items={event.target.item_uuid: None},
-            )
-        except ValueError as exc:
-            return EventResult(
-                event_id=event.id,
-                status=(EventStatusCode.InternalServerError, str(exc)),
-            )
+        except (StaleDataError, ValueError):
+            # `utils.delete_file_object()` is non-atomic: it guarantees database
+            # deletion but not filesystem deletion.  The former is all we need
+            # for consistency with the client, and the latter will be caught by
+            # monitoring for "disconnected" submissions.
+            pass
+
+        return EventResult(
+            event_id=event.id,
+            status=(EventStatusCode.OK, None),
+            items={event.target.item_uuid: None},
+        )
 
     @staticmethod
     def handle_reply_sent(event: Event, minor: int) -> EventResult:
@@ -255,7 +257,7 @@ class EventHandler:
             if item.interaction_count <= event.data.upper_bound:
                 try:
                     utils.delete_file_object(item)
-                except ValueError:
+                except (StaleDataError, ValueError):
                     # `utils.delete_file_object()` is non-atomic: it guarantees
                     # database deletion but not filesystem deletion.  The former
                     # is all we need for consistency with the client, and the

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -701,7 +701,7 @@ def test_api2_item_deleted(
         assert response.json["items"][event.target.item_uuid] is None
         assert Reply.query.filter(Reply.uuid == event.target.item_uuid).one_or_none() is None
 
-        # Try to delete something that doesn't exist:
+        # Try to delete something that doesn't exist (database-level idempotence):
         nonexistent_event = Event(
             id="345678",
             target=ItemTarget(item_uuid=str(uuid.uuid4()), version=reply_version),
@@ -714,6 +714,22 @@ def test_api2_item_deleted(
         )
         assert response.json["events"][nonexistent_event.id] == [410, None]
         assert nonexistent_event.target.item_uuid not in response.json["items"]
+
+        # File already gone from disk but DB record still present (filesystem-level idempotence):
+        stale_submission_uuid = test_files["submissions"][1].uuid
+        stale_submission_version = index.json["items"][stale_submission_uuid]
+        stale_event = Event(
+            id="410001",
+            target=ItemTarget(item_uuid=stale_submission_uuid, version=stale_submission_version),
+            type=EventType.ITEM_DELETED,
+        )
+        with patch("journalist_app.utils.delete_file_object", side_effect=FileNotFoundError):
+            response = app.post(
+                url_for("api2.data"),
+                json={"events": [asdict(stale_event)]},
+                headers=get_api_headers(journalist_api_token),
+            )
+        assert response.json["events"][stale_event.id] == [410, None]
 
 
 def test_api2_source_deleted(

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -1,3 +1,4 @@
+import os
 import threading
 import uuid
 from contextlib import contextmanager
@@ -655,6 +656,7 @@ def test_api2_item_deleted(
     journalist_api_token,
     test_files,
     test_journo,
+    app_storage,
 ):
     """Test processing of the "item_deleted" event."""
     with journalist_app.test_client() as app:
@@ -716,20 +718,21 @@ def test_api2_item_deleted(
         assert nonexistent_event.target.item_uuid not in response.json["items"]
 
         # File already gone from disk but DB record still present (filesystem-level idempotence):
-        stale_submission_uuid = test_files["submissions"][1].uuid
+        stale_submission = test_files["submissions"][1]
+        stale_submission_uuid = stale_submission.uuid
         stale_submission_version = index.json["items"][stale_submission_uuid]
+        os.remove(app_storage.path(test_files["filesystem_id"], stale_submission.filename))
         stale_event = Event(
             id="410001",
             target=ItemTarget(item_uuid=stale_submission_uuid, version=stale_submission_version),
             type=EventType.ITEM_DELETED,
         )
-        with patch("journalist_app.utils.delete_file_object", side_effect=FileNotFoundError):
-            response = app.post(
-                url_for("api2.data"),
-                json={"events": [asdict(stale_event)]},
-                headers=get_api_headers(journalist_api_token),
-            )
-        assert response.json["events"][stale_event.id] == [410, None]
+        response = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(stale_event)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.json["events"][stale_event.id] == [200, None]
 
 
 def test_api2_source_deleted(


### PR DESCRIPTION
* [ ] Depends on #7850
    * Change the target branch to `develop` once this has been merged.

Fixes #7835.  Originally part of #7837.

## Test plan

The Inbox works normally in smoke-testing, including deleting source accounts and truncating source conversations.