### PR TITLE
admin: prefer SFTP for Ansible file transfer; enable sshd SFTP subsystem

### DIFF
--- a/install_files/ansible-base/ansible.cfg
+++ b/install_files/ansible-base/ansible.cfg
@@ -12,8 +12,8 @@ inventory=inventory-dynamic
 agnostic_become_prompt=False
 
 [ssh_connection]
-scp_if_ssh=True
-ssh_transfer_method=scp
-scp_extra_args = -O
+# Prefer SFTP only (OpenSSH is deprecating classic scp). Requires Subsystem sftp
+# in the hardened sshd_config template — see issue #7126.
+ssh_transfer_method=sftp
 ssh_args = -o ControlMaster=auto -o ControlPersist=1200 -o ServerAliveInterval=10 -o ServerAliveCountMax=3
 pipelining=True

--- a/install_files/ansible-base/roles/restrict-direct-access/templates/sshd_config
+++ b/install_files/ansible-base/roles/restrict-direct-access/templates/sshd_config
@@ -56,6 +56,11 @@ PermitTunnel no
 X11Forwarding no
 X11DisplayOffset 10
 
+# File transfer
+# Enable SFTP for Ansible (ssh_transfer_method=sftp). Classic scp is deprecated
+# in OpenSSH 9+. Keep other hardening above; do not broaden auth/forwarding.
+Subsystem sftp /usr/lib/openssh/sftp-server
+
 # Misc configuration
 
 PrintMotd no


### PR DESCRIPTION
## Summary
Fixes / implements https://github.com/freedomofpress/securedrop/issues/7126.

OpenSSH is deprecating classic `scp`. SecureDrop currently forces SCP because the hardened `sshd_config` has no SFTP subsystem and `ansible.cfg` sets `ssh_transfer_method=scp`.

This PR:
- Adds `Subsystem sftp /usr/lib/openssh/sftp-server` to the hardened `sshd_config` template (as suggested by @legoktm on the issue)
- Sets Ansible `ssh_transfer_method=sftp` only (no scp / smart fallback)
- Removes SCP-only knobs (`scp_if_ssh`, `scp_extra_args=-O`)

Hardening otherwise unchanged (no password auth, `AllowGroups sdssh`, forwarding still disabled).

## Test plan
- [ ] Diff-review `install_files/ansible-base/ansible.cfg` and `roles/restrict-direct-access/templates/sshd_config`
- [ ] On a staging/dev install, run ansible so the new `sshd_config` is applied, confirm `sshd -t` / service restart OK
- [ ] Confirm Ansible file transfers succeed with SFTP-only (`ssh_transfer_method=sftp`)
- [ ] Confirm existing auth/forwarding restrictions still hold

## Upgrade note
Existing installs pick up the new `sshd_config` on the next ansible run that applies the restrict-direct-access role.

## Notes
Intent comment: https://github.com/freedomofpress/securedrop/issues/7126#issuecomment-5606360219