### PR TITLE
Add `securedrop-admin-qubes` metapackage

### DIFF
--- a/admin/debian/control
+++ b/admin/debian/control
@@ -10,3 +10,11 @@ Package: securedrop-admin
 Architecture: amd64
 Depends: ${shlibs:Depends}, python3, sq, netcat-openbsd, tor, rsync, keepassxc-minimal
 Description: SecureDrop server administration utility
+
+Package: securedrop-admin-qubes
+Architecture: amd64
+Depends:
+ qubes-vm-recommended,
+ xfce4-terminal,
+ securedrop-admin, torbrowser-launcher, firefox-esr
+Description: Metapackage for using SecureDrop admin tools on Qubes


### PR DESCRIPTION
This wraps around the existing `securedrop-admin` package to install dependencies that are only needed on Qubes.

This is an incomplete list, but gets us started.

* torbrowser-launcher is for sd-admin to access JI and SI
* firefox-esr is for sd-firewall-setup, which uses clearnet
* xfce4-terminal is for general debugging

Refs <https://github.com/freedomofpress/securedrop-workstation/issues/1789>. 
Refs <https://github.com/freedomofpress/securedrop-workstation/issues/1790>.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] `make build-debs-admin` locally spits out a second package
* [x] `dpkg --info build/trixie/securedrop-admin-qubes_2.17.0~rc1+trixie_amd64.deb` looks reasonable 

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)