### PR TITLE
Update rust and rustup to latest stable versions, update pyo3 to 0.29.0

### DIFF
--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -14,7 +14,7 @@ jobs:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.90.0
+    container: rust:1.96.0
     env:
       CARGO_VET_VERSION: 0.10.2
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.90.0
+    container: rust:1.96.0
     steps:
       - uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,7 +12,7 @@ jobs:
   rust-audit:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.90.0
+    container: rust:1.96.0
     steps:
       - uses: actions/checkout@v6.0.2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,12 +530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
-
-[[package]]
 name = "is-terminal"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,15 +633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "memsec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
@@ -791,37 +776,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -829,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -841,13 +821,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -1076,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -1160,12 +1139,6 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "unindent"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "utf16_iter"

--- a/builder/serverDockerfile
+++ b/builder/serverDockerfile
@@ -29,9 +29,9 @@ RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
         unzip \
         zlib1g-dev
 
-ENV RUST_VERSION 1.90.0
-ENV RUSTUP_VERSION 1.28.2
-ENV RUSTUP_INIT_SHA256 20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
+ENV RUST_VERSION 1.96.0
+ENV RUSTUP_VERSION 1.29.0
+ENV RUSTUP_INIT_SHA256 4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
 ENV RUSTUP_HOME /opt/rustup
 ENV CARGO_HOME /opt/cargo
 

--- a/redwood/Cargo.toml
+++ b/redwood/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0"
-pyo3 = { version = "0.24.1", features = ["extension-module"] }
+pyo3 = { version = "0.29.0", features = ["extension-module"] }
 sequoia-openpgp = { version = "1.21.1", default-features = false, features = ["crypto-openssl", "compression"]}
 thiserror = "1.0.31"
 

--- a/redwood/src/stream.rs
+++ b/redwood/src/stream.rs
@@ -16,7 +16,7 @@ impl Stream<'_> {
         // In Python this is effectively calling `reader.read(len)`
         let args: Bound<PyTuple> = PyTuple::new(self.reader.py(), vec![len])?;
         let bytes: Bound<PyAny> = func.call1(args)?;
-        let bytes = bytes.downcast::<PyBytes>()?;
+        let bytes = bytes.cast::<PyBytes>()?;
         bytes.extract()
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.96.0"

--- a/securedrop/dockerfiles/noble/python3/DemoDockerfile
+++ b/securedrop/dockerfiles/noble/python3/DemoDockerfile
@@ -13,9 +13,9 @@ RUN apt-get update && \
 # 1) Download rustup-init and verify it matches hardcoded checksum
 # 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
 # 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
-ENV RUST_VERSION 1.90.0
-ENV RUSTUP_VERSION 1.28.2
-ENV RUSTUP_INIT_SHA256 20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
+ENV RUST_VERSION 1.96.0
+ENV RUSTUP_VERSION 1.29.0
+ENV RUSTUP_INIT_SHA256 4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
 ENV RUSTUP_HOME /opt/rustup
 ENV CARGO_HOME /opt/cargo
 

--- a/securedrop/dockerfiles/noble/python3/SlimDockerfile
+++ b/securedrop/dockerfiles/noble/python3/SlimDockerfile
@@ -14,9 +14,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
 # 1) Download rustup-init and verify it matches hardcoded checksum
 # 2) Run it to install rustup and the rustc/cargo "minimal" toolchain
 # 3) Add `/opt/cargo/bin` to $PATH, which is where cargo & rustc are installed
-ENV RUST_VERSION 1.90.0
-ENV RUSTUP_VERSION 1.28.2
-ENV RUSTUP_INIT_SHA256 20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
+ENV RUST_VERSION 1.96.0
+ENV RUSTUP_VERSION 1.29.0
+ENV RUSTUP_INIT_SHA256 4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
 ENV RUSTUP_HOME /opt/rustup
 ENV CARGO_HOME /opt/cargo
 

