### PR TITLE
fix(`process`): clear cache for an event that returns `501 Not Implemented`

### DIFF
--- a/securedrop/journalist_app/api2/events.py
+++ b/securedrop/journalist_app/api2/events.py
@@ -82,6 +82,7 @@ class EventHandler:
                 EventType.SOURCE_CONVERSATION_SEEN: self.handle_source_conversation_seen,
             }[event.type]
         except KeyError:
+            self.record_status(event, EventStatusCode.NotImplemented)
             return EventResult(
                 event_id=event.id,
                 status=(


### PR DESCRIPTION
In the ["State Machine"](https://github.com/freedomofpress/securedrop/blob/cd21304f075dd6402cb25a32f43bf2298dd21523/API2.md#state-machine) section of the Journalist API documentation, we document that any error status for an event clears the cache entry for that event:

https://github.com/freedomofpress/securedrop/blob/cd21304f075dd6402cb25a32f43bf2298dd21523/API2.md?plain=1#L276-L281

All other error statuses satisfy this obligation in the try/except logic around the called handler function.  But an unimplemented event has no handler by definition, so we have to record this status before we return it.


## Test plan

Visual review.