### PR TITLE
fix: use `selectinload()` rather than `joinedload()` on one-to-many relationships to avoid Cartesian-product blow-up

### DIFF
--- a/securedrop/models.py
+++ b/securedrop/models.py
@@ -21,7 +21,15 @@ from flask_babel import gettext, ngettext
 from passphrases import PassphraseGenerator
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, LargeBinary, String, Text
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Load, Query, backref, configure_mappers, joinedload, relationship
+from sqlalchemy.orm import (
+    Load,
+    Query,
+    backref,
+    configure_mappers,
+    joinedload,
+    relationship,
+    selectinload,
+)
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from store import Storage
 
@@ -131,8 +139,8 @@ class Source(db.Model):
         base = base or Load(cls)
         return (
             joinedload(cls.star),
-            *Submission.query_options(joinedload(Source.submissions)),
-            *Reply.query_options(joinedload(Source.replies)),
+            *Submission.query_options(selectinload(Source.submissions)),
+            *Reply.query_options(selectinload(Source.replies)),
         )
 
     @property
@@ -281,8 +289,8 @@ class Submission(db.Model):
         base = base or Load(cls)
         return (
             base.joinedload(cls.source),  # type: ignore[attr-defined]
-            base.joinedload(cls.seen_files).joinedload(SeenFile.journalist),  # type: ignore[attr-defined]
-            base.joinedload(cls.seen_messages).joinedload(SeenMessage.journalist),  # type: ignore[attr-defined]
+            base.selectinload(cls.seen_files).joinedload(SeenFile.journalist),  # type: ignore[attr-defined]
+            base.selectinload(cls.seen_messages).joinedload(SeenMessage.journalist),  # type: ignore[attr-defined]
         )
 
     @property
@@ -414,7 +422,7 @@ class Reply(db.Model):
         return (
             base.joinedload(cls.source),  # type: ignore[attr-defined]
             base.joinedload(cls.journalist),  # type: ignore[attr-defined]
-            base.joinedload(cls.seen_replies).joinedload(SeenReply.journalist),  # type: ignore[attr-defined]
+            base.selectinload(cls.seen_replies).joinedload(SeenReply.journalist),  # type: ignore[attr-defined]
         )
 
     @property

--- a/securedrop/tests/test_journalist_api2.py
+++ b/securedrop/tests/test_journalist_api2.py
@@ -48,8 +48,8 @@ def filtered_queries():
 
 
 @contextmanager
-def assert_query_count(expected_count, expect_login=True):
-    """verify an API request makes the expected number of queries"""
+def assert_query_count(max_count, expect_login=True):
+    """verify an API request makes at most the expected number of queries"""
     initial_count = len(filtered_queries())
     yield
     new_queries = filtered_queries()[initial_count:]
@@ -62,8 +62,8 @@ def assert_query_count(expected_count, expect_login=True):
         new_queries = new_queries[1:]
 
     assert (
-        len(new_queries) == expected_count
-    ), f"Expected {expected_count} queries, but {len(new_queries)} were executed"
+        len(new_queries) <= max_count
+    ), f"Expected at most {max_count} queries, but {len(new_queries)} were executed"
 
 
 def test_json_version():
@@ -117,7 +117,7 @@ def test_index(journalist_app, test_files, journalist_api_token, app_storage):
 
     with journalist_app.test_client() as app:
         uuid = test_files["source"].uuid
-        with assert_query_count(2):
+        with assert_query_count(7):
             response = app.get(
                 url_for("api2.index"),
                 headers=get_api_headers(journalist_api_token),
@@ -132,7 +132,7 @@ def test_index(journalist_app, test_files, journalist_api_token, app_storage):
         assert pending_uuid not in response.json["sources"]
         assert deleted_uuid not in response.json["sources"]
 
-        with assert_query_count(2):
+        with assert_query_count(7):
             response2 = app.get(
                 url_for("api2.index"),
                 headers={
@@ -157,7 +157,7 @@ def test_index_with_shard(journalist_app, test_files, journalist_api_token):
         headers = get_api_headers(journalist_api_token)
 
         # Single-character prefix matching the source
-        with assert_query_count(2):
+        with assert_query_count(7):
             response = app.get(
                 url_for("api2.index", shard_spec=uuid[0]),
                 headers=headers,
@@ -167,7 +167,7 @@ def test_index_with_shard(journalist_app, test_files, journalist_api_token):
         assert len(response.json["items"]) == 3
 
         # ETag / 304 behavior
-        with assert_query_count(2):
+        with assert_query_count(7):
             response2 = app.get(
                 url_for("api2.index", shard_spec=uuid[0]),
                 headers={**headers, "If-None-Match": response.headers["ETag"]},
@@ -312,7 +312,7 @@ def test_metadata(journalist_app, test_files, test_journo, journalist_api_token)
         source_versions = index.json["sources"][uuid]
 
         # Get the full source
-        with assert_query_count(1):
+        with assert_query_count(6):
             response = app.post(
                 url_for("api2.data"),
                 json={"sources": [uuid]},
@@ -326,7 +326,7 @@ def test_metadata(journalist_app, test_files, test_journo, journalist_api_token)
 
         # Get an item
         item_uuid = test_files["submissions"][0].uuid
-        with assert_query_count(2):
+        with assert_query_count(5):
             response = app.post(
                 url_for("api2.data"),
                 json={"items": [item_uuid]},


### PR DESCRIPTION
Fixes #7862.  Since #7628, we've explicitly "prefer[red] expensive eager queries over *apparently* cheaper lazy queries".  That's the right instinct, but since #7604 we've overoptimized for the number of *queries* rather than the number of *results*.

Here we replace `joinedload()` for one-to-many relationships, guaranteeing $O(1)$ queries but giving us $O(n^2)$ results, with `selectinload()`, giving us us queries linear in the number of relationships (i.e., *tables*) involved and $O(n)$ results.  In the test suite, `assert_query_count()` now enforces a maximum rather than an exact number of queries.


## Test plan

1. [x] Have a large server.
    - Bonus: Have a large *production* server (either hardware or VM).

On `develop`:

2. [x] Log in with the Inbox, sync a bunch, and observe high memory usage.

On this branch (or, on a production installation, just overwrite `models.py` from this branch):

3. Restart the server.
4. [x] Log in with the Inbox, sync a bunch, and observe lower memory usage.