### PR TITLE
add Ansible task to create config.json while running localconfig

### DIFF
--- a/install_files/ansible-base/roles/qubes-config/tasks/create_sdw_config.yml
+++ b/install_files/ansible-base/roles/qubes-config/tasks/create_sdw_config.yml
@@ -1,0 +1,52 @@
+---
+# duplicated in tails-config role - make updates there as well if necessary
+
+- name: Import variables
+  include_vars: "{{ config_path }}/site-specific"
+
+- name: Confirm that the app-journalist auth file exists
+  stat:
+    path: "{{ config_path }}/app-journalist.auth_private"
+  register: "ji_app"
+  failed_when: not ji_app.stat.exists or not ji_app.stat.isreg
+
+- name: Read the app-journalist file content
+  slurp:
+    src: "{{ config_path }}/app-journalist.auth_private"
+  register: ji_app_file
+
+- name: Extract the JI onion address
+  set_fact:
+    ji_onion_address: "{{ (ji_app_file.content | b64decode).split('\n')[0].split(':')[0] }}"
+  no_log: true
+
+- name: Extract the JI auth key
+  set_fact:
+    ji_onion_key: "{{ (ji_app_file.content | b64decode).split('\n')[0].split(':')[3] }}"
+  no_log: true
+
+- name: Verify that the extracted fields are valid
+  assert:
+    that:
+      - ji_onion_address is match('^[a-z2-7]{56}$')
+      - ji_onion_key is match('^[A-Z2-7]{52}$')
+  no_log: true
+
+- name: Create a fact describing the SecureDrop Workstation config data
+  set_fact:
+    sdw_config:
+      environment: "prod"
+      submission_key_fpr: "{{ securedrop_app_gpg_fingerprint }}"
+      hidserv:
+        hostname: "{{ ji_onion_address }}.onion"
+        key: "{{ ji_onion_key }}"
+      vmsizes:
+        sd_app: 10
+        sd_log: 5
+  no_log: true
+
+- name: Create a config.json file with the SDW config data
+  copy:
+    content: "{{ sdw_config | to_nice_json(indent=2) }}"
+    dest: "{{ config_path }}/config.json"
+  no_log: true

--- a/install_files/ansible-base/roles/qubes-config/tasks/main.yml
+++ b/install_files/ansible-base/roles/qubes-config/tasks/main.yml
@@ -5,10 +5,4 @@
 
 - include_tasks: create_sdw_config.yml
 
-- name: Check that we are on an admin workstation
-  stat:
-    path: "{{ config_path }}/tor_v3_keys.json"
-  register: admin_check_result
-
 - include_tasks: create_ssh_aliases.yml
-  when: admin_check_result.stat.exists

--- a/install_files/ansible-base/roles/qubes-config/tasks/main.yml
+++ b/install_files/ansible-base/roles/qubes-config/tasks/main.yml
@@ -3,6 +3,8 @@
 
 - include_tasks: configure_tor.yml
 
+- include_tasks: create_sdw_config.yml
+
 - name: Check that we are on an admin workstation
   stat:
     path: "{{ config_path }}/tor_v3_keys.json"

--- a/install_files/ansible-base/roles/tails-config/tasks/create_sdw_config.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/create_sdw_config.yml
@@ -1,0 +1,50 @@
+---
+- name: Import variables
+  include_vars: "{{ config_path }}/site-specific"
+
+- name: Confirm that the app-journalist auth file exists
+  stat:
+    path: "{{ config_path }}/app-journalist.auth_private"
+  register: "ji_app"
+  failed_when: not ji_app.stat.exists or not ji_app.stat.isreg
+
+- name: Read the app-journalist file content
+  slurp:
+    src: "{{ config_path }}/app-journalist.auth_private"
+  register: ji_app_file
+
+- name: Extract the JI onion address
+  set_fact:
+    ji_onion_address: "{{ (ji_app_file.content | b64decode).split('\n')[0].split(':')[0] }}"
+  no_log: true
+
+- name: Extract the JI auth key
+  set_fact:
+    ji_onion_key: "{{ (ji_app_file.content | b64decode).split('\n')[0].split(':')[3] }}"
+  no_log: true
+
+- name: Verify that the extracted fields are valid
+  assert:
+    that:
+      - ji_onion_address is match('^[a-z2-7]{56}$')
+      - ji_onion_key is match('^[A-Z2-7]{52}$')
+  no_log: true
+
+- name: Create a fact describing the SecureDrop Workstation config data
+  set_fact:
+    sdw_config:
+      environment: "prod"
+      submission_key_fpr: "{{ securedrop_app_gpg_fingerprint }}"
+      hidserv:
+        hostname: "{{ ji_onion_address }}.onion"
+        key: "{{ ji_onion_key }}"
+      vmsizes:
+        sd_app: 10
+        sd_log: 5
+  no_log: true
+
+- name: Create a config.json file with the SDW config data
+  copy:
+    content: "{{ sdw_config | to_nice_json(indent=2) }}"
+    dest: "{{ config_path }}/config.json"
+  no_log: true

--- a/install_files/ansible-base/roles/tails-config/tasks/main.yml
+++ b/install_files/ansible-base/roles/tails-config/tasks/main.yml
@@ -19,3 +19,6 @@
 
 - include_tasks: create_ssh_aliases.yml
   when: admin_check_result.stat.exists
+
+- include_tasks: create_sdw_config.yml
+  when: admin_check_result.stat.exists


### PR DESCRIPTION
Alternate approach to #7915 

Adds (identical) ansible tasks to the qubes-config and tails-config roles to gather the facts required for the SecureDrop Workstation's config.json file and output those as part of the localconfig playbook

Refs https://github.com/freedomofpress/securedrop-workstation/issues/1853.

## Test plan
- [x] run `securedrop-admin localconfig` on a tails or qubes admin workstation either as part of or after a prod install.
- [x] verify that the file ./config/securedrop-admin/config.json has been created with the appropriate values and valid JSON
- [ ] (bonus) use the config,json file in an SDW setup and verify that it works

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [ ] any necessary AppArmor changes (added or removed application files)
- [ ] any impact on new SecureDrop installs and upgrades
- [ ] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)