### PR TITLE
fix(`SourceStar`): make unique per `SourceStar.source_id`

### DIFF
--- a/securedrop/alembic/versions/88bb7f366038_unique_constraint_on_source_stars_source_id.py
+++ b/securedrop/alembic/versions/88bb7f366038_unique_constraint_on_source_stars_source_id.py
@@ -1,0 +1,33 @@
+"""unique constraint on source_stars.source_id
+
+Revision ID: 88bb7f366038
+Revises: 17c559a7a685
+Create Date: 2026-05-15
+
+"""
+
+from alembic import op
+
+revision = "88bb7f366038"
+down_revision = "17c559a7a685"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Delete duplicate rows, keeping the one with the highest id (most recent).
+    op.execute(
+        """
+        DELETE FROM source_stars
+        WHERE id NOT IN (
+            SELECT MAX(id) FROM source_stars GROUP BY source_id
+        )
+        """
+    )
+    with op.batch_alter_table("source_stars") as batch_op:
+        batch_op.create_unique_constraint("uq_source_stars_source_id", ["source_id"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("source_stars") as batch_op:
+        batch_op.drop_constraint("uq_source_stars_source_id", type_="unique")

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -14,7 +14,8 @@ from journalist_app.api2.types import (
 from journalist_app.sessions import Session, session
 from models import Reply, Source, Submission
 from redis import Redis
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound, StaleDataError
 from store import NotEncrypted
 
 # `IDEMPOTENCE_PERIOD` MUST be greater than or equal to
@@ -131,16 +132,18 @@ class EventHandler:
 
         try:
             utils.delete_file_object(item)
-            return EventResult(
-                event_id=event.id,
-                status=(EventStatusCode.OK, None),
-                items={event.target.item_uuid: None},
-            )
-        except ValueError as exc:
-            return EventResult(
-                event_id=event.id,
-                status=(EventStatusCode.InternalServerError, str(exc)),
-            )
+        except (StaleDataError, ValueError):
+            # `utils.delete_file_object()` is non-atomic: it guarantees database
+            # deletion but not filesystem deletion.  The former is all we need
+            # for consistency with the client, and the latter will be caught by
+            # monitoring for "disconnected" submissions.
+            pass
+
+        return EventResult(
+            event_id=event.id,
+            status=(EventStatusCode.OK, None),
+            items={event.target.item_uuid: None},
+        )
 
     @staticmethod
     def handle_reply_sent(event: Event, minor: int) -> EventResult:
@@ -254,7 +257,7 @@ class EventHandler:
             if item.interaction_count <= event.data.upper_bound:
                 try:
                     utils.delete_file_object(item)
-                except ValueError:
+                except (StaleDataError, ValueError):
                     # `utils.delete_file_object()` is non-atomic: it guarantees
                     # database deletion but not filesystem deletion.  The former
                     # is all we need for consistency with the client, and the

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -324,15 +324,21 @@ class EventHandler:
                 ),
             )
 
-        utils.make_star_true(source.filesystem_id)
-        db.session.commit()
-        db.session.refresh(source)
+        try:
+            utils.make_star_true(source.filesystem_id)
+            db.session.commit()
+            db.session.refresh(source)
 
-        return EventResult(
-            event_id=event.id,
-            status=(EventStatusCode.OK, None),
-            sources={source.uuid: source},
-        )
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.OK, None),
+                sources={source.uuid: source},
+            )
+        except IntegrityError:
+            db.session.rollback()
+            return EventResult(
+                event_id=event.id, status=(EventStatusCode.Conflict, "duplicate star; please retry")
+            )
 
     @staticmethod
     def handle_source_unstarred(event: Event, minor: int) -> EventResult:
@@ -347,15 +353,21 @@ class EventHandler:
                 ),
             )
 
-        utils.make_star_false(source.filesystem_id)
-        db.session.commit()
-        db.session.refresh(source)
+        try:
+            utils.make_star_false(source.filesystem_id)
+            db.session.commit()
+            db.session.refresh(source)
 
-        return EventResult(
-            event_id=event.id,
-            status=(EventStatusCode.OK, None),
-            sources={source.uuid: source},
-        )
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.OK, None),
+                sources={source.uuid: source},
+            )
+        except IntegrityError:
+            db.session.rollback()
+            return EventResult(
+                event_id=event.id, status=(EventStatusCode.Conflict, "duplicate star; please retry")
+            )
 
 
 def find_item(item_uuid: ItemUUID) -> Submission | Reply | None:

