### PR TITLE
Display correct config path in ansible tails_config role message

### DIFF
--- a/install_files/ansible-base/roles/tails-config/defaults/main.yml
+++ b/install_files/ansible-base/roles/tails-config/defaults/main.yml
@@ -3,9 +3,6 @@
 tails_config_amnesia_home: /home/amnesia
 tails_config_amnesia_persistent: "{{ tails_config_amnesia_home }}/Persistent"
 
-# Directory containing Ansible config, including site-specific customizations.
-tails_config_ansible_base: "{{ tails_config_amnesia_persistent }}/securedrop/install_files/ansible-base"
-
 # Custom persistence directory whence site-specific configs will be copied
 # on every login under Tails.
 tails_config_securedrop_dotfiles: "{{ tails_config_amnesia_persistent }}/.securedrop"

--- a/install_files/ansible-base/roles/tails-config/tasks/configure_torrc_additions.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/configure_torrc_additions.yml
@@ -18,7 +18,7 @@
     msg: >-
       Failed to find Tor service info locally. Make sure you've installed SecureDrop
       on the servers, and that the `.auth_private` files are located in:
-      `{{ tails_config_ansible_base }}/`.
+      `{{ config_path }}/`.
 
 - name: Append ClientOnionAuthDir directive to torrc additions
   become: yes


### PR DESCRIPTION
Replaces the old ~/Persistent/securedrop/... path in a tails_config error message with the correct one for the packaged securedrop-admin tool.

## Test plan
- [ ] CI is passing
- [ ] visual review
- [ ] extra points - verify that the install and localconfig playbooks complete successfully.
