### PR TITLE
Run apache2 under jemalloc

### DIFF
--- a/securedrop/debian/app-code/etc/apparmor.d/usr.sbin.apache2
+++ b/securedrop/debian/app-code/etc/apparmor.d/usr.sbin.apache2
@@ -92,6 +92,7 @@
   /run/shm rw,
   /sbin/ldconfig rix,
   /sbin/ldconfig.real rix,
+  /sys/kernel/mm/transparent_hugepage/enabled r,
   /tmp/** rwm,
   /usr/bin/ r,
   /usr/bin/dash rix,

--- a/securedrop/debian/app-code/lib/systemd/system/apache2.service.d/jemalloc.conf
+++ b/securedrop/debian/app-code/lib/systemd/system/apache2.service.d/jemalloc.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2

--- a/securedrop/debian/control
+++ b/securedrop/debian/control
@@ -10,7 +10,7 @@ Package: securedrop-app-code
 Architecture: amd64
 Conflicts: libapache2-mod-wsgi, supervisor
 Replaces: libapache2-mod-wsgi, supervisor
-Depends: ${dist:Depends}, ${misc:Depends}, ${python3:Depends}, ${apparmor:Depends}, apache2, apparmor-utils, coreutils, gnupg2, libapache2-mod-xsendfile, paxctld, python3, redis-server, securedrop-config, securedrop-keyring, sqlite3
+Depends: ${dist:Depends}, ${misc:Depends}, ${python3:Depends}, ${apparmor:Depends}, apache2, apparmor-utils, coreutils, gnupg2, libapache2-mod-xsendfile, libjemalloc2, paxctld, python3, redis-server, securedrop-config, securedrop-keyring, sqlite3
 Description: SecureDrop application code, dependencies, Apache configuration, systemd services, and AppArmor profiles. This package will put the AppArmor profiles in enforce mode.
 
 Package: securedrop-config


### PR DESCRIPTION
jemalloc ends up resolving the memory fragmentation issues we've seen under APIv2 with the default glibc allocator.

It should be relatively safe to swap in given how battle tested jemalloc is by much larger corporate users.

See <https://github.com/freedomofpress/securedrop-client/issues/3234#issuecomment-4291394717> and following comments.

Fixes #7817.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] build debs and install on production hardware
* [ ] point the Inbox at said server and sync
* [ ] observe that memory usage is low/normal (below some X%?)

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)