--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -15,6 +15,7 @@ from journalist_app.sessions import Session, session
 from models import Reply, Source, Submission
 from redis import Redis
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from store import NotEncrypted
 
 # `IDEMPOTENCE_PERIOD` MUST be greater than or equal to
 # `sdconfig.SecureDropConfig.SESSION_LIFETIME`.  In practice, 24 hours is the
@@ -154,14 +155,37 @@ class EventHandler:
                 ),
             )
 
-        reply = save_reply(source, asdict(event.data))
-        db.session.refresh(source)
+        # SQLite will enforce uniqueness within Reply.uuid, but we need
+        # uniqueness within the combined set of Reply.uuid and Submission.uuid.
+        if find_item(event.data.uuid) is not None:
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.Conflict, "duplicate UUID"),
+            )
+
+        try:
+            reply = save_reply(source, asdict(event.data))
+            db.session.refresh(source)
+
+            return EventResult(
+                event_id=event.id,
+                status=(EventStatusCode.OK, None),
+                sources={source.uuid: source},
+                items={reply.uuid: reply},
+            )
+        except NotEncrypted:
+            db.session.rollback()
+            status = (EventStatusCode.BadRequest, "reply is not encrypted")
+        except IntegrityError:
+            db.session.rollback()
+            status = (EventStatusCode.Conflict, "duplicate UUID")
+        # `save_reply()` can also raise `InvalidUUID`, but this will have been
+        # caught by validation of the `ReplySentData` type before this handler
+        # is ever invoked.
 
         return EventResult(
             event_id=event.id,
-            status=(EventStatusCode.OK, None),
-            sources={source.uuid: source},
-            items={reply.uuid: reply},
+            status=status,
         )
 
     @staticmethod

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -46,7 +46,7 @@ class EventStatusCode(IntEnum):
     BadRequest = 400
     # The target UUID doesn't exist (non-deletion requests)
     NotFound = 404
-    # Provided version is out of date and it was a deletion request
+    # Version is out of date or the target UUID is already in use
     Conflict = 409
     # The target UUID doesn't exist and it was a deletion request
     Gone = 410

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -41,15 +41,23 @@ class EventType(StrEnum):
 class EventStatusCode(IntEnum):
     Processing = 102
     OK = 200
+
     # We already saw and processed this event
     AlreadyReported = 208
+
     BadRequest = 400
+
     # The target UUID doesn't exist (non-deletion requests)
     NotFound = 404
-    # Version is out of date or there is a database conflict
+
+    # REPLY_SENT: duplicate UUID
+    # SOURCE_DELETED: version conflict
+    # SOURCE_{STARRED,UNSTARRED}: duplicate SourceStar for Source
     Conflict = 409
+
     # The target UUID doesn't exist and it was a deletion request
     Gone = 410
+
     InternalServerError = 500
     NotImplemented = 501
 

--- a/securedrop/journalist_app/api2/types.py
+++ b/securedrop/journalist_app/api2/types.py
@@ -46,7 +46,7 @@ class EventStatusCode(IntEnum):
     BadRequest = 400
     # The target UUID doesn't exist (non-deletion requests)
     NotFound = 404
-    # Version is out of date or the target UUID is already in use
+    # Version is out of date or there is a database conflict
     Conflict = 409
     # The target UUID doesn't exist and it was a deletion request
     Gone = 410

--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -464,6 +464,7 @@ class Reply(db.Model):
 
 class SourceStar(db.Model):
     __tablename__ = "source_stars"
+    __table_args__ = (db.UniqueConstraint("source_id", name="uq_source_stars_source_id"),)
     id = Column("id", Integer, primary_key=True)
     source_id = Column("source_id", Integer, ForeignKey("sources.id"))
     starred = Column("starred", Boolean, default=True)

