### PR TITLE
Speed up loaddata.py by reusing source reply keys

### DIFF
--- a/securedrop/loaddata.py
+++ b/securedrop/loaddata.py
@@ -252,7 +252,7 @@ def add_reply(
     db.session.commit()
 
 
-def add_source(use_gpg: bool = False) -> tuple[Source, str]:
+def add_source() -> tuple[Source, str]:
     """
     Adds a single source.
     """
@@ -263,26 +263,6 @@ def add_source(use_gpg: bool = False) -> tuple[Source, str]:
         source_app_storage=Storage.get_default(),
     )
     source = source_user.get_db_record()
-    if use_gpg:
-        manager = EncryptionManager.get_default()
-        gen_key_input = manager.gpg().gen_key_input(
-            passphrase=source_user.gpg_secret,
-            name_email=source_user.filesystem_id,
-            key_type="RSA",
-            key_length=4096,
-            name_real="Source Key",
-            creation_date="2013-05-14",
-            # '0' is the magic value that tells GPG's batch key generation not
-            # to set an expiration date.
-            expire_date="0",
-        )
-        manager.gpg().gen_key(gen_key_input)
-
-        # Delete the Sequoia-generated keys
-        source.pgp_public_key = None
-        source.pgp_fingerprint = None
-        source.pgp_secret_key = None
-        db.session.add(source)
     db.session.commit()
 
     return source, codename
@@ -356,7 +336,7 @@ def add_sources(args: argparse.Namespace, journalists: tuple[Journalist, ...]) -
     )
 
     for i in range(1, args.source_count + 1):
-        source, codename = add_source(use_gpg=args.gpg)
+        source, codename = add_source()
 
         for _ in range(args.messages_per_source):
             submit_message(source, secrets.choice(journalists) if seen_message_count > 0 else None)
@@ -480,12 +460,6 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--seed",
         help=("Random number seed (for reproducible datasets)"),
-    )
-    parser.add_argument(
-        "--gpg",
-        help="Create sources with a key pair stored in GPG",
-        action="store_true",
-        default=False,
     )
     parser.add_argument(
         "--random-file-size",

--- a/securedrop/loaddata.py
+++ b/securedrop/loaddata.py
@@ -13,8 +13,10 @@ import os
 import random
 import secrets
 import string
+from functools import partial
 from itertools import cycle
 from pathlib import Path
+from unittest.mock import patch
 
 import journalist_app
 from db import db
@@ -37,8 +39,18 @@ from specialstrings import strings
 from sqlalchemy.exc import IntegrityError
 from store import Storage
 
+from redwood import generate_source_key_pair
+
 messages = cycle(strings)
 replies = cycle(strings)
+
+_key_cache: dict[str, tuple[str, str, str] | None] = {"result": None}
+
+
+def mock_keygen(reuse_reply_key: bool, *args, **kwargs):  # type: ignore
+    if _key_cache["result"] is None or not reuse_reply_key:
+        _key_cache["result"] = generate_source_key_pair(*args, **kwargs)
+    return _key_cache["result"]
 
 
 def fraction(s: str) -> float:
@@ -249,21 +261,20 @@ def add_reply(
         other_seen_reply = SeenReply(reply=reply, journalist=journalist_who_saw)
         db.session.add(other_seen_reply)
 
-    db.session.commit()
 
-
-def add_source() -> tuple[Source, str]:
+def add_source(reuse_reply_key: bool) -> tuple[Source, str]:
     """
     Adds a single source.
     """
     codename = PassphraseGenerator.get_default().generate_passphrase()
-    source_user = create_source_user(
-        db_session=db.session,
-        source_passphrase=codename,
-        source_app_storage=Storage.get_default(),
-    )
+    bound_mock_keygen = partial(mock_keygen, reuse_reply_key)
+    with patch("redwood.generate_source_key_pair", side_effect=bound_mock_keygen):
+        source_user = create_source_user(
+            db_session=db.session,
+            source_passphrase=codename,
+            source_app_storage=Storage.get_default(),
+        )
     source = source_user.get_db_record()
-    db.session.commit()
 
     return source, codename
 
@@ -274,7 +285,6 @@ def star_source(source: Source) -> None:
     """
     star = SourceStar(source, True)
     db.session.add(star)
-    db.session.commit()
 
 
 def create_default_journalists() -> tuple[Journalist, ...]:
@@ -336,7 +346,7 @@ def add_sources(args: argparse.Namespace, journalists: tuple[Journalist, ...]) -
     )
 
     for i in range(1, args.source_count + 1):
-        source, codename = add_source()
+        source, codename = add_source(reuse_reply_key=args.reuse_reply_keys)
 
         for _ in range(args.messages_per_source):
             submit_message(source, secrets.choice(journalists) if seen_message_count > 0 else None)
@@ -365,6 +375,7 @@ def add_sources(args: argparse.Namespace, journalists: tuple[Journalist, ...]) -
             f"files: {args.files_per_source}, messages: {args.messages_per_source}, "
             f"replies: {args.replies_per_source if i <= replied_sources_count else 0})"
         )
+    db.session.commit()
 
 
 def load(args: argparse.Namespace) -> None:
@@ -461,6 +472,16 @@ def parse_arguments() -> argparse.Namespace:
         "--seed",
         help=("Random number seed (for reproducible datasets)"),
     )
+    parser.add_argument(
+        "--reuse-reply-keys",
+        help=(
+            "Create sources with the same reply keypair - this is fast for large datasets"
+            ", but sources will not be able to read replies."
+        ),
+        action="store_true",
+        default=False,
+    )
+
     parser.add_argument(
         "--random-file-size",
         help="Create random submission files with size specified (in KB)",


### PR DESCRIPTION
The loaddata.py script is chronically slow for large datasets, as it generates a separate gpg reply key for every source. Unique reply keys are unnecessary for the majority of test scenarios, so sharing a single key across all sources should make it easier to test against large datasets.

This change adds a `--reuse-reply-keys` argument:
- when it is not set, a unique key is generated for each source - this is the default behaviour. 
- when it is  set, the first key generated is cached and used for all subsequent sources. 

The source passphrase is required to be unique - unfortunately this means that the correct (shared) passphrase cannot be stored for all sources, and tests/functionality relying on sources' ability to decrypt their reply key will fail for every source but the first created. Still, this may be useful for fast generation of large datasets for UI performance testing.

## Test plan
- [ ] CI is passing
- [x] `time ./loaddata.py --source_count 1000 --reuse-reply-keys` comes in in the single-digit minute range rather than hours
- [ ] JI, and Inbox basic functionality are unaffected when using a dataset with shared reply keys