### PR TITLE
Use Debian 13 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         ubuntu_version: [noble]
     runs-on: ubuntu-latest
-    container: debian:bookworm
+    container: debian:trixie
     needs:
       - build-debs
     steps:


### PR DESCRIPTION
Fixes #7848.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] All CI jobs pass
* [ ] no other bookworm references
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)