--- a/securedrop/tests/migrations/migration_88bb7f366038.py
+++ b/securedrop/tests/migrations/migration_88bb7f366038.py
@@ -1,0 +1,119 @@
+import uuid
+
+from db import db
+from journalist_app import create_app
+from sqlalchemy import exc, text
+
+
+def _insert_source(app, designation):
+    with app.app_context():
+        db.engine.execute(
+            text(
+                "INSERT INTO sources (uuid, filesystem_id, journalist_designation,"
+                " interaction_count) VALUES (:uuid, :filesystem_id, :designation, :count)"
+            ),
+            uuid=str(uuid.uuid4()),
+            filesystem_id=str(uuid.uuid4()),
+            designation=designation,
+            count=0,
+        )
+        return db.engine.execute("SELECT MAX(id) FROM sources").scalar()
+
+
+class UpgradeTester:
+    """The upgrade deletes duplicate source_stars rows (keeping the one with the
+    highest id per source_id), then enforces uniqueness on source_id."""
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+        self.source_ids = []
+
+    def load_data(self):
+        self.source_ids = [
+            _insert_source(self.app, "brave marmot"),
+            _insert_source(self.app, "quiet badger"),
+        ]
+        with self.app.app_context():
+            # Two duplicate stars for source 0; older starred=True, newer starred=False.
+            # The migration should keep the newer one (highest id).
+            for starred in (True, False):
+                db.engine.execute(
+                    text(
+                        "INSERT INTO source_stars (source_id, starred)" " VALUES (:sid, :starred)"
+                    ),
+                    sid=self.source_ids[0],
+                    starred=starred,
+                )
+            # One star for source 1 — should survive untouched.
+            db.engine.execute(
+                text("INSERT INTO source_stars (source_id, starred)" " VALUES (:sid, :starred)"),
+                sid=self.source_ids[1],
+                starred=True,
+            )
+
+    def check_upgrade(self):
+        with self.app.app_context():
+            rows = db.engine.execute(
+                "SELECT source_id, starred FROM source_stars ORDER BY id"
+            ).fetchall()
+            # Only one row per source_id remains.
+            assert len(rows) == 2
+            # The duplicate for source 0 was culled, keeping the newer row (starred=False).
+            assert rows[0] == (self.source_ids[0], False)
+            assert rows[1] == (self.source_ids[1], True)
+
+            # Unique constraint is now enforced.
+            try:
+                db.engine.execute(
+                    text(
+                        "INSERT INTO source_stars (source_id, starred)" " VALUES (:sid, :starred)"
+                    ),
+                    sid=self.source_ids[0],
+                    starred=True,
+                )
+                raise AssertionError("Expected a unique constraint violation")
+            except exc.IntegrityError:
+                pass
+
+
+class DowngradeTester:
+    """Downgrading drops the unique constraint but leaves existing data intact."""
+
+    def __init__(self, config):
+        self.config = config
+        self.app = create_app(config)
+        self.source_ids = []
+
+    def load_data(self):
+        self.source_ids = [
+            _insert_source(self.app, "bold sparrow"),
+            _insert_source(self.app, "dim walrus"),
+        ]
+        with self.app.app_context():
+            for sid in self.source_ids:
+                db.engine.execute(
+                    text(
+                        "INSERT INTO source_stars (source_id, starred)" " VALUES (:sid, :starred)"
+                    ),
+                    sid=sid,
+                    starred=True,
+                )
+
+    def check_downgrade(self):
+        with self.app.app_context():
+            rows = db.engine.execute("SELECT source_id FROM source_stars ORDER BY id").fetchall()
+            # Existing rows are still present.
+            assert len(rows) == 2
+
+            # After downgrade, the unique constraint is gone — duplicates are allowed again.
+            db.engine.execute(
+                text("INSERT INTO source_stars (source_id, starred)" " VALUES (:sid, :starred)"),
+                sid=self.source_ids[0],
+                starred=False,
+            )
+            duplicates = db.engine.execute(
+                text("SELECT id FROM source_stars WHERE source_id = :sid"),
+                sid=self.source_ids[0],
+            ).fetchall()
+            assert len(duplicates) == 2

--- a/securedrop/tests/test_journalist.py
+++ b/securedrop/tests/test_journalist.py
@@ -2,6 +2,7 @@ import base64
 import binascii
 import os
 import random
+import threading
 import time
 import zipfile
 from base64 import b64decode
@@ -17,7 +18,7 @@ from flaky import flaky
 from flask import g, url_for
 from flask_babel import gettext, ngettext
 from journalist_app.sessions import session
