### PR TITLE
Require Python 3.12 for developer virtualenv

### DIFF
--- a/devops/scripts/boot-strap-venv.sh
+++ b/devops/scripts/boot-strap-venv.sh
@@ -7,16 +7,16 @@ set -eo pipefail
 # shellcheck disable=SC2034
 OS_VERSION="${OS_VERSION:-noble}"
 
-# https://peps.python.org/pep-0508/#environment-markers
-PYTHON_VERSION="$(python3 -c 'import platform; print(".".join(platform.python_version_tuple()[:2]))')"
+PYTHON_VERSION="3.12"
 
 get_venv_version() {
-    "${1}/bin/python" -c "from __future__ import print_function; import sys; print(sys.version_info[0])"
+    "${1}/bin/python" -c \
+        'import sys; print(".".join(str(part) for part in sys.version_info[:2]))'
 }
 
 venv_instructions() {
-    echo "If you need to create a virtualenv, you can run the following"
-    echo "commands in the root directory of your SecureDrop working copy:"
+    echo "Python ${PYTHON_VERSION} is required."
+    echo "To create a virtualenv, run this in the SecureDrop repository:"
     echo
     echo "    make venv && . .venv/bin/activate"
     echo
@@ -30,7 +30,8 @@ function virtualenv_bootstrap() {
         VENV_VERSION=$(get_venv_version "${VIRTUAL_ENV}")
         if [ "${VENV_VERSION}" != "${PYTHON_VERSION}" ]
         then
-            venv_instructions "${PYTHON_VERSION}"
+            echo "Active virtualenv uses Python ${VENV_VERSION}."
+            venv_instructions
             if [[ $- != *i* ]]
             then
                 exit 1
@@ -44,17 +45,22 @@ function virtualenv_bootstrap() {
         if [ -d "${VENV}" ]
         then
             VENV_VERSION=$(get_venv_version "${VENV}")
-            if [[ "$VENV" = ".venv" && "$VENV_VERSION" == 2 ]]
+            if [ "${VENV_VERSION}" != "${PYTHON_VERSION}" ]
             then
-                relo="${VENV}-${VENV_VERSION}-$(date +'%Y%m%d-%H%M%S')"
-                echo "Default virtualenv in .venv is Python 2; renaming it to ${relo}."
-                mv "${VENV}" "${relo}"
+                echo "${VENV} uses Python ${VENV_VERSION}."
+                venv_instructions
+                exit 1
             fi
         fi
 
         if [ ! -d "$VENV" ]
         then
-            p=$(command -v "python${PYTHON_VERSION}" 2> /dev/null || command -v python3)
+            p=$(command -v "python${PYTHON_VERSION}" 2> /dev/null || true)
+            if [ -z "${p}" ]
+            then
+                venv_instructions
+                exit 1
+            fi
             echo "Creating ${p} virtualenv in ${VENV}"
             # be flexible in venv creation, e.g. staging has virtualenv while
             # deb-tests (GHA runner) has python3-venv

--- a/devops/scripts/boot-strap-venv.sh
+++ b/devops/scripts/boot-strap-venv.sh
@@ -32,10 +32,7 @@ function virtualenv_bootstrap() {
         then
             echo "Active virtualenv uses Python ${VENV_VERSION}."
             venv_instructions
-            if [[ $- != *i* ]]
-            then
-                exit 1
-            fi
+            return 1
         else
             echo "Using active Python ${VENV_VERSION} virtualenv in ${VIRTUAL_ENV}"
         fi

--- a/securedrop/tests/test_bootstrap_venv.py
+++ b/securedrop/tests/test_bootstrap_venv.py
@@ -7,14 +7,20 @@ SCRIPT = Path(__file__).parents[2] / "devops/scripts/boot-strap-venv.sh"
 
 
 def run_bootstrap(
-    command: str, *, cwd: Path, virtual_env: str = "", path: str | None = None
+    command: str,
+    *,
+    cwd: Path,
+    virtual_env: str = "",
+    path: str | None = None,
+    interactive: bool = False,
 ) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     env["VIRTUAL_ENV"] = virtual_env
     if path is not None:
         env["PATH"] = path
+    bash_arguments = ["/bin/bash", "--noprofile", "--norc", "-ic" if interactive else "-c"]
     return subprocess.run(
-        ["/bin/bash", "-c", f'source "{SCRIPT}"; {command}'],
+        [*bash_arguments, f'source "{SCRIPT}"; {command}'],
         cwd=cwd,
         env=env,
         check=False,
@@ -49,6 +55,19 @@ def test_incompatible_active_venv_is_rejected(tmp_path: Path) -> None:
     make_fake_venv(venv, "3.11")
 
     result = run_bootstrap("virtualenv_bootstrap", cwd=tmp_path, virtual_env=str(venv))
+
+    assert result.returncode == 1
+    assert "Active virtualenv uses Python 3.11." in result.stdout
+    assert "Python 3.12 is required." in result.stdout
+
+
+def test_incompatible_active_venv_is_rejected_in_interactive_shell(tmp_path: Path) -> None:
+    venv = tmp_path / "active"
+    make_fake_venv(venv, "3.11")
+
+    result = run_bootstrap(
+        "virtualenv_bootstrap", cwd=tmp_path, virtual_env=str(venv), interactive=True
+    )
 
     assert result.returncode == 1
     assert "Active virtualenv uses Python 3.11." in result.stdout

--- a/securedrop/tests/test_bootstrap_venv.py
+++ b/securedrop/tests/test_bootstrap_venv.py
@@ -1,0 +1,73 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[2] / "devops/scripts/boot-strap-venv.sh"
+
+
+def run_bootstrap(
+    command: str, *, cwd: Path, virtual_env: str = "", path: str | None = None
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["VIRTUAL_ENV"] = virtual_env
+    if path is not None:
+        env["PATH"] = path
+    return subprocess.run(
+        ["/bin/bash", "-c", f'source "{SCRIPT}"; {command}'],
+        cwd=cwd,
+        env=env,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def make_fake_venv(path: Path, version: str) -> None:
+    python = path / "bin/python"
+    python.parent.mkdir(parents=True)
+    python.write_text(f"#!/bin/sh\necho {version}\n")
+    python.chmod(0o755)
+
+
+def test_get_venv_version_includes_minor_version(tmp_path: Path) -> None:
+    result = run_bootstrap(f'get_venv_version "{sys.prefix}"', cwd=tmp_path)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "3.12"
+
+
+def test_compatible_active_venv_is_accepted(tmp_path: Path) -> None:
+    result = run_bootstrap("virtualenv_bootstrap", cwd=tmp_path, virtual_env=sys.prefix)
+
+    assert result.returncode == 0
+    assert "Using active Python 3.12 virtualenv" in result.stdout
+
+
+def test_incompatible_active_venv_is_rejected(tmp_path: Path) -> None:
+    venv = tmp_path / "active"
+    make_fake_venv(venv, "3.11")
+
+    result = run_bootstrap("virtualenv_bootstrap", cwd=tmp_path, virtual_env=str(venv))
+
+    assert result.returncode == 1
+    assert "Active virtualenv uses Python 3.11." in result.stdout
+    assert "Python 3.12 is required." in result.stdout
+
+
+def test_incompatible_default_venv_is_rejected(tmp_path: Path) -> None:
+    make_fake_venv(tmp_path / ".venv", "3.11")
+
+    result = run_bootstrap("virtualenv_bootstrap", cwd=tmp_path)
+
+    assert result.returncode == 1
+    assert ".venv uses Python 3.11." in result.stdout
+    assert "Python 3.12 is required." in result.stdout
+
+
+def test_missing_python_312_is_rejected(tmp_path: Path) -> None:
+    result = run_bootstrap("virtualenv_bootstrap", cwd=tmp_path, path=str(tmp_path))
+
+    assert result.returncode == 1
+    assert "Python 3.12 is required." in result.stdout
+    assert not (tmp_path / ".venv").exists()


### PR DESCRIPTION
Fixes #7490

Require Python 3.12 for developer virtualenvs, including returning an error for
an incompatible active virtualenv without closing an interactive shell.

## Test plan

- `TESTFILES=tests/test_bootstrap_venv.py make test`
- `make check-ruff`
- `make shellcheck`
- `git diff --check`

## Checklist

This change accounts for:

- [x] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our dependency update policy