--- a/securedrop/tests/test_redwood.py
+++ b/securedrop/tests/test_redwood.py
@@ -46,7 +46,7 @@ def test_encrypt_stream_bad(tmp_path, key_pair):
         redwood.encrypt_stream([public_key], not_stream, tmp_path / "file1.asc")
     # When `.read()` returns something other than bytes
     with pytest.raises(
-        redwood.RedwoodError, match="TypeError: 'str' object cannot be converted to 'PyBytes'"
+        redwood.RedwoodError, match="TypeError: 'str' object is not an instance of 'bytes'"
     ):
         redwood.encrypt_stream([public_key], StringIO(SECRET_MESSAGE), tmp_path / "file2.asc")
     with pytest.raises(redwood.RedwoodError, match='error: "RuntimeError: uhoh"'):

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -709,14 +709,14 @@ notes = "Rust Project member"
 criteria = "safe-to-deploy"
 user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2019-03-06"
-end = "2024-04-10"
+end = "2025-10-09"
 notes = "Rust Project member"
 
 [[trusted.target-lexicon]]
 criteria = "safe-to-deploy"
 user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2019-03-06"
-end = "2025-10-09"
+end = "2027-06-25"
 notes = "Rust Project member"
 
 [[trusted.thiserror]]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -560,38 +560,68 @@ notes = "Rust Project member"
 
 [[trusted.pyo3]]
 criteria = "safe-to-run"
-user-id = 6622 # David Hewitt (davidhewitt)
+user-id = 6622
 start = "2020-09-12"
 end = "2025-10-09"
 notes = "per https://github.com/freedomofpress/securedrop-engineering/issues/112"
 
+[[trusted.pyo3]]
+criteria = "safe-to-run"
+trusted-publisher = "github:PyO3/pyo3"
+start = "2025-08-29"
+end = "2027-06-25"
+
 [[trusted.pyo3-build-config]]
 criteria = "safe-to-deploy"
-user-id = 6622 # David Hewitt (davidhewitt)
+user-id = 6622
 start = "2021-05-25"
 end = "2025-10-09"
 notes = "per https://github.com/freedomofpress/securedrop-engineering/issues/112"
 
+[[trusted.pyo3-build-config]]
+criteria = "safe-to-run"
+trusted-publisher = "github:PyO3/pyo3"
+start = "2025-08-29"
+end = "2027-06-25"
+
 [[trusted.pyo3-ffi]]
 criteria = "safe-to-deploy"
-user-id = 6622 # David Hewitt (davidhewitt)
+user-id = 6622
 start = "2022-02-27"
 end = "2025-10-09"
 notes = "per https://github.com/freedomofpress/securedrop-engineering/issues/112"
 
+[[trusted.pyo3-ffi]]
+criteria = "safe-to-run"
+trusted-publisher = "github:PyO3/pyo3"
+start = "2025-08-29"
+end = "2027-06-25"
+
 [[trusted.pyo3-macros]]
 criteria = "safe-to-deploy"
-user-id = 6622 # David Hewitt (davidhewitt)
+user-id = 6622
+start = "2020-12-20"
+end = "2025-10-09"
+notes = "per https://github.com/freedomofpress/securedrop-engineering/issues/112"
+
+[[trusted.pyo3-macros]]
+criteria = "safe-to-run"
+trusted-publisher = "github:PyO3/pyo3"
+start = "2025-08-29"
+end = "2027-06-25"
+
+[[trusted.pyo3-macros-backend]]
+criteria = "safe-to-deploy"
+user-id = 6622
 start = "2020-12-20"
 end = "2025-10-09"
 notes = "per https://github.com/freedomofpress/securedrop-engineering/issues/112"
 
 [[trusted.pyo3-macros-backend]]
-criteria = "safe-to-deploy"
-user-id = 6622 # David Hewitt (davidhewitt)
-start = "2020-12-20"
-end = "2025-10-09"
-notes = "per https://github.com/freedomofpress/securedrop-engineering/issues/112"
+criteria = "safe-to-run"
+trusted-publisher = "github:PyO3/pyo3"
+start = "2025-08-29"
+end = "2027-06-25"
 
 [[trusted.quote]]
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -106,13 +106,6 @@ user-id = 539
 user-login = "cuviper"
 user-name = "Josh Stone"
 
