### PR TITLE
Fix stale seen events for deleted sources

### DIFF
--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -12,7 +12,7 @@ from journalist_app.api2.types import (
     ItemUUID,
 )
 from journalist_app.sessions import Session, session
-from models import Reply, Source, Submission
+from models import Reply, Source, Submission, eager_query
 from redis import Redis
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound, StaleDataError
@@ -287,7 +287,7 @@ class EventHandler:
         """
 
         try:
-            source = Source.query.filter(Source.uuid == event.target.source_uuid).one()
+            source = eager_query("Source").filter(Source.uuid == event.target.source_uuid).one()
         except NoResultFound:
             return EventResult(
                 event_id=event.id,

--- a/securedrop/tests/test_journalist_api2_stale_events.py
+++ b/securedrop/tests/test_journalist_api2_stale_events.py
@@ -1,0 +1,61 @@
+from dataclasses import asdict
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from flask import url_for
+from journalist_app.api2.types import Event, EventType, SourceTarget
+from models import Source, db
+from tests.utils.api_helper import get_api_headers
+
+
+def test_source_conversation_seen_deleted_source_is_gone(
+    journalist_app,
+    journalist_api_token,
+    test_files,
+):
+    """A stale seen event must not reintroduce a deleted source."""
+    source_uuid = test_files["source"].uuid
+    submission_uuid = test_files["submissions"][0].uuid
+    upper_bound = test_files["source"].interaction_count
+
+    with journalist_app.test_client() as app:
+        # Capture the version while the source is still visible to the client.
+        index = app.get(
+            url_for("api2.index"),
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert index.status_code == 200
+        source_version = index.json["sources"][source_uuid]
+
+        # A completed request removes Flask-SQLAlchemy's scoped session, so
+        # re-query the source before changing it instead of mutating the now
+        # detached fixture instance.
+        source = Source.query.filter(Source.uuid == source_uuid).one()
+        source.deleted_at = datetime.now(UTC)
+        db.session.commit()
+
+        # The authoritative index no longer exposes the source or its items.
+        index = app.get(
+            url_for("api2.index"),
+            headers=get_api_headers(journalist_api_token),
+        )
+        assert index.status_code == 200
+        assert source_uuid not in index.json["sources"]
+        assert submission_uuid not in index.json["items"]
+
+        event = Event(
+            id=str(uuid4().int % 10**18),
+            target=SourceTarget(source_uuid=source_uuid, version=source_version),
+            type=EventType.SOURCE_CONVERSATION_SEEN,
+            data={"upper_bound": upper_bound},
+        )
+        response = app.post(
+            url_for("api2.data"),
+            json={"events": [asdict(event)]},
+            headers=get_api_headers(journalist_api_token),
+        )
+
+        assert response.status_code == 200
+        assert response.json["events"][event.id] == [410, None]
+        assert source_uuid not in response.json["sources"]
+        assert submission_uuid not in response.json["items"]


### PR DESCRIPTION
## Description

`source_conversation_seen` was looking up sources with `Source.query`, while the API v2 index uses `eager_query("Source")` to exclude pending and deleted sources.

This meant a stale event could return a source and its items immediately after the index had removed them.

Use the same filtered query in the event handler so stale events for deleted sources return `410 Gone` instead.

Fixes #7884

## Testing

Added a regression test that deletes a source after its version has been read, verifies it disappears from the index, and then submits the stale `source_conversation_seen` event.

The event returns `410` and does not include the deleted source or submission.