### PR TITLE
Add `securedrop-admin export-journalist-config`

### DIFF
--- a/admin/securedrop_admin/__init__.py
+++ b/admin/securedrop_admin/__init__.py
@@ -83,6 +83,12 @@ ANSIBLE_PATH = os.path.join(READONLY_CONFIG_PATH, "ansible-base")
 TRANSLATIONS_PATH = os.path.join(READONLY_CONFIG_PATH, "translations")
 CONFIG_PATH = os.path.expanduser("~/.config/securedrop-admin")
 SITE_CONFIG_PATH = os.path.join(CONFIG_PATH, "site-specific")
+JOURNALIST_AUTH_PATH = os.path.join(CONFIG_PATH, "app-journalist.auth_private")
+
+# Values for the SecureDrop Workstation `config.json` we generate; see
+# `sdw_util/config_types.py` in the securedrop-workstation repository.
+SDW_ENVIRONMENT = "prod"
+SDW_VMSIZES = {"sd_app": 10, "sd_log": 5}
 
 
 # Check OpenSSH version - ansible requires an extra argument for scp on OpenSSH 9
@@ -916,6 +922,70 @@ def find_or_generate_new_torv3_keys(args: argparse.Namespace) -> int:
     return 0
 
 
+def export_journalist_config(args: argparse.Namespace) -> int:
+    """Export a config.json for SecureDrop Workstation"""
+    # Validate on load, so the fingerprint is normalized (spaces stripped,
+    # uppercased) before it goes into the config.json.
+    site_config = SiteConfig().load()
+    fingerprint = site_config.get("securedrop_app_gpg_fingerprint", "")
+    if not fingerprint:
+        raise ValueError(
+            "The Submission Key fingerprint is not set in the site configuration. "
+            'Please run "securedrop-admin sdconfig".'
+        )
+
+    hostname, key = read_journalist_onion_auth()
+
+    config = {
+        "submission_key_fpr": fingerprint,
+        "hidserv": {
+            "hostname": hostname,
+            "key": key,
+        },
+        "environment": SDW_ENVIRONMENT,
+        "vmsizes": SDW_VMSIZES,
+    }
+
+    print(json.dumps(config, indent=2))
+    return 0
+
+
+def read_journalist_onion_auth() -> tuple[str, str]:
+    """Read the Journalist Interface onion address and client auth private key.
+
+    The `app-journalist.auth_private` file is fetched back from the Application
+    Server during installation, and has the form::
+
+        <onion-address-without-suffix>:descriptor:x25519:<private-key>
+
+    :returns: Tuple(hostname, private_key)
+    """
+    try:
+        with open(JOURNALIST_AUTH_PATH) as fobj:
+            contents = fobj.read().strip()
+    except OSError:
+        raise ValueError(
+            f"The Journalist Interface onion service file is missing: {JOURNALIST_AUTH_PATH}. "
+            'Please run "securedrop-admin install" first, or copy the file from the '
+            "Admin Workstation."
+        )
+
+    fields = contents.split(":")
+    if len(fields) != 4 or fields[1] != "descriptor" or fields[2] != "x25519":
+        raise ValueError(f"Could not parse the onion service file: {JOURNALIST_AUTH_PATH}")
+
+    hostname = fields[0] + ".onion"
+    key = fields[3]
+    # Mirror the validation done by securedrop-workstation, so that admins find
+    # out about a malformed value here rather than halfway through provisioning.
+    if not re.match(r"^[a-z2-7]{56}\.onion$", hostname):
+        raise ValueError(f"Invalid onion address in {JOURNALIST_AUTH_PATH}: {hostname}")
+    if not re.match(r"^[A-Z2-7]{52}$", key):
+        raise ValueError(f"Invalid onion service key in {JOURNALIST_AUTH_PATH}")
+
+    return hostname, key
+
+
 @update_check_required("install")
 def install_securedrop(args: argparse.Namespace) -> int:
     """Install/Update SecureDrop"""
@@ -1127,6 +1197,11 @@ def parse_argv(argv: list[str]) -> argparse.Namespace:
         "generate_v3_keys", help=find_or_generate_new_torv3_keys.__doc__
     )
     parse_generate_tor_keys.set_defaults(func=find_or_generate_new_torv3_keys)