-[[publisher.indoc]]
-version = "2.0.5"
-when = "2024-03-23"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
 [[publisher.is-terminal]]
 version = "0.4.12"
 when = "2024-02-09"
@@ -309,8 +302,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.target-lexicon]]
-version = "0.13.2"
-when = "2025-02-07"
+version = "0.13.5"
+when = "2026-02-15"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
@@ -332,13 +325,6 @@ user-name = "David Tolnay"
 [[publisher.unicode-ident]]
 version = "1.0.12"
 when = "2023-09-13"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.unindent]]
-version = "0.2.3"
-when = "2023-09-16"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -624,15 +610,9 @@ delta = "0.6.5 -> 0.7.1"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.once_cell]]
-who = "crosvm"
+who = "Ying Hsu <yinghsu@chromium.org>"
 criteria = "safe-to-run"
-version = "1.17.0"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.once_cell]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-run"
-delta = "1.17.0 -> 1.18.0"
+version = "1.19.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.openssl-macros]]
@@ -992,6 +972,23 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.10.6 -> 0.10.7"
 
+[[audits.isrg.audits.once_cell]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.19.0 -> 1.20.1"
+
+[[audits.isrg.audits.once_cell]]
+who = "J.C. Jones <jc@insufficient.coffee>"
+criteria = "safe-to-deploy"
+delta = "1.21.1 -> 1.21.3"
+notes = "The unsafe code has moved from `compare_exchange` to a new `init` function, which makes it easier to reason about."
+
+[[audits.isrg.audits.once_cell]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.21.3 -> 1.21.4"
+notes = "The addition is a safe while loop around prior behavior. I don't see any way for that to become malicious."
+
 [[audits.mozilla.wildcard-audits.core-foundation-sys]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
@@ -1251,6 +1248,25 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 version = "1.0.4"
 notes = "This is a trivial crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.once_cell]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.20.1 -> 1.20.2"
+notes = "This update works around a Cargo bug that forces the addition of `portable-atomic` into a lockfile, which we have never needed to use."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.once_cell]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.20.2 -> 1.20.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.once_cell]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.20.3 -> 1.21.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.precomputed-hash]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -197,39 +197,29 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pyo3]]
-version = "0.24.1"
-when = "2025-03-31"
-user-id = 6622
-user-login = "davidhewitt"
-user-name = "David Hewitt"
+version = "0.29.0"
+when = "2026-06-11"
+trusted-publisher = "github:PyO3/pyo3"
 
 [[publisher.pyo3-build-config]]
-version = "0.24.1"
-when = "2025-03-31"
-user-id = 6622
-user-login = "davidhewitt"
-user-name = "David Hewitt"
+version = "0.29.0"
+when = "2026-06-11"
+trusted-publisher = "github:PyO3/pyo3"
 
 [[publisher.pyo3-ffi]]
-version = "0.24.1"
-when = "2025-03-31"
-user-id = 6622
-user-login = "davidhewitt"
-user-name = "David Hewitt"
+version = "0.29.0"
+when = "2026-06-11"
+trusted-publisher = "github:PyO3/pyo3"
 
 [[publisher.pyo3-macros]]
-version = "0.24.1"
-when = "2025-03-31"
-user-id = 6622
-user-login = "davidhewitt"
-user-name = "David Hewitt"
+version = "0.29.0"
+when = "2026-06-11"
+trusted-publisher = "github:PyO3/pyo3"
 
 [[publisher.pyo3-macros-backend]]
-version = "0.24.1"
-when = "2025-03-31"
-user-id = 6622
-user-login = "davidhewitt"
-user-name = "David Hewitt"
+version = "0.29.0"
+when = "2026-06-11"
+trusted-publisher = "github:PyO3/pyo3"
 
 [[publisher.regex]]
 version = "1.10.0"


### PR DESCRIPTION
- Updates Rust and Rustup to 1.96.0 and 1.29.0 respectively
- Updates pyo3 to `0.29.0` to clear some security warnings.
- Updates one retired pyo3 method call in redwood.

## Test plan
- [ ] CI is passing
- [ ] redwood is built successfully in dev env setup
- [ ] user actions involving GPG encryption work correctly.