### PR TITLE
Speed up `make build-debs-admin`

### DIFF
--- a/admin/debian/rules
+++ b/admin/debian/rules
@@ -2,8 +2,8 @@
 include /usr/share/dpkg/pkg-info.mk
 
 DEB_DH_INSTALL_ARGS=-X .git
-PIP_BOOTSTRAP_ARGS=--verbose --no-deps --no-cache-dir --only-binary=:all:
-PIP_ARGS=--verbose --no-deps --no-cache-dir --only-binary=:all: --require-hashes
+PIP_BOOTSTRAP_ARGS=--verbose --no-deps --no-cache-dir --no-compile --only-binary=:all:
+PIP_ARGS=--verbose --no-deps --no-cache-dir --no-compile --only-binary=:all: --require-hashes
 
 %:
 	dh $@ --buildsystem=pybuild
@@ -16,7 +16,7 @@ override_dh_auto_install:
 
 	./debian/securedrop-admin/usr/share/securedrop-admin/venv/bin/pip install $(PIP_ARGS) \
 		-r ./requirements.txt
-	./debian/securedrop-admin/usr/share/securedrop-admin/venv/bin/pip install /srv/securedrop-admin
+	./debian/securedrop-admin/usr/share/securedrop-admin/venv/bin/pip install --no-compile /srv/securedrop-admin
 	find ./debian/securedrop-admin/ -type f -exec sed -i "s#$(shell pwd)/debian/securedrop-admin##" {} \;
 	dh_auto_install $@
 

--- a/admin/debian/rules
+++ b/admin/debian/rules
@@ -29,3 +29,9 @@ override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name 'pip-selfcheck.json' -delete
 	find ./debian/ -type f -name 'RECORD' -delete
 	dh_strip_nondeterminism $@
+
+# Skip compression when FAST=1 to speed up local builds
+ifdef FAST
+override_dh_builddeb:
+	dh_builddeb -- -Znone
+endif

--- a/builder/build-debs.sh
+++ b/builder/build-debs.sh
@@ -24,7 +24,7 @@ else
     export OS_VERSION="${OS_VERSION:-noble}"
 fi
 
-OCI_RUN_ARGUMENTS="--user=root -v $(pwd):/src:Z -e HOST_UID=$(id -u) -e HOST_GID=$(id -g)"
+OCI_RUN_ARGUMENTS="--user=root -v $(pwd):/src:Z -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e FAST=${FAST:-}"
 
 # Default to podman if available
 if which podman > /dev/null 2>&1; then


### PR DESCRIPTION
I had Claude 5 Opus review where the build was slow and it discovered `--no-compile`; and then I had it port over our FAST=1 optimization from securedrop-client. 

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] `make build-debs-admin` feels faster :)
* [ ] `FAST=1 make build-debs-admin` is even faster
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)