+
+    parse_export_journalist_config = subparsers.add_parser(
+        "export-journalist-config", help=export_journalist_config.__doc__
+    )
+    parse_export_journalist_config.set_defaults(func=export_journalist_config)
 
     parse_backup = subparsers.add_parser("backup", help=backup_securedrop.__doc__)
     parse_backup.set_defaults(func=backup_securedrop)

--- a/admin/tests/test_securedrop-admin.py
+++ b/admin/tests/test_securedrop-admin.py
@@ -653,3 +653,72 @@ def test_find_or_generate_new_torv3_keys_subsequent_run(capsys):
         v3_onion_service_keys = json.load(f)
 
     assert v3_onion_service_keys == old_keys
+
+
+class TestExportJournalistConfig:
+    JOURNALIST_ONION = "sdolvtfhatvsysc6l34d65ymdwxcujausv7k5jk4cy5ttzhjoi6fzvyd.onion"
+    JOURNALIST_KEY = "5U4JPYSZ34N2ZDSOUAL2YLEX2NPI5BLL2Y66QJW24KLSH7R3FEPQ"
+    FINGERPRINT = "1234567890ABCDEF1234567890ABCDEF12345678"
+
+    def setup_method(self, method):
+        os.makedirs(CONFIG_DIR, exist_ok=True)
+        with open(SITE_CONFIG_PATH, "w") as f:
+            yaml.safe_dump({"securedrop_app_gpg_fingerprint": self.FINGERPRINT}, f)
+        self.write_auth_file(
+            f"{self.JOURNALIST_ONION[: -len('.onion')]}:descriptor:x25519:{self.JOURNALIST_KEY}"
+        )
+
+    def teardown_method(self, method):
+        for path in (SITE_CONFIG_PATH, join(CONFIG_DIR, "app-journalist.auth_private")):
+            if exists(path):
+                os.remove(path)
+
+    def write_auth_file(self, contents):
+        with open(join(CONFIG_DIR, "app-journalist.auth_private"), "w") as f:
+            f.write(contents + "\n")
+
+    def args(self):
+        return argparse.Namespace()
+
+    def test_export_to_stdout(self, capsys):
+        return_code = securedrop_admin.export_journalist_config(self.args())
+
+        assert return_code == 0
+        out, err = capsys.readouterr()
+        assert json.loads(out) == {
+            "submission_key_fpr": self.FINGERPRINT,
+            "hidserv": {"hostname": self.JOURNALIST_ONION, "key": self.JOURNALIST_KEY},
+            "environment": "prod",
+            "vmsizes": {"sd_app": 10, "sd_log": 5},
+        }
+
+    def test_export_missing_fingerprint(self):
+        with open(SITE_CONFIG_PATH, "w") as f:
+            yaml.safe_dump({"app_hostname": "app"}, f)
+
+        with pytest.raises(ValueError, match="Submission Key fingerprint is not set"):
+            securedrop_admin.export_journalist_config(self.args())
+
+    def test_export_missing_auth_file(self):
+        os.remove(join(CONFIG_DIR, "app-journalist.auth_private"))
+
+        with pytest.raises(ValueError, match="onion service file is missing"):
+            securedrop_admin.export_journalist_config(self.args())
+
+    def test_export_unparseable_auth_file(self):
+        self.write_auth_file("not-an-onion-service")
+
+        with pytest.raises(ValueError, match="Could not parse the onion service file"):
+            securedrop_admin.export_journalist_config(self.args())
+
+    def test_export_invalid_onion_address(self):
+        self.write_auth_file(f"notanonion:descriptor:x25519:{self.JOURNALIST_KEY}")
+
+        with pytest.raises(ValueError, match="Invalid onion address"):
+            securedrop_admin.export_journalist_config(self.args())
+
+    def test_export_invalid_key(self):
+        self.write_auth_file(f"{self.JOURNALIST_ONION[: -len('.onion')]}:descriptor:x25519:nope")
+
+        with pytest.raises(ValueError, match="Invalid onion service key"):
+            securedrop_admin.export_journalist_config(self.args())


### PR DESCRIPTION
This spits out a JSON blob that can be copied to a USB for provisioning a journalist workstation.

For a combined workstation, we'll want some additional layer in dom0 to facilitate copying it to dom0.

Refs https://github.com/freedomofpress/securedrop-workstation/issues/1853.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] try it out
