### PR TITLE
remove v2 service check  from OSSEC config

### DIFF
--- a/securedrop/debian/ossec-server/var/ossec/etc/ossec.conf
+++ b/securedrop/debian/ossec-server/var/ossec/etc/ossec.conf
@@ -106,13 +106,6 @@
 
   <localfile>
     <log_format>command</log_format>
-    <command>grep "HiddenServiceVersion 2" /etc/tor/torrc | head -1</command>
-    <alias>v2_service_check</alias>
-    <frequency>86400</frequency>
-  </localfile>
-
-  <localfile>
-    <log_format>command</log_format>
     <command>/bin/sh -c 'test -e /etc/securedrop-removed-config-files && echo /etc/securedrop-removed-config-files'</command>
     <alias>removed_config_check</alias>
     <frequency>86400</frequency>

--- a/securedrop/debian/ossec-server/var/ossec/rules/local_rules.xml
+++ b/securedrop/debian/ossec-server/var/ossec/rules/local_rules.xml
@@ -288,13 +288,6 @@
     <regex>System configuration error:</regex>
     <description>Indicates a problem with the configuration of the SecureDrop servers.</description>
   </rule>
-  <rule id="400901" level="12" >
-    <if_sid>530</if_sid>
-    <options>alert_by_email</options> <!-- force email to be sent -->
-    <match>ossec: output: 'v2_service_check'</match>
-    <regex>HiddenServiceVersion 2</regex>
-    <description>v2 onion services are still enabled. Support for v2 onion services is deprecated and will be removed starting in March 2021. To preserve access to SecureDrop, you must migrate to v3 onion services: https://securedrop.org/v2-onion-eol</description>
-  </rule>
   <rule id="400902" level="12" >
     <if_sid>530</if_sid>
     <options>alert_by_email</options> <!-- force email to be sent -->


### PR DESCRIPTION
This check is unnecessary as v2 onion services no longer work.


## Test plan
- [ ] CI is passing
- [ ] visual inspection of ossec files looks good.