### PR TITLE
Update rust anyhow to 1.0.103

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ascii-canvas"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -265,6 +265,12 @@ start = "2019-10-05"
 end = "2025-05-14"
 notes = "Rust Project member"
 
+[[trusted.anyhow]]
+criteria = "safe-to-run"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-10-05"
+end = "2027-07-06"
+
 [[trusted.buffered-reader]]
 criteria = "safe-to-deploy"
 user-id = 33886 # Neal H. Walfield (nwalfield)

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,8 +9,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.anyhow]]
-version = "1.0.93"
-when = "2024-11-06"
+version = "1.0.103"
+when = "2026-06-25"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"


### PR DESCRIPTION
Fixes https://rustsec.org/advisories/RUSTSEC-2026-0190

## Test plan
- [ ] CI is passing
- [ ] dependency update looks solid on visual inspection.
