### PR TITLE
Reject unsupported fixed-data item kinds

### DIFF
--- a/securedrop/loadfixeddata.py
+++ b/securedrop/loadfixeddata.py
@@ -29,6 +29,8 @@ from sdconfig import SecureDropConfig
 from source_user import create_source_user
 from store import Storage
 
+SUPPORTED_ITEM_KINDS = frozenset({"file", "message", "reply"})
+
 
 def verify_empty_database() -> None:
     """Verify that the database is empty before importing data."""
@@ -138,6 +140,14 @@ def record_source_interaction(source: Source) -> None:
     db.session.flush()
 
 
+def validate_item_kinds(sources_data: list[dict[str, Any]]) -> None:
+    for source_data in sources_data:
+        for item_data in source_data["items"]:
+            kind = item_data["kind"]
+            if kind not in SUPPORTED_ITEM_KINDS:
+                raise ValueError(f"Unsupported item kind {kind!r} for item {item_data['uuid']!r}")
+
+
 def import_submissions_and_replies(
     sources_data: list[dict[str, Any]],
     uuid_to_source: dict[str, Source],
@@ -145,6 +155,8 @@ def import_submissions_and_replies(
     yaml_dir: Path,
     save_items: bool = False,
 ) -> tuple[dict[str, Submission], dict[str, Reply]]:
+    validate_item_kinds(sources_data)
+
     uuid_to_submission = {}
     uuid_to_reply = {}
     storage = Storage.get_default()
@@ -345,6 +357,7 @@ def load_fixed_data(yaml_path: Path, save_items: bool = False) -> None:
         with yaml_path.open("r") as f:
             data = yaml.safe_load(f)
         yaml_dir = yaml_path.parent
+        validate_item_kinds(data["sources"])
 
         print("\n--- Importing journalists ---")
         uuid_to_journalist = import_journalists(data["journalists"])

--- a/securedrop/tests/test_loadfixeddata_item_validation.py
+++ b/securedrop/tests/test_loadfixeddata_item_validation.py
@@ -1,0 +1,28 @@
+import loadfixeddata
+import pytest
+
+
+def test_import_rejects_unsupported_item_kind_before_side_effects(mocker, tmp_path):
+    source = object()
+    record_source_interaction = mocker.patch.object(loadfixeddata, "record_source_interaction")
+    get_storage = mocker.patch.object(loadfixeddata.Storage, "get_default")
+    get_encryption_manager = mocker.patch.object(loadfixeddata.EncryptionManager, "get_default")
+    sources_data = [
+        {
+            "uuid": "source-uuid",
+            "items": [{"uuid": "item-uuid", "kind": "unsupported"}],
+        }
+    ]
+
+    expected_error = "Unsupported item kind 'unsupported' for item 'item-uuid'"
+    with pytest.raises(ValueError, match=expected_error):
+        loadfixeddata.import_submissions_and_replies(
+            sources_data=sources_data,
+            uuid_to_source={"source-uuid": source},
+            uuid_to_journalist={},
+            yaml_dir=tmp_path,
+        )
+
+    record_source_interaction.assert_not_called()
+    get_storage.assert_not_called()
+    get_encryption_manager.assert_not_called()


### PR DESCRIPTION
## Summary

Reject unsupported fixed-data item kinds instead of silently skipping them. Validate before importing records and retain validation for direct importer calls.

Add regression coverage confirming rejection occurs before storage, encryption, or interaction side effects.

## Testing

- `TESTFILES=tests/test_loadfixeddata_item_validation.py make test`
- `./securedrop/bin/run-mypy`
- Ruff and `git diff --check`
- Valid and deliberately malformed fixed-dataset development imports