-from journalist_app.utils import mark_seen
+from journalist_app.utils import make_star_false, make_star_true, mark_seen
 from markupsafe import escape
 from models import (
     InstanceConfig,
@@ -30,6 +31,7 @@ from models import (
     SeenMessage,
     SeenReply,
     Source,
+    SourceStar,
     Submission,
 )
 from passphrases import PassphraseGenerator
@@ -3771,6 +3773,38 @@ def test_single_source_is_successfully_unstarred(journalist_app, test_journo, te
 
         source = Source.query.get(test_source["id"])
         assert not source.star.starred
+
+
+@pytest.mark.parametrize("make_star", [make_star_true, make_star_false], ids=["true", "false"])
+def test_make_star_race(journalist_app, test_source, make_star):
+    """Concurrent make_star_{true,false} calls can't insert duplicate SourceStar rows."""
+    barrier = threading.Barrier(2)
+    errors = []
+    original_init = SourceStar.__init__
+
+    def slow_init(self, source, starred=True):
+        original_init(self, source, starred)
+        barrier.wait(timeout=5)
+
+    def run():
+        with journalist_app.app_context():
+            try:
+                make_star(test_source["filesystem_id"])
+                db.session.commit()
+            except IntegrityError:
+                db.session.rollback()
+                errors.append(True)
+
+    with patch.object(SourceStar, "__init__", slow_init):
+        threads = [threading.Thread(target=run) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+    assert len(errors) == 1
+    with journalist_app.app_context():
+        assert SourceStar.query.filter_by(source_id=test_source["id"]).count() == 1
 
 
 @flaky(rerun_filter=utils.flaky_filter_xfail)

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -701,7 +701,7 @@ def test_api2_item_deleted(
         assert response.json["items"][event.target.item_uuid] is None
         assert Reply.query.filter(Reply.uuid == event.target.item_uuid).one_or_none() is None
 
-        # Try to delete something that doesn't exist:
+        # Try to delete something that doesn't exist (database-level idempotence):
         nonexistent_event = Event(
             id="345678",
             target=ItemTarget(item_uuid=str(uuid.uuid4()), version=reply_version),
@@ -714,6 +714,22 @@ def test_api2_item_deleted(
         )
         assert response.json["events"][nonexistent_event.id] == [410, None]
         assert nonexistent_event.target.item_uuid not in response.json["items"]
+
+        # File already gone from disk but DB record still present (filesystem-level idempotence):
+        stale_submission_uuid = test_files["submissions"][1].uuid
+        stale_submission_version = index.json["items"][stale_submission_uuid]
+        stale_event = Event(
+            id="410001",
+            target=ItemTarget(item_uuid=stale_submission_uuid, version=stale_submission_version),
+            type=EventType.ITEM_DELETED,
+        )
+        with patch("journalist_app.utils.delete_file_object", side_effect=FileNotFoundError):
+            response = app.post(
+                url_for("api2.data"),
+                json={"events": [asdict(stale_event)]},
+                headers=get_api_headers(journalist_api_token),
+            )
+        assert response.json["events"][stale_event.id] == [410, None]
 
 
 def test_api2_source_deleted(

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -1,3 +1,4 @@
+import os
 import threading
 import uuid
 from contextlib import contextmanager
@@ -655,6 +656,7 @@ def test_api2_item_deleted(
     journalist_api_token,
     test_files,
     test_journo,
+    app_storage,
 ):
     """Test processing of the "item_deleted" event."""
     with journalist_app.test_client() as app:
@@ -716,20 +718,21 @@ def test_api2_item_deleted(
         assert nonexistent_event.target.item_uuid not in response.json["items"]
 
         # File already gone from disk but DB record still present (filesystem-level idempotence):
-        stale_submission_uuid = test_files["submissions"][1].uuid
+        stale_submission = test_files["submissions"][1]
+        stale_submission_uuid = stale_submission.uuid
         stale_submission_version = index.json["items"][stale_submission_uuid]
+        os.remove(app_storage.path(test_files["filesystem_id"], stale_submission.filename))
         stale_event = Event(
             id="410001",
             target=ItemTarget(item_uuid=stale_submission_uuid, version=stale_submission_version),
             type=EventType.ITEM_DELETED,
         )
-        with patch("journalist_app.utils.delete_file_object", side_effect=FileNotFoundError):
-            response = app.post(
-                url_for("api2.data"),
-                json={"events": [asdict(stale_event)]},
-                headers=get_api_headers(journalist_api_token),
-            )
-        assert response.json["events"][stale_event.id] == [410, None]
+        response = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(stale_event)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert response.json["events"][stale_event.id] == [200, None]
 
 
 def test_api2_source_deleted(


### PR DESCRIPTION
* [ ] Depends on #7851

Fixes #7834.  Originally part of #7837.

## Test plan

- [ ] The Inbox and Journalist Interface both work normally in smoke-testing, including starring and unstarring sources.
- [ ] Stars are preserved when upgrading a server.